### PR TITLE
Sync Design Tokens

### DIFF
--- a/lib/src/core/layout/app_desktop_shell.dart
+++ b/lib/src/core/layout/app_desktop_shell.dart
@@ -54,7 +54,7 @@ class AppDesktopSidebarSurface extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: backgroundColor ?? Colors.transparent,
-        borderRadius: BorderRadius.circular(AppRadii.small),
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
       ),
       clipBehavior: clipBehavior,
       child: child,
@@ -77,7 +77,7 @@ class AppDesktopPane extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: context.colors.background.ground,
-        borderRadius: BorderRadius.circular(AppRadii.small),
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
       ),
       clipBehavior: Clip.antiAlias,
       padding: padding,
@@ -161,7 +161,7 @@ class AppSidebarUserButton extends StatelessWidget {
       height: 40,
       padding: const EdgeInsets.all(AppSpacing.xs),
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(AppRadii.small),
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
       ),
       child: Row(
         children: [

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -280,7 +280,7 @@ class _SidebarAccountSelectorButton extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
           decoration: BoxDecoration(
             color: backgroundColor,
-            borderRadius: BorderRadius.circular(AppRadii.small),
+            borderRadius: BorderRadius.circular(AppRadii.xSmall),
           ),
           child: Row(
             children: [
@@ -355,10 +355,10 @@ class _SidebarAccountDropdown extends StatelessWidget {
       height: headerHeight + listViewportHeight + footerHeight,
       decoration: BoxDecoration(
         color: colors.surface.input,
-        borderRadius: BorderRadius.circular(AppRadii.small),
-        boxShadow: const [
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
+        boxShadow: [
           BoxShadow(
-            color: Color(0x40000000),
+            color: colors.background.neutralScrim,
             blurRadius: 25,
             spreadRadius: -10,
             offset: Offset(0, 10),

--- a/lib/src/core/theme/app_radii.dart
+++ b/lib/src/core/theme/app_radii.dart
@@ -1,12 +1,17 @@
 /// Corner-radius scale from the Figma token export (Mode 1 / Radii).
 ///
+/// Figma names these `XS / S / SM / M / L / Full`; Dart exposes full words so
+/// callers read like the rest of the design-system API.
+///
 /// [full] is the pill/stadium radius. Flutter's `StadiumBorder` is usually
 /// a better choice than `BorderRadius.circular(AppRadii.full)` since it
 /// adapts automatically to any element height. Keep [full] available for
 /// the few places where a literal radius is more convenient.
 abstract final class AppRadii {
-  static const double small = 8;
+  static const double xSmall = 8;
+  static const double small = 12;
   static const double medium = 16;
-  static const double large = 32;
+  static const double large = 24;
+  static const double xLarge = 32;
   static const double full = 999;
 }

--- a/lib/src/core/theme/app_typography.dart
+++ b/lib/src/core/theme/app_typography.dart
@@ -199,14 +199,14 @@ abstract final class AppTypography {
   // alignment matters: addresses, transaction IDs, mnemonics, hex
   // dumps.
 
-  /// Code M — primary monospace copy (e.g. unified address rows).
+  /// Code M — primary monospace copy (e.g. mnemonic word indices).
   ///
-  /// Geist Mono Medium, 13 / 21 px, letter-spacing 0.
+  /// Geist Mono Medium, 14 / 21 px, letter-spacing 0.
   static const codeMedium = TextStyle(
     fontFamily: 'Geist Mono',
     fontWeight: FontWeight.w500,
-    fontSize: 13,
-    height: 21 / 13,
+    fontSize: 14,
+    height: 21 / 14,
     letterSpacing: 0,
   );
 

--- a/lib/src/core/theme/colors/app_background_colors.dart
+++ b/lib/src/core/theme/colors/app_background_colors.dart
@@ -9,32 +9,67 @@ import '../primitives.dart';
 /// * [base] — Primary content surface, main panels.
 /// * [raised] — Cards, modals, sidebars, drawers.
 /// * [overlay] — Dropdowns, popovers, floating elements.
-/// * [brandCyanSubtle] / [brandCyanStrong] — Brand-accent backgrounds
-///   for cyan-tinted surfaces (info banners, onboarding highlights).
+/// * [neutralScrim] / [neutralSubtleOpacity] / [neutralStrongOpacity] —
+///   Alpha neutral overlays.
+/// * [brandCrimsonSubtle] / [brandCrimsonStrong] — Brand-accent backgrounds.
+/// * [brandCrimsonAlpha] — Alpha brand overlay.
+/// * [utilityDestructiveSubtle] / [utilitySuccessSubtle] / [utilitySuccessStrong]
+///   — Utility backgrounds.
+/// * [utilityDestructiveAlpha] / [utilitySuccessAlpha] — Alpha utility overlays.
 class AppBackgroundColors {
   const AppBackgroundColors({
     required this.ground,
     required this.base,
     required this.raised,
     required this.overlay,
-    required this.brandCyanSubtle,
-    required this.brandCyanStrong,
+    required this.inverse,
+    required this.neutralScrim,
+    required this.neutralSubtleOpacity,
+    required this.neutralStrongOpacity,
+    required this.brandCrimsonSubtle,
+    required this.brandCrimsonStrong,
+    required this.brandCrimsonAlpha,
+    required this.utilityDestructiveSubtle,
+    required this.utilityDestructiveAlpha,
+    required this.utilitySuccessSubtle,
+    required this.utilitySuccessStrong,
+    required this.utilitySuccessAlpha,
   });
 
   final Color ground;
   final Color base;
   final Color raised;
   final Color overlay;
-  final Color brandCyanSubtle;
-  final Color brandCyanStrong;
+  final Color inverse;
+  final Color neutralScrim;
+  final Color neutralSubtleOpacity;
+  final Color neutralStrongOpacity;
+  final Color brandCrimsonSubtle;
+  final Color brandCrimsonStrong;
+  final Color brandCrimsonAlpha;
+  final Color utilityDestructiveSubtle;
+  final Color utilityDestructiveAlpha;
+  final Color utilitySuccessSubtle;
+  final Color utilitySuccessStrong;
+  final Color utilitySuccessAlpha;
 
   static const dark = AppBackgroundColors(
     ground: Primitives.p0Dark,
     base: Primitives.p50Dark,
     raised: Primitives.p100Dark,
     overlay: Primitives.p150Dark,
-    brandCyanSubtle: CyanPrimitives.p0Dark,
-    brandCyanStrong: CyanPrimitives.p300Dark,
+    inverse: Primitives.p800Dark,
+    neutralScrim: Primitives.p400Alpha20Dark,
+    neutralSubtleOpacity: Primitives.p400Alpha35Dark,
+    neutralStrongOpacity: Primitives.p300Alpha50Dark,
+    brandCrimsonSubtle: CrimsonPrimitives.p100Dark,
+    brandCrimsonStrong: CrimsonPrimitives.p400Dark,
+    brandCrimsonAlpha: CrimsonPrimitives.p300Alpha35Dark,
+    utilityDestructiveSubtle: PlumPrimitives.p50Dark,
+    utilityDestructiveAlpha: PlumPrimitives.p400Alpha25Dark,
+    utilitySuccessSubtle: GoldPrimitives.p150Dark,
+    utilitySuccessStrong: GoldPrimitives.p500Dark,
+    utilitySuccessAlpha: GoldPrimitives.p400Alpha25Dark,
   );
 
   static const light = AppBackgroundColors(
@@ -42,7 +77,17 @@ class AppBackgroundColors {
     base: Primitives.p50Light,
     raised: Primitives.p100Light,
     overlay: Primitives.p150Light,
-    brandCyanSubtle: CyanPrimitives.p0Light,
-    brandCyanStrong: CyanPrimitives.p150Light,
+    inverse: Primitives.p800Light,
+    neutralScrim: Primitives.p900Alpha20Light,
+    neutralSubtleOpacity: Primitives.p400Alpha20Light,
+    neutralStrongOpacity: Primitives.p300Alpha35Light,
+    brandCrimsonSubtle: CrimsonPrimitives.p0Light,
+    brandCrimsonStrong: CrimsonPrimitives.p300Light,
+    brandCrimsonAlpha: CrimsonPrimitives.p300Alpha15Light,
+    utilityDestructiveSubtle: PlumPrimitives.p0Light,
+    utilityDestructiveAlpha: PlumPrimitives.p400Alpha15Light,
+    utilitySuccessSubtle: GoldPrimitives.p50Light,
+    utilitySuccessStrong: GoldPrimitives.p300Light,
+    utilitySuccessAlpha: GoldPrimitives.p300Alpha25Light,
   );
 }

--- a/lib/src/core/theme/colors/app_border_colors.dart
+++ b/lib/src/core/theme/colors/app_border_colors.dart
@@ -5,52 +5,54 @@ import '../primitives.dart';
 /// Border / divider weights.
 ///
 /// * [subtle] — Hairline dividers, row separators.
-/// * [regular] — Input fields, cards, chips. (Named `regular` instead of
-///   `default` because `default` is a reserved word in Dart.)
-/// * [strong] — Selected states, active tabs.
+/// * [subtleOpacity] — Alpha border used on strong filled controls.
+/// * [regular] — Default field/card/chip border. (Named `regular` instead of
+///   Figma's `default` because `default` is a reserved word in Dart.)
+/// * [medium] — Active/filled field border.
+/// * [strong] — Max-contrast border.
 /// * [utilityDestructive] — Validation / destructive emphasis.
-/// * [brandCyanSubtle] / [brandCyanStrong] — Brand-accent borders for
-///   cyan-tinted surfaces (info panels, selection on cyan brand pages).
-/// * [brandPurpleStrong] — Brand-purple border for affirmative feedback.
+/// * [utilitySuccess] — Success emphasis.
+/// * [brandCrimsonStrong] — Brand feedback / accent border.
 class AppBorderColors {
   const AppBorderColors({
     required this.subtle,
+    required this.subtleOpacity,
     required this.regular,
+    required this.medium,
     required this.strong,
     required this.utilityDestructive,
-    required this.brandCyanSubtle,
-    required this.brandCyanStrong,
-    required this.brandPurpleStrong,
+    required this.utilitySuccess,
+    required this.brandCrimsonStrong,
   });
 
   final Color subtle;
+  final Color subtleOpacity;
   final Color regular;
+  final Color medium;
   final Color strong;
   final Color utilityDestructive;
-  final Color brandCyanSubtle;
-  final Color brandCyanStrong;
-  final Color brandPurpleStrong;
+  final Color utilitySuccess;
+  final Color brandCrimsonStrong;
 
   static const dark = AppBorderColors(
-    subtle: Primitives.p200Dark,
+    subtle: Primitives.p150Dark,
+    subtleOpacity: Primitives.p900Alpha20Dark,
     regular: Primitives.p300Dark,
-    strong: Primitives.p400Dark,
-    utilityDestructive: YellowPrimitives.p400Dark,
-    brandCyanSubtle: CyanPrimitives.p100Dark,
-    brandCyanStrong: CyanPrimitives.p300Dark,
-    brandPurpleStrong: PurplePrimitives.p400Dark,
+    medium: Primitives.p400Dark,
+    strong: Primitives.p800Dark,
+    utilityDestructive: PlumPrimitives.p400Dark,
+    utilitySuccess: GoldPrimitives.p500Dark,
+    brandCrimsonStrong: CrimsonPrimitives.p400Dark,
   );
 
-  // Light-mode borders sit one step lighter than the symmetric position
-  // their dark counterparts occupy. Per the Figma sRGB token export,
-  // `subtle → P150 / regular → P200 / strong → P300` on the light face.
   static const light = AppBorderColors(
-    subtle: Primitives.p150Light,
+    subtle: Primitives.p100Light,
+    subtleOpacity: Primitives.p0Alpha15Light,
     regular: Primitives.p200Light,
-    strong: Primitives.p300Light,
-    utilityDestructive: YellowPrimitives.p300Light,
-    brandCyanSubtle: CyanPrimitives.p50Light,
-    brandCyanStrong: CyanPrimitives.p150Light,
-    brandPurpleStrong: PurplePrimitives.p150Light,
+    medium: Primitives.p300Light,
+    strong: Primitives.p900Light,
+    utilityDestructive: PlumPrimitives.p300Light,
+    utilitySuccess: GoldPrimitives.p400Light,
+    brandCrimsonStrong: CrimsonPrimitives.p300Light,
   );
 }

--- a/lib/src/core/theme/colors/app_button_colors.dart
+++ b/lib/src/core/theme/colors/app_button_colors.dart
@@ -54,19 +54,19 @@ class AppPrimaryButtonColors {
   final Color label;
 
   static const dark = AppPrimaryButtonColors(
-    bg: Color(0xFF0996A0),
-    bgHover: Color(0xFF3EC4CE),
-    bgPressed: Color(0xFF3EC4CE),
-    border: Color(0x33FFFFFF),
-    label: Color(0xFF041316),
+    bg: CrimsonPrimitives.p300Dark,
+    bgHover: CrimsonPrimitives.p200Dark,
+    bgPressed: CrimsonPrimitives.p200Dark,
+    border: Primitives.p900Alpha20Dark,
+    label: GoldPrimitives.p800Dark,
   );
 
   static const light = AppPrimaryButtonColors(
-    bg: Color(0xFF0996A0),
-    bgHover: Color(0xFF0A7680),
-    bgPressed: Color(0xFF0A7680),
-    border: Color(0x26FFFFFF),
-    label: Color(0xFFE0F3F5),
+    bg: CrimsonPrimitives.p400Light,
+    bgHover: CrimsonPrimitives.p500Light,
+    bgPressed: CrimsonPrimitives.p500Light,
+    border: Primitives.p0Alpha15Light,
+    label: GoldPrimitives.p100Light,
   );
 }
 
@@ -124,7 +124,7 @@ class AppGhostButtonColors {
     bg: Primitives.p0Light,
     bgHover: Primitives.p100Light,
     border: Primitives.p300Light,
-    label: Color(0xFF2E3232),
+    label: Primitives.p800Light,
   );
 }
 
@@ -161,18 +161,18 @@ class AppDestructiveButtonColors {
   final Color label;
 
   static const dark = AppDestructiveButtonColors(
-    bg: Color(0xFFB760C4),
-    bgHover: Color(0xFFCC88D6),
-    bgPressed: Color(0xFFCC88D6),
-    border: Color(0x33FFFFFF),
-    label: Color(0xFF150A17),
+    bg: PlumPrimitives.p400Dark,
+    bgHover: PlumPrimitives.p300Dark,
+    bgPressed: PlumPrimitives.p300Dark,
+    border: Primitives.p900Alpha20Dark,
+    label: PlumPrimitives.p50Dark,
   );
 
   static const light = AppDestructiveButtonColors(
-    bg: Color(0xFFB760C4),
-    bgHover: Color(0xFF93489E),
-    bgPressed: Color(0xFF93489E),
-    border: Color(0x26FFFFFF),
-    label: Color(0xFF211223),
+    bg: PlumPrimitives.p300Light,
+    bgHover: PlumPrimitives.p400Light,
+    bgPressed: PlumPrimitives.p400Light,
+    border: Primitives.p0Alpha15Light,
+    label: PlumPrimitives.p800Light,
   );
 }

--- a/lib/src/core/theme/colors/app_fade_colors.dart
+++ b/lib/src/core/theme/colors/app_fade_colors.dart
@@ -19,5 +19,5 @@ class AppFadeColors {
   // Fully transparent on light mode — keeps the same rgb anchor as the
   // dark face so fade animations between modes don't flicker through a
   // neutral color.
-  static const light = AppFadeColors(illustration: Color(0x00141818));
+  static const light = AppFadeColors(illustration: Primitives.p0Alpha0Dark);
 }

--- a/lib/src/core/theme/colors/app_icon_colors.dart
+++ b/lib/src/core/theme/colors/app_icon_colors.dart
@@ -11,8 +11,11 @@ import '../primitives.dart';
 /// * [disabled] — Icons on disabled controls.
 /// * [inverse] — Icons on inverted surfaces.
 /// * [onPrimary] — Icons placed inside a primary button.
-/// * [warning] — Warning-state icons. Theme-invariant brand yellow.
-/// * [brandPurple] / [brandCyan] — Brand-colored icons.
+/// * [warning] — Caution icons. Backed by the current gold utility token for
+///   compatibility with existing warning call sites.
+/// * [destructive] — Destructive-state icons.
+/// * [success] — Positive / success utility icons.
+/// * [brandCrimson] — Brand-colored icons.
 class AppIconColors {
   const AppIconColors({
     required this.accent,
@@ -22,8 +25,9 @@ class AppIconColors {
     required this.inverse,
     required this.onPrimary,
     required this.warning,
-    required this.brandPurple,
-    required this.brandCyan,
+    required this.destructive,
+    required this.success,
+    required this.brandCrimson,
   });
 
   final Color accent;
@@ -33,8 +37,9 @@ class AppIconColors {
   final Color inverse;
   final Color onPrimary;
   final Color warning;
-  final Color brandPurple;
-  final Color brandCyan;
+  final Color destructive;
+  final Color success;
+  final Color brandCrimson;
 
   static const dark = AppIconColors(
     accent: Primitives.p800Dark,
@@ -43,10 +48,10 @@ class AppIconColors {
     disabled: Primitives.p300Dark,
     inverse: Primitives.p0Dark,
     onPrimary: Primitives.p0Dark,
-    // Matches `text.warning` — same orange across modes.
-    warning: YellowPrimitives.p400Dark,
-    brandPurple: PurplePrimitives.p400Dark,
-    brandCyan: CyanPrimitives.p500Dark,
+    warning: GoldPrimitives.p600Dark,
+    destructive: PlumPrimitives.p400Dark,
+    success: GoldPrimitives.p600Dark,
+    brandCrimson: CrimsonPrimitives.p300Dark,
   );
 
   static const light = AppIconColors(
@@ -56,8 +61,9 @@ class AppIconColors {
     disabled: Primitives.p300Light,
     inverse: Primitives.p0Light,
     onPrimary: Primitives.p0Light,
-    warning: YellowPrimitives.p300Light,
-    brandPurple: PurplePrimitives.p300Light,
-    brandCyan: CyanPrimitives.p150Light,
+    warning: GoldPrimitives.p300Light,
+    destructive: PlumPrimitives.p300Light,
+    success: GoldPrimitives.p300Light,
+    brandCrimson: CrimsonPrimitives.p400Light,
   );
 }

--- a/lib/src/core/theme/colors/app_state_colors.dart
+++ b/lib/src/core/theme/colors/app_state_colors.dart
@@ -4,14 +4,16 @@ import '../primitives.dart';
 
 /// Interaction-state colors.
 ///
-/// [hover] and [pressed] are overlay tints layered over a base surface, not
-/// standalone backgrounds.
+/// [hover] is the alpha overlay layered over a base surface. [pressed] and
+/// [selected] are standalone neutral backgrounds.
+/// [selectedOpacity] is the matching alpha overlay token for selected states
+/// that need to preserve the underlying surface.
 ///
 /// [focusRing] + [focusGap] form the 2dp focus indicator: a ring with max
 /// contrast against the page, separated from the element by a 2dp gap so it
 /// reads cleanly on any surface.
 ///
-/// [focusRingBrand] is the brand-cyan variant used when focusing the
+/// [focusRingBrand] is the brand-crimson variant used when focusing the
 /// primary/accent button so the ring blends with the brand color instead of
 /// contrasting with it.
 class AppStateColors {
@@ -20,6 +22,7 @@ class AppStateColors {
     required this.pressed,
     required this.focus,
     required this.selected,
+    required this.selectedOpacity,
     required this.focusRing,
     required this.focusGap,
     required this.focusRingBrand,
@@ -30,30 +33,33 @@ class AppStateColors {
   final Color pressed;
   final Color focus;
   final Color selected;
+  final Color selectedOpacity;
   final Color focusRing;
   final Color focusGap;
   final Color focusRingBrand;
   final Color focusRingDestructive;
 
   static const dark = AppStateColors(
-    hover: Color(0x594D5252),
+    hover: Primitives.p0Alpha15Dark,
     pressed: Primitives.p150Dark,
     focus: Primitives.p200Dark,
     selected: Primitives.p150Dark,
+    selectedOpacity: Primitives.p0Alpha30Dark,
     focusRing: Primitives.p800Dark,
     focusGap: Primitives.p0Dark,
-    focusRingBrand: Color(0xFF3EC4CE),
-    focusRingDestructive: Color(0xFFCC88D6),
+    focusRingBrand: CrimsonPrimitives.p400Dark,
+    focusRingDestructive: PlumPrimitives.p500Dark,
   );
 
   static const light = AppStateColors(
-    hover: Color(0x33B8B8B8),
+    hover: Primitives.p0Alpha30Light,
     pressed: Primitives.p150Light,
     focus: Primitives.p200Light,
     selected: Primitives.p150Light,
+    selectedOpacity: Primitives.p0Alpha50Light,
     focusRing: Primitives.p900Light,
     focusGap: Primitives.p0Light,
-    focusRingBrand: Color(0xFF56BAC4),
-    focusRingDestructive: Color(0xFF93489E),
+    focusRingBrand: CrimsonPrimitives.p300Light,
+    focusRingDestructive: PlumPrimitives.p400Light,
   );
 }

--- a/lib/src/core/theme/colors/app_text_colors.dart
+++ b/lib/src/core/theme/colors/app_text_colors.dart
@@ -11,9 +11,11 @@ import '../primitives.dart';
 /// * [disabled] — Inactive, unavailable labels.
 /// * [inverse] — Text placed on inverted surfaces (e.g. dark text on a light
 ///   chip inside dark mode).
-/// * [warning] — Inline warning copy. Theme-invariant brand yellow.
+/// * [warning] — Inline caution copy. Backed by the current gold utility
+///   token for compatibility with existing warning call sites.
 /// * [destructive] — Destructive utility copy.
-/// * [brandPurple] / [brandCyan] — Brand-colored inline text accents.
+/// * [success] — Positive / success utility copy.
+/// * [brandCrimson] — Brand-colored inline text accent.
 class AppTextColors {
   const AppTextColors({
     required this.accent,
@@ -24,8 +26,8 @@ class AppTextColors {
     required this.inverse,
     required this.warning,
     required this.destructive,
-    required this.brandPurple,
-    required this.brandCyan,
+    required this.success,
+    required this.brandCrimson,
   });
 
   final Color accent;
@@ -36,23 +38,20 @@ class AppTextColors {
   final Color inverse;
   final Color warning;
   final Color destructive;
-  final Color brandPurple;
-  final Color brandCyan;
+  final Color success;
+  final Color brandCrimson;
 
   static const dark = AppTextColors(
-    accent: Primitives.p800Dark,
+    accent: Primitives.p900Dark,
     primary: Primitives.p700Dark,
     secondary: Primitives.p600Dark,
     muted: Primitives.p500Dark,
     disabled: Primitives.p400Dark,
     inverse: Primitives.p0Dark,
-    // Yellow 400 dark = #FF9617; the same warning hue is mirrored on
-    // the light face via `p300Light`, so the inline warning reads
-    // identically across modes.
-    warning: YellowPrimitives.p400Dark,
-    destructive: Color(0xFFB760C4),
-    brandPurple: PurplePrimitives.p500Dark,
-    brandCyan: CyanPrimitives.p600Dark,
+    warning: GoldPrimitives.p500Dark,
+    destructive: PlumPrimitives.p500Dark,
+    success: GoldPrimitives.p500Dark,
+    brandCrimson: CrimsonPrimitives.p400Dark,
   );
 
   static const light = AppTextColors(
@@ -64,9 +63,9 @@ class AppTextColors {
     muted: Primitives.p500Light,
     disabled: Primitives.p400Light,
     inverse: Primitives.p0Light,
-    warning: YellowPrimitives.p300Light,
-    destructive: Color(0xFF93489E),
-    brandPurple: PurplePrimitives.p300Light,
-    brandCyan: CyanPrimitives.p300Light,
+    warning: GoldPrimitives.p400Light,
+    destructive: PlumPrimitives.p300Light,
+    success: GoldPrimitives.p400Light,
+    brandCrimson: CrimsonPrimitives.p400Light,
   );
 }

--- a/lib/src/core/theme/primitives.dart
+++ b/lib/src/core/theme/primitives.dart
@@ -58,145 +58,209 @@ abstract final class Primitives {
 
   // Primitive/800 — accent / primary button fill.
   static const p800Dark = Color(0xFFE1E1E1);
-  static const p800Light = Color(0xFF393E3E);
+  static const p800Light = Color(0xFF2E3232);
 
   // Primitive/900 — lightest / inverse of ground.
   static const p900Dark = Color(0xFFFFFFFF);
   static const p900Light = Color(0xFF141818);
 
-  // Primitive/0 at 50% alpha — used as a scrim/fade primitive over
-  // illustrations and content that needs to dim into the background.
-  // Mode-invariant by design (the alpha carries the fade, the base
-  // color doesn't flip).
+  // Primitive/Gray/Alpha tokens. These are explicit Figma exports, not
+  // derived at runtime, because a few semantic alpha tokens intentionally
+  // point at different ladder steps per mode.
+  static const p0Alpha0Dark = Color(0x00141818);
+  static const p0Alpha0Light = Color(0x00FFFFFF);
+
+  static const p0Alpha15Dark = Color(0x26141818);
+  static const p0Alpha15Light = Color(0x26FFFFFF);
+
+  static const p0Alpha30Dark = Color(0x4D141818);
+  static const p0Alpha30Light = Color(0x4DFFFFFF);
+
   static const p0Alpha50Dark = Color(0x80141818);
-  static const p0Alpha50Light = Color(0x80141818);
+  static const p0Alpha50Light = Color(0x80FFFFFF);
+
+  static const p300Alpha50Dark = Color(0x804D5252);
+  static const p300Alpha35Light = Color(0x59B8B8B8);
+
+  static const p400Alpha20Dark = Color(0x33626767);
+  static const p400Alpha20Light = Color(0x339A9A9A);
+
+  static const p400Alpha35Dark = Color(0x59626767);
+
+  static const p900Alpha20Dark = Color(0x33FFFFFF);
+  static const p900Alpha20Light = Color(0x33141818);
 }
 
-/// Brand purple primitive ladder (12 steps).
+/// Brand crimson primitive ladder.
 ///
-/// Same mirrored pattern as [Primitives]: `*Dark.p(N)` equals
-/// `*Light.p(900-N)` in every step, so the same semantic token can reference
-/// step N in both modes while yielding mode-appropriate values. Used by the
-/// primary button fill, brand text/icon tokens, and the brand focus ring.
-abstract final class PurplePrimitives {
-  static const p0Dark = Color(0xFF0A0614);
-  static const p0Light = Color(0xFFF7F4FE);
+/// Current primary/accent color family in the Figma design system. Used by
+/// primary buttons, shielded-address feedback, and brand focus rings.
+abstract final class CrimsonPrimitives {
+  static const p0Dark = Color(0xFF0F0709);
+  static const p0Light = Color(0xFFFCF4F6);
 
-  static const p50Dark = Color(0xFF110A1F);
-  static const p50Light = Color(0xFFECE5FB);
+  static const p50Dark = Color(0xFF180A0E);
+  static const p50Light = Color(0xFFF8E2E7);
 
-  static const p100Dark = Color(0xFF1A1030);
-  static const p100Light = Color(0xFFDACCF8);
+  static const p100Dark = Color(0xFF241015);
+  static const p100Light = Color(0xFFF1C2CB);
 
-  static const p150Dark = Color(0xFF251743);
-  static const p150Light = Color(0xFFC5ADF4);
+  static const p150Dark = Color(0xFF36181F);
+  static const p150Light = Color(0xFFE59AA8);
 
-  static const p200Dark = Color(0xFF341F60);
-  static const p200Light = Color(0xFFAF8EF0);
+  static const p200Dark = Color(0xFF8A2D40);
+  static const p200Light = Color(0xFFD67284);
 
-  static const p300Dark = Color(0xFF5530A8);
-  static const p300Light = Color(0xFF9366EB);
+  static const p300Dark = Color(0xFFAE3E55);
+  static const p300Light = Color(0xFFC2546A);
 
-  static const p400Dark = Color(0xFF8F61EA);
-  static const p400Light = Color(0xFF5530A8);
+  static const p400Dark = Color(0xFFC75C72);
+  static const p400Light = Color(0xFFAE3E55);
 
-  static const p500Dark = Color(0xFFAF8EF0);
-  static const p500Light = Color(0xFF341F60);
+  static const p500Dark = Color(0xFFD8829A);
+  static const p500Light = Color(0xFF8A2D40);
 
-  static const p600Dark = Color(0xFFC5ADF4);
-  static const p600Light = Color(0xFF251743);
+  static const p600Dark = Color(0xFFE5A4B5);
+  static const p600Light = Color(0xFF5F1E2C);
 
-  static const p700Dark = Color(0xFFDACCF8);
-  static const p700Light = Color(0xFF1A1030);
+  static const p700Dark = Color(0xFFEFC3CE);
+  static const p700Light = Color(0xFF3D131C);
 
-  static const p800Dark = Color(0xFFECE5FB);
-  static const p800Light = Color(0xFF110A1F);
+  static const p800Dark = Color(0xFFF6DFE5);
+  static const p800Light = Color(0xFF240B11);
 
-  static const p900Dark = Color(0xFFF7F4FE);
-  static const p900Light = Color(0xFF0A0614);
+  static const p900Dark = Color(0xFFFCF4F6);
+  static const p900Light = Color(0xFF0F0709);
+
+  static const p300Alpha35Dark = Color(0x59AE3E55);
+  static const p300Alpha15Light = Color(0x26C2546A);
 }
 
-/// Brand cyan primitive ladder (12 steps).
+/// Utility plum primitive ladder.
 ///
-/// Same mirrored structure as [PurplePrimitives]. Used by brand text/icon
-/// tokens; not used by buttons or focus rings in the current design.
-abstract final class CyanPrimitives {
-  static const p0Dark = Color(0xFF00151A);
-  static const p0Light = Color(0xFFEBFDFF);
+/// Used for destructive actions and validation errors.
+abstract final class PlumPrimitives {
+  static const p0Dark = Color(0xFF0B060D);
+  static const p0Light = Color(0xFFF6EDF8);
 
-  static const p50Dark = Color(0xFF001E23);
-  static const p50Light = Color(0xFF7DE0EA);
+  static const p50Dark = Color(0xFF2D1835);
+  static const p50Light = Color(0xFFE2CBE6);
 
-  static const p100Dark = Color(0xFF002B32);
-  static const p100Light = Color(0xFF00CEDE);
+  static const p100Dark = Color(0xFF492B54);
+  static const p100Light = Color(0xFFC598CD);
 
-  static const p150Dark = Color(0xFF003B45);
-  static const p150Light = Color(0xFF00B8CF);
+  static const p150Dark = Color(0xFF583465);
+  static const p150Light = Color(0xFFB67CC0);
 
-  static const p200Dark = Color(0xFF00505E);
-  static const p200Light = Color(0xFF00A1BC);
+  static const p200Dark = Color(0xFF6C4077);
+  static const p200Light = Color(0xFFAC6CB7);
 
-  static const p300Dark = Color(0xFF00738A);
-  static const p300Light = Color(0xFF0092AF);
+  static const p300Dark = Color(0xFF854E91);
+  static const p300Light = Color(0xFF9A59A6);
 
-  static const p400Dark = Color(0xFF0092AF);
-  static const p400Light = Color(0xFF00738A);
+  static const p400Dark = Color(0xFF9A59A6);
+  static const p400Light = Color(0xFF854E91);
 
-  static const p500Dark = Color(0xFF00A1BC);
-  static const p500Light = Color(0xFF00505E);
+  static const p500Dark = Color(0xFFAC6CB7);
+  static const p500Light = Color(0xFF6C4077);
 
-  static const p600Dark = Color(0xFF00B8CF);
-  static const p600Light = Color(0xFF003B45);
+  static const p600Dark = Color(0xFFB67CC0);
+  static const p600Light = Color(0xFF583465);
 
-  static const p700Dark = Color(0xFF00CEDE);
-  static const p700Light = Color(0xFF002B32);
+  static const p700Dark = Color(0xFFC598CD);
+  static const p700Light = Color(0xFF492B54);
 
-  static const p800Dark = Color(0xFF7DE0EA);
-  static const p800Light = Color(0xFF001E23);
+  static const p800Dark = Color(0xFFE2CBE6);
+  static const p800Light = Color(0xFF2D1835);
 
-  static const p900Dark = Color(0xFFEBFDFF);
-  static const p900Light = Color(0xFF00151A);
+  static const p900Dark = Color(0xFFF6EDF8);
+  static const p900Light = Color(0xFF0B060D);
+
+  static const p400Alpha25Dark = Color(0x40B760C4);
+  static const p400Alpha15Light = Color(0x26854E91);
 }
 
-/// Brand yellow primitive ladder (12 steps).
+/// Utility gold primitive ladder.
 ///
-/// Same mirrored structure as [PurplePrimitives] / [CyanPrimitives].
-/// Used by warning text/icon tokens; reserved for future warning
-/// surfaces/borders.
-abstract final class YellowPrimitives {
-  static const p0Dark = Color(0xFF1A0E00);
-  static const p0Light = Color(0xFFFFF8EC);
+/// Used by the current Figma success/warning utility tokens.
+abstract final class GoldPrimitives {
+  static const p0Dark = Color(0xFF0E0905);
+  static const p0Light = Color(0xFFFCF8F2);
 
-  static const p50Dark = Color(0xFF231400);
-  static const p50Light = Color(0xFFFEEFD4);
+  static const p50Dark = Color(0xFF180F08);
+  static const p50Light = Color(0xFFF8EDDA);
 
-  static const p100Dark = Color(0xFF331D00);
-  static const p100Light = Color(0xFFFDD9A0);
+  static const p100Dark = Color(0xFF241810);
+  static const p100Light = Color(0xFFF2DCB8);
 
-  static const p150Dark = Color(0xFF4A2900);
-  static const p150Light = Color(0xFFFCBF5C);
+  static const p150Dark = Color(0xFF36251A);
+  static const p150Light = Color(0xFFEAC890);
 
-  static const p200Dark = Color(0xFF663800);
-  static const p200Light = Color(0xFFFFA832);
+  static const p200Dark = Color(0xFF4D3624);
+  static const p200Light = Color(0xFFDDB37A);
 
-  static const p300Dark = Color(0xFF994F00);
-  static const p300Light = Color(0xFFFF9617);
+  static const p300Dark = Color(0xFF6E4E33);
+  static const p300Light = Color(0xFFCD9F64);
 
-  static const p400Dark = Color(0xFFFF9617);
-  static const p400Light = Color(0xFFE07800);
+  static const p400Dark = Color(0xFF956B45);
+  static const p400Light = Color(0xFFB0844F);
 
-  static const p500Dark = Color(0xFFFFAD47);
-  static const p500Light = Color(0xFF994F00);
+  static const p500Dark = Color(0xFFCD9F64);
+  static const p500Light = Color(0xFF956B45);
 
-  static const p600Dark = Color(0xFFFFC470);
-  static const p600Light = Color(0xFF663800);
+  static const p600Dark = Color(0xFFDDB37A);
+  static const p600Light = Color(0xFF6E4E33);
 
-  static const p700Dark = Color(0xFFFFD99F);
-  static const p700Light = Color(0xFF4A2900);
+  static const p700Dark = Color(0xFFEAC890);
+  static const p700Light = Color(0xFF4D3624);
 
-  static const p800Dark = Color(0xFFFEEFD4);
-  static const p800Light = Color(0xFF331D00);
+  static const p800Dark = Color(0xFFF5E0B8);
+  static const p800Light = Color(0xFF241810);
 
-  static const p900Dark = Color(0xFFFFF8EC);
-  static const p900Light = Color(0xFF1A0E00);
+  static const p900Dark = Color(0xFFFCF8F2);
+  static const p900Light = Color(0xFF0E0905);
+
+  static const p400Alpha25Dark = Color(0x40956B45);
+  static const p300Alpha25Light = Color(0x40CD9F64);
+}
+
+/// Utility green primitive ladder.
+///
+/// Reserved for positive states that need an explicitly green affordance.
+abstract final class GreenPrimitives {
+  static const p0Dark = Color(0xFF031203);
+  static const p0Light = Color(0xFFF0FAF0);
+
+  static const p50Dark = Color(0xFF071A07);
+  static const p50Light = Color(0xFFE9FBE9);
+
+  static const p100Dark = Color(0xFF0D270D);
+  static const p100Light = Color(0xFFB8E8B8);
+
+  static const p150Dark = Color(0xFF153815);
+  static const p150Light = Color(0xFF92D892);
+
+  static const p200Dark = Color(0xFF1E4F1E);
+  static const p200Light = Color(0xFF6BCC6B);
+
+  static const p300Dark = Color(0xFF2D7A2D);
+  static const p300Light = Color(0xFF47BE47);
+
+  static const p400Dark = Color(0xFF47BE47);
+  static const p400Light = Color(0xFF2D7A2D);
+
+  static const p500Dark = Color(0xFF6BCC6B);
+  static const p500Light = Color(0xFF1E4F1E);
+
+  static const p600Dark = Color(0xFF92D892);
+  static const p600Light = Color(0xFF153815);
+
+  static const p700Dark = Color(0xFFB8E8B8);
+  static const p700Light = Color(0xFF0D270D);
+
+  static const p800Dark = Color(0xFFE9FBE9);
+  static const p800Light = Color(0xFF071A07);
+
+  static const p900Dark = Color(0xFFF0FAF0);
+  static const p900Light = Color(0xFF031203);
 }

--- a/lib/src/core/widgets/app_button.dart
+++ b/lib/src/core/widgets/app_button.dart
@@ -103,7 +103,7 @@ _VariantPalette _paletteFor(AppButtonVariant variant, AppColors c) {
         bg: c.button.secondary.bg,
         bgHover: c.button.secondary.bgHover,
         bgPressed: c.button.secondary.bgPressed,
-        border: const Color(0x00000000),
+        border: c.background.ground.withValues(alpha: 0),
         borderWidth: 0,
         label: c.button.secondary.label,
         focusRing: c.state.focusRing,
@@ -112,10 +112,10 @@ _VariantPalette _paletteFor(AppButtonVariant variant, AppColors c) {
       // Ghost's visible base is transparent regardless of the nominal token
       // value — that way it composes correctly over any surface.
       return _VariantPalette(
-        bg: const Color(0x00000000),
+        bg: c.background.ground.withValues(alpha: 0),
         bgHover: c.button.ghost.bgHover,
         bgPressed: c.button.ghost.bgHover,
-        border: const Color(0x00000000),
+        border: c.background.ground.withValues(alpha: 0),
         borderWidth: 0,
         label: c.button.ghost.label,
         focusRing: c.state.focusRing,

--- a/lib/src/core/widgets/app_button.dart
+++ b/lib/src/core/widgets/app_button.dart
@@ -245,14 +245,17 @@ class _AppButtonState extends State<AppButton> {
         )
         ..add(SizedBox(width: sizing.gap));
     }
+    final label = DefaultTextStyle.merge(
+      style: sizing.labelStyle.copyWith(color: labelColor),
+      child: widget.child,
+    );
     rowChildren.add(
-      Padding(
-        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
-        child: DefaultTextStyle.merge(
-          style: sizing.labelStyle.copyWith(color: labelColor),
-          child: widget.child,
-        ),
-      ),
+      widget.size == AppButtonSize.small
+          ? label
+          : Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+              child: label,
+            ),
     );
     if (widget.trailing != null) {
       rowChildren

--- a/lib/src/core/widgets/app_text_field.dart
+++ b/lib/src/core/widgets/app_text_field.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 import '../theme/app_theme.dart';
 import 'app_icon.dart';
 
-enum AppTextFieldTone { neutral, destructive, brandPurple }
+enum AppTextFieldTone { neutral, destructive, brandCrimson }
 
 class AppTextField extends StatefulWidget {
   const AppTextField({
@@ -250,12 +250,17 @@ class _AppTextFieldState extends State<AppTextField> {
     final resolvedHintStyle = hintStyle.copyWith(
       color: hintStyle.color ?? defaultHintStyle.color,
     );
-    final iconColor = _hasText || _isFocused
+    final neutralIconColor = _hasText || _isFocused
         ? colors.icon.accent
         : colors.icon.regular;
+    final leadingIconColor = switch (widget.tone) {
+      AppTextFieldTone.neutral => neutralIconColor,
+      AppTextFieldTone.destructive => colors.icon.destructive,
+      AppTextFieldTone.brandCrimson => colors.icon.brandCrimson,
+    };
     final gap = _multiline ? AppSpacing.xs : AppSpacing.xxs;
     final shellHeight = _multiline ? 148.0 : 46.0;
-    const shellRadius = 12.0;
+    const shellRadius = AppRadii.small;
     const focusRingWidth = 3.0;
     const focusRingStrokeWidth = 2.0;
     final useFixedSlotLayout =
@@ -274,20 +279,22 @@ class _AppTextFieldState extends State<AppTextField> {
 
     final isNeutralTone = widget.tone == AppTextFieldTone.neutral;
     final borderColor = switch (widget.tone) {
-      AppTextFieldTone.neutral when _isFocused => colors.border.strong,
+      AppTextFieldTone.neutral when _isFocused || _hasText =>
+        colors.border.medium,
+      AppTextFieldTone.neutral when _hovered => colors.border.regular,
       AppTextFieldTone.neutral => colors.border.subtle,
       AppTextFieldTone.destructive => colors.border.utilityDestructive,
-      AppTextFieldTone.brandPurple => colors.border.brandPurpleStrong,
+      AppTextFieldTone.brandCrimson => colors.border.brandCrimsonStrong,
     };
     final focusRingColor = switch (widget.tone) {
       AppTextFieldTone.neutral => colors.state.focusRing,
       AppTextFieldTone.destructive => colors.border.utilityDestructive,
-      AppTextFieldTone.brandPurple => colors.border.brandPurpleStrong,
+      AppTextFieldTone.brandCrimson => colors.border.brandCrimsonStrong,
     };
     final messageColor = switch (widget.tone) {
       AppTextFieldTone.neutral => colors.text.secondary,
-      AppTextFieldTone.destructive => colors.text.warning,
-      AppTextFieldTone.brandPurple => colors.text.brandPurple,
+      AppTextFieldTone.destructive => colors.text.destructive,
+      AppTextFieldTone.brandCrimson => colors.text.brandCrimson,
     };
     final defaultMessageIcon = switch (widget.tone) {
       AppTextFieldTone.neutral => null,
@@ -296,7 +303,7 @@ class _AppTextFieldState extends State<AppTextField> {
         size: AppIconSize.medium,
         color: messageColor,
       ),
-      AppTextFieldTone.brandPurple => AppIcon(
+      AppTextFieldTone.brandCrimson => AppIcon(
         AppIcons.shieldKeyhole,
         size: AppIconSize.medium,
         color: messageColor,
@@ -311,7 +318,7 @@ class _AppTextFieldState extends State<AppTextField> {
         ? GestureDetector(
             behavior: HitTestBehavior.opaque,
             onTap: _clear,
-            child: AppIcon(AppIcons.cross, size: 20, color: iconColor),
+            child: AppIcon(AppIcons.cross, size: 20, color: neutralIconColor),
           )
         : widget.trailing;
 
@@ -440,7 +447,7 @@ class _AppTextFieldState extends State<AppTextField> {
               Positioned.fill(
                 child: IconTheme.merge(
                   data: IconThemeData(
-                    color: iconColor,
+                    color: neutralIconColor,
                     size: AppIconSize.large,
                   ),
                   child: _multiline
@@ -459,7 +466,7 @@ class _AppTextFieldState extends State<AppTextField> {
                                     alignment: Alignment.centerLeft,
                                     child: IconTheme.merge(
                                       data: IconThemeData(
-                                        color: iconColor,
+                                        color: leadingIconColor,
                                         size: 20,
                                       ),
                                       child: SizedBox(
@@ -509,10 +516,16 @@ class _AppTextFieldState extends State<AppTextField> {
                                 height: shellHeight,
                                 child: Align(
                                   alignment: Alignment.centerRight,
-                                  child: SizedBox(
-                                    width: 20,
-                                    height: 20,
-                                    child: widget.leading,
+                                  child: IconTheme.merge(
+                                    data: IconThemeData(
+                                      color: leadingIconColor,
+                                      size: 20,
+                                    ),
+                                    child: SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: widget.leading,
+                                    ),
                                   ),
                                 ),
                               ),
@@ -556,10 +569,16 @@ class _AppTextFieldState extends State<AppTextField> {
                             crossAxisAlignment: CrossAxisAlignment.center,
                             children: [
                               if (widget.leading != null)
-                                SizedBox(
-                                  width: AppIconSize.large,
-                                  height: AppIconSize.large,
-                                  child: widget.leading,
+                                IconTheme.merge(
+                                  data: IconThemeData(
+                                    color: leadingIconColor,
+                                    size: AppIconSize.large,
+                                  ),
+                                  child: SizedBox(
+                                    width: AppIconSize.large,
+                                    height: AppIconSize.large,
+                                    child: widget.leading,
+                                  ),
                                 ),
                               if (widget.leading != null)
                                 const SizedBox(width: AppSpacing.xs),

--- a/lib/src/core/widgets/password_text_field.dart
+++ b/lib/src/core/widgets/password_text_field.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/widgets.dart';
 
-import '../theme/app_theme.dart';
 import 'app_icon.dart';
 import 'app_text_field.dart';
 
@@ -75,11 +74,7 @@ class _PasswordTextFieldState extends State<PasswordTextField> {
       inputHorizontalPadding: widget.inputHorizontalPadding,
       inputBottomPadding: widget.inputBottomPadding,
       tone: widget.tone,
-      leading: AppIcon(
-        AppIcons.lock,
-        size: 20,
-        color: context.colors.icon.accent,
-      ),
+      leading: const AppIcon(AppIcons.lock, size: 20),
       trailing: widget.showVisibilityToggle
           ? GestureDetector(
               behavior: HitTestBehavior.opaque,

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart'
-    show
-        CircularProgressIndicator,
-        Scrollbar,
-        Theme;
+    show CircularProgressIndicator, Scrollbar, Theme;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -390,11 +387,11 @@ class _HomePaneState extends State<_HomePane> {
           leadingBackgroundColor: colors.background.base,
           leadingIconColor: isIncoming
               ? colors.icon.accent
-              : colors.icon.brandPurple,
+              : colors.icon.brandCrimson,
           subIconName: isPending ? AppIcons.loader : null,
           subIconBackgroundColor: isPending
               ? colors.background.overlay.withValues(alpha: 0.5)
-              : colors.background.brandCyanStrong,
+              : colors.background.brandCrimsonStrong,
           amountText: widget.formatSignedZec(
             BigInt.from(tx.accountBalanceDelta),
           ),
@@ -402,7 +399,7 @@ class _HomePaneState extends State<_HomePane> {
               ? colors.text.muted
               : isIncoming
               ? colors.text.accent
-              : colors.text.brandPurple,
+              : colors.text.brandCrimson,
         ),
       );
     }
@@ -533,7 +530,7 @@ class _HomeBalanceCard extends StatelessWidget {
                             children: [
                               _HomeBalanceShieldIcon(
                                 isDark: isDark,
-                                iconColor: colors.icon.brandPurple,
+                                iconColor: colors.icon.brandCrimson,
                               ),
                               const SizedBox(width: AppSpacing.xxs),
                               Text(
@@ -710,7 +707,7 @@ class _HomeNoticeCard extends StatelessWidget {
       padding: const EdgeInsets.all(AppSpacing.xs),
       decoration: BoxDecoration(
         color: colors.background.base,
-        borderRadius: BorderRadius.circular(AppRadii.small),
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
       ),
       child: Row(
         children: [
@@ -862,7 +859,7 @@ class _HomeActivityRow extends StatelessWidget {
       height: 40,
       padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(AppRadii.small),
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
       ),
       child: Row(
         children: [
@@ -888,7 +885,7 @@ class _HomeActivityRow extends StatelessWidget {
                         style: AppTypography.labelMedium.copyWith(
                           color: row.subtitleIconName == null
                               ? colors.text.secondary
-                              : colors.text.brandPurple,
+                              : colors.text.brandCrimson,
                         ),
                       ),
                       if (row.subtitleIconName != null) ...[
@@ -896,7 +893,7 @@ class _HomeActivityRow extends StatelessWidget {
                         AppIcon(
                           row.subtitleIconName!,
                           size: 16,
-                          color: colors.icon.brandPurple,
+                          color: colors.icon.brandCrimson,
                         ),
                       ],
                     ],
@@ -964,7 +961,7 @@ class _ActivityAvatar extends StatelessWidget {
                 height: 16,
                 decoration: BoxDecoration(
                   color: row.subIconBackgroundColor,
-                  borderRadius: BorderRadius.circular(AppRadii.small),
+                  borderRadius: BorderRadius.circular(AppRadii.xSmall),
                 ),
                 child: Center(
                   child: AppIcon(

--- a/lib/src/features/onboarding/create/address_types_screen.dart
+++ b/lib/src/features/onboarding/create/address_types_screen.dart
@@ -109,7 +109,7 @@ class _HeroBlock extends StatelessWidget {
               TextSpan(
                 text: 'Privacy',
                 style: bodyStyle.copyWith(
-                  color: colors.text.brandPurple,
+                  color: colors.text.brandCrimson,
                   fontWeight: FontWeight.w500,
                 ),
               ),
@@ -171,14 +171,14 @@ class _ShieldedAddressCard extends StatelessWidget {
             TextSpan(
               text: 'u1',
               style: AppTypography.bodyMediumStrong.copyWith(
-                color: colors.text.brandPurple,
+                color: colors.text.brandCrimson,
               ),
             ),
             const TextSpan(text: ' (or '),
             TextSpan(
               text: 'zs',
               style: AppTypography.bodyMediumStrong.copyWith(
-                color: colors.text.brandPurple,
+                color: colors.text.brandCrimson,
               ),
             ),
             const TextSpan(text: ' for legacy).\n'),
@@ -274,7 +274,7 @@ class _PreviewImage extends StatelessWidget {
     return Container(
       height: 96,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(AppRadii.small),
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
       ),
       clipBehavior: Clip.antiAlias,
       child: Image.asset(

--- a/lib/src/features/onboarding/create/intro_zcash_screen.dart
+++ b/lib/src/features/onboarding/create/intro_zcash_screen.dart
@@ -174,7 +174,10 @@ class _VizorLogo extends StatelessWidget {
       height: 28,
       child: SvgPicture.asset(
         'assets/icons/vizor_logo.svg',
-        colorFilter: ColorFilter.mode(colors.text.brandPurple, BlendMode.srcIn),
+        colorFilter: ColorFilter.mode(
+          colors.text.brandCrimson,
+          BlendMode.srcIn,
+        ),
       ),
     );
   }

--- a/lib/src/features/onboarding/create/things_to_know_screen.dart
+++ b/lib/src/features/onboarding/create/things_to_know_screen.dart
@@ -185,7 +185,7 @@ class _InfoColumn extends StatelessWidget {
               ),
             ),
             const SizedBox(width: AppSpacing.xxs),
-            AppIcon(iconName, size: 20, color: colors.text.brandPurple),
+            AppIcon(iconName, size: 20, color: colors.text.brandCrimson),
           ],
         ),
         const SizedBox(height: AppSpacing.sm),

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -300,7 +300,7 @@ class _ImportSecretPassphraseScreenState
                                 Text(
                                   _errorText!,
                                   style: AppTypography.bodyMedium.copyWith(
-                                    color: colors.text.warning,
+                                    color: colors.text.destructive,
                                   ),
                                   textAlign: TextAlign.center,
                                 ),
@@ -452,15 +452,17 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
     );
     final borderColor = widget.destructive
         ? colors.border.utilityDestructive
+        : _hovered && !isFocused && !hasText
+        ? colors.border.regular
         : isFocused
-        ? colors.border.strong
+        ? colors.border.medium
         : colors.border.subtle;
     final focusRingColor = widget.destructive
         ? colors.border.utilityDestructive
         : colors.state.focusRing;
 
     final numberColor = widget.destructive
-        ? colors.text.warning
+        ? colors.text.destructive
         : hasText || isFocused
         ? colors.text.accent
         : colors.text.secondary;
@@ -503,7 +505,7 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
                   child: DecoratedBox(
                     decoration: BoxDecoration(
                       color: colors.surface.input,
-                      borderRadius: BorderRadius.circular(AppRadii.small),
+                      borderRadius: BorderRadius.circular(AppRadii.xSmall),
                       border: Border.all(
                         color: borderColor,
                         width: hasText || isFocused || widget.destructive
@@ -522,7 +524,7 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
                     child: DecoratedBox(
                       decoration: BoxDecoration(
                         color: colors.state.hover,
-                        borderRadius: BorderRadius.circular(AppRadii.small),
+                        borderRadius: BorderRadius.circular(AppRadii.xSmall),
                       ),
                     ),
                   ),

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -191,7 +191,7 @@ class _ImportWalletBirthdayScreenState
         final baseTheme = material.Theme.of(context);
         final theme = baseTheme.copyWith(
           colorScheme: baseTheme.colorScheme.copyWith(
-            primary: colors.border.brandPurpleStrong,
+            primary: colors.border.brandCrimsonStrong,
             onPrimary: colors.text.inverse,
             surface: colors.background.ground,
             onSurface: colors.text.accent,
@@ -201,11 +201,11 @@ class _ImportWalletBirthdayScreenState
           ),
           datePickerTheme: material.DatePickerThemeData(
             backgroundColor: colors.background.ground,
-            surfaceTintColor: const Color(0x00000000),
-            shadowColor: const Color(0x33000000),
+            surfaceTintColor: colors.background.ground.withValues(alpha: 0),
+            shadowColor: colors.background.neutralScrim,
             dividerColor: colors.border.subtle.withValues(alpha: 0.2),
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(AppRadii.large),
+              borderRadius: BorderRadius.circular(AppRadii.xLarge),
             ),
             headerForegroundColor: colors.text.accent,
             headerBackgroundColor: colors.background.ground,
@@ -233,7 +233,7 @@ class _ImportWalletBirthdayScreenState
               states,
             ) {
               if (states.contains(material.WidgetState.selected)) {
-                return colors.border.brandPurpleStrong;
+                return colors.border.brandCrimsonStrong;
               }
               return null;
             }),
@@ -249,7 +249,7 @@ class _ImportWalletBirthdayScreenState
               states,
             ) {
               if (states.contains(material.WidgetState.selected)) {
-                return colors.border.brandPurpleStrong;
+                return colors.border.brandCrimsonStrong;
               }
               return null;
             }),
@@ -696,15 +696,15 @@ class _BlockHeightField extends StatelessWidget {
     final borderColor = hasError
         ? colors.border.utilityDestructive
         : focusNode.hasFocus
-        ? colors.border.strong
+        ? colors.border.medium
         : colors.border.subtle;
 
     return Container(
       width: width,
       height: 46,
       decoration: BoxDecoration(
-        color: colors.background.base,
-        borderRadius: BorderRadius.circular(AppRadii.medium),
+        color: colors.surface.input,
+        borderRadius: BorderRadius.circular(AppRadii.small),
         border: Border.all(color: borderColor, width: 1.5),
       ),
       child: Row(
@@ -715,7 +715,7 @@ class _BlockHeightField extends StatelessWidget {
               child: AppIcon(
                 AppIcons.block,
                 size: 20,
-                color: hasError ? colors.text.warning : colors.icon.accent,
+                color: hasError ? colors.icon.destructive : colors.icon.accent,
               ),
             ),
           ),
@@ -758,13 +758,13 @@ class _InlineMessage extends StatelessWidget {
     final colors = context.colors;
     return Row(
       children: [
-        AppIcon(AppIcons.warning, size: 16, color: colors.text.warning),
+        AppIcon(AppIcons.warning, size: 16, color: colors.text.destructive),
         const SizedBox(width: AppSpacing.xxs),
         Expanded(
           child: Text(
             text!,
             style: AppTypography.labelMedium.copyWith(
-              color: colors.text.warning,
+              color: colors.text.destructive,
             ),
           ),
         ),

--- a/lib/src/features/onboarding/lost_password_screen.dart
+++ b/lib/src/features/onboarding/lost_password_screen.dart
@@ -154,7 +154,7 @@ class _LostPasswordPane extends StatelessWidget {
       height: double.infinity,
       decoration: BoxDecoration(
         color: colors.background.ground,
-        borderRadius: BorderRadius.circular(AppRadii.small),
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
       ),
       clipBehavior: Clip.antiAlias,
       child: LayoutBuilder(

--- a/lib/src/features/onboarding/shared/set_password_screen.dart
+++ b/lib/src/features/onboarding/shared/set_password_screen.dart
@@ -295,7 +295,7 @@ class _SetPasswordContent extends StatelessWidget {
                         child: Text(
                           submitError!,
                           style: AppTypography.bodyMedium.copyWith(
-                            color: colors.text.warning,
+                            color: colors.text.destructive,
                           ),
                           textAlign: TextAlign.center,
                         ),

--- a/lib/src/features/onboarding/unlock_screen.dart
+++ b/lib/src/features/onboarding/unlock_screen.dart
@@ -139,7 +139,7 @@ class _UnlockPane extends StatelessWidget {
       height: double.infinity,
       decoration: BoxDecoration(
         color: colors.background.ground,
-        borderRadius: BorderRadius.circular(AppRadii.small),
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
       ),
       clipBehavior: Clip.antiAlias,
       child: LayoutBuilder(
@@ -204,8 +204,6 @@ class _UnlockContent extends StatelessWidget {
   static const double _contentWidth = 256;
   static const double _titleWidth = 347;
   static const double _fieldGroupHeight = 66;
-  static const Color _fieldErrorIconColor = Color(0xFFB760C4);
-  static const Color _fieldErrorTextColor = Color(0xFF93489E);
 
   @override
   Widget build(BuildContext context) {
@@ -261,17 +259,9 @@ class _UnlockContent extends StatelessWidget {
                       controller: passwordController,
                       autofocus: false,
                       messageText: messageText,
-                      messageIcon: const AppIcon(
-                        AppIcons.warning,
-                        size: AppIconSize.medium,
-                        color: _fieldErrorIconColor,
-                      ),
-                      messageStyle: AppTypography.labelMedium.copyWith(
-                        color: _fieldErrorTextColor,
-                      ),
                       tone: messageText == null
                           ? AppTextFieldTone.neutral
-                          : AppTextFieldTone.brandPurple,
+                          : AppTextFieldTone.destructive,
                       onChanged: (_) => onChanged(),
                       onSubmitted: (_) => onSubmit(),
                     ),

--- a/lib/src/features/onboarding/welcome.dart
+++ b/lib/src/features/onboarding/welcome.dart
@@ -123,7 +123,7 @@ class _Pane extends StatelessWidget {
       height: double.infinity,
       decoration: BoxDecoration(
         color: colors.background.ground,
-        borderRadius: BorderRadius.circular(AppRadii.small),
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
       ),
       clipBehavior: Clip.antiAlias,
       // OverflowBox with tight canvas-sized constraints parks the

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -118,7 +118,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
       TextSpan(
         text: prefix,
         style: AppTypography.labelLarge.copyWith(
-          color: colors.text.brandPurple,
+          color: colors.text.brandCrimson,
         ),
       ),
       TextSpan(
@@ -129,7 +129,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
         TextSpan(
           text: suffix,
           style: AppTypography.labelLarge.copyWith(
-            color: colors.text.brandPurple,
+            color: colors.text.brandCrimson,
           ),
         ),
     ];
@@ -400,7 +400,7 @@ class _SendReviewStatusBadge extends StatelessWidget {
         Text(
           isShielded ? 'Shielded' : 'Transparent',
           style: AppTypography.labelLarge.copyWith(
-            color: isShielded ? colors.text.brandPurple : colors.text.muted,
+            color: isShielded ? colors.text.brandCrimson : colors.text.muted,
           ),
         ),
         const SizedBox(width: AppSpacing.xxs),
@@ -491,7 +491,7 @@ class _SendShieldedBadgeIcon extends StatelessWidget {
           AppIcon(
             AppIcons.shieldKeyhole,
             size: 16,
-            color: colors.text.brandPurple,
+            color: colors.text.brandCrimson,
           ),
         ],
       ),

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -444,7 +444,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     final colors = context.colors;
 
     final addressTone = switch (_addressType) {
-      'unified' || 'sapling' => AppTextFieldTone.brandPurple,
+      'unified' || 'sapling' => AppTextFieldTone.brandCrimson,
       'invalid' || 'error' => AppTextFieldTone.destructive,
       _ => AppTextFieldTone.neutral,
     };
@@ -459,12 +459,12 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       'unified' || 'sapling' => AppIcon(
         AppIcons.shieldKeyhole,
         size: 16,
-        color: colors.text.brandPurple,
+        color: colors.text.brandCrimson,
       ),
       'invalid' || 'error' => AppIcon(
         AppIcons.warning,
         size: 16,
-        color: colors.text.warning,
+        color: colors.text.destructive,
       ),
       'transparent' => AppIcon(
         AppIcons.eye,
@@ -491,7 +491,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
               child: Text(
                 'Error: $err',
                 style: AppTypography.bodyMedium.copyWith(
-                  color: context.colors.text.warning,
+                  color: context.colors.text.destructive,
                 ),
               ),
             ),
@@ -611,8 +611,9 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                                   ? AppIcon(
                                                       AppIcons.warning,
                                                       size: 16,
-                                                      color:
-                                                          colors.text.warning,
+                                                      color: colors
+                                                          .text
+                                                          .destructive,
                                                     )
                                                   : null,
                                               keyboardType:
@@ -706,8 +707,9 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                                     ? AppIcon(
                                                         AppIcons.warning,
                                                         size: 16,
-                                                        color:
-                                                            colors.text.warning,
+                                                        color: colors
+                                                            .text
+                                                            .destructive,
                                                       )
                                                     : null,
                                                 minLines: 6,
@@ -923,13 +925,17 @@ class _SendGlobalError extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        AppIcon(AppIcons.warning, size: 16, color: context.colors.text.warning),
+        AppIcon(
+          AppIcons.warning,
+          size: 16,
+          color: context.colors.text.destructive,
+        ),
         const SizedBox(width: AppSpacing.xxs),
         Expanded(
           child: Text(
             message,
             style: AppTypography.labelMedium.copyWith(
-              color: context.colors.text.warning,
+              color: context.colors.text.destructive,
             ),
           ),
         ),

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -165,7 +165,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
       TextSpan(
         text: prefix,
         style: AppTypography.labelLarge.copyWith(
-          color: colors.text.brandPurple,
+          color: colors.text.brandCrimson,
         ),
       ),
       TextSpan(
@@ -176,7 +176,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
         TextSpan(
           text: suffix,
           style: AppTypography.labelLarge.copyWith(
-            color: colors.text.brandPurple,
+            color: colors.text.brandCrimson,
           ),
         ),
     ];
@@ -703,8 +703,8 @@ class _SendStatusHeadline extends StatelessWidget {
     };
     final labelColor = switch (phase) {
       _SendStatusPhase.sending => colors.text.accent,
-      _SendStatusPhase.succeeded => const Color(0xFF47BE47),
-      _SendStatusPhase.failed => colors.text.warning,
+      _SendStatusPhase.succeeded => colors.text.success,
+      _SendStatusPhase.failed => colors.text.destructive,
     };
 
     return Column(
@@ -808,13 +808,17 @@ class _SendStatusFailureMessage extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        AppIcon(AppIcons.warning, size: 16, color: context.colors.text.warning),
+        AppIcon(
+          AppIcons.warning,
+          size: 16,
+          color: context.colors.text.destructive,
+        ),
         const SizedBox(width: AppSpacing.xxs),
         Expanded(
           child: Text(
             message,
             style: AppTypography.labelMedium.copyWith(
-              color: context.colors.text.warning,
+              color: context.colors.text.destructive,
             ),
           ),
         ),

--- a/lib/widgetbook/color_swatch.dart
+++ b/lib/widgetbook/color_swatch.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../src/core/theme/app_theme.dart';
+import '../src/core/theme/primitives.dart';
 
 /// A single design-token swatch card that mirrors the Figma spec layout.
 ///
@@ -137,8 +138,8 @@ class _ColorHalf extends StatelessWidget {
 
   static Color _textColorFor(Color bg) {
     return bg.computeLuminance() > 0.5
-        ? const Color(0xFF151818)
-        : const Color(0xFFE1E1E1);
+        ? Primitives.p900Light
+        : Primitives.p800Dark;
   }
 
   static String _hex(Color c) {

--- a/lib/widgetbook/color_use_cases.dart
+++ b/lib/widgetbook/color_use_cases.dart
@@ -9,6 +9,36 @@ import 'color_swatch.dart';
 // the Widgetbook always mirrors the token truth — if the token file changes,
 // the swatch updates automatically.
 
+List<TokenSwatch> _primitiveScaleSwatches({
+  required String prefix,
+  required List<Color> dark,
+  required List<Color> light,
+}) {
+  const steps = [
+    '0',
+    '50',
+    '100',
+    '150',
+    '200',
+    '300',
+    '400',
+    '500',
+    '600',
+    '700',
+    '800',
+    '900',
+  ];
+  return [
+    for (var i = 0; i < steps.length; i++)
+      TokenSwatch(
+        name: '$prefix/${steps[i]}',
+        description: '$prefix step ${steps[i]}',
+        dark: dark[i],
+        light: light[i],
+      ),
+  ];
+}
+
 Widget buildPrimitivesNeutralUseCase(BuildContext context) {
   return ColorCategoryPage(
     title: 'Primitives / Neutral',
@@ -89,243 +119,151 @@ Widget buildPrimitivesNeutralUseCase(BuildContext context) {
   );
 }
 
-Widget buildPrimitivesPurpleUseCase(BuildContext context) {
+Widget buildPrimitivesCrimsonUseCase(BuildContext context) {
   return ColorCategoryPage(
-    title: 'Primitives / Purple',
-    swatches: [
-      TokenSwatch(
-        name: '_ Primitive/Purple/0',
-        description: 'Brand purple — darkest',
-        dark: PurplePrimitives.p0Dark,
-        light: PurplePrimitives.p0Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Purple/50',
-        description: 'Brand purple step 50',
-        dark: PurplePrimitives.p50Dark,
-        light: PurplePrimitives.p50Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Purple/100',
-        description: 'Brand purple step 100',
-        dark: PurplePrimitives.p100Dark,
-        light: PurplePrimitives.p100Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Purple/150',
-        description: 'Primary button fill (Light)',
-        dark: PurplePrimitives.p150Dark,
-        light: PurplePrimitives.p150Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Purple/200',
-        description: 'Light-mode brand accent',
-        dark: PurplePrimitives.p200Dark,
-        light: PurplePrimitives.p200Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Purple/300',
-        description: 'Primary hover (Light) / pressed (Dark)',
-        dark: PurplePrimitives.p300Dark,
-        light: PurplePrimitives.p300Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Purple/400',
-        description: 'Primary hover (Dark) / pressed (Light)',
-        dark: PurplePrimitives.p400Dark,
-        light: PurplePrimitives.p400Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Purple/500',
-        description: 'Dark-mode brand accent / primary button fill',
-        dark: PurplePrimitives.p500Dark,
-        light: PurplePrimitives.p500Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Purple/600',
-        description: 'Brand purple step 600',
-        dark: PurplePrimitives.p600Dark,
-        light: PurplePrimitives.p600Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Purple/700',
-        description: 'Brand purple step 700',
-        dark: PurplePrimitives.p700Dark,
-        light: PurplePrimitives.p700Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Purple/800',
-        description: 'Brand purple step 800',
-        dark: PurplePrimitives.p800Dark,
-        light: PurplePrimitives.p800Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Purple/900',
-        description: 'Brand purple — lightest',
-        dark: PurplePrimitives.p900Dark,
-        light: PurplePrimitives.p900Light,
-      ),
-    ],
+    title: 'Primitives / Crimson',
+    swatches: _primitiveScaleSwatches(
+      prefix: '_ Primitive/Crimson',
+      dark: const [
+        CrimsonPrimitives.p0Dark,
+        CrimsonPrimitives.p50Dark,
+        CrimsonPrimitives.p100Dark,
+        CrimsonPrimitives.p150Dark,
+        CrimsonPrimitives.p200Dark,
+        CrimsonPrimitives.p300Dark,
+        CrimsonPrimitives.p400Dark,
+        CrimsonPrimitives.p500Dark,
+        CrimsonPrimitives.p600Dark,
+        CrimsonPrimitives.p700Dark,
+        CrimsonPrimitives.p800Dark,
+        CrimsonPrimitives.p900Dark,
+      ],
+      light: const [
+        CrimsonPrimitives.p0Light,
+        CrimsonPrimitives.p50Light,
+        CrimsonPrimitives.p100Light,
+        CrimsonPrimitives.p150Light,
+        CrimsonPrimitives.p200Light,
+        CrimsonPrimitives.p300Light,
+        CrimsonPrimitives.p400Light,
+        CrimsonPrimitives.p500Light,
+        CrimsonPrimitives.p600Light,
+        CrimsonPrimitives.p700Light,
+        CrimsonPrimitives.p800Light,
+        CrimsonPrimitives.p900Light,
+      ],
+    ),
   );
 }
 
-Widget buildPrimitivesCyanUseCase(BuildContext context) {
+Widget buildPrimitivesPlumUseCase(BuildContext context) {
   return ColorCategoryPage(
-    title: 'Primitives / Cyan',
-    swatches: [
-      TokenSwatch(
-        name: '_ Primitive/Cyan/0',
-        description: 'Brand cyan — darkest',
-        dark: CyanPrimitives.p0Dark,
-        light: CyanPrimitives.p0Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Cyan/50',
-        description: 'Brand cyan step 50',
-        dark: CyanPrimitives.p50Dark,
-        light: CyanPrimitives.p50Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Cyan/100',
-        description: 'Brand cyan step 100',
-        dark: CyanPrimitives.p100Dark,
-        light: CyanPrimitives.p100Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Cyan/150',
-        description: 'icon/brand-cyan (Light)',
-        dark: CyanPrimitives.p150Dark,
-        light: CyanPrimitives.p150Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Cyan/200',
-        description: 'Brand cyan step 200',
-        dark: CyanPrimitives.p200Dark,
-        light: CyanPrimitives.p200Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Cyan/300',
-        description: 'Brand cyan step 300',
-        dark: CyanPrimitives.p300Dark,
-        light: CyanPrimitives.p300Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Cyan/400',
-        description: 'text/brand-cyan (Light)',
-        dark: CyanPrimitives.p400Dark,
-        light: CyanPrimitives.p400Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Cyan/500',
-        description: 'icon/brand-cyan (Dark)',
-        dark: CyanPrimitives.p500Dark,
-        light: CyanPrimitives.p500Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Cyan/600',
-        description: 'text/brand-cyan (Dark)',
-        dark: CyanPrimitives.p600Dark,
-        light: CyanPrimitives.p600Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Cyan/700',
-        description: 'Brand cyan step 700',
-        dark: CyanPrimitives.p700Dark,
-        light: CyanPrimitives.p700Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Cyan/800',
-        description: 'Brand cyan step 800',
-        dark: CyanPrimitives.p800Dark,
-        light: CyanPrimitives.p800Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Cyan/900',
-        description: 'Brand cyan — lightest',
-        dark: CyanPrimitives.p900Dark,
-        light: CyanPrimitives.p900Light,
-      ),
-    ],
+    title: 'Primitives / Plum',
+    swatches: _primitiveScaleSwatches(
+      prefix: '_ Primitive/Plum',
+      dark: const [
+        PlumPrimitives.p0Dark,
+        PlumPrimitives.p50Dark,
+        PlumPrimitives.p100Dark,
+        PlumPrimitives.p150Dark,
+        PlumPrimitives.p200Dark,
+        PlumPrimitives.p300Dark,
+        PlumPrimitives.p400Dark,
+        PlumPrimitives.p500Dark,
+        PlumPrimitives.p600Dark,
+        PlumPrimitives.p700Dark,
+        PlumPrimitives.p800Dark,
+        PlumPrimitives.p900Dark,
+      ],
+      light: const [
+        PlumPrimitives.p0Light,
+        PlumPrimitives.p50Light,
+        PlumPrimitives.p100Light,
+        PlumPrimitives.p150Light,
+        PlumPrimitives.p200Light,
+        PlumPrimitives.p300Light,
+        PlumPrimitives.p400Light,
+        PlumPrimitives.p500Light,
+        PlumPrimitives.p600Light,
+        PlumPrimitives.p700Light,
+        PlumPrimitives.p800Light,
+        PlumPrimitives.p900Light,
+      ],
+    ),
   );
 }
 
-Widget buildPrimitivesYellowUseCase(BuildContext context) {
+Widget buildPrimitivesGoldUseCase(BuildContext context) {
   return ColorCategoryPage(
-    title: 'Primitives / Yellow',
-    swatches: [
-      TokenSwatch(
-        name: '_ Primitive/Yellow/0',
-        description: 'Brand yellow — darkest',
-        dark: YellowPrimitives.p0Dark,
-        light: YellowPrimitives.p0Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Yellow/50',
-        description: 'Brand yellow step 50',
-        dark: YellowPrimitives.p50Dark,
-        light: YellowPrimitives.p50Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Yellow/100',
-        description: 'Brand yellow step 100',
-        dark: YellowPrimitives.p100Dark,
-        light: YellowPrimitives.p100Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Yellow/150',
-        description: 'Brand yellow step 150',
-        dark: YellowPrimitives.p150Dark,
-        light: YellowPrimitives.p150Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Yellow/200',
-        description: 'Brand yellow step 200',
-        dark: YellowPrimitives.p200Dark,
-        light: YellowPrimitives.p200Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Yellow/300',
-        description: 'text/icon warning (Light)',
-        dark: YellowPrimitives.p300Dark,
-        light: YellowPrimitives.p300Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Yellow/400',
-        description: 'text/icon warning (Dark)',
-        dark: YellowPrimitives.p400Dark,
-        light: YellowPrimitives.p400Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Yellow/500',
-        description: 'Brand yellow step 500',
-        dark: YellowPrimitives.p500Dark,
-        light: YellowPrimitives.p500Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Yellow/600',
-        description: 'Brand yellow step 600',
-        dark: YellowPrimitives.p600Dark,
-        light: YellowPrimitives.p600Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Yellow/700',
-        description: 'Brand yellow step 700',
-        dark: YellowPrimitives.p700Dark,
-        light: YellowPrimitives.p700Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Yellow/800',
-        description: 'Brand yellow step 800',
-        dark: YellowPrimitives.p800Dark,
-        light: YellowPrimitives.p800Light,
-      ),
-      TokenSwatch(
-        name: '_ Primitive/Yellow/900',
-        description: 'Brand yellow — lightest',
-        dark: YellowPrimitives.p900Dark,
-        light: YellowPrimitives.p900Light,
-      ),
-    ],
+    title: 'Primitives / Gold',
+    swatches: _primitiveScaleSwatches(
+      prefix: '_ Primitive/Gold',
+      dark: const [
+        GoldPrimitives.p0Dark,
+        GoldPrimitives.p50Dark,
+        GoldPrimitives.p100Dark,
+        GoldPrimitives.p150Dark,
+        GoldPrimitives.p200Dark,
+        GoldPrimitives.p300Dark,
+        GoldPrimitives.p400Dark,
+        GoldPrimitives.p500Dark,
+        GoldPrimitives.p600Dark,
+        GoldPrimitives.p700Dark,
+        GoldPrimitives.p800Dark,
+        GoldPrimitives.p900Dark,
+      ],
+      light: const [
+        GoldPrimitives.p0Light,
+        GoldPrimitives.p50Light,
+        GoldPrimitives.p100Light,
+        GoldPrimitives.p150Light,
+        GoldPrimitives.p200Light,
+        GoldPrimitives.p300Light,
+        GoldPrimitives.p400Light,
+        GoldPrimitives.p500Light,
+        GoldPrimitives.p600Light,
+        GoldPrimitives.p700Light,
+        GoldPrimitives.p800Light,
+        GoldPrimitives.p900Light,
+      ],
+    ),
+  );
+}
+
+Widget buildPrimitivesGreenUseCase(BuildContext context) {
+  return ColorCategoryPage(
+    title: 'Primitives / Green',
+    swatches: _primitiveScaleSwatches(
+      prefix: '_ Primitive/Green',
+      dark: const [
+        GreenPrimitives.p0Dark,
+        GreenPrimitives.p50Dark,
+        GreenPrimitives.p100Dark,
+        GreenPrimitives.p150Dark,
+        GreenPrimitives.p200Dark,
+        GreenPrimitives.p300Dark,
+        GreenPrimitives.p400Dark,
+        GreenPrimitives.p500Dark,
+        GreenPrimitives.p600Dark,
+        GreenPrimitives.p700Dark,
+        GreenPrimitives.p800Dark,
+        GreenPrimitives.p900Dark,
+      ],
+      light: const [
+        GreenPrimitives.p0Light,
+        GreenPrimitives.p50Light,
+        GreenPrimitives.p100Light,
+        GreenPrimitives.p150Light,
+        GreenPrimitives.p200Light,
+        GreenPrimitives.p300Light,
+        GreenPrimitives.p400Light,
+        GreenPrimitives.p500Light,
+        GreenPrimitives.p600Light,
+        GreenPrimitives.p700Light,
+        GreenPrimitives.p800Light,
+        GreenPrimitives.p900Light,
+      ],
+    ),
   );
 }
 
@@ -360,16 +298,76 @@ Widget buildBackgroundUseCase(BuildContext context) {
         light: l.background.overlay,
       ),
       TokenSwatch(
-        name: 'bg/brand-cyan-subtle',
-        description: 'Brand-cyan tinted surface — info panels',
-        dark: d.background.brandCyanSubtle,
-        light: l.background.brandCyanSubtle,
+        name: 'bg/inverse',
+        description: 'Inverted neutral background',
+        dark: d.background.inverse,
+        light: l.background.inverse,
       ),
       TokenSwatch(
-        name: 'bg/brand-cyan-strong',
-        description: 'Brand-cyan emphasis surface',
-        dark: d.background.brandCyanStrong,
-        light: l.background.brandCyanStrong,
+        name: 'bg/neutral/alpha/scrim',
+        description: 'Neutral alpha scrim',
+        dark: d.background.neutralScrim,
+        light: l.background.neutralScrim,
+      ),
+      TokenSwatch(
+        name: 'bg/neutral/alpha/subtle-opacity',
+        description: 'Subtle neutral alpha overlay',
+        dark: d.background.neutralSubtleOpacity,
+        light: l.background.neutralSubtleOpacity,
+      ),
+      TokenSwatch(
+        name: 'bg/neutral/alpha/strong-opacity',
+        description: 'Strong neutral alpha overlay',
+        dark: d.background.neutralStrongOpacity,
+        light: l.background.neutralStrongOpacity,
+      ),
+      TokenSwatch(
+        name: 'bg/brand/crimson-subtle',
+        description: 'Brand-crimson tinted surface',
+        dark: d.background.brandCrimsonSubtle,
+        light: l.background.brandCrimsonSubtle,
+      ),
+      TokenSwatch(
+        name: 'bg/brand/crimson-strong',
+        description: 'Brand-crimson emphasis surface',
+        dark: d.background.brandCrimsonStrong,
+        light: l.background.brandCrimsonStrong,
+      ),
+      TokenSwatch(
+        name: 'bg/brand/alpha/crimson-alpha',
+        description: 'Brand-crimson alpha overlay',
+        dark: d.background.brandCrimsonAlpha,
+        light: l.background.brandCrimsonAlpha,
+      ),
+      TokenSwatch(
+        name: 'bg/utility/destructive-subtle',
+        description: 'Destructive utility surface',
+        dark: d.background.utilityDestructiveSubtle,
+        light: l.background.utilityDestructiveSubtle,
+      ),
+      TokenSwatch(
+        name: 'bg/utility/alpha/destructive-alpha',
+        description: 'Destructive utility alpha overlay',
+        dark: d.background.utilityDestructiveAlpha,
+        light: l.background.utilityDestructiveAlpha,
+      ),
+      TokenSwatch(
+        name: 'bg/utility/success-subtle',
+        description: 'Success utility surface',
+        dark: d.background.utilitySuccessSubtle,
+        light: l.background.utilitySuccessSubtle,
+      ),
+      TokenSwatch(
+        name: 'bg/utility/success-strong',
+        description: 'Strong success utility surface',
+        dark: d.background.utilitySuccessStrong,
+        light: l.background.utilitySuccessStrong,
+      ),
+      TokenSwatch(
+        name: 'bg/utility/alpha/success-alpha',
+        description: 'Success utility alpha overlay',
+        dark: d.background.utilitySuccessAlpha,
+        light: l.background.utilitySuccessAlpha,
       ),
     ],
   );
@@ -434,14 +432,26 @@ Widget buildBorderUseCase(BuildContext context) {
         light: l.border.subtle,
       ),
       TokenSwatch(
-        name: 'border/regular',
-        description: 'Input fields, cards, chips',
+        name: 'border/neutral/alpha/subtle-opacity',
+        description: 'Alpha border used on strong filled controls',
+        dark: d.border.subtleOpacity,
+        light: l.border.subtleOpacity,
+      ),
+      TokenSwatch(
+        name: 'border/default',
+        description: 'Default border for hover / cards / chips',
         dark: d.border.regular,
         light: l.border.regular,
       ),
       TokenSwatch(
+        name: 'border/medium',
+        description: 'Active / filled input fields',
+        dark: d.border.medium,
+        light: l.border.medium,
+      ),
+      TokenSwatch(
         name: 'border/strong',
-        description: 'Selected states, active tabs',
+        description: 'Max-contrast border',
         dark: d.border.strong,
         light: l.border.strong,
       ),
@@ -452,22 +462,16 @@ Widget buildBorderUseCase(BuildContext context) {
         light: l.border.utilityDestructive,
       ),
       TokenSwatch(
-        name: 'border/brand-cyan-subtle',
-        description: 'Brand-cyan border for subtle info surfaces',
-        dark: d.border.brandCyanSubtle,
-        light: l.border.brandCyanSubtle,
+        name: 'border/utility/success',
+        description: 'Success utility border',
+        dark: d.border.utilitySuccess,
+        light: l.border.utilitySuccess,
       ),
       TokenSwatch(
-        name: 'border/brand-cyan-strong',
-        description: 'Brand-cyan border for emphasis',
-        dark: d.border.brandCyanStrong,
-        light: l.border.brandCyanStrong,
-      ),
-      TokenSwatch(
-        name: 'border/brand-purple-strong',
-        description: 'Brand-purple border for affirmative feedback',
-        dark: d.border.brandPurpleStrong,
-        light: l.border.brandPurpleStrong,
+        name: 'border/brand/crimson-strong',
+        description: 'Brand-crimson border for feedback',
+        dark: d.border.brandCrimsonStrong,
+        light: l.border.brandCrimsonStrong,
       ),
     ],
   );
@@ -517,7 +521,7 @@ Widget buildTextUseCase(BuildContext context) {
       ),
       TokenSwatch(
         name: 'text/warning',
-        description: 'Inline warning copy — brand yellow',
+        description: 'Legacy warning copy — gold utility',
         dark: d.text.warning,
         light: l.text.warning,
       ),
@@ -528,16 +532,16 @@ Widget buildTextUseCase(BuildContext context) {
         light: l.text.destructive,
       ),
       TokenSwatch(
-        name: 'text/brand-purple',
-        description: 'Brand-purple inline text accent',
-        dark: d.text.brandPurple,
-        light: l.text.brandPurple,
+        name: 'text/utility/success',
+        description: 'Success utility copy',
+        dark: d.text.success,
+        light: l.text.success,
       ),
       TokenSwatch(
-        name: 'text/brand-cyan',
-        description: 'Brand-cyan inline text accent',
-        dark: d.text.brandCyan,
-        light: l.text.brandCyan,
+        name: 'text/brand/crimson',
+        description: 'Brand-crimson inline text accent',
+        dark: d.text.brandCrimson,
+        light: l.text.brandCrimson,
       ),
     ],
   );
@@ -587,21 +591,27 @@ Widget buildIconUseCase(BuildContext context) {
       ),
       TokenSwatch(
         name: 'icon/warning',
-        description: 'Warning-state icon — brand yellow',
+        description: 'Legacy warning icon — gold utility',
         dark: d.icon.warning,
         light: l.icon.warning,
       ),
       TokenSwatch(
-        name: 'icon/brand-purple',
-        description: 'Brand-purple icon',
-        dark: d.icon.brandPurple,
-        light: l.icon.brandPurple,
+        name: 'icon/utility/destructive',
+        description: 'Destructive utility icon',
+        dark: d.icon.destructive,
+        light: l.icon.destructive,
       ),
       TokenSwatch(
-        name: 'icon/brand-cyan',
-        description: 'Brand-cyan icon',
-        dark: d.icon.brandCyan,
-        light: l.icon.brandCyan,
+        name: 'icon/utility/success',
+        description: 'Success utility icon',
+        dark: d.icon.success,
+        light: l.icon.success,
+      ),
+      TokenSwatch(
+        name: 'icon/brand/crimson',
+        description: 'Brand-crimson icon',
+        dark: d.icon.brandCrimson,
+        light: l.icon.brandCrimson,
       ),
     ],
   );
@@ -776,6 +786,12 @@ Widget buildStateUseCase(BuildContext context) {
         light: l.state.selected,
       ),
       TokenSwatch(
+        name: 'state/neutral/alpha/selected-opacity',
+        description: 'Alpha overlay for selected row / chip',
+        dark: d.state.selectedOpacity,
+        light: l.state.selectedOpacity,
+      ),
+      TokenSwatch(
         name: 'state/focus-ring',
         description: '2dp ring — max contrast vs page bg',
         dark: d.state.focusRing,
@@ -789,7 +805,7 @@ Widget buildStateUseCase(BuildContext context) {
       ),
       TokenSwatch(
         name: 'state/focus-ring-brand',
-        description: 'Brand-cyan ring for primary button focus',
+        description: 'Brand-crimson ring for primary button focus',
         dark: d.state.focusRingBrand,
         light: l.state.focusRingBrand,
       ),

--- a/lib/widgetbook/icon_use_cases.dart
+++ b/lib/widgetbook/icon_use_cases.dart
@@ -62,7 +62,7 @@ Widget _iconCard(BuildContext context, String name) {
     decoration: BoxDecoration(
       color: colors.surface.card,
       border: Border.all(color: colors.border.subtle, width: 0.5),
-      borderRadius: BorderRadius.circular(AppRadii.small),
+      borderRadius: BorderRadius.circular(AppRadii.xSmall),
     ),
     padding: const EdgeInsets.all(AppSpacing.sm),
     child: Column(

--- a/lib/widgetbook/text_field_use_cases.dart
+++ b/lib/widgetbook/text_field_use_cases.dart
@@ -80,7 +80,7 @@ Widget buildTextFieldGalleryUseCase(BuildContext context) {
                 initialValue: 'Value',
                 leading: const AppIcon(AppIcons.users, size: 20),
                 messageText: 'Shielded Address',
-                tone: AppTextFieldTone.brandPurple,
+                tone: AppTextFieldTone.brandCrimson,
               ),
             ),
             SizedBox(
@@ -189,7 +189,11 @@ Widget buildTextFieldInteractiveUseCase(BuildContext context) {
   );
   final tone = context.knobs.object.dropdown<AppTextFieldTone>(
     label: 'Tone',
-    options: AppTextFieldTone.values,
+    options: const [
+      AppTextFieldTone.neutral,
+      AppTextFieldTone.brandCrimson,
+      AppTextFieldTone.destructive,
+    ],
     initialOption: AppTextFieldTone.neutral,
     labelBuilder: (value) => value.name,
   );

--- a/lib/widgetbook/token_use_cases.dart
+++ b/lib/widgetbook/token_use_cases.dart
@@ -30,9 +30,11 @@ const _iconSizeRows = <_TokenRow>[
 ];
 
 const _radiiRows = <_TokenRow>[
+  _TokenRow('xSmall', AppRadii.xSmall),
   _TokenRow('small', AppRadii.small),
   _TokenRow('medium', AppRadii.medium),
   _TokenRow('large', AppRadii.large),
+  _TokenRow('xLarge', AppRadii.xLarge),
   _TokenRow('full', AppRadii.full),
 ];
 

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -224,16 +224,20 @@ class WidgetbookApp extends StatelessWidget {
                   builder: buildPrimitivesNeutralUseCase,
                 ),
                 WidgetbookUseCase(
-                  name: 'Purple',
-                  builder: buildPrimitivesPurpleUseCase,
+                  name: 'Crimson',
+                  builder: buildPrimitivesCrimsonUseCase,
                 ),
                 WidgetbookUseCase(
-                  name: 'Cyan',
-                  builder: buildPrimitivesCyanUseCase,
+                  name: 'Plum',
+                  builder: buildPrimitivesPlumUseCase,
                 ),
                 WidgetbookUseCase(
-                  name: 'Yellow',
-                  builder: buildPrimitivesYellowUseCase,
+                  name: 'Gold',
+                  builder: buildPrimitivesGoldUseCase,
+                ),
+                WidgetbookUseCase(
+                  name: 'Green',
+                  builder: buildPrimitivesGreenUseCase,
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary

- Sync the Flutter design-token layer with the latest Figma token set: neutral alpha tokens, brand crimson, utility plum/gold/green primitives, and updated dark/light semantic mappings for background, border, icon, text, state, and button colors.
- Normalize shared design-system APIs around the new tokens: radii now use the expanded `xSmall` / `small` / `large` / `xLarge` scale, `codeMedium` matches the updated 14 / 21 typography token, and text-field brand tone now maps to `brandCrimson`.
- Update shared widgets to consume semantic tokens instead of inline values: `AppButton` uses token-backed transparent surfaces and fixes the small-label padding, while `AppTextField` / `PasswordTextField` use tone-aware icon, border, focus, and message colors.
- Apply the refreshed tokens across onboarding, home, send, desktop shell/sidebar, and Widgetbook coverage.

## Widgetbook Checks

- Colors: primitive palettes and semantic token pages, in both light and dark modes.
- Buttons: primary / secondary / ghost / destructive variants, especially `small` size labels.
- Text Fields: neutral, destructive, and brand-crimson tone states.
- Screens: onboarding, home, send, and send-status surfaces touched by token changes.

## Validation

- `fvm dart analyze lib/src/core/widgets/app_button.dart lib/src/core/widgets/app_text_field.dart`

## Notes

- Base branch: `rowan/unlock-screen`.
- This PR is limited to design-token synchronization and token consumer cleanup; wallet-flow behavior changes stay in the unlock-screen branch.