### PR TITLE
[codex] Split home balances and add shield action

### DIFF
--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -58,6 +58,9 @@ class AppSyncSnapshot {
     required this.transparentPendingBalance,
     required this.saplingPendingBalance,
     required this.orchardPendingBalance,
+    required this.canShieldTransparentBalance,
+    required this.shieldTransparentFee,
+    required this.shieldTransparentAmount,
     required this.spendableBalance,
     required this.totalBalance,
     required this.recentTransactions,
@@ -72,6 +75,9 @@ class AppSyncSnapshot {
   final BigInt transparentPendingBalance;
   final BigInt saplingPendingBalance;
   final BigInt orchardPendingBalance;
+  final bool canShieldTransparentBalance;
+  final BigInt shieldTransparentFee;
+  final BigInt shieldTransparentAmount;
   final BigInt spendableBalance;
   final BigInt totalBalance;
   final List<rust_sync.TransactionInfo> recentTransactions;
@@ -86,6 +92,9 @@ class AppSyncSnapshot {
     transparentPendingBalance: BigInt.zero,
     saplingPendingBalance: BigInt.zero,
     orchardPendingBalance: BigInt.zero,
+    canShieldTransparentBalance: false,
+    shieldTransparentFee: BigInt.zero,
+    shieldTransparentAmount: BigInt.zero,
     spendableBalance: BigInt.zero,
     totalBalance: BigInt.zero,
     recentTransactions: [],
@@ -149,6 +158,9 @@ Future<AppBootstrapState> loadAppBootstrap() async {
         dbPath: dbPath,
         network: network,
         accountUuid: activeAccountUuid,
+        isHardwareAccount: accounts.any(
+          (account) => account.uuid == activeAccountUuid && account.isHardware,
+        ),
       );
     }
 
@@ -211,6 +223,7 @@ Future<AppSyncSnapshot> _loadInitialSyncSnapshot({
   required String dbPath,
   required String network,
   required String accountUuid,
+  required bool isHardwareAccount,
 }) async {
   try {
     final syncStatus = await rust_sync.getSyncStatus(
@@ -228,6 +241,23 @@ Future<AppSyncSnapshot> _loadInitialSyncSnapshot({
       limit: 10,
       accountUuid: accountUuid,
     );
+    var canShieldTransparentBalance = false;
+    var shieldTransparentFee = BigInt.zero;
+    var shieldTransparentAmount = BigInt.zero;
+    if (!isHardwareAccount && balance.transparent > BigInt.zero) {
+      try {
+        final shieldStatus = await rust_sync.getShieldTransparentStatus(
+          dbPath: dbPath,
+          network: network,
+          accountUuid: accountUuid,
+        );
+        canShieldTransparentBalance = shieldStatus.canShield;
+        shieldTransparentFee = shieldStatus.feeZatoshi;
+        shieldTransparentAmount = shieldStatus.shieldedZatoshi;
+      } catch (e) {
+        log('bootstrap: failed to load shield transparent status: $e');
+      }
+    }
     final scannedHeight = syncStatus.scannedHeight.toInt();
     final chainTipHeight = syncStatus.chainTipHeight.toInt();
     final percentage = chainTipHeight == 0
@@ -249,6 +279,9 @@ Future<AppSyncSnapshot> _loadInitialSyncSnapshot({
       transparentPendingBalance: balance.transparentPending,
       saplingPendingBalance: balance.saplingPending,
       orchardPendingBalance: balance.orchardPending,
+      canShieldTransparentBalance: canShieldTransparentBalance,
+      shieldTransparentFee: shieldTransparentFee,
+      shieldTransparentAmount: shieldTransparentAmount,
       spendableBalance: balance.spendable,
       totalBalance: balance.total,
       recentTransactions: recentTransactions,

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -55,6 +55,9 @@ class AppSyncSnapshot {
     required this.transparentBalance,
     required this.saplingBalance,
     required this.orchardBalance,
+    required this.transparentPendingBalance,
+    required this.saplingPendingBalance,
+    required this.orchardPendingBalance,
     required this.spendableBalance,
     required this.totalBalance,
     required this.recentTransactions,
@@ -66,6 +69,9 @@ class AppSyncSnapshot {
   final BigInt transparentBalance;
   final BigInt saplingBalance;
   final BigInt orchardBalance;
+  final BigInt transparentPendingBalance;
+  final BigInt saplingPendingBalance;
+  final BigInt orchardPendingBalance;
   final BigInt spendableBalance;
   final BigInt totalBalance;
   final List<rust_sync.TransactionInfo> recentTransactions;
@@ -77,6 +83,9 @@ class AppSyncSnapshot {
     transparentBalance: BigInt.zero,
     saplingBalance: BigInt.zero,
     orchardBalance: BigInt.zero,
+    transparentPendingBalance: BigInt.zero,
+    saplingPendingBalance: BigInt.zero,
+    orchardPendingBalance: BigInt.zero,
     spendableBalance: BigInt.zero,
     totalBalance: BigInt.zero,
     recentTransactions: [],
@@ -237,6 +246,9 @@ Future<AppSyncSnapshot> _loadInitialSyncSnapshot({
       transparentBalance: balance.transparent,
       saplingBalance: balance.sapling,
       orchardBalance: balance.orchard,
+      transparentPendingBalance: balance.transparentPending,
+      saplingPendingBalance: balance.saplingPending,
+      orchardPendingBalance: balance.orchardPending,
       spendableBalance: balance.spendable,
       totalBalance: balance.total,
       recentTransactions: recentTransactions,

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -29,8 +29,6 @@ class HomeScreen extends ConsumerStatefulWidget {
 }
 
 class _HomeScreenState extends ConsumerState<HomeScreen> {
-  static final BigInt _shieldingThresholdZatoshi = BigInt.from(100000);
-
   bool _canBackgroundSync = false;
   bool _isBalanceVisible = true;
   bool _isShieldingBalance = false;
@@ -112,9 +110,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         );
       }
 
-      final transparentBalance =
-          ref.read(syncProvider).value?.transparentBalance ?? BigInt.zero;
-      if (transparentBalance <= _shieldingThresholdZatoshi) {
+      final sync = ref.read(syncProvider).value ?? SyncState();
+      if (!sync.canShieldTransparentBalance) {
         throw Exception(
           'Transparent balance is too small to shield after fees.',
         );
@@ -210,8 +207,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         sync.orchardPendingBalance;
     final transparentBalance =
         sync.transparentBalance + sync.transparentPendingBalance;
-    final canShieldTransparentBalance =
-        sync.transparentBalance > _shieldingThresholdZatoshi;
+    final canShieldTransparentBalance = sync.canShieldTransparentBalance;
 
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
@@ -867,12 +863,14 @@ class _HomeTransparentBalanceStrip extends StatelessWidget {
                 ],
               ),
             ),
-            const SizedBox(width: AppSpacing.xs),
-            _HomeShieldBalanceButton(
-              enabled: canShieldBalance,
-              isLoading: isShieldingBalance,
-              onPressed: onShieldBalancePressed,
-            ),
+            if (canShieldBalance || isShieldingBalance) ...[
+              const SizedBox(width: AppSpacing.xs),
+              _HomeShieldBalanceButton(
+                enabled: canShieldBalance,
+                isLoading: isShieldingBalance,
+                onPressed: onShieldBalancePressed,
+              ),
+            ],
           ],
         ),
       ),

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart'
-    show
-        CircularProgressIndicator,
-        Scrollbar,
-        Theme;
+    show CircularProgressIndicator, Scrollbar, Theme;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -97,6 +94,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final walletAsync = ref.watch(walletProvider);
     final syncAsync = ref.watch(syncProvider);
     final sync = syncAsync.value ?? SyncState();
+    final shieldedBalance =
+        sync.saplingBalance +
+        sync.orchardBalance +
+        sync.saplingPendingBalance +
+        sync.orchardPendingBalance;
+    final transparentBalance =
+        sync.transparentBalance + sync.transparentPendingBalance;
 
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
@@ -117,10 +121,13 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               sync: sync,
               canBackgroundSync: _canBackgroundSync,
               isBalanceVisible: _isBalanceVisible,
-              balanceText: _formatZec(sync.totalBalance),
+              shieldedBalanceText: _formatZec(shieldedBalance),
+              transparentBalanceText: _formatZec(transparentBalance),
+              hasTransparentBalance: transparentBalance > BigInt.zero,
               formatSignedZec: _formatSignedZec,
               groupLabelForTx: _groupLabelForTx,
               onToggleBalanceVisibility: _toggleBalanceVisibility,
+              onShieldBalancePressed: () {},
               onSyncInBackground: () =>
                   ref.read(syncProvider.notifier).enableBackgroundSync(),
               onStopBackgroundSync: () =>
@@ -158,10 +165,13 @@ class _HomePane extends StatefulWidget {
     required this.sync,
     required this.canBackgroundSync,
     required this.isBalanceVisible,
-    required this.balanceText,
+    required this.shieldedBalanceText,
+    required this.transparentBalanceText,
+    required this.hasTransparentBalance,
     required this.formatSignedZec,
     required this.groupLabelForTx,
     required this.onToggleBalanceVisibility,
+    required this.onShieldBalancePressed,
     required this.onSyncInBackground,
     required this.onStopBackgroundSync,
     required this.onRetrySync,
@@ -170,10 +180,13 @@ class _HomePane extends StatefulWidget {
   final SyncState sync;
   final bool canBackgroundSync;
   final bool isBalanceVisible;
-  final String balanceText;
+  final String shieldedBalanceText;
+  final String transparentBalanceText;
+  final bool hasTransparentBalance;
   final String Function(BigInt zatoshi) formatSignedZec;
   final String Function(rust_sync.TransactionInfo tx) groupLabelForTx;
   final VoidCallback onToggleBalanceVisibility;
+  final VoidCallback onShieldBalancePressed;
   final VoidCallback onSyncInBackground;
   final VoidCallback onStopBackgroundSync;
   final VoidCallback onRetrySync;
@@ -265,10 +278,13 @@ class _HomePaneState extends State<_HomePane> {
                       children: [
                         const SizedBox(height: AppSpacing.sm),
                         _HomeBalanceCard(
-                          balanceText: widget.balanceText,
+                          shieldedBalanceText: widget.shieldedBalanceText,
+                          transparentBalanceText: widget.transparentBalanceText,
+                          hasTransparentBalance: widget.hasTransparentBalance,
                           isBalanceVisible: widget.isBalanceVisible,
                           onToggleBalanceVisibility:
                               widget.onToggleBalanceVisibility,
+                          onShieldBalancePressed: widget.onShieldBalancePressed,
                         ),
                         if (notice != null) ...[
                           const SizedBox(height: AppSpacing.xs),
@@ -424,182 +440,337 @@ class _HomePaneState extends State<_HomePane> {
 
 class _HomeBalanceCard extends StatelessWidget {
   const _HomeBalanceCard({
-    required this.balanceText,
+    required this.shieldedBalanceText,
+    required this.transparentBalanceText,
+    required this.hasTransparentBalance,
     required this.isBalanceVisible,
     required this.onToggleBalanceVisibility,
+    required this.onShieldBalancePressed,
+  });
+
+  final String shieldedBalanceText;
+  final String transparentBalanceText;
+  final bool hasTransparentBalance;
+  final bool isBalanceVisible;
+  final VoidCallback onToggleBalanceVisibility;
+  final VoidCallback onShieldBalancePressed;
+
+  static const _shieldedCardHeight = 196.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final displayedShieldedBalance = isBalanceVisible
+        ? '$shieldedBalanceText zec'
+        : '•••••• zec';
+    final isDark = AppTheme.of(context) == AppThemeData.dark;
+
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 240),
+      curve: Curves.easeOutCubic,
+      alignment: Alignment.topCenter,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppRadii.medium),
+        child: DecoratedBox(
+          decoration: BoxDecoration(color: colors.background.base),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                height: _shieldedCardHeight,
+                child: Stack(
+                  children: [
+                    Positioned.fill(
+                      child: IgnorePointer(
+                        child: Stack(
+                          children: [
+                            Positioned.fill(
+                              child: DecoratedBox(
+                                decoration: BoxDecoration(
+                                  gradient: LinearGradient(
+                                    begin: Alignment.centerLeft,
+                                    end: Alignment.centerRight,
+                                    colors: isDark
+                                        ? [
+                                            colors.background.base.withValues(
+                                              alpha: 0.90,
+                                            ),
+                                            colors.background.base.withValues(
+                                              alpha: 0.82,
+                                            ),
+                                            colors.background.base.withValues(
+                                              alpha: 0.48,
+                                            ),
+                                            colors.background.base.withValues(
+                                              alpha: 0.00,
+                                            ),
+                                          ]
+                                        : [
+                                            colors.background.base.withValues(
+                                              alpha: 0.98,
+                                            ),
+                                            colors.background.base.withValues(
+                                              alpha: 0.95,
+                                            ),
+                                            colors.background.base.withValues(
+                                              alpha: 0.70,
+                                            ),
+                                            colors.background.base.withValues(
+                                              alpha: 0.00,
+                                            ),
+                                          ],
+                                    stops: const [0.0, 0.28, 0.56, 0.86],
+                                  ),
+                                ),
+                              ),
+                            ),
+                            Positioned.fill(
+                              child: Align(
+                                alignment: Alignment.centerRight,
+                                child: Image.asset(
+                                  isDark
+                                      ? 'assets/illustrations/home_balance_card_bg_dark.png'
+                                      : 'assets/illustrations/home_balance_card_bg_light.png',
+                                  fit: BoxFit.cover,
+                                  width: 604,
+                                  height: _shieldedCardHeight,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    Positioned.fill(
+                      child: Padding(
+                        padding: const EdgeInsets.fromLTRB(
+                          AppSpacing.sm,
+                          AppSpacing.md,
+                          AppSpacing.sm,
+                          AppSpacing.md,
+                        ),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              children: [
+                                Container(
+                                  padding: const EdgeInsets.all(AppSpacing.xxs),
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      _HomeBalanceShieldIcon(
+                                        isDark: isDark,
+                                        iconColor: colors.icon.brandPurple,
+                                      ),
+                                      const SizedBox(width: AppSpacing.xxs),
+                                      Text(
+                                        'Shielded Balance',
+                                        style: AppTypography.labelLarge
+                                            .copyWith(
+                                              color: colors.text.accent,
+                                            ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                                const Spacer(),
+                                _IconPillButton(
+                                  iconName: isBalanceVisible
+                                      ? AppIcons.eye
+                                      : AppIcons.eyeClosed,
+                                  onPressed: onToggleBalanceVisibility,
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: AppSpacing.xs),
+                            Text(
+                              displayedShieldedBalance,
+                              style: AppTypography.displayMedium.copyWith(
+                                color: colors.text.accent,
+                              ),
+                            ),
+                            const Spacer(),
+                            Row(
+                              children: [
+                                Expanded(
+                                  child: LayoutBuilder(
+                                    builder: (context, constraints) {
+                                      return AppButton(
+                                        onPressed: () => context.push('/send'),
+                                        variant: AppButtonVariant.primary,
+                                        minWidth: constraints.maxWidth,
+                                        leading: const AppIcon(AppIcons.plane),
+                                        child: const Text('Send'),
+                                      );
+                                    },
+                                  ),
+                                ),
+                                const SizedBox(width: AppSpacing.xs),
+                                Expanded(
+                                  child: LayoutBuilder(
+                                    builder: (context, constraints) {
+                                      return AppButton(
+                                        onPressed: () =>
+                                            context.push('/receive'),
+                                        variant: AppButtonVariant.secondary,
+                                        minWidth: constraints.maxWidth,
+                                        leading: const AppIcon(
+                                          AppIcons.arrowDownCircle,
+                                        ),
+                                        child: const Text('Receive'),
+                                      );
+                                    },
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              AnimatedSwitcher(
+                duration: const Duration(milliseconds: 220),
+                switchInCurve: Curves.easeOutCubic,
+                switchOutCurve: Curves.easeInCubic,
+                transitionBuilder: (child, animation) {
+                  final curved = CurvedAnimation(
+                    parent: animation,
+                    curve: Curves.easeOutCubic,
+                    reverseCurve: Curves.easeInCubic,
+                  );
+                  return ClipRect(
+                    child: SizeTransition(
+                      sizeFactor: curved,
+                      axisAlignment: -1,
+                      child: SlideTransition(
+                        position: Tween<Offset>(
+                          begin: const Offset(0, -0.85),
+                          end: Offset.zero,
+                        ).animate(curved),
+                        child: child,
+                      ),
+                    ),
+                  );
+                },
+                child: hasTransparentBalance
+                    ? _HomeTransparentBalanceStrip(
+                        key: const ValueKey('transparent-balance-strip'),
+                        balanceText: transparentBalanceText,
+                        isBalanceVisible: isBalanceVisible,
+                        onShieldBalancePressed: onShieldBalancePressed,
+                      )
+                    : const SizedBox.shrink(
+                        key: ValueKey('transparent-balance-empty'),
+                      ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeTransparentBalanceStrip extends StatelessWidget {
+  const _HomeTransparentBalanceStrip({
+    required this.balanceText,
+    required this.isBalanceVisible,
+    required this.onShieldBalancePressed,
+    super.key,
   });
 
   final String balanceText;
   final bool isBalanceVisible;
-  final VoidCallback onToggleBalanceVisibility;
+  final VoidCallback onShieldBalancePressed;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
     final displayedBalance = isBalanceVisible
-        ? '$balanceText zec'
-        : '•••••• zec';
-    final isDark = AppTheme.of(context) == AppThemeData.dark;
+        ? '$balanceText ZEC'
+        : '•••••• ZEC';
 
     return SizedBox(
-      height: 196,
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(AppRadii.medium),
-        child: Stack(
+      height: 56,
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.s),
+        child: Row(
           children: [
-            Positioned.fill(
-              child: DecoratedBox(
-                decoration: BoxDecoration(color: colors.background.base),
-              ),
-            ),
-            Positioned.fill(
-              child: IgnorePointer(
-                child: Stack(
-                  children: [
-                    Positioned.fill(
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            begin: Alignment.centerLeft,
-                            end: Alignment.centerRight,
-                            colors: isDark
-                                ? [
-                                    colors.background.base.withValues(
-                                      alpha: 0.90,
-                                    ),
-                                    colors.background.base.withValues(
-                                      alpha: 0.82,
-                                    ),
-                                    colors.background.base.withValues(
-                                      alpha: 0.48,
-                                    ),
-                                    colors.background.base.withValues(
-                                      alpha: 0.00,
-                                    ),
-                                  ]
-                                : [
-                                    colors.background.base.withValues(
-                                      alpha: 0.98,
-                                    ),
-                                    colors.background.base.withValues(
-                                      alpha: 0.95,
-                                    ),
-                                    colors.background.base.withValues(
-                                      alpha: 0.70,
-                                    ),
-                                    colors.background.base.withValues(
-                                      alpha: 0.00,
-                                    ),
-                                  ],
-                            stops: const [0.0, 0.28, 0.56, 0.86],
-                          ),
-                        ),
-                      ),
-                    ),
-                    Positioned.fill(
-                      child: Align(
-                        alignment: Alignment.centerRight,
-                        child: Image.asset(
-                          isDark
-                              ? 'assets/illustrations/home_balance_card_bg_dark.png'
-                              : 'assets/illustrations/home_balance_card_bg_light.png',
-                          fit: BoxFit.cover,
-                          width: 604,
-                          height: 196,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            Positioned.fill(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(
-                  AppSpacing.sm,
-                  AppSpacing.md,
-                  AppSpacing.sm,
-                  AppSpacing.md,
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      children: [
-                        Container(
-                          padding: const EdgeInsets.all(AppSpacing.xxs),
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              _HomeBalanceShieldIcon(
-                                isDark: isDark,
-                                iconColor: colors.icon.brandPurple,
-                              ),
-                              const SizedBox(width: AppSpacing.xxs),
-                              Text(
-                                'Shielded Balance',
-                                style: AppTypography.labelLarge.copyWith(
-                                  color: colors.text.accent,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        const Spacer(),
-                        _IconPillButton(
-                          iconName: isBalanceVisible
-                              ? AppIcons.eye
-                              : AppIcons.eyeClosed,
-                          onPressed: onToggleBalanceVisibility,
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: AppSpacing.xs),
-                    Text(
-                      displayedBalance,
-                      style: AppTypography.displayMedium.copyWith(
+            Expanded(
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  AppIcon(
+                    AppIcons.transparentBalance,
+                    size: 16,
+                    color: colors.text.accent,
+                  ),
+                  const SizedBox(width: AppSpacing.xxs),
+                  Flexible(
+                    child: Text(
+                      'Transparent balance: $displayedBalance',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTypography.labelLarge.copyWith(
                         color: colors.text.accent,
                       ),
                     ),
-                    const Spacer(),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: LayoutBuilder(
-                            builder: (context, constraints) {
-                              return AppButton(
-                                onPressed: () => context.push('/send'),
-                                variant: AppButtonVariant.primary,
-                                minWidth: constraints.maxWidth,
-                                leading: const AppIcon(AppIcons.plane),
-                                child: const Text('Send'),
-                              );
-                            },
-                          ),
-                        ),
-                        const SizedBox(width: AppSpacing.xs),
-                        Expanded(
-                          child: LayoutBuilder(
-                            builder: (context, constraints) {
-                              return AppButton(
-                                onPressed: () => context.push('/receive'),
-                                variant: AppButtonVariant.secondary,
-                                minWidth: constraints.maxWidth,
-                                leading: const AppIcon(
-                                  AppIcons.arrowDownCircle,
-                                ),
-                                child: const Text('Receive'),
-                              );
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
+                  ),
+                ],
               ),
             ),
+            const SizedBox(width: AppSpacing.xs),
+            _HomeShieldBalanceButton(onPressed: onShieldBalancePressed),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeShieldBalanceButton extends StatelessWidget {
+  const _HomeShieldBalanceButton({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Semantics(
+      button: true,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onPressed,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(minWidth: 96, minHeight: 32),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  AppIcon(
+                    AppIcons.shieldKeyholeOutline,
+                    size: 16,
+                    color: colors.text.accent,
+                  ),
+                  const SizedBox(width: AppSpacing.xxs),
+                  Text(
+                    'Shield Balance',
+                    style: AppTypography.labelLarge.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart'
     show CircularProgressIndicator, Scrollbar, Theme;
 import 'package:flutter/widgets.dart';
@@ -5,15 +7,19 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/config/network_config.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
+import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
+import '../../../providers/account_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
+import '../../../rust/api/wallet.dart' as rust_wallet;
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -23,8 +29,12 @@ class HomeScreen extends ConsumerStatefulWidget {
 }
 
 class _HomeScreenState extends ConsumerState<HomeScreen> {
+  static final BigInt _shieldingThresholdZatoshi = BigInt.from(100000);
+
   bool _canBackgroundSync = false;
   bool _isBalanceVisible = true;
+  bool _isShieldingBalance = false;
+  String? _shieldBalanceError;
 
   @override
   void initState() {
@@ -74,6 +84,105 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     });
   }
 
+  void _dismissShieldBalanceError() {
+    setState(() {
+      _shieldBalanceError = null;
+    });
+  }
+
+  Future<void> _shieldTransparentBalance() async {
+    if (_isShieldingBalance) return;
+
+    setState(() {
+      _isShieldingBalance = true;
+      _shieldBalanceError = null;
+    });
+
+    try {
+      final wallet = ref.read(walletProvider).value;
+      final accountUuid = wallet?.activeAccountUuid;
+      if (accountUuid == null) {
+        throw Exception('No active account.');
+      }
+
+      final accountNotifier = ref.read(accountProvider.notifier);
+      if (accountNotifier.isHardwareAccount(accountUuid)) {
+        throw Exception(
+          'Shielding transparent balance is only available for software accounts.',
+        );
+      }
+
+      final transparentBalance =
+          ref.read(syncProvider).value?.transparentBalance ?? BigInt.zero;
+      if (transparentBalance <= _shieldingThresholdZatoshi) {
+        throw Exception(
+          'Transparent balance is too small to shield after fees.',
+        );
+      }
+
+      final mnemonic = await accountNotifier.getMnemonicForAccount(accountUuid);
+      if (mnemonic == null) {
+        throw Exception('Mnemonic not found for the active account.');
+      }
+
+      final seedBytes = await rust_wallet.deriveSeed(mnemonic: mnemonic);
+      final dbPath = await getWalletDbPath();
+      final result = await rust_sync.shieldTransparentBalance(
+        dbPath: dbPath,
+        lightwalletdUrl: ZcashNetwork.mainnet.lightwalletdUrl,
+        network: ZcashNetwork.mainnet.name,
+        accountUuid: accountUuid,
+        seed: seedBytes,
+      );
+      log(
+        'HomeScreen: shielded transparent balance txids=${result.txids} '
+        'fee=${result.feeZatoshi} shielded=${result.shieldedZatoshi}',
+      );
+
+      try {
+        await ref.read(syncProvider.notifier).refreshAfterSend();
+      } catch (e) {
+        log('HomeScreen: refreshAfterSend after shielding failed: $e');
+      }
+    } catch (e, st) {
+      log('HomeScreen: shield transparent balance failed: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _shieldBalanceError = _friendlyShieldBalanceError(e);
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isShieldingBalance = false;
+        });
+      }
+    }
+  }
+
+  String _friendlyShieldBalanceError(Object error) {
+    final message = error.toString();
+    final lower = message.toLowerCase();
+    if (lower.contains('hardware')) {
+      return 'Shield balance is only available for software accounts.';
+    }
+    if (lower.contains('mnemonic')) {
+      return 'Mnemonic not found for the active account.';
+    }
+    if (lower.contains('sync')) {
+      return 'Sync the wallet before shielding transparent balance.';
+    }
+    if (lower.contains('insufficient') ||
+        lower.contains('threshold') ||
+        lower.contains('too small') ||
+        lower.contains('no transparent funds')) {
+      return 'Transparent balance is too small to shield after fees.';
+    }
+    if (lower.contains('broadcast') || lower.contains('sendtransaction')) {
+      return 'Shield transaction could not be broadcast.';
+    }
+    return 'Shield balance failed. Please try again.';
+  }
+
   String _groupLabelForTx(rust_sync.TransactionInfo tx) {
     if (tx.minedHeight == BigInt.zero && !tx.expiredUnmined) {
       return 'Today';
@@ -101,6 +210,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         sync.orchardPendingBalance;
     final transparentBalance =
         sync.transparentBalance + sync.transparentPendingBalance;
+    final canShieldTransparentBalance =
+        sync.transparentBalance > _shieldingThresholdZatoshi;
 
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
@@ -124,10 +235,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               shieldedBalanceText: _formatZec(shieldedBalance),
               transparentBalanceText: _formatZec(transparentBalance),
               hasTransparentBalance: transparentBalance > BigInt.zero,
+              canShieldBalance: canShieldTransparentBalance,
+              isShieldingBalance: _isShieldingBalance,
+              shieldBalanceError: _shieldBalanceError,
               formatSignedZec: _formatSignedZec,
               groupLabelForTx: _groupLabelForTx,
               onToggleBalanceVisibility: _toggleBalanceVisibility,
-              onShieldBalancePressed: () {},
+              onShieldBalancePressed: () =>
+                  unawaited(_shieldTransparentBalance()),
+              onDismissShieldBalanceError: _dismissShieldBalanceError,
               onSyncInBackground: () =>
                   ref.read(syncProvider.notifier).enableBackgroundSync(),
               onStopBackgroundSync: () =>
@@ -168,10 +284,14 @@ class _HomePane extends StatefulWidget {
     required this.shieldedBalanceText,
     required this.transparentBalanceText,
     required this.hasTransparentBalance,
+    required this.canShieldBalance,
+    required this.isShieldingBalance,
+    required this.shieldBalanceError,
     required this.formatSignedZec,
     required this.groupLabelForTx,
     required this.onToggleBalanceVisibility,
     required this.onShieldBalancePressed,
+    required this.onDismissShieldBalanceError,
     required this.onSyncInBackground,
     required this.onStopBackgroundSync,
     required this.onRetrySync,
@@ -183,10 +303,14 @@ class _HomePane extends StatefulWidget {
   final String shieldedBalanceText;
   final String transparentBalanceText;
   final bool hasTransparentBalance;
+  final bool canShieldBalance;
+  final bool isShieldingBalance;
+  final String? shieldBalanceError;
   final String Function(BigInt zatoshi) formatSignedZec;
   final String Function(rust_sync.TransactionInfo tx) groupLabelForTx;
   final VoidCallback onToggleBalanceVisibility;
   final VoidCallback onShieldBalancePressed;
+  final VoidCallback onDismissShieldBalanceError;
   final VoidCallback onSyncInBackground;
   final VoidCallback onStopBackgroundSync;
   final VoidCallback onRetrySync;
@@ -281,6 +405,8 @@ class _HomePaneState extends State<_HomePane> {
                           shieldedBalanceText: widget.shieldedBalanceText,
                           transparentBalanceText: widget.transparentBalanceText,
                           hasTransparentBalance: widget.hasTransparentBalance,
+                          canShieldBalance: widget.canShieldBalance,
+                          isShieldingBalance: widget.isShieldingBalance,
                           isBalanceVisible: widget.isBalanceVisible,
                           onToggleBalanceVisibility:
                               widget.onToggleBalanceVisibility,
@@ -306,6 +432,14 @@ class _HomePaneState extends State<_HomePane> {
   }
 
   _HomeNoticeData? _noticeData() {
+    if (widget.shieldBalanceError != null) {
+      return _HomeNoticeData(
+        iconName: AppIcons.warning,
+        message: widget.shieldBalanceError!,
+        actionLabel: 'Dismiss',
+        onTap: widget.onDismissShieldBalanceError,
+      );
+    }
     if (widget.sync.error != null) {
       return _HomeNoticeData(
         iconName: AppIcons.warning,
@@ -443,6 +577,8 @@ class _HomeBalanceCard extends StatelessWidget {
     required this.shieldedBalanceText,
     required this.transparentBalanceText,
     required this.hasTransparentBalance,
+    required this.canShieldBalance,
+    required this.isShieldingBalance,
     required this.isBalanceVisible,
     required this.onToggleBalanceVisibility,
     required this.onShieldBalancePressed,
@@ -451,6 +587,8 @@ class _HomeBalanceCard extends StatelessWidget {
   final String shieldedBalanceText;
   final String transparentBalanceText;
   final bool hasTransparentBalance;
+  final bool canShieldBalance;
+  final bool isShieldingBalance;
   final bool isBalanceVisible;
   final VoidCallback onToggleBalanceVisibility;
   final VoidCallback onShieldBalancePressed;
@@ -660,6 +798,8 @@ class _HomeBalanceCard extends StatelessWidget {
                     ? _HomeTransparentBalanceStrip(
                         key: const ValueKey('transparent-balance-strip'),
                         balanceText: transparentBalanceText,
+                        canShieldBalance: canShieldBalance,
+                        isShieldingBalance: isShieldingBalance,
                         isBalanceVisible: isBalanceVisible,
                         onShieldBalancePressed: onShieldBalancePressed,
                       )
@@ -678,12 +818,16 @@ class _HomeBalanceCard extends StatelessWidget {
 class _HomeTransparentBalanceStrip extends StatelessWidget {
   const _HomeTransparentBalanceStrip({
     required this.balanceText,
+    required this.canShieldBalance,
+    required this.isShieldingBalance,
     required this.isBalanceVisible,
     required this.onShieldBalancePressed,
     super.key,
   });
 
   final String balanceText;
+  final bool canShieldBalance;
+  final bool isShieldingBalance;
   final bool isBalanceVisible;
   final VoidCallback onShieldBalancePressed;
 
@@ -724,7 +868,11 @@ class _HomeTransparentBalanceStrip extends StatelessWidget {
               ),
             ),
             const SizedBox(width: AppSpacing.xs),
-            _HomeShieldBalanceButton(onPressed: onShieldBalancePressed),
+            _HomeShieldBalanceButton(
+              enabled: canShieldBalance,
+              isLoading: isShieldingBalance,
+              onPressed: onShieldBalancePressed,
+            ),
           ],
         ),
       ),
@@ -733,20 +881,34 @@ class _HomeTransparentBalanceStrip extends StatelessWidget {
 }
 
 class _HomeShieldBalanceButton extends StatelessWidget {
-  const _HomeShieldBalanceButton({required this.onPressed});
+  const _HomeShieldBalanceButton({
+    required this.enabled,
+    required this.isLoading,
+    required this.onPressed,
+  });
 
+  final bool enabled;
+  final bool isLoading;
   final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final isInteractive = enabled && !isLoading;
+    final contentColor = enabled
+        ? colors.text.accent
+        : colors.text.secondary.withValues(alpha: 0.64);
+
     return Semantics(
       button: true,
+      enabled: isInteractive,
       child: MouseRegion(
-        cursor: SystemMouseCursors.click,
+        cursor: isInteractive
+            ? SystemMouseCursors.click
+            : SystemMouseCursors.basic,
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
-          onTap: onPressed,
+          onTap: isInteractive ? onPressed : null,
           child: ConstrainedBox(
             constraints: const BoxConstraints(minWidth: 96, minHeight: 32),
             child: Padding(
@@ -755,16 +917,26 @@ class _HomeShieldBalanceButton extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  AppIcon(
-                    AppIcons.shieldKeyholeOutline,
-                    size: 16,
-                    color: colors.text.accent,
-                  ),
+                  if (isLoading)
+                    SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: contentColor,
+                      ),
+                    )
+                  else
+                    AppIcon(
+                      AppIcons.shieldKeyholeOutline,
+                      size: 16,
+                      color: contentColor,
+                    ),
                   const SizedBox(width: AppSpacing.xxs),
                   Text(
                     'Shield Balance',
                     style: AppTypography.labelLarge.copyWith(
-                      color: colors.text.accent,
+                      color: contentColor,
                     ),
                   ),
                 ],

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -22,6 +22,9 @@ class SyncState {
   final BigInt transparentBalance;
   final BigInt saplingBalance;
   final BigInt orchardBalance;
+  final BigInt transparentPendingBalance;
+  final BigInt saplingPendingBalance;
+  final BigInt orchardPendingBalance;
 
   /// Sum of spendable balances across all pools. Use for "available to send".
   final BigInt spendableBalance;
@@ -48,6 +51,9 @@ class SyncState {
     BigInt? transparentBalance,
     BigInt? saplingBalance,
     BigInt? orchardBalance,
+    BigInt? transparentPendingBalance,
+    BigInt? saplingPendingBalance,
+    BigInt? orchardPendingBalance,
     BigInt? spendableBalance,
     BigInt? totalBalance,
     this.error,
@@ -56,6 +62,9 @@ class SyncState {
   }) : transparentBalance = transparentBalance ?? BigInt.zero,
        saplingBalance = saplingBalance ?? BigInt.zero,
        orchardBalance = orchardBalance ?? BigInt.zero,
+       transparentPendingBalance = transparentPendingBalance ?? BigInt.zero,
+       saplingPendingBalance = saplingPendingBalance ?? BigInt.zero,
+       orchardPendingBalance = orchardPendingBalance ?? BigInt.zero,
        spendableBalance = spendableBalance ?? BigInt.zero,
        totalBalance = totalBalance ?? BigInt.zero;
 
@@ -68,6 +77,9 @@ class SyncState {
     BigInt? transparentBalance,
     BigInt? saplingBalance,
     BigInt? orchardBalance,
+    BigInt? transparentPendingBalance,
+    BigInt? saplingPendingBalance,
+    BigInt? orchardPendingBalance,
     BigInt? spendableBalance,
     BigInt? totalBalance,
     String? error,
@@ -83,6 +95,12 @@ class SyncState {
       transparentBalance: transparentBalance ?? this.transparentBalance,
       saplingBalance: saplingBalance ?? this.saplingBalance,
       orchardBalance: orchardBalance ?? this.orchardBalance,
+      transparentPendingBalance:
+          transparentPendingBalance ?? this.transparentPendingBalance,
+      saplingPendingBalance:
+          saplingPendingBalance ?? this.saplingPendingBalance,
+      orchardPendingBalance:
+          orchardPendingBalance ?? this.orchardPendingBalance,
       spendableBalance: spendableBalance ?? this.spendableBalance,
       totalBalance: totalBalance ?? this.totalBalance,
       error: error ?? this.error,
@@ -207,6 +225,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       transparentBalance: initial.transparentBalance,
       saplingBalance: initial.saplingBalance,
       orchardBalance: initial.orchardBalance,
+      transparentPendingBalance: initial.transparentPendingBalance,
+      saplingPendingBalance: initial.saplingPendingBalance,
+      orchardPendingBalance: initial.orchardPendingBalance,
       spendableBalance: initial.spendableBalance,
       totalBalance: initial.totalBalance,
       recentTransactions: initial.recentTransactions,
@@ -286,6 +307,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         transparentBalance: prev?.transparentBalance,
         saplingBalance: prev?.saplingBalance,
         orchardBalance: prev?.orchardBalance,
+        transparentPendingBalance: prev?.transparentPendingBalance,
+        saplingPendingBalance: prev?.saplingPendingBalance,
+        orchardPendingBalance: prev?.orchardPendingBalance,
         spendableBalance: prev?.spendableBalance,
         totalBalance: prev?.totalBalance,
         recentTransactions: prev?.recentTransactions ?? const [],
@@ -356,6 +380,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
                   transparentBalance: prev?.transparentBalance,
                   saplingBalance: prev?.saplingBalance,
                   orchardBalance: prev?.orchardBalance,
+                  transparentPendingBalance: prev?.transparentPendingBalance,
+                  saplingPendingBalance: prev?.saplingPendingBalance,
+                  orchardPendingBalance: prev?.orchardPendingBalance,
                   spendableBalance: prev?.spendableBalance,
                   totalBalance: prev?.totalBalance,
                   recentTransactions: prev?.recentTransactions ?? const [],
@@ -383,6 +410,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               transparentBalance: prev?.transparentBalance,
               saplingBalance: prev?.saplingBalance,
               orchardBalance: prev?.orchardBalance,
+              transparentPendingBalance: prev?.transparentPendingBalance,
+              saplingPendingBalance: prev?.saplingPendingBalance,
+              orchardPendingBalance: prev?.orchardPendingBalance,
               spendableBalance: prev?.spendableBalance,
               totalBalance: prev?.totalBalance,
               recentTransactions: prev?.recentTransactions ?? const [],
@@ -469,6 +499,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         transparentBalance: prev?.transparentBalance,
         saplingBalance: prev?.saplingBalance,
         orchardBalance: prev?.orchardBalance,
+        transparentPendingBalance: prev?.transparentPendingBalance,
+        saplingPendingBalance: prev?.saplingPendingBalance,
+        orchardPendingBalance: prev?.orchardPendingBalance,
         spendableBalance: prev?.spendableBalance,
         totalBalance: prev?.totalBalance,
         recentTransactions: prev?.recentTransactions ?? const [],
@@ -842,7 +875,14 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
     // Only fetch balance/history when there are new transactions or sync is complete.
     // Skipping intermediate batches avoids opening a new DB connection per batch.
-    BigInt? transparent, sapling, orchard, spendable, total;
+    BigInt? transparent;
+    BigInt? sapling;
+    BigInt? orchard;
+    BigInt? transparentPending;
+    BigInt? saplingPending;
+    BigInt? orchardPending;
+    BigInt? spendable;
+    BigInt? total;
     var recentTxs =
         prev?.recentTransactions ?? const <rust_sync.TransactionInfo>[];
     if (event.hasNewTx || event.isComplete) {
@@ -855,6 +895,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         transparent = balance.transparent;
         sapling = balance.sapling;
         orchard = balance.orchard;
+        transparentPending = balance.transparentPending;
+        saplingPending = balance.saplingPending;
+        orchardPending = balance.orchardPending;
         spendable = balance.spendable;
         total = balance.total;
       } catch (e) {
@@ -892,6 +935,10 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         transparentBalance: transparent ?? prev?.transparentBalance,
         saplingBalance: sapling ?? prev?.saplingBalance,
         orchardBalance: orchard ?? prev?.orchardBalance,
+        transparentPendingBalance:
+            transparentPending ?? prev?.transparentPendingBalance,
+        saplingPendingBalance: saplingPending ?? prev?.saplingPendingBalance,
+        orchardPendingBalance: orchardPending ?? prev?.orchardPendingBalance,
         spendableBalance: spendable ?? prev?.spendableBalance,
         totalBalance: total ?? prev?.totalBalance,
         recentTransactions: recentTxs,
@@ -929,7 +976,14 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       return;
     }
 
-    BigInt? transparent, sapling, orchard, spendable, total;
+    BigInt? transparent;
+    BigInt? sapling;
+    BigInt? orchard;
+    BigInt? transparentPending;
+    BigInt? saplingPending;
+    BigInt? orchardPending;
+    BigInt? spendable;
+    BigInt? total;
     try {
       final balance = await rust_sync.getBalance(
         dbPath: dbPath,
@@ -939,6 +993,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       transparent = balance.transparent;
       sapling = balance.sapling;
       orchard = balance.orchard;
+      transparentPending = balance.transparentPending;
+      saplingPending = balance.saplingPending;
+      orchardPending = balance.orchardPending;
       spendable = balance.spendable;
       total = balance.total;
     } catch (e) {
@@ -981,6 +1038,10 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         transparentBalance: transparent ?? prev?.transparentBalance,
         saplingBalance: sapling ?? prev?.saplingBalance,
         orchardBalance: orchard ?? prev?.orchardBalance,
+        transparentPendingBalance:
+            transparentPending ?? prev?.transparentPendingBalance,
+        saplingPendingBalance: saplingPending ?? prev?.saplingPendingBalance,
+        orchardPendingBalance: orchardPending ?? prev?.orchardPendingBalance,
         spendableBalance: spendable ?? prev?.spendableBalance,
         totalBalance: total ?? prev?.totalBalance,
         recentTransactions: recentTxs,

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -25,6 +25,9 @@ class SyncState {
   final BigInt transparentPendingBalance;
   final BigInt saplingPendingBalance;
   final BigInt orchardPendingBalance;
+  final bool canShieldTransparentBalance;
+  final BigInt shieldTransparentFee;
+  final BigInt shieldTransparentAmount;
 
   /// Sum of spendable balances across all pools. Use for "available to send".
   final BigInt spendableBalance;
@@ -54,6 +57,9 @@ class SyncState {
     BigInt? transparentPendingBalance,
     BigInt? saplingPendingBalance,
     BigInt? orchardPendingBalance,
+    this.canShieldTransparentBalance = false,
+    BigInt? shieldTransparentFee,
+    BigInt? shieldTransparentAmount,
     BigInt? spendableBalance,
     BigInt? totalBalance,
     this.error,
@@ -65,6 +71,8 @@ class SyncState {
        transparentPendingBalance = transparentPendingBalance ?? BigInt.zero,
        saplingPendingBalance = saplingPendingBalance ?? BigInt.zero,
        orchardPendingBalance = orchardPendingBalance ?? BigInt.zero,
+       shieldTransparentFee = shieldTransparentFee ?? BigInt.zero,
+       shieldTransparentAmount = shieldTransparentAmount ?? BigInt.zero,
        spendableBalance = spendableBalance ?? BigInt.zero,
        totalBalance = totalBalance ?? BigInt.zero;
 
@@ -80,6 +88,9 @@ class SyncState {
     BigInt? transparentPendingBalance,
     BigInt? saplingPendingBalance,
     BigInt? orchardPendingBalance,
+    bool? canShieldTransparentBalance,
+    BigInt? shieldTransparentFee,
+    BigInt? shieldTransparentAmount,
     BigInt? spendableBalance,
     BigInt? totalBalance,
     String? error,
@@ -101,6 +112,11 @@ class SyncState {
           saplingPendingBalance ?? this.saplingPendingBalance,
       orchardPendingBalance:
           orchardPendingBalance ?? this.orchardPendingBalance,
+      canShieldTransparentBalance:
+          canShieldTransparentBalance ?? this.canShieldTransparentBalance,
+      shieldTransparentFee: shieldTransparentFee ?? this.shieldTransparentFee,
+      shieldTransparentAmount:
+          shieldTransparentAmount ?? this.shieldTransparentAmount,
       spendableBalance: spendableBalance ?? this.spendableBalance,
       totalBalance: totalBalance ?? this.totalBalance,
       error: error ?? this.error,
@@ -228,6 +244,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       transparentPendingBalance: initial.transparentPendingBalance,
       saplingPendingBalance: initial.saplingPendingBalance,
       orchardPendingBalance: initial.orchardPendingBalance,
+      canShieldTransparentBalance: initial.canShieldTransparentBalance,
+      shieldTransparentFee: initial.shieldTransparentFee,
+      shieldTransparentAmount: initial.shieldTransparentAmount,
       spendableBalance: initial.spendableBalance,
       totalBalance: initial.totalBalance,
       recentTransactions: initial.recentTransactions,
@@ -310,6 +329,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         transparentPendingBalance: prev?.transparentPendingBalance,
         saplingPendingBalance: prev?.saplingPendingBalance,
         orchardPendingBalance: prev?.orchardPendingBalance,
+        canShieldTransparentBalance: prev?.canShieldTransparentBalance ?? false,
+        shieldTransparentFee: prev?.shieldTransparentFee,
+        shieldTransparentAmount: prev?.shieldTransparentAmount,
         spendableBalance: prev?.spendableBalance,
         totalBalance: prev?.totalBalance,
         recentTransactions: prev?.recentTransactions ?? const [],
@@ -383,6 +405,10 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
                   transparentPendingBalance: prev?.transparentPendingBalance,
                   saplingPendingBalance: prev?.saplingPendingBalance,
                   orchardPendingBalance: prev?.orchardPendingBalance,
+                  canShieldTransparentBalance:
+                      prev?.canShieldTransparentBalance ?? false,
+                  shieldTransparentFee: prev?.shieldTransparentFee,
+                  shieldTransparentAmount: prev?.shieldTransparentAmount,
                   spendableBalance: prev?.spendableBalance,
                   totalBalance: prev?.totalBalance,
                   recentTransactions: prev?.recentTransactions ?? const [],
@@ -413,6 +439,10 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               transparentPendingBalance: prev?.transparentPendingBalance,
               saplingPendingBalance: prev?.saplingPendingBalance,
               orchardPendingBalance: prev?.orchardPendingBalance,
+              canShieldTransparentBalance:
+                  prev?.canShieldTransparentBalance ?? false,
+              shieldTransparentFee: prev?.shieldTransparentFee,
+              shieldTransparentAmount: prev?.shieldTransparentAmount,
               spendableBalance: prev?.spendableBalance,
               totalBalance: prev?.totalBalance,
               recentTransactions: prev?.recentTransactions ?? const [],
@@ -502,6 +532,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         transparentPendingBalance: prev?.transparentPendingBalance,
         saplingPendingBalance: prev?.saplingPendingBalance,
         orchardPendingBalance: prev?.orchardPendingBalance,
+        canShieldTransparentBalance: prev?.canShieldTransparentBalance ?? false,
+        shieldTransparentFee: prev?.shieldTransparentFee,
+        shieldTransparentAmount: prev?.shieldTransparentAmount,
         spendableBalance: prev?.spendableBalance,
         totalBalance: prev?.totalBalance,
         recentTransactions: prev?.recentTransactions ?? const [],
@@ -883,6 +916,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     BigInt? orchardPending;
     BigInt? spendable;
     BigInt? total;
+    bool? canShieldTransparentBalance;
+    BigInt? shieldTransparentFee;
+    BigInt? shieldTransparentAmount;
     var recentTxs =
         prev?.recentTransactions ?? const <rust_sync.TransactionInfo>[];
     if (event.hasNewTx || event.isComplete) {
@@ -913,6 +949,18 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       } catch (e) {
         log('SyncNotifier: tx history fetch failed: $e');
       }
+      final shieldStatus = await _getShieldTransparentStatus(
+        dbPath: dbPath,
+        network: network,
+        accountUuid: accountUuid,
+        transparentBalance:
+            transparent ?? prev?.transparentBalance ?? BigInt.zero,
+      );
+      if (shieldStatus != null) {
+        canShieldTransparentBalance = shieldStatus.canShield;
+        shieldTransparentFee = shieldStatus.fee;
+        shieldTransparentAmount = shieldStatus.amount;
+      }
     }
 
     if (epoch != _sensitiveStateEpoch || _requiresUnlock) {
@@ -939,6 +987,14 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
             transparentPending ?? prev?.transparentPendingBalance,
         saplingPendingBalance: saplingPending ?? prev?.saplingPendingBalance,
         orchardPendingBalance: orchardPending ?? prev?.orchardPendingBalance,
+        canShieldTransparentBalance:
+            canShieldTransparentBalance ??
+            prev?.canShieldTransparentBalance ??
+            false,
+        shieldTransparentFee:
+            shieldTransparentFee ?? prev?.shieldTransparentFee,
+        shieldTransparentAmount:
+            shieldTransparentAmount ?? prev?.shieldTransparentAmount,
         spendableBalance: spendable ?? prev?.spendableBalance,
         totalBalance: total ?? prev?.totalBalance,
         recentTransactions: recentTxs,
@@ -984,6 +1040,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     BigInt? orchardPending;
     BigInt? spendable;
     BigInt? total;
+    bool? canShieldTransparentBalance;
+    BigInt? shieldTransparentFee;
+    BigInt? shieldTransparentAmount;
     try {
       final balance = await rust_sync.getBalance(
         dbPath: dbPath,
@@ -1023,6 +1082,19 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       );
     }
 
+    final shieldStatus = await _getShieldTransparentStatus(
+      dbPath: dbPath,
+      network: network,
+      accountUuid: accountUuid,
+      transparentBalance:
+          transparent ?? prev?.transparentBalance ?? BigInt.zero,
+    );
+    if (shieldStatus != null) {
+      canShieldTransparentBalance = shieldStatus.canShield;
+      shieldTransparentFee = shieldStatus.fee;
+      shieldTransparentAmount = shieldStatus.amount;
+    }
+
     if (epoch != _sensitiveStateEpoch || _requiresUnlock) {
       log('SyncNotifier: discarding balance refresh after lock transition');
       return;
@@ -1042,6 +1114,14 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
             transparentPending ?? prev?.transparentPendingBalance,
         saplingPendingBalance: saplingPending ?? prev?.saplingPendingBalance,
         orchardPendingBalance: orchardPending ?? prev?.orchardPendingBalance,
+        canShieldTransparentBalance:
+            canShieldTransparentBalance ??
+            prev?.canShieldTransparentBalance ??
+            false,
+        shieldTransparentFee:
+            shieldTransparentFee ?? prev?.shieldTransparentFee,
+        shieldTransparentAmount:
+            shieldTransparentAmount ?? prev?.shieldTransparentAmount,
         spendableBalance: spendable ?? prev?.spendableBalance,
         totalBalance: total ?? prev?.totalBalance,
         recentTransactions: recentTxs,
@@ -1051,6 +1131,40 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
   String? _getActiveAccountUuid() {
     return ref.read(accountProvider).value?.activeAccountUuid;
+  }
+
+  Future<({bool canShield, BigInt fee, BigInt amount})?>
+  _getShieldTransparentStatus({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required BigInt transparentBalance,
+  }) async {
+    final isHardware =
+        ref.read(accountProvider).value?.activeAccount?.isHardware ?? false;
+    if (isHardware || transparentBalance <= BigInt.zero) {
+      return (canShield: false, fee: BigInt.zero, amount: BigInt.zero);
+    }
+
+    try {
+      final status = await rust_sync.getShieldTransparentStatus(
+        dbPath: dbPath,
+        network: network,
+        accountUuid: accountUuid,
+      );
+      return (
+        canShield: status.canShield,
+        fee: status.feeZatoshi,
+        amount: status.shieldedZatoshi,
+      );
+    } catch (e) {
+      _logRefreshReadError(
+        label: 'shield transparent status',
+        fallback: 'keeping previous value',
+        error: e,
+      );
+      return null;
+    }
   }
 
   void _logRefreshReadError({

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -252,6 +252,23 @@ Future<String> executeProposal({
   outputParamsPath: outputParamsPath,
 );
 
+/// Shield spendable transparent funds into the account's shielded balance.
+/// Software-account only; hardware shielding will be added separately through
+/// the PCZT flow.
+Future<ShieldTransparentResult> shieldTransparentBalance({
+  required String dbPath,
+  required String lightwalletdUrl,
+  required String network,
+  required String accountUuid,
+  required List<int> seed,
+}) => RustLib.instance.api.crateApiSyncShieldTransparentBalance(
+  dbPath: dbPath,
+  lightwalletdUrl: lightwalletdUrl,
+  network: network,
+  accountUuid: accountUuid,
+  seed: seed,
+);
+
 Future<String> getNextAvailableAddress({
   required String dbPath,
   required String network,
@@ -574,6 +591,31 @@ class ScanResult {
       other is ScanResult &&
           runtimeType == other.runtimeType &&
           blocksScanned == other.blocksScanned;
+}
+
+class ShieldTransparentResult {
+  final String txids;
+  final BigInt feeZatoshi;
+  final BigInt shieldedZatoshi;
+
+  const ShieldTransparentResult({
+    required this.txids,
+    required this.feeZatoshi,
+    required this.shieldedZatoshi,
+  });
+
+  @override
+  int get hashCode =>
+      txids.hashCode ^ feeZatoshi.hashCode ^ shieldedZatoshi.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ShieldTransparentResult &&
+          runtimeType == other.runtimeType &&
+          txids == other.txids &&
+          feeZatoshi == other.feeZatoshi &&
+          shieldedZatoshi == other.shieldedZatoshi;
 }
 
 class SubtreeIndices {

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -252,6 +252,17 @@ Future<String> executeProposal({
   outputParamsPath: outputParamsPath,
 );
 
+/// Dry-run transparent shielding without creating or broadcasting a transaction.
+Future<ShieldTransparentStatus> getShieldTransparentStatus({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+}) => RustLib.instance.api.crateApiSyncGetShieldTransparentStatus(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+);
+
 /// Shield spendable transparent funds into the account's shielded balance.
 /// Software-account only; hardware shielding will be added separately through
 /// the PCZT flow.
@@ -616,6 +627,37 @@ class ShieldTransparentResult {
           txids == other.txids &&
           feeZatoshi == other.feeZatoshi &&
           shieldedZatoshi == other.shieldedZatoshi;
+}
+
+class ShieldTransparentStatus {
+  final bool canShield;
+  final BigInt feeZatoshi;
+  final BigInt shieldedZatoshi;
+  final String reason;
+
+  const ShieldTransparentStatus({
+    required this.canShield,
+    required this.feeZatoshi,
+    required this.shieldedZatoshi,
+    required this.reason,
+  });
+
+  @override
+  int get hashCode =>
+      canShield.hashCode ^
+      feeZatoshi.hashCode ^
+      shieldedZatoshi.hashCode ^
+      reason.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ShieldTransparentStatus &&
+          runtimeType == other.runtimeType &&
+          canShield == other.canShield &&
+          feeZatoshi == other.feeZatoshi &&
+          shieldedZatoshi == other.shieldedZatoshi &&
+          reason == other.reason;
 }
 
 class SubtreeIndices {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -70,7 +70,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1009375303;
+  int get rustContentHash => -1901376488;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -198,6 +198,12 @@ abstract class RustLibApi extends BaseApi {
   Future<SubtreeIndices> crateApiSyncGetNextSubtreeIndices({
     required String dbPath,
     required String network,
+  });
+
+  Future<ShieldTransparentStatus> crateApiSyncGetShieldTransparentStatus({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
   });
 
   int crateApiSyncGetSyncMode();
@@ -1252,12 +1258,49 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<ShieldTransparentStatus> crateApiSyncGetShieldTransparentStatus({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 25,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_shield_transparent_status,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSyncGetShieldTransparentStatusConstMeta,
+        argValues: [dbPath, network, accountUuid],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncGetShieldTransparentStatusConstMeta =>
+      const TaskConstMeta(
+        debugName: "get_shield_transparent_status",
+        argNames: ["dbPath", "network", "accountUuid"],
+      );
+
+  @override
   int crateApiSyncGetSyncMode() {
     return handler.executeSync(
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -1287,7 +1330,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1321,7 +1364,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1360,7 +1403,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1397,7 +1440,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1434,7 +1477,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1462,7 +1505,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1502,7 +1545,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1559,7 +1602,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1594,7 +1637,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1621,7 +1664,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1645,7 +1688,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 36)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1670,7 +1713,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1692,7 +1735,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1720,7 +1763,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1755,7 +1798,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1797,7 +1840,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -1853,7 +1896,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1900,7 +1943,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -1927,7 +1970,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -1959,7 +2002,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -1997,7 +2040,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -2050,7 +2093,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -2101,7 +2144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2135,7 +2178,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -2176,7 +2219,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 51,
             port: port_,
           );
         },
@@ -2224,7 +2267,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 51,
+              funcId: 52,
               port: port_,
             );
           },
@@ -2265,7 +2308,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 52,
+              funcId: 53,
               port: port_,
             );
           },
@@ -2294,7 +2337,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2324,7 +2367,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 55,
             port: port_,
           );
         },
@@ -2361,7 +2404,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2393,7 +2436,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 57,
             port: port_,
           );
         },
@@ -2418,7 +2461,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(mnemonic, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2444,7 +2487,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2474,7 +2517,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2777,6 +2820,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       txids: dco_decode_String(arr[0]),
       feeZatoshi: dco_decode_u_64(arr[1]),
       shieldedZatoshi: dco_decode_u_64(arr[2]),
+    );
+  }
+
+  @protected
+  ShieldTransparentStatus dco_decode_shield_transparent_status(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    return ShieldTransparentStatus(
+      canShield: dco_decode_bool(arr[0]),
+      feeZatoshi: dco_decode_u_64(arr[1]),
+      shieldedZatoshi: dco_decode_u_64(arr[2]),
+      reason: dco_decode_String(arr[3]),
     );
   }
 
@@ -3315,6 +3372,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ShieldTransparentStatus sse_decode_shield_transparent_status(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_canShield = sse_decode_bool(deserializer);
+    var var_feeZatoshi = sse_decode_u_64(deserializer);
+    var var_shieldedZatoshi = sse_decode_u_64(deserializer);
+    var var_reason = sse_decode_String(deserializer);
+    return ShieldTransparentStatus(
+      canShield: var_canShield,
+      feeZatoshi: var_feeZatoshi,
+      shieldedZatoshi: var_shieldedZatoshi,
+      reason: var_reason,
+    );
+  }
+
+  @protected
   SubtreeIndices sse_decode_subtree_indices(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_nextSapling = sse_decode_u_64(deserializer);
@@ -3840,6 +3914,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.txids, serializer);
     sse_encode_u_64(self.feeZatoshi, serializer);
     sse_encode_u_64(self.shieldedZatoshi, serializer);
+  }
+
+  @protected
+  void sse_encode_shield_transparent_status(
+    ShieldTransparentStatus self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_bool(self.canShield, serializer);
+    sse_encode_u_64(self.feeZatoshi, serializer);
+    sse_encode_u_64(self.shieldedZatoshi, serializer);
+    sse_encode_String(self.reason, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -70,7 +70,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1440350829;
+  int get rustContentHash => -1009375303;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -328,6 +328,14 @@ abstract class RustLibApi extends BaseApi {
     required String network,
     required String txidHex,
     required PlatformInt64 status,
+  });
+
+  Future<ShieldTransparentResult> crateApiSyncShieldTransparentBalance({
+    required String dbPath,
+    required String lightwalletdUrl,
+    required String network,
+    required String accountUuid,
+    required List<int> seed,
   });
 
   Stream<ApiSyncProgressEvent> crateApiSyncStartFullSync({
@@ -2149,6 +2157,53 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<ShieldTransparentResult> crateApiSyncShieldTransparentBalance({
+    required String dbPath,
+    required String lightwalletdUrl,
+    required String network,
+    required String accountUuid,
+    required List<int> seed,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
+          sse_encode_list_prim_u_8_loose(seed, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 50,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_shield_transparent_result,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSyncShieldTransparentBalanceConstMeta,
+        argValues: [dbPath, lightwalletdUrl, network, accountUuid, seed],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncShieldTransparentBalanceConstMeta =>
+      const TaskConstMeta(
+        debugName: "shield_transparent_balance",
+        argNames: [
+          "dbPath",
+          "lightwalletdUrl",
+          "network",
+          "accountUuid",
+          "seed",
+        ],
+      );
+
+  @override
   Stream<ApiSyncProgressEvent> crateApiSyncStartFullSync({
     required String dbPath,
     required String lightwalletdUrl,
@@ -2169,7 +2224,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 50,
+              funcId: 51,
               port: port_,
             );
           },
@@ -2210,7 +2265,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 51,
+              funcId: 52,
               port: port_,
             );
           },
@@ -2239,7 +2294,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2269,7 +2324,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -2306,7 +2361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 55,
             port: port_,
           );
         },
@@ -2338,7 +2393,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2363,7 +2418,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(mnemonic, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2389,7 +2444,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2419,7 +2474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 59,
             port: port_,
           );
         },
@@ -2710,6 +2765,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ScanResult(blocksScanned: dco_decode_u_64(arr[0]));
+  }
+
+  @protected
+  ShieldTransparentResult dco_decode_shield_transparent_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return ShieldTransparentResult(
+      txids: dco_decode_String(arr[0]),
+      feeZatoshi: dco_decode_u_64(arr[1]),
+      shieldedZatoshi: dco_decode_u_64(arr[2]),
+    );
   }
 
   @protected
@@ -3232,6 +3300,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ShieldTransparentResult sse_decode_shield_transparent_result(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_txids = sse_decode_String(deserializer);
+    var var_feeZatoshi = sse_decode_u_64(deserializer);
+    var var_shieldedZatoshi = sse_decode_u_64(deserializer);
+    return ShieldTransparentResult(
+      txids: var_txids,
+      feeZatoshi: var_feeZatoshi,
+      shieldedZatoshi: var_shieldedZatoshi,
+    );
+  }
+
+  @protected
   SubtreeIndices sse_decode_subtree_indices(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_nextSapling = sse_decode_u_64(deserializer);
@@ -3746,6 +3829,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_scan_result(ScanResult self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.blocksScanned, serializer);
+  }
+
+  @protected
+  void sse_encode_shield_transparent_result(
+    ShieldTransparentResult self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.txids, serializer);
+    sse_encode_u_64(self.feeZatoshi, serializer);
+    sse_encode_u_64(self.shieldedZatoshi, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -127,6 +127,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ShieldTransparentResult dco_decode_shield_transparent_result(dynamic raw);
 
   @protected
+  ShieldTransparentStatus dco_decode_shield_transparent_status(dynamic raw);
+
+  @protected
   SubtreeIndices dco_decode_subtree_indices(dynamic raw);
 
   @protected
@@ -293,6 +296,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ShieldTransparentResult sse_decode_shield_transparent_result(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ShieldTransparentStatus sse_decode_shield_transparent_status(
     SseDeserializer deserializer,
   );
 
@@ -501,6 +509,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_shield_transparent_result(
     ShieldTransparentResult self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_shield_transparent_status(
+    ShieldTransparentStatus self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -124,6 +124,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ScanResult dco_decode_scan_result(dynamic raw);
 
   @protected
+  ShieldTransparentResult dco_decode_shield_transparent_result(dynamic raw);
+
+  @protected
   SubtreeIndices dco_decode_subtree_indices(dynamic raw);
 
   @protected
@@ -287,6 +290,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ScanResult sse_decode_scan_result(SseDeserializer deserializer);
+
+  @protected
+  ShieldTransparentResult sse_decode_shield_transparent_result(
+    SseDeserializer deserializer,
+  );
 
   @protected
   SubtreeIndices sse_decode_subtree_indices(SseDeserializer deserializer);
@@ -489,6 +497,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_scan_result(ScanResult self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_shield_transparent_result(
+    ShieldTransparentResult self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_subtree_indices(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -126,6 +126,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ScanResult dco_decode_scan_result(dynamic raw);
 
   @protected
+  ShieldTransparentResult dco_decode_shield_transparent_result(dynamic raw);
+
+  @protected
   SubtreeIndices dco_decode_subtree_indices(dynamic raw);
 
   @protected
@@ -289,6 +292,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ScanResult sse_decode_scan_result(SseDeserializer deserializer);
+
+  @protected
+  ShieldTransparentResult sse_decode_shield_transparent_result(
+    SseDeserializer deserializer,
+  );
 
   @protected
   SubtreeIndices sse_decode_subtree_indices(SseDeserializer deserializer);
@@ -491,6 +499,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_scan_result(ScanResult self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_shield_transparent_result(
+    ShieldTransparentResult self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_subtree_indices(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -129,6 +129,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ShieldTransparentResult dco_decode_shield_transparent_result(dynamic raw);
 
   @protected
+  ShieldTransparentStatus dco_decode_shield_transparent_status(dynamic raw);
+
+  @protected
   SubtreeIndices dco_decode_subtree_indices(dynamic raw);
 
   @protected
@@ -295,6 +298,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ShieldTransparentResult sse_decode_shield_transparent_result(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ShieldTransparentStatus sse_decode_shield_transparent_status(
     SseDeserializer deserializer,
   );
 
@@ -503,6 +511,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_shield_transparent_result(
     ShieldTransparentResult self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_shield_transparent_status(
+    ShieldTransparentStatus self,
     SseSerializer serializer,
   );
 

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -571,6 +571,13 @@ pub struct ShieldTransparentResult {
     pub shielded_zatoshi: u64,
 }
 
+pub struct ShieldTransparentStatus {
+    pub can_shield: bool,
+    pub fee_zatoshi: u64,
+    pub shielded_zatoshi: u64,
+    pub reason: String,
+}
+
 /// Step 1: Propose a transfer. Returns proposal info including whether Sapling params are needed.
 pub fn propose_send(
     db_path: String,
@@ -640,6 +647,24 @@ pub fn execute_proposal(
             spend_params_path.as_deref(),
             output_params_path.as_deref(),
         ))
+    })
+}
+
+/// Dry-run transparent shielding without creating or broadcasting a transaction.
+pub fn get_shield_transparent_status(
+    db_path: String,
+    network: String,
+    account_uuid: String,
+) -> Result<ShieldTransparentStatus, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        let r = wallet_sync::get_shield_transparent_status(&db_path, network, &account_uuid)?;
+        Ok(ShieldTransparentStatus {
+            can_shield: r.can_shield,
+            fee_zatoshi: r.fee_zatoshi,
+            shielded_zatoshi: r.shielded_zatoshi,
+            reason: r.reason,
+        })
     })
 }
 

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -565,6 +565,12 @@ pub struct ProposalResult {
     pub fee_zatoshi: u64,
 }
 
+pub struct ShieldTransparentResult {
+    pub txids: String,
+    pub fee_zatoshi: u64,
+    pub shielded_zatoshi: u64,
+}
+
 /// Step 1: Propose a transfer. Returns proposal info including whether Sapling params are needed.
 pub fn propose_send(
     db_path: String,
@@ -634,6 +640,34 @@ pub fn execute_proposal(
             spend_params_path.as_deref(),
             output_params_path.as_deref(),
         ))
+    })
+}
+
+/// Shield spendable transparent funds into the account's shielded balance.
+/// Software-account only; hardware shielding will be added separately through
+/// the PCZT flow.
+pub fn shield_transparent_balance(
+    db_path: String,
+    lightwalletd_url: String,
+    network: String,
+    account_uuid: String,
+    seed: Vec<u8>,
+) -> Result<ShieldTransparentResult, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
+        let r = rt.block_on(wallet_sync::shield_transparent_balance(
+            &db_path,
+            &lightwalletd_url,
+            network,
+            &account_uuid,
+            &seed,
+        ))?;
+        Ok(ShieldTransparentResult {
+            txids: r.txids,
+            fee_zatoshi: r.fee_zatoshi,
+            shielded_zatoshi: r.shielded_zatoshi,
+        })
     })
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1009375303;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1901376488;
 
 // Section: executor
 
@@ -923,6 +923,45 @@ fn wire__crate__api__sync__get_next_subtree_indices_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok =
                         crate::api::sync::get_next_subtree_indices(api_db_path, api_network)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__sync__get_shield_transparent_status_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_shield_transparent_status",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::sync::get_shield_transparent_status(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -2602,6 +2641,22 @@ impl SseDecode for crate::api::sync::ShieldTransparentResult {
     }
 }
 
+impl SseDecode for crate::api::sync::ShieldTransparentStatus {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_canShield = <bool>::sse_decode(deserializer);
+        let mut var_feeZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_shieldedZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_reason = <String>::sse_decode(deserializer);
+        return crate::api::sync::ShieldTransparentStatus {
+            can_shield: var_canShield,
+            fee_zatoshi: var_feeZatoshi,
+            shielded_zatoshi: var_shieldedZatoshi,
+            reason: var_reason,
+        };
+    }
+}
+
 impl SseDecode for crate::api::sync::SubtreeIndices {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2855,71 +2910,77 @@ fn pde_ffi_dispatcher_primary_impl(
         24 => {
             wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len)
         }
-        26 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__sync__get_transaction_data_requests_impl(
+        25 => wire__crate__api__sync__get_shield_transparent_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        28 => {
+        27 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__sync__get_transaction_data_requests_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        29 => {
             wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len)
         }
-        29 => wire__crate__api__wallet__get_transparent_address_impl(
+        30 => wire__crate__api__wallet__get_transparent_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        30 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__wallet__import_hardware_account_impl(
+        31 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__wallet__import_hardware_account_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        33 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__keystone__is_keystone_connected_impl(
+        34 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__keystone__is_keystone_connected_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        39 => wire__crate__api__keystone__keystone_usb_sign_pczt_impl(
+        40 => wire__crate__api__keystone__keystone_usb_sign_pczt_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        40 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-        43 => {
+        41 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+        44 => {
             wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len)
         }
-        45 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-        46 => {
+        46 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+        47 => {
             wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len)
         }
-        47 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-        49 => {
+        48 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+        50 => {
             wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len)
         }
-        50 => wire__crate__api__sync__shield_transparent_balance_impl(
+        51 => wire__crate__api__sync__shield_transparent_balance_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        51 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-        52 => {
+        52 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+        53 => {
             wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len)
         }
-        54 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-        56 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+        55 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -2935,16 +2996,16 @@ fn pde_ffi_dispatcher_sync_impl(
         3 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
         19 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
         21 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        31 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        26 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3186,6 +3247,29 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ShieldTransparentResult
     for crate::api::sync::ShieldTransparentResult
 {
     fn into_into_dart(self) -> crate::api::sync::ShieldTransparentResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sync::ShieldTransparentStatus {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.can_shield.into_into_dart().into_dart(),
+            self.fee_zatoshi.into_into_dart().into_dart(),
+            self.shielded_zatoshi.into_into_dart().into_dart(),
+            self.reason.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sync::ShieldTransparentStatus
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ShieldTransparentStatus>
+    for crate::api::sync::ShieldTransparentStatus
+{
+    fn into_into_dart(self) -> crate::api::sync::ShieldTransparentStatus {
         self
     }
 }
@@ -3681,6 +3765,16 @@ impl SseEncode for crate::api::sync::ShieldTransparentResult {
         <String>::sse_encode(self.txids, serializer);
         <u64>::sse_encode(self.fee_zatoshi, serializer);
         <u64>::sse_encode(self.shielded_zatoshi, serializer);
+    }
+}
+
+impl SseEncode for crate::api::sync::ShieldTransparentStatus {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.can_shield, serializer);
+        <u64>::sse_encode(self.fee_zatoshi, serializer);
+        <u64>::sse_encode(self.shielded_zatoshi, serializer);
+        <String>::sse_encode(self.reason, serializer);
     }
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1440350829;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1009375303;
 
 // Section: executor
 
@@ -1857,6 +1857,49 @@ fn wire__crate__api__sync__set_transaction_status_impl(
         },
     )
 }
+fn wire__crate__api__sync__shield_transparent_balance_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "shield_transparent_balance",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_seed = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::sync::shield_transparent_balance(
+                        api_db_path,
+                        api_lightwalletd_url,
+                        api_network,
+                        api_account_uuid,
+                        api_seed,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__sync__start_full_sync_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -2545,6 +2588,20 @@ impl SseDecode for crate::api::sync::ScanResult {
     }
 }
 
+impl SseDecode for crate::api::sync::ShieldTransparentResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_txids = <String>::sse_decode(deserializer);
+        let mut var_feeZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_shieldedZatoshi = <u64>::sse_decode(deserializer);
+        return crate::api::sync::ShieldTransparentResult {
+            txids: var_txids,
+            fee_zatoshi: var_feeZatoshi,
+            shielded_zatoshi: var_shieldedZatoshi,
+        };
+    }
+}
+
 impl SseDecode for crate::api::sync::SubtreeIndices {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2849,14 +2906,20 @@ fn pde_ffi_dispatcher_primary_impl(
         49 => {
             wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len)
         }
-        50 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-        51 => {
+        50 => wire__crate__api__sync__shield_transparent_balance_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        51 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+        52 => {
             wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len)
         }
-        53 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-        54 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+        55 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -2879,9 +2942,9 @@ fn pde_ffi_dispatcher_sync_impl(
         38 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
         44 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
         48 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        52 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        56 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        53 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3101,6 +3164,28 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ScanResult>
     for crate::api::sync::ScanResult
 {
     fn into_into_dart(self) -> crate::api::sync::ScanResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sync::ShieldTransparentResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.txids.into_into_dart().into_dart(),
+            self.fee_zatoshi.into_into_dart().into_dart(),
+            self.shielded_zatoshi.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sync::ShieldTransparentResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ShieldTransparentResult>
+    for crate::api::sync::ShieldTransparentResult
+{
+    fn into_into_dart(self) -> crate::api::sync::ShieldTransparentResult {
         self
     }
 }
@@ -3587,6 +3672,15 @@ impl SseEncode for crate::api::sync::ScanResult {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.blocks_scanned, serializer);
+    }
+}
+
+impl SseEncode for crate::api::sync::ShieldTransparentResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.txids, serializer);
+        <u64>::sse_encode(self.fee_zatoshi, serializer);
+        <u64>::sse_encode(self.shielded_zatoshi, serializer);
     }
 }
 

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -41,12 +41,15 @@ pub use pczt::{
     add_proofs_to_pczt, create_pczt_from_proposal, discard_proposal, extract_and_broadcast_pczt,
     redact_pczt_for_signer,
 };
+pub(crate) use send::shield_transparent_balance;
 pub use send::{estimate_fee, execute_proposal, propose_send};
 // Internal-only re-export for `sync_engine::run_sync_impl`'s
 // auto-resubmit pass. Not part of the `wallet::sync` public surface.
 pub(crate) use send::resubmit_pending_transactions;
 #[allow(unused_imports)] // names reachable via `crate::wallet::sync::*`; pre-refactor surface
 pub(crate) use send::ProposalResult;
+#[allow(unused_imports)] // names reachable via `crate::wallet::sync::*`; pre-refactor surface
+pub(crate) use send::ShieldTransparentResult;
 pub use transactions::{
     check_tx_mined, decrypt_and_store_transaction, get_next_available_address,
     get_pending_transactions, get_transaction_data_requests, get_transaction_history,

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -41,8 +41,8 @@ pub use pczt::{
     add_proofs_to_pczt, create_pczt_from_proposal, discard_proposal, extract_and_broadcast_pczt,
     redact_pczt_for_signer,
 };
-pub(crate) use send::shield_transparent_balance;
 pub use send::{estimate_fee, execute_proposal, propose_send};
+pub(crate) use send::{get_shield_transparent_status, shield_transparent_balance};
 // Internal-only re-export for `sync_engine::run_sync_impl`'s
 // auto-resubmit pass. Not part of the `wallet::sync` public surface.
 pub(crate) use send::resubmit_pending_transactions;
@@ -50,6 +50,8 @@ pub(crate) use send::resubmit_pending_transactions;
 pub(crate) use send::ProposalResult;
 #[allow(unused_imports)] // names reachable via `crate::wallet::sync::*`; pre-refactor surface
 pub(crate) use send::ShieldTransparentResult;
+#[allow(unused_imports)] // names reachable via `crate::wallet::sync::*`; pre-refactor surface
+pub(crate) use send::ShieldTransparentStatus;
 pub use transactions::{
     check_tx_mined, decrypt_and_store_transaction, get_next_available_address,
     get_pending_transactions, get_transaction_data_requests, get_transaction_history,

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -49,9 +49,11 @@ use zcash_client_backend::{
         Account as _, Balance, InputSource, WalletRead,
     },
     fees::{zip317::MultiOutputChangeStrategy, DustOutputPolicy, SplitPolicy, StandardFeeRule},
+    proposal::Proposal,
     wallet::OvkPolicy,
     zip321::{Payment, TransactionRequest},
 };
+use zcash_client_sqlite::AccountUuid;
 use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_primitives::transaction::TxId;
 use zcash_proofs::prover::LocalTxProver;
@@ -86,6 +88,13 @@ pub(crate) struct ShieldTransparentResult {
     pub txids: String,
     pub fee_zatoshi: u64,
     pub shielded_zatoshi: u64,
+}
+
+pub(crate) struct ShieldTransparentStatus {
+    pub can_shield: bool,
+    pub fee_zatoshi: u64,
+    pub shielded_zatoshi: u64,
+    pub reason: String,
 }
 
 const SHIELDING_THRESHOLD_ZATOSHI: u64 = 100_000;
@@ -219,6 +228,34 @@ pub fn estimate_fee(
     Ok(fee)
 }
 
+/// Dry-run the transparent shielding proposal path without creating or
+/// broadcasting a transaction. This is used to decide whether the home screen
+/// should offer the Shield Balance action.
+pub(crate) fn get_shield_transparent_status(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+) -> Result<ShieldTransparentStatus, String> {
+    let shielding_threshold = shielding_threshold()?;
+    let mut db = open_wallet_db_for_read(db_path, network)?;
+    let account_id = parse_account_uuid(account_uuid)?;
+
+    match build_shielding_proposal(&mut db, network, account_id, shielding_threshold) {
+        Ok((proposal, _)) => Ok(ShieldTransparentStatus {
+            can_shield: true,
+            fee_zatoshi: proposal_fee_zatoshi(&proposal),
+            shielded_zatoshi: proposal_shielded_zatoshi(&proposal),
+            reason: String::new(),
+        }),
+        Err(reason) => Ok(ShieldTransparentStatus {
+            can_shield: false,
+            fee_zatoshi: 0,
+            shielded_zatoshi: 0,
+            reason,
+        }),
+    }
+}
+
 /// Shield spendable transparent funds for a software account to its
 /// internal shielded address. This is intentionally a one-shot API:
 /// unlike normal sends there is no confirmation screen, proposal ID,
@@ -230,8 +267,7 @@ pub(crate) async fn shield_transparent_balance(
     account_uuid: &str,
     seed_bytes: &[u8],
 ) -> Result<ShieldTransparentResult, String> {
-    let shielding_threshold =
-        Zatoshis::from_u64(SHIELDING_THRESHOLD_ZATOSHI).map_err(|_| "Bad shielding threshold")?;
+    let shielding_threshold = shielding_threshold()?;
 
     let (txids, fee_zatoshi, shielded_zatoshi) = with_wallet_db_write_lock(
         "send.shield_transparent_balance.create_transactions",
@@ -243,45 +279,10 @@ pub(crate) async fn shield_transparent_balance(
                 .map_err(|e| format!("{e}"))?
                 .ok_or("Account not found")?;
 
-            let chain_height = db
-                .chain_height()
-                .map_err(|e| format!("Failed to read chain height: {e}"))?
-                .ok_or("Wallet must sync before shielding transparent funds")?;
-            let balances = db
-                .get_transparent_balances(
-                    account_id,
-                    (chain_height + 1).into(),
-                    ConfirmationsPolicy::MIN,
-                )
-                .map_err(|e| format!("Failed to get transparent balances: {e}"))?;
-            let (from_addrs, selected_value) =
-                select_shielding_sources(balances, shielding_threshold)?;
-            if from_addrs.is_empty() {
-                return Err(
-                    "No transparent funds available to shield above the fee threshold".to_string(),
-                );
-            }
-
-            let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None);
-            let proposal = propose_shielding::<_, _, _, _, Infallible>(
-                &mut db,
-                &network,
-                &input_selector,
-                &change_strategy,
-                shielding_threshold,
-                &from_addrs,
-                account_id,
-                ConfirmationsPolicy::MIN,
-            )
-            .map_err(|e| format!("Shield proposal failed: {e}"))?;
-
-            let fee_zatoshi: u64 = proposal
-                .steps()
-                .iter()
-                .map(|step| u64::from(step.balance().fee_required()))
-                .sum();
-            let selected_value_zatoshi = u64::from(selected_value);
-            let shielded_zatoshi = selected_value_zatoshi.saturating_sub(fee_zatoshi);
+            let (proposal, _) =
+                build_shielding_proposal(&mut db, network, account_id, shielding_threshold)?;
+            let fee_zatoshi = proposal_fee_zatoshi(&proposal);
+            let shielded_zatoshi = proposal_shielded_zatoshi(&proposal);
 
             let seed = SecretVec::new(seed_bytes.to_vec());
             let zip32_index = account
@@ -397,6 +398,46 @@ pub async fn execute_proposal(
     broadcast_created_transactions(db_path, lightwalletd_url, &txids, "send").await
 }
 
+fn shielding_threshold() -> Result<Zatoshis, String> {
+    Zatoshis::from_u64(SHIELDING_THRESHOLD_ZATOSHI)
+        .map_err(|_| "Bad shielding threshold".to_string())
+}
+
+fn build_shielding_proposal(
+    db: &mut WalletDatabase,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    shielding_threshold: Zatoshis,
+) -> Result<(Proposal<StandardFeeRule, Infallible>, Zatoshis), String> {
+    let chain_height = db
+        .chain_height()
+        .map_err(|e| format!("Failed to read chain height: {e}"))?
+        .ok_or("Wallet must sync before shielding transparent funds")?;
+    let balances = db
+        .get_transparent_balances(
+            account_id,
+            (chain_height + 1).into(),
+            ConfirmationsPolicy::MIN,
+        )
+        .map_err(|e| format!("Failed to get transparent balances: {e}"))?;
+    let (from_addrs, selected_value) = select_shielding_sources(balances, shielding_threshold)?;
+
+    let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None);
+    let proposal = propose_shielding::<_, _, _, _, Infallible>(
+        db,
+        &network,
+        &input_selector,
+        &change_strategy,
+        shielding_threshold,
+        &from_addrs,
+        account_id,
+        ConfirmationsPolicy::MIN,
+    )
+    .map_err(|e| format!("Shield proposal failed: {e}"))?;
+
+    Ok((proposal, selected_value))
+}
+
 fn select_shielding_sources(
     account_receivers: HashMap<TransparentAddress, (TransparentKeyScope, Balance)>,
     shielding_threshold: Zatoshis,
@@ -406,7 +447,7 @@ fn select_shielding_sources(
 
     for (address, (scope, balance)) in account_receivers {
         let spendable = balance.spendable_value();
-        if spendable >= shielding_threshold {
+        if spendable > Zatoshis::ZERO {
             if scope == TransparentKeyScope::EPHEMERAL {
                 ephemeral.push((address, spendable));
             } else {
@@ -419,7 +460,11 @@ fn select_shielding_sources(
     // together, but never link more than one ephemeral receiver in a single
     // shielding transaction.
     let selected = if non_ephemeral.is_empty() {
-        ephemeral.into_iter().take(1).collect()
+        ephemeral
+            .into_iter()
+            .max_by_key(|(_, value)| u64::from(*value))
+            .into_iter()
+            .collect()
     } else {
         non_ephemeral
     };
@@ -431,7 +476,28 @@ fn select_shielding_sources(
         addresses.push(address);
     }
 
+    if addresses.is_empty() || total < shielding_threshold {
+        return Err("No transparent funds available to shield above the fee threshold".to_string());
+    }
+
     Ok((addresses, total))
+}
+
+fn proposal_fee_zatoshi(proposal: &Proposal<StandardFeeRule, Infallible>) -> u64 {
+    proposal
+        .steps()
+        .iter()
+        .map(|step| u64::from(step.balance().fee_required()))
+        .sum()
+}
+
+fn proposal_shielded_zatoshi(proposal: &Proposal<StandardFeeRule, Infallible>) -> u64 {
+    proposal
+        .steps()
+        .iter()
+        .flat_map(|step| step.balance().proposed_change().iter())
+        .map(|change| u64::from(change.value()))
+        .sum()
 }
 
 async fn broadcast_created_transactions(
@@ -791,5 +857,77 @@ impl OutputProver for NoOpOutputProver {
 
     fn encode_proof(_proof: Self::Proof) -> GrothProofBytes {
         [0u8; GROTH_PROOF_SIZE]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn taddr(seed: u8) -> TransparentAddress {
+        TransparentAddress::PublicKeyHash([seed; 20])
+    }
+
+    fn balance(value: u64) -> Balance {
+        let mut balance = Balance::ZERO;
+        balance
+            .add_spendable_value(Zatoshis::from_u64(value).unwrap())
+            .unwrap();
+        balance
+    }
+
+    fn receiver(value: u64, scope: TransparentKeyScope) -> (TransparentKeyScope, Balance) {
+        (scope, balance(value))
+    }
+
+    #[test]
+    fn selects_fragmented_non_ephemeral_sources_by_aggregate_threshold() {
+        let mut receivers = HashMap::new();
+        receivers.insert(taddr(1), receiver(60_000, TransparentKeyScope::EXTERNAL));
+        receivers.insert(taddr(2), receiver(50_000, TransparentKeyScope::INTERNAL));
+
+        let threshold = Zatoshis::from_u64(100_000).unwrap();
+        let (addresses, total) = select_shielding_sources(receivers, threshold).unwrap();
+
+        assert_eq!(addresses.len(), 2);
+        assert_eq!(u64::from(total), 110_000);
+    }
+
+    #[test]
+    fn rejects_non_ephemeral_sources_below_aggregate_threshold() {
+        let mut receivers = HashMap::new();
+        receivers.insert(taddr(1), receiver(40_000, TransparentKeyScope::EXTERNAL));
+        receivers.insert(taddr(2), receiver(50_000, TransparentKeyScope::INTERNAL));
+
+        let threshold = Zatoshis::from_u64(100_000).unwrap();
+        let err = select_shielding_sources(receivers, threshold).unwrap_err();
+
+        assert!(err.contains("No transparent funds available"));
+    }
+
+    #[test]
+    fn selects_largest_ephemeral_source_only() {
+        let mut receivers = HashMap::new();
+        receivers.insert(taddr(1), receiver(110_000, TransparentKeyScope::EPHEMERAL));
+        receivers.insert(taddr(2), receiver(150_000, TransparentKeyScope::EPHEMERAL));
+
+        let threshold = Zatoshis::from_u64(100_000).unwrap();
+        let (addresses, total) = select_shielding_sources(receivers, threshold).unwrap();
+
+        assert_eq!(addresses, vec![taddr(2)]);
+        assert_eq!(u64::from(total), 150_000);
+    }
+
+    #[test]
+    fn prefers_non_ephemeral_sources_over_ephemeral_sources() {
+        let mut receivers = HashMap::new();
+        receivers.insert(taddr(1), receiver(140_000, TransparentKeyScope::EPHEMERAL));
+        receivers.insert(taddr(2), receiver(120_000, TransparentKeyScope::EXTERNAL));
+
+        let threshold = Zatoshis::from_u64(100_000).unwrap();
+        let (addresses, total) = select_shielding_sources(receivers, threshold).unwrap();
+
+        assert_eq!(addresses, vec![taddr(2)]);
+        assert_eq!(u64::from(total), 120_000);
     }
 }

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -33,21 +33,27 @@
 //! components) and the provers log+fail loudly rather than produce a
 //! silently-invalid proof.
 
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::num::NonZeroUsize;
 
 use secrecy::{ExposeSecret, SecretVec};
+use transparent::{address::TransparentAddress, keys::TransparentKeyScope};
 use zcash_client_backend::data_api::wallet::input_selection::GreedyInputSelector;
 use zcash_client_backend::{
     data_api::{
-        wallet::{self, create_proposed_transactions, propose_transfer, ConfirmationsPolicy},
-        Account as _, InputSource, WalletRead,
+        wallet::{
+            self, create_proposed_transactions, propose_shielding, propose_transfer,
+            ConfirmationsPolicy,
+        },
+        Account as _, Balance, InputSource, WalletRead,
     },
     fees::{zip317::MultiOutputChangeStrategy, DustOutputPolicy, SplitPolicy, StandardFeeRule},
     wallet::OvkPolicy,
     zip321::{Payment, TransactionRequest},
 };
 use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_primitives::transaction::TxId;
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
     memo::{Memo, MemoBytes},
@@ -75,6 +81,14 @@ pub(crate) struct ProposalResult {
     pub needs_sapling_params: bool,
     pub fee_zatoshi: u64,
 }
+
+pub(crate) struct ShieldTransparentResult {
+    pub txids: String,
+    pub fee_zatoshi: u64,
+    pub shielded_zatoshi: u64,
+}
+
+const SHIELDING_THRESHOLD_ZATOSHI: u64 = 100_000;
 
 pub fn propose_send(
     db_path: &str,
@@ -205,6 +219,105 @@ pub fn estimate_fee(
     Ok(fee)
 }
 
+/// Shield spendable transparent funds for a software account to its
+/// internal shielded address. This is intentionally a one-shot API:
+/// unlike normal sends there is no confirmation screen, proposal ID,
+/// or hardware-wallet branch.
+pub(crate) async fn shield_transparent_balance(
+    db_path: &str,
+    lightwalletd_url: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    seed_bytes: &[u8],
+) -> Result<ShieldTransparentResult, String> {
+    let shielding_threshold =
+        Zatoshis::from_u64(SHIELDING_THRESHOLD_ZATOSHI).map_err(|_| "Bad shielding threshold")?;
+
+    let (txids, fee_zatoshi, shielded_zatoshi) = with_wallet_db_write_lock(
+        "send.shield_transparent_balance.create_transactions",
+        || {
+            let mut db = open_wallet_db(db_path, network)?;
+            let account_id = parse_account_uuid(account_uuid)?;
+            let account = db
+                .get_account(account_id)
+                .map_err(|e| format!("{e}"))?
+                .ok_or("Account not found")?;
+
+            let chain_height = db
+                .chain_height()
+                .map_err(|e| format!("Failed to read chain height: {e}"))?
+                .ok_or("Wallet must sync before shielding transparent funds")?;
+            let balances = db
+                .get_transparent_balances(
+                    account_id,
+                    (chain_height + 1).into(),
+                    ConfirmationsPolicy::MIN,
+                )
+                .map_err(|e| format!("Failed to get transparent balances: {e}"))?;
+            let (from_addrs, selected_value) =
+                select_shielding_sources(balances, shielding_threshold)?;
+            if from_addrs.is_empty() {
+                return Err(
+                    "No transparent funds available to shield above the fee threshold".to_string(),
+                );
+            }
+
+            let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None);
+            let proposal = propose_shielding::<_, _, _, _, Infallible>(
+                &mut db,
+                &network,
+                &input_selector,
+                &change_strategy,
+                shielding_threshold,
+                &from_addrs,
+                account_id,
+                ConfirmationsPolicy::MIN,
+            )
+            .map_err(|e| format!("Shield proposal failed: {e}"))?;
+
+            let fee_zatoshi: u64 = proposal
+                .steps()
+                .iter()
+                .map(|step| u64::from(step.balance().fee_required()))
+                .sum();
+            let selected_value_zatoshi = u64::from(selected_value);
+            let shielded_zatoshi = selected_value_zatoshi.saturating_sub(fee_zatoshi);
+
+            let seed = SecretVec::new(seed_bytes.to_vec());
+            let zip32_index = account
+                .source()
+                .key_derivation()
+                .ok_or("No key derivation")?
+                .account_index();
+            let usk = UnifiedSpendingKey::from_seed(&network, seed.expose_secret(), zip32_index)
+                .map_err(|e| format!("USK derivation failed: {e:?}"))?;
+
+            let spend_prover = NoOpSpendProver;
+            let output_prover = NoOpOutputProver;
+            let txids = create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+                &mut db,
+                &network,
+                &spend_prover,
+                &output_prover,
+                &wallet::SpendingKeys::from_unified_spending_key(usk),
+                OvkPolicy::Sender,
+                &proposal,
+            )
+            .map_err(|e| format!("Create shielding TX failed: {e}"))?;
+
+            Ok::<_, String>((txids, fee_zatoshi, shielded_zatoshi))
+        },
+    )?;
+
+    let txids: Vec<TxId> = txids.iter().cloned().collect();
+    let txids = broadcast_created_transactions(db_path, lightwalletd_url, &txids, "shield").await?;
+    Ok(ShieldTransparentResult {
+        txids,
+        fee_zatoshi,
+        shielded_zatoshi,
+    })
+}
+
 /// Execute a previously proposed transfer, then broadcast to the
 /// network. Returns comma-separated txids on success.
 ///
@@ -280,19 +393,65 @@ pub async fn execute_proposal(
         Ok::<_, String>(txids)
     })?;
 
+    let txids: Vec<TxId> = txids.iter().cloned().collect();
+    broadcast_created_transactions(db_path, lightwalletd_url, &txids, "send").await
+}
+
+fn select_shielding_sources(
+    account_receivers: HashMap<TransparentAddress, (TransparentKeyScope, Balance)>,
+    shielding_threshold: Zatoshis,
+) -> Result<(Vec<TransparentAddress>, Zatoshis), String> {
+    let mut ephemeral = Vec::new();
+    let mut non_ephemeral = Vec::new();
+
+    for (address, (scope, balance)) in account_receivers {
+        let spendable = balance.spendable_value();
+        if spendable >= shielding_threshold {
+            if scope == TransparentKeyScope::EPHEMERAL {
+                ephemeral.push((address, spendable));
+            } else {
+                non_ephemeral.push((address, spendable));
+            }
+        }
+    }
+
+    // Match the SDK policy: spend all non-ephemeral transparent receivers
+    // together, but never link more than one ephemeral receiver in a single
+    // shielding transaction.
+    let selected = if non_ephemeral.is_empty() {
+        ephemeral.into_iter().take(1).collect()
+    } else {
+        non_ephemeral
+    };
+
+    let mut total = Zatoshis::ZERO;
+    let mut addresses = Vec::with_capacity(selected.len());
+    for (address, value) in selected {
+        total = (total + value).ok_or("Selected transparent balance overflow")?;
+        addresses.push(address);
+    }
+
+    Ok((addresses, total))
+}
+
+async fn broadcast_created_transactions(
+    db_path: &str,
+    lightwalletd_url: &str,
+    txids: &[TxId],
+    log_label: &str,
+) -> Result<String, String> {
     // Connect to lightwalletd once for all broadcasts.
     let mut client = crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url)
         .await
         .map_err(|e| e.to_string())?;
 
-    // Broadcast each transaction.
     let txid_strings: Vec<String> = txids.iter().map(|id| format!("{id}")).collect();
 
     let read_conn =
         open_readonly_conn(db_path).map_err(|e| format!("Failed to open DB for broadcast: {e}"))?;
 
     let mut broadcast_ok: Vec<String> = Vec::new();
-    for txid in &txids {
+    for txid in txids.iter() {
         let raw_tx = read_conn
             .query_row(
                 "SELECT raw FROM transactions WHERE txid = ?1",
@@ -304,7 +463,7 @@ pub async fn execute_proposal(
         match broadcast_raw_transaction(&mut client, &raw_tx).await {
             Ok(()) => {
                 broadcast_ok.push(format!("{txid}"));
-                log::info!("send: broadcast {txid} ({} bytes)", raw_tx.len());
+                log::info!("{log_label}: broadcast {txid} ({} bytes)", raw_tx.len());
             }
             Err(e) => {
                 return Err(format!(


### PR DESCRIPTION
## Summary

- Split the home balance display into shielded and transparent balances, including pending pool balances.
- Add the transparent balance strip with slide transitions and a Shield Balance action.
- Implement software-account transparent shielding through Rust, gated by a dry-run shielding proposal so the button only appears when shielding is actually feasible.
- Fix transparent source selection to evaluate non-ephemeral balances by aggregate threshold and select only the largest ephemeral source.

## Validation

- `cd rust && cargo test`
- `fvm flutter test`
- `git diff --check`
- `fvm flutter analyze` still reports the existing 3 issues in `integration_test/simple_test.dart`, `lib/src/services/background_sync_delegate.dart`, and `test_driver/integration_test.dart`.