### PR TITLE
Desktop fixed-ratio layouts + iOS nusb gating

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -5,8 +5,6 @@ PODS:
   - flutter_secure_storage_darwin (10.0.0):
     - Flutter
     - FlutterMacOS
-  - integration_test (0.0.1):
-    - Flutter
   - mobile_scanner (7.0.0):
     - Flutter
     - FlutterMacOS
@@ -20,7 +18,6 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_foreground_task (from `.symlinks/plugins/flutter_foreground_task/ios`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
-  - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
   - rust_lib_zcash_wallet (from `.symlinks/plugins/rust_lib_zcash_wallet/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
@@ -32,8 +29,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_foreground_task/ios"
   flutter_secure_storage_darwin:
     :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
-  integration_test:
-    :path: ".symlinks/plugins/integration_test/ios"
   mobile_scanner:
     :path: ".symlinks/plugins/mobile_scanner/darwin"
   rust_lib_zcash_wallet:
@@ -45,7 +40,6 @@ SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_foreground_task: a159d2c2173b33699ddb3e6c2a067045d7cebb89
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   rust_lib_zcash_wallet: d6589a01236ae44ae19405ee82fe86ec80bd0366
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'app.dart';
+import 'src/core/layout/app_layout.dart';
 import 'src/rust/frb_generated.dart';
 
 void log(String message) => debugPrint('[zcash] $message');
@@ -11,6 +12,8 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   log('main: initializing RustLib');
   await RustLib.init();
-  log('main: RustLib initialized, launching app');
+  log('main: initializing desktop window (no-op on mobile/web)');
+  await initializeDesktopWindow();
+  log('main: launching app');
   runApp(const ProviderScope(child: ZcashWalletApp()));
 }

--- a/lib/src/core/layout/app_layout.dart
+++ b/lib/src/core/layout/app_layout.dart
@@ -1,0 +1,186 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:window_manager/window_manager.dart';
+
+/// Two fixed-aspect-ratio layouts the desktop app supports.
+///
+/// - [large]: landscape, width:height = 133:100  (≈ 1.33, wider than tall)
+/// - [small]: portrait,  width:height =  65:133  (≈ 0.489, taller than wide)
+///
+/// Mobile and web are permanently [small]. On desktop the OS window is
+/// reshaped to the selected ratio and its aspect ratio is enforced for
+/// user drag-resize.
+enum AppLayoutMode {
+  large,
+  small;
+
+  /// Width / height for this layout.
+  double get aspectRatio {
+    switch (this) {
+      case AppLayoutMode.large:
+        return 133.0 / 100.0;
+      case AppLayoutMode.small:
+        return (50.0 * 1.3) / 133.0;
+    }
+  }
+
+  /// Default window size applied at startup and on explicit toggle.
+  Size get defaultSize {
+    switch (this) {
+      case AppLayoutMode.large:
+        return const Size(1064, 800);
+      case AppLayoutMode.small:
+        return const Size(416, 851);
+    }
+  }
+
+  /// Minimum allowed drag-resize size — prevents the window from
+  /// collapsing narrower than the top bar's chrome.
+  Size get minimumSize {
+    switch (this) {
+      case AppLayoutMode.large:
+        return const Size(600, 451);
+      case AppLayoutMode.small:
+        return const Size(364, 745);
+    }
+  }
+}
+
+/// True on the desktop platforms that `window_manager` supports and where
+/// layout switching is meaningful.
+bool get isDesktopLayoutPlatform {
+  if (kIsWeb) return false;
+  return Platform.isMacOS || Platform.isWindows || Platform.isLinux;
+}
+
+/// Decision boundary for inferring the current layout mode from the
+/// window's width/height ratio — the midpoint between the two
+/// configured aspect ratios. Above it the window is "landscape enough"
+/// to imply [AppLayoutMode.large]; below it it's "portrait enough" to
+/// imply [AppLayoutMode.small].
+const double _largeRatioThreshold =
+    (133.0 / 100.0 + (50.0 * 1.3) / 133.0) / 2;
+
+/// Initialize the OS window for desktop at startup.
+///
+/// Must be called after `WidgetsFlutterBinding.ensureInitialized()` and
+/// before `runApp`. No-op on mobile/web.
+Future<void> initializeDesktopWindow({
+  AppLayoutMode initialMode = AppLayoutMode.large,
+}) async {
+  if (!isDesktopLayoutPlatform) return;
+
+  await windowManager.ensureInitialized();
+
+  final options = WindowOptions(
+    size: initialMode.defaultSize,
+    minimumSize: initialMode.minimumSize,
+    center: true,
+    title: 'Zcash Wallet',
+  );
+
+  await windowManager.waitUntilReadyToShow(options, () async {
+    await windowManager.setMinimumSize(initialMode.minimumSize);
+    await windowManager.setAspectRatio(initialMode.aspectRatio);
+    await windowManager.setSize(initialMode.defaultSize, animate: false);
+    await windowManager.show();
+    await windowManager.focus();
+  });
+}
+
+@immutable
+class AppLayoutState {
+  final AppLayoutMode mode;
+  const AppLayoutState(this.mode);
+}
+
+/// Riverpod notifier that owns the current layout mode and, on desktop,
+/// drives the OS window to match.
+///
+/// Observes [WindowListener] events so that when the user breaks out of
+/// the configured aspect-ratio constraint (macOS green-button zoom,
+/// Windows maximize/snap, manual drag past the limit) — or restores
+/// the window back to the other ratio's shape — the notifier infers
+/// the current layout from the observed window ratio using a single
+/// midpoint threshold.
+///
+/// The inference is idempotent, so the listener doesn't need a
+/// re-entrancy guard against the notifier's own `setSize` events:
+/// `setSize(large default)` → observed ratio ≈ 1.33 → infers large →
+/// state was already large → no-op. `setSize(small default)` → observed
+/// ratio ≈ 0.489 → infers small → state was already small → no-op.
+class AppLayoutNotifier extends Notifier<AppLayoutState> with WindowListener {
+  @override
+  AppLayoutState build() {
+    if (isDesktopLayoutPlatform) {
+      windowManager.addListener(this);
+      ref.onDispose(() => windowManager.removeListener(this));
+    }
+    // Mobile is fixed at `small`. Desktop boots in `large` to match
+    // the initial window size applied by [initializeDesktopWindow].
+    return AppLayoutState(
+      isDesktopLayoutPlatform ? AppLayoutMode.large : AppLayoutMode.small,
+    );
+  }
+
+  Future<void> setMode(AppLayoutMode mode) async {
+    if (!isDesktopLayoutPlatform) return;
+    if (state.mode == mode) return;
+    state = AppLayoutState(mode);
+    try {
+      await windowManager.setMinimumSize(mode.minimumSize);
+      await windowManager.setAspectRatio(mode.aspectRatio);
+      await windowManager.setSize(mode.defaultSize, animate: false);
+    } catch (e, st) {
+      // On platform-call failure, log and fall back to the assumption
+      // that the window is in [large]. The auto-switch listener will
+      // subsequently correct this if the window is actually shaped
+      // like small.
+      debugPrint('AppLayoutNotifier.setMode($mode) failed: $e\n$st');
+      state = const AppLayoutState(AppLayoutMode.large);
+    }
+  }
+
+  Future<void> toggle() => setMode(
+        state.mode == AppLayoutMode.large
+            ? AppLayoutMode.small
+            : AppLayoutMode.large,
+      );
+
+  @override
+  void onWindowResize() => _reconcileLayoutWithWindow();
+
+  @override
+  void onWindowMaximize() => _reconcileLayoutWithWindow();
+
+  @override
+  void onWindowUnmaximize() => _reconcileLayoutWithWindow();
+
+  @override
+  void onWindowEnterFullScreen() => _reconcileLayoutWithWindow();
+
+  @override
+  void onWindowLeaveFullScreen() => _reconcileLayoutWithWindow();
+
+  Future<void> _reconcileLayoutWithWindow() async {
+    try {
+      final size = await windowManager.getSize();
+      if (size.height <= 0) return;
+      final ratio = size.width / size.height;
+      final inferred = ratio >= _largeRatioThreshold
+          ? AppLayoutMode.large
+          : AppLayoutMode.small;
+      if (state.mode != inferred) {
+        state = AppLayoutState(inferred);
+      }
+    } catch (e) {
+      debugPrint('AppLayoutNotifier auto-reconcile failed: $e');
+    }
+  }
+}
+
+final appLayoutProvider =
+    NotifierProvider<AppLayoutNotifier, AppLayoutState>(AppLayoutNotifier.new);

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/layout/app_layout.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
@@ -131,22 +132,28 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          GestureDetector(
-            onTap: () => context.push('/accounts'),
-            child: Row(
-              children: [
-                Icon(Icons.shield, color: colors.onSurface.withValues(alpha: 0.8), size: 22),
-                const SizedBox(width: 8),
-                Text(
-                  accountName,
-                  style: text.titleLarge?.copyWith(
-                    fontWeight: FontWeight.w800,
-                    letterSpacing: -0.5,
+          Flexible(
+            child: GestureDetector(
+              onTap: () => context.push('/accounts'),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.shield, color: colors.onSurface.withValues(alpha: 0.8), size: 22),
+                  const SizedBox(width: 8),
+                  Flexible(
+                    child: Text(
+                      accountName,
+                      overflow: TextOverflow.ellipsis,
+                      style: text.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w800,
+                        letterSpacing: -0.5,
+                      ),
+                    ),
                   ),
-                ),
-                const SizedBox(width: 4),
-                Icon(Icons.keyboard_arrow_down, color: colors.onSurfaceVariant, size: 20),
-              ],
+                  const SizedBox(width: 4),
+                  Icon(Icons.keyboard_arrow_down, color: colors.onSurfaceVariant, size: 20),
+                ],
+              ),
             ),
           ),
           Row(
@@ -156,6 +163,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                   icon: Icon(Icons.delete_forever, color: colors.error),
                   onPressed: () => _resetWallet(context),
                 ),
+              if (isDesktopLayoutPlatform) _buildLayoutToggle(context),
               IconButton(
                 icon: Icon(Icons.qr_code_scanner, color: colors.onSurface),
                 onPressed: () {},
@@ -164,6 +172,20 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildLayoutToggle(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    final mode = ref.watch(appLayoutProvider).mode;
+    final isLarge = mode == AppLayoutMode.large;
+    return IconButton(
+      tooltip: isLarge ? 'Switch to compact layout' : 'Switch to tall layout',
+      icon: Icon(
+        isLarge ? Icons.unfold_less : Icons.unfold_more,
+        color: colors.onSurface,
+      ),
+      onPressed: () => ref.read(appLayoutProvider.notifier).toggle(),
     );
   }
 
@@ -197,21 +219,24 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           ),
           const SizedBox(height: 24),
           // Balance
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.baseline,
-            textBaseline: TextBaseline.alphabetic,
-            children: [
-              Text(
-                _formatZec(sync.totalBalance),
-                style: text.displayLarge,
-              ),
-              const SizedBox(width: 8),
-              Text(
-                'ZEC',
-                style: text.displayMedium?.copyWith(color: colors.secondary),
-              ),
-            ],
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.baseline,
+              textBaseline: TextBaseline.alphabetic,
+              children: [
+                Text(
+                  _formatZec(sync.totalBalance),
+                  style: text.displayLarge,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  'ZEC',
+                  style: text.displayMedium?.copyWith(color: colors.secondary),
+                ),
+              ],
+            ),
           ),
           const SizedBox(height: 48),
         ],
@@ -646,10 +671,17 @@ class _ActionButton extends StatelessWidget {
         ),
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
           children: [
             Icon(icon, size: 20, color: fg),
             const SizedBox(width: 12),
-            Text(label, style: text.labelMedium?.copyWith(color: fg)),
+            Flexible(
+              child: Text(
+                label,
+                overflow: TextOverflow.ellipsis,
+                style: text.labelMedium?.copyWith(color: fg),
+              ),
+            ),
           ],
         ),
       ),

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,10 +7,14 @@ import Foundation
 
 import flutter_secure_storage_darwin
 import mobile_scanner
+import screen_retriever_macos
 import shared_preferences_foundation
+import window_manager
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
+  ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -8,8 +8,12 @@ PODS:
     - FlutterMacOS
   - rust_lib_zcash_wallet (0.0.1):
     - FlutterMacOS
+  - screen_retriever_macos (0.0.1):
+    - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
     - Flutter
+    - FlutterMacOS
+  - window_manager (0.5.0):
     - FlutterMacOS
 
 DEPENDENCIES:
@@ -17,7 +21,9 @@ DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
   - mobile_scanner (from `Flutter/ephemeral/.symlinks/plugins/mobile_scanner/darwin`)
   - rust_lib_zcash_wallet (from `Flutter/ephemeral/.symlinks/plugins/rust_lib_zcash_wallet/macos`)
+  - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
 
 EXTERNAL SOURCES:
   flutter_secure_storage_darwin:
@@ -28,15 +34,21 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/mobile_scanner/darwin
   rust_lib_zcash_wallet:
     :path: Flutter/ephemeral/.symlinks/plugins/rust_lib_zcash_wallet/macos
+  screen_retriever_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  window_manager:
+    :path: Flutter/ephemeral/.symlinks/plugins/window_manager/macos
 
 SPEC CHECKSUMS:
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   rust_lib_zcash_wallet: e6239745a9c854f6b4aa85577092ca55b5e78f3b
+  screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  window_manager: b729e31d38fb04905235df9ea896128991cad99e
 
 PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
 

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -12,4 +12,9 @@ class MainFlutterWindow: NSWindow {
 
     super.awakeFromNib()
   }
+
+  override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {
+    super.order(place, relativeTo: otherWin)
+    hiddenWindowAtLaunch()
+  }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -725,6 +725,46 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
+  screen_retriever:
+    dependency: transitive
+    description:
+      name: screen_retriever
+      sha256: "570dbc8e4f70bac451e0efc9c9bb19fa2d6799a11e6ef04f946d7886d2e23d0c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_linux:
+    dependency: transitive
+    description:
+      name: screen_retriever_linux
+      sha256: f7f8120c92ef0784e58491ab664d01efda79a922b025ff286e29aa123ea3dd18
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_macos:
+    dependency: transitive
+    description:
+      name: screen_retriever_macos
+      sha256: "71f956e65c97315dd661d71f828708bd97b6d358e776f1a30d5aa7d22d78a149"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_retriever_platform_interface
+      sha256: ee197f4581ff0d5608587819af40490748e1e39e648d7680ecf95c05197240c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
+  screen_retriever_windows:
+    dependency: transitive
+    description:
+      name: screen_retriever_windows
+      sha256: "449ee257f03ca98a57288ee526a301a430a344a161f9202b4fcc38576716fe13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   shared_preferences:
     dependency: transitive
     description:
@@ -1018,6 +1058,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  window_manager:
+    dependency: "direct main"
+    description:
+      name: window_manager
+      sha256: "7eb6d6c4164ec08e1bf978d6e733f3cebe792e2a23fb07cbca25c2872bfdbdcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   mobile_scanner: ^7.2.0
   crypto: ^3.0.7
   flutter_foreground_task: ^9.2.1
+  window_manager: ^0.5.1
 
 dev_dependencies:
   flutter_test:

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,11 +55,18 @@ log = "0.4"
 hex = "0.4"
 
 # Keystone hardware wallet
-nusb = { version = "0.2", features = ["tokio"] }
 ur = { git = "https://github.com/KeystoneHQ/ur-rs", tag = "0.3.3" }
 pczt = "0.5"
 ur-registry = { git = "https://github.com/KeystoneHQ/keystone-sdk-rust", package = "ur-registry", default-features = false, features = ["std"] }
 serde_json = "1"
+
+# USB transport is not available on iOS simulator/device (no IOKit /
+# no raw USB syscalls); Keystone over USB is desktop+Android only.
+# The Dart-side `KeystoneTransport.available()` already excludes USB on
+# iOS, so the functions keep their signatures via iOS stubs in
+# `wallet/keystone.rs` — only the actual nusb crate is skipped here.
+[target.'cfg(not(target_os = "ios"))'.dependencies]
+nusb = { version = "0.2", features = ["tokio"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/rust/src/wallet/keystone.rs
+++ b/rust/src/wallet/keystone.rs
@@ -4,23 +4,37 @@
 //! UR encoding/decoding for QR-based communication. Uses PCZT (ZIP-332)
 //! for transaction signing.
 
+#[cfg(not(target_os = "ios"))]
 use nusb::transfer::{Bulk, In, Out};
+#[cfg(not(target_os = "ios"))]
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use ur_registry::traits::{RegistryItem, To, UR};
 use ur_registry::zcash::zcash_accounts::ZcashAccounts;
 use ur_registry::zcash::zcash_pczt::ZcashPczt;
 
 // ==================== USB Constants ====================
+// USB over nusb is unavailable on iOS (no IOKit / no raw USB syscalls).
+// The constants and the EAPDU helper below are only compiled for
+// non-iOS targets; iOS gets stub implementations further down.
 
+#[cfg(not(target_os = "ios"))]
 const KEYSTONE_VID: u16 = 0x1209;
+#[cfg(not(target_os = "ios"))]
 const KEYSTONE_PID: u16 = 0x3001;
+#[cfg(not(target_os = "ios"))]
 const USB_INTERFACE: u8 = 0;
+#[cfg(not(target_os = "ios"))]
 const USB_ENDPOINT_OUT: u8 = 0x03;
+#[cfg(not(target_os = "ios"))]
 const USB_ENDPOINT_IN: u8 = 0x83;
+#[cfg(not(target_os = "ios"))]
 const EAPDU_HEADER_SIZE: usize = 9;
+#[cfg(not(target_os = "ios"))]
 const USB_PACKET_SIZE: usize = 64;
+#[cfg(not(target_os = "ios"))]
 const MAX_DATA_PER_PACKET: usize = USB_PACKET_SIZE - EAPDU_HEADER_SIZE;
 
+#[cfg(not(target_os = "ios"))]
 const CMD_RESOLVE_UR: u16 = 0x0002;
 
 // ==================== Data Types ====================
@@ -263,6 +277,7 @@ pub fn encode_pczt_ur_parts(pczt_bytes: &[u8], max_fragment_len: usize) -> Resul
 // ==================== USB EAPDU Protocol ====================
 
 /// Encode data into EAPDU packets for USB transmission.
+#[cfg(not(target_os = "ios"))]
 fn encode_eapdu_packets(command: u16, request_id: u16, data: &[u8]) -> Vec<Vec<u8>> {
     let total_packets = if data.is_empty() {
         1
@@ -296,6 +311,7 @@ fn encode_eapdu_packets(command: u16, request_id: u16, data: &[u8]) -> Vec<Vec<u
 // ==================== USB Device Communication ====================
 
 /// Check if a Keystone device is connected via USB.
+#[cfg(not(target_os = "ios"))]
 pub async fn is_keystone_connected() -> bool {
     match nusb::list_devices().await {
         Ok(devices) => devices
@@ -305,7 +321,17 @@ pub async fn is_keystone_connected() -> bool {
     }
 }
 
+/// iOS stub: USB transport is unavailable on iOS, so always report "not
+/// connected". Dart-side `KeystoneTransport.available()` also excludes
+/// USB on iOS so this is belt-and-suspenders; FFI surface stays uniform
+/// across platforms.
+#[cfg(target_os = "ios")]
+pub async fn is_keystone_connected() -> bool {
+    false
+}
+
 /// Sign PCZT bytes via Keystone USB. Returns signed PCZT bytes.
+#[cfg(not(target_os = "ios"))]
 pub async fn usb_sign_pczt(pczt_bytes: &[u8]) -> Result<Vec<u8>, String> {
     let ur_string = encode_pczt_to_ur(pczt_bytes)?;
 
@@ -410,4 +436,14 @@ pub async fn usb_sign_pczt(pczt_bytes: &[u8]) -> Result<Vec<u8>, String> {
     );
 
     decode_ur_to_pczt(signed_ur)
+}
+
+/// iOS stub: USB transport is unavailable on iOS (no IOKit / no raw
+/// USB syscalls). Dart-side `KeystoneTransport.available()` already
+/// excludes USB on iOS, so this should never actually be invoked from
+/// iOS; it exists purely to keep the FFI surface uniform across
+/// platforms so FRB bindings don't need to be regenerated per target.
+#[cfg(target_os = "ios")]
+pub async fn usb_sign_pczt(_pczt_bytes: &[u8]) -> Result<Vec<u8>, String> {
+    Err("USB signing is not supported on iOS; use the QR transport.".to_string())
 }


### PR DESCRIPTION
## Summary
- Adds two aspect-ratio-constrained desktop window layouts (`large` 133:100 landscape, `small` 65:133 portrait) driven by `window_manager`. Mobile is permanently `small`.
- A Riverpod `AppLayoutNotifier` owns the mode, drives `setMinimumSize` / `setAspectRatio` / `setSize(animate: false)` on toggle, and observes `WindowListener` events so OS-level breakouts (macOS zoom, Windows maximize, unmaximize, fullscreen enter/leave) reconcile the app's mode with whatever ratio the OS lands on — a single midpoint threshold picks `large` when the window is landscape-enough and `small` when it's portrait-enough.
- Home top bar gains a desktop-only toggle button; the balance Row and action button labels are made narrow-width tolerant for the portrait `small` layout.
- Target-gates the `nusb` Rust crate to non-iOS builds (via `[target.'cfg(not(target_os = "ios"))'.dependencies]`) and provides iOS stubs for `is_keystone_connected` / `usb_sign_pczt` so `flutter run -d ios` builds cleanly; the Dart side already hides USB from iOS via `KeystoneTransport.available()`.

## Design notes
- Listener is intentionally idempotent wrt the notifier's own `setSize` events — no re-entrancy guard needed. `setSize(large default)` → observed ratio ≈ 1.33 → infers `large` → state was already `large` → no-op. Same for `small`.
- On platform-call failure during `setMode`, logs and falls back to assuming `large`; the next resize event reconciles if the window actually ended up shaped differently.
- No rollback machinery, no `_applyingLayout` guard, no `screen_retriever` dependency, no per-failure snapshot/tracking — deliberately minimal per spec ("good enough, ignore subtle edge cases").

## Test plan
- [ ] `fvm flutter run -d macos` — verify window opens at 1064×800 landscape, toggle swaps to 416×851 portrait instantly (no animation), drag-resize preserves ratio, green-button zoom auto-switches to `large` and restore snaps back to `small`.
- [ ] `fvm flutter run -d "iPhone 17 Pro"` simulator — verify `small` layout renders, no toggle button, no `nusb` build errors.
- [ ] `cd rust && cargo check` + `cargo check --target aarch64-apple-ios-sim` both clean.
- [ ] `fvm flutter analyze lib/` shows only the pre-existing `receivePort` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)