### PR TITLE
[codex] Bind wallet DB path and add password onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,18 @@ What this means for our DB shape:
 
 **Mnemonic storage**: Per-account in Flutter secure storage (`zcash_account_mnemonic_{uuid}`). Account list stored as JSON in `zcash_accounts` key. Active account in `zcash_active_account` key.
 
+### Wallet Password Policy
+
+- The local wallet setup/unlock password is **ASCII-only**. Accept only printable
+  English letters, numbers, and symbols (`0x21`-`0x7E`).
+- Do **not** implement keyboard-layout or IME normalization for passwords
+  (for example, treating Korean 2-beolsik input as QWERTY). Passwords are
+  compared as exact strings under this ASCII-only policy.
+- Reuse the shared Dart helper in
+  `lib/src/core/security/password_policy.dart` for all password validation.
+- The charset validation message must stay exactly:
+  `Use only English letters, numbers, and symbols.`
+
 ### Dart Provider Structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,18 @@ What this means for our DB shape:
 
 **Mnemonic storage**: Per-account in Flutter secure storage (`zcash_account_mnemonic_{uuid}`). Account list stored as JSON in `zcash_accounts` key. Active account in `zcash_active_account` key.
 
+### Wallet Password Policy
+
+- The local wallet setup/unlock password is **ASCII-only**. Accept only printable
+  English letters, numbers, and symbols (`0x21`-`0x7E`).
+- Do **not** implement keyboard-layout or IME normalization for passwords
+  (for example, treating Korean 2-beolsik input as QWERTY). Passwords are
+  compared as exact strings under this ASCII-only policy.
+- Reuse the shared Dart helper in
+  `lib/src/core/security/password_policy.dart` for all password validation.
+- The charset validation message must stay exactly:
+  `Use only English letters, numbers, and symbols.`
+
 ### Dart Provider Structure
 
 ```

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		42257B77B623F2ABAD2A1912 /* DynamicIslandManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4D4F9C0A149C751B796E19 /* DynamicIslandManager.swift */; };
+		5736417E0A4E184E8572693A /* WalletPathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5736417D0A4E184E8572693A /* WalletPathResolver.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */; };
 		8108A5A50BC98B3D741F1711 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FED55156EBDEE425125AD2C /* Pods_Runner.framework */; };
@@ -83,6 +84,7 @@
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		363BC99CD33184F9C3C7E797 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		5736417D0A4E184E8572693A /* WalletPathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletPathResolver.swift; sourceTree = "<group>"; };
 		603F096B051231C6A1C6A5B1 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		64501DB95B6D078121FE7DE1 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		6A4D4F9C0A149C751B796E19 /* DynamicIslandManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DynamicIslandManager.swift; sourceTree = "<group>"; };
@@ -241,6 +243,7 @@
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				BGSYNC000ED2DC5600515810 /* BackgroundSyncManager.swift */,
+				5736417D0A4E184E8572693A /* WalletPathResolver.swift */,
 				SYNCPSH00ED2DC5600515810 /* SyncProgressStreamHandler.swift */,
 				ZSYNC000ED2DC5600515810 /* zcash_sync.h */,
 				7884E8672EC3CC0400C636F2 /* SceneDelegate.swift */,
@@ -507,6 +510,7 @@
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				BGSYNC001ED2DC5600515810 /* BackgroundSyncManager.swift in Sources */,
+				5736417E0A4E184E8572693A /* WalletPathResolver.swift in Sources */,
 				SYNCPSH01ED2DC5600515810 /* SyncProgressStreamHandler.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,

--- a/ios/Runner/BackgroundSyncManager.swift
+++ b/ios/Runner/BackgroundSyncManager.swift
@@ -152,22 +152,7 @@ class BackgroundSyncManager {
     }
 
     private func walletDbPath() throws -> String {
-        let supportDir = try walletSupportDirectory()
-        return supportDir.appendingPathComponent("zcash_wallet.db").path
-    }
-
-    private func walletSupportDirectory() throws -> URL {
-        let supportDir = try FileManager.default.url(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        )
-        try FileManager.default.createDirectory(
-            at: supportDir,
-            withIntermediateDirectories: true
-        )
-        return supportDir
+        try resolveWalletDbPath()
     }
 
     func startBackgroundSync() -> Bool {

--- a/ios/Runner/TxTrackManager.swift
+++ b/ios/Runner/TxTrackManager.swift
@@ -173,21 +173,6 @@ class TxTrackManager {
     }
 
     private func walletDbPath() throws -> String {
-        let supportDir = try walletSupportDirectory()
-        return supportDir.appendingPathComponent("zcash_wallet.db").path
-    }
-
-    private func walletSupportDirectory() throws -> URL {
-        let supportDir = try FileManager.default.url(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        )
-        try FileManager.default.createDirectory(
-            at: supportDir,
-            withIntermediateDirectories: true
-        )
-        return supportDir
+        try resolveWalletDbPath()
     }
 }

--- a/ios/Runner/WalletPathResolver.swift
+++ b/ios/Runner/WalletPathResolver.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Security
+
+private let walletDbNameKey = "zcash_wallet_db_name"
+private let secureStoreService = "com.zcash.zcashWallet.secure_store"
+
+enum WalletPathResolverError: Error {
+    case dbNameMissing
+    case invalidDbNameData
+    case keychainStatus(OSStatus)
+}
+
+func resolveWalletDbPath() throws -> String {
+    let supportDir = try resolveWalletSupportDirectory()
+    let dbName = try resolveWalletDbName()
+    return supportDir.appendingPathComponent(dbName).path
+}
+
+func resolveWalletSupportDirectory() throws -> URL {
+    let supportDir = try FileManager.default.url(
+        for: .applicationSupportDirectory,
+        in: .userDomainMask,
+        appropriateFor: nil,
+        create: true
+    )
+    try FileManager.default.createDirectory(
+        at: supportDir,
+        withIntermediateDirectories: true
+    )
+    return supportDir
+}
+
+private func resolveWalletDbName() throws -> String {
+    let query: [CFString: Any] = [
+        kSecClass: kSecClassGenericPassword,
+        kSecAttrAccount: walletDbNameKey,
+        kSecAttrService: secureStoreService,
+        kSecReturnData: true,
+        kSecMatchLimit: kSecMatchLimitOne,
+    ]
+
+    var item: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &item)
+    switch status {
+    case errSecSuccess:
+        guard let data = item as? Data else {
+            throw WalletPathResolverError.invalidDbNameData
+        }
+        guard let dbName = String(data: data, encoding: .utf8), !dbName.isEmpty else {
+            throw WalletPathResolverError.invalidDbNameData
+        }
+        return dbName
+    case errSecItemNotFound:
+        throw WalletPathResolverError.dbNameMissing
+    default:
+        throw WalletPathResolverError.keychainStatus(status)
+    }
+}

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -14,8 +14,10 @@ import 'src/features/onboarding/screens/create_wallet_screen.dart';
 import 'src/features/onboarding/screens/import_wallet_screen.dart';
 import 'src/features/onboarding/screens/intro_zcash_screen.dart';
 import 'src/features/onboarding/screens/onboarding_split_view.dart';
+import 'src/features/onboarding/screens/set_password_screen.dart';
 import 'src/features/onboarding/screens/secret_passphrase_screen.dart';
 import 'src/features/onboarding/screens/things_to_know_screen.dart';
+import 'src/features/onboarding/screens/unlock_screen.dart';
 import 'src/features/onboarding/welcome.dart';
 import 'src/features/history/screens/history_screen.dart';
 import 'src/features/receive/screens/receive_screen.dart';
@@ -26,6 +28,7 @@ import 'src/features/send/screens/send_screen.dart';
 import 'src/features/send/screens/send_status_screen.dart';
 import 'src/features/settings/screens/settings_screen.dart';
 import 'src/providers/theme_mode_provider.dart';
+import 'src/providers/app_security_provider.dart';
 import 'src/providers/wallet_provider.dart';
 
 final _routerProvider = Provider<GoRouter>((ref) {
@@ -35,6 +38,9 @@ final _routerProvider = Provider<GoRouter>((ref) {
   ref.listen(walletProvider, (_, _) {
     refresh.value++;
   });
+  ref.listen(appSecurityProvider, (_, _) {
+    refresh.value++;
+  });
   log('router: initialized');
 
   return GoRouter(
@@ -42,24 +48,36 @@ final _routerProvider = Provider<GoRouter>((ref) {
     refreshListenable: refresh,
     redirect: (context, state) {
       final walletAsync = ref.read(walletProvider);
+      final security = ref.read(appSecurityProvider);
 
       // Don't redirect on error — let the error screen show instead of onboarding
       if (walletAsync.hasError) return null;
 
       final wallet = walletAsync.value;
       final hasWallet = wallet?.hasWallet ?? bootstrap.hasWallet;
+      final isPasswordConfigured =
+          security.isPasswordConfigured || bootstrap.isPasswordConfigured;
+      final isUnlocked = security.isUnlocked || bootstrap.isUnlocked;
+      final requiresUnlock = hasWallet && isPasswordConfigured && !isUnlocked;
       final isOnboarding =
           state.matchedLocation == '/welcome' ||
           state.matchedLocation.startsWith('/onboarding/') ||
           state.matchedLocation == '/create' ||
           state.matchedLocation == '/import';
+      final isUnlock = state.matchedLocation == '/unlock';
 
       log(
-        'router redirect: location=${state.matchedLocation}, hasWallet=$hasWallet, isOnboarding=$isOnboarding',
+        'router redirect: location=${state.matchedLocation}, hasWallet=$hasWallet, '
+        'requiresUnlock=$requiresUnlock, isOnboarding=$isOnboarding',
       );
 
+      if (!hasWallet && isUnlock) return '/welcome';
       if (!hasWallet && !isOnboarding) return '/welcome';
-      if (hasWallet && state.matchedLocation == '/welcome') return '/home';
+      if (requiresUnlock && !isUnlock) return '/unlock';
+      if (!requiresUnlock && isUnlock) return hasWallet ? '/home' : '/welcome';
+      if (hasWallet && state.matchedLocation == '/welcome') {
+        return requiresUnlock ? '/unlock' : '/home';
+      }
       return null;
     },
     routes: [
@@ -67,10 +85,16 @@ final _routerProvider = Provider<GoRouter>((ref) {
         path: '/',
         redirect: (_, _) {
           final walletAsync = ref.read(walletProvider);
+          final security = ref.read(appSecurityProvider);
           if (walletAsync.hasError) return '/home'; // home shows error state
           final wallet = walletAsync.value;
           final hasWallet = wallet?.hasWallet ?? bootstrap.hasWallet;
-          return hasWallet ? '/home' : '/welcome';
+          final isPasswordConfigured =
+              security.isPasswordConfigured || bootstrap.isPasswordConfigured;
+          final isUnlocked = security.isUnlocked || bootstrap.isUnlocked;
+          if (!hasWallet) return '/welcome';
+          if (isPasswordConfigured && !isUnlocked) return '/unlock';
+          return '/home';
         },
       ),
       // Onboarding-route transitions. Desktop acrylic visibly stutters
@@ -98,6 +122,9 @@ final _routerProvider = Provider<GoRouter>((ref) {
           reverseTransitionDuration: kOnboardingReverseDuration,
           child: OnboardingSplitViewShell(
             activeStep: onboardingStepFromLocation(state.matchedLocation),
+            showPasswordStep: !ref
+                .read(appSecurityProvider)
+                .isPasswordConfigured,
             child: child,
           ),
           transitionsBuilder: (_, _, _, child) => child,
@@ -143,10 +170,25 @@ final _routerProvider = Provider<GoRouter>((ref) {
               transitionsBuilder: _onboardingFadeTransition,
             ),
           ),
+          GoRoute(
+            path: '/onboarding/set-password',
+            pageBuilder: (context, state) => CustomTransitionPage<void>(
+              key: state.pageKey,
+              transitionDuration: kOnboardingForwardDuration,
+              reverseTransitionDuration: kOnboardingReverseDuration,
+              child: SetPasswordScreen(
+                args: state.extra is SetPasswordScreenArgs
+                    ? state.extra as SetPasswordScreenArgs
+                    : null,
+              ),
+              transitionsBuilder: _onboardingFadeTransition,
+            ),
+          ),
         ],
       ),
       GoRoute(path: '/create', builder: (_, _) => const CreateWalletScreen()),
       GoRoute(path: '/import', builder: (_, _) => const ImportWalletScreen()),
+      GoRoute(path: '/unlock', builder: (_, _) => const UnlockScreen()),
       GoRoute(path: '/home', builder: (_, _) => const HomeScreen()),
       GoRoute(path: '/send', builder: (_, _) => const SendScreen()),
       GoRoute(

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../main.dart' show log;
+import 'core/storage/app_secure_store.dart';
 import 'core/storage/wallet_paths.dart';
 import 'providers/account_models.dart';
 import 'rust/api/sync.dart' as rust_sync;
@@ -77,14 +77,15 @@ class AppSyncSnapshot {
 }
 
 Future<AppBootstrapState> loadAppBootstrap() async {
-  const storage = FlutterSecureStorage();
+  final storage = AppSecureStore.instance;
 
   try {
     log('bootstrap: loading startup snapshot');
-    final network = await storage.read(key: _networkKey) ?? 'main';
+    await storage.ensureWalletDbName();
+    final network = await storage.readString(_networkKey) ?? 'main';
     final dbPath = await _getDbPath();
     final storedAccounts = await _readStoredAccounts(storage);
-    final storedActiveUuid = await storage.read(key: _activeAccountKey);
+    final storedActiveUuid = await storage.readString(_activeAccountKey);
 
     var rustAccounts = <AccountInfo>[];
     final rustAddressesByUuid = <String, String>{};
@@ -98,8 +99,8 @@ Future<AppBootstrapState> loadAppBootstrap() async {
           listed.indexed.map((entry) async {
             final (index, account) = entry;
             rustAddressesByUuid[account.uuid] = account.unifiedAddress;
-            final mnemonic = await storage.read(
-              key: 'zcash_account_mnemonic_${account.uuid}',
+            final mnemonic = await storage.readString(
+              'zcash_account_mnemonic_${account.uuid}',
             );
             return AccountInfo(
               uuid: account.uuid,
@@ -153,10 +154,8 @@ Future<AppBootstrapState> loadAppBootstrap() async {
   }
 }
 
-Future<List<AccountInfo>> _readStoredAccounts(
-  FlutterSecureStorage storage,
-) async {
-  final accountsJson = await storage.read(key: _accountsKey);
+Future<List<AccountInfo>> _readStoredAccounts(AppSecureStore storage) async {
+  final accountsJson = await storage.readString(_accountsKey);
   if (accountsJson == null || accountsJson.isEmpty) return const [];
 
   final List<dynamic> decoded = jsonDecode(accountsJson);

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -23,20 +23,27 @@ class AppBootstrapState {
     required this.initialAccountState,
     required this.initialSyncSnapshot,
     required this.network,
+    required this.isPasswordConfigured,
+    required this.isUnlocked,
   });
 
   final String initialLocation;
   final AccountState initialAccountState;
   final AppSyncSnapshot initialSyncSnapshot;
   final String network;
+  final bool isPasswordConfigured;
+  final bool isUnlocked;
 
   bool get hasWallet => initialAccountState.hasAccounts;
+  bool get requiresUnlock => hasWallet && isPasswordConfigured && !isUnlocked;
 
   static final empty = AppBootstrapState(
     initialLocation: '/welcome',
     initialAccountState: AccountState(),
     initialSyncSnapshot: AppSyncSnapshot.empty,
     network: 'main',
+    isPasswordConfigured: false,
+    isUnlocked: false,
   );
 }
 
@@ -83,6 +90,8 @@ Future<AppBootstrapState> loadAppBootstrap() async {
     log('bootstrap: loading startup snapshot');
     await storage.ensureWalletDbName();
     final network = await storage.readString(_networkKey) ?? 'main';
+    final isPasswordConfigured = await storage.isPasswordConfigured();
+    final isUnlocked = storage.hasSessionPassword;
     final dbPath = await _getDbPath();
     final storedAccounts = await _readStoredAccounts(storage);
     final storedActiveUuid = await storage.readString(_activeAccountKey);
@@ -134,12 +143,19 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       );
     }
 
+    final initialLocation = !hasWallet
+        ? '/welcome'
+        : isPasswordConfigured && !isUnlocked
+        ? '/unlock'
+        : '/home';
+
     log(
-      'bootstrap: hasWallet=$hasWallet, initialLocation=${hasWallet ? '/home' : '/welcome'}',
+      'bootstrap: hasWallet=$hasWallet, passwordConfigured=$isPasswordConfigured, '
+      'unlocked=$isUnlocked, initialLocation=$initialLocation',
     );
 
     return AppBootstrapState(
-      initialLocation: hasWallet ? '/home' : '/welcome',
+      initialLocation: initialLocation,
       initialAccountState: AccountState(
         accounts: accounts,
         activeAccountUuid: activeAccountUuid,
@@ -147,6 +163,8 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       ),
       initialSyncSnapshot: initialSyncSnapshot,
       network: network,
+      isPasswordConfigured: isPasswordConfigured,
+      isUnlocked: isUnlocked,
     );
   } catch (e) {
     log('bootstrap: failed, falling back to welcome: $e');

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -1,6 +1,3 @@
-import 'dart:io' show Platform;
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
@@ -13,12 +10,10 @@ class AppMainSidebar extends StatelessWidget {
     super.key,
     required this.accountName,
     required this.matchedLocation,
-    this.onResetWallet,
   });
 
   final String accountName;
   final String matchedLocation;
-  final VoidCallback? onResetWallet;
 
   bool _matches(String routePath) =>
       matchedLocation == routePath || matchedLocation.startsWith('$routePath/');
@@ -39,12 +34,6 @@ class AppMainSidebar extends StatelessWidget {
                     onTap: () => context.push('/accounts'),
                   ),
                 ),
-                if (onResetWallet != null &&
-                    kDebugMode &&
-                    Platform.isMacOS) ...[
-                  const SizedBox(width: AppSpacing.xs),
-                  _DebugResetButton(onPressed: onResetWallet!),
-                ],
               ],
             ),
             const SizedBox(height: AppSpacing.xs),
@@ -118,34 +107,6 @@ class AppMainSidebar extends StatelessWidget {
               ),
             ),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-class _DebugResetButton extends StatelessWidget {
-  const _DebugResetButton({required this.onPressed});
-
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onPressed,
-        child: Container(
-          width: 40,
-          height: 40,
-          padding: const EdgeInsets.all(AppSpacing.xs),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(AppRadii.small),
-            color: colors.background.overlay.withValues(alpha: 0.12),
-          ),
-          child: AppIcon(AppIcons.block, size: 20, color: colors.text.warning),
         ),
       ),
     );

--- a/lib/src/core/security/password_policy.dart
+++ b/lib/src/core/security/password_policy.dart
@@ -1,0 +1,24 @@
+const kWalletPasswordMinLength = 8;
+const kWalletPasswordMinLengthMessage =
+    'Password must be at least 8 characters.';
+const kWalletPasswordAsciiMessage =
+    'Use only English letters, numbers, and symbols.';
+
+bool isWalletPasswordAsciiOnly(String value) {
+  return value.runes.every((rune) => rune >= 0x21 && rune <= 0x7E);
+}
+
+String? validateWalletPassword(String value) {
+  if (value.isEmpty) return null;
+  if (!isWalletPasswordAsciiOnly(value)) {
+    return kWalletPasswordAsciiMessage;
+  }
+  if (value.length < kWalletPasswordMinLength) {
+    return kWalletPasswordMinLengthMessage;
+  }
+  return null;
+}
+
+bool isWalletPasswordValid(String value) {
+  return value.isNotEmpty && validateWalletPassword(value) == null;
+}

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -4,6 +4,8 @@ import 'dart:math';
 import 'package:cryptography/cryptography.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
+import '../security/password_policy.dart';
+
 const kWalletDbNameKey = 'zcash_wallet_db_name';
 const _secureStoreSaltKey = 'zcash_secure_store_salt';
 const _passwordVerifierKey = 'zcash_password_verifier';
@@ -119,6 +121,10 @@ class AppSecureStore {
   }
 
   Future<void> configurePassword(String password) async {
+    final error = validateWalletPassword(password);
+    if (error != null) {
+      throw ArgumentError(error);
+    }
     final salt = _randomBytes(16);
     final verifier = await _derivePasswordVerifier(password, salt);
     await writePlain(_passwordVerifierSaltKey, base64Encode(salt));
@@ -127,6 +133,9 @@ class AppSecureStore {
   }
 
   Future<bool> verifyPassword(String password) async {
+    if (!isWalletPasswordValid(password)) {
+      return false;
+    }
     final encodedSalt = await readPlain(_passwordVerifierSaltKey);
     final storedVerifier = await readPlain(_passwordVerifierKey);
     if (encodedSalt == null ||

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -6,6 +6,8 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 const kWalletDbNameKey = 'zcash_wallet_db_name';
 const _secureStoreSaltKey = 'zcash_secure_store_salt';
+const _passwordVerifierKey = 'zcash_password_verifier';
+const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';
 const _secureStorePassword = 'zcash-wallet-dev-password';
 const _secureStoreService = 'com.zcash.zcashWallet.secure_store';
 
@@ -35,6 +37,8 @@ class AppSecureStore {
 
   static SecretKey? _cachedSecretKey;
   static String? _sessionPassword;
+
+  bool get hasSessionPassword => _sessionPassword != null;
 
   Future<String> ensureWalletDbName() async {
     final existing = await readPlain(kWalletDbNameKey);
@@ -105,14 +109,50 @@ class AppSecureStore {
     return _storage.write(key: key, value: value);
   }
 
+  Future<bool> isPasswordConfigured() async {
+    final verifier = await readPlain(_passwordVerifierKey);
+    final salt = await readPlain(_passwordVerifierSaltKey);
+    return verifier != null &&
+        verifier.isNotEmpty &&
+        salt != null &&
+        salt.isNotEmpty;
+  }
+
+  Future<void> configurePassword(String password) async {
+    final salt = _randomBytes(16);
+    final verifier = await _derivePasswordVerifier(password, salt);
+    await writePlain(_passwordVerifierSaltKey, base64Encode(salt));
+    await writePlain(_passwordVerifierKey, verifier);
+    _sessionPassword = password;
+  }
+
+  Future<bool> verifyPassword(String password) async {
+    final encodedSalt = await readPlain(_passwordVerifierSaltKey);
+    final storedVerifier = await readPlain(_passwordVerifierKey);
+    if (encodedSalt == null ||
+        encodedSalt.isEmpty ||
+        storedVerifier == null ||
+        storedVerifier.isEmpty) {
+      return false;
+    }
+
+    final derived = await _derivePasswordVerifier(
+      password,
+      base64Decode(encodedSalt),
+    );
+    final isMatch = derived == storedVerifier;
+    if (isMatch) {
+      _sessionPassword = password;
+    }
+    return isMatch;
+  }
+
   void setSessionPassword(String password) {
     _sessionPassword = password;
-    _cachedSecretKey = null;
   }
 
   void clearSessionPassword() {
     _sessionPassword = null;
-    _cachedSecretKey = null;
   }
 
   Future<SecretKey> _getSecretKey() async {
@@ -120,13 +160,23 @@ class AppSecureStore {
     if (cached != null) return cached;
 
     final salt = await _getOrCreateSalt();
-    final password = _sessionPassword ?? _secureStorePassword;
     final key = await _kdf.deriveKeyFromPassword(
-      password: password,
+      password: _secureStorePassword,
       nonce: salt,
     );
     _cachedSecretKey = key;
     return key;
+  }
+
+  Future<String> _derivePasswordVerifier(
+    String password,
+    List<int> salt,
+  ) async {
+    final key = await _kdf.deriveKeyFromPassword(
+      password: password,
+      nonce: salt,
+    );
+    return base64Encode(await key.extractBytes());
   }
 
   Future<List<int>> _getOrCreateSalt() async {

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -1,0 +1,192 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:cryptography/cryptography.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+const kWalletDbNameKey = 'zcash_wallet_db_name';
+const _secureStoreSaltKey = 'zcash_secure_store_salt';
+const _secureStorePassword = 'zcash-wallet-dev-password';
+const _secureStoreService = 'com.zcash.zcashWallet.secure_store';
+
+class AppSecureStore {
+  AppSecureStore._();
+
+  static final AppSecureStore instance = AppSecureStore._();
+
+  static const _storage = FlutterSecureStorage(
+    iOptions: IOSOptions(
+      accountName: _secureStoreService,
+      accessibility: KeychainAccessibility.first_unlock,
+    ),
+    mOptions: MacOsOptions(
+      accountName: _secureStoreService,
+      accessibility: KeychainAccessibility.first_unlock,
+      usesDataProtectionKeychain: true,
+    ),
+  );
+
+  static final Cipher _cipher = AesGcm.with256bits();
+  static final Pbkdf2 _kdf = Pbkdf2(
+    macAlgorithm: Hmac.sha256(),
+    iterations: 100000,
+    bits: 256,
+  );
+
+  static SecretKey? _cachedSecretKey;
+  static String? _sessionPassword;
+
+  Future<String> ensureWalletDbName() async {
+    final existing = await readPlain(kWalletDbNameKey);
+    if (existing != null && existing.isNotEmpty) {
+      return existing;
+    }
+
+    final suffix = _randomHex(12);
+    final dbName = 'zcash_wallet_$suffix.db';
+    await writePlain(kWalletDbNameKey, dbName);
+    return dbName;
+  }
+
+  Future<String?> readString(String key) async {
+    final raw = await _storage.read(key: key);
+    if (raw == null || raw.isEmpty) return null;
+
+    final payload = _EncryptedPayload.tryParse(raw);
+    if (payload == null) {
+      return null;
+    }
+
+    final secretKey = await _getSecretKey();
+    final clearText = await _cipher.decrypt(
+      SecretBox(
+        payload.cipherText,
+        nonce: payload.nonce,
+        mac: Mac(payload.mac),
+      ),
+      secretKey: secretKey,
+    );
+    return utf8.decode(clearText);
+  }
+
+  Future<void> writeString(String key, String value) async {
+    final secretKey = await _getSecretKey();
+    final nonce = _randomBytes(12);
+    final secretBox = await _cipher.encrypt(
+      utf8.encode(value),
+      secretKey: secretKey,
+      nonce: nonce,
+    );
+    await _storage.write(
+      key: key,
+      value: _EncryptedPayload(
+        nonce: secretBox.nonce,
+        cipherText: secretBox.cipherText,
+        mac: secretBox.mac.bytes,
+      ).serialize(),
+    );
+  }
+
+  Future<void> delete(String key) async {
+    await _storage.delete(key: key);
+  }
+
+  Future<void> deleteAll() async {
+    await _storage.deleteAll();
+    _cachedSecretKey = null;
+    _sessionPassword = null;
+  }
+
+  Future<String?> readPlain(String key) {
+    return _storage.read(key: key);
+  }
+
+  Future<void> writePlain(String key, String value) {
+    return _storage.write(key: key, value: value);
+  }
+
+  void setSessionPassword(String password) {
+    _sessionPassword = password;
+    _cachedSecretKey = null;
+  }
+
+  void clearSessionPassword() {
+    _sessionPassword = null;
+    _cachedSecretKey = null;
+  }
+
+  Future<SecretKey> _getSecretKey() async {
+    final cached = _cachedSecretKey;
+    if (cached != null) return cached;
+
+    final salt = await _getOrCreateSalt();
+    final password = _sessionPassword ?? _secureStorePassword;
+    final key = await _kdf.deriveKeyFromPassword(
+      password: password,
+      nonce: salt,
+    );
+    _cachedSecretKey = key;
+    return key;
+  }
+
+  Future<List<int>> _getOrCreateSalt() async {
+    final encoded = await readPlain(_secureStoreSaltKey);
+    if (encoded != null && encoded.isNotEmpty) {
+      return base64Decode(encoded);
+    }
+
+    final salt = _randomBytes(16);
+    await writePlain(_secureStoreSaltKey, base64Encode(salt));
+    return salt;
+  }
+
+  List<int> _randomBytes(int length) {
+    final random = Random.secure();
+    return List<int>.generate(length, (_) => random.nextInt(256));
+  }
+
+  String _randomHex(int bytes) {
+    final data = _randomBytes(bytes);
+    final buffer = StringBuffer();
+    for (final byte in data) {
+      buffer.write(byte.toRadixString(16).padLeft(2, '0'));
+    }
+    return buffer.toString();
+  }
+}
+
+class _EncryptedPayload {
+  const _EncryptedPayload({
+    required this.nonce,
+    required this.cipherText,
+    required this.mac,
+  });
+
+  final List<int> nonce;
+  final List<int> cipherText;
+  final List<int> mac;
+
+  String serialize() {
+    return jsonEncode({
+      'v': 1,
+      'n': base64Encode(nonce),
+      'c': base64Encode(cipherText),
+      'm': base64Encode(mac),
+    });
+  }
+
+  static _EncryptedPayload? tryParse(String raw) {
+    try {
+      final json = jsonDecode(raw);
+      if (json is! Map<String, dynamic>) return null;
+      if (json['v'] != 1) return null;
+      return _EncryptedPayload(
+        nonce: base64Decode(json['n'] as String),
+        cipherText: base64Decode(json['c'] as String),
+        mac: base64Decode(json['m'] as String),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/src/core/storage/wallet_paths.dart
+++ b/lib/src/core/storage/wallet_paths.dart
@@ -2,13 +2,20 @@ import 'dart:io';
 
 import 'package:path_provider/path_provider.dart';
 
+import 'app_secure_store.dart';
+
 Future<Directory> getWalletSupportDirectory() async {
   final dir = await getApplicationSupportDirectory();
   await dir.create(recursive: true);
   return dir;
 }
 
+Future<String> getWalletDbName() async {
+  return AppSecureStore.instance.ensureWalletDbName();
+}
+
 Future<String> getWalletDbPath() async {
   final dir = await getWalletSupportDirectory();
-  return '${dir.path}${Platform.pathSeparator}zcash_wallet.db';
+  final dbName = await getWalletDbName();
+  return '${dir.path}${Platform.pathSeparator}$dbName';
 }

--- a/lib/src/core/widgets/app_text_field.dart
+++ b/lib/src/core/widgets/app_text_field.dart
@@ -38,6 +38,9 @@ class AppTextField extends StatefulWidget {
     this.enabled = true,
     this.readOnly = false,
     this.autofocus = false,
+    this.obscureText = false,
+    this.enableSuggestions = true,
+    this.autocorrect = true,
   }) : assert(
          controller == null || initialValue == null,
          'Provide either controller or initialValue, not both.',
@@ -76,6 +79,9 @@ class AppTextField extends StatefulWidget {
   final bool enabled;
   final bool readOnly;
   final bool autofocus;
+  final bool obscureText;
+  final bool enableSuggestions;
+  final bool autocorrect;
 
   @override
   State<AppTextField> createState() => _AppTextFieldState();
@@ -298,6 +304,9 @@ class _AppTextFieldState extends State<AppTextField> {
       enabled: widget.enabled,
       readOnly: widget.readOnly,
       autofocus: widget.autofocus,
+      obscureText: widget.obscureText,
+      enableSuggestions: widget.enableSuggestions,
+      autocorrect: widget.autocorrect,
       keyboardType: widget.keyboardType,
       textInputAction: widget.textInputAction,
       inputFormatters: widget.inputFormatters,

--- a/lib/src/core/widgets/password_text_field.dart
+++ b/lib/src/core/widgets/password_text_field.dart
@@ -15,6 +15,7 @@ class PasswordTextField extends StatefulWidget {
     this.onSubmitted,
     this.autofocus = false,
     this.enabled = true,
+    this.showVisibilityToggle = true,
   });
 
   final String label;
@@ -26,6 +27,7 @@ class PasswordTextField extends StatefulWidget {
   final ValueChanged<String>? onSubmitted;
   final bool autofocus;
   final bool enabled;
+  final bool showVisibilityToggle;
 
   @override
   State<PasswordTextField> createState() => _PasswordTextFieldState();
@@ -49,14 +51,16 @@ class _PasswordTextFieldState extends State<PasswordTextField> {
       messageText: widget.messageText,
       tone: widget.tone,
       leading: const AppIcon(AppIcons.lock),
-      trailing: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: _toggleVisibility,
-        child: AppIcon(
-          _obscureText ? AppIcons.eyeClosed : AppIcons.eye,
-          size: 20,
-        ),
-      ),
+      trailing: widget.showVisibilityToggle
+          ? GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: _toggleVisibility,
+              child: AppIcon(
+                _obscureText ? AppIcons.eyeClosed : AppIcons.eye,
+                size: 20,
+              ),
+            )
+          : null,
       onChanged: widget.onChanged,
       onSubmitted: widget.onSubmitted,
       keyboardType: TextInputType.visiblePassword,

--- a/lib/src/core/widgets/password_text_field.dart
+++ b/lib/src/core/widgets/password_text_field.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/widgets.dart';
+
+import 'app_icon.dart';
+import 'app_text_field.dart';
+
+class PasswordTextField extends StatefulWidget {
+  const PasswordTextField({
+    super.key,
+    required this.label,
+    this.controller,
+    this.focusNode,
+    this.messageText,
+    this.tone = AppTextFieldTone.neutral,
+    this.onChanged,
+    this.onSubmitted,
+    this.autofocus = false,
+    this.enabled = true,
+  });
+
+  final String label;
+  final TextEditingController? controller;
+  final FocusNode? focusNode;
+  final String? messageText;
+  final AppTextFieldTone tone;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final bool autofocus;
+  final bool enabled;
+
+  @override
+  State<PasswordTextField> createState() => _PasswordTextFieldState();
+}
+
+class _PasswordTextFieldState extends State<PasswordTextField> {
+  bool _obscureText = true;
+
+  void _toggleVisibility() {
+    setState(() {
+      _obscureText = !_obscureText;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppTextField(
+      label: widget.label,
+      controller: widget.controller,
+      focusNode: widget.focusNode,
+      messageText: widget.messageText,
+      tone: widget.tone,
+      leading: const AppIcon(AppIcons.lock),
+      trailing: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: _toggleVisibility,
+        child: AppIcon(
+          _obscureText ? AppIcons.eyeClosed : AppIcons.eye,
+          size: 20,
+        ),
+      ),
+      onChanged: widget.onChanged,
+      onSubmitted: widget.onSubmitted,
+      keyboardType: TextInputType.visiblePassword,
+      obscureText: _obscureText,
+      enableSuggestions: false,
+      autocorrect: false,
+      enabled: widget.enabled,
+      autofocus: widget.autofocus,
+    );
+  }
+}

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -1,13 +1,8 @@
-import 'dart:io' show exit;
 import 'package:flutter/material.dart'
     show
-        AlertDialog,
         CircularProgressIndicator,
         Scrollbar,
-        TextButton,
-        TextStyle,
-        Theme,
-        showDialog;
+        Theme;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -83,42 +78,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     });
   }
 
-  Future<void> _resetWallet(BuildContext context) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Reset Wallet'),
-        content: const Text(
-          'Delete all wallet data (DB + keychain)? This cannot be undone.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text(
-              'Reset',
-              style: TextStyle(color: Color(0xFFFF3B30)),
-            ),
-          ),
-        ],
-      ),
-    );
-    if (confirmed != true || !mounted) return;
-
-    ref.read(syncProvider.notifier).stopSync();
-    var waited = 0;
-    while (rust_sync.isSyncRunning() && waited < 5000) {
-      await Future.delayed(const Duration(milliseconds: 100));
-      waited += 100;
-    }
-
-    await ref.read(accountProvider.notifier).resetWallet();
-    exit(0);
-  }
-
   String _groupLabelForTx(rust_sync.TransactionInfo tx) {
     if (tx.minedHeight == BigInt.zero && !tx.expiredUnmined) {
       return 'Today';
@@ -147,7 +106,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       sidebar: AppMainSidebar(
         accountName: accountName,
         matchedLocation: matchedLocation,
-        onResetWallet: () => _resetWallet(context),
       ),
       pane: AppDesktopPane(
         padding: const EdgeInsets.fromLTRB(AppSpacing.sm, 0, 0, 0),

--- a/lib/src/features/onboarding/screens/onboarding_split_view.dart
+++ b/lib/src/features/onboarding/screens/onboarding_split_view.dart
@@ -5,7 +5,13 @@ import '../../../core/motion/onboarding_motion.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
 
-enum OnboardingStep { intro, addressTypes, thingsToKnow, secretPassphrase }
+enum OnboardingStep {
+  intro,
+  addressTypes,
+  thingsToKnow,
+  secretPassphrase,
+  setPassword,
+}
 
 extension OnboardingStepX on OnboardingStep {
   String get label => switch (this) {
@@ -13,6 +19,7 @@ extension OnboardingStepX on OnboardingStep {
     OnboardingStep.addressTypes => 'Address types',
     OnboardingStep.thingsToKnow => 'Things to know',
     OnboardingStep.secretPassphrase => 'Secret Passphrase',
+    OnboardingStep.setPassword => 'Set Password',
   };
 
   String get iconName => switch (this) {
@@ -20,6 +27,7 @@ extension OnboardingStepX on OnboardingStep {
     OnboardingStep.addressTypes => AppIcons.shieldKeyhole,
     OnboardingStep.thingsToKnow => AppIcons.crystalBall,
     OnboardingStep.secretPassphrase => AppIcons.key,
+    OnboardingStep.setPassword => AppIcons.lock,
   };
 
   String get routePath => switch (this) {
@@ -27,10 +35,14 @@ extension OnboardingStepX on OnboardingStep {
     OnboardingStep.addressTypes => '/onboarding/address-types',
     OnboardingStep.thingsToKnow => '/onboarding/things-to-know',
     OnboardingStep.secretPassphrase => '/onboarding/secret-passphrase',
+    OnboardingStep.setPassword => '/onboarding/set-password',
   };
 }
 
 OnboardingStep onboardingStepFromLocation(String location) {
+  if (location.startsWith(OnboardingStep.setPassword.routePath)) {
+    return OnboardingStep.setPassword;
+  }
   if (location.startsWith(OnboardingStep.secretPassphrase.routePath)) {
     return OnboardingStep.secretPassphrase;
   }
@@ -49,11 +61,13 @@ OnboardingStep onboardingStepFromLocation(String location) {
 class OnboardingSplitViewShell extends StatelessWidget {
   const OnboardingSplitViewShell({
     required this.activeStep,
+    required this.showPasswordStep,
     required this.child,
     super.key,
   });
 
   final OnboardingStep activeStep;
+  final bool showPasswordStep;
   final Widget child;
 
   @override
@@ -74,7 +88,10 @@ class OnboardingSplitViewShell extends StatelessWidget {
     return AppDesktopShell(
       sidebar: SlideTransition(
         position: sidebarOffset,
-        child: _Sidebar(activeStep: activeStep),
+        child: _Sidebar(
+          activeStep: activeStep,
+          showPasswordStep: showPasswordStep,
+        ),
       ),
       pane: FadeTransition(opacity: entrance, child: child),
     );
@@ -93,9 +110,10 @@ class OnboardingTrailingPane extends StatelessWidget {
 }
 
 class _Sidebar extends StatelessWidget {
-  const _Sidebar({required this.activeStep});
+  const _Sidebar({required this.activeStep, required this.showPasswordStep});
 
   final OnboardingStep activeStep;
+  final bool showPasswordStep;
 
   @override
   Widget build(BuildContext context) {
@@ -129,7 +147,10 @@ class _Sidebar extends StatelessWidget {
                 transitionBuilder: _fadeTransition,
                 child: KeyedSubtree(
                   key: ValueKey(activeStep),
-                  child: _SidebarNav(activeStep: activeStep),
+                  child: _SidebarNav(
+                    activeStep: activeStep,
+                    showPasswordStep: showPasswordStep,
+                  ),
                 ),
               ),
             ),
@@ -145,15 +166,17 @@ class _Sidebar extends StatelessWidget {
 }
 
 class _SidebarNav extends StatelessWidget {
-  const _SidebarNav({required this.activeStep});
+  const _SidebarNav({required this.activeStep, required this.showPasswordStep});
 
   final OnboardingStep activeStep;
+  final bool showPasswordStep;
 
-  static const _steps = [
+  List<OnboardingStep> get _steps => [
     OnboardingStep.intro,
     OnboardingStep.addressTypes,
     OnboardingStep.thingsToKnow,
     OnboardingStep.secretPassphrase,
+    if (showPasswordStep) OnboardingStep.setPassword,
   ];
 
   @override
@@ -190,6 +213,10 @@ class _SidebarIllustration extends StatelessWidget {
     final isDark = AppTheme.of(context) == AppThemeData.dark;
     final asset = switch (step) {
       OnboardingStep.secretPassphrase =>
+        isDark
+            ? 'assets/illustrations/onboarding_secret_passphrase_sidebar_dark.png'
+            : 'assets/illustrations/onboarding_secret_passphrase_sidebar_light.png',
+      OnboardingStep.setPassword =>
         isDark
             ? 'assets/illustrations/onboarding_secret_passphrase_sidebar_dark.png'
             : 'assets/illustrations/onboarding_secret_passphrase_sidebar_light.png',

--- a/lib/src/features/onboarding/screens/secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/screens/secret_passphrase_screen.dart
@@ -13,8 +13,10 @@ import '../../../core/widgets/app_chip.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/app_security_provider.dart';
 import '../../../rust/api/wallet.dart' as rust_wallet;
 import 'onboarding_split_view.dart';
+import 'set_password_screen.dart';
 
 class SecretPassphraseScreen extends ConsumerStatefulWidget {
   const SecretPassphraseScreen({super.key});
@@ -61,6 +63,15 @@ class _SecretPassphraseScreenState
     }
     final mnemonic = _mnemonic;
     if (mnemonic == null) return;
+    final security = ref.read(appSecurityProvider);
+
+    if (!security.isPasswordConfigured) {
+      context.go(
+        OnboardingStep.setPassword.routePath,
+        extra: SetPasswordScreenArgs(mnemonic: mnemonic),
+      );
+      return;
+    }
 
     setState(() {
       _isCreating = true;
@@ -91,6 +102,7 @@ class _SecretPassphraseScreenState
 
   @override
   Widget build(BuildContext context) {
+    final security = ref.watch(appSecurityProvider);
     return OnboardingTrailingPane(
       child: Column(
         children: [
@@ -104,6 +116,7 @@ class _SecretPassphraseScreenState
                   isPreparing: _isPreparing,
                   isCreating: _isCreating,
                   revealed: _revealed,
+                  needsPasswordStep: !security.isPasswordConfigured,
                   prepareError: _prepareError,
                   submitError: _submitError,
                   onPrimaryPressed: _handlePrimaryAction,
@@ -160,6 +173,7 @@ class _HeroLayout extends StatelessWidget {
     required this.isPreparing,
     required this.isCreating,
     required this.revealed,
+    required this.needsPasswordStep,
     required this.prepareError,
     required this.submitError,
     required this.onPrimaryPressed,
@@ -170,6 +184,7 @@ class _HeroLayout extends StatelessWidget {
   final bool isPreparing;
   final bool isCreating;
   final bool revealed;
+  final bool needsPasswordStep;
   final String? prepareError;
   final String? submitError;
   final Future<void> Function() onPrimaryPressed;
@@ -194,6 +209,7 @@ class _HeroLayout extends StatelessWidget {
           isPreparing: isPreparing,
           isCreating: isCreating,
           revealed: revealed,
+          needsPasswordStep: needsPasswordStep,
           submitError: submitError,
           onPrimaryPressed: onPrimaryPressed,
         ),
@@ -255,6 +271,7 @@ class _BottomActions extends StatelessWidget {
     required this.isPreparing,
     required this.isCreating,
     required this.revealed,
+    required this.needsPasswordStep,
     required this.submitError,
     required this.onPrimaryPressed,
   });
@@ -262,6 +279,7 @@ class _BottomActions extends StatelessWidget {
   final bool isPreparing;
   final bool isCreating;
   final bool revealed;
+  final bool needsPasswordStep;
   final String? submitError;
   final Future<void> Function() onPrimaryPressed;
 
@@ -280,7 +298,9 @@ class _BottomActions extends StatelessWidget {
             isCreating
                 ? 'Creating wallet...'
                 : revealed
-                ? 'I’m ready to use Vizor'
+                ? needsPasswordStep
+                      ? 'Continue to Set Password'
+                      : 'I’m ready to use Vizor'
                 : 'Reveal the Phrase',
           ),
         ),

--- a/lib/src/features/onboarding/screens/set_password_screen.dart
+++ b/lib/src/features/onboarding/screens/set_password_screen.dart
@@ -29,6 +29,11 @@ class SetPasswordScreen extends ConsumerStatefulWidget {
 }
 
 class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
+  static const _contentWidth = 256.0;
+  static const _contentGap = 16.0;
+  static const _fieldGroupGap = 12.0;
+  static const _fieldReservedMessageHeight = 20.0;
+
   final _passwordController = TextEditingController();
   final _confirmController = TextEditingController();
   bool _isSubmitting = false;
@@ -108,85 +113,147 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
     return OnboardingTrailingPane(
       child: Column(
         children: [
-          const _BackRow(),
+          const SizedBox(height: 32, child: _BackRow()),
+          const SizedBox(height: AppSpacing.s),
           Expanded(
-            child: Center(
-              child: SizedBox(
-                width: 432,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      'Set Password',
-                      style: AppTypography.displaySmall.copyWith(
-                        color: colors.text.accent,
+            child: Column(
+              children: [
+                Expanded(
+                  child: Center(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: AppSpacing.s,
                       ),
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    Text(
-                      'Minimum 8 symbols including characters.',
-                      style: AppTypography.bodyMedium.copyWith(
-                        color: colors.text.accent,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    const AppDecorativeDivider(),
-                    const SizedBox(height: AppSpacing.s),
-                    PasswordTextField(
-                      label: 'Password',
-                      controller: _passwordController,
-                      messageText: _passwordMessage,
-                      tone: _passwordMessage == null
-                          ? AppTextFieldTone.neutral
-                          : AppTextFieldTone.destructive,
-                      autofocus: true,
-                      onChanged: (_) => setState(() {
-                        _submitError = null;
-                      }),
-                      onSubmitted: (_) => _submit(),
-                    ),
-                    const SizedBox(height: AppSpacing.s),
-                    PasswordTextField(
-                      label: 'Confirm Password',
-                      controller: _confirmController,
-                      messageText: _confirmMessage,
-                      tone: _confirmMessage == null
-                          ? AppTextFieldTone.neutral
-                          : AppTextFieldTone.destructive,
-                      onChanged: (_) => setState(() {
-                        _submitError = null;
-                      }),
-                      onSubmitted: (_) => _submit(),
-                    ),
-                    if (_submitError != null) ...[
-                      const SizedBox(height: AppSpacing.xs),
-                      Text(
-                        _submitError!,
-                        style: AppTypography.bodyMedium.copyWith(
-                          color: colors.text.warning,
+                      child: SizedBox(
+                        width: _contentWidth,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  'Set Password',
+                                  style: AppTypography.displaySmall.copyWith(
+                                    color: colors.text.accent,
+                                  ),
+                                  textAlign: TextAlign.center,
+                                ),
+                                const SizedBox(height: AppSpacing.s),
+                                SizedBox(
+                                  width: 270,
+                                  child: Text(
+                                    'Minimum 8 symbols including characters.',
+                                    style: AppTypography.bodyMedium.copyWith(
+                                      color: colors.text.accent,
+                                    ),
+                                    textAlign: TextAlign.center,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: _contentGap),
+                            const AppDecorativeDivider(width: _contentWidth),
+                            const SizedBox(height: _contentGap),
+                            Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                _PasswordFieldBlock(
+                                  reserveMessageSpace:
+                                      _fieldReservedMessageHeight,
+                                  child: PasswordTextField(
+                                    label: 'Password',
+                                    controller: _passwordController,
+                                    messageText: _passwordMessage,
+                                    tone: _passwordMessage == null
+                                        ? AppTextFieldTone.neutral
+                                        : AppTextFieldTone.destructive,
+                                    autofocus: true,
+                                    onChanged: (_) => setState(() {
+                                      _submitError = null;
+                                    }),
+                                    onSubmitted: (_) => _submit(),
+                                  ),
+                                ),
+                                const SizedBox(height: _fieldGroupGap),
+                                _PasswordFieldBlock(
+                                  reserveMessageSpace:
+                                      _fieldReservedMessageHeight,
+                                  child: PasswordTextField(
+                                    label: 'Confirm Password',
+                                    controller: _confirmController,
+                                    messageText: _confirmMessage,
+                                    tone: _confirmMessage == null
+                                        ? AppTextFieldTone.neutral
+                                        : AppTextFieldTone.destructive,
+                                    onChanged: (_) => setState(() {
+                                      _submitError = null;
+                                    }),
+                                    onSubmitted: (_) => _submit(),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
                         ),
-                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                ),
+                SizedBox(
+                  width: _contentWidth,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (_submitError != null) ...[
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+                          child: Text(
+                            _submitError!,
+                            style: AppTypography.bodyMedium.copyWith(
+                              color: colors.text.warning,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      ],
+                      AppButton(
+                        onPressed: _canSubmit ? _submit : null,
+                        variant: AppButtonVariant.primary,
+                        minWidth: _contentWidth,
+                        trailing: const AppIcon(AppIcons.chevronForward),
+                        child: Text(
+                          _isSubmitting
+                              ? 'Setting password...'
+                              : 'Set Password',
+                        ),
                       ),
                     ],
-                    const SizedBox(height: AppSpacing.s),
-                    AppButton(
-                      onPressed: _canSubmit ? _submit : null,
-                      variant: AppButtonVariant.primary,
-                      minWidth: 256,
-                      trailing: const AppIcon(AppIcons.chevronForward),
-                      child: Text(
-                        _isSubmitting ? 'Setting password...' : 'Set Password',
-                      ),
-                    ),
-                  ],
+                  ),
                 ),
-              ),
+              ],
             ),
           ),
         ],
       ),
+    );
+  }
+}
+
+class _PasswordFieldBlock extends StatelessWidget {
+  const _PasswordFieldBlock({
+    required this.child,
+    required this.reserveMessageSpace,
+  });
+
+  final Widget child;
+  final double reserveMessageSpace;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: reserveMessageSpace),
+      child: child,
     );
   }
 }

--- a/lib/src/features/onboarding/screens/set_password_screen.dart
+++ b/lib/src/features/onboarding/screens/set_password_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/security/password_policy.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
@@ -57,29 +58,35 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
     super.dispose();
   }
 
-  bool get _hasMinLength => _passwordController.text.length >= 8;
+  String? get _passwordPolicyError =>
+      validateWalletPassword(_passwordController.text);
   bool get _matches =>
       _confirmController.text.isNotEmpty &&
       _confirmController.text == _passwordController.text;
 
   bool get _canSubmit =>
-      !_isSubmitting && widget.args != null && _hasMinLength && _matches;
+      !_isSubmitting &&
+      widget.args != null &&
+      _passwordPolicyError == null &&
+      _matches;
 
-  String? get _passwordMessage {
-    final value = _passwordController.text;
-    if (value.isEmpty || _hasMinLength) return null;
-    return 'Password must be at least 8 characters.';
-  }
+  String? get _passwordMessage => _passwordPolicyError;
 
   String? get _confirmMessage {
     final value = _confirmController.text;
-    if (value.isEmpty || _matches) return null;
+    if (value.isEmpty || _passwordPolicyError != null || _matches) return null;
     return 'Passwords do not match.';
   }
 
   Future<void> _submit() async {
     final args = widget.args;
-    if (!_canSubmit || args == null) return;
+    final passwordPolicyError = _passwordPolicyError;
+    if (_isSubmitting ||
+        args == null ||
+        passwordPolicyError != null ||
+        !_matches) {
+      return;
+    }
 
     setState(() {
       _isSubmitting = true;

--- a/lib/src/features/onboarding/screens/set_password_screen.dart
+++ b/lib/src/features/onboarding/screens/set_password_screen.dart
@@ -1,0 +1,228 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_decorative_divider.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_text_field.dart';
+import '../../../core/widgets/password_text_field.dart';
+import '../../../providers/account_provider.dart';
+import '../../../providers/app_security_provider.dart';
+import 'onboarding_split_view.dart';
+
+class SetPasswordScreenArgs {
+  const SetPasswordScreenArgs({required this.mnemonic});
+
+  final String mnemonic;
+}
+
+class SetPasswordScreen extends ConsumerStatefulWidget {
+  const SetPasswordScreen({super.key, required this.args});
+
+  final SetPasswordScreenArgs? args;
+
+  @override
+  ConsumerState<SetPasswordScreen> createState() => _SetPasswordScreenState();
+}
+
+class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
+  final _passwordController = TextEditingController();
+  final _confirmController = TextEditingController();
+  bool _isSubmitting = false;
+  String? _submitError;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.args == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        context.go(OnboardingStep.secretPassphrase.routePath);
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  bool get _hasMinLength => _passwordController.text.length >= 8;
+  bool get _matches =>
+      _confirmController.text.isNotEmpty &&
+      _confirmController.text == _passwordController.text;
+
+  bool get _canSubmit =>
+      !_isSubmitting && widget.args != null && _hasMinLength && _matches;
+
+  String? get _passwordMessage {
+    final value = _passwordController.text;
+    if (value.isEmpty || _hasMinLength) return null;
+    return 'Password must be at least 8 characters.';
+  }
+
+  String? get _confirmMessage {
+    final value = _confirmController.text;
+    if (value.isEmpty || _matches) return null;
+    return 'Passwords do not match.';
+  }
+
+  Future<void> _submit() async {
+    final args = widget.args;
+    if (!_canSubmit || args == null) return;
+
+    setState(() {
+      _isSubmitting = true;
+      _submitError = null;
+    });
+
+    try {
+      await ref
+          .read(appSecurityProvider.notifier)
+          .configurePassword(_passwordController.text);
+      await ref
+          .read(accountProvider.notifier)
+          .createAccountFromMnemonic(mnemonic: args.mnemonic);
+    } catch (e, st) {
+      log('SetPasswordScreen._submit: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _isSubmitting = false;
+        _submitError = e.toString();
+      });
+      return;
+    }
+
+    if (!mounted) return;
+    context.go('/home');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return OnboardingTrailingPane(
+      child: Column(
+        children: [
+          const _BackRow(),
+          Expanded(
+            child: Center(
+              child: SizedBox(
+                width: 432,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Set Password',
+                      style: AppTypography.displaySmall.copyWith(
+                        color: colors.text.accent,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    Text(
+                      'Minimum 8 symbols including characters.',
+                      style: AppTypography.bodyMedium.copyWith(
+                        color: colors.text.accent,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    const AppDecorativeDivider(),
+                    const SizedBox(height: AppSpacing.s),
+                    PasswordTextField(
+                      label: 'Password',
+                      controller: _passwordController,
+                      messageText: _passwordMessage,
+                      tone: _passwordMessage == null
+                          ? AppTextFieldTone.neutral
+                          : AppTextFieldTone.destructive,
+                      autofocus: true,
+                      onChanged: (_) => setState(() {
+                        _submitError = null;
+                      }),
+                      onSubmitted: (_) => _submit(),
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    PasswordTextField(
+                      label: 'Confirm Password',
+                      controller: _confirmController,
+                      messageText: _confirmMessage,
+                      tone: _confirmMessage == null
+                          ? AppTextFieldTone.neutral
+                          : AppTextFieldTone.destructive,
+                      onChanged: (_) => setState(() {
+                        _submitError = null;
+                      }),
+                      onSubmitted: (_) => _submit(),
+                    ),
+                    if (_submitError != null) ...[
+                      const SizedBox(height: AppSpacing.xs),
+                      Text(
+                        _submitError!,
+                        style: AppTypography.bodyMedium.copyWith(
+                          color: colors.text.warning,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                    const SizedBox(height: AppSpacing.s),
+                    AppButton(
+                      onPressed: _canSubmit ? _submit : null,
+                      variant: AppButtonVariant.primary,
+                      minWidth: 256,
+                      trailing: const AppIcon(AppIcons.chevronForward),
+                      child: Text(
+                        _isSubmitting ? 'Setting password...' : 'Set Password',
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BackRow extends StatelessWidget {
+  const _BackRow();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => context.go(OnboardingStep.secretPassphrase.routePath),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.xxs),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AppIcon(
+                AppIcons.chevronBackward,
+                size: AppIconSize.medium,
+                color: colors.text.accent,
+              ),
+              const SizedBox(width: AppSpacing.xxs),
+              Text(
+                'Back',
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/onboarding/screens/unlock_screen.dart
+++ b/lib/src/features/onboarding/screens/unlock_screen.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart' show Colors, Scaffold;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/layout/app_desktop_shell.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_decorative_divider.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_text_field.dart';
+import '../../../core/widgets/password_text_field.dart';
+import '../../../providers/app_security_provider.dart';
+
+class UnlockScreen extends ConsumerStatefulWidget {
+  const UnlockScreen({super.key});
+
+  @override
+  ConsumerState<UnlockScreen> createState() => _UnlockScreenState();
+}
+
+class _UnlockScreenState extends ConsumerState<UnlockScreen> {
+  final _passwordController = TextEditingController();
+  bool _isSubmitting = false;
+  String? _errorText;
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_isSubmitting || _passwordController.text.isEmpty) return;
+
+    setState(() {
+      _isSubmitting = true;
+      _errorText = null;
+    });
+
+    final isValid = await ref
+        .read(appSecurityProvider.notifier)
+        .unlock(_passwordController.text);
+    if (!mounted) return;
+    if (!isValid) {
+      log('UnlockScreen._submit: invalid password');
+      setState(() {
+        _isSubmitting = false;
+        _errorText = 'Incorrect password. Please try again.';
+      });
+      return;
+    }
+
+    context.go('/home');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.xs),
+          child: AppDesktopPane(
+            child: Center(
+              child: SizedBox(
+                width: 432,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 48,
+                      height: 48,
+                      decoration: BoxDecoration(
+                        color: colors.background.overlay.withValues(alpha: 0.2),
+                        borderRadius: BorderRadius.circular(AppRadii.full),
+                      ),
+                      child: const Center(
+                        child: AppIcon(AppIcons.unlock, size: 24),
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    Text(
+                      'Unlock Wallet',
+                      style: AppTypography.displaySmall.copyWith(
+                        color: colors.text.accent,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    Text(
+                      'Enter your password to access your wallet.',
+                      style: AppTypography.bodyMedium.copyWith(
+                        color: colors.text.accent,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    const AppDecorativeDivider(),
+                    const SizedBox(height: AppSpacing.s),
+                    PasswordTextField(
+                      label: 'Password',
+                      controller: _passwordController,
+                      autofocus: true,
+                      messageText: _errorText,
+                      tone: _errorText == null
+                          ? AppTextFieldTone.neutral
+                          : AppTextFieldTone.destructive,
+                      onChanged: (_) {
+                        setState(() {
+                          _errorText = null;
+                        });
+                      },
+                      onSubmitted: (_) => _submit(),
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    AppButton(
+                      onPressed:
+                          _isSubmitting || _passwordController.text.isEmpty
+                          ? null
+                          : _submit,
+                      variant: AppButtonVariant.primary,
+                      minWidth: 256,
+                      trailing: const AppIcon(AppIcons.chevronForward),
+                      child: Text(_isSubmitting ? 'Unlocking...' : 'Unlock'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/onboarding/screens/unlock_screen.dart
+++ b/lib/src/features/onboarding/screens/unlock_screen.dart
@@ -1,4 +1,14 @@
-import 'package:flutter/material.dart' show Colors, Scaffold;
+import 'dart:io' show Platform, exit;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart'
+    show
+        AlertDialog,
+        Colors,
+        Scaffold,
+        TextButton,
+        TextStyle,
+        showDialog;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -11,7 +21,10 @@ import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_text_field.dart';
 import '../../../core/widgets/password_text_field.dart';
+import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
+import '../../../providers/sync_provider.dart';
+import '../../../rust/api/sync.dart' as rust_sync;
 
 class UnlockScreen extends ConsumerStatefulWidget {
   const UnlockScreen({super.key});
@@ -53,6 +66,42 @@ class _UnlockScreenState extends ConsumerState<UnlockScreen> {
     }
 
     context.go('/home');
+  }
+
+  Future<void> _resetWallet(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Reset Wallet'),
+        content: const Text(
+          'Delete all wallet data (DB + keychain)? This cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text(
+              'Reset',
+              style: TextStyle(color: Color(0xFFFF3B30)),
+            ),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    ref.read(syncProvider.notifier).stopSync();
+    var waited = 0;
+    while (rust_sync.isSyncRunning() && waited < 5000) {
+      await Future.delayed(const Duration(milliseconds: 100));
+      waited += 100;
+    }
+
+    await ref.read(accountProvider.notifier).resetWallet();
+    exit(0);
   }
 
   @override
@@ -126,6 +175,25 @@ class _UnlockScreenState extends ConsumerState<UnlockScreen> {
                       trailing: const AppIcon(AppIcons.chevronForward),
                       child: Text(_isSubmitting ? 'Unlocking...' : 'Unlock'),
                     ),
+                    if (kDebugMode && Platform.isMacOS) ...[
+                      const SizedBox(height: AppSpacing.xs),
+                      GestureDetector(
+                        behavior: HitTestBehavior.opaque,
+                        onTap: () => _resetWallet(context),
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: AppSpacing.xs,
+                            vertical: AppSpacing.xxs,
+                          ),
+                          child: Text(
+                            'Reset State',
+                            style: AppTypography.labelLarge.copyWith(
+                              color: colors.text.warning,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
                   ],
                 ),
               ),

--- a/lib/src/features/onboarding/screens/unlock_screen.dart
+++ b/lib/src/features/onboarding/screens/unlock_screen.dart
@@ -15,6 +15,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/layout/app_desktop_shell.dart';
+import '../../../core/security/password_policy.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
@@ -38,6 +39,12 @@ class _UnlockScreenState extends ConsumerState<UnlockScreen> {
   bool _isSubmitting = false;
   String? _errorText;
 
+  String? get _passwordPolicyMessage =>
+      validateWalletPassword(_passwordController.text);
+
+  bool get _canSubmit =>
+      !_isSubmitting && isWalletPasswordValid(_passwordController.text);
+
   @override
   void dispose() {
     _passwordController.dispose();
@@ -45,7 +52,15 @@ class _UnlockScreenState extends ConsumerState<UnlockScreen> {
   }
 
   Future<void> _submit() async {
-    if (_isSubmitting || _passwordController.text.isEmpty) return;
+    final policyError = _passwordPolicyMessage;
+    if (_isSubmitting) return;
+    if (!isWalletPasswordValid(_passwordController.text)) {
+      if (policyError == null) return;
+      setState(() {
+        _errorText = policyError;
+      });
+      return;
+    }
 
     setState(() {
       _isSubmitting = true;
@@ -153,8 +168,8 @@ class _UnlockScreenState extends ConsumerState<UnlockScreen> {
                       label: 'Password',
                       controller: _passwordController,
                       autofocus: true,
-                      messageText: _errorText,
-                      tone: _errorText == null
+                      messageText: _errorText ?? _passwordPolicyMessage,
+                      tone: (_errorText ?? _passwordPolicyMessage) == null
                           ? AppTextFieldTone.neutral
                           : AppTextFieldTone.destructive,
                       onChanged: (_) {
@@ -166,10 +181,7 @@ class _UnlockScreenState extends ConsumerState<UnlockScreen> {
                     ),
                     const SizedBox(height: AppSpacing.s),
                     AppButton(
-                      onPressed:
-                          _isSubmitting || _passwordController.text.isEmpty
-                          ? null
-                          : _submit,
+                      onPressed: _canSubmit ? _submit : null,
                       variant: AppButtonVariant.primary,
                       minWidth: 256,
                       trailing: const AppIcon(AppIcons.chevronForward),

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -11,6 +11,7 @@ import '../core/storage/app_secure_store.dart';
 import '../core/storage/wallet_paths.dart';
 import '../rust/api/wallet.dart' as rust_wallet;
 import 'account_models.dart';
+import 'app_security_provider.dart';
 
 export 'account_models.dart';
 
@@ -306,6 +307,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     final dbPath = await _getDbPath();
     _deleteExistingDb(dbPath);
     await _storage.deleteAll();
+    ref.read(appSecurityProvider.notifier).reset();
     state = const AsyncData(AccountState());
     log('resetWallet: all data cleared');
   }

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -3,11 +3,11 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../../main.dart' show log;
 import '../app_bootstrap.dart';
 import '../core/config/network_config.dart';
+import '../core/storage/app_secure_store.dart';
 import '../core/storage/wallet_paths.dart';
 import '../rust/api/wallet.dart' as rust_wallet;
 import 'account_models.dart';
@@ -19,7 +19,7 @@ const _activeAccountKey = 'zcash_active_account';
 const _networkKey = 'zcash_wallet_network';
 
 class AccountNotifier extends AsyncNotifier<AccountState> {
-  static const _storage = FlutterSecureStorage();
+  static final _storage = AppSecureStore.instance;
 
   @override
   FutureOr<AccountState> build() {
@@ -64,7 +64,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         mnemonic = result.mnemonic;
         accountUuid = result.accountUuid;
         unifiedAddress = result.unifiedAddress;
-        await _storage.write(key: _networkKey, value: network);
+        await _storage.writeString(_networkKey, network);
       } else {
         // Additional account — generate mnemonic + add to existing DB
         mnemonic = rust_wallet.generateMnemonic();
@@ -80,9 +80,9 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       }
 
       // Store mnemonic per-account
-      await _storage.write(
-        key: 'zcash_account_mnemonic_$accountUuid',
-        value: mnemonic,
+      await _storage.writeString(
+        'zcash_account_mnemonic_$accountUuid',
+        mnemonic,
       );
 
       // Update account list
@@ -93,7 +93,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       );
       final updatedAccounts = [...accounts, newAccount];
       await _saveAccounts(updatedAccounts);
-      await _storage.write(key: _activeAccountKey, value: accountUuid);
+      await _storage.writeString(_activeAccountKey, accountUuid);
 
       state = AsyncData(
         AccountState(
@@ -149,7 +149,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         );
         accountUuid = result.accountUuid;
         unifiedAddress = result.unifiedAddress;
-        await _storage.write(key: _networkKey, value: network);
+        await _storage.writeString(_networkKey, network);
       } else {
         final result = await rust_wallet.addAccount(
           dbPath: dbPath,
@@ -162,9 +162,9 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         unifiedAddress = result.unifiedAddress;
       }
 
-      await _storage.write(
-        key: 'zcash_account_mnemonic_$accountUuid',
-        value: mnemonic,
+      await _storage.writeString(
+        'zcash_account_mnemonic_$accountUuid',
+        mnemonic,
       );
 
       final newAccount = AccountInfo(
@@ -174,7 +174,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       );
       final updatedAccounts = [...accounts, newAccount];
       await _saveAccounts(updatedAccounts);
-      await _storage.write(key: _activeAccountKey, value: accountUuid);
+      await _storage.writeString(_activeAccountKey, accountUuid);
 
       state = AsyncData(
         AccountState(
@@ -220,7 +220,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         );
         accountUuid = result.accountUuid;
         unifiedAddress = result.unifiedAddress;
-        await _storage.write(key: _networkKey, value: network);
+        await _storage.writeString(_networkKey, network);
       } else {
         // Additional account
         final result = await rust_wallet.addAccount(
@@ -236,9 +236,9 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         unifiedAddress = result.unifiedAddress;
       }
 
-      await _storage.write(
-        key: 'zcash_account_mnemonic_$accountUuid',
-        value: mnemonic,
+      await _storage.writeString(
+        'zcash_account_mnemonic_$accountUuid',
+        mnemonic,
       );
 
       final newAccount = AccountInfo(
@@ -248,7 +248,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       );
       final updatedAccounts = [...accounts, newAccount];
       await _saveAccounts(updatedAccounts);
-      await _storage.write(key: _activeAccountKey, value: accountUuid);
+      await _storage.writeString(_activeAccountKey, accountUuid);
 
       state = AsyncData(
         AccountState(
@@ -267,7 +267,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
 
   /// Switch active account.
   Future<void> switchAccount(String uuid) async {
-    await _storage.write(key: _activeAccountKey, value: uuid);
+    await _storage.writeString(_activeAccountKey, uuid);
 
     String? address;
     try {
@@ -360,7 +360,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       );
       final updated = [...prev.accounts, newAccount];
       await _saveAccounts(updated);
-      await _storage.write(key: _activeAccountKey, value: accountUuid);
+      await _storage.writeString(_activeAccountKey, accountUuid);
 
       state = AsyncData(
         AccountState(
@@ -386,14 +386,14 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   Future<String?> getActiveMnemonic() async {
     final uuid = state.value?.activeAccountUuid;
     if (uuid == null) return null;
-    return _storage.read(key: 'zcash_account_mnemonic_$uuid');
+    return _storage.readString('zcash_account_mnemonic_$uuid');
   }
 
   // ======================== Helpers ========================
 
   Future<void> _saveAccounts(List<AccountInfo> accounts) async {
     final json = jsonEncode(accounts.map((a) => a.toJson()).toList());
-    await _storage.write(key: _accountsKey, value: json);
+    await _storage.writeString(_accountsKey, json);
   }
 
   Future<String> _getDbPath() async {
@@ -401,7 +401,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   }
 
   Future<String> _getNetwork() async {
-    return await _storage.read(key: _networkKey) ?? 'main';
+    return await _storage.readString(_networkKey) ?? 'main';
   }
 
   Future<void> _deleteExistingDb(String dbPath) async {

--- a/lib/src/providers/app_security_provider.dart
+++ b/lib/src/providers/app_security_provider.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../app_bootstrap.dart';
+import '../core/storage/app_secure_store.dart';
+
+class AppSecurityState {
+  const AppSecurityState({
+    required this.isPasswordConfigured,
+    required this.isUnlocked,
+  });
+
+  final bool isPasswordConfigured;
+  final bool isUnlocked;
+
+  bool get requiresUnlock => isPasswordConfigured && !isUnlocked;
+
+  AppSecurityState copyWith({bool? isPasswordConfigured, bool? isUnlocked}) {
+    return AppSecurityState(
+      isPasswordConfigured: isPasswordConfigured ?? this.isPasswordConfigured,
+      isUnlocked: isUnlocked ?? this.isUnlocked,
+    );
+  }
+}
+
+class AppSecurityNotifier extends Notifier<AppSecurityState> {
+  static final _store = AppSecureStore.instance;
+
+  @override
+  AppSecurityState build() {
+    final bootstrap = ref.watch(appBootstrapProvider);
+    return AppSecurityState(
+      isPasswordConfigured: bootstrap.isPasswordConfigured,
+      isUnlocked: bootstrap.isUnlocked,
+    );
+  }
+
+  Future<void> configurePassword(String password) async {
+    await _store.configurePassword(password);
+    state = const AppSecurityState(
+      isPasswordConfigured: true,
+      isUnlocked: true,
+    );
+  }
+
+  Future<bool> unlock(String password) async {
+    final isValid = await _store.verifyPassword(password);
+    if (isValid) {
+      state = state.copyWith(isUnlocked: true);
+    }
+    return isValid;
+  }
+
+  void lock() {
+    _store.clearSessionPassword();
+    state = state.copyWith(isUnlocked: false);
+  }
+
+  void reset() {
+    _store.clearSessionPassword();
+    state = const AppSecurityState(
+      isPasswordConfigured: false,
+      isUnlocked: false,
+    );
+  }
+}
+
+final appSecurityProvider =
+    NotifierProvider<AppSecurityNotifier, AppSecurityState>(
+      AppSecurityNotifier.new,
+    );

--- a/lib/src/providers/app_security_provider.dart
+++ b/lib/src/providers/app_security_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../app_bootstrap.dart';
+import '../core/security/password_policy.dart';
 import '../core/storage/app_secure_store.dart';
 
 class AppSecurityState {
@@ -35,6 +36,10 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
   }
 
   Future<void> configurePassword(String password) async {
+    final error = validateWalletPassword(password);
+    if (error != null) {
+      throw ArgumentError(error);
+    }
     await _store.configurePassword(password);
     state = const AppSecurityState(
       isPasswordConfigured: true,
@@ -43,6 +48,9 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
   }
 
   Future<bool> unlock(String password) async {
+    if (!isWalletPasswordValid(password)) {
+      return false;
+    }
     final isValid = await _store.verifyPassword(password);
     if (isValid) {
       state = state.copyWith(isUnlocked: true);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -185,6 +185,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  cryptography:
+    dependency: "direct main"
+    description:
+      name: cryptography
+      sha256: "3eda3029d34ec9095a27a198ac9785630fe525c0eb6a49f3d575272f8e792ef0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.0"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
       url: https://github.com/chainapsis/desktop_window_bootstrap.git
       ref: c0e1f77025b2458b731d9413a00c4bb033648335
   crypto: ^3.0.7
+  cryptography: ^2.7.0
   flutter_foreground_task: ^9.2.1
   window_manager: ^0.5.1
   # Renders the Figma-exported icon SVGs under `assets/icons/`.


### PR DESCRIPTION
## What changed

- bind the wallet SQLite database path to a secure-storage-managed `dbName` under Application Support
- add password setup and unlock flows to onboarding, including a reusable password field component
- move the debug reset action from Home to the unlock screen
- restrict local wallet passwords to printable ASCII characters and document that constraint in agent docs

## Why

Two issues were being addressed across this branch:

1. wallet state could become inconsistent when secure-storage data and the SQLite file drifted apart, so the DB path now comes from secure storage and stays tied to the installation state
2. password setup and unlock were missing from onboarding, and IME/layout-dependent password entry was producing confusing failures, so the app now has an explicit password flow and an ASCII-only local password policy

## Impact

- first-run onboarding now ends with a Set Password step before the initial account is created when no password is configured yet
- existing wallets that are locked are redirected to an unlock screen before entering Home
- the app uses a secure-storage-backed randomized DB filename under Application Support instead of a fixed DB filename
- local wallet passwords now accept only English letters, numbers, and symbols

## Validation

- `fvm flutter analyze`
- `fvm flutter analyze lib/src/core/security/password_policy.dart lib/src/core/storage/app_secure_store.dart lib/src/providers/app_security_provider.dart lib/src/features/onboarding/screens/set_password_screen.dart lib/src/features/onboarding/screens/unlock_screen.dart`
