### PR TITLE
feat: send transaction with broadcast, tracking, and Dynamic Island

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -14,12 +14,15 @@
 		265BA9BA2F7BDB1E00287691 /* SyncWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 265BA9A92F7BDB1D00287691 /* SyncWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		42257B77B623F2ABAD2A1912 /* DynamicIslandManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4D4F9C0A149C751B796E19 /* DynamicIslandManager.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		8108A5A50BC98B3D741F1711 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FED55156EBDEE425125AD2C /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		AC93183A00FB6E944C717D3B /* TxTrackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CDA4682F625C9EA7328E886 /* TxTrackManager.swift */; };
+		B7C6E66ECB0517259883CB1B /* LiveActivitiesAppAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F754445942A6FAE31362F45C /* LiveActivitiesAppAttributes.swift */; };
 		BGSYNC001ED2DC5600515810 /* BackgroundSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BGSYNC000ED2DC5600515810 /* BackgroundSyncManager.swift */; };
 		SYNCPSH01ED2DC5600515810 /* SyncProgressStreamHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = SYNCPSH00ED2DC5600515810 /* SyncProgressStreamHandler.swift */; };
 /* End PBXBuildFile section */
@@ -74,6 +77,7 @@
 		265BA9AC2F7BDB1D00287691 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		265BA9C32F7BDBE100287691 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		265BA9C42F7BDBF600287691 /* SyncWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SyncWidgetExtension.entitlements; sourceTree = "<group>"; };
+		2CDA4682F625C9EA7328E886 /* TxTrackManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TxTrackManager.swift; sourceTree = "<group>"; };
 		30B62B9066558FE48CCA6832 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -81,6 +85,7 @@
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		603F096B051231C6A1C6A5B1 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		64501DB95B6D078121FE7DE1 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		6A4D4F9C0A149C751B796E19 /* DynamicIslandManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DynamicIslandManager.swift; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -96,6 +101,7 @@
 		BGSYNC000ED2DC5600515810 /* BackgroundSyncManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundSyncManager.swift; sourceTree = "<group>"; };
 		DF27B9D22ECBFA88CAE99FA5 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		EF9D05AE0B7A994911C4F6F2 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		F754445942A6FAE31362F45C /* LiveActivitiesAppAttributes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveActivitiesAppAttributes.swift; sourceTree = "<group>"; };
 		SYNCPSH00ED2DC5600515810 /* SyncProgressStreamHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyncProgressStreamHandler.swift; sourceTree = "<group>"; };
 		ZSYNC000ED2DC5600515810 /* zcash_sync.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = zcash_sync.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -237,6 +243,9 @@
 				ZSYNC000ED2DC5600515810 /* zcash_sync.h */,
 				7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+				6A4D4F9C0A149C751B796E19 /* DynamicIslandManager.swift */,
+				F754445942A6FAE31362F45C /* LiveActivitiesAppAttributes.swift */,
+				2CDA4682F625C9EA7328E886 /* TxTrackManager.swift */,
 			);
 			path = Runner;
 			sourceTree = "<group>";
@@ -499,6 +508,9 @@
 				SYNCPSH01ED2DC5600515810 /* SyncProgressStreamHandler.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,
+				42257B77B623F2ABAD2A1912 /* DynamicIslandManager.swift in Sources */,
+				B7C6E66ECB0517259883CB1B /* LiveActivitiesAppAttributes.swift in Sources */,
+				AC93183A00FB6E944C717D3B /* TxTrackManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -9,6 +9,7 @@ import UIKit
   ) -> Bool {
     if #available(iOS 26.0, *) {
       BackgroundSyncManager.shared.registerBackgroundTask()
+      TxTrackManager.shared.registerTask()
     }
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
@@ -38,6 +39,13 @@ import UIKit
       case "startBackgroundSync":
         if #available(iOS 26.0, *) {
           let success = BackgroundSyncManager.shared.startBackgroundSync()
+          result(success)
+        } else {
+          result(false)
+        }
+      case "startTxTracking":
+        if #available(iOS 26.0, *) {
+          let success = TxTrackManager.shared.startTxTracking()
           result(success)
         } else {
           result(false)

--- a/ios/Runner/BackgroundSyncManager.swift
+++ b/ios/Runner/BackgroundSyncManager.swift
@@ -109,12 +109,18 @@ class BackgroundSyncManager {
             { progress in
                 if #available(iOS 26.0, *) {
                     let mgr = BackgroundSyncManager.shared
-                    // Use note-based percentage from Rust (0.0~1.0)
                     // Scale to 10000 for fine-grained NSProgress reporting
                     let completed = Int64(progress.percentage * 10000)
                     mgr.taskProgress?.totalUnitCount = 10000
                     mgr.taskProgress?.completedUnitCount = completed
                     print("[BGSync] batch: \(String(format: "%.1f", progress.percentage * 100))% (\(progress.scanned_height)/\(progress.chain_tip_height))")
+
+                    // Update Dynamic Island via DynamicIslandManager
+                    DynamicIslandManager.shared.showSyncProgress(
+                        percentage: progress.percentage,
+                        scannedHeight: progress.scanned_height,
+                        chainTipHeight: progress.chain_tip_height
+                    )
                 }
                 SyncProgressStreamHandler.shared.sendProgress(progress)
             }
@@ -125,6 +131,11 @@ class BackgroundSyncManager {
         taskProgress = nil
 
         print("[BGSync] zcash_run_full_sync returned: \(result)")
+
+        // End Dynamic Island if sync is fully done (not resubmitting)
+        if !(result == 0 && zcash_get_sync_mode() == 2) {
+            DynamicIslandManager.shared.endActivity()
+        }
 
         if result == 0 && zcash_get_sync_mode() == 2 {
             let resubmitted = startBackgroundSync()

--- a/ios/Runner/BackgroundSyncManager.swift
+++ b/ios/Runner/BackgroundSyncManager.swift
@@ -117,9 +117,7 @@ class BackgroundSyncManager {
 
                     // Update Dynamic Island via DynamicIslandManager
                     DynamicIslandManager.shared.showSyncProgress(
-                        percentage: progress.percentage,
-                        scannedHeight: progress.scanned_height,
-                        chainTipHeight: progress.chain_tip_height
+                        percentage: progress.percentage
                     )
                 }
                 SyncProgressStreamHandler.shared.sendProgress(progress)

--- a/ios/Runner/DynamicIslandManager.swift
+++ b/ios/Runner/DynamicIslandManager.swift
@@ -20,25 +20,19 @@ class DynamicIslandManager {
 
     // Cache last sync progress for restoration after TX tracking
     private var lastSyncPercentage: Double = 0
-    private var lastScannedHeight: UInt64 = 0
-    private var lastChainTipHeight: UInt64 = 0
 
     private init() {}
 
     // MARK: - Sync Progress
 
-    func showSyncProgress(percentage: Double, scannedHeight: UInt64, chainTipHeight: UInt64) {
+    func showSyncProgress(percentage: Double) {
         lastSyncPercentage = percentage
-        lastScannedHeight = scannedHeight
-        lastChainTipHeight = chainTipHeight
 
         // Always update UserDefaults so widget has latest data
         updateDefaults(
             displayMode: .sync,
             status: "Syncing...",
             percentage: percentage,
-            scannedHeight: "\(scannedHeight)",
-            chainTipHeight: "\(chainTipHeight)",
             txStatus: nil
         )
 
@@ -58,8 +52,6 @@ class DynamicIslandManager {
             displayMode: .txTrack,
             status: "Tracking \(pendingCount) transaction\(pendingCount == 1 ? "" : "s")",
             percentage: 0,
-            scannedHeight: nil,
-            chainTipHeight: nil,
             txStatus: "pending"
         )
         ensureActivityStarted()
@@ -78,8 +70,6 @@ class DynamicIslandManager {
             displayMode: .txTrack,
             status: status,
             percentage: nil,
-            scannedHeight: nil,
-            chainTipHeight: nil,
             txStatus: remaining > 0 ? "pending" : "done"
         )
         refreshActivity()
@@ -91,8 +81,6 @@ class DynamicIslandManager {
             displayMode: .sync,
             status: "Syncing...",
             percentage: lastSyncPercentage,
-            scannedHeight: "\(lastScannedHeight)",
-            chainTipHeight: "\(lastChainTipHeight)",
             txStatus: nil
         )
         refreshActivity()
@@ -146,8 +134,6 @@ class DynamicIslandManager {
         displayMode: DisplayMode,
         status: String?,
         percentage: Double?,
-        scannedHeight: String?,
-        chainTipHeight: String?,
         txStatus: String?
     ) {
         guard let id = activityId ?? self.activityId else { return }
@@ -155,8 +141,6 @@ class DynamicIslandManager {
         defaults?.set(displayMode.rawValue, forKey: prefix + "displayMode")
         if let status { defaults?.set(status, forKey: prefix + "status") }
         if let percentage { defaults?.set(String(percentage), forKey: prefix + "percentage") }
-        if let scannedHeight { defaults?.set(scannedHeight, forKey: prefix + "scannedHeight") }
-        if let chainTipHeight { defaults?.set(chainTipHeight, forKey: prefix + "chainTipHeight") }
         if let txStatus { defaults?.set(txStatus, forKey: prefix + "txStatus") }
     }
 }

--- a/ios/Runner/DynamicIslandManager.swift
+++ b/ios/Runner/DynamicIslandManager.swift
@@ -1,0 +1,162 @@
+import ActivityKit
+import Foundation
+
+/// Central manager for Live Activity / Dynamic Island.
+/// Handles priority switching between sync progress and TX tracking.
+@available(iOS 26.0, *)
+class DynamicIslandManager {
+    static let shared = DynamicIslandManager()
+
+    enum DisplayMode: String {
+        case idle
+        case sync
+        case txTrack
+    }
+
+    private(set) var displayMode: DisplayMode = .idle
+    private var currentActivity: Activity<LiveActivitiesAppAttributes>?
+    private let defaults = UserDefaults(suiteName: "group.com.zcash.zcashWallet")
+    private var activityId: UUID?
+
+    // Cache last sync progress for restoration after TX tracking
+    private var lastSyncPercentage: Double = 0
+    private var lastScannedHeight: UInt64 = 0
+    private var lastChainTipHeight: UInt64 = 0
+
+    private init() {}
+
+    // MARK: - Sync Progress
+
+    func showSyncProgress(percentage: Double, scannedHeight: UInt64, chainTipHeight: UInt64) {
+        lastSyncPercentage = percentage
+        lastScannedHeight = scannedHeight
+        lastChainTipHeight = chainTipHeight
+
+        // Always update UserDefaults so widget has latest data
+        updateDefaults(
+            displayMode: .sync,
+            status: "Syncing...",
+            percentage: percentage,
+            scannedHeight: "\(scannedHeight)",
+            chainTipHeight: "\(chainTipHeight)",
+            txStatus: nil
+        )
+
+        // Only update Live Activity if TX tracking isn't active
+        if displayMode == .txTrack { return }
+
+        displayMode = .sync
+        ensureActivityStarted()
+        refreshActivity()
+    }
+
+    // MARK: - TX Tracking
+
+    func showTxTracking(pendingCount: Int) {
+        displayMode = .txTrack
+        updateDefaults(
+            displayMode: .txTrack,
+            status: "Tracking \(pendingCount) transaction\(pendingCount == 1 ? "" : "s")",
+            percentage: 0,
+            scannedHeight: nil,
+            chainTipHeight: nil,
+            txStatus: "pending"
+        )
+        ensureActivityStarted()
+        refreshActivity()
+    }
+
+    func updateTxStatus(confirmed: Int, expired: Int, remaining: Int) {
+        let parts: [String] = [
+            confirmed > 0 ? "\(confirmed) confirmed" : nil,
+            expired > 0 ? "\(expired) expired" : nil,
+            remaining > 0 ? "\(remaining) pending" : nil,
+        ].compactMap { $0 }
+
+        let status = parts.joined(separator: ", ")
+        updateDefaults(
+            displayMode: .txTrack,
+            status: status,
+            percentage: nil,
+            scannedHeight: nil,
+            chainTipHeight: nil,
+            txStatus: remaining > 0 ? "pending" : "done"
+        )
+        refreshActivity()
+    }
+
+    func restoreSyncDisplay() {
+        displayMode = .sync
+        updateDefaults(
+            displayMode: .sync,
+            status: "Syncing...",
+            percentage: lastSyncPercentage,
+            scannedHeight: "\(lastScannedHeight)",
+            chainTipHeight: "\(lastChainTipHeight)",
+            txStatus: nil
+        )
+        refreshActivity()
+    }
+
+    func endActivity() {
+        displayMode = .idle
+        guard let activity = currentActivity else { return }
+        let state = LiveActivitiesAppAttributes.ContentState(
+            appGroupId: "group.com.zcash.zcashWallet"
+        )
+        Task {
+            await activity.end(state, dismissalPolicy: .immediate)
+        }
+        currentActivity = nil
+        activityId = nil
+    }
+
+    // MARK: - Private
+
+    private func ensureActivityStarted() {
+        guard currentActivity == nil else { return }
+        let id = UUID()
+        activityId = id
+        let attributes = LiveActivitiesAppAttributes(id: id)
+        let state = LiveActivitiesAppAttributes.ContentState(
+            appGroupId: "group.com.zcash.zcashWallet"
+        )
+        do {
+            currentActivity = try Activity.request(
+                attributes: attributes,
+                content: .init(state: state, staleDate: nil)
+            )
+            print("[DI] Activity started: \(id)")
+        } catch {
+            print("[DI] Failed to start activity: \(error)")
+        }
+    }
+
+    private func refreshActivity() {
+        guard let activity = currentActivity else { return }
+        let state = LiveActivitiesAppAttributes.ContentState(
+            appGroupId: "group.com.zcash.zcashWallet"
+        )
+        Task {
+            await activity.update(.init(state: state, staleDate: nil))
+        }
+    }
+
+    private func updateDefaults(
+        displayMode: DisplayMode,
+        status: String?,
+        percentage: Double?,
+        scannedHeight: String?,
+        chainTipHeight: String?,
+        txStatus: String?
+    ) {
+        guard let id = activityId ?? self.activityId else { return }
+        let prefix = "\(id)_"
+        defaults?.set(displayMode.rawValue, forKey: prefix + "displayMode")
+        if let status { defaults?.set(status, forKey: prefix + "status") }
+        if let percentage { defaults?.set(String(percentage), forKey: prefix + "percentage") }
+        if let scannedHeight { defaults?.set(scannedHeight, forKey: prefix + "scannedHeight") }
+        if let chainTipHeight { defaults?.set(chainTipHeight, forKey: prefix + "chainTipHeight") }
+        if let txStatus { defaults?.set(txStatus, forKey: prefix + "txStatus") }
+    }
+}

--- a/ios/Runner/DynamicIslandManager.swift
+++ b/ios/Runner/DynamicIslandManager.swift
@@ -117,6 +117,8 @@ class DynamicIslandManager {
             print("[DI] Activity started: \(id)")
         } catch {
             print("[DI] Failed to start activity: \(error)")
+            displayMode = .idle
+            activityId = nil
         }
     }
 

--- a/ios/Runner/DynamicIslandManager.swift
+++ b/ios/Runner/DynamicIslandManager.swift
@@ -93,7 +93,7 @@ class DynamicIslandManager {
             appGroupId: "group.com.zcash.zcashWallet"
         )
         Task {
-            await activity.end(state, dismissalPolicy: .immediate)
+            await activity.end(.init(state: state, staleDate: nil), dismissalPolicy: .immediate)
         }
         currentActivity = nil
         activityId = nil

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -10,6 +10,7 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.zcash.zcashWallet.sync</string>
+		<string>com.zcash.zcashWallet.txtrack</string>
 		<string>com.pravera.flutter_foreground_task.refresh</string>
 	</array>
 	<key>NSSupportsLiveActivities</key>

--- a/ios/Runner/LiveActivitiesAppAttributes.swift
+++ b/ios/Runner/LiveActivitiesAppAttributes.swift
@@ -1,0 +1,20 @@
+import ActivityKit
+import Foundation
+
+/// Shared definition with SyncWidget extension.
+/// Both targets need this struct to start/update Live Activities.
+struct LiveActivitiesAppAttributes: ActivityAttributes, Identifiable {
+    public typealias LiveDeliveryData = ContentState
+
+    public struct ContentState: Codable, Hashable {
+        var appGroupId: String
+    }
+
+    var id = UUID()
+}
+
+extension LiveActivitiesAppAttributes {
+    func prefixedKey(_ key: String) -> String {
+        return "\(id)_\(key)"
+    }
+}

--- a/ios/Runner/TxTrackManager.swift
+++ b/ios/Runner/TxTrackManager.swift
@@ -1,0 +1,164 @@
+import BackgroundTasks
+import Foundation
+
+/// Manages TX tracking via BGContinuedProcessingTask.
+/// Polls lightwalletd to detect when pending transactions are mined or expired.
+@available(iOS 26.0, *)
+class TxTrackManager {
+    static let shared = TxTrackManager()
+    static let taskIdentifier = "com.zcash.zcashWallet.txtrack"
+
+    private let trackQueue = DispatchQueue(label: "com.zcash.txtrack", qos: .utility)
+    private let pollInterval: TimeInterval = 10.0
+    private let resultDisplayDelay: TimeInterval = 5.0
+    private let lightwalletdUrl = "https://zec.rocks:443"
+
+    private init() {}
+
+    func registerTask() {
+        print("[TxTrack] registering \(Self.taskIdentifier)")
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: Self.taskIdentifier,
+            using: nil
+        ) { task in
+            print("[TxTrack] handler invoked")
+            guard let continuedTask = task as? BGContinuedProcessingTask else {
+                print("[TxTrack] ERROR: not BGContinuedProcessingTask")
+                task.setTaskCompleted(success: false)
+                return
+            }
+            self.handleTask(continuedTask)
+        }
+        print("[TxTrack] registered")
+    }
+
+    func startTxTracking() -> Bool {
+        print("[TxTrack] submitting task request")
+        let request = BGContinuedProcessingTaskRequest(
+            identifier: Self.taskIdentifier,
+            title: "Tracking Transaction",
+            subtitle: "Waiting for confirmation"
+        )
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            print("[TxTrack] submitted OK")
+            return true
+        } catch {
+            print("[TxTrack] submit FAILED: \(error)")
+            return false
+        }
+    }
+
+    private func handleTask(_ task: BGContinuedProcessingTask) {
+        let semaphore = DispatchSemaphore(value: 0)
+        var success = false
+
+        task.expirationHandler = {
+            print("[TxTrack] EXPIRATION")
+            semaphore.signal()
+        }
+
+        trackQueue.async { [weak self] in
+            guard let self else { semaphore.signal(); return }
+            success = self.runTracking()
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        task.setTaskCompleted(success: success)
+        print("[TxTrack] task completed, success=\(success)")
+    }
+
+    private func runTracking() -> Bool {
+        let documentsDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let dbPath = documentsDir.appendingPathComponent("zcash_wallet.db").path
+
+        // Get initial pending TXs
+        var pendingBuf = [CPendingTx](repeating: CPendingTx(), count: 16)
+        let count = zcash_get_pending_txs(dbPath, &pendingBuf, 16)
+
+        if count <= 0 {
+            print("[TxTrack] no pending TXs, exiting")
+            return true
+        }
+
+        var pending: [(txid: String, expiryHeight: UInt64)] = []
+        for i in 0..<Int(count) {
+            let tx = pendingBuf[i]
+            let txid = withUnsafePointer(to: tx.txid_hex) { ptr in
+                ptr.withMemoryRebound(to: CChar.self, capacity: 65) {
+                    String(cString: $0)
+                }
+            }
+            pending.append((txid: txid, expiryHeight: tx.expiry_height))
+        }
+
+        print("[TxTrack] tracking \(pending.count) transaction(s)")
+        DynamicIslandManager.shared.showTxTracking(pendingCount: pending.count)
+
+        var confirmed = 0
+        var expired = 0
+
+        // Poll loop
+        while !pending.isEmpty {
+            Thread.sleep(forTimeInterval: pollInterval)
+
+            var stillPending: [(txid: String, expiryHeight: UInt64)] = []
+
+            for tx in pending {
+                let status = zcash_check_tx_status(lightwalletdUrl, tx.txid)
+                print("[TxTrack] \(tx.txid.prefix(16))...: status=\(status)")
+
+                if status > 0 {
+                    // Mined
+                    confirmed += 1
+                    print("[TxTrack] \(tx.txid.prefix(16))... confirmed at height \(status)")
+                } else if status == 0 {
+                    // Still pending — check expiry
+                    // We can't easily get chain tip here without another gRPC call,
+                    // so we rely on the wallet DB's expired_unmined flag on next check
+                    let currentCount = zcash_get_pending_tx_count(dbPath)
+                    if currentCount >= 0 && currentCount < Int32(pending.count) {
+                        // Something changed — a TX may have expired via DB update
+                        // Re-fetch pending list
+                        let refreshCount = zcash_get_pending_txs(dbPath, &pendingBuf, 16)
+                        if refreshCount >= 0 {
+                            let refreshSet = Set((0..<Int(refreshCount)).map { i -> String in
+                                withUnsafePointer(to: pendingBuf[i].txid_hex) { ptr in
+                                    ptr.withMemoryRebound(to: CChar.self, capacity: 65) {
+                                        String(cString: $0)
+                                    }
+                                }
+                            })
+                            if !refreshSet.contains(tx.txid) {
+                                expired += 1
+                                print("[TxTrack] \(tx.txid.prefix(16))... expired")
+                                continue
+                            }
+                        }
+                    }
+                    stillPending.append(tx)
+                } else {
+                    // Error — keep tracking
+                    stillPending.append(tx)
+                }
+            }
+
+            pending = stillPending
+
+            DynamicIslandManager.shared.updateTxStatus(
+                confirmed: confirmed,
+                expired: expired,
+                remaining: pending.count
+            )
+        }
+
+        print("[TxTrack] all TXs resolved: \(confirmed) confirmed, \(expired) expired")
+
+        // Show result briefly before ending
+        Thread.sleep(forTimeInterval: resultDisplayDelay)
+        DynamicIslandManager.shared.restoreSyncDisplay()
+
+        return true
+    }
+}

--- a/ios/Runner/TxTrackManager.swift
+++ b/ios/Runner/TxTrackManager.swift
@@ -9,7 +9,7 @@ class TxTrackManager {
     static let taskIdentifier = "com.zcash.zcashWallet.txtrack"
 
     private let trackQueue = DispatchQueue(label: "com.zcash.txtrack", qos: .utility)
-    private let pollInterval: TimeInterval = 10.0
+    private let pollInterval: TimeInterval = 5.0
     private let resultDisplayDelay: TimeInterval = 5.0
     private let lightwalletdUrl = "https://zec.rocks:443"
 

--- a/ios/Runner/TxTrackManager.swift
+++ b/ios/Runner/TxTrackManager.swift
@@ -12,6 +12,7 @@ class TxTrackManager {
     private let pollInterval: TimeInterval = 5.0
     private let resultDisplayDelay: TimeInterval = 5.0
     private let lightwalletdUrl = "https://zec.rocks:443"
+    private var cancelled = false
 
     private init() {}
 
@@ -53,8 +54,11 @@ class TxTrackManager {
         let semaphore = DispatchSemaphore(value: 0)
         var success = false
 
-        task.expirationHandler = {
+        cancelled = false
+
+        task.expirationHandler = { [weak self] in
             print("[TxTrack] EXPIRATION")
+            self?.cancelled = true
             semaphore.signal()
         }
 
@@ -100,8 +104,9 @@ class TxTrackManager {
         var expired = 0
 
         // Poll loop
-        while !pending.isEmpty {
+        while !pending.isEmpty && !cancelled {
             Thread.sleep(forTimeInterval: pollInterval)
+            if cancelled { break }
 
             var stillPending: [(txid: String, expiryHeight: UInt64)] = []
 

--- a/ios/Runner/zcash_sync.h
+++ b/ios/Runner/zcash_sync.h
@@ -36,4 +36,21 @@ void zcash_set_sync_mode(uint8_t mode);
 /// Check if a sync is currently running.
 bool zcash_is_sync_running(void);
 
+// ======================== TX Tracking ========================
+
+typedef struct {
+    uint8_t txid_hex[65]; // 64 hex chars + null
+    uint64_t expiry_height;
+} CPendingTx;
+
+/// Get number of pending (unmined, unexpired) transactions. Returns -1 on error.
+int32_t zcash_get_pending_tx_count(const char* db_path);
+
+/// Fill buffer with pending transactions. Returns count written, -1 on error.
+int32_t zcash_get_pending_txs(const char* db_path, CPendingTx* out_buf, int32_t buf_len);
+
+/// Check if a TX has been mined via lightwalletd gRPC.
+/// Returns: >0 = mined height, 0 = pending, -1 = error.
+int64_t zcash_check_tx_status(const char* lightwalletd_url, const char* txid_hex);
+
 #endif // ZCASH_SYNC_H

--- a/ios/SyncWidget/SyncWidgetLiveActivity.swift
+++ b/ios/SyncWidget/SyncWidgetLiveActivity.swift
@@ -38,8 +38,6 @@ struct SyncWidgetLiveActivity: Widget {
 
     private func syncBanner(context: ActivityViewContext<LiveActivitiesAppAttributes>, defaults: UserDefaults) -> some View {
         let percentage = Double(defaults.string(forKey: context.attributes.prefixedKey("percentage")) ?? "0") ?? 0
-        let scannedHeight = defaults.string(forKey: context.attributes.prefixedKey("scannedHeight")) ?? "0"
-        let chainTipHeight = defaults.string(forKey: context.attributes.prefixedKey("chainTipHeight")) ?? "0"
 
         return VStack(alignment: .leading, spacing: 8) {
             HStack {
@@ -55,9 +53,6 @@ struct SyncWidgetLiveActivity: Widget {
             }
             ProgressView(value: percentage)
                 .tint(.yellow)
-            Text("Block \(scannedHeight) / \(chainTipHeight)")
-                .font(.caption)
-                .foregroundColor(.gray)
         }
         .padding()
         .background(Color.black)

--- a/ios/SyncWidget/SyncWidgetLiveActivity.swift
+++ b/ios/SyncWidget/SyncWidgetLiveActivity.swift
@@ -14,69 +14,155 @@ struct SyncWidgetLiveActivity: Widget {
         ActivityConfiguration(for: LiveActivitiesAppAttributes.self) { context in
             // Lock Screen banner
             let sharedDefault = UserDefaults(suiteName: appGroupId)!
-            let status = sharedDefault.string(forKey: context.attributes.prefixedKey("status")) ?? "Syncing..."
-            let percentage = Double(sharedDefault.string(forKey: context.attributes.prefixedKey("percentage")) ?? "0") ?? 0
-            let scannedHeight = sharedDefault.string(forKey: context.attributes.prefixedKey("scannedHeight")) ?? "0"
-            let chainTipHeight = sharedDefault.string(forKey: context.attributes.prefixedKey("chainTipHeight")) ?? "0"
+            let displayMode = sharedDefault.string(forKey: context.attributes.prefixedKey("displayMode")) ?? "sync"
 
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Image(systemName: "shield.checkered")
-                        .foregroundColor(.yellow)
-                    Text("Zcash Sync")
-                        .font(.headline)
-                        .foregroundColor(.white)
-                    Spacer()
-                    Text("\(Int(percentage * 100))%")
-                        .font(.headline)
-                        .foregroundColor(.yellow)
-                }
-
-                ProgressView(value: percentage)
-                    .tint(.yellow)
-
-                Text("Block \(scannedHeight) / \(chainTipHeight)")
-                    .font(.caption)
-                    .foregroundColor(.gray)
+            if displayMode == "txTrack" {
+                txTrackBanner(context: context, defaults: sharedDefault)
+            } else {
+                syncBanner(context: context, defaults: sharedDefault)
             }
-            .padding()
-            .background(Color.black)
 
         } dynamicIsland: { context in
             let sharedDefault = UserDefaults(suiteName: appGroupId)!
-            let percentage = Double(sharedDefault.string(forKey: context.attributes.prefixedKey("percentage")) ?? "0") ?? 0
-            let status = sharedDefault.string(forKey: context.attributes.prefixedKey("status")) ?? "Syncing..."
+            let displayMode = sharedDefault.string(forKey: context.attributes.prefixedKey("displayMode")) ?? "sync"
 
-            return DynamicIsland {
-                DynamicIslandExpandedRegion(.leading) {
-                    Image(systemName: "shield.checkered")
-                        .foregroundColor(.yellow)
-                }
-                DynamicIslandExpandedRegion(.trailing) {
-                    Text("\(Int(percentage * 100))%")
-                        .font(.title2)
-                        .foregroundColor(.yellow)
-                }
-                DynamicIslandExpandedRegion(.bottom) {
-                    VStack(spacing: 4) {
-                        ProgressView(value: percentage)
-                            .tint(.yellow)
-                        Text(status)
-                            .font(.caption)
-                            .foregroundColor(.gray)
-                    }
-                }
-            } compactLeading: {
+            if displayMode == "txTrack" {
+                return txTrackIsland(context: context, defaults: sharedDefault)
+            } else {
+                return syncIsland(context: context, defaults: sharedDefault)
+            }
+        }
+    }
+
+    // MARK: - Sync UI
+
+    private func syncBanner(context: ActivityViewContext<LiveActivitiesAppAttributes>, defaults: UserDefaults) -> some View {
+        let percentage = Double(defaults.string(forKey: context.attributes.prefixedKey("percentage")) ?? "0") ?? 0
+        let scannedHeight = defaults.string(forKey: context.attributes.prefixedKey("scannedHeight")) ?? "0"
+        let chainTipHeight = defaults.string(forKey: context.attributes.prefixedKey("chainTipHeight")) ?? "0"
+
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack {
                 Image(systemName: "shield.checkered")
                     .foregroundColor(.yellow)
-            } compactTrailing: {
+                Text("Zcash Sync")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                Spacer()
                 Text("\(Int(percentage * 100))%")
-                    .font(.caption)
+                    .font(.headline)
                     .foregroundColor(.yellow)
-            } minimal: {
+            }
+            ProgressView(value: percentage)
+                .tint(.yellow)
+            Text("Block \(scannedHeight) / \(chainTipHeight)")
+                .font(.caption)
+                .foregroundColor(.gray)
+        }
+        .padding()
+        .background(Color.black)
+    }
+
+    private func syncIsland(context: ActivityViewContext<LiveActivitiesAppAttributes>, defaults: UserDefaults) -> DynamicIsland {
+        let percentage = Double(defaults.string(forKey: context.attributes.prefixedKey("percentage")) ?? "0") ?? 0
+        let status = defaults.string(forKey: context.attributes.prefixedKey("status")) ?? "Syncing..."
+
+        return DynamicIsland {
+            DynamicIslandExpandedRegion(.leading) {
                 Image(systemName: "shield.checkered")
                     .foregroundColor(.yellow)
             }
+            DynamicIslandExpandedRegion(.trailing) {
+                Text("\(Int(percentage * 100))%")
+                    .font(.title2)
+                    .foregroundColor(.yellow)
+            }
+            DynamicIslandExpandedRegion(.bottom) {
+                VStack(spacing: 4) {
+                    ProgressView(value: percentage)
+                        .tint(.yellow)
+                    Text(status)
+                        .font(.caption)
+                        .foregroundColor(.gray)
+                }
+            }
+        } compactLeading: {
+            Image(systemName: "shield.checkered")
+                .foregroundColor(.yellow)
+        } compactTrailing: {
+            Text("\(Int(percentage * 100))%")
+                .font(.caption)
+                .foregroundColor(.yellow)
+        } minimal: {
+            Image(systemName: "shield.checkered")
+                .foregroundColor(.yellow)
+        }
+    }
+
+    // MARK: - TX Tracking UI
+
+    private func txTrackBanner(context: ActivityViewContext<LiveActivitiesAppAttributes>, defaults: UserDefaults) -> some View {
+        let status = defaults.string(forKey: context.attributes.prefixedKey("status")) ?? "Tracking transactions"
+        let txStatus = defaults.string(forKey: context.attributes.prefixedKey("txStatus")) ?? "pending"
+        let isDone = txStatus == "done"
+
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Image(systemName: isDone ? "checkmark.circle.fill" : "clock.arrow.circlepath")
+                    .foregroundColor(isDone ? .green : .orange)
+                Text("Zcash Transaction")
+                    .font(.headline)
+                    .foregroundColor(.white)
+                Spacer()
+                if !isDone {
+                    ProgressView()
+                        .tint(.orange)
+                }
+            }
+            Text(status)
+                .font(.subheadline)
+                .foregroundColor(isDone ? .green : .orange)
+        }
+        .padding()
+        .background(Color.black)
+    }
+
+    private func txTrackIsland(context: ActivityViewContext<LiveActivitiesAppAttributes>, defaults: UserDefaults) -> DynamicIsland {
+        let status = defaults.string(forKey: context.attributes.prefixedKey("status")) ?? "Tracking"
+        let txStatus = defaults.string(forKey: context.attributes.prefixedKey("txStatus")) ?? "pending"
+        let isDone = txStatus == "done"
+
+        return DynamicIsland {
+            DynamicIslandExpandedRegion(.leading) {
+                Image(systemName: isDone ? "checkmark.circle.fill" : "clock.arrow.circlepath")
+                    .foregroundColor(isDone ? .green : .orange)
+            }
+            DynamicIslandExpandedRegion(.trailing) {
+                if !isDone {
+                    ProgressView()
+                        .tint(.orange)
+                }
+            }
+            DynamicIslandExpandedRegion(.bottom) {
+                Text(status)
+                    .font(.caption)
+                    .foregroundColor(isDone ? .green : .orange)
+            }
+        } compactLeading: {
+            Image(systemName: isDone ? "checkmark.circle.fill" : "clock.arrow.circlepath")
+                .foregroundColor(isDone ? .green : .orange)
+        } compactTrailing: {
+            if isDone {
+                Image(systemName: "checkmark")
+                    .font(.caption)
+                    .foregroundColor(.green)
+            } else {
+                ProgressView()
+                    .tint(.orange)
+            }
+        } minimal: {
+            Image(systemName: isDone ? "checkmark.circle.fill" : "clock.arrow.circlepath")
+                .foregroundColor(isDone ? .green : .orange)
         }
     }
 }

--- a/lib/src/features/history/screens/history_screen.dart
+++ b/lib/src/features/history/screens/history_screen.dart
@@ -63,6 +63,70 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
         '${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
   }
 
+  Widget _buildTransactionTile(BuildContext context, rust_sync.TransactionInfo tx) {
+    final colors = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+    final isIncoming = tx.accountBalanceDelta.toInt() >= 0;
+    final isPending = tx.minedHeight == BigInt.zero && !tx.expiredUnmined;
+    final isExpired = tx.expiredUnmined;
+
+    final IconData icon;
+    final Color iconColor;
+    final String title;
+    final String status;
+    final Color amountColor;
+
+    if (isExpired) {
+      icon = Icons.cancel_outlined;
+      iconColor = colors.error;
+      title = isIncoming ? 'Receive Expired' : 'Send Expired';
+      status = 'Transaction expired';
+      amountColor = colors.outline;
+    } else if (isPending) {
+      icon = Icons.schedule;
+      iconColor = colors.secondary;
+      title = isIncoming ? 'Receiving...' : 'Sending...';
+      status = 'Waiting for confirmation';
+      amountColor = colors.outline;
+    } else {
+      icon = isIncoming ? Icons.arrow_downward : Icons.arrow_upward;
+      iconColor = isIncoming ? colors.tertiary : colors.secondary;
+      title = isIncoming ? 'Received' : 'Sent';
+      status = 'Block ${tx.minedHeight} \u2022 ${_formatDate(tx.blockTime.toInt())}';
+      amountColor = isIncoming ? colors.tertiary : colors.onSurface;
+    }
+
+    return ListTile(
+      leading: isPending
+          ? SizedBox(
+              width: 24,
+              height: 24,
+              child: CircularProgressIndicator(strokeWidth: 2, color: iconColor),
+            )
+          : Icon(icon, color: iconColor),
+      title: Text(title, style: text.titleSmall),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(status, style: text.bodySmall?.copyWith(color: colors.outline)),
+          if (tx.fee > BigInt.zero)
+            Text(
+              'Fee: ${(tx.fee.toInt() / 100000000).toStringAsFixed(5)} ZEC',
+              style: text.labelSmall?.copyWith(color: colors.outline),
+            ),
+        ],
+      ),
+      trailing: Text(
+        _formatZec(tx.accountBalanceDelta.toInt()),
+        style: text.titleSmall?.copyWith(
+          color: amountColor,
+          fontWeight: FontWeight.w600,
+          decoration: isExpired ? TextDecoration.lineThrough : null,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -86,49 +150,8 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
                   ? const Center(child: Text('No transactions yet'))
                   : ListView.builder(
                       itemCount: _transactions!.length,
-                      itemBuilder: (context, index) {
-                        final tx = _transactions![index];
-                        final isIncoming = tx.accountBalanceDelta.toInt() >= 0;
-                        final colors = Theme.of(context).colorScheme;
-                        return ListTile(
-                          leading: Icon(
-                            isIncoming ? Icons.arrow_downward : Icons.arrow_upward,
-                            color: isIncoming ? colors.tertiary : colors.error,
-                          ),
-                          title: Text(
-                            _formatZec(tx.accountBalanceDelta.toInt()),
-                            style: TextStyle(
-                              color: isIncoming ? colors.tertiary : colors.onSurface,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                          subtitle: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                tx.expiredUnmined
-                                    ? 'Expired'
-                                    : tx.minedHeight.toInt() > 0
-                                        ? 'Block ${tx.minedHeight}'
-                                        : 'Pending',
-                                style: Theme.of(context).textTheme.bodySmall,
-                              ),
-                              Text(
-                                _formatDate(tx.blockTime.toInt()),
-                                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: Theme.of(context).colorScheme.onSurfaceVariant,
-                                    ),
-                              ),
-                            ],
-                          ),
-                          trailing: tx.fee.toInt() > 0
-                              ? Text(
-                                  'Fee: ${(tx.fee.toInt() / 100000000).toStringAsFixed(5)}',
-                                  style: Theme.of(context).textTheme.labelSmall,
-                                )
-                              : null,
-                        );
-                      },
+                      itemBuilder: (context, index) =>
+                          _buildTransactionTile(context, _transactions![index]),
                     ),
     );
   }

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -34,10 +34,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   String _formatZec(BigInt zatoshi) {
-    final zec = zatoshi.toDouble() / 100000000;
-    if (zec == 0) return '0.00';
-    if (zec < 0.01) return zec.toStringAsFixed(8);
-    return zec.toStringAsFixed(2);
+    if (zatoshi == BigInt.zero) return '0.00';
+    final whole = zatoshi ~/ BigInt.from(100000000);
+    final frac = (zatoshi % BigInt.from(100000000)).toString().padLeft(8, '0');
+    if (whole == BigInt.zero && int.parse(frac) < 1000000) {
+      return '0.$frac'; // < 0.01: show full 8 digits
+    }
+    return '$whole.${frac.substring(0, 2)}'; // >= 0.01: show 2 decimals
   }
 
   @override

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -415,17 +415,47 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final colors = Theme.of(context).colorScheme;
     final text = Theme.of(context).textTheme;
     final isIncoming = tx.accountBalanceDelta >= 0;
+    final isPending = tx.minedHeight == BigInt.zero && !tx.expiredUnmined;
+    final isExpired = tx.expiredUnmined;
     final zec = tx.accountBalanceDelta.abs() / 100000000;
     final sign = isIncoming ? '+' : '-';
     final amount = '$sign${zec.toStringAsFixed(zec < 0.01 ? 8 : 3)} ZEC';
 
-    // Format date
-    String dateStr = '';
-    if (tx.blockTime > BigInt.zero) {
-      final date = DateTime.fromMillisecondsSinceEpoch(tx.blockTime.toInt() * 1000);
-      dateStr = '${_monthName(date.month)} ${date.day}, ${date.year} \u2022 ${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
+    // Status-dependent styling
+    final IconData icon;
+    final Color iconColor;
+    final Color iconBgColor;
+    final String label;
+    final String dateStr;
+    final String statusLabel;
+    final Color amountColor;
+
+    if (isExpired) {
+      icon = Icons.cancel_outlined;
+      iconColor = colors.error;
+      iconBgColor = colors.error.withValues(alpha: 0.1);
+      label = isIncoming ? 'Receive Expired' : 'Send Expired';
+      dateStr = 'Transaction expired';
+      statusLabel = 'EXPIRED';
+      amountColor = colors.outline;
+    } else if (isPending) {
+      icon = Icons.schedule;
+      iconColor = colors.secondary;
+      iconBgColor = colors.secondary.withValues(alpha: 0.1);
+      label = isIncoming ? 'Receiving...' : 'Sending...';
+      dateStr = 'Waiting for confirmation';
+      statusLabel = 'PENDING';
+      amountColor = colors.outline;
     } else {
-      dateStr = 'Pending';
+      icon = isIncoming ? Icons.check_circle : Icons.arrow_outward;
+      iconColor = isIncoming ? colors.tertiary : colors.secondary;
+      iconBgColor = colors.surfaceContainerLow;
+      label = isIncoming ? 'Received' : 'Sent';
+      final date = DateTime.fromMillisecondsSinceEpoch(tx.blockTime.toInt() * 1000);
+      dateStr = '${_monthName(date.month)} ${date.day}, ${date.year} \u2022 '
+          '${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
+      statusLabel = isIncoming ? 'SHIELDED' : 'EXTERNAL';
+      amountColor = isIncoming ? colors.tertiary : colors.onSurface;
     }
 
     return Padding(
@@ -436,16 +466,18 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             width: 48,
             height: 48,
             decoration: BoxDecoration(
-              color: colors.surfaceContainerLow,
+              color: iconBgColor,
               shape: BoxShape.circle,
             ),
-            child: Center(
-              child: Icon(
-                isIncoming ? Icons.check_circle : Icons.arrow_outward,
-                color: isIncoming ? colors.tertiary : colors.secondary,
-                size: 24,
-              ),
-            ),
+            child: isPending
+                ? Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: iconColor,
+                    ),
+                  )
+                : Center(child: Icon(icon, color: iconColor, size: 24)),
           ),
           const SizedBox(width: 20),
           Expanded(
@@ -453,8 +485,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  isIncoming ? 'Received' : 'Sent',
-                  style: text.titleMedium,
+                  label,
+                  style: text.titleMedium?.copyWith(
+                    color: isExpired ? colors.outline : null,
+                  ),
                 ),
                 const SizedBox(height: 2),
                 Text(
@@ -470,13 +504,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               Text(
                 amount,
                 style: text.titleMedium?.copyWith(
-                  color: isIncoming ? colors.tertiary : colors.onSurface,
+                  color: amountColor,
+                  decoration: isExpired ? TextDecoration.lineThrough : null,
                 ),
               ),
               const SizedBox(height: 2),
               Text(
-                isIncoming ? 'SHIELDED' : 'EXTERNAL',
-                style: text.labelSmall?.copyWith(color: colors.outline),
+                statusLabel,
+                style: text.labelSmall?.copyWith(
+                  color: isExpired ? colors.error : colors.outline,
+                ),
               ),
             ],
           ),

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -181,12 +181,15 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       // Refresh balance and tx list so pending TX appears immediately
       await ref.read(syncProvider.notifier).refreshAfterSend();
 
-      // Start iOS TX tracking BGTask for Dynamic Island
+      // Start iOS TX tracking BGTask for Dynamic Island (iOS 26+, not simulator)
       if (Platform.isIOS) {
         try {
           const channel = MethodChannel('com.zcash.wallet/background_sync');
-          await channel.invokeMethod('startTxTracking');
-          log('Send: iOS TX tracking started');
+          final available = await channel.invokeMethod<bool>('isAvailable') ?? false;
+          if (available) {
+            await channel.invokeMethod('startTxTracking');
+            log('Send: iOS TX tracking started');
+          }
         } catch (e) {
           log('Send: iOS TX tracking failed: $e');
         }

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -32,6 +32,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
   String? _error;
   String _addressType = '';
   String? _amountError; // null = no error, empty string = silent invalid (empty/dot)
+  int _validateSeq = 0;
 
   @override
   void dispose() {
@@ -62,6 +63,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
   }
 
   Future<void> _validateAmount() async {
+    final seq = ++_validateSeq;
     final text = _amountController.text.trim();
 
     // Empty or just "." — silently invalid (no error shown, button disabled)
@@ -76,17 +78,16 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       return;
     }
 
-    // Quick balance pre-check before calling propose
+    // Quick balance pre-check
     final spendable = _getSpendableBalance();
     if (BigInt.from(zatoshi) > spendable) {
       setState(() => _amountError = 'Insufficient balance');
       return;
     }
 
-    // Use propose to get actual fee
+    // Need valid address to estimate fee
     final address = _addressController.text.trim();
     if (address.isEmpty || _addressType == 'invalid' || _addressType == 'error' || _addressType.isEmpty) {
-      // Can't propose without valid address — accept amount for now
       setState(() => _amountError = null);
       return;
     }
@@ -95,27 +96,31 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       final dir = await getApplicationDocumentsDirectory();
       final dbPath = '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
       final memo = _memoController.text.trim();
-      final proposal = await rust_sync.proposeSend(
+      final fee = await rust_sync.estimateFee(
         dbPath: dbPath,
         network: 'main',
         toAddress: address,
         amountZatoshi: BigInt.from(zatoshi),
         memo: memo.isNotEmpty ? memo : null,
       );
-      final totalNeeded = BigInt.from(zatoshi) + proposal.feeZatoshi;
+
+      // Stale check — new input arrived while awaiting
+      if (seq != _validateSeq) return;
+
+      final totalNeeded = BigInt.from(zatoshi) + fee;
       if (totalNeeded > spendable) {
-        final feeZec = _formatZec(proposal.feeZatoshi);
+        final feeZec = _formatZec(fee);
         setState(() => _amountError = 'Insufficient balance (fee: $feeZec ZEC)');
       } else {
         setState(() => _amountError = null);
       }
     } catch (e) {
-      // Propose failed — likely insufficient funds or invalid params
+      if (seq != _validateSeq) return;
       final msg = e.toString();
       if (msg.contains('InsufficientFunds') || msg.contains('insufficient')) {
         setState(() => _amountError = 'Insufficient balance including fee');
       } else {
-        // Other propose errors — don't block, let _send() handle it
+        log('Send: fee estimation failed (non-blocking): $e');
         setState(() => _amountError = null);
       }
     }

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/config/network_config.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../../rust/api/wallet.dart' as rust_wallet;
@@ -167,6 +168,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       log('Send: executing proposal ${proposal.proposalId}');
       final txidResult = await rust_sync.executeProposal(
         dbPath: dbPath,
+        lightwalletdUrl: ZcashNetwork.mainnet.lightwalletdUrl,
         proposalId: proposal.proposalId,
         seed: seedBytes,
         spendParamsPath: proposal.needsSaplingParams ? spendPath : null,

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -133,8 +133,13 @@ class _SendScreenState extends ConsumerState<SendScreen> {
     if (lower.contains('insufficientfunds') || lower.contains('insufficient')) {
       return 'Insufficient balance to cover amount and fee.';
     }
-    if (lower.contains('grpc connect failed') || lower.contains('network')) {
+    if (lower.contains('grpc connect failed') || lower.contains('connection refused') || lower.contains('dns error') || lower.contains('tls error')) {
       return 'Network error. Please check your connection and try again.';
+    }
+    // Partial broadcast must be checked before generic "broadcast rejected"
+    if (lower.contains('broadcast failed after') && lower.contains('txs sent')) {
+      return 'Some transactions were broadcast but not all. '
+             'Please check your transaction history before retrying.';
     }
     if (lower.contains('broadcast rejected')) {
       return 'Transaction was rejected by the network. Please try again.';

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -123,6 +123,23 @@ class _SendScreenState extends ConsumerState<SendScreen> {
 
   bool get _isAmountValid => _amountError == null;
 
+  String _friendlyError(String raw) {
+    final lower = raw.toLowerCase();
+    if (lower.contains('insufficientfunds') || lower.contains('insufficient')) {
+      return 'Insufficient balance to cover amount and fee.';
+    }
+    if (lower.contains('grpc connect failed') || lower.contains('network')) {
+      return 'Network error. Please check your connection and try again.';
+    }
+    if (lower.contains('broadcast rejected')) {
+      return 'Transaction was rejected by the network. Please try again.';
+    }
+    if (lower.contains('proposal not found')) {
+      return 'Transaction expired. Please try again.';
+    }
+    return 'Send failed. Please try again.';
+  }
+
   String _formatZec(BigInt zatoshi) {
     final abs = zatoshi.abs();
     final whole = abs ~/ BigInt.from(100000000);
@@ -299,7 +316,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       Navigator.of(context).pop();
     } catch (e) {
       log('Send: ERROR: $e');
-      setState(() { _error = e.toString(); _isSending = false; });
+      setState(() { _error = _friendlyError(e.toString()); _isSending = false; });
     }
   }
 

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -60,8 +60,34 @@ class _SendScreenState extends ConsumerState<SendScreen> {
   }
 
   String _formatZec(BigInt zatoshi) {
-    final zec = zatoshi.toDouble() / 100000000;
-    return zec.toStringAsFixed(8);
+    final abs = zatoshi.abs();
+    final whole = abs ~/ BigInt.from(100000000);
+    final frac = (abs % BigInt.from(100000000)).toString().padLeft(8, '0');
+    final sign = zatoshi < BigInt.zero ? '-' : '';
+    return '$sign$whole.$frac';
+  }
+
+  /// Parse a ZEC string to zatoshi without floating-point.
+  /// Handles: "1.5", ".01", "100", "0.00000001"
+  int? _parseZecToZatoshi(String input) {
+    var s = input.trim();
+    if (s.isEmpty) return null;
+    if (s.startsWith('.')) s = '0$s';
+
+    final parts = s.split('.');
+    if (parts.length > 2) return null;
+
+    final whole = int.tryParse(parts[0].isEmpty ? '0' : parts[0]);
+    if (whole == null || whole < 0) return null;
+
+    String frac = parts.length > 1 ? parts[1] : '';
+    if (frac.length > 8) frac = frac.substring(0, 8);
+    frac = frac.padRight(8, '0');
+
+    final fracInt = int.tryParse(frac);
+    if (fracInt == null) return null;
+
+    return whole * 100000000 + fracInt;
   }
 
   Future<void> _send() async {
@@ -69,10 +95,9 @@ class _SendScreenState extends ConsumerState<SendScreen> {
 
     try {
       final address = _addressController.text.trim();
-      final amountZec = double.tryParse(_amountController.text.trim()) ?? 0;
-      final amountZatoshi = (amountZec * 100000000).round();
+      final amountZatoshi = _parseZecToZatoshi(_amountController.text.trim());
 
-      if (amountZatoshi <= 0) {
+      if (amountZatoshi == null || amountZatoshi <= 0) {
         setState(() { _error = 'Invalid amount'; _isSending = false; });
         return;
       }
@@ -399,6 +424,10 @@ class _SendScreenState extends ConsumerState<SendScreen> {
               TextField(
                 controller: _amountController,
                 keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                inputFormatters: [
+                  FilteringTextInputFormatter.allow(RegExp(r'[\d.]')),
+                  _ZecAmountFormatter(),
+                ],
                 decoration: const InputDecoration(
                   border: OutlineInputBorder(),
                   labelText: 'Amount (ZEC)',
@@ -451,5 +480,28 @@ class _SendScreenState extends ConsumerState<SendScreen> {
         ),
       ),
     );
+  }
+}
+
+/// Enforces: one decimal point max, up to 8 fractional digits.
+class _ZecAmountFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final text = newValue.text;
+
+    // Allow empty
+    if (text.isEmpty) return newValue;
+
+    // Only one decimal point
+    if ('.'.allMatches(text).length > 1) return oldValue;
+
+    // Limit fractional digits to 8
+    final dotIndex = text.indexOf('.');
+    if (dotIndex != -1 && text.length - dotIndex - 1 > 8) return oldValue;
+
+    return newValue;
   }
 }

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:path_provider/path_provider.dart';
@@ -179,6 +180,17 @@ class _SendScreenState extends ConsumerState<SendScreen> {
 
       // Refresh balance and tx list so pending TX appears immediately
       await ref.read(syncProvider.notifier).refreshAfterSend();
+
+      // Start iOS TX tracking BGTask for Dynamic Island
+      if (Platform.isIOS) {
+        try {
+          const channel = MethodChannel('com.zcash.wallet/background_sync');
+          await channel.invokeMethod('startTxTracking');
+          log('Send: iOS TX tracking started');
+        } catch (e) {
+          log('Send: iOS TX tracking failed: $e');
+        }
+      }
 
       // Show success and navigate back to home
       if (!mounted) return;

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -339,6 +339,9 @@ class _SendScreenState extends ConsumerState<SendScreen> {
     try {
       final request = await client.getUrl(Uri.parse(url));
       final response = await request.close();
+      if (response.statusCode != 200) {
+        throw Exception('Download failed: HTTP ${response.statusCode} for $url');
+      }
       final tempPath = '${destPath}_tmp';
       final file = File(tempPath);
       final sink = file.openWrite();

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -61,9 +61,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
     return syncState?.totalBalance ?? BigInt.zero;
   }
 
-  static const int _minFeeZatoshi = 10000;
-
-  void _validateAmount() {
+  Future<void> _validateAmount() async {
     final text = _amountController.text.trim();
 
     // Empty or just "." — silently invalid (no error shown, button disabled)
@@ -78,13 +76,49 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       return;
     }
 
+    // Quick balance pre-check before calling propose
     final spendable = _getSpendableBalance();
-    if (BigInt.from(zatoshi + _minFeeZatoshi) > spendable) {
-      setState(() => _amountError = 'Insufficient balance (fee: 0.0001 ZEC)');
+    if (BigInt.from(zatoshi) > spendable) {
+      setState(() => _amountError = 'Insufficient balance');
       return;
     }
 
-    setState(() => _amountError = null);
+    // Use propose to get actual fee
+    final address = _addressController.text.trim();
+    if (address.isEmpty || _addressType == 'invalid' || _addressType == 'error' || _addressType.isEmpty) {
+      // Can't propose without valid address — accept amount for now
+      setState(() => _amountError = null);
+      return;
+    }
+
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      final dbPath = '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
+      final memo = _memoController.text.trim();
+      final proposal = await rust_sync.proposeSend(
+        dbPath: dbPath,
+        network: 'main',
+        toAddress: address,
+        amountZatoshi: BigInt.from(zatoshi),
+        memo: memo.isNotEmpty ? memo : null,
+      );
+      final totalNeeded = BigInt.from(zatoshi) + proposal.feeZatoshi;
+      if (totalNeeded > spendable) {
+        final feeZec = _formatZec(proposal.feeZatoshi);
+        setState(() => _amountError = 'Insufficient balance (fee: $feeZec ZEC)');
+      } else {
+        setState(() => _amountError = null);
+      }
+    } catch (e) {
+      // Propose failed — likely insufficient funds or invalid params
+      final msg = e.toString();
+      if (msg.contains('InsufficientFunds') || msg.contains('insufficient')) {
+        setState(() => _amountError = 'Insufficient balance including fee');
+      } else {
+        // Other propose errors — don't block, let _send() handle it
+        setState(() => _amountError = null);
+      }
+    }
   }
 
   bool get _isAmountValid => _amountError == null;

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -55,7 +55,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
   }
 
   BigInt _getSpendableBalance() {
-    final syncState = ref.read(syncProvider).valueOrNull;
+    final syncState = ref.read(syncProvider).value;
     return syncState?.totalBalance ?? BigInt.zero;
   }
 
@@ -335,7 +335,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
-    final syncState = ref.watch(syncProvider).valueOrNull;
+    final syncState = ref.watch(syncProvider).value;
     final spendable = syncState?.totalBalance ?? BigInt.zero;
 
     return Scaffold(

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -177,6 +177,9 @@ class _SendScreenState extends ConsumerState<SendScreen> {
 
       log('Send: success, txids=$txidResult');
 
+      // Refresh balance and tx list so pending TX appears immediately
+      await ref.read(syncProvider.notifier).refreshAfterSend();
+
       // Show success and navigate back to home
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -203,10 +203,14 @@ class _SendScreenState extends ConsumerState<SendScreen> {
 
       log('Send: success, txids=$txidResult');
 
-      // Refresh balance and tx list so pending TX appears immediately
-      await ref.read(syncProvider.notifier).refreshAfterSend();
+      // === Send confirmed at this point — all below is non-critical ===
 
-      // Start iOS TX tracking BGTask for Dynamic Island (iOS 26+, not simulator)
+      try {
+        await ref.read(syncProvider.notifier).refreshAfterSend();
+      } catch (e) {
+        log('Send: refreshAfterSend failed (non-critical): $e');
+      }
+
       if (Platform.isIOS) {
         try {
           const channel = MethodChannel('com.zcash.wallet/background_sync');
@@ -216,11 +220,10 @@ class _SendScreenState extends ConsumerState<SendScreen> {
             log('Send: iOS TX tracking started');
           }
         } catch (e) {
-          log('Send: iOS TX tracking failed: $e');
+          log('Send: iOS TX tracking failed (non-critical): $e');
         }
       }
 
-      // Show success and navigate back to home
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../../../main.dart' show log;
+import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../../rust/api/wallet.dart' as rust_wallet;
 
@@ -27,7 +28,6 @@ class _SendScreenState extends ConsumerState<SendScreen> {
   final _memoController = TextEditingController();
   bool _isSending = false;
   String? _error;
-  String? _txid;
   String _addressType = '';
 
   @override
@@ -52,20 +52,40 @@ class _SendScreenState extends ConsumerState<SendScreen> {
     }
   }
 
+  BigInt _getSpendableBalance() {
+    final syncState = ref.read(syncProvider).valueOrNull;
+    return syncState?.totalBalance ?? BigInt.zero;
+  }
+
+  String _formatZec(BigInt zatoshi) {
+    final zec = zatoshi.toDouble() / 100000000;
+    return zec.toStringAsFixed(8);
+  }
+
   Future<void> _send() async {
-    setState(() { _isSending = true; _error = null; _txid = null; });
+    setState(() { _isSending = true; _error = null; });
 
     try {
       final address = _addressController.text.trim();
       final amountZec = double.tryParse(_amountController.text.trim()) ?? 0;
       final amountZatoshi = (amountZec * 100000000).round();
-      final memo = _memoController.text.trim();
 
       if (amountZatoshi <= 0) {
         setState(() { _error = 'Invalid amount'; _isSending = false; });
         return;
       }
 
+      // Check balance before proposing
+      final spendable = _getSpendableBalance();
+      if (BigInt.from(amountZatoshi) > spendable) {
+        setState(() {
+          _error = 'Insufficient balance. Available: ${_formatZec(spendable)} ZEC';
+          _isSending = false;
+        });
+        return;
+      }
+
+      final memo = _memoController.text.trim();
       final dir = await getApplicationDocumentsDirectory();
       final dbPath = '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
 
@@ -81,7 +101,20 @@ class _SendScreenState extends ConsumerState<SendScreen> {
 
       log('Send: proposal_id=${proposal.proposalId}, needs_sapling=${proposal.needsSaplingParams}, fee=${proposal.feeZatoshi}');
 
-      // Step 2: Check Sapling params if needed
+      // Step 2: Show confirmation with fee
+      if (!mounted) return;
+      final confirmed = await _showConfirmationDialog(
+        address: address,
+        amountZatoshi: BigInt.from(amountZatoshi),
+        feeZatoshi: proposal.feeZatoshi,
+        memo: memo.isNotEmpty ? memo : null,
+      );
+      if (!confirmed) {
+        setState(() => _isSending = false);
+        return;
+      }
+
+      // Step 3: Check Sapling params if needed
       final paramsDir = '${dir.path}${Platform.pathSeparator}sapling_params';
       final spendPath = '$paramsDir${Platform.pathSeparator}sapling-spend.params';
       final outputPath = '$paramsDir${Platform.pathSeparator}sapling-output.params';
@@ -91,15 +124,13 @@ class _SendScreenState extends ConsumerState<SendScreen> {
         final outputExists = File(outputPath).existsSync();
 
         if (!spendExists || !outputExists) {
-          // Show confirmation dialog
           if (!mounted) return;
-          final confirmed = await _showSaplingParamsDialog();
-          if (!confirmed) {
+          final downloadConfirmed = await _showSaplingParamsDialog();
+          if (!downloadConfirmed) {
             setState(() => _isSending = false);
             return;
           }
 
-          // Download params
           await Directory(paramsDir).create(recursive: true);
           if (!spendExists) {
             log('Send: downloading sapling-spend.params (~47MB)');
@@ -123,7 +154,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
         }
       }
 
-      // Step 3: Get seed and execute proposal
+      // Step 4: Get seed and execute proposal
       const storage = FlutterSecureStorage();
       final mnemonic = await storage.read(key: 'zcash_wallet_mnemonic');
       if (mnemonic == null) {
@@ -131,7 +162,6 @@ class _SendScreenState extends ConsumerState<SendScreen> {
         return;
       }
 
-      // Derive seed bytes from mnemonic
       final seedBytes = await rust_wallet.deriveSeed(mnemonic: mnemonic);
 
       log('Send: executing proposal ${proposal.proposalId}');
@@ -144,14 +174,91 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       );
 
       log('Send: success, txids=$txidResult');
-      setState(() {
-        _txid = txidResult;
-        _isSending = false;
-      });
+
+      // Show success and navigate back to home
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text('Transaction sent successfully'),
+          backgroundColor: Theme.of(context).colorScheme.tertiary,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+      Navigator.of(context).pop();
     } catch (e) {
       log('Send: ERROR: $e');
       setState(() { _error = e.toString(); _isSending = false; });
     }
+  }
+
+  Future<bool> _showConfirmationDialog({
+    required String address,
+    required BigInt amountZatoshi,
+    required BigInt feeZatoshi,
+    String? memo,
+  }) async {
+    final theme = Theme.of(context);
+    final totalZatoshi = amountZatoshi + feeZatoshi;
+
+    return await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Confirm Transaction'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('To', style: theme.textTheme.labelSmall?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            )),
+            const SizedBox(height: 4),
+            Text(
+              '${address.substring(0, 16)}...${address.substring(address.length - 8)}',
+              style: theme.textTheme.bodyMedium?.copyWith(fontFamily: 'monospace'),
+            ),
+            const SizedBox(height: 16),
+            _buildConfirmRow(theme, 'Amount', '${_formatZec(amountZatoshi)} ZEC'),
+            const SizedBox(height: 8),
+            _buildConfirmRow(theme, 'Fee', '${_formatZec(feeZatoshi)} ZEC'),
+            Divider(height: 24, color: theme.colorScheme.outlineVariant),
+            _buildConfirmRow(theme, 'Total', '${_formatZec(totalZatoshi)} ZEC',
+              bold: true),
+            if (memo != null && memo.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              Text('Memo', style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              )),
+              const SizedBox(height: 4),
+              Text(memo, style: theme.textTheme.bodySmall),
+            ],
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Confirm & Send'),
+          ),
+        ],
+      ),
+    ) ?? false;
+  }
+
+  Widget _buildConfirmRow(ThemeData theme, String label, String value, {bool bold = false}) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(label, style: theme.textTheme.bodyMedium?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+        )),
+        Text(value, style: theme.textTheme.bodyMedium?.copyWith(
+          fontWeight: bold ? FontWeight.w700 : FontWeight.w400,
+        )),
+      ],
+    );
   }
 
   Future<bool> _showSaplingParamsDialog() async {
@@ -206,6 +313,11 @@ class _SendScreenState extends ConsumerState<SendScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    final syncState = ref.watch(syncProvider).valueOrNull;
+    final spendable = syncState?.totalBalance ?? BigInt.zero;
+
     return Scaffold(
       appBar: AppBar(title: const Text('Send ZEC')),
       body: SafeArea(
@@ -214,6 +326,30 @@ class _SendScreenState extends ConsumerState<SendScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
+              // Available balance
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: colors.surfaceContainerLow,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Available Balance',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: colors.onSurfaceVariant,
+                      )),
+                    const SizedBox(height: 4),
+                    Text('${_formatZec(spendable)} ZEC',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      )),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 24),
               TextField(
                 controller: _addressController,
                 decoration: InputDecoration(
@@ -222,7 +358,9 @@ class _SendScreenState extends ConsumerState<SendScreen> {
                   suffixIcon: _addressType.isNotEmpty
                       ? Icon(
                           _addressType == 'invalid' ? Icons.error : Icons.check_circle,
-                          color: _addressType == 'invalid' ? Colors.red : Colors.green,
+                          color: _addressType == 'invalid'
+                              ? colors.error
+                              : colors.tertiary,
                         )
                       : null,
                 ),
@@ -233,7 +371,9 @@ class _SendScreenState extends ConsumerState<SendScreen> {
                 Padding(
                   padding: const EdgeInsets.only(top: 4),
                   child: Text('Address type: $_addressType',
-                      style: Theme.of(context).textTheme.labelSmall),
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: colors.onSurfaceVariant,
+                      )),
                 ),
               const SizedBox(height: 16),
               TextField(
@@ -248,42 +388,30 @@ class _SendScreenState extends ConsumerState<SendScreen> {
               const SizedBox(height: 16),
               TextField(
                 controller: _memoController,
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
                   labelText: 'Memo (optional)',
-                  helperText: 'Only available for shielded addresses',
+                  helperText: _addressType == 'transparent'
+                      ? 'Memo not available for transparent addresses'
+                      : 'Only available for shielded addresses',
+                  helperStyle: _addressType == 'transparent'
+                      ? TextStyle(color: colors.error)
+                      : null,
                 ),
                 maxLines: 2,
+                enabled: _addressType != 'transparent',
               ),
               if (_error != null) ...[
                 const SizedBox(height: 16),
                 Container(
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.errorContainer,
+                    color: colors.errorContainer,
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(_error!, style: TextStyle(
-                    color: Theme.of(context).colorScheme.onErrorContainer,
+                    color: colors.onErrorContainer,
                   )),
-                ),
-              ],
-              if (_txid != null) ...[
-                const SizedBox(height: 16),
-                Container(
-                  padding: const EdgeInsets.all(12),
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.tertiaryContainer,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const Text('Transaction sent!', style: TextStyle(fontWeight: FontWeight.bold)),
-                      const SizedBox(height: 4),
-                      Text('TxID: $_txid', style: Theme.of(context).textTheme.bodySmall?.copyWith(fontFamily: 'monospace')),
-                    ],
-                  ),
                 ),
               ],
               const SizedBox(height: 24),

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -31,6 +31,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
   bool _isSending = false;
   String? _error;
   String _addressType = '';
+  String? _amountError; // null = no error, empty string = silent invalid (empty/dot)
 
   @override
   void dispose() {
@@ -59,6 +60,34 @@ class _SendScreenState extends ConsumerState<SendScreen> {
     final syncState = ref.read(syncProvider).value;
     return syncState?.totalBalance ?? BigInt.zero;
   }
+
+  static const int _minFeeZatoshi = 10000;
+
+  void _validateAmount() {
+    final text = _amountController.text.trim();
+
+    // Empty or just "." — silently invalid (no error shown, button disabled)
+    if (text.isEmpty || text == '.') {
+      setState(() => _amountError = '');
+      return;
+    }
+
+    final zatoshi = _parseZecToZatoshi(text);
+    if (zatoshi == null || zatoshi <= 0) {
+      setState(() => _amountError = 'Invalid amount');
+      return;
+    }
+
+    final spendable = _getSpendableBalance();
+    if (BigInt.from(zatoshi + _minFeeZatoshi) > spendable) {
+      setState(() => _amountError = 'Insufficient balance (fee: 0.0001 ZEC)');
+      return;
+    }
+
+    setState(() => _amountError = null);
+  }
+
+  bool get _isAmountValid => _amountError == null;
 
   String _formatZec(BigInt zatoshi) {
     final abs = zatoshi.abs();
@@ -444,10 +473,14 @@ class _SendScreenState extends ConsumerState<SendScreen> {
                   FilteringTextInputFormatter.allow(RegExp(r'[\d.]')),
                   _ZecAmountFormatter(),
                 ],
-                decoration: const InputDecoration(
-                  border: OutlineInputBorder(),
+                onChanged: (_) => _validateAmount(),
+                decoration: InputDecoration(
+                  border: const OutlineInputBorder(),
                   labelText: 'Amount (ZEC)',
                   hintText: '0.00000000',
+                  errorText: _amountError != null && _amountError!.isNotEmpty
+                      ? _amountError
+                      : null,
                 ),
               ),
               const SizedBox(height: 16),
@@ -483,7 +516,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
               SizedBox(
                 width: double.infinity,
                 child: FilledButton(
-                  onPressed: _isSending || _addressType == 'invalid' || _addressType == 'error' || _addressType.isEmpty
+                  onPressed: _isSending || _addressType == 'invalid' || _addressType == 'error' || _addressType.isEmpty || !_isAmountValid
                       ? null
                       : _send,
                   child: _isSending

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -49,8 +49,9 @@ class _SendScreenState extends ConsumerState<SendScreen> {
     try {
       final result = await rust_sync.validateAddress(address: addr);
       setState(() => _addressType = result.isValid ? result.addressType : 'invalid');
-    } catch (_) {
-      setState(() => _addressType = 'invalid');
+    } catch (e) {
+      log('Send: address validation error: $e');
+      setState(() => _addressType = 'error');
     }
   }
 
@@ -405,8 +406,9 @@ class _SendScreenState extends ConsumerState<SendScreen> {
                   labelText: 'Recipient Address',
                   suffixIcon: _addressType.isNotEmpty
                       ? Icon(
-                          _addressType == 'invalid' ? Icons.error : Icons.check_circle,
-                          color: _addressType == 'invalid'
+                          (_addressType == 'invalid' || _addressType == 'error')
+                              ? Icons.error : Icons.check_circle,
+                          color: (_addressType == 'invalid' || _addressType == 'error')
                               ? colors.error
                               : colors.tertiary,
                         )
@@ -415,7 +417,15 @@ class _SendScreenState extends ConsumerState<SendScreen> {
                 onChanged: (_) => _validateAddress(),
                 maxLines: 2,
               ),
-              if (_addressType.isNotEmpty && _addressType != 'invalid')
+              if (_addressType == 'error')
+                Padding(
+                  padding: const EdgeInsets.only(top: 4),
+                  child: Text('Address validation failed. Please try again.',
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: colors.error,
+                      )),
+                ),
+              if (_addressType.isNotEmpty && _addressType != 'invalid' && _addressType != 'error')
                 Padding(
                   padding: const EdgeInsets.only(top: 4),
                   child: Text('Address type: $_addressType',
@@ -470,7 +480,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
               SizedBox(
                 width: double.infinity,
                 child: FilledButton(
-                  onPressed: _isSending || _addressType == 'invalid' || _addressType.isEmpty
+                  onPressed: _isSending || _addressType == 'invalid' || _addressType == 'error' || _addressType.isEmpty
                       ? null
                       : _send,
                   child: _isSending

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -320,6 +320,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
   // ======================== Balance Refresh ========================
 
+  /// Public: refresh balance and recent transactions (e.g. after send).
+  Future<void> refreshAfterSend() => _refreshBalance();
+
   Future<void> _refreshBalance() async {
     final prev = state.value;
     final dbPath = await _getDbPath();

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -156,6 +156,21 @@ Future<ProposalResult> proposeSend({
   memo: memo,
 );
 
+/// Estimate the fee for a transfer without storing a proposal.
+Future<BigInt> estimateFee({
+  required String dbPath,
+  required String network,
+  required String toAddress,
+  required BigInt amountZatoshi,
+  String? memo,
+}) => RustLib.instance.api.crateApiSyncEstimateFee(
+  dbPath: dbPath,
+  network: network,
+  toAddress: toAddress,
+  amountZatoshi: amountZatoshi,
+  memo: memo,
+);
+
 /// Step 2: Execute a previously proposed transfer and broadcast to the network.
 /// spend_params_path and output_params_path are required only if needs_sapling_params was true.
 Future<String> executeProposal({

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -156,16 +156,18 @@ Future<ProposalResult> proposeSend({
   memo: memo,
 );
 
-/// Step 2: Execute a previously proposed transfer.
+/// Step 2: Execute a previously proposed transfer and broadcast to the network.
 /// spend_params_path and output_params_path are required only if needs_sapling_params was true.
 Future<String> executeProposal({
   required String dbPath,
+  required String lightwalletdUrl,
   required BigInt proposalId,
   required List<int> seed,
   String? spendParamsPath,
   String? outputParamsPath,
 }) => RustLib.instance.api.crateApiSyncExecuteProposal(
   dbPath: dbPath,
+  lightwalletdUrl: lightwalletdUrl,
   proposalId: proposalId,
   seed: seed,
   spendParamsPath: spendParamsPath,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -68,7 +68,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1372295428;
+  int get rustContentHash => -2017955125;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -95,6 +95,14 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<Uint8List> crateApiWalletDeriveSeed({required String mnemonic});
+
+  Future<BigInt> crateApiSyncEstimateFee({
+    required String dbPath,
+    required String network,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+  });
 
   Future<String> crateApiSyncExecuteProposal({
     required String dbPath,
@@ -379,6 +387,46 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "derive_seed", argNames: ["mnemonic"]);
 
   @override
+  Future<BigInt> crateApiSyncEstimateFee({
+    required String dbPath,
+    required String network,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(toAddress, serializer);
+          sse_encode_u_64(amountZatoshi, serializer);
+          sse_encode_opt_String(memo, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 5,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_u_64,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSyncEstimateFeeConstMeta,
+        argValues: [dbPath, network, toAddress, amountZatoshi, memo],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncEstimateFeeConstMeta => const TaskConstMeta(
+    debugName: "estimate_fee",
+    argNames: ["dbPath", "network", "toAddress", "amountZatoshi", "memo"],
+  );
+
+  @override
   Future<String> crateApiSyncExecuteProposal({
     required String dbPath,
     required String lightwalletdUrl,
@@ -400,7 +448,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 6,
             port: port_,
           );
         },
@@ -449,7 +497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 7,
             port: port_,
           );
         },
@@ -476,7 +524,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cachePath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 7)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -504,7 +552,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 9,
             port: port_,
           );
         },
@@ -539,7 +587,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 10,
             port: port_,
           );
         },
@@ -574,7 +622,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 11,
             port: port_,
           );
         },
@@ -601,7 +649,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 11)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -631,7 +679,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 13,
             port: port_,
           );
         },
@@ -665,7 +713,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 14,
             port: port_,
           );
         },
@@ -702,7 +750,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -737,7 +785,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 16,
             port: port_,
           );
         },
@@ -772,7 +820,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 17,
             port: port_,
           );
         },
@@ -800,7 +848,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 17)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -834,7 +882,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 19,
             port: port_,
           );
         },
@@ -863,7 +911,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 20,
             port: port_,
           );
         },
@@ -887,7 +935,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -923,7 +971,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 22,
             port: port_,
           );
         },
@@ -965,7 +1013,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 23,
             port: port_,
           );
         },
@@ -1016,7 +1064,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 24,
             port: port_,
           );
         },
@@ -1068,7 +1116,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1119,7 +1167,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1153,7 +1201,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1195,7 +1243,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 27,
+              funcId: 28,
               port: port_,
             );
           },
@@ -1231,7 +1279,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1268,7 +1316,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1300,7 +1348,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1325,7 +1373,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(mnemonic, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1351,7 +1399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1381,7 +1429,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -98,6 +98,7 @@ abstract class RustLibApi extends BaseApi {
 
   Future<String> crateApiSyncExecuteProposal({
     required String dbPath,
+    required String lightwalletdUrl,
     required BigInt proposalId,
     required List<int> seed,
     String? spendParamsPath,
@@ -380,6 +381,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @override
   Future<String> crateApiSyncExecuteProposal({
     required String dbPath,
+    required String lightwalletdUrl,
     required BigInt proposalId,
     required List<int> seed,
     String? spendParamsPath,
@@ -390,6 +392,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
+          sse_encode_String(lightwalletdUrl, serializer);
           sse_encode_u_64(proposalId, serializer);
           sse_encode_list_prim_u_8_loose(seed, serializer);
           sse_encode_opt_String(spendParamsPath, serializer);
@@ -408,6 +411,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         constMeta: kCrateApiSyncExecuteProposalConstMeta,
         argValues: [
           dbPath,
+          lightwalletdUrl,
           proposalId,
           seed,
           spendParamsPath,
@@ -423,6 +427,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         debugName: "execute_proposal",
         argNames: [
           "dbPath",
+          "lightwalletdUrl",
           "proposalId",
           "seed",
           "spendParamsPath",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1989,12 +1989,15 @@ name = "rust_lib_zcash_wallet"
 version = "0.1.0"
 dependencies = [
  "bip0039",
+ "bls12_381",
  "flutter_rust_bridge",
  "hex",
+ "jubjub",
  "log",
  "nonempty 0.10.0",
  "orchard",
  "rand",
+ "rand_core",
  "rusqlite",
  "sapling-crypto",
  "secrecy",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,6 +19,10 @@ zcash_client_sqlite = { version = "0.19.5", features = ["orchard", "transparent-
 # Must match versions used by zcash_client_sqlite to avoid type conflicts
 orchard = "0.11"
 sapling-crypto = { version = "0.5", default-features = false }
+# Required by no-op Sapling prover trait impls
+jubjub = "0.10"
+bls12_381 = "0.8"
+rand_core = "0.6"
 
 # Proofs
 zcash_proofs = "0.26.1"

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -298,17 +298,18 @@ pub fn propose_send(
     })
 }
 
-/// Step 2: Execute a previously proposed transfer.
+/// Step 2: Execute a previously proposed transfer and broadcast to the network.
 /// spend_params_path and output_params_path are required only if needs_sapling_params was true.
 pub fn execute_proposal(
-    db_path: String, proposal_id: u64, seed: Vec<u8>,
+    db_path: String, lightwalletd_url: String, proposal_id: u64, seed: Vec<u8>,
     spend_params_path: Option<String>, output_params_path: Option<String>,
 ) -> Result<String, String> {
     catch(|| {
-        wallet_sync::execute_proposal(
-            &db_path, proposal_id, &seed,
+        let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
+        rt.block_on(wallet_sync::execute_proposal(
+            &db_path, &lightwalletd_url, proposal_id, &seed,
             spend_params_path.as_deref(), output_params_path.as_deref(),
-        )
+        ))
     })
 }
 

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -298,6 +298,17 @@ pub fn propose_send(
     })
 }
 
+/// Estimate the fee for a transfer without storing a proposal.
+pub fn estimate_fee(
+    db_path: String, network: String,
+    to_address: String, amount_zatoshi: u64, memo: Option<String>,
+) -> Result<u64, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        wallet_sync::estimate_fee(&db_path, network, &to_address, amount_zatoshi, memo.as_deref())
+    })
+}
+
 /// Step 2: Execute a previously proposed transfer and broadcast to the network.
 /// spend_params_path and output_params_path are required only if needs_sapling_params was true.
 pub fn execute_proposal(

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -138,3 +138,88 @@ pub extern "C" fn zcash_set_sync_mode(mode: u8) {
 pub extern "C" fn zcash_is_sync_running() -> bool {
     SYNC_RUNNING.load(Ordering::SeqCst)
 }
+
+// ======================== TX Tracking FFI ========================
+
+/// Pending transaction info for C callers.
+#[repr(C)]
+pub struct CPendingTx {
+    pub txid_hex: [u8; 65], // 64 hex chars + null terminator
+    pub expiry_height: u64,
+}
+
+/// Get the number of pending (unmined, unexpired, locally-created) transactions.
+/// Returns count on success, -1 on error.
+#[no_mangle]
+pub extern "C" fn zcash_get_pending_tx_count(db_path: *const c_char) -> i32 {
+    let db_path = match unsafe { CStr::from_ptr(db_path) }.to_str() {
+        Ok(s) if !s.is_empty() => s,
+        _ => { log::error!("ffi: invalid db_path"); return -1; }
+    };
+    match crate::wallet::sync::get_pending_transactions(db_path) {
+        Ok(txs) => txs.len() as i32,
+        Err(e) => { log::error!("ffi: get_pending_tx_count: {e}"); -1 }
+    }
+}
+
+/// Fill buffer with pending transactions. Returns number written, -1 on error.
+#[no_mangle]
+pub extern "C" fn zcash_get_pending_txs(
+    db_path: *const c_char,
+    out_buf: *mut CPendingTx,
+    buf_len: i32,
+) -> i32 {
+    let db_path = match unsafe { CStr::from_ptr(db_path) }.to_str() {
+        Ok(s) if !s.is_empty() => s,
+        _ => { log::error!("ffi: invalid db_path"); return -1; }
+    };
+    let txs = match crate::wallet::sync::get_pending_transactions(db_path) {
+        Ok(t) => t,
+        Err(e) => { log::error!("ffi: get_pending_txs: {e}"); return -1; }
+    };
+
+    let count = std::cmp::min(txs.len(), buf_len as usize);
+    for (i, tx) in txs.iter().take(count).enumerate() {
+        let mut hex_buf = [0u8; 65];
+        let hex_bytes = tx.txid_hex.as_bytes();
+        let copy_len = std::cmp::min(hex_bytes.len(), 64);
+        hex_buf[..copy_len].copy_from_slice(&hex_bytes[..copy_len]);
+        // null terminator already 0
+        unsafe {
+            (*out_buf.add(i)).txid_hex = hex_buf;
+            (*out_buf.add(i)).expiry_height = tx.expiry_height;
+        }
+    }
+    count as i32
+}
+
+/// Check if a transaction has been mined via lightwalletd gRPC.
+/// Returns: >0 = mined height, 0 = still pending, -1 = error.
+#[no_mangle]
+pub extern "C" fn zcash_check_tx_status(
+    lightwalletd_url: *const c_char,
+    txid_hex: *const c_char,
+) -> i64 {
+    let url = match unsafe { CStr::from_ptr(lightwalletd_url) }.to_str() {
+        Ok(s) if !s.is_empty() => s,
+        _ => { log::error!("ffi: invalid lightwalletd_url"); return -1; }
+    };
+    let hex_str = match unsafe { CStr::from_ptr(txid_hex) }.to_str() {
+        Ok(s) if !s.is_empty() => s,
+        _ => { log::error!("ffi: invalid txid_hex"); return -1; }
+    };
+    let txid_bytes = match hex::decode(hex_str) {
+        Ok(b) if b.len() == 32 => b,
+        _ => { log::error!("ffi: bad txid hex"); return -1; }
+    };
+
+    let rt = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => { log::error!("ffi: tokio runtime failed: {e}"); return -1; }
+    };
+
+    rt.block_on(crate::wallet::sync::check_tx_mined(url, &txid_bytes))
+}

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1372295428;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -2017955125;
 
 // Section: executor
 
@@ -183,6 +183,49 @@ fn wire__crate__api__wallet__derive_seed_impl(
             move |context| {
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::api::wallet::derive_seed(api_mnemonic)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__sync__estimate_fee_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "estimate_fee",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_to_address = <String>::sse_decode(&mut deserializer);
+            let api_amount_zatoshi = <u64>::sse_decode(&mut deserializer);
+            let api_memo = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::sync::estimate_fee(
+                        api_db_path,
+                        api_network,
+                        api_to_address,
+                        api_amount_zatoshi,
+                        api_memo,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -1663,54 +1706,55 @@ fn pde_ffi_dispatcher_primary_impl(
             data_len,
         ),
         4 => wire__crate__api__wallet__derive_seed_impl(port, ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__wallet__get_latest_block_height_impl(
+        5 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__wallet__get_latest_block_height_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        9 => wire__crate__api__sync__get_next_available_address_impl(
+        10 => wire__crate__api__sync__get_next_available_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        10 => {
+        11 => {
             wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len)
         }
-        12 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__sync__get_transaction_data_requests_impl(
+        13 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__sync__get_transaction_data_requests_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        14 => {
+        15 => {
             wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len)
         }
-        15 => wire__crate__api__wallet__get_transparent_address_impl(
+        16 => wire__crate__api__wallet__get_transparent_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        16 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-        26 => {
+        17 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+        27 => {
             wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len)
         }
-        27 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1724,13 +1768,13 @@ fn pde_ffi_dispatcher_sync_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         1 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        11 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        12 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -212,6 +212,7 @@ fn wire__crate__api__sync__execute_proposal_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
             let api_proposal_id = <u64>::sse_decode(&mut deserializer);
             let api_seed = <Vec<u8>>::sse_decode(&mut deserializer);
             let api_spend_params_path = <Option<String>>::sse_decode(&mut deserializer);
@@ -221,6 +222,7 @@ fn wire__crate__api__sync__execute_proposal_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::api::sync::execute_proposal(
                         api_db_path,
+                        api_lightwalletd_url,
                         api_proposal_id,
                         api_seed,
                         api_spend_params_path,

--- a/rust/src/wallet/sync.rs
+++ b/rust/src/wallet/sync.rs
@@ -542,6 +542,81 @@ pub fn get_transaction_history(
         .map_err(|e| format!("Row error: {e}"))
 }
 
+// ======================== Pending TX Tracking ========================
+
+pub(crate) struct PendingTxInfo {
+    pub txid_bytes: Vec<u8>,
+    pub txid_hex: String,
+    pub expiry_height: u64,
+}
+
+/// Get all pending (unmined, unexpired) transactions that we created (have raw bytes).
+pub fn get_pending_transactions(db_path: &str) -> Result<Vec<PendingTxInfo>, String> {
+    let conn = rusqlite::Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    ).map_err(|e| format!("Failed to open DB: {e}"))?;
+
+    let mut stmt = conn.prepare(
+        "SELECT txid, COALESCE(expiry_height, 0) \
+         FROM transactions \
+         WHERE mined_height IS NULL AND expired_unmined = 0 AND raw IS NOT NULL"
+    ).map_err(|e| format!("SQL error: {e}"))?;
+
+    let rows = stmt.query_map([], |row| {
+        let txid_bytes: Vec<u8> = row.get(0)?;
+        let expiry_height: u64 = row.get::<_, i64>(1)?.unsigned_abs();
+        let txid_hex = hex::encode(&txid_bytes);
+        Ok(PendingTxInfo { txid_bytes, txid_hex, expiry_height })
+    }).map_err(|e| format!("Query error: {e}"))?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Row error: {e}"))
+}
+
+/// Check if a transaction has been mined by querying lightwalletd.
+/// Returns: 0 = still in mempool, >0 = mined at height, -1 = error/not found.
+pub async fn check_tx_mined(lightwalletd_url: &str, txid_bytes: &[u8]) -> i64 {
+    use tonic::transport::{ClientTlsConfig, Endpoint};
+    use zcash_client_backend::proto::service::{
+        compact_tx_streamer_client::CompactTxStreamerClient, TxFilter,
+    };
+
+    let channel = match Endpoint::from_shared(lightwalletd_url.to_string())
+        .and_then(|e| e.tls_config(ClientTlsConfig::new().with_webpki_roots()))
+    {
+        Ok(e) => match e.connect().await {
+            Ok(c) => c,
+            Err(e) => { log::warn!("txtrack: gRPC connect failed: {e}"); return -1; }
+        },
+        Err(e) => { log::warn!("txtrack: endpoint error: {e}"); return -1; }
+    };
+
+    let mut client = CompactTxStreamerClient::new(channel);
+
+    let filter = TxFilter {
+        block: None,
+        index: 0,
+        hash: txid_bytes.to_vec(),
+    };
+
+    match client.get_transaction(filter).await {
+        Ok(resp) => {
+            let height = resp.into_inner().height;
+            // height 0 = mempool, 0xffffffffffffffff = fork, else = mined
+            if height == 0 || height == u64::MAX {
+                0 // still pending
+            } else {
+                height as i64
+            }
+        }
+        Err(e) => {
+            log::warn!("txtrack: GetTransaction failed: {e}");
+            -1
+        }
+    }
+}
+
 // ======================== Helpers ========================
 
 pub fn get_blocks_dir(cache_path: &str) -> String {

--- a/rust/src/wallet/sync.rs
+++ b/rust/src/wallet/sync.rs
@@ -274,6 +274,44 @@ pub fn propose_send(
     Ok(ProposalResult { proposal_id: id, needs_sapling_params: needs_sapling, fee_zatoshi: fee })
 }
 
+/// Estimate the fee for a transfer without storing the proposal.
+/// Used for validation only — does not consume resources in PROPOSAL_STORE.
+pub fn estimate_fee(
+    db_path: &str, network: Network,
+    to_address: &str, amount_zatoshi: u64, memo_str: Option<&str>,
+) -> Result<u64, String> {
+    use zcash_protocol::ShieldedProtocol as SP;
+
+    let mut db = open_wallet_db(db_path, network)?;
+    let account_id = get_first_account_id(&db)?;
+
+    let to: zcash_address::ZcashAddress = to_address.parse().map_err(|e| format!("Bad address: {e}"))?;
+    let value = Zatoshis::from_u64(amount_zatoshi).map_err(|_| "Bad amount")?;
+    let memo_bytes = match memo_str {
+        Some(m) => {
+            let bytes = MemoBytes::from(Memo::from_bytes(m.as_bytes()).map_err(|e| format!("Bad memo: {e}"))?);
+            Some(bytes)
+        }
+        None => None,
+    };
+
+    let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None);
+    let payment = Payment::new(to, value, memo_bytes, None, None, vec![])
+        .ok_or("Cannot send memo to this address type")?;
+    let request = TransactionRequest::new(vec![payment]).map_err(|e| format!("{e:?}"))?;
+
+    let proposal = propose_transfer::<_, _, _, _, Infallible>(
+        &mut db, &network, account_id, &input_selector, &change_strategy,
+        request, ConfirmationsPolicy::default(),
+    ).map_err(|e| format!("Propose failed: {e}"))?;
+
+    let fee: u64 = proposal.steps().iter()
+        .map(|step| u64::from(step.balance().fee_required()))
+        .sum();
+
+    Ok(fee)
+}
+
 /// Execute a previously proposed transfer, then broadcast to the network.
 /// Returns comma-separated txids on success.
 pub async fn execute_proposal(

--- a/rust/src/wallet/sync.rs
+++ b/rust/src/wallet/sync.rs
@@ -274,9 +274,11 @@ pub fn propose_send(
     Ok(ProposalResult { proposal_id: id, needs_sapling_params: needs_sapling, fee_zatoshi: fee })
 }
 
-/// Execute a previously proposed transfer. Requires seed and optionally Sapling params paths.
-pub fn execute_proposal(
+/// Execute a previously proposed transfer, then broadcast to the network.
+/// Returns comma-separated txids on success.
+pub async fn execute_proposal(
     db_path: &str,
+    lightwalletd_url: &str,
     proposal_id: u64,
     seed_bytes: &[u8],
     spend_params_path: Option<&str>,
@@ -308,7 +310,61 @@ pub fn execute_proposal(
         OvkPolicy::Sender, &stored.proposal,
     ).map_err(|e| format!("Create TX failed: {e}"))?;
 
-    Ok(txids.into_iter().map(|id| format!("{id}")).collect::<Vec<_>>().join(","))
+    // Broadcast each transaction to lightwalletd
+    let txid_strings: Vec<String> = txids.iter().map(|id| format!("{id}")).collect();
+
+    // Open separate read-only connection (WalletDb.conn is private)
+    let read_conn = rusqlite::Connection::open_with_flags(
+        db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+    ).map_err(|e| format!("Failed to open DB for broadcast: {e}"))?;
+
+    for txid in &txids {
+        let raw_tx = read_conn
+            .query_row(
+                "SELECT raw FROM transactions WHERE txid = ?1",
+                rusqlite::params![txid.as_ref()],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .map_err(|e| format!("Failed to get raw tx for {txid}: {e}"))?;
+
+        broadcast_raw_transaction(lightwalletd_url, &raw_tx).await?;
+        log::info!("send: broadcast {txid} ({} bytes)", raw_tx.len());
+    }
+
+    Ok(txid_strings.join(","))
+}
+
+/// Broadcast a raw transaction to lightwalletd via gRPC.
+async fn broadcast_raw_transaction(lightwalletd_url: &str, raw_tx: &[u8]) -> Result<(), String> {
+    use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
+    use zcash_client_backend::proto::service::{
+        compact_tx_streamer_client::CompactTxStreamerClient, RawTransaction,
+    };
+
+    let channel = Endpoint::from_shared(lightwalletd_url.to_string())
+        .map_err(|e| format!("Invalid URL: {e}"))?
+        .tls_config(ClientTlsConfig::new().with_webpki_roots())
+        .map_err(|e| format!("TLS error: {e}"))?
+        .connect()
+        .await
+        .map_err(|e| format!("gRPC connect failed: {e}"))?;
+
+    let mut client = CompactTxStreamerClient::new(channel);
+
+    let resp = client
+        .send_transaction(RawTransaction {
+            data: raw_tx.to_vec(),
+            height: 0,
+        })
+        .await
+        .map_err(|e| format!("SendTransaction gRPC failed: {e}"))?
+        .into_inner();
+
+    if resp.error_code != 0 {
+        return Err(format!("Broadcast rejected: {} (code {})", resp.error_message, resp.error_code));
+    }
+
+    Ok(())
 }
 
 pub(crate) struct ProposalResult {

--- a/rust/src/wallet/sync.rs
+++ b/rust/src/wallet/sync.rs
@@ -299,16 +299,29 @@ pub async fn execute_proposal(
     let usk = UnifiedSpendingKey::from_seed(&network, seed.expose_secret(), zip32_index)
         .map_err(|e| format!("USK derivation failed: {e:?}"))?;
 
-    let prover = LocalTxProver::new(
-        std::path::Path::new(spend_params_path.unwrap_or("")),
-        std::path::Path::new(output_params_path.unwrap_or("")),
-    );
-
-    let txids = create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
-        &mut db, &network, &prover, &prover,
-        &wallet::SpendingKeys::from_unified_spending_key(usk),
-        OvkPolicy::Sender, &stored.proposal,
-    ).map_err(|e| format!("Create TX failed: {e}"))?;
+    let txids = match (spend_params_path, output_params_path) {
+        (Some(sp), Some(op)) if !sp.is_empty() && !op.is_empty() => {
+            let prover = LocalTxProver::new(
+                std::path::Path::new(sp),
+                std::path::Path::new(op),
+            );
+            create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+                &mut db, &network, &prover, &prover,
+                &wallet::SpendingKeys::from_unified_spending_key(usk),
+                OvkPolicy::Sender, &stored.proposal,
+            ).map_err(|e| format!("Create TX failed: {e}"))?
+        }
+        _ => {
+            // No Sapling params — use no-op prover (safe for Orchard-only TXs)
+            let spend_prover = NoOpSpendProver;
+            let output_prover = NoOpOutputProver;
+            create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+                &mut db, &network, &spend_prover, &output_prover,
+                &wallet::SpendingKeys::from_unified_spending_key(usk),
+                OvkPolicy::Sender, &stored.proposal,
+            ).map_err(|e| format!("Create TX failed: {e}"))?
+        }
+    };
 
     // Broadcast each transaction to lightwalletd
     let txid_strings: Vec<String> = txids.iter().map(|id| format!("{id}")).collect();
@@ -540,6 +553,76 @@ pub fn get_transaction_history(
 
     rows.collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("Row error: {e}"))
+}
+
+// ======================== No-op Sapling Provers ========================
+// Used for Orchard-only transactions where Sapling params are not available.
+// The prover methods will never be called for Orchard-only TXs.
+
+use sapling_crypto::{
+    bundle::GrothProofBytes,
+    circuit,
+    keys::EphemeralSecretKey,
+    prover::{OutputProver, SpendProver},
+    value::{NoteValue, ValueCommitTrapdoor},
+    Diversifier, MerklePath, PaymentAddress, ProofGenerationKey, Rseed,
+};
+
+const GROTH_PROOF_SIZE: usize = 192;
+
+struct NoOpSpendProver;
+
+impl SpendProver for NoOpSpendProver {
+    type Proof = GrothProofBytes;
+
+    fn prepare_circuit(
+        _proof_generation_key: ProofGenerationKey,
+        _diversifier: Diversifier,
+        _rseed: Rseed,
+        _value: NoteValue,
+        _alpha: jubjub::Fr,
+        _rcv: ValueCommitTrapdoor,
+        _anchor: bls12_381::Scalar,
+        _merkle_path: MerklePath,
+    ) -> Option<circuit::Spend> {
+        unreachable!("NoOpSpendProver should not be called for Orchard-only TXs")
+    }
+
+    fn create_proof<R: rand_core::RngCore>(
+        &self, _circuit: circuit::Spend, _rng: &mut R,
+    ) -> Self::Proof {
+        unreachable!("NoOpSpendProver should not be called for Orchard-only TXs")
+    }
+
+    fn encode_proof(_proof: Self::Proof) -> GrothProofBytes {
+        [0u8; GROTH_PROOF_SIZE]
+    }
+}
+
+struct NoOpOutputProver;
+
+impl OutputProver for NoOpOutputProver {
+    type Proof = GrothProofBytes;
+
+    fn prepare_circuit(
+        _esk: &EphemeralSecretKey,
+        _payment_address: PaymentAddress,
+        _rcm: jubjub::Fr,
+        _value: NoteValue,
+        _rcv: ValueCommitTrapdoor,
+    ) -> circuit::Output {
+        unreachable!("NoOpOutputProver should not be called for Orchard-only TXs")
+    }
+
+    fn create_proof<R: rand_core::RngCore>(
+        &self, _circuit: circuit::Output, _rng: &mut R,
+    ) -> Self::Proof {
+        unreachable!("NoOpOutputProver should not be called for Orchard-only TXs")
+    }
+
+    fn encode_proof(_proof: Self::Proof) -> GrothProofBytes {
+        [0u8; GROTH_PROOF_SIZE]
+    }
 }
 
 // ======================== Pending TX Tracking ========================

--- a/rust/src/wallet/sync.rs
+++ b/rust/src/wallet/sync.rs
@@ -331,6 +331,7 @@ pub async fn execute_proposal(
         db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
     ).map_err(|e| format!("Failed to open DB for broadcast: {e}"))?;
 
+    let mut broadcast_ok: Vec<String> = Vec::new();
     for txid in &txids {
         let raw_tx = read_conn
             .query_row(
@@ -340,8 +341,18 @@ pub async fn execute_proposal(
             )
             .map_err(|e| format!("Failed to get raw tx for {txid}: {e}"))?;
 
-        broadcast_raw_transaction(lightwalletd_url, &raw_tx).await?;
-        log::info!("send: broadcast {txid} ({} bytes)", raw_tx.len());
+        match broadcast_raw_transaction(lightwalletd_url, &raw_tx).await {
+            Ok(()) => {
+                broadcast_ok.push(format!("{txid}"));
+                log::info!("send: broadcast {txid} ({} bytes)", raw_tx.len());
+            }
+            Err(e) => {
+                return Err(format!(
+                    "Broadcast failed after {}/{} txs sent ({}). Error: {e}",
+                    broadcast_ok.len(), txids.len(), broadcast_ok.join(",")
+                ));
+            }
+        }
     }
 
     Ok(txid_strings.join(","))

--- a/rust/src/wallet/sync.rs
+++ b/rust/src/wallet/sync.rs
@@ -294,33 +294,36 @@ pub async fn execute_proposal(
     let account_id = get_first_account_id(&db)?;
     let account = db.get_account(account_id).map_err(|e| format!("{e}"))?.ok_or("Account not found")?;
 
-    let seed = SecretVec::new(seed_bytes.to_vec());
-    let zip32_index = account.source().key_derivation().ok_or("No key derivation")?.account_index();
-    let usk = UnifiedSpendingKey::from_seed(&network, seed.expose_secret(), zip32_index)
-        .map_err(|e| format!("USK derivation failed: {e:?}"))?;
+    // Scope seed/USK so they are dropped before network I/O (broadcast)
+    let txids = {
+        let seed = SecretVec::new(seed_bytes.to_vec());
+        let zip32_index = account.source().key_derivation().ok_or("No key derivation")?.account_index();
+        let usk = UnifiedSpendingKey::from_seed(&network, seed.expose_secret(), zip32_index)
+            .map_err(|e| format!("USK derivation failed: {e:?}"))?;
 
-    let txids = match (spend_params_path, output_params_path) {
-        (Some(sp), Some(op)) if !sp.is_empty() && !op.is_empty() => {
-            let prover = LocalTxProver::new(
-                std::path::Path::new(sp),
-                std::path::Path::new(op),
-            );
-            create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
-                &mut db, &network, &prover, &prover,
-                &wallet::SpendingKeys::from_unified_spending_key(usk),
-                OvkPolicy::Sender, &stored.proposal,
-            ).map_err(|e| format!("Create TX failed: {e}"))?
+        match (spend_params_path, output_params_path) {
+            (Some(sp), Some(op)) if !sp.is_empty() && !op.is_empty() => {
+                let prover = LocalTxProver::new(
+                    std::path::Path::new(sp),
+                    std::path::Path::new(op),
+                );
+                create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+                    &mut db, &network, &prover, &prover,
+                    &wallet::SpendingKeys::from_unified_spending_key(usk),
+                    OvkPolicy::Sender, &stored.proposal,
+                ).map_err(|e| format!("Create TX failed: {e}"))?
+            }
+            _ => {
+                let spend_prover = NoOpSpendProver;
+                let output_prover = NoOpOutputProver;
+                create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+                    &mut db, &network, &spend_prover, &output_prover,
+                    &wallet::SpendingKeys::from_unified_spending_key(usk),
+                    OvkPolicy::Sender, &stored.proposal,
+                ).map_err(|e| format!("Create TX failed: {e}"))?
+            }
         }
-        _ => {
-            // No Sapling params — use no-op prover (safe for Orchard-only TXs)
-            let spend_prover = NoOpSpendProver;
-            let output_prover = NoOpOutputProver;
-            create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
-                &mut db, &network, &spend_prover, &output_prover,
-                &wallet::SpendingKeys::from_unified_spending_key(usk),
-                OvkPolicy::Sender, &stored.proposal,
-            ).map_err(|e| format!("Create TX failed: {e}"))?
-        }
+        // seed + usk dropped here, before broadcast
     };
 
     // Broadcast each transaction to lightwalletd
@@ -596,13 +599,15 @@ impl SpendProver for NoOpSpendProver {
         _anchor: bls12_381::Scalar,
         _merkle_path: MerklePath,
     ) -> Option<circuit::Spend> {
-        unreachable!("NoOpSpendProver should not be called for Orchard-only TXs")
+        log::error!("NoOpSpendProver::prepare_circuit called — proposal contains unexpected Sapling spend");
+        None
     }
 
     fn create_proof<R: rand_core::RngCore>(
         &self, _circuit: circuit::Spend, _rng: &mut R,
     ) -> Self::Proof {
-        unreachable!("NoOpSpendProver should not be called for Orchard-only TXs")
+        log::error!("NoOpSpendProver::create_proof called — should never happen");
+        [0u8; GROTH_PROOF_SIZE]
     }
 
     fn encode_proof(_proof: Self::Proof) -> GrothProofBytes {
@@ -622,13 +627,20 @@ impl OutputProver for NoOpOutputProver {
         _value: NoteValue,
         _rcv: ValueCommitTrapdoor,
     ) -> circuit::Output {
-        unreachable!("NoOpOutputProver should not be called for Orchard-only TXs")
+        log::error!("NoOpOutputProver::prepare_circuit called — proposal contains unexpected Sapling output");
+        circuit::Output {
+            value_commitment_opening: None,
+            payment_address: None,
+            commitment_randomness: None,
+            esk: None,
+        }
     }
 
     fn create_proof<R: rand_core::RngCore>(
         &self, _circuit: circuit::Output, _rng: &mut R,
     ) -> Self::Proof {
-        unreachable!("NoOpOutputProver should not be called for Orchard-only TXs")
+        log::error!("NoOpOutputProver::create_proof called — should never happen");
+        [0u8; GROTH_PROOF_SIZE]
     }
 
     fn encode_proof(_proof: Self::Proof) -> GrothProofBytes {

--- a/rust/src/wallet/sync.rs
+++ b/rust/src/wallet/sync.rs
@@ -326,10 +326,24 @@ pub async fn execute_proposal(
         // seed + usk dropped here, before broadcast
     };
 
-    // Broadcast each transaction to lightwalletd
+    // Connect to lightwalletd once for all broadcasts
+    use tonic::transport::{ClientTlsConfig, Endpoint};
+    use zcash_client_backend::proto::service::{
+        compact_tx_streamer_client::CompactTxStreamerClient, RawTransaction,
+    };
+
+    let channel = Endpoint::from_shared(lightwalletd_url.to_string())
+        .map_err(|e| format!("Invalid URL: {e}"))?
+        .tls_config(ClientTlsConfig::new().with_webpki_roots())
+        .map_err(|e| format!("TLS error: {e}"))?
+        .connect()
+        .await
+        .map_err(|e| format!("gRPC connect failed: {e}"))?;
+    let mut client = CompactTxStreamerClient::new(channel);
+
+    // Broadcast each transaction
     let txid_strings: Vec<String> = txids.iter().map(|id| format!("{id}")).collect();
 
-    // Open separate read-only connection (WalletDb.conn is private)
     let read_conn = rusqlite::Connection::open_with_flags(
         db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
     ).map_err(|e| format!("Failed to open DB for broadcast: {e}"))?;
@@ -344,7 +358,7 @@ pub async fn execute_proposal(
             )
             .map_err(|e| format!("Failed to get raw tx for {txid}: {e}"))?;
 
-        match broadcast_raw_transaction(lightwalletd_url, &raw_tx).await {
+        match broadcast_raw_transaction(&mut client, &raw_tx).await {
             Ok(()) => {
                 broadcast_ok.push(format!("{txid}"));
                 log::info!("send: broadcast {txid} ({} bytes)", raw_tx.len());
@@ -361,22 +375,12 @@ pub async fn execute_proposal(
     Ok(txid_strings.join(","))
 }
 
-/// Broadcast a raw transaction to lightwalletd via gRPC.
-async fn broadcast_raw_transaction(lightwalletd_url: &str, raw_tx: &[u8]) -> Result<(), String> {
-    use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
-    use zcash_client_backend::proto::service::{
-        compact_tx_streamer_client::CompactTxStreamerClient, RawTransaction,
-    };
-
-    let channel = Endpoint::from_shared(lightwalletd_url.to_string())
-        .map_err(|e| format!("Invalid URL: {e}"))?
-        .tls_config(ClientTlsConfig::new().with_webpki_roots())
-        .map_err(|e| format!("TLS error: {e}"))?
-        .connect()
-        .await
-        .map_err(|e| format!("gRPC connect failed: {e}"))?;
-
-    let mut client = CompactTxStreamerClient::new(channel);
+/// Broadcast a raw transaction using an existing gRPC client.
+async fn broadcast_raw_transaction(
+    client: &mut zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient<tonic::transport::Channel>,
+    raw_tx: &[u8],
+) -> Result<(), String> {
+    use zcash_client_backend::proto::service::RawTransaction;
 
     let resp = client
         .send_transaction(RawTransaction {

--- a/rust/src/wallet/sync_engine.rs
+++ b/rust/src/wallet/sync_engine.rs
@@ -221,7 +221,7 @@ pub async fn run_sync_inner(
             is_complete: false,
             has_new_tx,
         };
-        log::info!("[{}] sync: {:.1}% ({} remaining)", elapsed(), pct * 100.0, remaining);
+        log::info!("[{}] sync: {:.1}% (remaining={}, total={}, scanned={})", elapsed(), pct * 100.0, remaining, total, total - remaining);
         progress_fn(progress);
     }
 


### PR DESCRIPTION
## Summary

- **Send screen improvements**: confirmation dialog with fee display, integer-only ZEC-to-zatoshi parsing, balance validation with real fee estimation, input formatters, user-friendly error messages
- **Transaction broadcast**: execute_proposal now broadcasts via lightwalletd SendTransaction gRPC with channel reuse, partial broadcast tracking, no-op Sapling prover for Orchard-only TXs
- **TX state UI**: pending (spinner), confirmed (check), expired (strikethrough) states in home Recent Activity and history screen
- **iOS TX tracking**: separate BGContinuedProcessingTask polls lightwalletd GetTransaction for pending TX confirmation/expiry, with cancellation flag
- **Dynamic Island**: DynamicIslandManager for Live Activity lifecycle with sync/txtrack priority switching, widget extension dual UI

## Test plan

- [ ] Send ZEC to a valid Orchard address → confirm dialog shows fee → broadcast succeeds → pending TX appears in home
- [ ] Wait ~75s → TX confirmed → spinner changes to check icon
- [ ] Send with insufficient balance → "Insufficient balance (fee: ...)" error before send button
- [ ] Enter invalid address → error icon, send disabled
- [ ] Enter "." or empty amount → send button disabled, no error shown
- [ ] iOS: after send, Dynamic Island shows TX tracking → confirmed → returns to sync display
- [ ] Sapling address send → download params dialog → download + verify → send succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)