### PR TITLE
feat: multi-account support with different seeds in single DB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,40 @@ Removes the app from the booted iOS simulator including Keychain data. This is n
 
 Flutter + Rust FFI via `flutter_rust_bridge` v2. All Zcash cryptography and sync run in Rust (`librustzcash` crates). Dart handles UI, state management (Riverpod), and secure storage only. Supports iOS, Android, and macOS.
 
+### Multi-Account Model
+
+Single DB (`zcash_wallet.db`) holds multiple accounts from different seeds. Single sync loop decrypts notes for all accounts simultaneously via `scan_cached_blocks` (uses all UFVKs). UI shows one "active account" at a time.
+
+**Account creation strategy** (due to `zcash_client_sqlite` constraints):
+- **First account**: `create_account()` → `AccountSource::Derived`. Uses `init_wallet_db(seed)` so the seed is stored for future schema migrations.
+- **Additional accounts (different seeds)**: `import_account_ufvk(AccountPurpose::Spending { derivation })` → `AccountSource::Imported`. Bypasses the single-seed fingerprint constraint in `create_account`.
+- **DB init for additional accounts**: `init_wallet_db(None)` (no seed) to avoid `SeedNotRelevant` error when only Imported accounts exist.
+
+**Account identification**: `AccountUuid` (UUID string like `"550e8400-e29b-41d4-a716-446655440000"`). Passed as `String` between Dart and Rust via `Uuid::parse_str()` / `Uuid::to_string()`.
+
+**Mnemonic storage**: Per-account in Flutter secure storage (`zcash_account_mnemonic_{uuid}`). Account list stored as JSON in `zcash_accounts` key. Active account in `zcash_active_account` key.
+
+### Dart Provider Structure
+
+```
+AccountProvider (account_provider.dart)
+  ├── Manages account list, active account, per-account mnemonics
+  ├── createAccount() — first: create_wallet, additional: generateMnemonic + addAccount
+  ├── importAccount() — first: import_wallet, additional: addAccount
+  ├── switchAccount() — updates active, refreshes address
+  └── getActiveMnemonic() — reads from secure storage
+
+WalletProvider (wallet_provider.dart)
+  ├── Watches AccountProvider
+  ├── Exposes hasWallet, unifiedAddress, activeAccountUuid
+  └── Propagates errors (does NOT mask as empty state)
+
+SyncProvider (sync_provider.dart)
+  ├── Passes activeAccountUuid to getBalance, getTransactionHistory
+  ├── Sync itself is account-agnostic (covers all accounts)
+  └── refreshAfterSend() called after account switch for immediate update
+```
+
 ### Sync Engine (Rust-only)
 
 The entire sync loop runs in Rust (`rust/src/wallet/sync_engine.rs`). A single call from Dart (`startFullSync()`) triggers the full pipeline:
@@ -52,20 +86,29 @@ rust/src/
 ├── api/
 │   ├── mod.rs          # pub mod simple, sync, wallet
 │   ├── simple.rs       # init_app() with setup_default_user_utils() + log level filter
-│   ├── wallet.rs       # FRB: create_wallet(birthday), import_wallet, get_latest_block_height
+│   ├── wallet.rs       # FRB: create_wallet, import_wallet, add_account, list_accounts,
+│   │                    # generate_mnemonic, get_unified_address(account_uuid),
+│   │                    # get_transparent_address(account_uuid), get_latest_block_height
 │   └── sync.rs         # FRB: start_full_sync(StreamSink, mode), cancel_full_sync(),
 │                        # set_sync_mode(), get_sync_mode(), is_sync_running(),
-│                        # get_balance(), get_transaction_history(limit), send, etc.
+│                        # get_balance(account_uuid), get_transaction_history(account_uuid),
+│                        # propose_send(account_uuid), estimate_fee(account_uuid),
+│                        # execute_proposal, get_next_available_address(account_uuid)
 │                        # DESIRED_SYNC_MODE, SYNC_RUNNING, SYNC_CANCEL globals
 ├── ffi.rs              # C FFI for Swift: zcash_run_full_sync(), zcash_cancel_sync(),
 │                        # zcash_get/set_sync_mode(), zcash_is_sync_running()
+│                        # TX tracking: zcash_get_pending_txs(), zcash_check_tx_status()
 │                        # Validates C strings, logs all errors, checks mode before starting
 │                        # Uses current_thread tokio runtime (inherits iOS .utility QoS)
 │                        # Located outside api/ to avoid FRB codegen picking it up
 ├── wallet/
 │   ├── mod.rs          # pub mod keys, sync, sync_engine
-│   ├── keys.rs         # Key derivation, mnemonic, account creation
-│   ├── sync.rs         # Individual wallet operations (balance, send, history, etc.)
+│   ├── keys.rs         # Key derivation, mnemonic, account creation (Derived + Imported),
+│   │                    # list_accounts, ensure_db_initialized, parse_account_uuid
+│   ├── sync.rs         # Per-account wallet operations (balance, send, history, etc.)
+│   │                    # All per-account functions take account_uuid parameter
+│   │                    # NoOp Sapling provers for Orchard-only transactions
+│   │                    # TX broadcast via gRPC SendTransaction
 │   └── sync_engine.rs  # Unified sync loop: run_sync_inner()
 │                        # MemoryBlockSource (BlockSource trait impl)
 │                        # Single DB connection reused across entire sync
@@ -155,7 +198,23 @@ Key files:
 - `ios/Runner/SyncProgressStreamHandler.swift` — bridges C callback → Dart EventChannel
 - `ios/Runner/zcash_sync.h` — C header for all FFI functions
 
-System provides progress UI (Dynamic Island / Lock Screen) via `task.progress`. Progress uses scan-queue percentage scaled to 0-10000. Heartbeat fills gaps between batch callbacks.
+### iOS TX Tracking
+
+Separate `BGContinuedProcessingTask` (`com.zcash.zcashWallet.txtrack`) polls lightwalletd `GetTransaction` every 5s to detect when pending transactions are mined or expired.
+
+- `TxTrackManager.swift` — manages BGTask lifecycle, poll loop with `cancelled` flag
+- `DynamicIslandManager.swift` — Live Activity lifecycle, priority switching (TX tracking > sync)
+- Widget extension (`SyncWidget/`) — dual UI for sync progress and TX tracking states
+
+### Send Flow
+
+2-step: `propose_send(account_uuid)` → confirmation dialog (shows fee) → `execute_proposal()` → broadcast via `SendTransaction` gRPC.
+
+- Integer-only ZEC-to-zatoshi parsing (no floating-point)
+- Real fee estimation via `estimate_fee(account_uuid)` on each keystroke
+- No-op Sapling provers for Orchard-only TXs (avoids 50MB param download)
+- Post-send: `refreshAfterSend()` for immediate pending TX display
+- Friendly error messages via `_friendlyError()` pattern matching
 
 ### Wallet Creation
 
@@ -165,13 +224,15 @@ System provides progress UI (Dynamic Island / Lock Screen) via `task.progress`. 
 
 FRB codegen works best with simple types. Keep the `rust/src/api/` surface limited to primitives, `String`, and flat structs. Do all complex Zcash type manipulation inside `rust/src/wallet/` and return simple results through `rust/src/api/`.
 
+All per-account API functions take `account_uuid: String`. Sync-level operations (`start_full_sync`, etc.) operate on all accounts and do NOT take account_uuid.
+
 ### Key Security Model
 
-`zcash_client_sqlite` intentionally does NOT store spending keys in the DB — only viewing keys (UFVK). The mnemonic/seed lives in Flutter's `flutter_secure_storage` (iOS Keychain / Android Keystore) and is passed to Rust only when needed for transaction signing.
+`zcash_client_sqlite` intentionally does NOT store spending keys in the DB — only viewing keys (UFVK). The mnemonic/seed lives in Flutter's `flutter_secure_storage` (iOS Keychain / Android Keystore) per-account (`zcash_account_mnemonic_{uuid}`) and is passed to Rust only when needed for transaction signing. Seed is scoped in a block and dropped before network I/O (broadcast).
 
 ### WalletDb Initialization
 
-`WalletDb::for_path()` requires 4 params: `(path, Network, SystemClock, OsRng)`. `init_wallet_db()` must be called before `create_account()` — it runs schema migrations.
+`WalletDb::for_path()` requires 4 params: `(path, Network, SystemClock, OsRng)`. `init_wallet_db()` must be called before `create_account()` — it runs schema migrations. First account uses `init_wallet_db(Some(seed))` for migration support; subsequent DB opens use `init_wallet_db(None)`.
 
 ### Dart Sync Provider
 
@@ -186,6 +247,7 @@ FRB codegen works best with simple types. Keep the `rust/src/api/` surface limit
 - iOS EventChannel listener for background sync progress with all fields (isSyncing, isComplete, hasNewTx)
 - No polling — all state updates driven by stream events, EventChannel, and onResume
 - `SyncState.recentTransactions`: latest 10 transactions, updated on `hasNewTx`, sync completion, and app resume
+- All balance/history queries pass `activeAccountUuid` from `AccountProvider`
 - `background_sync_service.dart`: platform abstraction (Android foreground service + iOS MethodChannel)
 
 ## Testing
@@ -202,6 +264,8 @@ Pinned in `rust/Cargo.toml`. Key crates: `zcash_client_backend` 0.21.2, `zcash_c
 `tonic` 0.14 with `tls-ring` + `tls-webpki-roots` features for gRPC TLS. `rustls` 0.23+ requires explicit crypto provider — `tls-ring` provides this.
 
 `log` 0.4 for Rust logging — forwarded to Flutter console via FRB. Level set to `Info` in `init_app()`.
+
+Additional crates for multi-account: `uuid` 1.1, `zip32` 0.2, `jubjub` 0.10, `bls12_381` 0.8, `rand_core` 0.6.
 
 ## Ignored Paths
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -21,6 +21,9 @@ final _routerProvider = Provider<GoRouter>((ref) {
   return GoRouter(
     initialLocation: '/',
     redirect: (context, state) {
+      // Don't redirect on error — let the error screen show instead of onboarding
+      if (walletAsync.hasError) return null;
+
       final wallet = walletAsync.value;
       final hasWallet = wallet?.hasWallet ?? false;
       final isOnboarding = state.matchedLocation == '/welcome' ||
@@ -37,6 +40,7 @@ final _routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/',
         redirect: (_, _) {
+          if (walletAsync.hasError) return '/home'; // home shows error state
           final wallet = walletAsync.value;
           final hasWallet = wallet?.hasWallet ?? false;
           return hasWallet ? '/home' : '/welcome';

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -10,6 +10,7 @@ import 'src/features/onboarding/screens/import_wallet_screen.dart';
 import 'src/features/onboarding/screens/welcome_screen.dart';
 import 'src/features/history/screens/history_screen.dart';
 import 'src/features/receive/screens/receive_screen.dart';
+import 'src/features/accounts/screens/accounts_screen.dart';
 import 'src/features/send/screens/send_screen.dart';
 import 'src/providers/wallet_provider.dart';
 
@@ -68,6 +69,10 @@ final _routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/history',
         builder: (_, _) => const HistoryScreen(),
+      ),
+      GoRoute(
+        path: '/accounts',
+        builder: (_, _) => const AccountsScreen(),
       ),
     ],
   );

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -120,18 +120,17 @@ class AccountsScreen extends ConsumerWidget {
             child: const Text('Cancel'),
           ),
           FilledButton(
-            onPressed: () {
+            onPressed: () async {
               final newName = controller.text.trim();
               if (newName.isNotEmpty) {
-                ref.read(accountProvider.notifier).renameAccount(account.uuid, newName);
+                await ref.read(accountProvider.notifier).renameAccount(account.uuid, newName);
               }
-              Navigator.pop(context);
+              if (context.mounted) Navigator.pop(context);
             },
             child: const Text('Rename'),
           ),
         ],
       ),
-    );
-    controller.dispose;
+    ).then((_) => controller.dispose());
   }
 }

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../providers/account_provider.dart';
+
+class AccountsScreen extends ConsumerWidget {
+  const AccountsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final accountState = ref.watch(accountProvider);
+    final colors = Theme.of(context).colorScheme;
+    final text = Theme.of(context).textTheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Accounts'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () => _showAddAccountSheet(context),
+          ),
+        ],
+      ),
+      body: accountState.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (state) => ListView.builder(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          itemCount: state.accounts.length,
+          itemBuilder: (context, index) {
+            final account = state.accounts[index];
+            final isActive = account.uuid == state.activeAccountUuid;
+
+            return ListTile(
+              leading: CircleAvatar(
+                backgroundColor: isActive
+                    ? colors.primary
+                    : colors.surfaceContainerHigh,
+                child: Text(
+                  account.name.isNotEmpty ? account.name[0].toUpperCase() : '?',
+                  style: TextStyle(
+                    color: isActive ? colors.onPrimary : colors.onSurface,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+              title: Text(
+                account.name,
+                style: text.titleMedium?.copyWith(
+                  fontWeight: isActive ? FontWeight.w700 : FontWeight.w400,
+                ),
+              ),
+              trailing: isActive
+                  ? Icon(Icons.check_circle, color: colors.primary)
+                  : null,
+              onTap: () async {
+                if (!isActive) {
+                  await ref.read(accountProvider.notifier).switchAccount(account.uuid);
+                }
+                if (context.mounted) context.pop();
+              },
+              onLongPress: () => _showRenameDialog(context, ref, account),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  void _showAddAccountSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.add_circle_outline),
+              title: const Text('Create New Wallet'),
+              subtitle: const Text('Generate a new mnemonic'),
+              onTap: () {
+                Navigator.pop(context);
+                context.push('/create');
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.download),
+              title: const Text('Import Wallet'),
+              subtitle: const Text('From existing mnemonic'),
+              onTap: () {
+                Navigator.pop(context);
+                context.push('/import');
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showRenameDialog(BuildContext context, WidgetRef ref, AccountInfo account) {
+    final controller = TextEditingController(text: account.name);
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Rename Account'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            labelText: 'Account Name',
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              final newName = controller.text.trim();
+              if (newName.isNotEmpty) {
+                ref.read(accountProvider.notifier).renameAccount(account.uuid, newName);
+              }
+              Navigator.pop(context);
+            },
+            child: const Text('Rename'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose;
+  }
+}

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../providers/account_provider.dart';
+import '../../../providers/sync_provider.dart';
 
 class AccountsScreen extends ConsumerWidget {
   const AccountsScreen({super.key});
@@ -58,6 +59,7 @@ class AccountsScreen extends ConsumerWidget {
               onTap: () async {
                 if (!isActive) {
                   await ref.read(accountProvider.notifier).switchAccount(account.uuid);
+                  await ref.read(syncProvider.notifier).refreshAfterSend();
                 }
                 if (context.mounted) context.pop();
               },

--- a/lib/src/features/history/screens/history_screen.dart
+++ b/lib/src/features/history/screens/history_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../../../main.dart' show log;
+import '../../../providers/account_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 
 class HistoryScreen extends ConsumerStatefulWidget {
@@ -29,9 +30,11 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     try {
       final dir = await getApplicationDocumentsDirectory();
       final dbPath = '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
+      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid ?? '';
       final txs = await rust_sync.getTransactionHistory(
         dbPath: dbPath,
         network: 'main',
+        accountUuid: accountUuid,
       );
       if (mounted) {
         setState(() {

--- a/lib/src/features/history/screens/history_screen.dart
+++ b/lib/src/features/history/screens/history_screen.dart
@@ -30,7 +30,8 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     try {
       final dir = await getApplicationDocumentsDirectory();
       final dbPath = '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
-      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid ?? '';
+      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+      if (accountUuid == null) return;
       final txs = await rust_sync.getTransactionHistory(
         dbPath: dbPath,
         network: 'main',

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../providers/account_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
@@ -96,24 +97,31 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   Widget _buildTopBar(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
     final text = Theme.of(context).textTheme;
+    final accountState = ref.watch(accountProvider).value;
+    final accountName = accountState?.activeAccount?.name ?? 'Zcash';
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          Row(
-            children: [
-              Icon(Icons.shield, color: colors.onSurface.withValues(alpha: 0.8), size: 22),
-              const SizedBox(width: 8),
-              Text(
-                'Zcash',
-                style: text.titleLarge?.copyWith(
-                  fontWeight: FontWeight.w800,
-                  letterSpacing: -0.5,
+          GestureDetector(
+            onTap: () => context.push('/accounts'),
+            child: Row(
+              children: [
+                Icon(Icons.shield, color: colors.onSurface.withValues(alpha: 0.8), size: 22),
+                const SizedBox(width: 8),
+                Text(
+                  accountName,
+                  style: text.titleLarge?.copyWith(
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: -0.5,
+                  ),
                 ),
-              ),
-            ],
+                const SizedBox(width: 4),
+                Icon(Icons.keyboard_arrow_down, color: colors.onSurfaceVariant, size: 20),
+              ],
+            ),
           ),
           IconButton(
             icon: Icon(Icons.qr_code_scanner, color: colors.onSurface),

--- a/lib/src/features/onboarding/screens/create_wallet_screen.dart
+++ b/lib/src/features/onboarding/screens/create_wallet_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
-import '../../../providers/wallet_provider.dart';
+import '../../../providers/account_provider.dart';
 
 class CreateWalletScreen extends ConsumerStatefulWidget {
   const CreateWalletScreen({super.key});
@@ -28,7 +28,7 @@ class _CreateWalletScreenState extends ConsumerState<CreateWalletScreen> {
   Future<void> _createWallet() async {
     log('CreateScreen._createWallet: starting');
     try {
-      final mnemonic = await ref.read(walletProvider.notifier).createWallet();
+      final mnemonic = await ref.read(accountProvider.notifier).createAccount();
       log('CreateScreen._createWallet: success, got ${mnemonic.split(' ').length} words');
       if (mounted) {
         setState(() {

--- a/lib/src/features/onboarding/screens/import_wallet_screen.dart
+++ b/lib/src/features/onboarding/screens/import_wallet_screen.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../rust/api/wallet.dart' as rust_wallet;
-import '../../../providers/wallet_provider.dart';
+import '../../../providers/account_provider.dart';
 
 class ImportWalletScreen extends ConsumerStatefulWidget {
   const ImportWalletScreen({super.key});
@@ -49,7 +49,7 @@ class _ImportWalletScreenState extends ConsumerState<ImportWalletScreen> {
           birthdayText.isNotEmpty ? int.tryParse(birthdayText) : null;
       log('ImportScreen._import: calling importWallet, birthdayHeight=$birthdayHeight');
 
-      await ref.read(walletProvider.notifier).importWallet(
+      await ref.read(accountProvider.notifier).importAccount(
             mnemonic: _mnemonicController.text.trim(),
             birthdayHeight: birthdayHeight,
           );

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -35,7 +35,11 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
       final dir = await getApplicationDocumentsDirectory();
       final dbPath = '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
       final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
-      if (accountUuid == null) return;
+      if (accountUuid == null) {
+        log('Receive: no active account');
+        setState(() => _isGenerating = false);
+        return;
+      }
       final newAddr = await rust_sync.getNextAvailableAddress(
         dbPath: dbPath,
         network: 'main',

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -34,7 +34,8 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
     try {
       final dir = await getApplicationDocumentsDirectory();
       final dbPath = '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
-      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid ?? '';
+      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+      if (accountUuid == null) return;
       final newAddr = await rust_sync.getNextAvailableAddress(
         dbPath: dbPath,
         network: 'main',

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -7,6 +7,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
 import '../../../../main.dart' show log;
+import '../../../providers/account_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 
@@ -33,9 +34,11 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
     try {
       final dir = await getApplicationDocumentsDirectory();
       final dbPath = '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
+      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid ?? '';
       final newAddr = await rust_sync.getNextAvailableAddress(
         dbPath: dbPath,
         network: 'main',
+        accountUuid: accountUuid,
       );
       log('Receive: new diversified address generated');
       setState(() {

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -96,7 +96,8 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       final dir = await getApplicationDocumentsDirectory();
       final dbPath = '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
       final memo = _memoController.text.trim();
-      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid ?? '';
+      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+      if (accountUuid == null) { setState(() => _amountError = null); return; }
       final fee = await rust_sync.estimateFee(
         dbPath: dbPath,
         network: 'main',
@@ -211,7 +212,11 @@ class _SendScreenState extends ConsumerState<SendScreen> {
 
       // Step 1: Propose transfer
       log('Send: proposing transfer');
-      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid ?? '';
+      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+      if (accountUuid == null) {
+        setState(() { _error = 'No active account'; _isSending = false; });
+        return;
+      }
       final proposal = await rust_sync.proposeSend(
         dbPath: dbPath,
         network: 'main',

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -4,11 +4,11 @@ import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/config/network_config.dart';
+import '../../../providers/account_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../../rust/api/wallet.dart' as rust_wallet;
@@ -96,9 +96,11 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       final dir = await getApplicationDocumentsDirectory();
       final dbPath = '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
       final memo = _memoController.text.trim();
+      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid ?? '';
       final fee = await rust_sync.estimateFee(
         dbPath: dbPath,
         network: 'main',
+        accountUuid: accountUuid,
         toAddress: address,
         amountZatoshi: BigInt.from(zatoshi),
         memo: memo.isNotEmpty ? memo : null,
@@ -209,9 +211,11 @@ class _SendScreenState extends ConsumerState<SendScreen> {
 
       // Step 1: Propose transfer
       log('Send: proposing transfer');
+      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid ?? '';
       final proposal = await rust_sync.proposeSend(
         dbPath: dbPath,
         network: 'main',
+        accountUuid: accountUuid,
         toAddress: address,
         amountZatoshi: BigInt.from(amountZatoshi),
         memo: memo.isNotEmpty ? memo : null,
@@ -273,10 +277,9 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       }
 
       // Step 4: Get seed and execute proposal
-      const storage = FlutterSecureStorage();
-      final mnemonic = await storage.read(key: 'zcash_wallet_mnemonic');
+      final mnemonic = await ref.read(accountProvider.notifier).getActiveMnemonic();
       if (mnemonic == null) {
-        setState(() { _error = 'Mnemonic not found in secure storage'; _isSending = false; });
+        setState(() { _error = 'Mnemonic not found for active account'; _isSending = false; });
         return;
       }
 

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -127,6 +127,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       await _deleteExistingDb(dbPath);
       final result = await rust_wallet.createWallet(
         network: network, dbPath: dbPath, birthdayHeight: birthday,
+        accountName: accountName,
       );
       mnemonic = result.mnemonic;
       accountUuid = result.accountUuid;
@@ -188,6 +189,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         mnemonic: mnemonic,
         birthdayHeight: birthdayHeight != null ? BigInt.from(birthdayHeight) : null,
         network: network, dbPath: dbPath,
+        accountName: accountName,
       );
       accountUuid = result.accountUuid;
       unifiedAddress = result.unifiedAddress;

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -1,0 +1,286 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:path_provider/path_provider.dart';
+
+import '../../main.dart' show log;
+import '../core/config/network_config.dart';
+import '../rust/api/wallet.dart' as rust_wallet;
+
+const _accountsKey = 'zcash_accounts';
+const _activeAccountKey = 'zcash_active_account';
+const _networkKey = 'zcash_wallet_network';
+
+class AccountInfo {
+  final String uuid;
+  final String name;
+  final int order;
+
+  const AccountInfo({required this.uuid, required this.name, required this.order});
+
+  Map<String, dynamic> toJson() => {'uuid': uuid, 'name': name, 'order': order};
+
+  factory AccountInfo.fromJson(Map<String, dynamic> json) => AccountInfo(
+    uuid: json['uuid'] as String,
+    name: json['name'] as String,
+    order: json['order'] as int? ?? 0,
+  );
+}
+
+class AccountState {
+  final List<AccountInfo> accounts;
+  final String? activeAccountUuid;
+  final String? activeAddress;
+
+  const AccountState({
+    this.accounts = const [],
+    this.activeAccountUuid,
+    this.activeAddress,
+  });
+
+  bool get hasAccounts => accounts.isNotEmpty;
+
+  AccountInfo? get activeAccount {
+    if (activeAccountUuid == null) return null;
+    try {
+      return accounts.firstWhere((a) => a.uuid == activeAccountUuid);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  AccountState copyWith({
+    List<AccountInfo>? accounts,
+    String? activeAccountUuid,
+    String? activeAddress,
+  }) => AccountState(
+    accounts: accounts ?? this.accounts,
+    activeAccountUuid: activeAccountUuid ?? this.activeAccountUuid,
+    activeAddress: activeAddress ?? this.activeAddress,
+  );
+}
+
+class AccountNotifier extends AsyncNotifier<AccountState> {
+  static const _storage = FlutterSecureStorage();
+
+  @override
+  Future<AccountState> build() async {
+    log('AccountNotifier.build: starting');
+
+    // Load account list from secure storage
+    final accountsJson = await _storage.read(key: _accountsKey);
+    if (accountsJson == null || accountsJson.isEmpty) {
+      log('AccountNotifier.build: no accounts found');
+      return const AccountState();
+    }
+
+    final List<dynamic> decoded = jsonDecode(accountsJson);
+    final accounts = decoded.map((e) => AccountInfo.fromJson(e as Map<String, dynamic>)).toList();
+    final activeUuid = await _storage.read(key: _activeAccountKey);
+
+    // Resolve active account address
+    String? address;
+    final effectiveUuid = activeUuid ?? (accounts.isNotEmpty ? accounts.first.uuid : null);
+    if (effectiveUuid != null) {
+      try {
+        final dbPath = await _getDbPath();
+        final network = await _getNetwork();
+        address = await rust_wallet.getUnifiedAddress(
+          dbPath: dbPath, network: network, accountUuid: effectiveUuid,
+        );
+        log('AccountNotifier.build: active=$effectiveUuid, address=${address.substring(0, 20)}...');
+      } catch (e) {
+        log('AccountNotifier.build: failed to get address: $e');
+      }
+    }
+
+    return AccountState(
+      accounts: accounts,
+      activeAccountUuid: effectiveUuid,
+      activeAddress: address,
+    );
+  }
+
+  /// Create a new wallet with a fresh mnemonic. Returns the mnemonic.
+  Future<String> createAccount({String? name}) async {
+    final dbPath = await _getDbPath();
+    final network = await _getNetwork();
+    final networkConfig = network == 'main' ? ZcashNetwork.mainnet : ZcashNetwork.testnet;
+
+    // Fetch chain tip as birthday
+    final birthday = await rust_wallet.getLatestBlockHeight(
+      lightwalletdUrl: networkConfig.lightwalletdUrl,
+    );
+    log('createAccount: birthday=$birthday');
+
+    final accounts = state.value?.accounts ?? [];
+    final accountName = name ?? 'Account ${accounts.length + 1}';
+
+    String mnemonic;
+    String accountUuid;
+    String unifiedAddress;
+
+    if (accounts.isEmpty) {
+      // First account — create wallet (init DB + create account)
+      await _deleteExistingDb(dbPath);
+      final result = await rust_wallet.createWallet(
+        network: network, dbPath: dbPath, birthdayHeight: birthday,
+      );
+      mnemonic = result.mnemonic;
+      accountUuid = result.accountUuid;
+      unifiedAddress = result.unifiedAddress;
+      await _storage.write(key: _networkKey, value: network);
+    } else {
+      // Additional account — generate mnemonic + add to existing DB
+      mnemonic = rust_wallet.generateMnemonic();
+      final result = await rust_wallet.addAccount(
+        dbPath: dbPath, network: network, name: accountName,
+        mnemonic: mnemonic, birthdayHeight: birthday,
+      );
+      accountUuid = result.accountUuid;
+      unifiedAddress = result.unifiedAddress;
+    }
+
+    // Store mnemonic per-account
+    await _storage.write(key: 'zcash_account_mnemonic_$accountUuid', value: mnemonic);
+
+    // Update account list
+    final newAccount = AccountInfo(uuid: accountUuid, name: accountName, order: accounts.length);
+    final updatedAccounts = [...accounts, newAccount];
+    await _saveAccounts(updatedAccounts);
+    await _storage.write(key: _activeAccountKey, value: accountUuid);
+
+    state = AsyncData(AccountState(
+      accounts: updatedAccounts,
+      activeAccountUuid: accountUuid,
+      activeAddress: unifiedAddress,
+    ));
+
+    log('createAccount: success, uuid=$accountUuid');
+    return mnemonic;
+  }
+
+  /// Import a wallet from mnemonic.
+  Future<void> importAccount({
+    required String mnemonic,
+    int? birthdayHeight,
+    String? name,
+  }) async {
+    final dbPath = await _getDbPath();
+    final network = await _getNetwork();
+    final accounts = state.value?.accounts ?? [];
+    final accountName = name ?? 'Account ${accounts.length + 1}';
+
+    String accountUuid;
+    String unifiedAddress;
+
+    if (accounts.isEmpty) {
+      // First account — import wallet (init DB + import)
+      await _deleteExistingDb(dbPath);
+      final result = await rust_wallet.importWallet(
+        mnemonic: mnemonic,
+        birthdayHeight: birthdayHeight != null ? BigInt.from(birthdayHeight) : null,
+        network: network, dbPath: dbPath,
+      );
+      accountUuid = result.accountUuid;
+      unifiedAddress = result.unifiedAddress;
+      await _storage.write(key: _networkKey, value: network);
+    } else {
+      // Additional account
+      final result = await rust_wallet.addAccount(
+        dbPath: dbPath, network: network, name: accountName,
+        mnemonic: mnemonic,
+        birthdayHeight: birthdayHeight != null ? BigInt.from(birthdayHeight) : null,
+      );
+      accountUuid = result.accountUuid;
+      unifiedAddress = result.unifiedAddress;
+    }
+
+    await _storage.write(key: 'zcash_account_mnemonic_$accountUuid', value: mnemonic);
+
+    final newAccount = AccountInfo(uuid: accountUuid, name: accountName, order: accounts.length);
+    final updatedAccounts = [...accounts, newAccount];
+    await _saveAccounts(updatedAccounts);
+    await _storage.write(key: _activeAccountKey, value: accountUuid);
+
+    state = AsyncData(AccountState(
+      accounts: updatedAccounts,
+      activeAccountUuid: accountUuid,
+      activeAddress: unifiedAddress,
+    ));
+
+    log('importAccount: success, uuid=$accountUuid');
+  }
+
+  /// Switch active account.
+  Future<void> switchAccount(String uuid) async {
+    await _storage.write(key: _activeAccountKey, value: uuid);
+
+    String? address;
+    try {
+      final dbPath = await _getDbPath();
+      final network = await _getNetwork();
+      address = await rust_wallet.getUnifiedAddress(
+        dbPath: dbPath, network: network, accountUuid: uuid,
+      );
+    } catch (e) {
+      log('switchAccount: failed to get address: $e');
+    }
+
+    final prev = state.value ?? const AccountState();
+    state = AsyncData(prev.copyWith(
+      activeAccountUuid: uuid,
+      activeAddress: address,
+    ));
+
+    log('switchAccount: switched to $uuid');
+  }
+
+  /// Rename an account.
+  Future<void> renameAccount(String uuid, String newName) async {
+    final prev = state.value ?? const AccountState();
+    final updated = prev.accounts.map((a) =>
+      a.uuid == uuid ? AccountInfo(uuid: a.uuid, name: newName, order: a.order) : a
+    ).toList();
+    await _saveAccounts(updated);
+    state = AsyncData(prev.copyWith(accounts: updated));
+    log('renameAccount: $uuid → $newName');
+  }
+
+  /// Get the mnemonic for the active account.
+  Future<String?> getActiveMnemonic() async {
+    final uuid = state.value?.activeAccountUuid;
+    if (uuid == null) return null;
+    return _storage.read(key: 'zcash_account_mnemonic_$uuid');
+  }
+
+  // ======================== Helpers ========================
+
+  Future<void> _saveAccounts(List<AccountInfo> accounts) async {
+    final json = jsonEncode(accounts.map((a) => a.toJson()).toList());
+    await _storage.write(key: _accountsKey, value: json);
+  }
+
+  Future<String> _getDbPath() async {
+    final dir = await getApplicationDocumentsDirectory();
+    return '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
+  }
+
+  Future<String> _getNetwork() async {
+    return await _storage.read(key: _networkKey) ?? 'main';
+  }
+
+  Future<void> _deleteExistingDb(String dbPath) async {
+    final file = File(dbPath);
+    if (file.existsSync()) file.deleteSync();
+    for (final suffix in ['-journal', '-wal', '-shm']) {
+      final f = File('$dbPath$suffix');
+      if (f.existsSync()) f.deleteSync();
+    }
+  }
+}
+
+final accountProvider =
+    AsyncNotifierProvider<AccountNotifier, AccountState>(AccountNotifier.new);

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -44,11 +44,10 @@ class AccountState {
 
   AccountInfo? get activeAccount {
     if (activeAccountUuid == null) return null;
-    try {
-      return accounts.firstWhere((a) => a.uuid == activeAccountUuid);
-    } catch (_) {
-      return null;
+    for (final a in accounts) {
+      if (a.uuid == activeAccountUuid) return a;
     }
+    return null;
   }
 
   AccountState copyWith({
@@ -105,6 +104,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
 
   /// Create a new wallet with a fresh mnemonic. Returns the mnemonic.
   Future<String> createAccount({String? name}) async {
+    try {
     final dbPath = await _getDbPath();
     final network = await _getNetwork();
     final networkConfig = network == 'main' ? ZcashNetwork.mainnet : ZcashNetwork.testnet;
@@ -160,6 +160,10 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
 
     log('createAccount: success, uuid=$accountUuid');
     return mnemonic;
+    } catch (e, st) {
+      log('createAccount: ERROR: $e\n$st');
+      rethrow;
+    }
   }
 
   /// Import a wallet from mnemonic.
@@ -168,6 +172,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     int? birthdayHeight,
     String? name,
   }) async {
+    try {
     final dbPath = await _getDbPath();
     final network = await _getNetwork();
     final accounts = state.value?.accounts ?? [];
@@ -212,6 +217,10 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     ));
 
     log('importAccount: success, uuid=$accountUuid');
+    } catch (e, st) {
+      log('importAccount: ERROR: $e\n$st');
+      rethrow;
+    }
   }
 
   /// Switch active account.

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -10,6 +10,7 @@ import 'package:path_provider/path_provider.dart';
 import '../../main.dart' show log;
 import '../core/config/network_config.dart';
 import '../rust/api/sync.dart' as rust_sync;
+import 'account_provider.dart';
 import '../services/background_sync_service.dart' as bg_sync;
 
 const _progressChannel = EventChannel('com.zcash.wallet/sync_progress');
@@ -274,10 +275,12 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     final prev = state.value;
     final dbPath = await _getDbPath();
     final network = ZcashNetwork.mainnet.name;
+    final accountUuid = _getActiveAccountUuid();
+    if (accountUuid == null) return;
 
     BigInt? transparent, sapling, orchard, total;
     try {
-      final balance = await rust_sync.getBalance(dbPath: dbPath, network: network);
+      final balance = await rust_sync.getBalance(dbPath: dbPath, network: network, accountUuid: accountUuid);
       transparent = balance.transparent;
       sapling = balance.sapling;
       orchard = balance.orchard;
@@ -289,7 +292,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     var recentTxs = prev?.recentTransactions ?? const <rust_sync.TransactionInfo>[];
     if (hasNewTx || isComplete) {
       try {
-        recentTxs = await rust_sync.getTransactionHistory(dbPath: dbPath, network: network, limit: 10);
+        recentTxs = await rust_sync.getTransactionHistory(dbPath: dbPath, network: network, limit: 10, accountUuid: accountUuid);
       } catch (e) {
         log('SyncNotifier: tx history fetch failed: $e');
       }
@@ -327,10 +330,12 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     final prev = state.value;
     final dbPath = await _getDbPath();
     final network = ZcashNetwork.mainnet.name;
+    final accountUuid = _getActiveAccountUuid();
+    if (accountUuid == null) return;
 
     BigInt? transparent, sapling, orchard, total;
     try {
-      final balance = await rust_sync.getBalance(dbPath: dbPath, network: network);
+      final balance = await rust_sync.getBalance(dbPath: dbPath, network: network, accountUuid: accountUuid);
       transparent = balance.transparent;
       sapling = balance.sapling;
       orchard = balance.orchard;
@@ -341,7 +346,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
     var recentTxs = prev?.recentTransactions ?? const <rust_sync.TransactionInfo>[];
     try {
-      recentTxs = await rust_sync.getTransactionHistory(dbPath: dbPath, network: network, limit: 10);
+      recentTxs = await rust_sync.getTransactionHistory(dbPath: dbPath, network: network, limit: 10, accountUuid: accountUuid);
     } catch (e) {
       log('SyncNotifier: tx history refresh failed: $e');
     }
@@ -358,6 +363,10 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       totalBalance: total ?? prev?.totalBalance,
       recentTransactions: recentTxs,
     ));
+  }
+
+  String? _getActiveAccountUuid() {
+    return ref.read(accountProvider).value?.activeAccountUuid;
   }
 
   Future<String> _getDbPath() async {

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -276,7 +276,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     final dbPath = await _getDbPath();
     final network = ZcashNetwork.mainnet.name;
     final accountUuid = _getActiveAccountUuid();
-    if (accountUuid == null) return;
+    if (accountUuid == null) { log('SyncNotifier: no active account, skipping refresh'); return; }
 
     BigInt? transparent, sapling, orchard, total;
     try {
@@ -331,7 +331,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     final dbPath = await _getDbPath();
     final network = ZcashNetwork.mainnet.name;
     final accountUuid = _getActiveAccountUuid();
-    if (accountUuid == null) return;
+    if (accountUuid == null) { log('SyncNotifier: no active account, skipping refresh'); return; }
 
     BigInt? transparent, sapling, orchard, total;
     try {

--- a/lib/src/providers/wallet_provider.dart
+++ b/lib/src/providers/wallet_provider.dart
@@ -1,166 +1,42 @@
-import 'dart:io';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:path_provider/path_provider.dart';
 
 import '../../main.dart' show log;
-import '../core/config/network_config.dart';
-import '../rust/api/wallet.dart' as rust_wallet;
-
-const _mnemonicKey = 'zcash_wallet_mnemonic';
-const _networkKey = 'zcash_wallet_network';
+import 'account_provider.dart';
 
 class WalletState {
   final bool hasWallet;
   final String? unifiedAddress;
   final String? network;
+  final String? activeAccountUuid;
 
   const WalletState({
     this.hasWallet = false,
     this.unifiedAddress,
     this.network,
+    this.activeAccountUuid,
   });
-
-  WalletState copyWith({
-    bool? hasWallet,
-    String? unifiedAddress,
-    String? network,
-  }) =>
-      WalletState(
-        hasWallet: hasWallet ?? this.hasWallet,
-        unifiedAddress: unifiedAddress ?? this.unifiedAddress,
-        network: network ?? this.network,
-      );
 }
 
 class WalletNotifier extends AsyncNotifier<WalletState> {
-  static const _storage = FlutterSecureStorage();
-
   @override
   Future<WalletState> build() async {
-    log('WalletNotifier.build: starting');
-    final dbPath = await _getDbPath();
-    log('WalletNotifier.build: dbPath=$dbPath');
-    final exists = rust_wallet.walletExists(dbPath: dbPath);
-    log('WalletNotifier.build: walletExists=$exists');
-    if (!exists) {
-      log('WalletNotifier.build: no wallet found, returning empty state');
-      return const WalletState();
-    }
+    final accountState = ref.watch(accountProvider);
 
-    final network = await _storage.read(key: _networkKey) ?? 'main';
-    log('WalletNotifier.build: network=$network');
-    try {
-      final address = await rust_wallet.getUnifiedAddress(
-        dbPath: dbPath,
-        network: network,
-      );
-      log('WalletNotifier.build: address=${address.substring(0, 20)}...');
-      return WalletState(
-        hasWallet: true,
-        unifiedAddress: address,
-        network: network,
-      );
-    } catch (e) {
-      log('WalletNotifier.build: ERROR getting address: $e');
-      return const WalletState();
-    }
-  }
-
-  /// Create a new wallet. Returns the mnemonic that must be shown to the user.
-  Future<String> createWallet({String network = 'main'}) async {
-    log('createWallet: starting, network=$network');
-    final dbPath = await _getDbPath();
-    log('createWallet: dbPath=$dbPath');
-    try {
-      // Fetch chain tip as birthday so new wallets don't full-scan
-      final networkConfig = network == 'main' ? ZcashNetwork.mainnet : ZcashNetwork.testnet;
-      final birthday = await rust_wallet.getLatestBlockHeight(
-        lightwalletdUrl: networkConfig.lightwalletdUrl,
-      );
-      log('createWallet: birthday=$birthday');
-
-      // Delete existing DB only after birthday fetch succeeds
-      await _deleteExistingDb(dbPath);
-
-      final result = await rust_wallet.createWallet(
-        network: network,
-        dbPath: dbPath,
-        birthdayHeight: birthday,
-      );
-      log('createWallet: success, address=${result.unifiedAddress.substring(0, 20)}...');
-
-      await _storage.write(key: _mnemonicKey, value: result.mnemonic);
-      await _storage.write(key: _networkKey, value: network);
-      log('createWallet: mnemonic and network saved to secure storage');
-
-      state = AsyncData(WalletState(
-        hasWallet: true,
-        unifiedAddress: result.unifiedAddress,
-        network: network,
-      ));
-
-      return result.mnemonic;
-    } catch (e, st) {
-      log('createWallet: ERROR: $e\n$st');
-      rethrow;
-    }
-  }
-
-  /// Import a wallet from an existing mnemonic.
-  Future<void> importWallet({
-    required String mnemonic,
-    int? birthdayHeight,
-    String network = 'main',
-  }) async {
-    log('importWallet: starting, network=$network, birthdayHeight=$birthdayHeight');
-    log('importWallet: mnemonic word count=${mnemonic.trim().split(' ').length}');
-    final dbPath = await _getDbPath();
-    log('importWallet: dbPath=$dbPath');
-    await _deleteExistingDb(dbPath);
-    try {
-      final result = await rust_wallet.importWallet(
-        mnemonic: mnemonic,
-        birthdayHeight:
-            birthdayHeight != null ? BigInt.from(birthdayHeight) : null,
-        network: network,
-        dbPath: dbPath,
-      );
-      log('importWallet: success, address=${result.unifiedAddress.substring(0, 20)}...');
-
-      await _storage.write(key: _mnemonicKey, value: mnemonic);
-      await _storage.write(key: _networkKey, value: network);
-      log('importWallet: saved to secure storage');
-
-      state = AsyncData(WalletState(
-        hasWallet: true,
-        unifiedAddress: result.unifiedAddress,
-        network: network,
-      ));
-      log('importWallet: state updated');
-    } catch (e, st) {
-      log('importWallet: ERROR: $e\n$st');
-      rethrow;
-    }
-  }
-
-  Future<String> _getDbPath() async {
-    final dir = await getApplicationDocumentsDirectory();
-    return '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
-  }
-
-  Future<void> _deleteExistingDb(String dbPath) async {
-    final file = File(dbPath);
-    if (file.existsSync()) {
-      log('_deleteExistingDb: removing existing DB at $dbPath');
-      file.deleteSync();
-    }
-    // Also remove SQLite journal/wal files
-    for (final suffix in ['-journal', '-wal', '-shm']) {
-      final f = File('$dbPath$suffix');
-      if (f.existsSync()) f.deleteSync();
-    }
+    return accountState.when(
+      data: (state) {
+        if (!state.hasAccounts) return const WalletState();
+        return WalletState(
+          hasWallet: true,
+          unifiedAddress: state.activeAddress,
+          activeAccountUuid: state.activeAccountUuid,
+        );
+      },
+      loading: () => const WalletState(),
+      error: (e, _) {
+        log('WalletNotifier: error from accountProvider: $e');
+        return const WalletState();
+      },
+    );
   }
 }
 

--- a/lib/src/providers/wallet_provider.dart
+++ b/lib/src/providers/wallet_provider.dart
@@ -32,9 +32,9 @@ class WalletNotifier extends AsyncNotifier<WalletState> {
         );
       },
       loading: () => const WalletState(),
-      error: (e, _) {
+      error: (e, st) {
         log('WalletNotifier: error from accountProvider: $e');
-        return const WalletState();
+        Error.throwWithStackTrace(e, st);
       },
     );
   }

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -123,9 +123,11 @@ Future<SyncProgress> getSyncStatus({
 Future<WalletBalance> getBalance({
   required String dbPath,
   required String network,
+  required String accountUuid,
 }) => RustLib.instance.api.crateApiSyncGetBalance(
   dbPath: dbPath,
   network: network,
+  accountUuid: accountUuid,
 );
 
 Future<BigInt> rewindToHeight({
@@ -145,12 +147,14 @@ Future<AddressValidationResult> validateAddress({required String address}) =>
 Future<ProposalResult> proposeSend({
   required String dbPath,
   required String network,
+  required String accountUuid,
   required String toAddress,
   required BigInt amountZatoshi,
   String? memo,
 }) => RustLib.instance.api.crateApiSyncProposeSend(
   dbPath: dbPath,
   network: network,
+  accountUuid: accountUuid,
   toAddress: toAddress,
   amountZatoshi: amountZatoshi,
   memo: memo,
@@ -160,12 +164,14 @@ Future<ProposalResult> proposeSend({
 Future<BigInt> estimateFee({
   required String dbPath,
   required String network,
+  required String accountUuid,
   required String toAddress,
   required BigInt amountZatoshi,
   String? memo,
 }) => RustLib.instance.api.crateApiSyncEstimateFee(
   dbPath: dbPath,
   network: network,
+  accountUuid: accountUuid,
   toAddress: toAddress,
   amountZatoshi: amountZatoshi,
   memo: memo,
@@ -192,9 +198,11 @@ Future<String> executeProposal({
 Future<String> getNextAvailableAddress({
   required String dbPath,
   required String network,
+  required String accountUuid,
 }) => RustLib.instance.api.crateApiSyncGetNextAvailableAddress(
   dbPath: dbPath,
   network: network,
+  accountUuid: accountUuid,
 );
 
 Future<List<TxDataRequest>> getTransactionDataRequests({
@@ -233,10 +241,12 @@ Future<List<TransactionInfo>> getTransactionHistory({
   required String dbPath,
   required String network,
   int? limit,
+  required String accountUuid,
 }) => RustLib.instance.api.crateApiSyncGetTransactionHistory(
   dbPath: dbPath,
   network: network,
   limit: limit,
+  accountUuid: accountUuid,
 );
 
 String getBlocksDir({required String cachePath}) =>

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -20,10 +20,12 @@ Future<WalletCreationResult> createWallet({
   required String network,
   required String dbPath,
   BigInt? birthdayHeight,
+  String? accountName,
 }) => RustLib.instance.api.crateApiWalletCreateWallet(
   network: network,
   dbPath: dbPath,
   birthdayHeight: birthdayHeight,
+  accountName: accountName,
 );
 
 /// Import an existing wallet from a mnemonic phrase.
@@ -32,11 +34,13 @@ Future<WalletImportResult> importWallet({
   BigInt? birthdayHeight,
   required String network,
   required String dbPath,
+  String? accountName,
 }) => RustLib.instance.api.crateApiWalletImportWallet(
   mnemonic: mnemonic,
   birthdayHeight: birthdayHeight,
   network: network,
   dbPath: dbPath,
+  accountName: accountName,
 );
 
 /// Add an additional account to an existing wallet database.

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -39,13 +39,39 @@ Future<WalletImportResult> importWallet({
   dbPath: dbPath,
 );
 
-/// Get the Unified Address for the wallet.
+/// Add an additional account to an existing wallet database.
+Future<AccountCreationResult> addAccount({
+  required String dbPath,
+  required String network,
+  required String name,
+  required String mnemonic,
+  BigInt? birthdayHeight,
+}) => RustLib.instance.api.crateApiWalletAddAccount(
+  dbPath: dbPath,
+  network: network,
+  name: name,
+  mnemonic: mnemonic,
+  birthdayHeight: birthdayHeight,
+);
+
+/// List all accounts in the wallet database.
+Future<List<AccountInfo>> listAccounts({
+  required String dbPath,
+  required String network,
+}) => RustLib.instance.api.crateApiWalletListAccounts(
+  dbPath: dbPath,
+  network: network,
+);
+
+/// Get the Unified Address for a specific account (or first account if uuid is None).
 Future<String> getUnifiedAddress({
   required String dbPath,
   required String network,
+  String? accountUuid,
 }) => RustLib.instance.api.crateApiWalletGetUnifiedAddress(
   dbPath: dbPath,
   network: network,
+  accountUuid: accountUuid,
 );
 
 /// Check if a wallet database exists at the given path.
@@ -61,27 +87,79 @@ bool validateMnemonic({required String mnemonic}) =>
 Future<Uint8List> deriveSeed({required String mnemonic}) =>
     RustLib.instance.api.crateApiWalletDeriveSeed(mnemonic: mnemonic);
 
-/// Get the transparent address for the wallet (separate from the shielded UA).
+/// Get the transparent address for a specific account (or first account if uuid is None).
 Future<String> getTransparentAddress({
   required String dbPath,
   required String network,
+  String? accountUuid,
 }) => RustLib.instance.api.crateApiWalletGetTransparentAddress(
   dbPath: dbPath,
   network: network,
+  accountUuid: accountUuid,
 );
 
-/// Result of wallet creation, containing the mnemonic and unified address.
-class WalletCreationResult {
-  final String mnemonic;
+/// Result of adding an account to an existing wallet.
+class AccountCreationResult {
+  final String accountUuid;
   final String unifiedAddress;
 
-  const WalletCreationResult({
-    required this.mnemonic,
+  const AccountCreationResult({
+    required this.accountUuid,
     required this.unifiedAddress,
   });
 
   @override
-  int get hashCode => mnemonic.hashCode ^ unifiedAddress.hashCode;
+  int get hashCode => accountUuid.hashCode ^ unifiedAddress.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AccountCreationResult &&
+          runtimeType == other.runtimeType &&
+          accountUuid == other.accountUuid &&
+          unifiedAddress == other.unifiedAddress;
+}
+
+/// Account info returned by list_accounts.
+class AccountInfo {
+  final String uuid;
+  final String name;
+  final String unifiedAddress;
+
+  const AccountInfo({
+    required this.uuid,
+    required this.name,
+    required this.unifiedAddress,
+  });
+
+  @override
+  int get hashCode => uuid.hashCode ^ name.hashCode ^ unifiedAddress.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AccountInfo &&
+          runtimeType == other.runtimeType &&
+          uuid == other.uuid &&
+          name == other.name &&
+          unifiedAddress == other.unifiedAddress;
+}
+
+/// Result of wallet creation, containing the mnemonic, unified address, and account UUID.
+class WalletCreationResult {
+  final String mnemonic;
+  final String unifiedAddress;
+  final String accountUuid;
+
+  const WalletCreationResult({
+    required this.mnemonic,
+    required this.unifiedAddress,
+    required this.accountUuid,
+  });
+
+  @override
+  int get hashCode =>
+      mnemonic.hashCode ^ unifiedAddress.hashCode ^ accountUuid.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -89,22 +167,28 @@ class WalletCreationResult {
       other is WalletCreationResult &&
           runtimeType == other.runtimeType &&
           mnemonic == other.mnemonic &&
-          unifiedAddress == other.unifiedAddress;
+          unifiedAddress == other.unifiedAddress &&
+          accountUuid == other.accountUuid;
 }
 
-/// Result of wallet import, containing the unified address.
+/// Result of wallet import, containing the unified address and account UUID.
 class WalletImportResult {
   final String unifiedAddress;
+  final String accountUuid;
 
-  const WalletImportResult({required this.unifiedAddress});
+  const WalletImportResult({
+    required this.unifiedAddress,
+    required this.accountUuid,
+  });
 
   @override
-  int get hashCode => unifiedAddress.hashCode;
+  int get hashCode => unifiedAddress.hashCode ^ accountUuid.hashCode;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is WalletImportResult &&
           runtimeType == other.runtimeType &&
-          unifiedAddress == other.unifiedAddress;
+          unifiedAddress == other.unifiedAddress &&
+          accountUuid == other.accountUuid;
 }

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -74,6 +74,10 @@ Future<String> getUnifiedAddress({
   accountUuid: accountUuid,
 );
 
+/// Generate a new 24-word BIP-39 mnemonic phrase.
+String generateMnemonic() =>
+    RustLib.instance.api.crateApiWalletGenerateMnemonic();
+
 /// Check if a wallet database exists at the given path.
 bool walletExists({required String dbPath}) =>
     RustLib.instance.api.crateApiWalletWalletExists(dbPath: dbPath);

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -107,6 +107,7 @@ abstract class RustLibApi extends BaseApi {
   Future<BigInt> crateApiSyncEstimateFee({
     required String dbPath,
     required String network,
+    required String accountUuid,
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
@@ -124,6 +125,7 @@ abstract class RustLibApi extends BaseApi {
   Future<WalletBalance> crateApiSyncGetBalance({
     required String dbPath,
     required String network,
+    required String accountUuid,
   });
 
   String crateApiSyncGetBlocksDir({required String cachePath});
@@ -135,6 +137,7 @@ abstract class RustLibApi extends BaseApi {
   Future<String> crateApiSyncGetNextAvailableAddress({
     required String dbPath,
     required String network,
+    required String accountUuid,
   });
 
   Future<SubtreeIndices> crateApiSyncGetNextSubtreeIndices({
@@ -158,6 +161,7 @@ abstract class RustLibApi extends BaseApi {
     required String dbPath,
     required String network,
     int? limit,
+    required String accountUuid,
   });
 
   Future<String> crateApiWalletGetTransparentAddress({
@@ -193,6 +197,7 @@ abstract class RustLibApi extends BaseApi {
   Future<ProposalResult> crateApiSyncProposeSend({
     required String dbPath,
     required String network,
+    required String accountUuid,
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
@@ -445,6 +450,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<BigInt> crateApiSyncEstimateFee({
     required String dbPath,
     required String network,
+    required String accountUuid,
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
@@ -455,6 +461,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
           sse_encode_String(toAddress, serializer);
           sse_encode_u_64(amountZatoshi, serializer);
           sse_encode_opt_String(memo, serializer);
@@ -470,7 +477,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncEstimateFeeConstMeta,
-        argValues: [dbPath, network, toAddress, amountZatoshi, memo],
+        argValues: [
+          dbPath,
+          network,
+          accountUuid,
+          toAddress,
+          amountZatoshi,
+          memo,
+        ],
         apiImpl: this,
       ),
     );
@@ -478,7 +492,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiSyncEstimateFeeConstMeta => const TaskConstMeta(
     debugName: "estimate_fee",
-    argNames: ["dbPath", "network", "toAddress", "amountZatoshi", "memo"],
+    argNames: [
+      "dbPath",
+      "network",
+      "accountUuid",
+      "toAddress",
+      "amountZatoshi",
+      "memo",
+    ],
   );
 
   @override
@@ -542,6 +563,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<WalletBalance> crateApiSyncGetBalance({
     required String dbPath,
     required String network,
+    required String accountUuid,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -549,6 +571,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -561,7 +584,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncGetBalanceConstMeta,
-        argValues: [dbPath, network],
+        argValues: [dbPath, network, accountUuid],
         apiImpl: this,
       ),
     );
@@ -569,7 +592,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiSyncGetBalanceConstMeta => const TaskConstMeta(
     debugName: "get_balance",
-    argNames: ["dbPath", "network"],
+    argNames: ["dbPath", "network", "accountUuid"],
   );
 
   @override
@@ -632,6 +655,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<String> crateApiSyncGetNextAvailableAddress({
     required String dbPath,
     required String network,
+    required String accountUuid,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -639,6 +663,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -651,7 +676,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncGetNextAvailableAddressConstMeta,
-        argValues: [dbPath, network],
+        argValues: [dbPath, network, accountUuid],
         apiImpl: this,
       ),
     );
@@ -660,7 +685,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiSyncGetNextAvailableAddressConstMeta =>
       const TaskConstMeta(
         debugName: "get_next_available_address",
-        argNames: ["dbPath", "network"],
+        argNames: ["dbPath", "network", "accountUuid"],
       );
 
   @override
@@ -794,6 +819,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String dbPath,
     required String network,
     int? limit,
+    required String accountUuid,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -802,6 +828,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(dbPath, serializer);
           sse_encode_String(network, serializer);
           sse_encode_opt_box_autoadd_u_32(limit, serializer);
+          sse_encode_String(accountUuid, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -814,7 +841,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncGetTransactionHistoryConstMeta,
-        argValues: [dbPath, network, limit],
+        argValues: [dbPath, network, limit, accountUuid],
         apiImpl: this,
       ),
     );
@@ -823,7 +850,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiSyncGetTransactionHistoryConstMeta =>
       const TaskConstMeta(
         debugName: "get_transaction_history",
-        argNames: ["dbPath", "network", "limit"],
+        argNames: ["dbPath", "network", "limit", "accountUuid"],
       );
 
   @override
@@ -1048,6 +1075,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<ProposalResult> crateApiSyncProposeSend({
     required String dbPath,
     required String network,
+    required String accountUuid,
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
@@ -1058,6 +1086,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
           sse_encode_String(toAddress, serializer);
           sse_encode_u_64(amountZatoshi, serializer);
           sse_encode_opt_String(memo, serializer);
@@ -1073,7 +1102,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncProposeSendConstMeta,
-        argValues: [dbPath, network, toAddress, amountZatoshi, memo],
+        argValues: [
+          dbPath,
+          network,
+          accountUuid,
+          toAddress,
+          amountZatoshi,
+          memo,
+        ],
         apiImpl: this,
       ),
     );
@@ -1081,7 +1117,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiSyncProposeSendConstMeta => const TaskConstMeta(
     debugName: "propose_send",
-    argNames: ["dbPath", "network", "toAddress", "amountZatoshi", "memo"],
+    argNames: [
+      "dbPath",
+      "network",
+      "accountUuid",
+      "toAddress",
+      "amountZatoshi",
+      "memo",
+    ],
   );
 
   @override

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -68,7 +68,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -2017955125;
+  int get rustContentHash => 1789710638;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -79,6 +79,14 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
 }
 
 abstract class RustLibApi extends BaseApi {
+  Future<AccountCreationResult> crateApiWalletAddAccount({
+    required String dbPath,
+    required String network,
+    required String name,
+    required String mnemonic,
+    BigInt? birthdayHeight,
+  });
+
   void crateApiSyncCancelFullSync();
 
   Future<WalletCreationResult> crateApiWalletCreateWallet({
@@ -155,11 +163,13 @@ abstract class RustLibApi extends BaseApi {
   Future<String> crateApiWalletGetTransparentAddress({
     required String dbPath,
     required String network,
+    String? accountUuid,
   });
 
   Future<String> crateApiWalletGetUnifiedAddress({
     required String dbPath,
     required String network,
+    String? accountUuid,
   });
 
   String crateApiSimpleGreet({required String name});
@@ -174,6 +184,11 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiSimpleInitApp();
 
   bool crateApiSyncIsSyncRunning();
+
+  Future<List<AccountInfo>> crateApiWalletListAccounts({
+    required String dbPath,
+    required String network,
+  });
 
   Future<ProposalResult> crateApiSyncProposeSend({
     required String dbPath,
@@ -262,12 +277,52 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   });
 
   @override
+  Future<AccountCreationResult> crateApiWalletAddAccount({
+    required String dbPath,
+    required String network,
+    required String name,
+    required String mnemonic,
+    BigInt? birthdayHeight,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(name, serializer);
+          sse_encode_String(mnemonic, serializer);
+          sse_encode_opt_box_autoadd_u_64(birthdayHeight, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 1,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_account_creation_result,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletAddAccountConstMeta,
+        argValues: [dbPath, network, name, mnemonic, birthdayHeight],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletAddAccountConstMeta => const TaskConstMeta(
+    debugName: "add_account",
+    argNames: ["dbPath", "network", "name", "mnemonic", "birthdayHeight"],
+  );
+
+  @override
   void crateApiSyncCancelFullSync() {
     return handler.executeSync(
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 1)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 2)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -299,7 +354,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 2,
+            funcId: 3,
             port: port_,
           );
         },
@@ -337,7 +392,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 3,
+            funcId: 4,
             port: port_,
           );
         },
@@ -368,7 +423,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 4,
+            funcId: 5,
             port: port_,
           );
         },
@@ -406,7 +461,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 6,
             port: port_,
           );
         },
@@ -448,7 +503,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 7,
             port: port_,
           );
         },
@@ -497,7 +552,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 8,
             port: port_,
           );
         },
@@ -524,7 +579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cachePath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -552,7 +607,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 10,
             port: port_,
           );
         },
@@ -587,7 +642,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 11,
             port: port_,
           );
         },
@@ -622,7 +677,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 12,
             port: port_,
           );
         },
@@ -649,7 +704,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 12)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -679,7 +734,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 14,
             port: port_,
           );
         },
@@ -713,7 +768,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -750,7 +805,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 16,
             port: port_,
           );
         },
@@ -775,6 +830,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<String> crateApiWalletGetTransparentAddress({
     required String dbPath,
     required String network,
+    String? accountUuid,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -782,41 +838,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(network, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 16,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_String,
-          decodeErrorData: sse_decode_String,
-        ),
-        constMeta: kCrateApiWalletGetTransparentAddressConstMeta,
-        argValues: [dbPath, network],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiWalletGetTransparentAddressConstMeta =>
-      const TaskConstMeta(
-        debugName: "get_transparent_address",
-        argNames: ["dbPath", "network"],
-      );
-
-  @override
-  Future<String> crateApiWalletGetUnifiedAddress({
-    required String dbPath,
-    required String network,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(dbPath, serializer);
-          sse_encode_String(network, serializer);
+          sse_encode_opt_String(accountUuid, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -828,8 +850,45 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeSuccessData: sse_decode_String,
           decodeErrorData: sse_decode_String,
         ),
+        constMeta: kCrateApiWalletGetTransparentAddressConstMeta,
+        argValues: [dbPath, network, accountUuid],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletGetTransparentAddressConstMeta =>
+      const TaskConstMeta(
+        debugName: "get_transparent_address",
+        argNames: ["dbPath", "network", "accountUuid"],
+      );
+
+  @override
+  Future<String> crateApiWalletGetUnifiedAddress({
+    required String dbPath,
+    required String network,
+    String? accountUuid,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_opt_String(accountUuid, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 18,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_String,
+          decodeErrorData: sse_decode_String,
+        ),
         constMeta: kCrateApiWalletGetUnifiedAddressConstMeta,
-        argValues: [dbPath, network],
+        argValues: [dbPath, network, accountUuid],
         apiImpl: this,
       ),
     );
@@ -838,7 +897,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiWalletGetUnifiedAddressConstMeta =>
       const TaskConstMeta(
         debugName: "get_unified_address",
-        argNames: ["dbPath", "network"],
+        argNames: ["dbPath", "network", "accountUuid"],
       );
 
   @override
@@ -848,7 +907,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 18)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -882,7 +941,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 20,
             port: port_,
           );
         },
@@ -911,7 +970,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 21,
             port: port_,
           );
         },
@@ -935,7 +994,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -950,6 +1009,40 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiSyncIsSyncRunningConstMeta =>
       const TaskConstMeta(debugName: "is_sync_running", argNames: []);
+
+  @override
+  Future<List<AccountInfo>> crateApiWalletListAccounts({
+    required String dbPath,
+    required String network,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 23,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_account_info,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletListAccountsConstMeta,
+        argValues: [dbPath, network],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletListAccountsConstMeta => const TaskConstMeta(
+    debugName: "list_accounts",
+    argNames: ["dbPath", "network"],
+  );
 
   @override
   Future<ProposalResult> crateApiSyncProposeSend({
@@ -971,7 +1064,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 24,
             port: port_,
           );
         },
@@ -1013,7 +1106,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1064,7 +1157,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1116,7 +1209,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1167,7 +1260,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1201,7 +1294,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1243,7 +1336,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 28,
+              funcId: 30,
               port: port_,
             );
           },
@@ -1279,7 +1372,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1316,7 +1409,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1348,7 +1441,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1373,7 +1466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(mnemonic, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1399,7 +1492,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1429,7 +1522,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1467,6 +1560,31 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   String dco_decode_String(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as String;
+  }
+
+  @protected
+  AccountCreationResult dco_decode_account_creation_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return AccountCreationResult(
+      accountUuid: dco_decode_String(arr[0]),
+      unifiedAddress: dco_decode_String(arr[1]),
+    );
+  }
+
+  @protected
+  AccountInfo dco_decode_account_info(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return AccountInfo(
+      uuid: dco_decode_String(arr[0]),
+      name: dco_decode_String(arr[1]),
+      unifiedAddress: dco_decode_String(arr[2]),
+    );
   }
 
   @protected
@@ -1540,6 +1658,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PlatformInt64 dco_decode_i_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return dcoDecodeI64(raw);
+  }
+
+  @protected
+  List<AccountInfo> dco_decode_list_account_info(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_account_info).toList();
   }
 
   @protected
@@ -1750,11 +1874,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   WalletCreationResult dco_decode_wallet_creation_result(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return WalletCreationResult(
       mnemonic: dco_decode_String(arr[0]),
       unifiedAddress: dco_decode_String(arr[1]),
+      accountUuid: dco_decode_String(arr[2]),
     );
   }
 
@@ -1762,9 +1887,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   WalletImportResult dco_decode_wallet_import_result(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 1)
-      throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return WalletImportResult(unifiedAddress: dco_decode_String(arr[0]));
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return WalletImportResult(
+      unifiedAddress: dco_decode_String(arr[0]),
+      accountUuid: dco_decode_String(arr[1]),
+    );
   }
 
   @protected
@@ -1788,6 +1916,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var inner = sse_decode_list_prim_u_8_strict(deserializer);
     return utf8.decoder.convert(inner);
+  }
+
+  @protected
+  AccountCreationResult sse_decode_account_creation_result(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_accountUuid = sse_decode_String(deserializer);
+    var var_unifiedAddress = sse_decode_String(deserializer);
+    return AccountCreationResult(
+      accountUuid: var_accountUuid,
+      unifiedAddress: var_unifiedAddress,
+    );
+  }
+
+  @protected
+  AccountInfo sse_decode_account_info(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_uuid = sse_decode_String(deserializer);
+    var var_name = sse_decode_String(deserializer);
+    var var_unifiedAddress = sse_decode_String(deserializer);
+    return AccountInfo(
+      uuid: var_uuid,
+      name: var_name,
+      unifiedAddress: var_unifiedAddress,
+    );
   }
 
   @protected
@@ -1869,6 +2023,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   PlatformInt64 sse_decode_i_64(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return deserializer.buffer.getPlatformInt64();
+  }
+
+  @protected
+  List<AccountInfo> sse_decode_list_account_info(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <AccountInfo>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_account_info(deserializer));
+    }
+    return ans_;
   }
 
   @protected
@@ -2141,9 +2307,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_mnemonic = sse_decode_String(deserializer);
     var var_unifiedAddress = sse_decode_String(deserializer);
+    var var_accountUuid = sse_decode_String(deserializer);
     return WalletCreationResult(
       mnemonic: var_mnemonic,
       unifiedAddress: var_unifiedAddress,
+      accountUuid: var_accountUuid,
     );
   }
 
@@ -2153,7 +2321,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_unifiedAddress = sse_decode_String(deserializer);
-    return WalletImportResult(unifiedAddress: var_unifiedAddress);
+    var var_accountUuid = sse_decode_String(deserializer);
+    return WalletImportResult(
+      unifiedAddress: var_unifiedAddress,
+      accountUuid: var_accountUuid,
+    );
   }
 
   @protected
@@ -2192,6 +2364,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_String(String self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_list_prim_u_8_strict(utf8.encoder.convert(self), serializer);
+  }
+
+  @protected
+  void sse_encode_account_creation_result(
+    AccountCreationResult self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.accountUuid, serializer);
+    sse_encode_String(self.unifiedAddress, serializer);
+  }
+
+  @protected
+  void sse_encode_account_info(AccountInfo self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.uuid, serializer);
+    sse_encode_String(self.name, serializer);
+    sse_encode_String(self.unifiedAddress, serializer);
   }
 
   @protected
@@ -2259,6 +2449,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     serializer.buffer.putPlatformInt64(self);
+  }
+
+  @protected
+  void sse_encode_list_account_info(
+    List<AccountInfo> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_account_info(item, serializer);
+    }
   }
 
   @protected
@@ -2496,6 +2698,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.mnemonic, serializer);
     sse_encode_String(self.unifiedAddress, serializer);
+    sse_encode_String(self.accountUuid, serializer);
   }
 
   @protected
@@ -2505,6 +2708,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.unifiedAddress, serializer);
+    sse_encode_String(self.accountUuid, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -93,6 +93,7 @@ abstract class RustLibApi extends BaseApi {
     required String network,
     required String dbPath,
     BigInt? birthdayHeight,
+    String? accountName,
   });
 
   Future<void> crateApiSyncDecryptAndStoreTransaction({
@@ -185,6 +186,7 @@ abstract class RustLibApi extends BaseApi {
     BigInt? birthdayHeight,
     required String network,
     required String dbPath,
+    String? accountName,
   });
 
   Future<void> crateApiSimpleInitApp();
@@ -350,6 +352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String network,
     required String dbPath,
     BigInt? birthdayHeight,
+    String? accountName,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -358,6 +361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(network, serializer);
           sse_encode_String(dbPath, serializer);
           sse_encode_opt_box_autoadd_u_64(birthdayHeight, serializer);
+          sse_encode_opt_String(accountName, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -370,7 +374,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiWalletCreateWalletConstMeta,
-        argValues: [network, dbPath, birthdayHeight],
+        argValues: [network, dbPath, birthdayHeight, accountName],
         apiImpl: this,
       ),
     );
@@ -378,7 +382,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiWalletCreateWalletConstMeta => const TaskConstMeta(
     debugName: "create_wallet",
-    argNames: ["network", "dbPath", "birthdayHeight"],
+    argNames: ["network", "dbPath", "birthdayHeight", "accountName"],
   );
 
   @override
@@ -980,6 +984,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     BigInt? birthdayHeight,
     required String network,
     required String dbPath,
+    String? accountName,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -989,6 +994,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_box_autoadd_u_64(birthdayHeight, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(dbPath, serializer);
+          sse_encode_opt_String(accountName, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1001,7 +1007,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiWalletImportWalletConstMeta,
-        argValues: [mnemonic, birthdayHeight, network, dbPath],
+        argValues: [mnemonic, birthdayHeight, network, dbPath, accountName],
         apiImpl: this,
       ),
     );
@@ -1009,7 +1015,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiWalletImportWalletConstMeta => const TaskConstMeta(
     debugName: "import_wallet",
-    argNames: ["mnemonic", "birthdayHeight", "network", "dbPath"],
+    argNames: [
+      "mnemonic",
+      "birthdayHeight",
+      "network",
+      "dbPath",
+      "accountName",
+    ],
   );
 
   @override

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -68,7 +68,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1789710638;
+  int get rustContentHash => 1185829757;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -121,6 +121,8 @@ abstract class RustLibApi extends BaseApi {
     String? spendParamsPath,
     String? outputParamsPath,
   });
+
+  String crateApiWalletGenerateMnemonic();
 
   Future<WalletBalance> crateApiSyncGetBalance({
     required String dbPath,
@@ -560,6 +562,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  String crateApiWalletGenerateMnemonic() {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 8)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_String,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiWalletGenerateMnemonicConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletGenerateMnemonicConstMeta =>
+      const TaskConstMeta(debugName: "generate_mnemonic", argNames: []);
+
+  @override
   Future<WalletBalance> crateApiSyncGetBalance({
     required String dbPath,
     required String network,
@@ -575,7 +599,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 9,
             port: port_,
           );
         },
@@ -602,7 +626,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cachePath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 9)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 10)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -630,7 +654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 11,
             port: port_,
           );
         },
@@ -667,7 +691,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 12,
             port: port_,
           );
         },
@@ -702,7 +726,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 13,
             port: port_,
           );
         },
@@ -729,7 +753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 13)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 14)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -759,7 +783,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 15,
             port: port_,
           );
         },
@@ -793,7 +817,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 16,
             port: port_,
           );
         },
@@ -832,7 +856,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 17,
             port: port_,
           );
         },
@@ -869,7 +893,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 18,
             port: port_,
           );
         },
@@ -906,7 +930,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 19,
             port: port_,
           );
         },
@@ -934,7 +958,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -968,7 +992,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 21,
             port: port_,
           );
         },
@@ -997,7 +1021,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 22,
             port: port_,
           );
         },
@@ -1021,7 +1045,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 23)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1051,7 +1075,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 24,
             port: port_,
           );
         },
@@ -1093,7 +1117,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1149,7 +1173,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1200,7 +1224,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1252,7 +1276,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1303,7 +1327,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 29)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1337,7 +1361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1379,7 +1403,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 30,
+              funcId: 31,
               port: port_,
             );
           },
@@ -1415,7 +1439,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1452,7 +1476,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1484,7 +1508,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1509,7 +1533,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(mnemonic, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1535,7 +1559,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1565,7 +1589,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -31,6 +31,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String dco_decode_String(dynamic raw);
 
   @protected
+  AccountCreationResult dco_decode_account_creation_result(dynamic raw);
+
+  @protected
+  AccountInfo dco_decode_account_info(dynamic raw);
+
+  @protected
   AddressValidationResult dco_decode_address_validation_result(dynamic raw);
 
   @protected
@@ -53,6 +59,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 dco_decode_i_64(dynamic raw);
+
+  @protected
+  List<AccountInfo> dco_decode_list_account_info(dynamic raw);
 
   @protected
   List<BlockMetaInfo> dco_decode_list_block_meta_info(dynamic raw);
@@ -142,6 +151,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
+  AccountCreationResult sse_decode_account_creation_result(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  AccountInfo sse_decode_account_info(SseDeserializer deserializer);
+
+  @protected
   AddressValidationResult sse_decode_address_validation_result(
     SseDeserializer deserializer,
   );
@@ -168,6 +185,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 sse_decode_i_64(SseDeserializer deserializer);
+
+  @protected
+  List<AccountInfo> sse_decode_list_account_info(SseDeserializer deserializer);
 
   @protected
   List<BlockMetaInfo> sse_decode_list_block_meta_info(
@@ -275,6 +295,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
+  void sse_encode_account_creation_result(
+    AccountCreationResult self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_account_info(AccountInfo self, SseSerializer serializer);
+
+  @protected
   void sse_encode_address_validation_result(
     AddressValidationResult self,
     SseSerializer serializer,
@@ -303,6 +332,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_account_info(
+    List<AccountInfo> self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_list_block_meta_info(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -33,6 +33,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String dco_decode_String(dynamic raw);
 
   @protected
+  AccountCreationResult dco_decode_account_creation_result(dynamic raw);
+
+  @protected
+  AccountInfo dco_decode_account_info(dynamic raw);
+
+  @protected
   AddressValidationResult dco_decode_address_validation_result(dynamic raw);
 
   @protected
@@ -55,6 +61,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 dco_decode_i_64(dynamic raw);
+
+  @protected
+  List<AccountInfo> dco_decode_list_account_info(dynamic raw);
 
   @protected
   List<BlockMetaInfo> dco_decode_list_block_meta_info(dynamic raw);
@@ -144,6 +153,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String sse_decode_String(SseDeserializer deserializer);
 
   @protected
+  AccountCreationResult sse_decode_account_creation_result(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  AccountInfo sse_decode_account_info(SseDeserializer deserializer);
+
+  @protected
   AddressValidationResult sse_decode_address_validation_result(
     SseDeserializer deserializer,
   );
@@ -170,6 +187,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   PlatformInt64 sse_decode_i_64(SseDeserializer deserializer);
+
+  @protected
+  List<AccountInfo> sse_decode_list_account_info(SseDeserializer deserializer);
 
   @protected
   List<BlockMetaInfo> sse_decode_list_block_meta_info(
@@ -277,6 +297,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_String(String self, SseSerializer serializer);
 
   @protected
+  void sse_encode_account_creation_result(
+    AccountCreationResult self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_account_info(AccountInfo self, SseSerializer serializer);
+
+  @protected
   void sse_encode_address_validation_result(
     AddressValidationResult self,
     SseSerializer serializer,
@@ -305,6 +334,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_i_64(PlatformInt64 self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_list_account_info(
+    List<AccountInfo> self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_list_block_meta_info(

--- a/onboarding/api-reference.html
+++ b/onboarding/api-reference.html
@@ -16,28 +16,46 @@
 <table>
   <tr><th>Dart Function</th><th>Rust Function</th><th>Sync?</th><th>설명</th></tr>
   <tr>
-    <td><code>createWallet({network, dbPath})</code></td>
-    <td><code>create_wallet(network, db_path)</code></td>
+    <td><code>createWallet({network, dbPath, birthdayHeight?, accountName?})</code></td>
+    <td><code>create_wallet(network, db_path, birthday_height, account_name)</code></td>
     <td>async</td>
-    <td>니모닉 생성, 계정 생성, <code>WalletCreationResult { mnemonic, unifiedAddress }</code> 반환</td>
+    <td>첫 번째 계정 (Derived). <code>WalletCreationResult { mnemonic, unifiedAddress, accountUuid }</code> 반환</td>
   </tr>
   <tr>
-    <td><code>importWallet({mnemonic, birthdayHeight?, network, dbPath})</code></td>
-    <td><code>import_wallet(mnemonic, birthday_height, network, db_path)</code></td>
+    <td><code>importWallet({mnemonic, birthdayHeight?, network, dbPath, accountName?})</code></td>
+    <td><code>import_wallet(mnemonic, birthday_height, network, db_path, account_name)</code></td>
     <td>async</td>
-    <td>니모닉에서 가져오기, <code>WalletImportResult { unifiedAddress }</code> 반환</td>
+    <td>첫 번째 계정을 니모닉에서 가져오기 (Derived). <code>WalletImportResult { unifiedAddress, accountUuid }</code> 반환</td>
   </tr>
   <tr>
-    <td><code>getUnifiedAddress({dbPath, network})</code></td>
-    <td><code>get_unified_address(db_path, network)</code></td>
+    <td><code>addAccount({dbPath, network, name, mnemonic, birthdayHeight?})</code></td>
+    <td><code>add_account(db_path, network, name, mnemonic, birthday_height)</code></td>
     <td>async</td>
-    <td>DB에서 shielded UA (Sapling+Orchard) 반환</td>
+    <td>추가 계정 (Imported via import_account_ufvk). 다른 seed 가능. <code>AccountCreationResult { accountUuid, unifiedAddress }</code> 반환</td>
   </tr>
   <tr>
-    <td><code>getTransparentAddress({dbPath, network})</code></td>
-    <td><code>get_transparent_address(db_path, network)</code></td>
+    <td><code>listAccounts({dbPath, network})</code></td>
+    <td><code>list_accounts(db_path, network)</code></td>
     <td>async</td>
-    <td>DB에서 transparent 전용 주소 반환</td>
+    <td>DB의 모든 계정 조회. <code>List&lt;AccountInfo { uuid, name, unifiedAddress }&gt;</code> 반환</td>
+  </tr>
+  <tr>
+    <td><code>generateMnemonic()</code></td>
+    <td><code>generate_mnemonic()</code></td>
+    <td><strong>sync</strong></td>
+    <td>새 24단어 BIP-39 니모닉 생성</td>
+  </tr>
+  <tr>
+    <td><code>getUnifiedAddress({dbPath, network, accountUuid?})</code></td>
+    <td><code>get_unified_address(db_path, network, account_uuid)</code></td>
+    <td>async</td>
+    <td>특정 계정의 shielded UA (Sapling+Orchard) 반환. uuid 생략 시 첫 번째 계정.</td>
+  </tr>
+  <tr>
+    <td><code>getTransparentAddress({dbPath, network, accountUuid?})</code></td>
+    <td><code>get_transparent_address(db_path, network, account_uuid)</code></td>
+    <td>async</td>
+    <td>특정 계정의 transparent 전용 주소 반환. uuid 생략 시 첫 번째 계정.</td>
   </tr>
   <tr>
     <td><code>walletExists({dbPath})</code></td>
@@ -93,14 +111,14 @@
     <td>Trial decryption. TreeState는 개별 필드로 전달 (network, height, hash, time, saplingTree, orchardTree).</td>
   </tr>
   <tr>
-    <td><code>getBalance({dbPath, network})</code></td>
-    <td><code>get_balance(db_path, network)</code></td>
-    <td><code>WalletBalance { transparent, sapling, orchard, transparent_pending, sapling_pending, orchard_pending, total }</code> 반환 (zatoshi 단위). total은 confirmed + pending 합산.</td>
+    <td><code>getBalance({dbPath, network, accountUuid})</code></td>
+    <td><code>get_balance(db_path, network, account_uuid)</code></td>
+    <td>특정 계정의 <code>WalletBalance { transparent, sapling, orchard, transparent_pending, sapling_pending, orchard_pending, total }</code> 반환 (zatoshi 단위). total은 confirmed + pending 합산.</td>
   </tr>
   <tr>
-    <td><code>getTransactionHistory({dbPath, network, limit})</code></td>
-    <td><code>get_transaction_history(db_path, network, limit)</code></td>
-    <td><code>List&lt;TransactionInfo&gt;</code> 반환. limit으로 최근 N건 제한. null이면 전체.</td>
+    <td><code>getTransactionHistory({dbPath, network, limit, accountUuid})</code></td>
+    <td><code>get_transaction_history(db_path, network, limit, account_uuid)</code></td>
+    <td>특정 계정의 <code>List&lt;TransactionInfo&gt;</code> 반환. limit으로 최근 N건 제한. null이면 전체.</td>
   </tr>
   <tr>
     <td><code>getBlocksDir({cachePath})</code></td>
@@ -118,9 +136,9 @@
     <td><code>AddressValidationResult { isValid, addressType }</code> 반환 (unified/sapling/transparent/invalid)</td>
   </tr>
   <tr>
-    <td><code>getNextAvailableAddress({dbPath, network})</code></td>
-    <td><code>get_next_available_address(...)</code></td>
-    <td>다음 diversified UA 생성 (zodl 패턴: 매번 다른 diversifier)</td>
+    <td><code>getNextAvailableAddress({dbPath, network, accountUuid})</code></td>
+    <td><code>get_next_available_address(db_path, network, account_uuid)</code></td>
+    <td>특정 계정의 다음 diversified UA 생성 (zodl 패턴: 매번 다른 diversifier)</td>
   </tr>
   <tr>
     <td><code>getTransactionDataRequests({dbPath, network})</code></td>
@@ -144,35 +162,42 @@
   </tr>
 </table>
 
-<h3 id="api-send">6.3 Send 함수 (2단계)</h3>
-<p>전송은 propose → execute 2단계로 분리되어, Sapling proving parameters가 필요한지 사전에 확인할 수 있다.</p>
+<h3 id="api-send">6.3 Send 함수 (3단계: estimate → propose → execute)</h3>
+<p>전송은 estimate → propose → execute로 분리된다. 모든 함수가 <code>account_uuid</code>를 받아 계정별로 동작한다. ZEC 금액은 integer-only 파싱으로 zatoshi로 변환 (부동소수점 사용하지 않음).</p>
 <table>
   <tr><th>Dart Function</th><th>Rust Function</th><th>설명</th></tr>
   <tr>
-    <td><code>proposeSend({dbPath, network, toAddress, amountZatoshi, memo?})</code></td>
-    <td><code>propose_send(...)</code></td>
-    <td>전송 제안. <code>ProposalResult { proposalId, needsSaplingParams, feeZatoshi }</code> 반환. Proof 생성 없음, params 불필요.</td>
+    <td><code>estimateFee({dbPath, network, accountUuid, toAddress, amountZatoshi, memo?})</code></td>
+    <td><code>estimate_fee(...)</code></td>
+    <td>수수료 추정. proposal 저장 없이 수수료만 반환 (zatoshi). 전송 전 사용자에게 표시.</td>
   </tr>
   <tr>
-    <td><code>executeProposal({dbPath, proposalId, seed, spendParamsPath?, outputParamsPath?})</code></td>
+    <td><code>proposeSend({dbPath, network, accountUuid, toAddress, amountZatoshi, memo?})</code></td>
+    <td><code>propose_send(...)</code></td>
+    <td>전송 제안. <code>ProposalResult { proposalId, needsSaplingParams, feeZatoshi }</code> 반환. 내부적으로 <code>StoredProposal { proposal, network, account_id }</code>에 계정 ID 포함하여 메모리에 저장.</td>
+  </tr>
+  <tr>
+    <td><code>executeProposal({dbPath, lightwalletdUrl, proposalId, seed, spendParamsPath?, outputParamsPath?})</code></td>
     <td><code>execute_proposal(...)</code></td>
-    <td>제안 실행. zk-SNARK proof 생성 + 서명. <code>needsSaplingParams</code>가 true였을 경우에만 params 경로 필요.</td>
+    <td>제안 실행. zk-SNARK proof 생성 + 서명 + gRPC broadcast. Orchard-only TX에는 no-op Sapling prover 사용 (params 불필요). 니모닉은 <code>AccountProvider.getActiveMnemonic()</code>에서 조회하여 seed 유도. 친화적 에러 메시지 반환.</td>
   </tr>
 </table>
 
 <div class="note">
-  <p><strong>Sapling Proving Parameters:</strong> Sapling proof 생성에 <code>sapling-spend.params</code> (~47MB) + <code>sapling-output.params</code> (~3.5MB) 파일이 필요하다. Orchard (Halo 2)는 trusted setup이 없어 파라미터 파일이 불필요하다. <code>propose_send()</code>의 <code>needsSaplingParams</code> 플래그로 필요 여부를 사전에 확인한 후, 필요 시 <code>https://download.z.cash/downloads/</code>에서 다운로드하고 SHA-1 검증 후 저장한다. 한 번만 다운로드하면 이후에는 로컬 파일을 사용한다.</p>
+  <p><strong>Sapling Proving Parameters:</strong> Sapling proof 생성에 <code>sapling-spend.params</code> (~47MB) + <code>sapling-output.params</code> (~3.5MB) 파일이 필요하다. Orchard (Halo 2)는 trusted setup이 없어 파라미터 파일이 불필요하다. <code>propose_send()</code>의 <code>needsSaplingParams</code> 플래그로 필요 여부를 사전에 확인한 후, 필요 시 <code>https://download.z.cash/downloads/</code>에서 다운로드하고 SHA-1 검증 후 저장한다. 한 번만 다운로드하면 이후에는 로컬 파일을 사용한다. Orchard-only TX (needsSaplingParams=false)에서는 no-op Sapling prover가 사용되어 params 파일이 전혀 필요 없다.</p>
 </div>
 
 <h3 id="api-structs">6.4 데이터 구조체</h3>
-<pre><code>// Wallet
-WalletCreationResult { mnemonic: String, unifiedAddress: String }
-WalletImportResult   { unifiedAddress: String }
+<pre><code>// Wallet (멀티 계정)
+WalletCreationResult  { mnemonic: String, unifiedAddress: String, accountUuid: String }
+WalletImportResult    { unifiedAddress: String, accountUuid: String }
+AccountCreationResult { accountUuid: String, unifiedAddress: String }
+AccountInfo           { uuid: String, name: String, unifiedAddress: String }
 
 // Sync
 SyncProgress   { scannedHeight: u64, chainTipHeight: u64, isSyncing: bool }
 WalletBalance  { transparent: u64, sapling: u64, orchard: u64,
-                 saplingPending: u64, orchardPending: u64, total: u64 }
+                 transparentPending: u64, saplingPending: u64, orchardPending: u64, total: u64 }
 ScanRangeInfo  { start: u64, end: u64, priority: u8 }
 ScanResult     { blocksScanned: u64 }
 SubtreeRoot    { completingBlockHeight: u64, rootHash: Vec&lt;u8&gt; }
@@ -181,6 +206,7 @@ BlockMetaInfo  { height: u64, hash: Vec&lt;u8&gt;, time: u32,
 
 // Send
 ProposalResult { proposalId: u64, needsSaplingParams: bool, feeZatoshi: u64 }
+// Internal: StoredProposal { proposal, network, account_id } — account_id 포함
 
 // Enhancement
 TxDataRequest     { requestType: String, txid: String?, address: String?,

--- a/onboarding/architecture.html
+++ b/onboarding/architecture.html
@@ -37,7 +37,7 @@
   <tr>
     <td><span class="badge dart">Dart UI</span></td>
     <td>Dart / Flutter</td>
-    <td>UI 렌더링, 상태 관리(Riverpod), 네비게이션(GoRouter), 보안 저장소(iOS Keychain / Android Keystore). Sync는 Rust에서 실행되며 Dart는 Stream으로 진행률을 수신.</td>
+    <td>UI 렌더링, 상태 관리(Riverpod), 네비게이션(GoRouter), 보안 저장소(iOS Keychain / Android Keystore). 멀티 계정 지원: <code>AccountProvider</code>가 계정 목록, 활성 계정, per-account 니모닉을 관리. <code>WalletProvider</code>는 <code>AccountProvider</code>에 위임. Sync는 Rust에서 실행되며 Dart는 Stream으로 진행률을 수신. 모든 잔액/내역/전송/수신 함수는 <code>account_uuid</code> 파라미터로 계정별 분리.</td>
     <td><code>lib/src/providers/</code>, <code>lib/src/features/</code>, <code>lib/app.dart</code></td>
   </tr>
 </table>
@@ -72,7 +72,10 @@
                                     |
                     +---------------+---------------+
                     |          zcash_client_sqlite              |
-                    |              (WalletDb)                   |
+                    |    (WalletDb — 멀티 계정, 단일 DB)        |
+                    |    First account = Derived (create_account)|
+                    |    Additional = Imported (import_account_ufvk)|
+                    |    AccountUuid로 계정 식별                 |
                     +-------------------------------------------+
                                     |
                             SQLite Database

--- a/onboarding/background-sync.html
+++ b/onboarding/background-sync.html
@@ -94,7 +94,34 @@ Dart: "Sync on Background" 버튼 탭
   <li><code>Runner-Bridging-Header.h</code>: <code>#import "zcash_sync.h"</code></li>
 </ul>
 
-<h3 id="bg-android">9.2 Android Foreground Service</h3>
+<h3 id="bg-txtrack">9.2 TX Tracking BGTask (iOS 26+)</h3>
+
+<p>전송 후 트랜잭션이 채굴되었는지 추적하기 위한 별도의 <code>BGContinuedProcessingTask</code>이다. Sync BGTask와는 독립적으로 동작한다.</p>
+
+<p><strong>핵심 동작:</strong></p>
+<ul>
+  <li><code>TxTrackManager</code>가 <code>com.zcash.zcashWallet.txtrack</code> BGTask를 등록/관리</li>
+  <li>전송 성공 후 BGTask를 제출하면, background에서 lightwalletd를 주기적으로 폴링하여 TX 상태 확인</li>
+  <li>TX가 채굴되면 (mined) 또는 만료되면 (expired) 추적 종료</li>
+</ul>
+
+<h4>DynamicIslandManager</h4>
+<p><code>DynamicIslandManager</code>는 Live Activity / Dynamic Island의 표시 우선순위를 관리한다. Sync progress와 TX tracking이 동시에 활성화될 수 있으므로, 어느 것을 Dynamic Island에 표시할지 결정해야 한다.</p>
+<ul>
+  <li><code>DisplayMode</code>: <code>idle</code>, <code>sync</code>, <code>txTrack</code> 세 가지 상태</li>
+  <li><strong>TX tracking이 sync보다 우선</strong>: <code>displayMode == .txTrack</code>이면 sync progress가 Live Activity를 업데이트하지 않음 (UserDefaults는 항상 업데이트)</li>
+  <li>TX tracking 완료 후 마지막 sync progress로 복원 (<code>lastSyncPercentage</code> 캐시)</li>
+  <li>UserDefaults (<code>group.com.zcash.zcashWallet</code>)를 통해 Widget과 데이터 공유</li>
+</ul>
+
+<p><strong>주요 파일:</strong></p>
+<table>
+  <tr><th>파일</th><th>역할</th></tr>
+  <tr><td><code>ios/Runner/TxTrackManager.swift</code></td><td>TX tracking BGTask 등록/관리. lightwalletd 폴링으로 TX 상태 확인.</td></tr>
+  <tr><td><code>ios/Runner/DynamicIslandManager.swift</code></td><td>Live Activity 표시 우선순위 관리. sync ↔ txTrack 전환.</td></tr>
+</table>
+
+<h3 id="bg-android">9.3 Android Foreground Service</h3>
 <p>Android에서는 <code>flutter_foreground_task</code>를 사용하여 notification만 관리한다. Sync 자체는 foreground와 동일한 Dart FRB Stream으로 실행되며, mode 전환 메커니즘은 없다.</p>
 
 <ul>

--- a/onboarding/dart-layer.html
+++ b/onboarding/dart-layer.html
@@ -14,29 +14,50 @@
 
 <h3 id="dart-providers">4.1 Riverpod Providers</h3>
 
+<p><strong><code>accountProvider</code></strong> (<code>AsyncNotifierProvider&lt;AccountNotifier, AccountState&gt;</code>)</p>
+<p>멀티 계정의 중심 provider. 계정 목록, 활성 계정, per-account 니모닉을 관리한다.</p>
+<ul>
+  <li><code>build()</code>에서: secure storage에서 계정 목록(<code>zcash_accounts</code>)과 활성 계정(<code>zcash_active_account</code>)을 로드. 활성 계정의 주소를 Rust에서 조회.</li>
+  <li><code>createAccount({name?})</code>: 첫 번째 계정이면 <code>create_wallet()</code> (Derived), 추가 계정이면 <code>generate_mnemonic()</code> + <code>add_account()</code> (Imported). birthday는 chain tip에서 가져옴. 니모닉은 <code>zcash_account_mnemonic_{uuid}</code>로 per-account 저장.</li>
+  <li><code>importAccount({mnemonic, birthdayHeight?, name?})</code>: 첫 번째이면 <code>import_wallet()</code>, 추가이면 <code>add_account()</code>.</li>
+  <li><code>switchAccount(uuid)</code>: 활성 계정 전환. secure storage 업데이트 + 주소 조회.</li>
+  <li><code>renameAccount(uuid, newName)</code>: 계정 이름 변경.</li>
+  <li><code>getActiveMnemonic()</code>: 활성 계정의 니모닉을 secure storage에서 조회. 전송 시 seed 유도에 사용.</li>
+  <li><code>AccountState</code>: <code>{ accounts: List&lt;AccountInfo&gt;, activeAccountUuid, activeAddress }</code></li>
+</ul>
+
+<p><strong>Secure Storage 키 구조:</strong></p>
+<ul>
+  <li><code>zcash_accounts</code> — 계정 목록 JSON (<code>[{uuid, name, order}, ...]</code>)</li>
+  <li><code>zcash_account_mnemonic_{uuid}</code> — 계정별 니모닉</li>
+  <li><code>zcash_active_account</code> — 현재 활성 계정 UUID</li>
+  <li><code>zcash_wallet_network</code> — 네트워크 (main/test)</li>
+</ul>
+
 <p><strong><code>walletProvider</code></strong> (<code>AsyncNotifierProvider&lt;WalletNotifier, WalletState&gt;</code>)</p>
 <ul>
-  <li><code>build()</code>에서: 월렛 DB 존재 여부를 확인하고, UFVK에서 주소를 로드</li>
-  <li><code>createWallet()</code>: 니모닉을 생성하고, 계정을 만들고, 니모닉을 secure storage에 저장</li>
-  <li><code>importWallet()</code>: 니모닉을 검증하고, 기존 DB를 삭제하고, 계정을 생성</li>
-  <li><code>WalletState</code>: <code>{ hasWallet, unifiedAddress, network }</code></li>
+  <li><code>build()</code>에서: <code>ref.watch(accountProvider)</code>로 <code>AccountProvider</code>의 상태를 구독하여 자동 갱신. 계정이 있으면 hasWallet=true.</li>
+  <li><code>WalletState</code>: <code>{ hasWallet, unifiedAddress, network, activeAccountUuid }</code></li>
+  <li>직접 계정 생성/가져오기 로직은 없음 — 모두 <code>AccountProvider</code>에 위임.</li>
 </ul>
 
 <p><strong><code>syncProvider</code></strong> (<code>AsyncNotifierProvider&lt;SyncNotifier, SyncState&gt;</code>)</p>
 <ul>
-  <li><code>startSync()</code>: FRB <code>startFullSync(mode: 1)</code> 호출로 <code>Stream&lt;ApiSyncProgressEvent&gt;</code> 수신. <code>stream.listen(_onSyncProgress)</code>로 콜백 등록. <code>_onSyncProgress</code>에서 매 이벤트마다 <code>getBalance()</code> FFI를 호출하여 잔액 갱신. 10초 간격 폴링은 fallback으로 유지.</li>
+  <li><code>startSync()</code>: FRB <code>startFullSync(mode: 1)</code> 호출로 <code>Stream&lt;ApiSyncProgressEvent&gt;</code> 수신. <code>stream.listen(_onSyncProgress)</code>로 콜백 등록. <code>_onSyncProgress</code>에서 매 이벤트마다 <code>getBalance(accountUuid)</code> FFI를 호출하여 활성 계정의 잔액 갱신. Sync 자체는 계정에 무관하게 모든 계정의 노트를 스캔하지만, 잔액/내역 조회는 <code>activeAccountUuid</code>로 특정 계정만 반환.</li>
   <li><code>stopSync()</code>: 통합 <code>cancelFullSync()</code> 호출 (AtomicBool 설정)</li>
   <li><code>enableBackgroundSync()</code>: Android = <code>flutter_foreground_task</code>로 notification만 추가. iOS = <code>setSyncMode(2)</code> + MethodChannel로 BGContinuedProcessingTask 제출.</li>
   <li><code>disableBackgroundSync()</code>: Android = notification 제거. iOS = <code>setSyncMode(1)</code> + <code>while(isSyncRunning()) await 200ms</code> 대기 + foreground sync 재시작.</li>
   <li><code>AppLifecycleListener.onResume</code>: expiration 감지 (mode==0) → foreground sync 재시작</li>
   <li>iOS EventChannel listener: background sync 중 C callback → <code>SyncProgressStreamHandler</code> → Dart로 진행률 수신</li>
-  <li><code>SyncState</code>: <code>{ isSyncing, isBackgroundMode, percentage, scannedHeight, chainTipHeight, transparentBalance, saplingBalance, orchardBalance, totalBalance, error }</code></li>
+  <li><code>SyncState</code>: <code>{ isSyncing, isBackgroundMode, percentage, scannedHeight, chainTipHeight, transparentBalance, saplingBalance, orchardBalance, totalBalance, error, recentTransactions }</code></li>
 </ul>
 
 <h3 id="dart-sync-loop">4.2 Sync 실행</h3>
 <p>Sync 루프는 <strong>Rust</strong>에서 실행된다 (<code>sync_engine.rs</code>). Dart는 <code>startFullSync(mode: 1)</code>을 호출하여 <code>Stream&lt;ApiSyncProgressEvent&gt;</code>를 수신하고, <code>stream.listen()</code>으로 진행률 콜백을 등록한다.</p>
 
 <pre><code>// sync_provider.dart (간소화)
+final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+
 final stream = rust_sync.startFullSync(
   dbPath: dbPath,
   lightwalletdUrl: 'https://zec.rocks:443',
@@ -47,11 +68,15 @@ final stream = rust_sync.startFullSync(
 stream.listen(_onSyncProgress);
 
 void _onSyncProgress(ApiSyncProgressEvent event) {
-  // 매 batch마다 balance 갱신
-  final balance = await rust_sync.getBalance(dbPath: dbPath, network: 'main');
-  // hasNewTx 또는 isComplete이면 최근 트랜잭션도 갱신
+  // 매 batch마다 활성 계정의 balance 갱신
+  final balance = await rust_sync.getBalance(
+    dbPath: dbPath, network: 'main', accountUuid: accountUuid,
+  );
+  // hasNewTx 또는 isComplete이면 활성 계정의 최근 트랜잭션도 갱신
   if (event.hasNewTx || event.isComplete) {
-    final txs = await rust_sync.getTransactionHistory(dbPath: dbPath, network: 'main', limit: 10);
+    final txs = await rust_sync.getTransactionHistory(
+      dbPath: dbPath, network: 'main', limit: 10, accountUuid: accountUuid,
+    );
     // state에 recentTransactions 업데이트
   }
   state = state.copyWith(
@@ -60,6 +85,7 @@ void _onSyncProgress(ApiSyncProgressEvent event) {
     totalBalance: balance.total,
   );
 }
+// Sync는 모든 계정을 스캔하지만, 잔액/내역은 activeAccountUuid로 필터
 // 폴링 없음 — 모든 상태 업데이트는 stream, EventChannel, onResume으로 구동</code></pre>
 
 <p><strong>Rust 내부 sync 루프 (<code>run_sync_inner</code>):</strong></p>

--- a/onboarding/gotchas.html
+++ b/onboarding/gotchas.html
@@ -59,6 +59,26 @@
     <td>Rust 암호학 연산이 debug 빌드에서 5-10배 느림 (opt-level=0). sync 성능 테스트는 반드시 <code>--release</code>로.</td>
   </tr>
   <tr>
+    <td>Derived vs Imported 계정</td>
+    <td>첫 번째 계정은 반드시 <code>create_account()</code>으로 생성 (Derived)해야 한다. 이후 <code>init_wallet_db(seed)</code>가 seed relevance를 확인하기 때문. 추가 계정은 <code>import_account_ufvk()</code>로 생성 (Imported) — 다른 seed 가능. <code>create_account</code>은 단일 seed만 허용하므로 두 번째 seed로 호출하면 seed fingerprint 불일치 에러 발생.</td>
+  </tr>
+  <tr>
+    <td>Seed Fingerprint 불일치</td>
+    <td><code>ensure_db_initialized_with_seed()</code>를 다른 seed로 호출하면 안 된다. DB 초기화는 첫 번째 계정 seed로만 수행. 추가 계정의 seed는 <code>add_account()</code>에서 USK/UFVK 유도에만 사용되며, DB 초기화에는 관여하지 않는다.</td>
+  </tr>
+  <tr>
+    <td>Per-account 니모닉 저장</td>
+    <td>니모닉은 <code>zcash_account_mnemonic_{uuid}</code> 키로 secure storage에 계정별로 저장된다. 계정 UUID는 Rust DB에서 자동 생성되므로, 반드시 <code>create_wallet</code>/<code>add_account</code> 반환값의 <code>accountUuid</code>를 사용해야 한다.</td>
+  </tr>
+  <tr>
+    <td>Sync는 계정 무관</td>
+    <td><code>start_full_sync()</code>와 <code>run_sync_inner()</code>는 <code>account_uuid</code>를 받지 않는다. DB에 등록된 모든 계정의 UFVK로 trial decryption을 수행한다. 잔액/내역 조회만 <code>account_uuid</code>로 필터링.</td>
+  </tr>
+  <tr>
+    <td>Integer-only ZEC 파싱</td>
+    <td>ZEC 금액을 zatoshi로 변환할 때 부동소수점을 사용하지 않는다. 소수점 기준으로 문자열을 분리하여 정수 연산만으로 변환. <code>0.1 ZEC</code>을 <code>double</code>로 파싱하면 <code>9999999</code>가 될 수 있다 (IEEE 754 오차).</td>
+  </tr>
+  <tr>
     <td>Wallet Creation Birthday</td>
     <td>새 지갑 생성 시 lightwalletd에서 chain tip을 birthday로 가져옴. 네트워크 실패 시 지갑 생성 차단 (full scan 방지). DB 삭제는 birthday fetch 성공 후에만.</td>
   </tr>

--- a/onboarding/rust-core.html
+++ b/onboarding/rust-core.html
@@ -22,9 +22,14 @@
                           # Uses current_thread tokio runtime (inherits iOS .utility QoS)
   api/
     mod.rs                # API 모듈 선언
-    wallet.rs             # FRB 노출 wallet 함수 (7개), get_latest_block_height()
+    wallet.rs             # FRB 노출 wallet 함수: create_wallet, import_wallet,
+                          # add_account, list_accounts, generate_mnemonic,
+                          # get_unified_address(account_uuid), get_transparent_address(account_uuid),
+                          # get_latest_block_height 등
     sync.rs               # FRB 노출: start_full_sync(), cancel_full_sync(),
-                          # get_balance(), get_transaction_history(limit), send 등
+                          # get_balance(account_uuid), get_transaction_history(account_uuid, limit),
+                          # propose_send(account_uuid), estimate_fee(account_uuid),
+                          # get_next_available_address(account_uuid) 등
     simple.rs             # init_app() — setup_default_user_utils() + log level filter (Info)
   wallet/
     mod.rs                # 내부 모듈 선언
@@ -56,7 +61,12 @@
   <li><strong>Orchard:</strong> Pallas 곡선 위의 ZIP-32 HD 유도</li>
 </ul>
 
-<p><strong>계정 생성:</strong> <code>WalletDb::create_account()</code>은 Unified Full Viewing Key (UFVK)만 데이터베이스에 저장한다. Spending key는 DB에 영속화하지 않는다.</p>
+<p><strong>계정 생성 (멀티 계정 모델):</strong> 단일 DB에 여러 계정이 공존한다. 두 가지 계정 유형이 있다:</p>
+<ul>
+  <li><strong>Derived (첫 번째 계정):</strong> <code>WalletDb::create_account()</code>으로 생성. seed relevance check를 위해 최소 하나의 Derived 계정이 필요하다.</li>
+  <li><strong>Imported (추가 계정):</strong> <code>WalletDb::import_account_ufvk()</code>로 생성. 다른 seed에서 USK를 유도하고 UFVK를 추출하여 <code>AccountPurpose::Spending { derivation: Some(Zip32Derivation) }</code>로 import한다. 이렇게 하면 서로 다른 seed의 계정이 같은 DB에 공존할 수 있다 (<code>create_account</code>은 단일 seed만 허용).</li>
+</ul>
+<p>DB에는 UFVK만 저장되며, spending key는 영속화하지 않는다. 각 계정은 <code>AccountUuid</code>로 식별된다.</p>
 
 <p><strong>주소 인코딩:</strong> Unified Address는 <code>Require Orchard + Require Sapling + Omit Transparent</code>로 생성하며, zodl/Zashi 월렛 동작과 일치한다. <code>shielded_address_request()</code> 헬퍼 함수가 이를 제어한다.</p>
 
@@ -78,12 +88,13 @@
   <tr><th>Function</th><th>역할</th></tr>
   <tr><td><code>start_full_sync(mode)</code></td><td>통합 sync 실행 (gRPC + scan + enhancement). <code>Stream&lt;ApiSyncProgressEvent&gt;</code> 반환. mode 파라미터로 foreground(1)/background(2) 구분.</td></tr>
   <tr><td><code>cancel_full_sync()</code></td><td>AtomicBool로 sync 취소 신호. sync</td></tr>
-  <tr><td><code>get_balance()</code></td><td><code>WalletBalance { transparent, sapling, orchard, transparent_pending, sapling_pending, orchard_pending, total }</code> 반환 (zatoshi). total은 confirmed + pending 합산.</td></tr>
-  <tr><td><code>get_transaction_history(limit)</code></td><td>v_transactions SQL view에서 TX 내역 조회. limit 파라미터로 최근 N건 제한 가능.</td></tr>
+  <tr><td><code>get_balance(account_uuid)</code></td><td>계정별 <code>WalletBalance { transparent, sapling, orchard, transparent_pending, sapling_pending, orchard_pending, total }</code> 반환 (zatoshi). total은 confirmed + pending 합산.</td></tr>
+  <tr><td><code>get_transaction_history(account_uuid, limit)</code></td><td>계정별 v_transactions SQL view에서 TX 내역 조회. limit 파라미터로 최근 N건 제한 가능.</td></tr>
   <tr><td><code>validate_address()</code></td><td>주소 타입 검증 (unified/sapling/transparent/invalid)</td></tr>
-  <tr><td><code>get_next_available_address()</code></td><td>다음 diversified UA 생성</td></tr>
-  <tr><td><code>propose_send()</code></td><td>전송 제안: 노트 선택 + ZIP-317 수수료 계산</td></tr>
-  <tr><td><code>execute_proposal()</code></td><td>제안 실행: zk-SNARK proof 생성 + 서명</td></tr>
+  <tr><td><code>get_next_available_address(account_uuid)</code></td><td>계정별 다음 diversified UA 생성</td></tr>
+  <tr><td><code>propose_send(account_uuid)</code></td><td>계정별 전송 제안: 노트 선택 + ZIP-317 수수료 계산. Integer-only ZEC-to-zatoshi 변환 (부동소수점 사용하지 않음). <code>StoredProposal</code>에 <code>account_id</code> 포함.</td></tr>
+  <tr><td><code>estimate_fee(account_uuid)</code></td><td>계정별 수수료 추정 (proposal 저장 없이). 전송 전 실제 수수료를 사용자에게 표시.</td></tr>
+  <tr><td><code>execute_proposal()</code></td><td>제안 실행: zk-SNARK proof 생성 + 서명. Orchard-only TX에는 no-op Sapling prover 사용. TX broadcast via gRPC. 친화적 에러 메시지 반환.</td></tr>
   <tr><td><code>rewind_to_height()</code></td><td>chain reorg 시 롤백</td></tr>
 </table>
 
@@ -114,7 +125,7 @@
 <p>이것은 <code>librustzcash</code>의 의도적인 설계이며, 우리의 선택이 아니다:</p>
 <ul>
   <li><code>WalletDb</code>에는 <strong>Unified Full Viewing Key (UFVK)</strong>만 저장된다 — 트랜잭션 감지와 잔액 계산에는 충분하지만, 자금을 사용할 수는 없다.</li>
-  <li><strong>니모닉 / seed</strong>는 Dart의 <code>flutter_secure_storage</code>(iOS Keychain / Android Keystore)에 저장되며, OS에 의해 rest 상태에서 암호화된다.</li>
+  <li><strong>니모닉 / seed</strong>는 Dart의 <code>flutter_secure_storage</code>(iOS Keychain / Android Keystore)에 계정별로 저장된다 (<code>zcash_account_mnemonic_{uuid}</code>). OS에 의해 rest 상태에서 암호화된다.</li>
   <li>Spending key는 트랜잭션 서명이 필요할 때만 seed에서 즉석에서 유도되고, FFI를 통해 Rust에 전달되며, 사용 후 <code>secrecy::SecretVec</code>으로 메모리 제로화된다.</li>
   <li><code>mnemonic_to_seed()</code>는 <code>SecretVec&lt;u8&gt;</code>을 반환한다. plain <code>Vec&lt;u8&gt;</code>이 아니므로 drop 시 자동 제로화된다.</li>
   <li>모든 API 함수 (<code>api/wallet.rs</code>, <code>api/sync.rs</code>)에 <code>catch_unwind</code> panic guard가 적용되어 있다. Rust panic이 발생해도 Flutter 프로세스가 크래시하지 않고 <code>Result::Err("Rust panic: ...")</code>으로 변환된다.</li>

--- a/onboarding/sync-engine.html
+++ b/onboarding/sync-engine.html
@@ -90,11 +90,14 @@ impl BlockSource for MemoryBlockSource {
 <h3 id="sync-scanning">5.4 Trial Decryption &amp; 노트 발견</h3>
 <p><code>zcash_client_backend</code>의 <code>scan_cached_blocks()</code>가 캐시된 블록의 모든 shielded 출력에 trial decryption을 수행한다:</p>
 <ul>
-  <li>각 Sapling 출력에 대해: 월렛의 Sapling IVK로 복호화 시도</li>
-  <li>각 Orchard 액션에 대해: 월렛의 Orchard IVK로 복호화 시도</li>
-  <li>복호화 성공 = 이 월렛의 노트 &rarr; 월렛 DB에 저장</li>
+  <li>각 Sapling 출력에 대해: DB에 있는 <strong>모든 계정</strong>의 Sapling IVK로 복호화 시도</li>
+  <li>각 Orchard 액션에 대해: DB에 있는 <strong>모든 계정</strong>의 Orchard IVK로 복호화 시도</li>
+  <li>복호화 성공 = 해당 계정의 노트 &rarr; 월렛 DB에 저장 (어떤 계정의 것인지 자동 판별)</li>
   <li>Nullifier를 추적하여 노트가 사용되었는지 감지</li>
 </ul>
+<div class="note">
+  <p><strong>멀티 계정과 Sync:</strong> Sync는 계정에 무관하게 실행된다. <code>run_sync_inner()</code>는 <code>account_uuid</code> 파라미터를 받지 않으며, DB에 등록된 모든 계정의 UFVK로 trial decryption을 수행한다. 잔액과 트랜잭션 내역 조회만 <code>account_uuid</code>로 특정 계정을 필터링한다.</p>
+</div>
 
 <h3 id="sync-progress">5.5 진행률 보고</h3>
 <p>진행률은 scan-queue 기반으로 계산한다. 매 배치 후 <code>suggest_scan_ranges()</code>에서 남은 블록 수(remaining)와 전체 블록 수(total, <code>Ignored</code> 제외)를 계산하여 <code>pct = 1.0 - remaining / total</code>로 산출한다. 이 방식은 스캔 순서(ChainTip 우선, FoundNote, Historic)에 관계없이 정확하며, 노트가 없는 지갑에서도 올바르게 동작한다.</p>

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2012,6 +2012,7 @@ dependencies = [
  "zcash_primitives",
  "zcash_proofs",
  "zcash_protocol",
+ "zip32",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2004,6 +2004,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tonic",
+ "uuid",
  "zcash_address",
  "zcash_client_backend",
  "zcash_client_sqlite",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,6 +20,7 @@ zcash_client_sqlite = { version = "0.19.5", features = ["orchard", "transparent-
 orchard = "0.11"
 sapling-crypto = { version = "0.5", default-features = false }
 uuid = "1.1"
+zip32 = "0.2"
 # Required by no-op Sapling prover trait impls
 jubjub = "0.10"
 bls12_381 = "0.8"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,6 +19,7 @@ zcash_client_sqlite = { version = "0.19.5", features = ["orchard", "transparent-
 # Must match versions used by zcash_client_sqlite to avoid type conflicts
 orchard = "0.11"
 sapling-crypto = { version = "0.5", default-features = false }
+uuid = "1.1"
 # Required by no-op Sapling prover trait impls
 jubjub = "0.10"
 bls12_381 = "0.8"

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -242,10 +242,10 @@ pub fn get_sync_status(db_path: String, network: String) -> Result<SyncProgress,
     })
 }
 
-pub fn get_balance(db_path: String, network: String) -> Result<WalletBalance, String> {
+pub fn get_balance(db_path: String, network: String, account_uuid: String) -> Result<WalletBalance, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
-        let b = wallet_sync::get_wallet_balance(&db_path, network)?;
+        let b = wallet_sync::get_wallet_balance(&db_path, network, &account_uuid)?;
         Ok(WalletBalance {
             transparent: b.transparent, sapling: b.sapling, orchard: b.orchard,
             transparent_pending: b.transparent_pending, sapling_pending: b.sapling_pending, orchard_pending: b.orchard_pending,
@@ -284,12 +284,12 @@ pub struct ProposalResult {
 
 /// Step 1: Propose a transfer. Returns proposal info including whether Sapling params are needed.
 pub fn propose_send(
-    db_path: String, network: String,
+    db_path: String, network: String, account_uuid: String,
     to_address: String, amount_zatoshi: u64, memo: Option<String>,
 ) -> Result<ProposalResult, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
-        let r = wallet_sync::propose_send(&db_path, network, &to_address, amount_zatoshi, memo.as_deref())?;
+        let r = wallet_sync::propose_send(&db_path, network, &account_uuid, &to_address, amount_zatoshi, memo.as_deref())?;
         Ok(ProposalResult {
             proposal_id: r.proposal_id,
             needs_sapling_params: r.needs_sapling_params,
@@ -300,12 +300,12 @@ pub fn propose_send(
 
 /// Estimate the fee for a transfer without storing a proposal.
 pub fn estimate_fee(
-    db_path: String, network: String,
+    db_path: String, network: String, account_uuid: String,
     to_address: String, amount_zatoshi: u64, memo: Option<String>,
 ) -> Result<u64, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
-        wallet_sync::estimate_fee(&db_path, network, &to_address, amount_zatoshi, memo.as_deref())
+        wallet_sync::estimate_fee(&db_path, network, &account_uuid, &to_address, amount_zatoshi, memo.as_deref())
     })
 }
 
@@ -326,10 +326,10 @@ pub fn execute_proposal(
 
 // ======================== Diversified Address ========================
 
-pub fn get_next_available_address(db_path: String, network: String) -> Result<String, String> {
+pub fn get_next_available_address(db_path: String, network: String, account_uuid: String) -> Result<String, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
-        wallet_sync::get_next_available_address(&db_path, network)
+        wallet_sync::get_next_available_address(&db_path, network, &account_uuid)
     })
 }
 
@@ -383,10 +383,10 @@ pub struct TransactionInfo {
     pub block_time: u64,
 }
 
-pub fn get_transaction_history(db_path: String, network: String, limit: Option<u32>) -> Result<Vec<TransactionInfo>, String> {
+pub fn get_transaction_history(db_path: String, network: String, limit: Option<u32>, account_uuid: String) -> Result<Vec<TransactionInfo>, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
-        let txs = wallet_sync::get_transaction_history(&db_path, network, limit)?;
+        let txs = wallet_sync::get_transaction_history(&db_path, network, limit, &account_uuid)?;
         Ok(txs.into_iter().map(|t| TransactionInfo {
             txid_hex: t.txid_hex, mined_height: t.mined_height, expired_unmined: t.expired_unmined,
             account_balance_delta: t.account_balance_delta, fee: t.fee, block_time: t.block_time,

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -151,6 +151,12 @@ pub fn get_unified_address(db_path: String, network: String, account_uuid: Optio
     })
 }
 
+/// Generate a new 24-word BIP-39 mnemonic phrase.
+#[flutter_rust_bridge::frb(sync)]
+pub fn generate_mnemonic() -> String {
+    keys::generate_mnemonic()
+}
+
 /// Check if a wallet database exists at the given path.
 #[flutter_rust_bridge::frb(sync)]
 pub fn wallet_exists(db_path: String) -> bool {

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -122,7 +122,8 @@ pub fn add_account(
         let network = keys::parse_network(&network)?;
         let seed = keys::mnemonic_to_seed(&mnemonic)?;
 
-        keys::ensure_db_initialized(&db_path, network, &seed)?;
+        // DB is already initialized by the first account — do not call ensure_db_initialized
+        // with a different seed (seed fingerprint mismatch would cause an error).
         let (account_uuid, unified_address) =
             keys::add_account(&db_path, network, &name, &seed, birthday_height)?;
 

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -79,13 +79,14 @@ pub fn get_latest_block_height(lightwalletd_url: String) -> Result<u64, String> 
 
 /// Create a new Zcash wallet with a fresh mnemonic.
 /// birthday_height should be the current chain tip (from get_latest_block_height).
-pub fn create_wallet(network: String, db_path: String, birthday_height: Option<u64>) -> Result<WalletCreationResult, String> {
+pub fn create_wallet(network: String, db_path: String, birthday_height: Option<u64>, account_name: Option<String>) -> Result<WalletCreationResult, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
         let mnemonic = keys::generate_mnemonic();
         let seed = keys::mnemonic_to_seed(&mnemonic)?;
+        let name = account_name.as_deref().unwrap_or("Account 1");
 
-        let (account_uuid, unified_address) = keys::init_db_and_create_account(&db_path, network, &seed, birthday_height)?;
+        let (account_uuid, unified_address) = keys::init_db_and_create_account(&db_path, network, &seed, birthday_height, name)?;
 
         Ok(WalletCreationResult {
             mnemonic,
@@ -101,13 +102,15 @@ pub fn import_wallet(
     birthday_height: Option<u64>,
     network: String,
     db_path: String,
+    account_name: Option<String>,
 ) -> Result<WalletImportResult, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
         let seed = keys::mnemonic_to_seed(&mnemonic)?;
+        let name = account_name.as_deref().unwrap_or("Account 1");
 
         let (account_uuid, unified_address) =
-            keys::init_db_and_create_account(&db_path, network, &seed, birthday_height)?;
+            keys::init_db_and_create_account(&db_path, network, &seed, birthday_height, name)?;
 
         Ok(WalletImportResult { unified_address, account_uuid })
     })

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -4,14 +4,29 @@ use secrecy::ExposeSecret;
 
 use crate::wallet::keys;
 
-/// Result of wallet creation, containing the mnemonic and unified address.
+/// Result of wallet creation, containing the mnemonic, unified address, and account UUID.
 pub struct WalletCreationResult {
     pub mnemonic: String,
     pub unified_address: String,
+    pub account_uuid: String,
 }
 
-/// Result of wallet import, containing the unified address.
+/// Result of wallet import, containing the unified address and account UUID.
 pub struct WalletImportResult {
+    pub unified_address: String,
+    pub account_uuid: String,
+}
+
+/// Result of adding an account to an existing wallet.
+pub struct AccountCreationResult {
+    pub account_uuid: String,
+    pub unified_address: String,
+}
+
+/// Account info returned by list_accounts.
+pub struct AccountInfo {
+    pub uuid: String,
+    pub name: String,
     pub unified_address: String,
 }
 
@@ -70,11 +85,12 @@ pub fn create_wallet(network: String, db_path: String, birthday_height: Option<u
         let mnemonic = keys::generate_mnemonic();
         let seed = keys::mnemonic_to_seed(&mnemonic)?;
 
-        let unified_address = keys::init_db_and_create_account(&db_path, network, &seed, birthday_height)?;
+        let (account_uuid, unified_address) = keys::init_db_and_create_account(&db_path, network, &seed, birthday_height)?;
 
         Ok(WalletCreationResult {
             mnemonic,
             unified_address,
+            account_uuid,
         })
     })
 }
@@ -90,18 +106,48 @@ pub fn import_wallet(
         let network = keys::parse_network(&network)?;
         let seed = keys::mnemonic_to_seed(&mnemonic)?;
 
-        let unified_address =
+        let (account_uuid, unified_address) =
             keys::init_db_and_create_account(&db_path, network, &seed, birthday_height)?;
 
-        Ok(WalletImportResult { unified_address })
+        Ok(WalletImportResult { unified_address, account_uuid })
     })
 }
 
-/// Get the Unified Address for the wallet.
-pub fn get_unified_address(db_path: String, network: String) -> Result<String, String> {
+/// Add an additional account to an existing wallet database.
+pub fn add_account(
+    db_path: String, network: String, name: String,
+    mnemonic: String, birthday_height: Option<u64>,
+) -> Result<AccountCreationResult, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
-        keys::get_address_from_db(&db_path, network)
+        let seed = keys::mnemonic_to_seed(&mnemonic)?;
+
+        keys::ensure_db_initialized(&db_path, network, &seed)?;
+        let (account_uuid, unified_address) =
+            keys::add_account(&db_path, network, &name, &seed, birthday_height)?;
+
+        Ok(AccountCreationResult { account_uuid, unified_address })
+    })
+}
+
+/// List all accounts in the wallet database.
+pub fn list_accounts(db_path: String, network: String) -> Result<Vec<AccountInfo>, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        let accounts = keys::list_accounts(&db_path, network)?;
+        Ok(accounts.into_iter().map(|a| AccountInfo {
+            uuid: a.uuid,
+            name: a.name,
+            unified_address: a.unified_address,
+        }).collect())
+    })
+}
+
+/// Get the Unified Address for a specific account (or first account if uuid is None).
+pub fn get_unified_address(db_path: String, network: String, account_uuid: Option<String>) -> Result<String, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        keys::get_address_from_db(&db_path, network, account_uuid.as_deref())
     })
 }
 
@@ -126,10 +172,10 @@ pub fn derive_seed(mnemonic: String) -> Result<Vec<u8>, String> {
     })
 }
 
-/// Get the transparent address for the wallet (separate from the shielded UA).
-pub fn get_transparent_address(db_path: String, network: String) -> Result<String, String> {
+/// Get the transparent address for a specific account (or first account if uuid is None).
+pub fn get_transparent_address(db_path: String, network: String, account_uuid: Option<String>) -> Result<String, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
-        keys::get_transparent_address_from_db(&db_path, network)
+        keys::get_transparent_address_from_db(&db_path, network, account_uuid.as_deref())
     })
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -2017955125;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1789710638;
 
 // Section: executor
 
@@ -45,6 +45,49 @@ flutter_rust_bridge::frb_generated_default_handler!();
 
 // Section: wire_funcs
 
+fn wire__crate__api__wallet__add_account_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "add_account",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_name = <String>::sse_decode(&mut deserializer);
+            let api_mnemonic = <String>::sse_decode(&mut deserializer);
+            let api_birthday_height = <Option<u64>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::wallet::add_account(
+                        api_db_path,
+                        api_network,
+                        api_name,
+                        api_mnemonic,
+                        api_birthday_height,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__sync__cancel_full_sync_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -607,11 +650,15 @@ fn wire__crate__api__wallet__get_transparent_address_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
-                    let output_ok =
-                        crate::api::wallet::get_transparent_address(api_db_path, api_network)?;
+                    let output_ok = crate::api::wallet::get_transparent_address(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -642,11 +689,15 @@ fn wire__crate__api__wallet__get_unified_address_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
-                    let output_ok =
-                        crate::api::wallet::get_unified_address(api_db_path, api_network)?;
+                    let output_ok = crate::api::wallet::get_unified_address(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -784,6 +835,40 @@ fn wire__crate__api__sync__is_sync_running_impl(
                 let output_ok = Result::<_, ()>::Ok(crate::api::sync::is_sync_running())?;
                 Ok(output_ok)
             })())
+        },
+    )
+}
+fn wire__crate__api__wallet__list_accounts_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "list_accounts",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::wallet::list_accounts(api_db_path, api_network)?;
+                    Ok(output_ok)
+                })())
+            }
         },
     )
 }
@@ -1320,6 +1405,32 @@ impl SseDecode for String {
     }
 }
 
+impl SseDecode for crate::api::wallet::AccountCreationResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_accountUuid = <String>::sse_decode(deserializer);
+        let mut var_unifiedAddress = <String>::sse_decode(deserializer);
+        return crate::api::wallet::AccountCreationResult {
+            account_uuid: var_accountUuid,
+            unified_address: var_unifiedAddress,
+        };
+    }
+}
+
+impl SseDecode for crate::api::wallet::AccountInfo {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_uuid = <String>::sse_decode(deserializer);
+        let mut var_name = <String>::sse_decode(deserializer);
+        let mut var_unifiedAddress = <String>::sse_decode(deserializer);
+        return crate::api::wallet::AccountInfo {
+            uuid: var_uuid,
+            name: var_name,
+            unified_address: var_unifiedAddress,
+        };
+    }
+}
+
 impl SseDecode for crate::api::sync::AddressValidationResult {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -1388,6 +1499,18 @@ impl SseDecode for i64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         deserializer.cursor.read_i64::<NativeEndian>().unwrap()
+    }
+}
+
+impl SseDecode for Vec<crate::api::wallet::AccountInfo> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::wallet::AccountInfo>::sse_decode(deserializer));
+        }
+        return ans_;
     }
 }
 
@@ -1665,9 +1788,11 @@ impl SseDecode for crate::api::wallet::WalletCreationResult {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_mnemonic = <String>::sse_decode(deserializer);
         let mut var_unifiedAddress = <String>::sse_decode(deserializer);
+        let mut var_accountUuid = <String>::sse_decode(deserializer);
         return crate::api::wallet::WalletCreationResult {
             mnemonic: var_mnemonic,
             unified_address: var_unifiedAddress,
+            account_uuid: var_accountUuid,
         };
     }
 }
@@ -1676,8 +1801,10 @@ impl SseDecode for crate::api::wallet::WalletImportResult {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_unifiedAddress = <String>::sse_decode(deserializer);
+        let mut var_accountUuid = <String>::sse_decode(deserializer);
         return crate::api::wallet::WalletImportResult {
             unified_address: var_unifiedAddress,
+            account_uuid: var_accountUuid,
         };
     }
 }
@@ -1698,63 +1825,65 @@ fn pde_ffi_dispatcher_primary_impl(
 ) {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        2 => wire__crate__api__wallet__create_wallet_impl(port, ptr, rust_vec_len, data_len),
-        3 => wire__crate__api__sync__decrypt_and_store_transaction_impl(
+        1 => wire__crate__api__wallet__add_account_impl(port, ptr, rust_vec_len, data_len),
+        3 => wire__crate__api__wallet__create_wallet_impl(port, ptr, rust_vec_len, data_len),
+        4 => wire__crate__api__sync__decrypt_and_store_transaction_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        4 => wire__crate__api__wallet__derive_seed_impl(port, ptr, rust_vec_len, data_len),
-        5 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__wallet__get_latest_block_height_impl(
+        5 => wire__crate__api__wallet__derive_seed_impl(port, ptr, rust_vec_len, data_len),
+        6 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
+        7 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__wallet__get_latest_block_height_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        10 => wire__crate__api__sync__get_next_available_address_impl(
+        11 => wire__crate__api__sync__get_next_available_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        11 => {
+        12 => {
             wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len)
         }
-        13 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__sync__get_transaction_data_requests_impl(
+        14 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__sync__get_transaction_data_requests_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        15 => {
+        16 => {
             wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len)
         }
-        16 => wire__crate__api__wallet__get_transparent_address_impl(
+        17 => wire__crate__api__wallet__get_transparent_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        17 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-        27 => {
+        18 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+        29 => {
             wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len)
         }
-        28 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1767,20 +1896,63 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        1 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        2 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
+        9 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        13 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
 
 // Section: rust2dart
 
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::wallet::AccountCreationResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.account_uuid.into_into_dart().into_dart(),
+            self.unified_address.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::wallet::AccountCreationResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::AccountCreationResult>
+    for crate::api::wallet::AccountCreationResult
+{
+    fn into_into_dart(self) -> crate::api::wallet::AccountCreationResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::wallet::AccountInfo {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.uuid.into_into_dart().into_dart(),
+            self.name.into_into_dart().into_dart(),
+            self.unified_address.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::wallet::AccountInfo
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::AccountInfo>
+    for crate::api::wallet::AccountInfo
+{
+    fn into_into_dart(self) -> crate::api::wallet::AccountInfo {
+        self
+    }
+}
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::sync::AddressValidationResult {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
@@ -2051,6 +2223,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::wallet::WalletCreationResult 
         [
             self.mnemonic.into_into_dart().into_dart(),
             self.unified_address.into_into_dart().into_dart(),
+            self.account_uuid.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -2069,7 +2242,11 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::WalletCreationResult>
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::wallet::WalletImportResult {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [self.unified_address.into_into_dart().into_dart()].into_dart()
+        [
+            self.unified_address.into_into_dart().into_dart(),
+            self.account_uuid.into_into_dart().into_dart(),
+        ]
+        .into_dart()
     }
 }
 impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
@@ -2107,6 +2284,23 @@ impl SseEncode for String {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <Vec<u8>>::sse_encode(self.into_bytes(), serializer);
+    }
+}
+
+impl SseEncode for crate::api::wallet::AccountCreationResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.account_uuid, serializer);
+        <String>::sse_encode(self.unified_address, serializer);
+    }
+}
+
+impl SseEncode for crate::api::wallet::AccountInfo {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.uuid, serializer);
+        <String>::sse_encode(self.name, serializer);
+        <String>::sse_encode(self.unified_address, serializer);
     }
 }
 
@@ -2159,6 +2353,16 @@ impl SseEncode for i64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         serializer.cursor.write_i64::<NativeEndian>(self).unwrap();
+    }
+}
+
+impl SseEncode for Vec<crate::api::wallet::AccountInfo> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::wallet::AccountInfo>::sse_encode(item, serializer);
+        }
     }
 }
 
@@ -2369,6 +2573,7 @@ impl SseEncode for crate::api::wallet::WalletCreationResult {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.mnemonic, serializer);
         <String>::sse_encode(self.unified_address, serializer);
+        <String>::sse_encode(self.account_uuid, serializer);
     }
 }
 
@@ -2376,6 +2581,7 @@ impl SseEncode for crate::api::wallet::WalletImportResult {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.unified_address, serializer);
+        <String>::sse_encode(self.account_uuid, serializer);
     }
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -144,6 +144,7 @@ fn wire__crate__api__wallet__create_wallet_impl(
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_birthday_height = <Option<u64>>::sse_decode(&mut deserializer);
+            let api_account_name = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -151,6 +152,7 @@ fn wire__crate__api__wallet__create_wallet_impl(
                         api_network,
                         api_db_path,
                         api_birthday_height,
+                        api_account_name,
                     )?;
                     Ok(output_ok)
                 })())
@@ -799,6 +801,7 @@ fn wire__crate__api__wallet__import_wallet_impl(
             let api_birthday_height = <Option<u64>>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_name = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -807,6 +810,7 @@ fn wire__crate__api__wallet__import_wallet_impl(
                         api_birthday_height,
                         api_network,
                         api_db_path,
+                        api_account_name,
                     )?;
                     Ok(output_ok)
                 })())

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -256,6 +256,7 @@ fn wire__crate__api__sync__estimate_fee_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_to_address = <String>::sse_decode(&mut deserializer);
             let api_amount_zatoshi = <u64>::sse_decode(&mut deserializer);
             let api_memo = <Option<String>>::sse_decode(&mut deserializer);
@@ -265,6 +266,7 @@ fn wire__crate__api__sync__estimate_fee_impl(
                     let output_ok = crate::api::sync::estimate_fee(
                         api_db_path,
                         api_network,
+                        api_account_uuid,
                         api_to_address,
                         api_amount_zatoshi,
                         api_memo,
@@ -344,10 +346,12 @@ fn wire__crate__api__sync__get_balance_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
-                    let output_ok = crate::api::sync::get_balance(api_db_path, api_network)?;
+                    let output_ok =
+                        crate::api::sync::get_balance(api_db_path, api_network, api_account_uuid)?;
                     Ok(output_ok)
                 })())
             }
@@ -443,11 +447,15 @@ fn wire__crate__api__sync__get_next_available_address_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
-                    let output_ok =
-                        crate::api::sync::get_next_available_address(api_db_path, api_network)?;
+                    let output_ok = crate::api::sync::get_next_available_address(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -612,6 +620,7 @@ fn wire__crate__api__sync__get_transaction_history_impl(
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_limit = <Option<u32>>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -619,6 +628,7 @@ fn wire__crate__api__sync__get_transaction_history_impl(
                         api_db_path,
                         api_network,
                         api_limit,
+                        api_account_uuid,
                     )?;
                     Ok(output_ok)
                 })())
@@ -896,6 +906,7 @@ fn wire__crate__api__sync__propose_send_impl(
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_to_address = <String>::sse_decode(&mut deserializer);
             let api_amount_zatoshi = <u64>::sse_decode(&mut deserializer);
             let api_memo = <Option<String>>::sse_decode(&mut deserializer);
@@ -905,6 +916,7 @@ fn wire__crate__api__sync__propose_send_impl(
                     let output_ok = crate::api::sync::propose_send(
                         api_db_path,
                         api_network,
+                        api_account_uuid,
                         api_to_address,
                         api_amount_zatoshi,
                         api_memo,

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1789710638;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1185829757;
 
 // Section: executor
 
@@ -319,6 +319,35 @@ fn wire__crate__api__sync__execute_proposal_impl(
                     Ok(output_ok)
                 })())
             }
+        },
+    )
+}
+fn wire__crate__api__wallet__generate_mnemonic_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "generate_mnemonic",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::wallet::generate_mnemonic())?;
+                Ok(output_ok)
+            })())
         },
     )
 }
@@ -1848,54 +1877,54 @@ fn pde_ffi_dispatcher_primary_impl(
         5 => wire__crate__api__wallet__derive_seed_impl(port, ptr, rust_vec_len, data_len),
         6 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
         7 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-        8 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        10 => wire__crate__api__wallet__get_latest_block_height_impl(
+        9 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+        11 => wire__crate__api__wallet__get_latest_block_height_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        11 => wire__crate__api__sync__get_next_available_address_impl(
+        12 => wire__crate__api__sync__get_next_available_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        12 => {
+        13 => {
             wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len)
         }
-        14 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__sync__get_transaction_data_requests_impl(
+        15 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+        16 => wire__crate__api__sync__get_transaction_data_requests_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        16 => {
+        17 => {
             wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len)
         }
-        17 => wire__crate__api__wallet__get_transparent_address_impl(
+        18 => wire__crate__api__wallet__get_transparent_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        18 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-        29 => {
+        19 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+        30 => {
             wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len)
         }
-        30 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1909,13 +1938,14 @@ fn pde_ffi_dispatcher_sync_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         2 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        13 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        10 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        14 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -4,12 +4,13 @@ use bip0039::{Count, English, Mnemonic};
 use rand::rngs::OsRng;
 use secrecy::{ExposeSecret, SecretVec};
 use zcash_client_backend::data_api::{
-    Account as _, AccountBirthday, WalletRead, WalletWrite,
+    Account as _, AccountBirthday, AccountPurpose, WalletRead, WalletWrite, Zip32Derivation,
     chain::ChainState,
 };
 use zcash_client_sqlite::{AccountUuid, WalletDb, util::SystemClock, wallet::init::init_wallet_db};
-use zcash_keys::keys::{ReceiverRequirement, UnifiedAddressRequest};
+use zcash_keys::keys::{ReceiverRequirement, UnifiedAddressRequest, UnifiedSpendingKey};
 use zcash_primitives::block::BlockHash;
+use zip32::fingerprint::SeedFingerprint;
 use zcash_protocol::consensus::{BlockHeight, Network, NetworkUpgrade, Parameters};
 
 /// Generate a new 24-word BIP-39 mnemonic phrase.
@@ -69,6 +70,8 @@ fn make_birthday(network: Network, birthday_height: Option<u64>) -> AccountBirth
 }
 
 /// Add a new account to the wallet database. Returns (account_uuid, unified_address).
+/// Uses import_account_ufvk with AccountPurpose::Spending so that accounts from
+/// different seeds can coexist in the same DB (create_account enforces single-seed).
 pub fn add_account(
     db_path: &str,
     network: Network,
@@ -81,11 +84,23 @@ pub fn add_account(
 
     let birthday = make_birthday(network, birthday_height);
 
-    let (account_id, usk) = db
-        .create_account(name, seed, &birthday, None)
-        .map_err(|e| format!("Failed to create account: {e}"))?;
-
+    // Derive USK and UFVK from seed
+    let seed_fp = SeedFingerprint::from_seed(seed.expose_secret())
+        .ok_or("Invalid seed length for fingerprint")?;
+    let account_index = zip32::AccountId::ZERO;
+    let usk = UnifiedSpendingKey::from_seed(&network, seed.expose_secret(), account_index)
+        .map_err(|e| format!("USK derivation failed: {e:?}"))?;
     let ufvk = usk.to_unified_full_viewing_key();
+
+    // Import as UFVK with Spending purpose + derivation info
+    let derivation = Zip32Derivation::new(seed_fp, account_index);
+    let purpose = AccountPurpose::Spending { derivation: Some(derivation) };
+
+    let account = db
+        .import_account_ufvk(name, &ufvk, &birthday, purpose, None)
+        .map_err(|e| format!("Failed to import account: {e}"))?;
+
+    let account_id = account.id();
     let (ua, _di) = ufvk
         .default_address(shielded_address_request())
         .map_err(|e| format!("Failed to derive address: {e}"))?;

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -37,7 +37,21 @@ pub fn parse_network(network: &str) -> Result<Network, String> {
 }
 
 /// Initialize the wallet database schema. Idempotent — safe to call multiple times.
+/// Called without seed to avoid SeedNotRelevant errors when only Imported accounts exist.
 pub fn ensure_db_initialized(
+    db_path: &str,
+    network: Network,
+) -> Result<(), String> {
+    let mut db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
+        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+    init_wallet_db(&mut db, None)
+        .map_err(|e| format!("Failed to init wallet DB: {e}"))?;
+    Ok(())
+}
+
+/// Initialize DB with seed for the first account (creates a Derived account).
+/// The seed is needed so that seed-requiring migrations can run in the future.
+fn ensure_db_initialized_with_seed(
     db_path: &str,
     network: Network,
     seed: &SecretVec<u8>,
@@ -69,9 +83,10 @@ fn make_birthday(network: Network, birthday_height: Option<u64>) -> AccountBirth
     }
 }
 
-/// Add a new account to the wallet database. Returns (account_uuid, unified_address).
+/// Add an additional account (from a different seed) to the wallet database.
 /// Uses import_account_ufvk with AccountPurpose::Spending so that accounts from
 /// different seeds can coexist in the same DB (create_account enforces single-seed).
+/// The first account should be created via init_db_and_create_account (Derived).
 pub fn add_account(
     db_path: &str,
     network: Network,
@@ -109,7 +124,8 @@ pub fn add_account(
     Ok((uuid_str, ua.encode(&network)))
 }
 
-/// Init DB + create account. Returns (account_uuid, unified_address).
+/// Init DB + create first account as Derived (so seed relevance checks pass on future migrations).
+/// Returns (account_uuid, unified_address).
 pub fn init_db_and_create_account(
     db_path: &str,
     network: Network,
@@ -117,8 +133,26 @@ pub fn init_db_and_create_account(
     birthday_height: Option<u64>,
     name: &str,
 ) -> Result<(String, String), String> {
-    ensure_db_initialized(db_path, network, seed)?;
-    add_account(db_path, network, name, seed, birthday_height)
+    ensure_db_initialized_with_seed(db_path, network, seed)?;
+
+    let mut db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
+        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+
+    let birthday = make_birthday(network, birthday_height);
+
+    // First account uses create_account (Derived) — ensures at least one Derived account
+    // exists for future init_wallet_db seed relevance checks.
+    let (account_id, usk) = db
+        .create_account(name, seed, &birthday, None)
+        .map_err(|e| format!("Failed to create account: {e}"))?;
+
+    let ufvk = usk.to_unified_full_viewing_key();
+    let (ua, _di) = ufvk
+        .default_address(shielded_address_request())
+        .map_err(|e| format!("Failed to derive address: {e}"))?;
+
+    let uuid_str = account_id.expose_uuid().to_string();
+    Ok((uuid_str, ua.encode(&network)))
 }
 
 pub struct AccountInfo {

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -94,15 +94,16 @@ pub fn add_account(
     Ok((uuid_str, ua.encode(&network)))
 }
 
-/// Legacy wrapper: init DB + create account named "default". Returns unified address.
+/// Init DB + create account. Returns (account_uuid, unified_address).
 pub fn init_db_and_create_account(
     db_path: &str,
     network: Network,
     seed: &SecretVec<u8>,
     birthday_height: Option<u64>,
+    name: &str,
 ) -> Result<(String, String), String> {
     ensure_db_initialized(db_path, network, seed)?;
-    add_account(db_path, network, "default", seed, birthday_height)
+    add_account(db_path, network, name, seed, birthday_height)
 }
 
 pub struct AccountInfo {
@@ -274,7 +275,7 @@ mod tests {
         let seed = mnemonic_to_seed(&phrase).unwrap();
 
         let (_uuid, address) =
-            init_db_and_create_account(db_path_str, Network::MainNetwork, &seed, None).unwrap();
+            init_db_and_create_account(db_path_str, Network::MainNetwork, &seed, None, "test").unwrap();
 
         // Mainnet unified addresses start with "u1"
         assert!(
@@ -297,7 +298,7 @@ mod tests {
         let seed = mnemonic_to_seed(&phrase).unwrap();
 
         let (_, address) =
-            init_db_and_create_account(db_path_str, Network::TestNetwork, &seed, None).unwrap();
+            init_db_and_create_account(db_path_str, Network::TestNetwork, &seed, None, "test").unwrap();
 
         assert!(
             address.starts_with("utest1"),
@@ -313,13 +314,13 @@ mod tests {
         let temp1 = tempfile::tempdir().unwrap();
         let db1 = temp1.path().join("wallet.db");
         let (_, addr1) =
-            init_db_and_create_account(db1.to_str().unwrap(), Network::MainNetwork, &seed, None)
+            init_db_and_create_account(db1.to_str().unwrap(), Network::MainNetwork, &seed, None, "test")
                 .unwrap();
 
         let temp2 = tempfile::tempdir().unwrap();
         let db2 = temp2.path().join("wallet.db");
         let (_, addr2) =
-            init_db_and_create_account(db2.to_str().unwrap(), Network::MainNetwork, &seed, None)
+            init_db_and_create_account(db2.to_str().unwrap(), Network::MainNetwork, &seed, None, "test")
                 .unwrap();
 
         assert_eq!(addr1, addr2, "Same seed should produce same address");
@@ -337,7 +338,7 @@ mod tests {
         let seed = mnemonic_to_seed(&phrase).unwrap();
 
         let (_, address) =
-            init_db_and_create_account(db_path_str, Network::MainNetwork, &seed, None).unwrap();
+            init_db_and_create_account(db_path_str, Network::MainNetwork, &seed, None, "test").unwrap();
 
         // Decode and verify receiver types
         let za = zcash_address::ZcashAddress::try_from_encoded(&address).unwrap();

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -7,7 +7,7 @@ use zcash_client_backend::data_api::{
     Account as _, AccountBirthday, WalletRead, WalletWrite,
     chain::ChainState,
 };
-use zcash_client_sqlite::{WalletDb, util::SystemClock, wallet::init::init_wallet_db};
+use zcash_client_sqlite::{AccountUuid, WalletDb, util::SystemClock, wallet::init::init_wallet_db};
 use zcash_keys::keys::{ReceiverRequirement, UnifiedAddressRequest};
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::{BlockHeight, Network, NetworkUpgrade, Parameters};
@@ -35,43 +35,54 @@ pub fn parse_network(network: &str) -> Result<Network, String> {
     }
 }
 
-/// Initialize the wallet database and create an account from a seed.
-/// Returns the Unified Address string.
-pub fn init_db_and_create_account(
+/// Initialize the wallet database schema. Idempotent — safe to call multiple times.
+pub fn ensure_db_initialized(
     db_path: &str,
     network: Network,
     seed: &SecretVec<u8>,
-    birthday_height: Option<u64>,
-) -> Result<String, String> {
+) -> Result<(), String> {
     let mut db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
         .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
-
     init_wallet_db(
         &mut db,
         Some(SecretVec::new(seed.expose_secret().to_vec())),
     )
     .map_err(|e| format!("Failed to init wallet DB: {e}"))?;
+    Ok(())
+}
 
-    let birthday = match birthday_height {
+fn make_birthday(network: Network, birthday_height: Option<u64>) -> AccountBirthday {
+    match birthday_height {
         Some(h) => {
             let height = BlockHeight::from_u32(h as u32);
-            let prior_height = height - 1;
-            let chain_state = ChainState::empty(prior_height, BlockHash([0u8; 32]));
+            let chain_state = ChainState::empty(height - 1, BlockHash([0u8; 32]));
             AccountBirthday::from_parts(chain_state, None)
         }
         None => {
-            // For new wallets, use Sapling activation as default
             let sapling_height = network
                 .activation_height(NetworkUpgrade::Sapling)
                 .expect("Sapling activation height must be known");
-            let chain_state =
-                ChainState::empty(sapling_height - 1, BlockHash([0u8; 32]));
+            let chain_state = ChainState::empty(sapling_height - 1, BlockHash([0u8; 32]));
             AccountBirthday::from_parts(chain_state, None)
         }
-    };
+    }
+}
 
-    let (_account_id, usk) = db
-        .create_account("default", &seed, &birthday, None)
+/// Add a new account to the wallet database. Returns (account_uuid, unified_address).
+pub fn add_account(
+    db_path: &str,
+    network: Network,
+    name: &str,
+    seed: &SecretVec<u8>,
+    birthday_height: Option<u64>,
+) -> Result<(String, String), String> {
+    let mut db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
+        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+
+    let birthday = make_birthday(network, birthday_height);
+
+    let (account_id, usk) = db
+        .create_account(name, seed, &birthday, None)
         .map_err(|e| format!("Failed to create account: {e}"))?;
 
     let ufvk = usk.to_unified_full_viewing_key();
@@ -79,22 +90,86 @@ pub fn init_db_and_create_account(
         .default_address(shielded_address_request())
         .map_err(|e| format!("Failed to derive address: {e}"))?;
 
-    Ok(ua.encode(&network))
+    let uuid_str = account_id.expose_uuid().to_string();
+    Ok((uuid_str, ua.encode(&network)))
 }
 
-/// Get the Unified Address from an existing wallet database.
-pub fn get_address_from_db(db_path: &str, network: Network) -> Result<String, String> {
+/// Legacy wrapper: init DB + create account named "default". Returns unified address.
+pub fn init_db_and_create_account(
+    db_path: &str,
+    network: Network,
+    seed: &SecretVec<u8>,
+    birthday_height: Option<u64>,
+) -> Result<(String, String), String> {
+    ensure_db_initialized(db_path, network, seed)?;
+    add_account(db_path, network, "default", seed, birthday_height)
+}
+
+pub struct AccountInfo {
+    pub uuid: String,
+    pub name: String,
+    pub unified_address: String,
+}
+
+/// List all accounts in the wallet database.
+pub fn list_accounts(db_path: &str, network: Network) -> Result<Vec<AccountInfo>, String> {
     let db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
         .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
 
-    let accounts = db
-        .get_account_ids()
+    let account_ids = db.get_account_ids()
         .map_err(|e| format!("Failed to list accounts: {e}"))?;
 
-    let account_id = accounts
-        .into_iter()
-        .next()
-        .ok_or("No accounts found in wallet")?;
+    let mut accounts = Vec::new();
+    for id in account_ids {
+        let account = db.get_account(id)
+            .map_err(|e| format!("Failed to get account: {e}"))?
+            .ok_or_else(|| format!("Account not found: {}", id.expose_uuid()))?;
+
+        let address = match account.ufvk() {
+            Some(ufvk) => {
+                let (ua, _) = ufvk.default_address(shielded_address_request())
+                    .map_err(|e| format!("Failed to derive address: {e}"))?;
+                ua.encode(&network)
+            }
+            None => String::new(),
+        };
+
+        accounts.push(AccountInfo {
+            uuid: id.expose_uuid().to_string(),
+            name: account.name().unwrap_or("").to_string(),
+            unified_address: address,
+        });
+    }
+
+    Ok(accounts)
+}
+
+/// Parse an account UUID string into AccountUuid.
+pub fn parse_account_uuid(s: &str) -> Result<AccountUuid, String> {
+    let uuid = uuid::Uuid::parse_str(s).map_err(|e| format!("Invalid account UUID: {e}"))?;
+    Ok(AccountUuid::from_uuid(uuid))
+}
+
+/// Resolve account_id: if uuid provided, parse it; otherwise take first account.
+fn resolve_account_id(
+    db: &WalletDb<rusqlite::Connection, Network, SystemClock, OsRng>,
+    account_uuid: Option<&str>,
+) -> Result<AccountUuid, String> {
+    match account_uuid {
+        Some(uuid_str) => parse_account_uuid(uuid_str),
+        None => {
+            let ids = db.get_account_ids().map_err(|e| format!("Failed to list accounts: {e}"))?;
+            ids.into_iter().next().ok_or_else(|| "No accounts found in wallet".to_string())
+        }
+    }
+}
+
+/// Get the Unified Address from an existing wallet database.
+pub fn get_address_from_db(db_path: &str, network: Network, account_uuid: Option<&str>) -> Result<String, String> {
+    let db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
+        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+
+    let account_id = resolve_account_id(&db, account_uuid)?;
 
     let account = db
         .get_account(account_id)
@@ -124,18 +199,11 @@ fn shielded_address_request() -> UnifiedAddressRequest {
 }
 
 /// Get the transparent address from an existing wallet database.
-pub fn get_transparent_address_from_db(db_path: &str, network: Network) -> Result<String, String> {
+pub fn get_transparent_address_from_db(db_path: &str, network: Network, account_uuid: Option<&str>) -> Result<String, String> {
     let db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
         .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
 
-    let accounts = db
-        .get_account_ids()
-        .map_err(|e| format!("Failed to list accounts: {e}"))?;
-
-    let account_id = accounts
-        .into_iter()
-        .next()
-        .ok_or("No accounts found in wallet")?;
+    let account_id = resolve_account_id(&db, account_uuid)?;
 
     let account = db
         .get_account(account_id)
@@ -205,7 +273,7 @@ mod tests {
         let phrase = generate_mnemonic();
         let seed = mnemonic_to_seed(&phrase).unwrap();
 
-        let address =
+        let (_uuid, address) =
             init_db_and_create_account(db_path_str, Network::MainNetwork, &seed, None).unwrap();
 
         // Mainnet unified addresses start with "u1"
@@ -215,7 +283,7 @@ mod tests {
         );
 
         // Verify we can read the address back
-        let address2 = get_address_from_db(db_path_str, Network::MainNetwork).unwrap();
+        let address2 = get_address_from_db(db_path_str, Network::MainNetwork, None).unwrap();
         assert_eq!(address, address2);
     }
 
@@ -228,7 +296,7 @@ mod tests {
         let phrase = generate_mnemonic();
         let seed = mnemonic_to_seed(&phrase).unwrap();
 
-        let address =
+        let (_, address) =
             init_db_and_create_account(db_path_str, Network::TestNetwork, &seed, None).unwrap();
 
         assert!(
@@ -244,13 +312,13 @@ mod tests {
 
         let temp1 = tempfile::tempdir().unwrap();
         let db1 = temp1.path().join("wallet.db");
-        let addr1 =
+        let (_, addr1) =
             init_db_and_create_account(db1.to_str().unwrap(), Network::MainNetwork, &seed, None)
                 .unwrap();
 
         let temp2 = tempfile::tempdir().unwrap();
         let db2 = temp2.path().join("wallet.db");
-        let addr2 =
+        let (_, addr2) =
             init_db_and_create_account(db2.to_str().unwrap(), Network::MainNetwork, &seed, None)
                 .unwrap();
 
@@ -268,7 +336,7 @@ mod tests {
         let phrase = generate_mnemonic();
         let seed = mnemonic_to_seed(&phrase).unwrap();
 
-        let address =
+        let (_, address) =
             init_db_and_create_account(db_path_str, Network::MainNetwork, &seed, None).unwrap();
 
         // Decode and verify receiver types

--- a/rust/src/wallet/sync.rs
+++ b/rust/src/wallet/sync.rs
@@ -272,7 +272,7 @@ pub fn propose_send(
     let mut store = PROPOSAL_STORE.lock().map_err(|e| format!("Lock error: {e}"))?;
     let id = store.next_id;
     store.next_id += 1;
-    store.proposals.insert(id, StoredProposal { proposal, network });
+    store.proposals.insert(id, StoredProposal { proposal, network, account_id });
 
     Ok(ProposalResult { proposal_id: id, needs_sapling_params: needs_sapling, fee_zatoshi: fee })
 }
@@ -332,7 +332,7 @@ pub async fn execute_proposal(
     drop(store);
 
     let mut db = open_wallet_db(db_path, network)?;
-    let account_id = get_first_account_id(&db)?;
+    let account_id = stored.account_id;
     let account = db.get_account(account_id).map_err(|e| format!("{e}"))?.ok_or("Account not found")?;
 
     // Scope seed/USK so they are dropped before network I/O (broadcast)
@@ -452,6 +452,7 @@ use std::sync::Mutex;
 struct StoredProposal {
     proposal: zcash_client_backend::proposal::Proposal<StandardFeeRule, zcash_client_sqlite::ReceivedNoteId>,
     network: Network,
+    account_id: AccountUuid,
 }
 
 static PROPOSAL_STORE: std::sync::LazyLock<Mutex<ProposalStore>> =

--- a/rust/src/wallet/sync.rs
+++ b/rust/src/wallet/sync.rs
@@ -23,11 +23,12 @@ use zcash_client_backend::{
     zip321::{Payment, TransactionRequest},
 };
 use zcash_client_sqlite::{
-    FsBlockDb,
+    AccountUuid, FsBlockDb,
     WalletDb,
     chain::{BlockMeta, init::init_blockmeta_db},
     util::SystemClock,
 };
+use crate::wallet::keys::parse_account_uuid;
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_primitives::block::BlockHash;
 use zcash_proofs::prover::LocalTxProver;
@@ -185,20 +186,22 @@ pub(crate) struct WalletBalance {
     pub transparent_pending: u64, pub sapling_pending: u64, pub orchard_pending: u64,
 }
 
-pub fn get_wallet_balance(db_path: &str, network: Network) -> Result<WalletBalance, String> {
+pub fn get_wallet_balance(db_path: &str, network: Network, account_uuid: &str) -> Result<WalletBalance, String> {
     let db = open_wallet_db(db_path, network)?;
+    let target_id = parse_account_uuid(account_uuid)?;
     match db.get_wallet_summary(ConfirmationsPolicy::default()).map_err(|e| format!("{e}"))? {
         Some(s) => {
-            let (mut t, mut sa, mut or, mut tp, mut sp, mut op) = (0u64, 0u64, 0u64, 0u64, 0u64, 0u64);
-            for (_, b) in s.account_balances() {
-                t += u64::from(b.unshielded_balance().spendable_value());
-                sa += u64::from(b.sapling_balance().spendable_value());
-                or += u64::from(b.orchard_balance().spendable_value());
-                tp += u64::from(b.unshielded_balance().change_pending_confirmation()) + u64::from(b.unshielded_balance().value_pending_spendability());
-                sp += u64::from(b.sapling_balance().change_pending_confirmation()) + u64::from(b.sapling_balance().value_pending_spendability());
-                op += u64::from(b.orchard_balance().change_pending_confirmation()) + u64::from(b.orchard_balance().value_pending_spendability());
+            match s.account_balances().get(&target_id) {
+                Some(b) => Ok(WalletBalance {
+                    transparent: u64::from(b.unshielded_balance().spendable_value()),
+                    sapling: u64::from(b.sapling_balance().spendable_value()),
+                    orchard: u64::from(b.orchard_balance().spendable_value()),
+                    transparent_pending: u64::from(b.unshielded_balance().change_pending_confirmation()) + u64::from(b.unshielded_balance().value_pending_spendability()),
+                    sapling_pending: u64::from(b.sapling_balance().change_pending_confirmation()) + u64::from(b.sapling_balance().value_pending_spendability()),
+                    orchard_pending: u64::from(b.orchard_balance().change_pending_confirmation()) + u64::from(b.orchard_balance().value_pending_spendability()),
+                }),
+                None => Ok(WalletBalance { transparent: 0, sapling: 0, orchard: 0, transparent_pending: 0, sapling_pending: 0, orchard_pending: 0 }),
             }
-            Ok(WalletBalance { transparent: t, sapling: sa, orchard: or, transparent_pending: tp, sapling_pending: sp, orchard_pending: op })
         }
         None => Ok(WalletBalance { transparent: 0, sapling: 0, orchard: 0, transparent_pending: 0, sapling_pending: 0, orchard_pending: 0 }),
     }
@@ -229,13 +232,13 @@ pub fn validate_address(address: &str) -> Result<String, String> {
 /// Propose a transfer. Returns (proposal_id, needs_sapling_params, fee_zatoshi).
 /// The proposal is stored internally and referenced by proposal_id for execute_proposal.
 pub fn propose_send(
-    db_path: &str, network: Network,
+    db_path: &str, network: Network, account_uuid: &str,
     to_address: &str, amount_zatoshi: u64, memo_str: Option<&str>,
 ) -> Result<ProposalResult, String> {
     use zcash_protocol::{PoolType, ShieldedProtocol as SP};
 
     let mut db = open_wallet_db(db_path, network)?;
-    let account_id = get_first_account_id(&db)?;
+    let account_id = parse_account_uuid(account_uuid)?;
 
     let to: zcash_address::ZcashAddress = to_address.parse().map_err(|e| format!("Bad address: {e}"))?;
     let value = Zatoshis::from_u64(amount_zatoshi).map_err(|_| "Bad amount")?;
@@ -277,13 +280,13 @@ pub fn propose_send(
 /// Estimate the fee for a transfer without storing the proposal.
 /// Used for validation only — does not consume resources in PROPOSAL_STORE.
 pub fn estimate_fee(
-    db_path: &str, network: Network,
+    db_path: &str, network: Network, account_uuid: &str,
     to_address: &str, amount_zatoshi: u64, memo_str: Option<&str>,
 ) -> Result<u64, String> {
     use zcash_protocol::ShieldedProtocol as SP;
 
     let mut db = open_wallet_db(db_path, network)?;
-    let account_id = get_first_account_id(&db)?;
+    let account_id = parse_account_uuid(account_uuid)?;
 
     let to: zcash_address::ZcashAddress = to_address.parse().map_err(|e| format!("Bad address: {e}"))?;
     let value = Zatoshis::from_u64(amount_zatoshi).map_err(|_| "Bad amount")?;
@@ -461,10 +464,10 @@ struct ProposalStore {
 
 // ======================== Diversified Address ========================
 
-pub fn get_next_available_address(db_path: &str, network: Network) -> Result<String, String> {
+pub fn get_next_available_address(db_path: &str, network: Network, account_uuid: &str) -> Result<String, String> {
     use zcash_keys::keys::{ReceiverRequirement, UnifiedAddressRequest};
     let mut db = open_wallet_db(db_path, network)?;
-    let account_id = get_first_account_id(&db)?;
+    let account_id = parse_account_uuid(account_uuid)?;
     let req = UnifiedAddressRequest::custom(
         ReceiverRequirement::Require, ReceiverRequirement::Require, ReceiverRequirement::Omit,
     ).map_err(|_| "bad request")?;
@@ -564,8 +567,11 @@ pub(crate) struct TransactionInfo {
 }
 
 pub fn get_transaction_history(
-    db_path: &str, _network: Network, limit: Option<u32>,
+    db_path: &str, _network: Network, limit: Option<u32>, account_uuid: &str,
 ) -> Result<Vec<TransactionInfo>, String> {
+    let uuid = uuid::Uuid::parse_str(account_uuid).map_err(|e| format!("Invalid UUID: {e}"))?;
+    let uuid_bytes = uuid.as_bytes().to_vec();
+
     // Open a separate read-only connection (WalletDb.conn is private)
     let conn = rusqlite::Connection::open_with_flags(
         db_path,
@@ -575,11 +581,13 @@ pub fn get_transaction_history(
         Some(_) => "SELECT txid, mined_height, expired_unmined, account_balance_delta, \
              COALESCE(fee_paid, 0), COALESCE(block_time, 0) \
              FROM v_transactions \
+             WHERE account_uuid = ?1 \
              ORDER BY COALESCE(mined_height, 999999999) DESC, tx_index DESC \
-             LIMIT ?1",
+             LIMIT ?2",
         None => "SELECT txid, mined_height, expired_unmined, account_balance_delta, \
              COALESCE(fee_paid, 0), COALESCE(block_time, 0) \
              FROM v_transactions \
+             WHERE account_uuid = ?1 \
              ORDER BY COALESCE(mined_height, 999999999) DESC, tx_index DESC",
     };
     let mut stmt = conn.prepare(sql).map_err(|e| format!("SQL error: {e}"))?;
@@ -602,9 +610,9 @@ pub fn get_transaction_history(
     };
 
     let rows = if let Some(n) = limit {
-        stmt.query_map(rusqlite::params![n], map_row)
+        stmt.query_map(rusqlite::params![&uuid_bytes, n], map_row)
     } else {
-        stmt.query_map([], map_row)
+        stmt.query_map(rusqlite::params![&uuid_bytes], map_row)
     }.map_err(|e| format!("Query error: {e}"))?;
 
     rows.collect::<Result<Vec<_>, _>>()

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -4,14 +4,14 @@ import 'package:zcash_wallet/src/rust/api/wallet.dart';
 
 void main() {
   test('WalletCreationResult equality', () {
-    const a = WalletCreationResult(mnemonic: 'test', unifiedAddress: 'u1abc');
-    const b = WalletCreationResult(mnemonic: 'test', unifiedAddress: 'u1abc');
+    const a = WalletCreationResult(mnemonic: 'test', unifiedAddress: 'u1abc', accountUuid: 'uuid1');
+    const b = WalletCreationResult(mnemonic: 'test', unifiedAddress: 'u1abc', accountUuid: 'uuid1');
     expect(a, equals(b));
   });
 
   test('WalletImportResult equality', () {
-    const a = WalletImportResult(unifiedAddress: 'u1abc');
-    const b = WalletImportResult(unifiedAddress: 'u1abc');
+    const a = WalletImportResult(unifiedAddress: 'u1abc', accountUuid: 'uuid1');
+    const b = WalletImportResult(unifiedAddress: 'u1abc', accountUuid: 'uuid1');
     expect(a, equals(b));
   });
 }


### PR DESCRIPTION
## Summary

- **Multi-account Rust API**: `add_account`, `list_accounts`, `generate_mnemonic`, `account_uuid` parameter on all per-account functions (balance, history, send, receive)
- **Multi-seed strategy**: First account uses `create_account` (Derived) for migration safety; additional accounts use `import_account_ufvk` (Imported) to bypass single-seed constraint
- **AccountProvider**: New Riverpod provider managing account list, active account, per-account mnemonics in secure storage
- **WalletProvider**: Simplified to delegate to AccountProvider, propagates errors instead of masking
- **SyncProvider**: Passes `activeAccountUuid` to balance/history queries; sync itself covers all accounts
- **AccountsScreen**: List/switch/rename accounts, add via create or import
- **HomeScreen**: Shows active account name with switcher
- **All screens**: Send, receive, history pass `account_uuid` for per-account data
- **Documentation**: CLAUDE.md and 7 onboarding files updated

## Architecture

Single `zcash_wallet.db` holds all accounts. `scan_cached_blocks` uses all UFVKs so one sync loop decrypts notes for every account. Account switching is instant — no resync needed, just re-query balance/history with new UUID.

```
First account  → create_account()     → AccountSource::Derived   (migration-safe)
Additional     → import_account_ufvk() → AccountSource::Imported  (multi-seed)
```

Verified against zcash_client_sqlite 0.19.5 source: scanning, balance, propose_transfer, create_proposed_transactions, key_derivation all work correctly for both Derived and Imported accounts.

## Test plan

- [ ] Create first account → verify sync starts, balance shows
- [ ] Add second account (different mnemonic) → verify both appear in accounts list
- [ ] Switch between accounts → balance/history updates immediately
- [ ] Send from account B → correct account's notes used, USK derived correctly
- [ ] Receive on account A → address belongs to account A
- [ ] Import account with earlier birthday → sync re-scans older blocks
- [ ] Rename account → persists across app restart
- [ ] `cargo test` → 8/8 pass
- [ ] `fvm flutter test` → 2/2 pass
- [ ] `fvm flutter analyze` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)