### PR TITLE
[codex] Align sidebar account switcher with Figma

### DIFF
--- a/lib/src/core/layout/app_desktop_shell.dart
+++ b/lib/src/core/layout/app_desktop_shell.dart
@@ -41,11 +41,13 @@ class AppDesktopSidebarSurface extends StatelessWidget {
   const AppDesktopSidebarSurface({
     required this.child,
     this.backgroundColor,
+    this.clipBehavior = Clip.antiAlias,
     super.key,
   });
 
   final Widget child;
   final Color? backgroundColor;
+  final Clip clipBehavior;
 
   @override
   Widget build(BuildContext context) {
@@ -54,7 +56,7 @@ class AppDesktopSidebarSurface extends StatelessWidget {
         color: backgroundColor ?? Colors.transparent,
         borderRadius: BorderRadius.circular(AppRadii.small),
       ),
-      clipBehavior: Clip.antiAlias,
+      clipBehavior: clipBehavior,
       child: child,
     );
   }

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -80,6 +80,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
     final accountName = activeAccount?.name ?? 'Username';
 
     return AppDesktopSidebarSurface(
+      clipBehavior: Clip.none,
       child: Padding(
         padding: const EdgeInsets.all(AppSpacing.xs),
         child: TapRegion(

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -23,7 +23,6 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
   static const double _dropdownFooterHeight = 50;
   static const double _accountRowHeight = 40;
   static const double _maxListViewportHeight = 164;
-  static const int _scrollbarThreshold = 4;
 
   final ScrollController _accountsScrollController = ScrollController();
   bool _isDropdownOpen = false;
@@ -200,7 +199,6 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                         footerHeight: _dropdownFooterHeight,
                         rowHeight: _accountRowHeight,
                         maxListViewportHeight: _maxListViewportHeight,
-                        showScrollbar: accounts.length > _scrollbarThreshold,
                         onSelectAccount: _handleAccountSelected,
                       ),
                     ],
@@ -284,7 +282,6 @@ class _SidebarAccountDropdown extends StatelessWidget {
     required this.footerHeight,
     required this.rowHeight,
     required this.maxListViewportHeight,
-    required this.showScrollbar,
     required this.onSelectAccount,
   });
 
@@ -295,7 +292,6 @@ class _SidebarAccountDropdown extends StatelessWidget {
   final double footerHeight;
   final double rowHeight;
   final double maxListViewportHeight;
-  final bool showScrollbar;
   final Future<void> Function(String uuid) onSelectAccount;
 
   @override
@@ -356,17 +352,8 @@ class _SidebarAccountDropdown extends StatelessWidget {
           SizedBox(
             height: listViewportHeight,
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
-              child: showScrollbar
-                  ? RawScrollbar(
-                      controller: scrollController,
-                      thumbVisibility: true,
-                      thickness: 8,
-                      radius: const Radius.circular(AppRadii.full),
-                      thumbColor: colors.border.regular,
-                      child: list,
-                    )
-                  : list,
+              padding: const EdgeInsets.only(left: AppSpacing.xxs),
+              child: list,
             ),
           ),
           SizedBox(
@@ -408,7 +395,10 @@ class _SidebarAccountRow extends StatelessWidget {
       child: Opacity(
         opacity: isActive ? 0.5 : 1,
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+          padding: const EdgeInsets.only(
+            left: AppSpacing.xs,
+            right: AppSpacing.s,
+          ),
           child: Row(
             children: [
               const _SidebarAccountAvatar(),

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -242,7 +242,9 @@ class _SidebarAccountSelectorButton extends StatelessWidget {
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: onTap,
-        child: Container(
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
           height: 40,
           padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
           decoration: BoxDecoration(

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -27,6 +27,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
 
   final ScrollController _accountsScrollController = ScrollController();
   bool _isDropdownOpen = false;
+  bool _isSelectorHovered = false;
 
   String get _matchedLocation => GoRouterState.of(context).matchedLocation;
 
@@ -180,6 +181,13 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                     _SidebarAccountSelectorButton(
                       label: accountName,
                       isOpen: _isDropdownOpen,
+                      isHovered: _isSelectorHovered,
+                      onHoverChanged: (hovered) {
+                        if (_isSelectorHovered == hovered) return;
+                        setState(() {
+                          _isSelectorHovered = hovered;
+                        });
+                      },
                       onTap: _toggleDropdown,
                     ),
                     if (_isDropdownOpen) ...[
@@ -211,22 +219,28 @@ class _SidebarAccountSelectorButton extends StatelessWidget {
   const _SidebarAccountSelectorButton({
     required this.label,
     required this.isOpen,
+    required this.isHovered,
+    required this.onHoverChanged,
     required this.onTap,
   });
 
   final String label;
   final bool isOpen;
+  final bool isHovered;
+  final ValueChanged<bool> onHoverChanged;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final backgroundColor = colors.surface.input;
+    final backgroundColor = (isOpen || isHovered) ? colors.surface.input : null;
     final textColor = colors.text.accent;
     final iconColor = colors.icon.accent;
 
     return MouseRegion(
       cursor: SystemMouseCursors.click,
+      onEnter: (_) => onHoverChanged(true),
+      onExit: (_) => onHoverChanged(false),
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: onTap,

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -6,6 +6,7 @@ import '../../providers/account_provider.dart';
 import '../../providers/sync_provider.dart';
 import '../theme/app_theme.dart';
 import '../widgets/app_icon.dart';
+import '../widgets/app_button.dart';
 import 'app_desktop_shell.dart';
 
 class AppMainSidebar extends ConsumerStatefulWidget {
@@ -30,7 +31,8 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
   String get _matchedLocation => GoRouterState.of(context).matchedLocation;
 
   bool _matches(String routePath) =>
-      _matchedLocation == routePath || _matchedLocation.startsWith('$routePath/');
+      _matchedLocation == routePath ||
+      _matchedLocation.startsWith('$routePath/');
 
   @override
   void dispose() {
@@ -39,7 +41,10 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
   }
 
   Future<void> _handleAccountSelected(String uuid) async {
-    final activeAccountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    final activeAccountUuid = ref
+        .read(accountProvider)
+        .value
+        ?.activeAccountUuid;
     if (uuid == activeAccountUuid) return;
     await ref.read(accountProvider.notifier).switchAccount(uuid);
     await ref.read(syncProvider.notifier).refreshAfterSend();
@@ -58,7 +63,9 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
   @override
   Widget build(BuildContext context) {
     final accountAsync = ref.watch(accountProvider);
-    final accounts = [...(accountAsync.value?.accounts ?? const <AccountInfo>[])];
+    final accounts = [
+      ...(accountAsync.value?.accounts ?? const <AccountInfo>[]),
+    ];
     accounts.sort((a, b) => a.order.compareTo(b.order));
     final activeAccountUuid = accountAsync.value?.activeAccountUuid;
     AccountInfo? activeAccount;
@@ -214,7 +221,7 @@ class _SidebarAccountSelectorButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final backgroundColor = isOpen ? colors.surface.input : null;
+    final backgroundColor = colors.surface.card;
     final textColor = colors.text.accent;
     final iconColor = colors.icon.accent;
 
@@ -228,7 +235,7 @@ class _SidebarAccountSelectorButton extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
           decoration: BoxDecoration(
             color: backgroundColor,
-            borderRadius: BorderRadius.circular(AppRadii.medium),
+            borderRadius: BorderRadius.circular(AppRadii.small),
           ),
           child: Row(
             children: [
@@ -305,7 +312,15 @@ class _SidebarAccountDropdown extends StatelessWidget {
       height: headerHeight + listViewportHeight + footerHeight,
       decoration: BoxDecoration(
         color: colors.surface.input,
-        borderRadius: BorderRadius.circular(AppRadii.medium),
+        borderRadius: BorderRadius.circular(AppRadii.small),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x40000000),
+            blurRadius: 25,
+            spreadRadius: -10,
+            offset: Offset(0, 10),
+          ),
+        ],
       ),
       child: Column(
         children: [
@@ -318,7 +333,7 @@ class _SidebarAccountDropdown extends StatelessWidget {
                 child: Text(
                   '${accounts.length} ${accounts.length == 1 ? 'Account' : 'Accounts'}',
                   style: AppTypography.labelLarge.copyWith(
-                    color: colors.text.primary,
+                    color: colors.text.accent,
                   ),
                 ),
               ),
@@ -343,7 +358,7 @@ class _SidebarAccountDropdown extends StatelessWidget {
           SizedBox(
             height: footerHeight,
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
               child: _SidebarCreateWalletRow(
                 onTap: () => context.go('/add-account'),
               ),
@@ -369,36 +384,31 @@ class _SidebarAccountRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final labelColor = isActive ? colors.text.secondary : colors.text.accent;
+    final labelColor = colors.text.accent;
     final trailing = isActive
-        ? AppIcon(
-            AppIcons.checkCircle,
-            size: 20,
-            color: colors.icon.regular,
-          )
-        : AppIcon(
-            AppIcons.chevronForward,
-            size: 20,
-            color: colors.icon.accent,
-          );
+        ? AppIcon(AppIcons.checkCircle, size: 20, color: colors.icon.regular)
+        : AppIcon(AppIcons.chevronForward, size: 20, color: colors.icon.accent);
 
     final row = SizedBox(
       height: 40,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
-        child: Row(
-          children: [
-            const _SidebarAccountAvatar(),
-            const SizedBox(width: AppSpacing.xs),
-            Expanded(
-              child: Text(
-                account.name,
-                overflow: TextOverflow.ellipsis,
-                style: AppTypography.labelLarge.copyWith(color: labelColor),
+      child: Opacity(
+        opacity: isActive ? 0.5 : 1,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+          child: Row(
+            children: [
+              const _SidebarAccountAvatar(),
+              const SizedBox(width: AppSpacing.xs),
+              Expanded(
+                child: Text(
+                  account.name,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTypography.labelLarge.copyWith(color: labelColor),
+                ),
               ),
-            ),
-            trailing,
-          ],
+              trailing,
+            ],
+          ),
         ),
       ),
     );
@@ -423,30 +433,13 @@ class _SidebarCreateWalletRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colors = context.colors;
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: SizedBox(
-          height: 40,
-          child: Center(
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                AppIcon(AppIcons.addNew, size: 16, color: colors.icon.regular),
-                const SizedBox(width: AppSpacing.xxs),
-                Text(
-                  'Create New Wallet',
-                  style: AppTypography.labelLarge.copyWith(
-                    color: colors.text.secondary,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
+    return LayoutBuilder(
+      builder: (context, constraints) => AppButton(
+        onPressed: onTap,
+        variant: AppButtonVariant.ghost,
+        minWidth: constraints.maxWidth,
+        leading: const AppIcon(AppIcons.addNew),
+        child: const Text('Create New Wallet'),
       ),
     );
   }

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -221,7 +221,7 @@ class _SidebarAccountSelectorButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final backgroundColor = colors.surface.card;
+    final backgroundColor = colors.surface.input;
     final textColor = colors.text.accent;
     final iconColor = colors.icon.accent;
 

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -441,12 +441,14 @@ class _SidebarCreateWalletRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
-      builder: (context, constraints) => AppButton(
-        onPressed: onTap,
-        variant: AppButtonVariant.ghost,
-        minWidth: constraints.maxWidth,
-        leading: const AppIcon(AppIcons.addNew),
-        child: const Text('Create New Wallet'),
+      builder: (context, constraints) => Center(
+        child: AppButton(
+          onPressed: onTap,
+          variant: AppButtonVariant.ghost,
+          minWidth: constraints.maxWidth,
+          leading: const AppIcon(AppIcons.addNew),
+          child: const Text('Create New Wallet'),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- align the desktop sidebar account switcher with the Figma dropdown treatment
- replace the custom footer row with the shared ghost button while keeping the 40px pill centered in the 50px footer slot
- remove the manual dropdown scrollbar and refine list/icon spacing to avoid duplicate scrollbars and match the layout more closely
- allow the main sidebar dropdown shadow to overflow without changing onboarding sidebar clipping behavior
- add a short selector background transition for hover/open states

## Why
The account switcher in the desktop home sidebar had drifted from the design in several visible ways: shape, state treatment, footer action styling, shadow clipping, and scrolling behavior. This patch brings that interaction back in line while keeping the rest of the sidebar shell behavior intact.

## User impact
Desktop users see an account switcher that matches the intended design more closely, with cleaner hover/open feedback, correct dropdown shadow rendering, and a single native scrollbar behavior in the account list.

## Validation
- `fvm flutter analyze lib/src/core/layout/app_desktop_shell.dart lib/src/core/layout/app_main_sidebar.dart`
