### PR TITLE
[codex] Rename app identifiers and display name to Vizor

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.zcash.zcash_wallet"
+    namespace = "com.keplr.vizor"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.zcash.zcash_wallet"
+        applicationId = "com.keplr.vizor"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
-        android:label="zcash_wallet"
+        android:label="Vizor"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
 

--- a/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.zcash.zcash_wallet
+package com.keplr.vizor
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -623,7 +623,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -662,7 +662,7 @@
 				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet.SyncWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor.SyncWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -706,7 +706,7 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet.SyncWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor.SyncWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -748,7 +748,7 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet.SyncWidget;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor.SyncWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -769,7 +769,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -787,7 +787,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -803,7 +803,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -936,7 +936,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -960,7 +960,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/BackgroundSyncManager.swift
+++ b/ios/Runner/BackgroundSyncManager.swift
@@ -4,13 +4,13 @@ import BackgroundTasks
 @available(iOS 26.0, *)
 class BackgroundSyncManager {
     static let shared = BackgroundSyncManager()
-    static let taskIdentifier = "com.zcash.zcashWallet.sync"
+    static let taskIdentifier = "com.keplr.vizor.sync"
 
     private var taskProgress: Progress?
     private var heartbeat: DispatchSourceTimer?
 
     /// Sync work runs on this .utility queue so Rust inherits the QoS.
-    private let syncQueue = DispatchQueue(label: "com.zcash.sync", qos: .utility)
+    private let syncQueue = DispatchQueue(label: "com.keplr.vizor.sync", qos: .utility)
 
     private init() {}
 

--- a/ios/Runner/BackgroundSyncManager.swift
+++ b/ios/Runner/BackgroundSyncManager.swift
@@ -176,7 +176,7 @@ class BackgroundSyncManager {
         print("[BGSync] startBackgroundSync: submitting BGContinuedProcessingTaskRequest")
         let request = BGContinuedProcessingTaskRequest(
             identifier: Self.taskIdentifier,
-            title: "Syncing Zcash Wallet",
+            title: "Syncing Vizor",
             subtitle: "Scanning blockchain blocks"
         )
 

--- a/ios/Runner/DynamicIslandManager.swift
+++ b/ios/Runner/DynamicIslandManager.swift
@@ -15,7 +15,7 @@ class DynamicIslandManager {
 
     private(set) var displayMode: DisplayMode = .idle
     private var currentActivity: Activity<LiveActivitiesAppAttributes>?
-    private let defaults = UserDefaults(suiteName: "group.com.zcash.zcashWallet")
+    private let defaults = UserDefaults(suiteName: "group.com.keplr.vizor")
     private var activityId: UUID?
 
     // Cache last sync progress for restoration after TX tracking
@@ -90,7 +90,7 @@ class DynamicIslandManager {
         displayMode = .idle
         guard let activity = currentActivity else { return }
         let state = LiveActivitiesAppAttributes.ContentState(
-            appGroupId: "group.com.zcash.zcashWallet"
+            appGroupId: "group.com.keplr.vizor"
         )
         Task {
             await activity.end(.init(state: state, staleDate: nil), dismissalPolicy: .immediate)
@@ -107,7 +107,7 @@ class DynamicIslandManager {
         activityId = id
         let attributes = LiveActivitiesAppAttributes(id: id)
         let state = LiveActivitiesAppAttributes.ContentState(
-            appGroupId: "group.com.zcash.zcashWallet"
+            appGroupId: "group.com.keplr.vizor"
         )
         do {
             currentActivity = try Activity.request(
@@ -125,7 +125,7 @@ class DynamicIslandManager {
     private func refreshActivity() {
         guard let activity = currentActivity else { return }
         let state = LiveActivitiesAppAttributes.ContentState(
-            appGroupId: "group.com.zcash.zcashWallet"
+            appGroupId: "group.com.keplr.vizor"
         )
         Task {
             await activity.update(.init(state: state, staleDate: nil))

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -20,7 +20,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Zcash Wallet</string>
+		<string>Vizor</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -28,7 +28,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>zcash_wallet</string>
+		<string>Vizor</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -9,8 +9,8 @@
 	</array>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
-		<string>com.zcash.zcashWallet.sync</string>
-		<string>com.zcash.zcashWallet.txtrack</string>
+			<string>com.keplr.vizor.sync</string>
+			<string>com.keplr.vizor.txtrack</string>
 		<string>com.pravera.flutter_foreground_task.refresh</string>
 	</array>
 	<key>NSSupportsLiveActivities</key>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.zcash.zcashWallet</string>
+		<string>group.com.keplr.vizor</string>
 	</array>
 </dict>
 </plist>

--- a/ios/Runner/TxTrackManager.swift
+++ b/ios/Runner/TxTrackManager.swift
@@ -6,9 +6,9 @@ import Foundation
 @available(iOS 26.0, *)
 class TxTrackManager {
     static let shared = TxTrackManager()
-    static let taskIdentifier = "com.zcash.zcashWallet.txtrack"
+    static let taskIdentifier = "com.keplr.vizor.txtrack"
 
-    private let trackQueue = DispatchQueue(label: "com.zcash.txtrack", qos: .utility)
+    private let trackQueue = DispatchQueue(label: "com.keplr.vizor.txtrack", qos: .utility)
     private let pollInterval: TimeInterval = 5.0
     private let resultDisplayDelay: TimeInterval = 5.0
     private let lightwalletdUrl = "https://zec.rocks:443"

--- a/ios/Runner/WalletPathResolver.swift
+++ b/ios/Runner/WalletPathResolver.swift
@@ -2,7 +2,7 @@ import Foundation
 import Security
 
 private let walletDbNameKey = "zcash_wallet_db_name"
-private let secureStoreService = "com.zcash.zcashWallet.secure_store"
+private let secureStoreService = "com.keplr.vizor.secure_store"
 
 enum WalletPathResolverError: Error {
     case dbNameMissing

--- a/ios/SyncWidget/SyncWidgetLiveActivity.swift
+++ b/ios/SyncWidget/SyncWidgetLiveActivity.swift
@@ -8,7 +8,7 @@ import SwiftUI
 import WidgetKit
 
 struct SyncWidgetLiveActivity: Widget {
-    let appGroupId = "group.com.zcash.zcashWallet"
+    let appGroupId = "group.com.keplr.vizor"
 
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: LiveActivitiesAppAttributes.self) { context in

--- a/ios/SyncWidget/SyncWidgetLiveActivity.swift
+++ b/ios/SyncWidget/SyncWidgetLiveActivity.swift
@@ -43,7 +43,7 @@ struct SyncWidgetLiveActivity: Widget {
             HStack {
                 Image(systemName: "shield.checkered")
                     .foregroundColor(.yellow)
-                Text("Zcash Sync")
+                Text("Vizor Sync")
                     .font(.headline)
                     .foregroundColor(.white)
                 Spacer()

--- a/ios/SyncWidgetExtension.entitlements
+++ b/ios/SyncWidgetExtension.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.zcash.zcashWallet</string>
+		<string>group.com.keplr.vizor</string>
 	</array>
 </dict>
 </plist>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -308,7 +308,7 @@ class ZcashWalletApp extends ConsumerWidget {
     final themeMode = ref.watch(themeModeProvider);
 
     return MaterialApp.router(
-      title: 'Zcash Wallet',
+      title: 'Vizor',
       debugShowCheckedModeBanner: false,
       theme: buildLegacyLightTheme(),
       darkTheme: buildLegacyDarkTheme(),

--- a/lib/src/core/layout/app_layout.dart
+++ b/lib/src/core/layout/app_layout.dart
@@ -80,7 +80,7 @@ Future<void> initializeDesktopWindow({
     size: initialMode.defaultSize,
     minimumSize: initialMode.minimumSize,
     center: true,
-    title: 'Zcash Wallet',
+    title: 'Vizor',
   );
 
   await windowManager.waitUntilReadyToShow(options, () async {

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -11,7 +11,7 @@ const _secureStoreSaltKey = 'zcash_secure_store_salt';
 const _passwordVerifierKey = 'zcash_password_verifier';
 const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';
 const _secureStorePassword = 'zcash-wallet-dev-password';
-const _secureStoreService = 'com.zcash.zcashWallet.secure_store';
+const _secureStoreService = 'com.keplr.vizor.secure_store';
 
 class AppSecureStore {
   AppSecureStore._();

--- a/lib/src/services/background_sync_service.dart
+++ b/lib/src/services/background_sync_service.dart
@@ -71,7 +71,7 @@ Future<void> updateBackgroundSyncProgress({
   if (Platform.isAndroid) {
     final pct = (percentage * 100).toStringAsFixed(1);
     FlutterForegroundTask.updateService(
-      notificationTitle: 'Zcash Wallet — Syncing $pct%',
+      notificationTitle: 'Vizor — Syncing $pct%',
       notificationText: 'Block $scannedHeight / $chainTipHeight',
     );
   }
@@ -105,7 +105,7 @@ Future<void> _startAndroidForegroundService() async {
   FlutterForegroundTask.init(
     androidNotificationOptions: AndroidNotificationOptions(
       channelId: 'zcash_sync',
-      channelName: 'Zcash Sync',
+      channelName: 'Vizor Sync',
       channelDescription: 'Blockchain synchronization progress',
       channelImportance: NotificationChannelImportance.LOW,
       priority: NotificationPriority.LOW,
@@ -124,7 +124,7 @@ Future<void> _startAndroidForegroundService() async {
   );
 
   final result = await FlutterForegroundTask.startService(
-    notificationTitle: 'Zcash Wallet',
+    notificationTitle: 'Vizor',
     notificationText: 'Syncing blockchain...',
     serviceId: 1001,
     callback: _foregroundTaskCallback,

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -68,7 +68,7 @@
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* zcash_wallet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = zcash_wallet.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* Vizor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Vizor.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -157,7 +157,7 @@
 		33CC10EE2044A3C60003C045 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				33CC10ED2044A3C60003C045 /* zcash_wallet.app */,
+				33CC10ED2044A3C60003C045 /* Vizor.app */,
 				331C80D5294CF71000263BE5 /* RunnerTests.xctest */,
 			);
 			name = Products;
@@ -248,7 +248,7 @@
 			);
 			name = Runner;
 			productName = Runner;
-			productReference = 33CC10ED2044A3C60003C045 /* zcash_wallet.app */;
+			productReference = 33CC10ED2044A3C60003C045 /* Vizor.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -481,7 +481,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/zcash_wallet.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/zcash_wallet";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Vizor.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Vizor";
 			};
 			name = Debug;
 		};
@@ -496,7 +496,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/zcash_wallet.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/zcash_wallet";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Vizor.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Vizor";
 			};
 			name = Release;
 		};
@@ -511,7 +511,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/zcash_wallet.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/zcash_wallet";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Vizor.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Vizor";
 			};
 			name = Profile;
 		};

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/zcash_wallet.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/zcash_wallet";
@@ -493,7 +493,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/zcash_wallet.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/zcash_wallet";
@@ -508,7 +508,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/zcash_wallet.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/zcash_wallet";

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-               BuildableName = "zcash_wallet.app"
+               BuildableName = "Vizor.app"
                BlueprintName = "Runner"
                ReferencedContainer = "container:Runner.xcodeproj">
             </BuildableReference>
@@ -31,7 +31,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "zcash_wallet.app"
+            BuildableName = "Vizor.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "zcash_wallet.app"
+            BuildableName = "Vizor.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "33CC10EC2044A3C60003C045"
-            BuildableName = "zcash_wallet.app"
+            BuildableName = "Vizor.app"
             BlueprintName = "Runner"
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = zcash_wallet
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.zcash.zcashWallet
+PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor
 
 // The copyright displayed in application information
 PRODUCT_COPYRIGHT = Copyright © 2026 com.zcash. All rights reserved.

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -5,7 +5,7 @@
 // 'flutter create' template.
 
 // The application's name. By default this is also the title of the Flutter window.
-PRODUCT_NAME = zcash_wallet
+PRODUCT_NAME = Vizor
 
 // The application's bundle identifier
 PRODUCT_BUNDLE_IDENTIFIER = com.keplr.vizor


### PR DESCRIPTION
## Summary
- rename the app bundle/application identifiers to `com.keplr.vizor` across iOS, macOS, and Android
- rename the user-facing app display name and desktop window title to `Vizor`
- update iOS widget/app-group/background-task and secure-storage identifiers to stay aligned with the new app namespace

## Why
This branch rebrands the app to Vizor and makes the platform identifiers and visible app naming consistent before production.

## User Impact
- installs from this branch appear as `Vizor` on iOS, macOS, and Android
- the macOS app bundle/output name changes to `Vizor.app`
- iOS widget/background-sync integration continues to use the matching `com.keplr.vizor*` identifiers

## Validation
- `fvm flutter analyze` (reports 3 pre-existing warnings unrelated to this rename)
- `fvm flutter build ios --simulator --debug --no-codesign`
- `xcodebuild -workspace macos/Runner.xcworkspace -scheme Runner -configuration Debug CODE_SIGNING_ALLOWED=NO build`
- `./gradlew :app:compileDebugKotlin`
