### PR TITLE
[codex] Remove address book UI

### DIFF
--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -157,11 +157,6 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                               : () => context.go('/receive'),
                         ),
                         const SizedBox(height: AppSpacing.xs),
-                        const AppSidebarItem(
-                          label: 'Address Book',
-                          iconName: AppIcons.users,
-                        ),
-                        const SizedBox(height: AppSpacing.xs),
                         AppSidebarItem(
                           label: 'Activity',
                           iconName: AppIcons.history,

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -316,17 +316,7 @@ class _SendReviewReceiptCard extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: AppSpacing.sm),
-                  _SendReviewFieldTitle(
-                    label: 'To',
-                    rightLabel: _SendReviewFieldTrailing(
-                      label: 'Andrew',
-                      icon: AppIcon(
-                        AppIcons.chevronForward,
-                        size: 16,
-                        color: colors.icon.regular,
-                      ),
-                    ),
-                  ),
+                  const _SendReviewFieldTitle(label: 'To'),
                   const SizedBox(height: AppSpacing.xs),
                   for (final line in addressLines)
                     RichText(
@@ -433,31 +423,6 @@ class _SendReviewFieldTitle extends StatelessWidget {
           ),
         ),
         if (rightLabel != null) ...[rightLabel!],
-      ],
-    );
-  }
-}
-
-class _SendReviewFieldTrailing extends StatelessWidget {
-  const _SendReviewFieldTrailing({required this.label, required this.icon});
-
-  final String label;
-  final Widget icon;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(
-          label,
-          style: AppTypography.labelMedium.copyWith(
-            color: colors.text.secondary,
-          ),
-        ),
-        const SizedBox(width: AppSpacing.xxs),
-        icon,
       ],
     );
   }

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -537,7 +537,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                               controller: _addressController,
                                               hintText: 'zCash Address',
                                               leading: AppIcon(
-                                                AppIcons.users,
+                                                AppIcons.link,
                                                 size: 20,
                                                 color:
                                                     _addressController.text
@@ -545,14 +545,6 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                                         .isNotEmpty
                                                     ? colors.icon.accent
                                                     : colors.icon.regular,
-                                              ),
-                                              rightSlot: _SendTrailingLabel(
-                                                label: 'Contacts',
-                                                icon: AppIcon(
-                                                  AppIcons.chevronForward,
-                                                  size: 16,
-                                                  color: colors.text.secondary,
-                                                ),
                                               ),
                                               messageText: addressMessage,
                                               messageIcon: addressMessageIcon,
@@ -832,30 +824,6 @@ class _SendBackRow extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-class _SendTrailingLabel extends StatelessWidget {
-  const _SendTrailingLabel({required this.label, this.icon});
-
-  final String label;
-  final Widget? icon;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(
-          label,
-          style: AppTypography.labelMedium.copyWith(
-            color: colors.text.secondary,
-          ),
-        ),
-        if (icon != null) ...[const SizedBox(width: AppSpacing.xxs), icon!],
-      ],
     );
   }
 }

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -604,7 +604,6 @@ class _SendStatusContent extends StatelessWidget {
               const SizedBox(height: AppSpacing.md),
               _SendStatusBlock(
                 title: 'To',
-                rightLabel: const _SendStatusFieldTrailing(label: 'Andrew'),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
@@ -737,20 +736,14 @@ class _SendStatusHeadline extends StatelessWidget {
 }
 
 class _SendStatusBlock extends StatelessWidget {
-  const _SendStatusBlock({
-    required this.title,
-    required this.child,
-    this.rightLabel,
-  });
+  const _SendStatusBlock({required this.title, required this.child});
 
   final String title;
   final Widget child;
-  final Widget? rightLabel;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final trailingChildren = rightLabel == null ? null : <Widget>[rightLabel!];
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -764,35 +757,10 @@ class _SendStatusBlock extends StatelessWidget {
                 ),
               ),
             ),
-            ...?trailingChildren,
           ],
         ),
         const SizedBox(height: AppSpacing.xs),
         child,
-      ],
-    );
-  }
-}
-
-class _SendStatusFieldTrailing extends StatelessWidget {
-  const _SendStatusFieldTrailing({required this.label});
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(
-          label,
-          style: AppTypography.labelMedium.copyWith(
-            color: colors.text.secondary,
-          ),
-        ),
-        const SizedBox(width: AppSpacing.xxs),
-        AppIcon(AppIcons.chevronForward, size: 16, color: colors.icon.regular),
       ],
     );
   }


### PR DESCRIPTION
## Summary

Removes address book and contacts-facing mock UI from the wallet navigation and send flow. The send screens now show only the actual recipient address instead of placeholder contact names.

## Changes

- Removed the sidebar Address Book item.
- Removed the Contacts affordance from the send address field and replaced the people icon with a link icon.
- Removed hardcoded mock recipient labels from send review and send status screens.

## Validation

- fvm dart format on changed Dart files.
- fvm flutter analyze lib/src/core/layout/app_main_sidebar.dart lib/src/features/send/screens/send_screen.dart
- fvm flutter analyze lib/src/features/send/screens/send_review_screen.dart lib/src/features/send/screens/send_status_screen.dart