### PR TITLE
[codex] Reduce wallet DB lock failures during account mutation

### DIFF
--- a/lib/src/features/keystone/screens/import_keystone_screen.dart
+++ b/lib/src/features/keystone/screens/import_keystone_screen.dart
@@ -17,10 +17,14 @@ class ImportKeystoneScreen extends ConsumerStatefulWidget {
       _ImportKeystoneScreenState();
 }
 
+enum _KeystoneLoadingPhase { idle, connecting, stoppingSync, importing }
+
 class _ImportKeystoneScreenState extends ConsumerState<ImportKeystoneScreen> {
   List<KeystoneAccountInfo>? _accounts;
-  bool _isLoading = false;
+  _KeystoneLoadingPhase _loadingPhase = _KeystoneLoadingPhase.idle;
   String? _error;
+
+  bool get _isLoading => _loadingPhase != _KeystoneLoadingPhase.idle;
 
   @override
   void initState() {
@@ -32,13 +36,13 @@ class _ImportKeystoneScreenState extends ConsumerState<ImportKeystoneScreen> {
     if (!QrScanner.isAvailable) {
       setState(() {
         _error = 'QR scanning not available on this platform';
-        _isLoading = false;
+        _loadingPhase = _KeystoneLoadingPhase.idle;
       });
       return;
     }
 
     setState(() {
-      _isLoading = true;
+      _loadingPhase = _KeystoneLoadingPhase.connecting;
       _error = null;
     });
 
@@ -49,21 +53,21 @@ class _ImportKeystoneScreenState extends ConsumerState<ImportKeystoneScreen> {
       if (!mounted) return;
       setState(() {
         _accounts = accounts;
-        _isLoading = false;
+        _loadingPhase = _KeystoneLoadingPhase.idle;
       });
     } catch (e) {
       log('ImportKeystone: error: $e');
       if (!mounted) return;
       setState(() {
         _error = e.toString();
-        _isLoading = false;
+        _loadingPhase = _KeystoneLoadingPhase.idle;
       });
     }
   }
 
   Future<void> _importAccount(KeystoneAccountInfo info) async {
     setState(() {
-      _isLoading = true;
+      _loadingPhase = _KeystoneLoadingPhase.importing;
       _error = null;
     });
 
@@ -78,6 +82,18 @@ class _ImportKeystoneScreenState extends ConsumerState<ImportKeystoneScreen> {
               seedFingerprint: info.seedFingerprint.toList(),
               zip32Index: info.index,
             ),
+        onStoppingSync: () {
+          if (!mounted) return;
+          setState(() {
+            _loadingPhase = _KeystoneLoadingPhase.stoppingSync;
+          });
+        },
+        onSyncPaused: () {
+          if (!mounted) return;
+          setState(() {
+            _loadingPhase = _KeystoneLoadingPhase.importing;
+          });
+        },
       );
 
       if (!mounted) return;
@@ -88,7 +104,7 @@ class _ImportKeystoneScreenState extends ConsumerState<ImportKeystoneScreen> {
       if (!mounted) return;
       setState(() {
         _error = e.toString();
-        _isLoading = false;
+        _loadingPhase = _KeystoneLoadingPhase.idle;
       });
     }
   }
@@ -97,17 +113,23 @@ class _ImportKeystoneScreenState extends ConsumerState<ImportKeystoneScreen> {
   Widget build(BuildContext context) {
     final colors = Theme.of(context).colorScheme;
     final text = Theme.of(context).textTheme;
+    final loadingText = switch (_loadingPhase) {
+      _KeystoneLoadingPhase.connecting => 'Connecting to Keystone...',
+      _KeystoneLoadingPhase.stoppingSync => 'Stop syncing...',
+      _KeystoneLoadingPhase.importing => 'Importing...',
+      _KeystoneLoadingPhase.idle => '',
+    };
 
     return Scaffold(
       appBar: AppBar(title: const Text('Connect Keystone')),
       body: _isLoading
-          ? const Center(
+          ? Center(
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  CircularProgressIndicator(),
-                  SizedBox(height: 16),
-                  Text('Connecting to Keystone...'),
+                  const CircularProgressIndicator(),
+                  const SizedBox(height: 16),
+                  Text(loadingText),
                 ],
               ),
             )

--- a/lib/src/features/keystone/screens/import_keystone_screen.dart
+++ b/lib/src/features/keystone/screens/import_keystone_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../providers/account_provider.dart';
+import '../../../providers/wallet_mutation_guard.dart';
 import '../../../rust/wallet/keystone.dart' show KeystoneAccountInfo;
 import '../../../services/keystone_transport.dart';
 import '../../../services/qr_scanner.dart';
@@ -12,7 +13,8 @@ class ImportKeystoneScreen extends ConsumerStatefulWidget {
   const ImportKeystoneScreen({super.key});
 
   @override
-  ConsumerState<ImportKeystoneScreen> createState() => _ImportKeystoneScreenState();
+  ConsumerState<ImportKeystoneScreen> createState() =>
+      _ImportKeystoneScreenState();
 }
 
 class _ImportKeystoneScreenState extends ConsumerState<ImportKeystoneScreen> {
@@ -28,34 +30,54 @@ class _ImportKeystoneScreenState extends ConsumerState<ImportKeystoneScreen> {
 
   Future<void> _connectAndGetAccounts() async {
     if (!QrScanner.isAvailable) {
-      setState(() { _error = 'QR scanning not available on this platform'; _isLoading = false; });
+      setState(() {
+        _error = 'QR scanning not available on this platform';
+        _isLoading = false;
+      });
       return;
     }
 
-    setState(() { _isLoading = true; _error = null; });
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
 
     try {
       final qrTransport = QrKeystoneTransport();
       final accounts = await qrTransport.getAccounts(context);
 
       if (!mounted) return;
-      setState(() { _accounts = accounts; _isLoading = false; });
+      setState(() {
+        _accounts = accounts;
+        _isLoading = false;
+      });
     } catch (e) {
       log('ImportKeystone: error: $e');
       if (!mounted) return;
-      setState(() { _error = e.toString(); _isLoading = false; });
+      setState(() {
+        _error = e.toString();
+        _isLoading = false;
+      });
     }
   }
 
   Future<void> _importAccount(KeystoneAccountInfo info) async {
-    setState(() { _isLoading = true; _error = null; });
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
 
     try {
-      await ref.read(accountProvider.notifier).importKeystoneAccount(
-        name: info.name,
-        ufvk: info.ufvk,
-        seedFingerprint: info.seedFingerprint.toList(),
-        zip32Index: info.index,
+      await runWithSyncPausedForAccountMutation(
+        ref,
+        () => ref
+            .read(accountProvider.notifier)
+            .importKeystoneAccount(
+              name: info.name,
+              ufvk: info.ufvk,
+              seedFingerprint: info.seedFingerprint.toList(),
+              zip32Index: info.index,
+            ),
       );
 
       if (!mounted) return;
@@ -64,7 +86,10 @@ class _ImportKeystoneScreenState extends ConsumerState<ImportKeystoneScreen> {
     } catch (e) {
       log('ImportKeystone: import error: $e');
       if (!mounted) return;
-      setState(() { _error = e.toString(); _isLoading = false; });
+      setState(() {
+        _error = e.toString();
+        _isLoading = false;
+      });
     }
   }
 
@@ -87,30 +112,33 @@ class _ImportKeystoneScreenState extends ConsumerState<ImportKeystoneScreen> {
               ),
             )
           : _error != null
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(Icons.error_outline, color: colors.error, size: 48),
-                        const SizedBox(height: 16),
-                        Text('Connection Failed', style: text.titleLarge),
-                        const SizedBox(height: 8),
-                        Text(_error!, textAlign: TextAlign.center,
-                            style: text.bodyMedium?.copyWith(color: colors.outline)),
-                        const SizedBox(height: 24),
-                        FilledButton(
-                          onPressed: _connectAndGetAccounts,
-                          child: const Text('Retry'),
-                        ),
-                      ],
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.error_outline, color: colors.error, size: 48),
+                    const SizedBox(height: 16),
+                    Text('Connection Failed', style: text.titleLarge),
+                    const SizedBox(height: 8),
+                    Text(
+                      _error!,
+                      textAlign: TextAlign.center,
+                      style: text.bodyMedium?.copyWith(color: colors.outline),
                     ),
-                  ),
-                )
-              : _accounts != null
-                  ? _buildAccountList()
-                  : const SizedBox.shrink(),
+                    const SizedBox(height: 24),
+                    FilledButton(
+                      onPressed: _connectAndGetAccounts,
+                      child: const Text('Retry'),
+                    ),
+                  ],
+                ),
+              ),
+            )
+          : _accounts != null
+          ? _buildAccountList()
+          : const SizedBox.shrink(),
     );
   }
 
@@ -129,8 +157,10 @@ class _ImportKeystoneScreenState extends ConsumerState<ImportKeystoneScreen> {
       children: [
         Padding(
           padding: const EdgeInsets.only(bottom: 16),
-          child: Text('Select an account to import',
-              style: text.titleMedium?.copyWith(color: colors.outline)),
+          child: Text(
+            'Select an account to import',
+            style: text.titleMedium?.copyWith(color: colors.outline),
+          ),
         ),
         for (final account in _accounts!)
           Card(

--- a/lib/src/features/onboarding/create/secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/create/secret_passphrase_screen.dart
@@ -14,6 +14,7 @@ import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
+import '../../../providers/wallet_mutation_guard.dart';
 import '../../../rust/api/wallet.dart' as rust_wallet;
 import 'onboarding_split_view.dart';
 import '../shared/onboarding_flow_args.dart';
@@ -89,7 +90,10 @@ class _SecretPassphraseScreenState
     final router = GoRouter.of(context);
     final accountNotifier = ref.read(accountProvider.notifier);
     try {
-      await accountNotifier.createAccountFromMnemonic(mnemonic: mnemonic);
+      await runWithSyncPausedForAccountMutation(
+        ref,
+        () => accountNotifier.createAccountFromMnemonic(mnemonic: mnemonic),
+      );
     } catch (e, st) {
       log('SecretPassphraseScreen._handlePrimaryAction: ERROR: $e\n$st');
       if (!mounted) return;

--- a/lib/src/features/onboarding/create/secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/create/secret_passphrase_screen.dart
@@ -29,14 +29,18 @@ class SecretPassphraseScreen extends ConsumerStatefulWidget {
       _SecretPassphraseScreenState();
 }
 
+enum _CreateWalletSubmitPhase { idle, stoppingSync, creating }
+
 class _SecretPassphraseScreenState
     extends ConsumerState<SecretPassphraseScreen> {
   String? _mnemonic;
   bool _isPreparing = true;
-  bool _isCreating = false;
+  _CreateWalletSubmitPhase _submitPhase = _CreateWalletSubmitPhase.idle;
   bool _revealed = false;
   String? _prepareError;
   String? _submitError;
+
+  bool get _isSubmitting => _submitPhase != _CreateWalletSubmitPhase.idle;
 
   @override
   void initState() {
@@ -63,7 +67,7 @@ class _SecretPassphraseScreenState
   }
 
   Future<void> _handlePrimaryAction() async {
-    if (_isPreparing || _isCreating || _prepareError != null) return;
+    if (_isPreparing || _isSubmitting || _prepareError != null) return;
     if (!_revealed) {
       setState(() {
         _revealed = true;
@@ -84,7 +88,7 @@ class _SecretPassphraseScreenState
     }
 
     setState(() {
-      _isCreating = true;
+      _submitPhase = _CreateWalletSubmitPhase.creating;
       _submitError = null;
     });
     final router = GoRouter.of(context);
@@ -93,12 +97,24 @@ class _SecretPassphraseScreenState
       await runWithSyncPausedForAccountMutation(
         ref,
         () => accountNotifier.createAccountFromMnemonic(mnemonic: mnemonic),
+        onStoppingSync: () {
+          if (!mounted) return;
+          setState(() {
+            _submitPhase = _CreateWalletSubmitPhase.stoppingSync;
+          });
+        },
+        onSyncPaused: () {
+          if (!mounted) return;
+          setState(() {
+            _submitPhase = _CreateWalletSubmitPhase.creating;
+          });
+        },
       );
     } catch (e, st) {
       log('SecretPassphraseScreen._handlePrimaryAction: ERROR: $e\n$st');
       if (!mounted) return;
       setState(() {
-        _isCreating = false;
+        _submitPhase = _CreateWalletSubmitPhase.idle;
         _submitError = e.toString();
       });
       return;
@@ -126,7 +142,7 @@ class _SecretPassphraseScreenState
                 child: _HeroLayout(
                   mnemonic: _mnemonic,
                   isPreparing: _isPreparing,
-                  isCreating: _isCreating,
+                  submitPhase: _submitPhase,
                   revealed: _revealed,
                   needsPasswordStep: !security.isPasswordConfigured,
                   prepareError: _prepareError,
@@ -183,7 +199,7 @@ class _HeroLayout extends StatelessWidget {
   const _HeroLayout({
     required this.mnemonic,
     required this.isPreparing,
-    required this.isCreating,
+    required this.submitPhase,
     required this.revealed,
     required this.needsPasswordStep,
     required this.prepareError,
@@ -194,7 +210,7 @@ class _HeroLayout extends StatelessWidget {
 
   final String? mnemonic;
   final bool isPreparing;
-  final bool isCreating;
+  final _CreateWalletSubmitPhase submitPhase;
   final bool revealed;
   final bool needsPasswordStep;
   final String? prepareError;
@@ -219,7 +235,7 @@ class _HeroLayout extends StatelessWidget {
         ),
         _BottomActions(
           isPreparing: isPreparing,
-          isCreating: isCreating,
+          submitPhase: submitPhase,
           revealed: revealed,
           needsPasswordStep: needsPasswordStep,
           submitError: submitError,
@@ -281,7 +297,7 @@ class _HeroBlock extends StatelessWidget {
 class _BottomActions extends StatelessWidget {
   const _BottomActions({
     required this.isPreparing,
-    required this.isCreating,
+    required this.submitPhase,
     required this.revealed,
     required this.needsPasswordStep,
     required this.submitError,
@@ -289,7 +305,7 @@ class _BottomActions extends StatelessWidget {
   });
 
   final bool isPreparing;
-  final bool isCreating;
+  final _CreateWalletSubmitPhase submitPhase;
   final bool revealed;
   final bool needsPasswordStep;
   final String? submitError;
@@ -299,22 +315,24 @@ class _BottomActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isSubmitting = submitPhase != _CreateWalletSubmitPhase.idle;
     return Column(
       children: [
         AppButton(
-          onPressed: !isPreparing && !isCreating ? onPrimaryPressed : null,
+          onPressed: !isPreparing && !isSubmitting ? onPrimaryPressed : null,
           variant: AppButtonVariant.primary,
           minWidth: _buttonWidth,
           trailing: const AppIcon(AppIcons.chevronForward),
-          child: Text(
-            isCreating
-                ? 'Creating wallet...'
-                : revealed
-                ? needsPasswordStep
-                      ? 'Continue to Set Password'
-                      : 'I’m ready to use Vizor'
-                : 'Reveal the Phrase',
-          ),
+          child: Text(switch (submitPhase) {
+            _CreateWalletSubmitPhase.stoppingSync => 'Stop syncing...',
+            _CreateWalletSubmitPhase.creating => 'Creating wallet...',
+            _CreateWalletSubmitPhase.idle =>
+              revealed
+                  ? needsPasswordStep
+                        ? 'Continue to Set Password'
+                        : 'I’m ready to use Vizor'
+                  : 'Reveal the Phrase',
+          }),
         ),
         if (submitError != null) ...[
           const SizedBox(height: AppSpacing.xs),

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -13,6 +13,7 @@ import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
+import '../../../providers/wallet_mutation_guard.dart';
 import '../shared/onboarding_flow_args.dart';
 import 'import_birthday_estimator.dart';
 import 'import_split_view.dart';
@@ -293,9 +294,12 @@ class _ImportWalletBirthdayScreenState
 
       final accountNotifier = ref.read(accountProvider.notifier);
       final router = GoRouter.of(context);
-      await accountNotifier.importAccount(
-        mnemonic: mnemonic,
-        birthdayHeight: birthdayHeight,
+      await runWithSyncPausedForAccountMutation(
+        ref,
+        () => accountNotifier.importAccount(
+          mnemonic: mnemonic,
+          birthdayHeight: birthdayHeight,
+        ),
       );
       router.go('/home');
     } catch (e, st) {

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -20,6 +20,8 @@ import 'import_split_view.dart';
 
 enum ImportBirthdayTab { date, blockHeight }
 
+enum _ImportWalletSubmitPhase { idle, stoppingSync, importing }
+
 class ImportWalletBirthdayScreen extends ConsumerStatefulWidget {
   const ImportWalletBirthdayScreen({required this.args, super.key});
 
@@ -47,10 +49,12 @@ class _ImportWalletBirthdayScreenState
   int? _birthdayHeight;
   bool _isLoadingMetadata = true;
   bool _isEstimating = false;
-  bool _isSubmitting = false;
+  _ImportWalletSubmitPhase _submitPhase = _ImportWalletSubmitPhase.idle;
   String? _metadataError;
   String? _submitError;
   int _estimateSeq = 0;
+
+  bool get _isSubmitting => _submitPhase != _ImportWalletSubmitPhase.idle;
 
   @override
   void initState() {
@@ -274,7 +278,7 @@ class _ImportWalletBirthdayScreenState
     }
 
     setState(() {
-      _isSubmitting = true;
+      _submitPhase = _ImportWalletSubmitPhase.importing;
       _submitError = null;
     });
 
@@ -300,13 +304,25 @@ class _ImportWalletBirthdayScreenState
           mnemonic: mnemonic,
           birthdayHeight: birthdayHeight,
         ),
+        onStoppingSync: () {
+          if (!mounted) return;
+          setState(() {
+            _submitPhase = _ImportWalletSubmitPhase.stoppingSync;
+          });
+        },
+        onSyncPaused: () {
+          if (!mounted) return;
+          setState(() {
+            _submitPhase = _ImportWalletSubmitPhase.importing;
+          });
+        },
       );
       router.go('/home');
     } catch (e, st) {
       log('ImportWalletBirthdayScreen._submit: ERROR: $e\n$st');
       if (!mounted) return;
       setState(() {
-        _isSubmitting = false;
+        _submitPhase = _ImportWalletSubmitPhase.idle;
         _submitError = e.toString();
       });
       return;
@@ -368,11 +384,14 @@ class _ImportWalletBirthdayScreenState
   @override
   Widget build(BuildContext context) {
     final activeTab = _activeTab;
-    final buttonLabel = _isSubmitting
-        ? 'Importing...'
-        : activeTab == ImportBirthdayTab.date && _isEstimating
-        ? 'Estimating...'
-        : 'Import';
+    final buttonLabel = switch (_submitPhase) {
+      _ImportWalletSubmitPhase.stoppingSync => 'Stop syncing...',
+      _ImportWalletSubmitPhase.importing => 'Importing...',
+      _ImportWalletSubmitPhase.idle =>
+        activeTab == ImportBirthdayTab.date && _isEstimating
+            ? 'Estimating...'
+            : 'Import',
+    };
 
     return ImportOnboardingTrailingPane(
       child: Column(

--- a/lib/src/features/onboarding/shared/set_password_screen.dart
+++ b/lib/src/features/onboarding/shared/set_password_screen.dart
@@ -27,10 +27,12 @@ class SetPasswordScreen extends ConsumerStatefulWidget {
   ConsumerState<SetPasswordScreen> createState() => _SetPasswordScreenState();
 }
 
+enum _SetPasswordSubmitPhase { idle, stoppingSync, settingPassword }
+
 class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
   final _passwordController = TextEditingController();
   final _confirmController = TextEditingController();
-  bool _isSubmitting = false;
+  _SetPasswordSubmitPhase _submitPhase = _SetPasswordSubmitPhase.idle;
   String? _submitError;
 
   @override
@@ -47,7 +49,9 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
       _confirmController.text == _passwordController.text;
 
   bool get _canSubmit =>
-      !_isSubmitting && _passwordPolicyError == null && _matches;
+      _submitPhase == _SetPasswordSubmitPhase.idle &&
+      _passwordPolicyError == null &&
+      _matches;
 
   String? get _passwordMessage => _passwordPolicyError;
 
@@ -61,12 +65,14 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
     final args = widget.args;
     final passwordPolicyError = _passwordPolicyError;
     final password = _passwordController.text;
-    if (_isSubmitting || passwordPolicyError != null || !_matches) {
+    if (_submitPhase != _SetPasswordSubmitPhase.idle ||
+        passwordPolicyError != null ||
+        !_matches) {
       return;
     }
 
     setState(() {
-      _isSubmitting = true;
+      _submitPhase = _SetPasswordSubmitPhase.settingPassword;
       _submitError = null;
     });
 
@@ -82,18 +88,33 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
         await securityNotifier.preparePasswordSetup(password);
         passwordPrepared = true;
 
-        await runWithSyncPausedForAccountMutation(ref, () async {
-          if (args.isImport) {
-            await accountNotifier.importAccount(
-              mnemonic: args.mnemonic,
-              birthdayHeight: args.importBirthdayHeight,
-            );
-          } else {
-            await accountNotifier.createAccountFromMnemonic(
-              mnemonic: args.mnemonic,
-            );
-          }
-        });
+        await runWithSyncPausedForAccountMutation(
+          ref,
+          () async {
+            if (args.isImport) {
+              await accountNotifier.importAccount(
+                mnemonic: args.mnemonic,
+                birthdayHeight: args.importBirthdayHeight,
+              );
+            } else {
+              await accountNotifier.createAccountFromMnemonic(
+                mnemonic: args.mnemonic,
+              );
+            }
+          },
+          onStoppingSync: () {
+            if (!mounted) return;
+            setState(() {
+              _submitPhase = _SetPasswordSubmitPhase.stoppingSync;
+            });
+          },
+          onSyncPaused: () {
+            if (!mounted) return;
+            setState(() {
+              _submitPhase = _SetPasswordSubmitPhase.settingPassword;
+            });
+          },
+        );
 
         securityNotifier.commitPasswordSetup();
         passwordCommitted = true;
@@ -113,7 +134,7 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
       log('SetPasswordScreen._submit: ERROR: $e\n$st');
       if (!mounted) return;
       setState(() {
-        _isSubmitting = false;
+        _submitPhase = _SetPasswordSubmitPhase.idle;
         _submitError = e.toString();
       });
       return;
@@ -126,7 +147,7 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
     final content = _SetPasswordContent(
       passwordController: _passwordController,
       confirmController: _confirmController,
-      isSubmitting: _isSubmitting,
+      submitPhase: _submitPhase,
       canSubmit: _canSubmit,
       passwordMessage: _passwordMessage,
       confirmMessage: _confirmMessage,
@@ -149,7 +170,7 @@ class _SetPasswordContent extends StatelessWidget {
   const _SetPasswordContent({
     required this.passwordController,
     required this.confirmController,
-    required this.isSubmitting,
+    required this.submitPhase,
     required this.canSubmit,
     required this.passwordMessage,
     required this.confirmMessage,
@@ -162,7 +183,7 @@ class _SetPasswordContent extends StatelessWidget {
 
   final TextEditingController passwordController;
   final TextEditingController confirmController;
-  final bool isSubmitting;
+  final _SetPasswordSubmitPhase submitPhase;
   final bool canSubmit;
   final String? passwordMessage;
   final String? confirmMessage;
@@ -285,9 +306,13 @@ class _SetPasswordContent extends StatelessWidget {
                       variant: AppButtonVariant.primary,
                       minWidth: _contentWidth,
                       trailing: const AppIcon(AppIcons.chevronForward),
-                      child: Text(
-                        isSubmitting ? 'Setting password...' : 'Set Password',
-                      ),
+                      child: Text(switch (submitPhase) {
+                        _SetPasswordSubmitPhase.stoppingSync =>
+                          'Stop syncing...',
+                        _SetPasswordSubmitPhase.settingPassword =>
+                          'Setting password...',
+                        _SetPasswordSubmitPhase.idle => 'Set Password',
+                      }),
                     ),
                   ],
                 ),

--- a/lib/src/features/onboarding/shared/set_password_screen.dart
+++ b/lib/src/features/onboarding/shared/set_password_screen.dart
@@ -13,6 +13,7 @@ import '../../../core/widgets/password_text_field.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
 import '../../../providers/router_refresh_provider.dart';
+import '../../../providers/wallet_mutation_guard.dart';
 import '../create/onboarding_split_view.dart';
 import '../import/import_split_view.dart';
 import 'onboarding_flow_args.dart';
@@ -81,16 +82,18 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
         await securityNotifier.preparePasswordSetup(password);
         passwordPrepared = true;
 
-        if (args.isImport) {
-          await accountNotifier.importAccount(
-            mnemonic: args.mnemonic,
-            birthdayHeight: args.importBirthdayHeight,
-          );
-        } else {
-          await accountNotifier.createAccountFromMnemonic(
-            mnemonic: args.mnemonic,
-          );
-        }
+        await runWithSyncPausedForAccountMutation(ref, () async {
+          if (args.isImport) {
+            await accountNotifier.importAccount(
+              mnemonic: args.mnemonic,
+              birthdayHeight: args.importBirthdayHeight,
+            );
+          } else {
+            await accountNotifier.createAccountFromMnemonic(
+              mnemonic: args.mnemonic,
+            );
+          }
+        });
 
         securityNotifier.commitPasswordSetup();
         passwordCommitted = true;

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -119,6 +119,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   StreamSubscription? _syncSub;
   AppLifecycleListener? _lifecycleListener;
   Timer? _pollTimer;
+  bool _pollCheckInFlight = false;
   int _sensitiveStateEpoch = 0;
   // Mempool observer subscription. Started in `startSync` and
   // cancelled in `stopSync`, so its lifetime matches the
@@ -478,7 +479,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   WalletMutationSyncPause _walletMutationSyncPauseSnapshot() {
     return WalletMutationSyncPause(
       hadActiveSync: _isSyncing || rust_sync.isSyncRunning(),
-      hadPolling: _pollTimer != null,
+      hadPolling: _pollTimer != null || _pollCheckInFlight,
       hadBackgroundSync: _bgDelegate.isActive,
       hadMempoolObserver: rust_sync.isMempoolObserverRunning(),
     );
@@ -496,10 +497,10 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       return pause;
     }
 
-    await onStoppingSync?.call();
-    log('SyncNotifier: pausing sync for wallet DB mutation');
     ++_syncGen;
     _stopPolling();
+    await onStoppingSync?.call();
+    log('SyncNotifier: pausing sync for wallet DB mutation');
     _isSyncing = false;
     rust_sync.setSyncMode(mode: 0);
     rust_sync.cancelFullSync();
@@ -678,15 +679,18 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   }
 
   Future<void> _checkAndSync() async {
+    final gen = _syncGen;
     final epoch = _sensitiveStateEpoch;
     final hasAccounts = ref.read(accountProvider).value?.hasAccounts ?? false;
-    if (_isSyncing ||
+    if (_pollCheckInFlight ||
+        _isSyncing ||
         _requiresUnlock ||
         _bgDelegate.shouldSuppressPolling ||
         !_isInForeground ||
         !hasAccounts) {
       return;
     }
+    _pollCheckInFlight = true;
     _stopPolling();
     try {
       final tip = await rust_wallet.getLatestBlockHeight(
@@ -694,7 +698,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       );
       final lastSynced = state.value?.chainTipHeight ?? 0;
       final syncComplete = (state.value?.percentage ?? 0) >= 1.0;
-      if (epoch != _sensitiveStateEpoch || _requiresUnlock) {
+      if (gen != _syncGen || epoch != _sensitiveStateEpoch || _requiresUnlock) {
         log('AutoSync: skipping restart after lock transition');
         return;
       }
@@ -706,6 +710,11 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       }
     } catch (e) {
       log('AutoSync: tip check failed: $e');
+    } finally {
+      _pollCheckInFlight = false;
+    }
+    if (gen != _syncGen || _requiresUnlock) {
+      return;
     }
     _startPolling();
   }

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -96,12 +96,17 @@ class WalletMutationSyncPause {
   final bool hadActiveSync;
   final bool hadPolling;
   final bool hadBackgroundSync;
+  final bool hadMempoolObserver;
 
   const WalletMutationSyncPause({
     required this.hadActiveSync,
     required this.hadPolling,
     required this.hadBackgroundSync,
+    required this.hadMempoolObserver,
   });
+
+  bool get hadWorkToPause =>
+      hadActiveSync || hadPolling || hadBackgroundSync || hadMempoolObserver;
 }
 
 class SyncNotifier extends AsyncNotifier<SyncState> {
@@ -470,20 +475,28 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     );
   }
 
-  Future<WalletMutationSyncPause> pauseForWalletMutation() async {
-    final pause = WalletMutationSyncPause(
+  WalletMutationSyncPause _walletMutationSyncPauseSnapshot() {
+    return WalletMutationSyncPause(
       hadActiveSync: _isSyncing || rust_sync.isSyncRunning(),
       hadPolling: _pollTimer != null,
       hadBackgroundSync: _bgDelegate.isActive,
+      hadMempoolObserver: rust_sync.isMempoolObserverRunning(),
     );
+  }
 
-    if (!pause.hadActiveSync &&
-        !pause.hadPolling &&
-        !pause.hadBackgroundSync &&
-        !rust_sync.isMempoolObserverRunning()) {
+  bool needsPauseForWalletMutation() =>
+      _walletMutationSyncPauseSnapshot().hadWorkToPause;
+
+  Future<WalletMutationSyncPause> pauseForWalletMutation({
+    FutureOr<void> Function()? onStoppingSync,
+  }) async {
+    final pause = _walletMutationSyncPauseSnapshot();
+
+    if (!pause.hadWorkToPause) {
       return pause;
     }
 
+    await onStoppingSync?.call();
     log('SyncNotifier: pausing sync for wallet DB mutation');
     ++_syncGen;
     _stopPolling();

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -92,6 +92,18 @@ class SyncState {
   }
 }
 
+class WalletMutationSyncPause {
+  final bool hadActiveSync;
+  final bool hadPolling;
+  final bool hadBackgroundSync;
+
+  const WalletMutationSyncPause({
+    required this.hadActiveSync,
+    required this.hadPolling,
+    required this.hadBackgroundSync,
+  });
+}
+
 class SyncNotifier extends AsyncNotifier<SyncState> {
   late final BackgroundSyncDelegate _bgDelegate;
   bool _isSyncing = false;
@@ -456,6 +468,76 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         recentTransactions: prev?.recentTransactions ?? const [],
       ),
     );
+  }
+
+  Future<WalletMutationSyncPause> pauseForWalletMutation() async {
+    final pause = WalletMutationSyncPause(
+      hadActiveSync: _isSyncing || rust_sync.isSyncRunning(),
+      hadPolling: _pollTimer != null,
+      hadBackgroundSync: _bgDelegate.isActive,
+    );
+
+    if (!pause.hadActiveSync &&
+        !pause.hadPolling &&
+        !pause.hadBackgroundSync &&
+        !rust_sync.isMempoolObserverRunning()) {
+      return pause;
+    }
+
+    log('SyncNotifier: pausing sync for wallet DB mutation');
+    ++_syncGen;
+    _stopPolling();
+    _isSyncing = false;
+    rust_sync.setSyncMode(mode: 0);
+    rust_sync.cancelFullSync();
+    _stopMempoolObserver();
+    await _syncSub?.cancel();
+    _syncSub = null;
+
+    if (_bgDelegate.isActive) {
+      try {
+        await _bgDelegate.shutdownForLock();
+      } catch (e) {
+        log(
+          'SyncNotifier: background shutdown before wallet mutation failed: $e',
+        );
+      }
+    }
+
+    final prev = state.value;
+    if (prev != null) {
+      state = AsyncData(
+        prev.copyWith(isSyncing: false, isBackgroundMode: false, phase: ''),
+      );
+    }
+
+    final stopped = await _waitForRustTasksToStop(
+      timeoutMs: 120000,
+      onSyncTimeout:
+          'SyncNotifier: timed out waiting for Rust sync to stop before wallet '
+          'mutation',
+      onMempoolTimeout:
+          'SyncNotifier: timed out waiting for mempool observer to stop before '
+          'wallet mutation',
+    );
+    if (!stopped) {
+      resumeAfterWalletMutation(pause);
+      throw StateError('Sync did not stop before wallet database mutation.');
+    }
+
+    return pause;
+  }
+
+  void resumeAfterWalletMutation(WalletMutationSyncPause pause) {
+    if (_requiresUnlock) return;
+
+    if (pause.hadActiveSync || pause.hadBackgroundSync) {
+      log('SyncNotifier: resuming sync after wallet DB mutation');
+      startSync();
+    }
+    if (pause.hadPolling || pause.hadActiveSync || pause.hadBackgroundSync) {
+      _startPolling();
+    }
   }
 
   Future<void> clearSensitiveStateForLock() async {

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -942,7 +942,11 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       spendable = balance.spendable;
       total = balance.total;
     } catch (e) {
-      log('SyncNotifier: balance refresh failed: $e');
+      _logRefreshReadError(
+        label: 'balance',
+        fallback: 'keeping previous value',
+        error: e,
+      );
     }
 
     var recentTxs =
@@ -955,7 +959,11 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         accountUuid: accountUuid,
       );
     } catch (e) {
-      log('SyncNotifier: tx history refresh failed: $e');
+      _logRefreshReadError(
+        label: 'tx history',
+        fallback: 'keeping previous list',
+        error: e,
+      );
     }
 
     if (epoch != _sensitiveStateEpoch || _requiresUnlock) {
@@ -982,6 +990,25 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
   String? _getActiveAccountUuid() {
     return ref.read(accountProvider).value?.activeAccountUuid;
+  }
+
+  void _logRefreshReadError({
+    required String label,
+    required String fallback,
+    required Object error,
+  }) {
+    if (_isDatabaseLockedError(error)) {
+      log(
+        'SyncNotifier: $label refresh skipped due to temporary DB lock; '
+        '$fallback',
+      );
+      return;
+    }
+    log('SyncNotifier: $label refresh failed: $error');
+  }
+
+  bool _isDatabaseLockedError(Object error) {
+    return error.toString().contains('database is locked');
   }
 
   Future<String> _getDbPath() async {

--- a/lib/src/providers/wallet_mutation_guard.dart
+++ b/lib/src/providers/wallet_mutation_guard.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'account_provider.dart';
+import 'sync_provider.dart';
+
+Future<T> runWithSyncPausedForAccountMutation<T>(
+  WidgetRef ref,
+  Future<T> Function() action,
+) async {
+  final hasExistingAccounts =
+      (ref.read(accountProvider).value?.accounts ?? const <AccountInfo>[])
+          .isNotEmpty;
+  if (!hasExistingAccounts) {
+    return action();
+  }
+
+  final pause = await ref.read(syncProvider.notifier).pauseForWalletMutation();
+  try {
+    return await action();
+  } finally {
+    ref.read(syncProvider.notifier).resumeAfterWalletMutation(pause);
+  }
+}

--- a/lib/src/providers/wallet_mutation_guard.dart
+++ b/lib/src/providers/wallet_mutation_guard.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'account_provider.dart';
@@ -5,8 +7,10 @@ import 'sync_provider.dart';
 
 Future<T> runWithSyncPausedForAccountMutation<T>(
   WidgetRef ref,
-  Future<T> Function() action,
-) async {
+  Future<T> Function() action, {
+  FutureOr<void> Function()? onStoppingSync,
+  FutureOr<void> Function()? onSyncPaused,
+}) async {
   final hasExistingAccounts =
       (ref.read(accountProvider).value?.accounts ?? const <AccountInfo>[])
           .isNotEmpty;
@@ -14,8 +18,13 @@ Future<T> runWithSyncPausedForAccountMutation<T>(
     return action();
   }
 
-  final pause = await ref.read(syncProvider.notifier).pauseForWalletMutation();
+  final pause = await ref
+      .read(syncProvider.notifier)
+      .pauseForWalletMutation(onStoppingSync: onStoppingSync);
   try {
+    if (pause.hadWorkToPause) {
+      await onSyncPaused?.call();
+    }
     return await action();
   } finally {
     ref.read(syncProvider.notifier).resumeAfterWalletMutation(pause);

--- a/rust/src/wallet/db.rs
+++ b/rust/src/wallet/db.rs
@@ -1,0 +1,44 @@
+use std::time::Duration;
+
+use rand::rngs::OsRng;
+use zcash_client_sqlite::{util::SystemClock, WalletDb};
+
+use crate::wallet::network::WalletNetwork;
+
+pub(crate) type WalletDatabase = WalletDb<rusqlite::Connection, WalletNetwork, SystemClock, OsRng>;
+
+/// User-driven wallet operations can afford a longer wait for a short sync write.
+pub(crate) const WALLET_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(10);
+/// Account creation/import runs after sync is paused, so a shorter wait exposes real stalls.
+pub(crate) const ACCOUNT_MUTATION_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+/// The sync loop should absorb brief read/write overlap without stretching cancel too far.
+pub(crate) const SYNC_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
+pub(crate) const READ_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub(crate) fn open_wallet_db_with_timeout(
+    db_path: &str,
+    network: WalletNetwork,
+    timeout: Duration,
+) -> Result<WalletDatabase, String> {
+    let conn = rusqlite::Connection::open(db_path)
+        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+    conn.busy_timeout(timeout)
+        .map_err(|e| format!("Failed to configure wallet DB busy timeout: {e}"))?;
+    rusqlite::vtab::array::load_module(&conn)
+        .map_err(|e| format!("Failed to load SQLite array module: {e}"))?;
+    Ok(WalletDb::from_connection(conn, network, SystemClock, OsRng))
+}
+
+pub(crate) fn open_readonly_conn_with_timeout(
+    db_path: &str,
+    timeout: Option<Duration>,
+) -> Result<rusqlite::Connection, String> {
+    let conn =
+        rusqlite::Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .map_err(|e| format!("Failed to open DB: {e}"))?;
+    if let Some(timeout) = timeout {
+        conn.busy_timeout(timeout)
+            .map_err(|e| format!("Failed to configure DB busy timeout: {e}"))?;
+    }
+    Ok(conn)
+}

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -1,13 +1,12 @@
 use std::path::Path;
 
 use bip0039::{Count, English, Mnemonic};
-use rand::rngs::OsRng;
 use secrecy::{ExposeSecret, SecretVec};
 use zcash_client_backend::data_api::{
     chain::ChainState, Account as _, AccountBirthday, AccountPurpose, AccountSource, WalletRead,
     WalletWrite, Zip32Derivation,
 };
-use zcash_client_sqlite::{util::SystemClock, wallet::init::init_wallet_db, AccountUuid, WalletDb};
+use zcash_client_sqlite::{wallet::init::init_wallet_db, AccountUuid};
 use zcash_keys::{
     encoding::encode_transparent_address,
     keys::{ReceiverRequirement, UnifiedAddressRequest, UnifiedSpendingKey},
@@ -16,20 +15,33 @@ use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::{BlockHeight, NetworkConstants, NetworkUpgrade, Parameters};
 use zip32::fingerprint::SeedFingerprint;
 
-use crate::wallet::network::WalletNetwork;
+use crate::wallet::{
+    db::{
+        open_wallet_db_with_timeout, WalletDatabase, ACCOUNT_MUTATION_DB_BUSY_TIMEOUT,
+        READ_DB_BUSY_TIMEOUT, WALLET_DB_BUSY_TIMEOUT,
+    },
+    network::WalletNetwork,
+};
 
-type WalletDatabase = WalletDb<rusqlite::Connection, WalletNetwork, SystemClock, OsRng>;
+fn open_wallet_db_for_init(
+    db_path: &str,
+    network: WalletNetwork,
+) -> Result<WalletDatabase, String> {
+    open_wallet_db_with_timeout(db_path, network, WALLET_DB_BUSY_TIMEOUT)
+}
 
-const WALLET_DB_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+fn open_wallet_db_for_mutation(
+    db_path: &str,
+    network: WalletNetwork,
+) -> Result<WalletDatabase, String> {
+    open_wallet_db_with_timeout(db_path, network, ACCOUNT_MUTATION_DB_BUSY_TIMEOUT)
+}
 
-fn open_wallet_db(db_path: &str, network: WalletNetwork) -> Result<WalletDatabase, String> {
-    let conn = rusqlite::Connection::open(db_path)
-        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
-    conn.busy_timeout(WALLET_DB_BUSY_TIMEOUT)
-        .map_err(|e| format!("Failed to configure wallet DB busy timeout: {e}"))?;
-    rusqlite::vtab::array::load_module(&conn)
-        .map_err(|e| format!("Failed to load SQLite array module: {e}"))?;
-    Ok(WalletDb::from_connection(conn, network, SystemClock, OsRng))
+fn open_wallet_db_for_read(
+    db_path: &str,
+    network: WalletNetwork,
+) -> Result<WalletDatabase, String> {
+    open_wallet_db_with_timeout(db_path, network, READ_DB_BUSY_TIMEOUT)
 }
 
 /// Generate a new 24-word BIP-39 mnemonic phrase.
@@ -54,7 +66,7 @@ pub fn parse_network(network: &str) -> Result<WalletNetwork, String> {
 /// Initialize the wallet database schema. Idempotent — safe to call multiple times.
 /// Called without seed to avoid SeedNotRelevant errors when only Imported accounts exist.
 pub fn ensure_db_initialized(db_path: &str, network: WalletNetwork) -> Result<(), String> {
-    let mut db = open_wallet_db(db_path, network)?;
+    let mut db = open_wallet_db_for_init(db_path, network)?;
     init_wallet_db(&mut db, None).map_err(|e| format!("Failed to init wallet DB: {e}"))?;
     Ok(())
 }
@@ -66,7 +78,7 @@ fn ensure_db_initialized_with_seed(
     network: WalletNetwork,
     seed: &SecretVec<u8>,
 ) -> Result<(), String> {
-    let mut db = open_wallet_db(db_path, network)?;
+    let mut db = open_wallet_db_for_init(db_path, network)?;
     init_wallet_db(&mut db, Some(SecretVec::new(seed.expose_secret().to_vec())))
         .map_err(|e| format!("Failed to init wallet DB: {e}"))?;
     Ok(())
@@ -100,7 +112,7 @@ pub fn add_account(
     seed: &SecretVec<u8>,
     birthday_height: Option<u64>,
 ) -> Result<(String, String), String> {
-    let mut db = open_wallet_db(db_path, network)?;
+    let mut db = open_wallet_db_for_mutation(db_path, network)?;
 
     let birthday = make_birthday(network, birthday_height);
 
@@ -154,7 +166,7 @@ pub fn import_hardware_account(
     // Ensure DB is initialized (without seed — hardware wallet has no local seed)
     ensure_db_initialized(db_path, network)?;
 
-    let mut db = open_wallet_db(db_path, network)?;
+    let mut db = open_wallet_db_for_mutation(db_path, network)?;
 
     // Invariant: there must be at least one Derived account already. Otherwise
     // this import would leave the DB in a state where future seed-requiring
@@ -233,7 +245,7 @@ pub fn init_db_and_create_account(
 ) -> Result<(String, String), String> {
     ensure_db_initialized_with_seed(db_path, network, seed)?;
 
-    let mut db = open_wallet_db(db_path, network)?;
+    let mut db = open_wallet_db_for_mutation(db_path, network)?;
 
     let birthday = make_birthday(network, birthday_height);
 
@@ -260,7 +272,7 @@ pub struct AccountInfo {
 
 /// List all accounts in the wallet database.
 pub fn list_accounts(db_path: &str, network: WalletNetwork) -> Result<Vec<AccountInfo>, String> {
-    let db = open_wallet_db(db_path, network)?;
+    let db = open_wallet_db_for_read(db_path, network)?;
 
     let account_ids = db
         .get_account_ids()
@@ -323,7 +335,7 @@ pub fn get_address_from_db(
     network: WalletNetwork,
     account_uuid: Option<&str>,
 ) -> Result<String, String> {
-    let db = open_wallet_db(db_path, network)?;
+    let db = open_wallet_db_for_read(db_path, network)?;
 
     let account_id = resolve_account_id(&db, account_uuid)?;
 
@@ -372,7 +384,7 @@ pub fn get_transparent_address_from_db(
     network: WalletNetwork,
     account_uuid: Option<&str>,
 ) -> Result<String, String> {
-    let db = open_wallet_db(db_path, network)?;
+    let db = open_wallet_db_for_read(db_path, network)?;
 
     let account_id = resolve_account_id(&db, account_uuid)?;
 

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -18,6 +18,20 @@ use zip32::fingerprint::SeedFingerprint;
 
 use crate::wallet::network::WalletNetwork;
 
+type WalletDatabase = WalletDb<rusqlite::Connection, WalletNetwork, SystemClock, OsRng>;
+
+const WALLET_DB_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+fn open_wallet_db(db_path: &str, network: WalletNetwork) -> Result<WalletDatabase, String> {
+    let conn = rusqlite::Connection::open(db_path)
+        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+    conn.busy_timeout(WALLET_DB_BUSY_TIMEOUT)
+        .map_err(|e| format!("Failed to configure wallet DB busy timeout: {e}"))?;
+    rusqlite::vtab::array::load_module(&conn)
+        .map_err(|e| format!("Failed to load SQLite array module: {e}"))?;
+    Ok(WalletDb::from_connection(conn, network, SystemClock, OsRng))
+}
+
 /// Generate a new 24-word BIP-39 mnemonic phrase.
 pub fn generate_mnemonic() -> String {
     let mnemonic = Mnemonic::<English>::generate(Count::Words24);
@@ -40,8 +54,7 @@ pub fn parse_network(network: &str) -> Result<WalletNetwork, String> {
 /// Initialize the wallet database schema. Idempotent — safe to call multiple times.
 /// Called without seed to avoid SeedNotRelevant errors when only Imported accounts exist.
 pub fn ensure_db_initialized(db_path: &str, network: WalletNetwork) -> Result<(), String> {
-    let mut db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
-        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+    let mut db = open_wallet_db(db_path, network)?;
     init_wallet_db(&mut db, None).map_err(|e| format!("Failed to init wallet DB: {e}"))?;
     Ok(())
 }
@@ -53,8 +66,7 @@ fn ensure_db_initialized_with_seed(
     network: WalletNetwork,
     seed: &SecretVec<u8>,
 ) -> Result<(), String> {
-    let mut db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
-        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+    let mut db = open_wallet_db(db_path, network)?;
     init_wallet_db(&mut db, Some(SecretVec::new(seed.expose_secret().to_vec())))
         .map_err(|e| format!("Failed to init wallet DB: {e}"))?;
     Ok(())
@@ -88,8 +100,7 @@ pub fn add_account(
     seed: &SecretVec<u8>,
     birthday_height: Option<u64>,
 ) -> Result<(String, String), String> {
-    let mut db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
-        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+    let mut db = open_wallet_db(db_path, network)?;
 
     let birthday = make_birthday(network, birthday_height);
 
@@ -143,8 +154,7 @@ pub fn import_hardware_account(
     // Ensure DB is initialized (without seed — hardware wallet has no local seed)
     ensure_db_initialized(db_path, network)?;
 
-    let mut db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
-        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+    let mut db = open_wallet_db(db_path, network)?;
 
     // Invariant: there must be at least one Derived account already. Otherwise
     // this import would leave the DB in a state where future seed-requiring
@@ -223,8 +233,7 @@ pub fn init_db_and_create_account(
 ) -> Result<(String, String), String> {
     ensure_db_initialized_with_seed(db_path, network, seed)?;
 
-    let mut db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
-        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+    let mut db = open_wallet_db(db_path, network)?;
 
     let birthday = make_birthday(network, birthday_height);
 
@@ -251,8 +260,7 @@ pub struct AccountInfo {
 
 /// List all accounts in the wallet database.
 pub fn list_accounts(db_path: &str, network: WalletNetwork) -> Result<Vec<AccountInfo>, String> {
-    let db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
-        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+    let db = open_wallet_db(db_path, network)?;
 
     let account_ids = db
         .get_account_ids()
@@ -293,7 +301,7 @@ pub fn parse_account_uuid(s: &str) -> Result<AccountUuid, String> {
 
 /// Resolve account_id: if uuid provided, parse it; otherwise take first account.
 fn resolve_account_id(
-    db: &WalletDb<rusqlite::Connection, WalletNetwork, SystemClock, OsRng>,
+    db: &WalletDatabase,
     account_uuid: Option<&str>,
 ) -> Result<AccountUuid, String> {
     match account_uuid {
@@ -315,8 +323,7 @@ pub fn get_address_from_db(
     network: WalletNetwork,
     account_uuid: Option<&str>,
 ) -> Result<String, String> {
-    let db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
-        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+    let db = open_wallet_db(db_path, network)?;
 
     let account_id = resolve_account_id(&db, account_uuid)?;
 
@@ -365,8 +372,7 @@ pub fn get_transparent_address_from_db(
     network: WalletNetwork,
     account_uuid: Option<&str>,
 ) -> Result<String, String> {
-    let db = WalletDb::for_path(db_path, network, SystemClock, OsRng)
-        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+    let db = open_wallet_db(db_path, network)?;
 
     let account_id = resolve_account_id(&db, account_uuid)?;
 

--- a/rust/src/wallet/mod.rs
+++ b/rust/src/wallet/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod db;
 pub mod keys;
 pub mod keystone;
 pub mod network;

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -1,4 +1,3 @@
-use rand::rngs::OsRng;
 use zcash_client_backend::{
     data_api::{
         chain::{scan_cached_blocks, CommitmentTreeRoot},
@@ -11,13 +10,18 @@ use zcash_client_backend::{
 };
 use zcash_client_sqlite::{
     chain::{init::init_blockmeta_db, BlockMeta},
-    util::SystemClock,
-    AccountUuid, FsBlockDb, WalletDb,
+    AccountUuid, FsBlockDb,
 };
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::BlockHeight;
 
-use crate::wallet::network::WalletNetwork;
+use crate::wallet::{
+    db::{
+        open_readonly_conn_with_timeout, open_wallet_db_with_timeout, WalletDatabase,
+        READ_DB_BUSY_TIMEOUT, WALLET_DB_BUSY_TIMEOUT,
+    },
+    network::WalletNetwork,
+};
 
 mod pczt;
 mod send;
@@ -50,42 +54,18 @@ pub use transactions::{
 #[allow(unused_imports)] // ditto
 pub(crate) use transactions::{PendingTxInfo, TransactionInfo, TxDataRequest, WalletBalance};
 
-pub(super) type WalletDatabase = WalletDb<rusqlite::Connection, WalletNetwork, SystemClock, OsRng>;
-const READ_DB_BUSY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
-
 pub(super) fn open_wallet_db(
     db_path: &str,
     network: WalletNetwork,
 ) -> Result<WalletDatabase, String> {
-    WalletDb::for_path(db_path, network, SystemClock, OsRng)
-        .map_err(|e| format!("Failed to open wallet DB: {e}"))
+    open_wallet_db_with_timeout(db_path, network, WALLET_DB_BUSY_TIMEOUT)
 }
 
 pub(crate) fn open_wallet_db_for_read(
     db_path: &str,
     network: WalletNetwork,
 ) -> Result<WalletDatabase, String> {
-    let conn = rusqlite::Connection::open(db_path)
-        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
-    conn.busy_timeout(READ_DB_BUSY_TIMEOUT)
-        .map_err(|e| format!("Failed to configure wallet DB busy timeout: {e}"))?;
-    rusqlite::vtab::array::load_module(&conn)
-        .map_err(|e| format!("Failed to load SQLite array module: {e}"))?;
-    Ok(WalletDb::from_connection(conn, network, SystemClock, OsRng))
-}
-
-fn open_readonly_conn_with_timeout(
-    db_path: &str,
-    timeout: Option<std::time::Duration>,
-) -> Result<rusqlite::Connection, String> {
-    let conn =
-        rusqlite::Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
-            .map_err(|e| format!("Failed to open DB: {e}"))?;
-    if let Some(timeout) = timeout {
-        conn.busy_timeout(timeout)
-            .map_err(|e| format!("Failed to configure DB busy timeout: {e}"))?;
-    }
-    Ok(conn)
+    open_wallet_db_with_timeout(db_path, network, READ_DB_BUSY_TIMEOUT)
 }
 
 pub(crate) fn open_readonly_conn(db_path: &str) -> Result<rusqlite::Connection, String> {

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -1,7 +1,6 @@
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 
-use rand::rngs::OsRng;
 use tonic::transport::Channel;
 use zcash_client_backend::{
     data_api::{
@@ -11,11 +10,14 @@ use zcash_client_backend::{
     },
     proto::service::{self, BlockId, ChainSpec},
 };
-use zcash_client_sqlite::{error::SqliteClientError, util::SystemClock, WalletDb};
+use zcash_client_sqlite::error::SqliteClientError;
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::BlockHeight;
 
-use crate::wallet::network::WalletNetwork;
+use crate::wallet::{
+    db::{open_wallet_db_with_timeout, WalletDatabase, SYNC_DB_BUSY_TIMEOUT},
+    network::WalletNetwork,
+};
 
 use {
     ::transparent::{
@@ -91,8 +93,6 @@ fn elapsed() -> String {
         .and_then(|g| g.map(|t| format!("{:.1}s", t.elapsed().as_secs_f64())))
         .unwrap_or_default()
 }
-
-type WalletDatabase = WalletDb<rusqlite::Connection, WalletNetwork, SystemClock, OsRng>;
 
 async fn refresh_utxos(
     client: &mut CompactTxStreamerClient<Channel>,
@@ -1015,7 +1015,7 @@ async fn run_sync_impl(
 // ==================== Helpers ====================
 
 fn open_db(path: &str, network: WalletNetwork) -> Result<WalletDatabase, SyncError> {
-    WalletDb::for_path(path, network, SystemClock, OsRng)
+    open_wallet_db_with_timeout(path, network, SYNC_DB_BUSY_TIMEOUT)
         .map_err(|e| SyncError::db(format!("DB open: {e}")))
 }
 


### PR DESCRIPTION
## Summary

- Pause foreground/background sync, polling, and the mempool observer before account create/import flows that mutate the wallet DB.
- Split account-mutation button loading states so `Stop syncing...` appears only while sync actually needs to stop, then the original loading text resumes.
- Centralize wallet DB open helpers and apply busy timeouts for sync, read, initialization, and account mutation paths.
- Treat `database is locked` during best-effort balance/history refresh as a transient skipped refresh while keeping previous UI values.

## Why

Adding accounts while sync is active can race with SQLite readers/writers and surface `database is locked` errors. This keeps the current single-DB multi-account design, but makes account mutation flows explicitly pause sync work and gives short read/write overlaps a busy timeout window instead of failing immediately.

## Validation

- `fvm dart analyze lib/src/providers/sync_provider.dart lib/src/providers/wallet_mutation_guard.dart lib/src/features/onboarding/create/secret_passphrase_screen.dart lib/src/features/onboarding/import/import_wallet_birthday_screen.dart lib/src/features/onboarding/shared/set_password_screen.dart lib/src/features/keystone/screens/import_keystone_screen.dart`
- `cd rust && cargo check`