### PR TITLE
[codex] Improve transaction Activity history

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,7 @@ import 'src/core/motion/onboarding_motion.dart';
 import 'src/core/theme/app_theme.dart';
 import 'src/core/theme/legacy_material_theme.dart';
 import 'src/features/activity/screens/activity_screen.dart';
+import 'src/features/activity/screens/activity_transaction_status_screen.dart';
 import 'src/features/home/screens/home_screen.dart';
 import 'src/features/onboarding/create/address_types_screen.dart';
 import 'src/features/onboarding/create/intro_zcash_screen.dart';
@@ -292,6 +293,22 @@ final _routerProvider = Provider<GoRouter>((ref) {
       ),
       GoRoute(path: '/home', builder: (_, _) => const HomeScreen()),
       GoRoute(path: '/activity', builder: (_, _) => const ActivityScreen()),
+      GoRoute(
+        path: '/activity/tx/:txid',
+        builder: (_, state) {
+          final txid = state.pathParameters['txid'];
+          if (txid == null || txid.isEmpty) {
+            return const ActivityScreen();
+          }
+          final extra = state.extra;
+          if (extra is ActivityTransactionStatusArgs) {
+            return ActivityTransactionStatusScreen(args: extra);
+          }
+          return ActivityTransactionStatusScreen(
+            args: ActivityTransactionStatusArgs(txidHex: txid),
+          );
+        },
+      ),
       GoRoute(path: '/send', builder: (_, _) => const SendScreen()),
       GoRoute(
         path: '/send/review',

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -8,6 +8,7 @@ import 'src/app_bootstrap.dart';
 import 'src/core/motion/onboarding_motion.dart';
 import 'src/core/theme/app_theme.dart';
 import 'src/core/theme/legacy_material_theme.dart';
+import 'src/features/activity/screens/activity_screen.dart';
 import 'src/features/home/screens/home_screen.dart';
 import 'src/features/onboarding/create/address_types_screen.dart';
 import 'src/features/onboarding/create/intro_zcash_screen.dart';
@@ -22,7 +23,6 @@ import 'src/features/onboarding/shared/onboarding_flow_args.dart';
 import 'src/features/onboarding/shared/set_password_screen.dart';
 import 'src/features/onboarding/unlock_screen.dart';
 import 'src/features/onboarding/welcome.dart';
-import 'src/features/history/screens/history_screen.dart';
 import 'src/features/receive/screens/receive_screen.dart';
 import 'src/features/accounts/screens/accounts_screen.dart';
 import 'src/features/keystone/screens/import_keystone_screen.dart';
@@ -291,6 +291,7 @@ final _routerProvider = Provider<GoRouter>((ref) {
         builder: (_, _) => const LostPasswordScreen(),
       ),
       GoRoute(path: '/home', builder: (_, _) => const HomeScreen()),
+      GoRoute(path: '/activity', builder: (_, _) => const ActivityScreen()),
       GoRoute(path: '/send', builder: (_, _) => const SendScreen()),
       GoRoute(
         path: '/send/review',
@@ -309,7 +310,6 @@ final _routerProvider = Provider<GoRouter>((ref) {
         },
       ),
       GoRoute(path: '/receive', builder: (_, _) => const ReceiveScreen()),
-      GoRoute(path: '/history', builder: (_, _) => const HistoryScreen()),
       GoRoute(path: '/accounts', builder: (_, _) => const AccountsScreen()),
       GoRoute(
         path: '/import-keystone',

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -160,10 +160,10 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                         AppSidebarItem(
                           label: 'Activity',
                           iconName: AppIcons.history,
-                          active: _matches('/history'),
-                          onTap: _matches('/history')
+                          active: _matches('/activity'),
+                          onTap: _matches('/activity')
                               ? null
-                              : () => context.go('/history'),
+                              : () => context.go('/activity'),
                         ),
                       ],
                     ),

--- a/lib/src/core/widgets/app_loading_icon.dart
+++ b/lib/src/core/widgets/app_loading_icon.dart
@@ -1,5 +1,6 @@
 import 'dart:math' as math;
 
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
 import '../theme/app_theme.dart';
@@ -31,7 +32,7 @@ class _AppLoadingIconState extends State<AppLoadingIcon>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller = AnimationController(
     vsync: this,
-    duration: const Duration(milliseconds: 900),
+    duration: AppLoadingIconTiming.period,
   );
 
   @override
@@ -72,7 +73,7 @@ class _AppLoadingIconState extends State<AppLoadingIcon>
     final icon = CustomPaint(
       painter: _LoaderIconPainter(
         color: resolved,
-        animation: widget.animated ? _controller : null,
+        repaint: widget.animated ? _controller : null,
       ),
       size: Size.square(widget.size),
     );
@@ -84,18 +85,51 @@ class _AppLoadingIconState extends State<AppLoadingIcon>
   }
 }
 
-class _LoaderIconPainter extends CustomPainter {
-  _LoaderIconPainter({required this.color, required this.animation})
-    : super(repaint: animation);
+abstract final class AppLoadingIconTiming {
+  static const period = Duration(milliseconds: 900);
 
-  static const _spokeCount = 8;
+  @visibleForTesting
+  static const spokeCount = 8;
+
+  @visibleForTesting
+  static const trailLength = 3.2;
+
+  @visibleForTesting
+  static const minOpacity = 0.28;
+
+  @visibleForTesting
+  static double progressForFrameTime(Duration frameTime) {
+    final frameMicros = frameTime.inMicroseconds;
+    final periodMicros = period.inMicroseconds;
+    return (frameMicros % periodMicros) / periodMicros;
+  }
+
+  @visibleForTesting
+  static double opacityForSpokeAtProgress(int index, double progress) {
+    final active = progress * spokeCount;
+    final trailDistance = (active - index + spokeCount) % spokeCount;
+    if (trailDistance > trailLength) {
+      return minOpacity;
+    }
+    final falloff = Curves.easeOutCubic.transform(
+      1 - trailDistance / trailLength,
+    );
+    return minOpacity + falloff * (1 - minOpacity);
+  }
+}
+
+class _LoaderIconPainter extends CustomPainter {
+  _LoaderIconPainter({required this.color, required super.repaint})
+    : _animated = repaint != null,
+      super();
+
   static const _viewBoxSize = 24.0;
   static const _center = Offset(12, 12);
   static const _spokeRect = Rect.fromLTWH(10.5724, 1, 2.8552, 6.0464);
   static const _spokeRadius = Radius.circular(1.4276);
 
   final Color color;
-  final Animation<double>? animation;
+  final bool _animated;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -110,7 +144,7 @@ class _LoaderIconPainter extends CustomPainter {
       ..translate(dx, dy)
       ..scale(scale);
 
-    for (var i = 0; i < _spokeCount; i++) {
+    for (var i = 0; i < AppLoadingIconTiming.spokeCount; i++) {
       paint.color = color.withValues(alpha: _opacityForSpoke(i));
       canvas
         ..save()
@@ -125,25 +159,17 @@ class _LoaderIconPainter extends CustomPainter {
   }
 
   double _opacityForSpoke(int index) {
-    final progress = animation?.value;
-    if (progress == null) {
+    if (!_animated) {
       return 1;
     }
-    final active = progress * _spokeCount;
-    final trailDistance = (active - index + _spokeCount) % _spokeCount;
-    const trailLength = 3.2;
-    const minOpacity = 0.28;
-    if (trailDistance > trailLength) {
-      return minOpacity;
-    }
-    final falloff = Curves.easeOutCubic.transform(
-      1 - trailDistance / trailLength,
+    final progress = AppLoadingIconTiming.progressForFrameTime(
+      SchedulerBinding.instance.currentFrameTimeStamp,
     );
-    return minOpacity + falloff * (1 - minOpacity);
+    return AppLoadingIconTiming.opacityForSpokeAtProgress(index, progress);
   }
 
   @override
   bool shouldRepaint(covariant _LoaderIconPainter oldDelegate) {
-    return oldDelegate.color != color || oldDelegate.animation != animation;
+    return oldDelegate.color != color || oldDelegate._animated != _animated;
   }
 }

--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -11,7 +11,7 @@ List<ActivityRowData> buildActivityRows({
   required SyncState sync,
   required Iterable<rust_sync.TransactionInfo> transactions,
   VoidCallback? onRetrySync,
-  VoidCallback? onTransactionTap,
+  ValueChanged<rust_sync.TransactionInfo>? onTransactionTap,
 }) {
   return [
     buildSyncActivityRow(
@@ -23,7 +23,7 @@ List<ActivityRowData> buildActivityRows({
       (tx) => buildTransactionActivityRow(
         context: context,
         transaction: tx,
-        onTap: onTransactionTap,
+        onTap: onTransactionTap == null ? null : () => onTransactionTap(tx),
       ),
     ),
   ];

--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -104,13 +104,19 @@ ActivityRowData buildTransactionActivityRow({
     subtitleIconName: transaction.displayPool == 'shielded'
         ? AppIcons.shieldKeyholeOutline
         : null,
-    amountText: amount == BigInt.zero
-        ? '--'
-        : isShielded || kind == 'internal'
-        ? formatActivityZec(amount)
-        : formatSignedActivityZec(signedAmount),
+    amountText: _transactionAmountText(
+      amount: amount,
+      signedAmount: signedAmount,
+      isFailed: isFailed,
+      isShielded: isShielded,
+      kind: kind,
+    ),
+    amountIconName: isFailed && amount != BigInt.zero
+        ? AppIcons.arrowBack
+        : null,
+    amountIconColor: isFailed ? colors.icon.regular : null,
     amountColor: isFailed
-        ? colors.text.muted
+        ? colors.text.accent
         : isReceived
         ? colors.text.brandCrimson
         : colors.text.accent,
@@ -127,6 +133,20 @@ ActivityRowData buildTransactionActivityRow({
     statusColor: isFailed ? colors.text.destructive : colors.text.secondary,
     timestampText: formatActivityTimestamp(_txTimestamp(transaction)),
   );
+}
+
+String _transactionAmountText({
+  required BigInt amount,
+  required BigInt signedAmount,
+  required bool isFailed,
+  required bool isShielded,
+  required String kind,
+}) {
+  if (amount == BigInt.zero) return '--';
+  if (isFailed || isShielded || kind == 'internal') {
+    return formatActivityZec(amount);
+  }
+  return formatSignedActivityZec(signedAmount);
 }
 
 String formatActivityZec(BigInt zatoshi) {

--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -1,0 +1,220 @@
+import 'package:flutter/widgets.dart';
+
+import '../../core/theme/app_theme.dart';
+import '../../core/widgets/app_icon.dart';
+import '../../providers/sync_provider.dart';
+import '../../rust/api/sync.dart' as rust_sync;
+import 'models/activity_row_data.dart';
+
+List<ActivityRowData> buildActivityRows({
+  required BuildContext context,
+  required SyncState sync,
+  required Iterable<rust_sync.TransactionInfo> transactions,
+  VoidCallback? onRetrySync,
+}) {
+  return [
+    buildSyncActivityRow(
+      context: context,
+      sync: sync,
+      onRetrySync: onRetrySync,
+    ),
+    ...transactions.map(
+      (tx) => buildTransactionActivityRow(context: context, transaction: tx),
+    ),
+  ];
+}
+
+ActivityRowData buildSyncActivityRow({
+  required BuildContext context,
+  required SyncState sync,
+  VoidCallback? onRetrySync,
+}) {
+  final colors = context.colors;
+
+  if (sync.error != null) {
+    return ActivityRowData(
+      title: 'Wallet Synced',
+      leadingIconName: AppIcons.sync,
+      leadingBackgroundColor: colors.background.neutralSubtleOpacity,
+      leadingIconColor: colors.icon.regular,
+      amountText: onRetrySync == null ? '--' : 'Retry',
+      amountColor: colors.text.warning,
+      statusText: 'Failed',
+      statusIconName: AppIcons.skull,
+      statusColor: colors.text.destructive,
+      timestampText: formatActivityTimestamp(sync.lastSyncFailedAt),
+      onTap: onRetrySync,
+    );
+  }
+
+  if (sync.isSyncing) {
+    final pct = (sync.percentage * 100).toStringAsFixed(0);
+    return ActivityRowData(
+      title: 'Wallet Synced',
+      leadingIconName: AppIcons.sync,
+      leadingBackgroundColor: colors.background.neutralSubtleOpacity,
+      leadingIconColor: colors.icon.regular,
+      subtitle: sync.phase.isEmpty ? null : _capitalize(sync.phase),
+      amountText: '$pct%',
+      amountColor: colors.text.secondary,
+      statusText: 'In progress',
+      statusIconName: AppIcons.loader,
+      statusColor: colors.text.secondary,
+      timestampText: formatActivityTimestamp(sync.lastSyncStartedAt),
+    );
+  }
+
+  return ActivityRowData(
+    title: 'Wallet Synced',
+    leadingIconName: AppIcons.sync,
+    leadingBackgroundColor: colors.background.neutralSubtleOpacity,
+    leadingIconColor: colors.icon.regular,
+    amountText: formatActivityZec(sync.totalBalance),
+    amountColor: colors.text.accent,
+    statusText: 'Completed',
+    statusColor: colors.text.secondary,
+    timestampText: formatActivityTimestamp(sync.lastSyncCompletedAt),
+  );
+}
+
+ActivityRowData buildTransactionActivityRow({
+  required BuildContext context,
+  required rust_sync.TransactionInfo transaction,
+}) {
+  final colors = context.colors;
+  final isPending =
+      transaction.minedHeight == BigInt.zero && !transaction.expiredUnmined;
+  final isFailed = transaction.expiredUnmined;
+  final kind = transaction.txKind;
+  final amount = transaction.displayAmount;
+  final isReceived = kind == 'received';
+  final isSent = kind == 'sent';
+  final isShielded = kind == 'shielded';
+  final signedAmount = isSent ? -amount : amount;
+  final subtitle = isReceived || isSent
+      ? _poolLabel(transaction.displayPool)
+      : null;
+
+  return ActivityRowData(
+    title: _txTitle(kind),
+    leadingIconName: _txIcon(kind),
+    leadingBackgroundColor: colors.background.neutralSubtleOpacity,
+    leadingIconColor: colors.icon.regular,
+    subtitle: subtitle,
+    subtitleIconName: transaction.displayPool == 'shielded'
+        ? AppIcons.shieldKeyholeOutline
+        : null,
+    amountText: amount == BigInt.zero
+        ? '--'
+        : isShielded || kind == 'internal'
+        ? formatActivityZec(amount)
+        : formatSignedActivityZec(signedAmount),
+    amountColor: isFailed
+        ? colors.text.muted
+        : isReceived
+        ? colors.text.brandCrimson
+        : colors.text.accent,
+    statusText: isFailed
+        ? 'Failed'
+        : isPending
+        ? 'In progress'
+        : 'Completed',
+    statusIconName: isFailed
+        ? AppIcons.skull
+        : isPending
+        ? AppIcons.loader
+        : null,
+    statusColor: isFailed ? colors.text.destructive : colors.text.secondary,
+    timestampText: formatActivityTimestamp(_txTimestamp(transaction)),
+  );
+}
+
+String formatActivityZec(BigInt zatoshi) {
+  final abs = zatoshi.abs();
+  final whole = abs ~/ BigInt.from(100000000);
+  final frac = (abs % BigInt.from(100000000)).toString().padLeft(8, '0');
+  final digits = whole == BigInt.zero && int.parse(frac) < 1000000
+      ? frac
+      : frac.substring(0, 2);
+  return '$whole.$digits ZEC';
+}
+
+String formatSignedActivityZec(BigInt zatoshi) {
+  final sign = zatoshi >= BigInt.zero ? '+' : '-';
+  return '$sign${formatActivityZec(zatoshi)}';
+}
+
+String formatActivityTimestamp(DateTime? timestamp) {
+  if (timestamp == null) return '--';
+  final now = DateTime.now();
+  final local = timestamp.toLocal();
+  final today = DateTime(now.year, now.month, now.day);
+  final date = DateTime(local.year, local.month, local.day);
+  final time =
+      '${local.hour.toString().padLeft(2, '0')}:${local.minute.toString().padLeft(2, '0')}';
+
+  if (date == today) return 'Today, $time';
+  if (date == today.subtract(const Duration(days: 1))) {
+    return 'Yesterday, $time';
+  }
+  return '${_monthName(local.month)} ${local.day}, $time';
+}
+
+String _txTitle(String kind) {
+  return switch (kind) {
+    'received' => 'Received',
+    'sent' => 'Sent',
+    'shielded' => 'Shielded',
+    'internal' => 'Internal',
+    _ => 'Transaction',
+  };
+}
+
+String _txIcon(String kind) {
+  return switch (kind) {
+    'received' => AppIcons.arrowDownCircle,
+    'sent' => AppIcons.plane,
+    'shielded' => AppIcons.shieldAsset,
+    'internal' => AppIcons.sync,
+    _ => AppIcons.history,
+  };
+}
+
+String? _poolLabel(String pool) {
+  return switch (pool) {
+    'transparent' => 'Transparent',
+    'shielded' => 'Shielded',
+    'mixed' => 'Mixed',
+    _ => null,
+  };
+}
+
+DateTime? _txTimestamp(rust_sync.TransactionInfo tx) {
+  final seconds = tx.blockTime > BigInt.zero ? tx.blockTime : tx.createdTime;
+  if (seconds <= BigInt.zero) return null;
+  return DateTime.fromMillisecondsSinceEpoch(seconds.toInt() * 1000);
+}
+
+String _capitalize(String value) {
+  if (value.isEmpty) return value;
+  return '${value[0].toUpperCase()}${value.substring(1)}';
+}
+
+String _monthName(int month) {
+  const months = [
+    '',
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return months[month];
+}

--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -11,6 +11,7 @@ List<ActivityRowData> buildActivityRows({
   required SyncState sync,
   required Iterable<rust_sync.TransactionInfo> transactions,
   VoidCallback? onRetrySync,
+  VoidCallback? onTransactionTap,
 }) {
   return [
     buildSyncActivityRow(
@@ -19,7 +20,11 @@ List<ActivityRowData> buildActivityRows({
       onRetrySync: onRetrySync,
     ),
     ...transactions.map(
-      (tx) => buildTransactionActivityRow(context: context, transaction: tx),
+      (tx) => buildTransactionActivityRow(
+        context: context,
+        transaction: tx,
+        onTap: onTransactionTap,
+      ),
     ),
   ];
 }
@@ -37,13 +42,12 @@ ActivityRowData buildSyncActivityRow({
       leadingIconName: AppIcons.sync,
       leadingBackgroundColor: colors.background.neutralSubtleOpacity,
       leadingIconColor: colors.icon.regular,
-      amountText: onRetrySync == null ? '--' : 'Retry',
-      amountColor: colors.text.warning,
+      amountText: '--',
+      amountColor: colors.text.secondary,
       statusText: 'Failed',
       statusIconName: AppIcons.skull,
       statusColor: colors.text.destructive,
       timestampText: formatActivityTimestamp(sync.lastSyncFailedAt),
-      onTap: onRetrySync,
     );
   }
 
@@ -80,6 +84,7 @@ ActivityRowData buildSyncActivityRow({
 ActivityRowData buildTransactionActivityRow({
   required BuildContext context,
   required rust_sync.TransactionInfo transaction,
+  VoidCallback? onTap,
 }) {
   final colors = context.colors;
   final isPending =
@@ -132,6 +137,7 @@ ActivityRowData buildTransactionActivityRow({
         : null,
     statusColor: isFailed ? colors.text.destructive : colors.text.secondary,
     timestampText: formatActivityTimestamp(_txTimestamp(transaction)),
+    onTap: onTap,
   );
 }
 

--- a/lib/src/features/activity/models/activity_row_data.dart
+++ b/lib/src/features/activity/models/activity_row_data.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/widgets.dart';
+
+class ActivityRowData {
+  const ActivityRowData({
+    required this.title,
+    required this.leadingIconName,
+    required this.leadingBackgroundColor,
+    required this.leadingIconColor,
+    this.subtitle,
+    this.subtitleIconName,
+    required this.amountText,
+    this.amountColor,
+    required this.statusText,
+    required this.timestampText,
+    this.statusIconName,
+    this.statusColor,
+    this.onTap,
+  });
+
+  final String title;
+  final String leadingIconName;
+  final Color leadingBackgroundColor;
+  final Color leadingIconColor;
+  final String? subtitle;
+  final String? subtitleIconName;
+  final String amountText;
+  final Color? amountColor;
+  final String statusText;
+  final String timestampText;
+  final String? statusIconName;
+  final Color? statusColor;
+  final VoidCallback? onTap;
+}

--- a/lib/src/features/activity/models/activity_row_data.dart
+++ b/lib/src/features/activity/models/activity_row_data.dart
@@ -9,6 +9,8 @@ class ActivityRowData {
     this.subtitle,
     this.subtitleIconName,
     required this.amountText,
+    this.amountIconName,
+    this.amountIconColor,
     this.amountColor,
     required this.statusText,
     required this.timestampText,
@@ -24,6 +26,8 @@ class ActivityRowData {
   final String? subtitle;
   final String? subtitleIconName;
   final String amountText;
+  final String? amountIconName;
+  final Color? amountIconColor;
   final Color? amountColor;
   final String statusText;
   final String timestampText;

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -18,18 +18,18 @@ import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
-import '../../activity/activity_row_mapper.dart';
-import '../../activity/models/activity_row_data.dart';
-import '../../activity/widgets/activity_table.dart';
+import '../activity_row_mapper.dart';
+import '../models/activity_row_data.dart';
+import '../widgets/activity_table.dart';
 
-class HistoryScreen extends ConsumerStatefulWidget {
-  const HistoryScreen({super.key});
+class ActivityScreen extends ConsumerStatefulWidget {
+  const ActivityScreen({super.key});
 
   @override
-  ConsumerState<HistoryScreen> createState() => _HistoryScreenState();
+  ConsumerState<ActivityScreen> createState() => _ActivityScreenState();
 }
 
-class _HistoryScreenState extends ConsumerState<HistoryScreen> {
+class _ActivityScreenState extends ConsumerState<ActivityScreen> {
   static const _transactionsPerPage = 5;
 
   final ScrollController _scrollController = ScrollController();
@@ -54,7 +54,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
   }
 
   @override
-  void didUpdateWidget(covariant HistoryScreen oldWidget) {
+  void didUpdateWidget(covariant ActivityScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -115,7 +115,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
         if (resetPage) _currentPage = 1;
       });
     } catch (e, st) {
-      log('Activity: history load failed: $e\n$st');
+      log('Activity: transaction load failed: $e\n$st');
       if (!mounted) return;
       setState(() {
         _error = 'Activity could not be loaded.';

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -30,7 +30,8 @@ class ActivityScreen extends ConsumerStatefulWidget {
 }
 
 class _ActivityScreenState extends ConsumerState<ActivityScreen> {
-  static const _transactionsPerPage = 5;
+  static const _activityRowsPerPage = 6;
+  static const _firstPageTransactionCount = _activityRowsPerPage - 1;
 
   final ScrollController _scrollController = ScrollController();
   List<rust_sync.TransactionInfo>? _transactions;
@@ -186,15 +187,23 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
     final sync = ref.watch(syncProvider).value ?? SyncState();
     final accountUuid = ref.watch(accountProvider).value?.activeAccountUuid;
     final transactions = _transactions ?? sync.recentTransactions;
-    final totalPages = math.max(
-      1,
-      (transactions.length / _transactionsPerPage).ceil(),
+    final transactionsAfterFirstPage = math.max(
+      0,
+      transactions.length - _firstPageTransactionCount,
     );
+    final totalPages =
+        1 + (transactionsAfterFirstPage / _activityRowsPerPage).ceil();
     final currentPage = math.min(math.max(_currentPage, 1), totalPages);
-    final firstTxIndex = (currentPage - 1) * _transactionsPerPage;
+    final firstTxIndex = currentPage == 1
+        ? 0
+        : _firstPageTransactionCount +
+              ((currentPage - 2) * _activityRowsPerPage);
+    final transactionCount = currentPage == 1
+        ? _firstPageTransactionCount
+        : _activityRowsPerPage;
     final pageTransactions = transactions
         .skip(firstTxIndex)
-        .take(_transactionsPerPage);
+        .take(transactionCount);
     final rows = accountUuid == null
         ? const <ActivityRowData>[]
         : [

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -158,6 +158,8 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
     }
   }
 
+  void _handleTransactionRowAction() {}
+
   String _recentSignature(SyncState? sync) {
     return sync?.recentTransactions
             .map(
@@ -217,6 +219,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
               (tx) => buildTransactionActivityRow(
                 context: context,
                 transaction: tx,
+                onTap: _handleTransactionRowAction,
               ),
             ),
           ];

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -190,7 +190,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
     ref.listen<AsyncValue<SyncState>>(syncProvider, (previous, next) {
       final prevSig = _recentSignature(previous?.value);
       final nextSig = _recentSignature(next.value);
-      if (prevSig != nextSig && nextSig.isNotEmpty) {
+      if (prevSig != nextSig) {
         unawaited(_loadTransactions(resetPage: true));
       }
     });

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -21,6 +21,7 @@ import '../../../rust/api/sync.dart' as rust_sync;
 import '../activity_row_mapper.dart';
 import '../models/activity_row_data.dart';
 import '../widgets/activity_table.dart';
+import 'activity_transaction_status_screen.dart';
 
 class ActivityScreen extends ConsumerStatefulWidget {
   const ActivityScreen({super.key});
@@ -158,7 +159,15 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
     }
   }
 
-  void _handleTransactionRowAction() {}
+  void _openTransactionStatus(rust_sync.TransactionInfo transaction) {
+    context.push(
+      '/activity/tx/${transaction.txidHex}',
+      extra: ActivityTransactionStatusArgs(
+        txidHex: transaction.txidHex,
+        initialTransaction: transaction,
+      ),
+    );
+  }
 
   String _recentSignature(SyncState? sync) {
     return sync?.recentTransactions
@@ -219,7 +228,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
               (tx) => buildTransactionActivityRow(
                 context: context,
                 transaction: tx,
-                onTap: _handleTransactionRowAction,
+                onTap: () => _openTransactionStatus(tx),
               ),
             ),
           ];

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -1,0 +1,311 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart' show ScaffoldMessenger, SnackBar;
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/config/network_config.dart';
+import '../../../core/layout/app_desktop_shell.dart';
+import '../../../core/layout/app_layout.dart';
+import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/storage/wallet_paths.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../providers/account_provider.dart';
+import '../../../providers/sync_provider.dart';
+import '../../../rust/api/sync.dart' as rust_sync;
+import '../../send/widgets/transaction_receipt_view.dart';
+import '../activity_row_mapper.dart';
+
+class ActivityTransactionStatusArgs {
+  const ActivityTransactionStatusArgs({
+    required this.txidHex,
+    this.initialTransaction,
+  });
+
+  final String txidHex;
+  final rust_sync.TransactionInfo? initialTransaction;
+}
+
+class ActivityTransactionStatusScreen extends ConsumerStatefulWidget {
+  const ActivityTransactionStatusScreen({super.key, required this.args});
+
+  final ActivityTransactionStatusArgs args;
+
+  @override
+  ConsumerState<ActivityTransactionStatusScreen> createState() =>
+      _ActivityTransactionStatusScreenState();
+}
+
+class _ActivityTransactionStatusScreenState
+    extends ConsumerState<ActivityTransactionStatusScreen> {
+  rust_sync.TransactionInfo? _transaction;
+  bool _isLoading = false;
+  String? _error;
+  String? _activeAccountUuid;
+
+  @override
+  void initState() {
+    super.initState();
+    _transaction = widget.args.initialTransaction;
+    _activeAccountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref.read(appLayoutProvider.notifier).setMode(AppLayoutMode.large);
+      unawaited(_loadTransaction(showLoading: _transaction == null));
+    });
+  }
+
+  Future<void> _loadTransaction({bool showLoading = false}) async {
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    _activeAccountUuid = accountUuid;
+
+    if (showLoading && mounted) {
+      setState(() {
+        _isLoading = true;
+        _error = null;
+      });
+    }
+
+    if (accountUuid == null) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'No active account.';
+      });
+      return;
+    }
+
+    try {
+      final dbPath = await getWalletDbPath();
+      final txs = await rust_sync.getTransactionHistory(
+        dbPath: dbPath,
+        network: ZcashNetwork.mainnet.name,
+        accountUuid: accountUuid,
+      );
+      if (!mounted) return;
+      if (accountUuid != ref.read(accountProvider).value?.activeAccountUuid) {
+        return;
+      }
+
+      final tx = _findTransaction(txs, widget.args.txidHex);
+      setState(() {
+        if (tx != null) {
+          _transaction = tx;
+          _error = null;
+        } else {
+          _error = _transaction == null
+              ? 'Transaction could not be loaded.'
+              : 'Latest transaction status could not be refreshed.';
+        }
+        _isLoading = false;
+      });
+    } catch (e, st) {
+      log('ActivityTransactionStatus: transaction load failed: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _error = _transaction == null
+            ? 'Transaction could not be loaded.'
+            : 'Latest transaction status could not be refreshed.';
+        _isLoading = false;
+      });
+    }
+  }
+
+  rust_sync.TransactionInfo? _findTransaction(
+    Iterable<rust_sync.TransactionInfo> transactions,
+    String txidHex,
+  ) {
+    final normalized = txidHex.toLowerCase();
+    for (final tx in transactions) {
+      if (tx.txidHex.toLowerCase() == normalized) return tx;
+    }
+    return null;
+  }
+
+  String _recentTxSignature(SyncState? sync) {
+    final txid = widget.args.txidHex.toLowerCase();
+    for (final tx in sync?.recentTransactions ?? const []) {
+      if (tx.txidHex.toLowerCase() == txid) {
+        return [
+          tx.txidHex,
+          tx.minedHeight,
+          tx.expiredUnmined,
+          tx.txKind,
+          tx.displayAmount,
+        ].join(':');
+      }
+    }
+    return '';
+  }
+
+  void _goBack() {
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      context.go('/activity');
+    }
+  }
+
+  Future<void> _copyTransactionHash() async {
+    await Clipboard.setData(ClipboardData(text: widget.args.txidHex));
+    if (!mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('Transaction hash copied')));
+  }
+
+  TransactionReceiptPhase _phaseFor(rust_sync.TransactionInfo? tx) {
+    if (tx == null) {
+      return _isLoading
+          ? TransactionReceiptPhase.loading
+          : TransactionReceiptPhase.failed;
+    }
+    if (tx.expiredUnmined) return TransactionReceiptPhase.failed;
+    if (tx.minedHeight == BigInt.zero) return TransactionReceiptPhase.pending;
+    return TransactionReceiptPhase.succeeded;
+  }
+
+  String _amountText(rust_sync.TransactionInfo? tx) {
+    if (tx == null) return '--';
+    if (tx.displayAmount == BigInt.zero) return '--';
+    return formatActivityZec(tx.displayAmount);
+  }
+
+  String _dateText(rust_sync.TransactionInfo? tx) {
+    if (tx == null) return '--';
+    final seconds = tx.blockTime > BigInt.zero ? tx.blockTime : tx.createdTime;
+    if (seconds <= BigInt.zero) return '--';
+    return _formatDate(
+      DateTime.fromMillisecondsSinceEpoch(seconds.toInt() * 1000),
+    );
+  }
+
+  String _feeText(rust_sync.TransactionInfo? tx) {
+    if (tx == null || tx.fee <= BigInt.zero) return '--';
+    return '${_formatZec(tx.fee)} ZEC';
+  }
+
+  String _formatZec(BigInt zatoshi) {
+    final whole = zatoshi ~/ BigInt.from(100000000);
+    var fraction = (zatoshi % BigInt.from(100000000)).toString().padLeft(
+      8,
+      '0',
+    );
+    fraction = fraction.replaceFirst(RegExp(r'0+$'), '');
+    return fraction.isEmpty ? '$whole' : '$whole.$fraction';
+  }
+
+  String _formatDate(DateTime value) {
+    const months = <String>[
+      '',
+      'January',
+      'February',
+      'March',
+      'April',
+      'May',
+      'June',
+      'July',
+      'August',
+      'September',
+      'October',
+      'November',
+      'December',
+    ];
+    final local = value.toLocal();
+    final hh = local.hour.toString().padLeft(2, '0');
+    final mm = local.minute.toString().padLeft(2, '0');
+    return '${months[local.month]} ${local.day}, ${local.year} $hh:$mm';
+  }
+
+  List<String> _splitTxid(String txid) {
+    if (txid.length <= 32) return [txid];
+    return [txid.substring(0, 32), txid.substring(32)];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<AsyncValue<AccountState>>(accountProvider, (previous, next) {
+      final nextUuid = next.value?.activeAccountUuid;
+      if (nextUuid != _activeAccountUuid) {
+        unawaited(_loadTransaction(showLoading: _transaction == null));
+      }
+    });
+    ref.listen<AsyncValue<SyncState>>(syncProvider, (previous, next) {
+      final prevSig = _recentTxSignature(previous?.value);
+      final nextSig = _recentTxSignature(next.value);
+      if (prevSig != nextSig) {
+        unawaited(_loadTransaction());
+      }
+    });
+
+    final tx = _transaction;
+    final colors = context.colors;
+    final txidLines = _splitTxid(widget.args.txidHex);
+    final error = tx?.expiredUnmined == true
+        ? 'Transaction expired before it was mined.'
+        : _error;
+
+    return AppDesktopShell(
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: EdgeInsets.zero,
+        child: Stack(
+          children: [
+            const Positioned.fill(
+              child: IgnorePointer(child: TransactionReceiptIllustration()),
+            ),
+            Positioned.fill(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.md,
+                  AppSpacing.md,
+                  0,
+                  AppSpacing.md,
+                ),
+                child: Column(
+                  children: [
+                    TransactionReceiptBackRow(onTap: _goBack),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.only(right: 255),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: TransactionReceiptView(
+                            phase: _phaseFor(tx),
+                            amountText: _amountText(tx),
+                            primaryBlock: TransactionReceiptBlockData(
+                              title: 'Transaction Hash',
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  for (final line in txidLines)
+                                    Text(
+                                      line,
+                                      style: AppTypography.codeSmall.copyWith(
+                                        color: colors.text.accent,
+                                      ),
+                                    ),
+                                ],
+                              ),
+                            ),
+                            dateText: _dateText(tx),
+                            feeText: _feeText(tx),
+                            error: error,
+                            onCopyTxid: _copyTransactionHash,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/activity/widgets/activity_table.dart
+++ b/lib/src/features/activity/widgets/activity_table.dart
@@ -526,9 +526,7 @@ class _PaginationPageButton extends StatelessWidget {
       child: Center(
         child: Text(
           '$page',
-          style: AppTypography.bodySmall.copyWith(
-            color: selected ? colors.text.accent : colors.text.secondary,
-          ),
+          style: AppTypography.bodySmall.copyWith(color: colors.text.accent),
         ),
       ),
     );
@@ -557,7 +555,7 @@ class _PaginationEllipsis extends StatelessWidget {
         child: Text(
           '...',
           style: AppTypography.bodySmall.copyWith(
-            color: context.colors.text.secondary,
+            color: context.colors.text.accent,
           ),
         ),
       ),

--- a/lib/src/features/activity/widgets/activity_table.dart
+++ b/lib/src/features/activity/widgets/activity_table.dart
@@ -1,0 +1,585 @@
+import 'dart:math' as math;
+
+import 'package:flutter/widgets.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../models/activity_row_data.dart';
+
+class ActivityTable extends StatelessWidget {
+  const ActivityTable({
+    required this.rows,
+    this.title,
+    this.onTitleTap,
+    this.isLoading = false,
+    this.errorText,
+    this.emptyText = 'No activity yet',
+    this.currentPage = 1,
+    this.totalPages = 1,
+    this.onPageChanged,
+    this.showPagination = false,
+    super.key,
+  });
+
+  final List<ActivityRowData> rows;
+  final String? title;
+  final VoidCallback? onTitleTap;
+  final bool isLoading;
+  final String? errorText;
+  final String emptyText;
+  final int currentPage;
+  final int totalPages;
+  final ValueChanged<int>? onPageChanged;
+  final bool showPagination;
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveTotalPages = math.max(1, totalPages);
+    final effectiveCurrentPage = math.min(
+      math.max(currentPage, 1),
+      effectiveTotalPages,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (title != null) ...[
+          _ActivityTableTitle(title: title!, onTap: onTitleTap),
+          const SizedBox(height: AppSpacing.xs),
+        ],
+        const _ActivityTableHeader(),
+        const SizedBox(height: AppSpacing.s),
+        if (errorText != null && rows.isEmpty)
+          _ActivityTableMessage(text: errorText!, isError: true)
+        else if (isLoading && rows.isEmpty)
+          const _ActivityTableMessage(text: 'Loading activity...')
+        else if (rows.isEmpty)
+          _ActivityTableMessage(text: emptyText)
+        else
+          for (var i = 0; i < rows.length; i++) ...[
+            ActivityTableRow(row: rows[i]),
+            if (i != rows.length - 1) ...[
+              const SizedBox(height: AppSpacing.xs),
+              const _ActivityTableDivider(),
+              const SizedBox(height: AppSpacing.xs),
+            ],
+          ],
+        if (showPagination) ...[
+          const SizedBox(height: AppSpacing.lg),
+          ActivityTablePagination(
+            currentPage: effectiveCurrentPage,
+            totalPages: effectiveTotalPages,
+            onPageChanged: onPageChanged,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _ActivityTableTitle extends StatelessWidget {
+  const _ActivityTableTitle({required this.title, this.onTap});
+
+  final String title;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final child = Padding(
+      padding: const EdgeInsets.all(AppSpacing.xxs),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            title,
+            style: AppTypography.labelLarge.copyWith(color: colors.text.accent),
+          ),
+          if (onTap != null) ...[
+            const SizedBox(width: AppSpacing.xxs),
+            AppIcon(
+              AppIcons.chevronForward,
+              size: 16,
+              color: colors.icon.accent,
+            ),
+          ],
+        ],
+      ),
+    );
+
+    if (onTap == null) {
+      return Align(alignment: Alignment.centerLeft, child: child);
+    }
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Align(alignment: Alignment.centerLeft, child: child),
+      ),
+    );
+  }
+}
+
+class _ActivityTableHeader extends StatelessWidget {
+  const _ActivityTableHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final mutedStyle = AppTypography.labelMedium.copyWith(
+      color: colors.text.muted,
+    );
+    final accentStyle = AppTypography.labelMedium.copyWith(
+      color: colors.text.accent,
+    );
+    return SizedBox(
+      height: 32,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+        child: _ActivityColumnLayout(
+          txType: Text('Tx Type', style: mutedStyle),
+          amount: Text('Amount', style: mutedStyle),
+          status: Text('Status', style: mutedStyle),
+          timestamp: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text('Time Stamp', textAlign: TextAlign.end, style: accentStyle),
+              const SizedBox(width: AppSpacing.xxs),
+              AppIcon(AppIcons.arrowDown, size: 16, color: colors.icon.accent),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+const double _activityLeftCellWidth = 190;
+const double _activityMiddleCellWidth = 160;
+const double _activityRightCellWidth = 140;
+const double _activityFixedColumnsWidth =
+    _activityLeftCellWidth +
+    (_activityMiddleCellWidth * 2) +
+    _activityRightCellWidth;
+
+class _ActivityTableDivider extends StatelessWidget {
+  const _ActivityTableDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(height: 1, color: context.colors.border.subtle);
+  }
+}
+
+class _ActivityColumnLayout extends StatelessWidget {
+  const _ActivityColumnLayout({
+    required this.txType,
+    required this.amount,
+    required this.status,
+    required this.timestamp,
+  });
+
+  final Widget txType;
+  final Widget amount;
+  final Widget status;
+  final Widget timestamp;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final useFixedColumns =
+            constraints.maxWidth >= _activityFixedColumnsWidth;
+        if (useFixedColumns) {
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              _ActivityCell(width: _activityLeftCellWidth, child: txType),
+              _ActivityCell(width: _activityMiddleCellWidth, child: amount),
+              _ActivityCell(width: _activityMiddleCellWidth, child: status),
+              _ActivityCell(
+                width: _activityRightCellWidth,
+                alignEnd: true,
+                child: timestamp,
+              ),
+            ],
+          );
+        }
+
+        return Row(
+          children: [
+            _ActivityCell(flex: 190, child: txType),
+            _ActivityCell(flex: 160, child: amount),
+            _ActivityCell(flex: 160, child: status),
+            _ActivityCell(flex: 140, alignEnd: true, child: timestamp),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ActivityCell extends StatelessWidget {
+  const _ActivityCell({
+    required this.child,
+    this.width,
+    this.flex,
+    this.alignEnd = false,
+  });
+
+  final Widget child;
+  final double? width;
+  final int? flex;
+  final bool alignEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    final content = Align(
+      alignment: alignEnd ? Alignment.centerRight : Alignment.centerLeft,
+      child: child,
+    );
+    final width = this.width;
+    if (width != null) {
+      return SizedBox(width: width, child: content);
+    }
+    return Expanded(flex: flex ?? 1, child: content);
+  }
+}
+
+class _StatusLabel extends StatelessWidget {
+  const _StatusLabel({required this.row});
+
+  final ActivityRowData row;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (row.statusIconName != null) ...[
+          AppIcon(
+            row.statusIconName!,
+            size: 16,
+            color: row.statusColor ?? colors.text.secondary,
+          ),
+          const SizedBox(width: AppSpacing.xxs),
+        ],
+        Flexible(
+          child: Text(
+            row.statusText,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.labelMedium.copyWith(
+              color: row.statusColor ?? colors.text.secondary,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class ActivityTableRow extends StatelessWidget {
+  const ActivityTableRow({required this.row, super.key});
+
+  final ActivityRowData row;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final content = Container(
+      height: 48,
+      padding: const EdgeInsets.all(AppSpacing.xxs),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
+      ),
+      child: _ActivityColumnLayout(
+        txType: Row(
+          children: [
+            _ActivityAvatar(row: row),
+            const SizedBox(width: AppSpacing.s),
+            Flexible(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    row.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                  if (row.subtitle != null)
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (row.subtitleIconName != null) ...[
+                          AppIcon(
+                            row.subtitleIconName!,
+                            size: 16,
+                            color: colors.icon.brandCrimson,
+                          ),
+                          const SizedBox(width: AppSpacing.xxs),
+                        ],
+                        Flexible(
+                          child: Text(
+                            row.subtitle!,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: AppTypography.labelMedium.copyWith(
+                              color: row.subtitleIconName == null
+                                  ? colors.text.secondary
+                                  : colors.text.brandCrimson,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        amount: Text(
+          row.amountText,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTypography.labelMedium.copyWith(
+            color: row.amountColor ?? colors.text.accent,
+          ),
+        ),
+        status: _StatusLabel(row: row),
+        timestamp: Text(
+          row.timestampText,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.end,
+          style: AppTypography.labelMedium.copyWith(
+            color: colors.text.secondary,
+          ),
+        ),
+      ),
+    );
+
+    if (row.onTap == null) return content;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: row.onTap,
+        child: content,
+      ),
+    );
+  }
+}
+
+class _ActivityAvatar extends StatelessWidget {
+  const _ActivityAvatar({required this.row});
+
+  final ActivityRowData row;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 32,
+      height: 32,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: row.leadingBackgroundColor,
+          shape: BoxShape.circle,
+        ),
+        child: Center(
+          child: AppIcon(
+            row.leadingIconName,
+            size: 16,
+            color: row.leadingIconColor,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ActivityTableMessage extends StatelessWidget {
+  const _ActivityTableMessage({required this.text, this.isError = false});
+
+  final String text;
+  final bool isError;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return SizedBox(
+      height: 120,
+      child: Center(
+        child: Text(
+          text,
+          style: AppTypography.labelLarge.copyWith(
+            color: isError ? colors.text.destructive : colors.text.secondary,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class ActivityTablePagination extends StatelessWidget {
+  const ActivityTablePagination({
+    required this.currentPage,
+    required this.totalPages,
+    this.onPageChanged,
+    super.key,
+  });
+
+  final int currentPage;
+  final int totalPages;
+  final ValueChanged<int>? onPageChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final pages = _visiblePages(currentPage, totalPages);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        _PaginationIconButton(
+          iconName: AppIcons.chevronBackward,
+          enabled: currentPage > 1,
+          onTap: () => onPageChanged?.call(currentPage - 1),
+        ),
+        for (final page in pages)
+          page == null
+              ? const _PaginationEllipsis()
+              : _PaginationPageButton(
+                  page: page,
+                  selected: page == currentPage,
+                  onTap: () => onPageChanged?.call(page),
+                ),
+        _PaginationIconButton(
+          iconName: AppIcons.chevronForward,
+          enabled: currentPage < totalPages,
+          onTap: () => onPageChanged?.call(currentPage + 1),
+        ),
+      ],
+    );
+  }
+}
+
+class _PaginationIconButton extends StatelessWidget {
+  const _PaginationIconButton({
+    required this.iconName,
+    required this.enabled,
+    required this.onTap,
+  });
+
+  final String iconName;
+  final bool enabled;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final child = SizedBox(
+      width: 32,
+      height: 32,
+      child: Center(
+        child: AppIcon(
+          iconName,
+          size: 16,
+          color: enabled ? colors.icon.accent : colors.text.disabled,
+        ),
+      ),
+    );
+
+    if (!enabled) return child;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: child,
+      ),
+    );
+  }
+}
+
+class _PaginationPageButton extends StatelessWidget {
+  const _PaginationPageButton({
+    required this.page,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final int page;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final child = SizedBox(
+      width: 32,
+      height: 32,
+      child: Center(
+        child: Text(
+          '$page',
+          style: AppTypography.bodySmall.copyWith(
+            color: selected ? colors.text.accent : colors.text.secondary,
+          ),
+        ),
+      ),
+    );
+
+    if (selected) return child;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: child,
+      ),
+    );
+  }
+}
+
+class _PaginationEllipsis extends StatelessWidget {
+  const _PaginationEllipsis();
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 32,
+      height: 32,
+      child: Center(
+        child: Text(
+          '...',
+          style: AppTypography.bodySmall.copyWith(
+            color: context.colors.text.secondary,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+List<int?> _visiblePages(int currentPage, int totalPages) {
+  if (totalPages <= 7) {
+    return [for (var i = 1; i <= totalPages; i++) i];
+  }
+
+  final pages = <int?>[1];
+  final start = math.max(2, currentPage - 1);
+  final end = math.min(totalPages - 1, currentPage + 1);
+
+  if (start > 2) pages.add(null);
+  for (var page = start; page <= end; page++) {
+    pages.add(page);
+  }
+  if (end < totalPages - 1) pages.add(null);
+  pages.add(totalPages);
+
+  return pages;
+}

--- a/lib/src/features/activity/widgets/activity_table.dart
+++ b/lib/src/features/activity/widgets/activity_table.dart
@@ -7,7 +7,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../models/activity_row_data.dart';
 
-const _paginationActivationShortcuts = <ShortcutActivator, Intent>{
+const _activityActivationShortcuts = <ShortcutActivator, Intent>{
   SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
   SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
 };
@@ -287,90 +287,172 @@ class _StatusLabel extends StatelessWidget {
   }
 }
 
-class ActivityTableRow extends StatelessWidget {
+class ActivityTableRow extends StatefulWidget {
   const ActivityTableRow({required this.row, super.key});
 
   final ActivityRowData row;
 
   @override
+  State<ActivityTableRow> createState() => _ActivityTableRowState();
+}
+
+class _ActivityTableRowState extends State<ActivityTableRow> {
+  bool _hovered = false;
+  bool _focused = false;
+
+  @override
+  void didUpdateWidget(covariant ActivityTableRow oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.row.title != widget.row.title ||
+        oldWidget.row.amountText != widget.row.amountText ||
+        oldWidget.row.statusText != widget.row.statusText ||
+        oldWidget.row.timestampText != widget.row.timestampText) {
+      _hovered = false;
+      _focused = false;
+    }
+  }
+
+  void _handleHoverChanged(bool value) {
+    if (_hovered == value) return;
+    setState(() {
+      _hovered = value;
+    });
+  }
+
+  void _handleFocusChanged(bool value) {
+    if (_focused == value) return;
+    setState(() {
+      _focused = value;
+    });
+  }
+
+  void _activate() {
+    _handleHoverChanged(false);
+    widget.row.onTap?.call();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final content = Container(
-      height: 48,
-      padding: const EdgeInsets.all(AppSpacing.xxs),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(AppRadii.xSmall),
-      ),
-      child: _ActivityColumnLayout(
-        txType: Row(
-          children: [
-            _ActivityAvatar(row: row),
-            const SizedBox(width: AppSpacing.s),
-            Flexible(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    row.title,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: AppTypography.bodyMedium.copyWith(
-                      color: colors.text.accent,
-                    ),
-                  ),
-                  if (row.subtitle != null)
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (row.subtitleIconName != null) ...[
-                          AppIcon(
-                            row.subtitleIconName!,
-                            size: 16,
-                            color: colors.icon.brandCrimson,
-                          ),
-                          const SizedBox(width: AppSpacing.xxs),
-                        ],
-                        Flexible(
-                          child: Text(
-                            row.subtitle!,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: AppTypography.labelMedium.copyWith(
-                              color: row.subtitleIconName == null
-                                  ? colors.text.secondary
-                                  : colors.text.brandCrimson,
-                            ),
-                          ),
+    final row = widget.row;
+    final isInteractive = row.onTap != null;
+    final content = Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Container(
+          height: 48,
+          padding: const EdgeInsets.all(AppSpacing.xxs),
+          decoration: BoxDecoration(
+            color: isInteractive && _hovered
+                ? _neutralHoverBackgroundColor(context)
+                : null,
+            borderRadius: BorderRadius.circular(AppRadii.xSmall),
+          ),
+          child: _ActivityColumnLayout(
+            txType: Row(
+              children: [
+                _ActivityAvatar(row: row),
+                const SizedBox(width: AppSpacing.s),
+                Flexible(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        row.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTypography.bodyMedium.copyWith(
+                          color: colors.text.accent,
                         ),
-                      ],
-                    ),
-                ],
+                      ),
+                      if (row.subtitle != null)
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (row.subtitleIconName != null) ...[
+                              AppIcon(
+                                row.subtitleIconName!,
+                                size: 16,
+                                color: colors.icon.brandCrimson,
+                              ),
+                              const SizedBox(width: AppSpacing.xxs),
+                            ],
+                            Flexible(
+                              child: Text(
+                                row.subtitle!,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: AppTypography.labelMedium.copyWith(
+                                  color: row.subtitleIconName == null
+                                      ? colors.text.secondary
+                                      : colors.text.brandCrimson,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            amount: _AmountLabel(row: row),
+            status: _StatusLabel(row: row),
+            timestamp: Text(
+              row.timestampText,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.end,
+              style: AppTypography.labelMedium.copyWith(
+                color: colors.text.secondary,
               ),
             ),
-          ],
-        ),
-        amount: _AmountLabel(row: row),
-        status: _StatusLabel(row: row),
-        timestamp: Text(
-          row.timestampText,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          textAlign: TextAlign.end,
-          style: AppTypography.labelMedium.copyWith(
-            color: colors.text.secondary,
           ),
         ),
-      ),
+        if (isInteractive && _focused)
+          Positioned(
+            left: -1,
+            top: -1,
+            right: -1,
+            bottom: -1,
+            child: IgnorePointer(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  border: Border.all(color: colors.state.focusRing, width: 2),
+                  borderRadius: BorderRadius.circular(AppRadii.xSmall),
+                ),
+              ),
+            ),
+          ),
+      ],
     );
 
-    if (row.onTap == null) return content;
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: row.onTap,
-        child: content,
+    if (!isInteractive) return content;
+    return Semantics(
+      button: true,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => _handleHoverChanged(true),
+        onExit: (_) => _handleHoverChanged(false),
+        child: FocusableActionDetector(
+          mouseCursor: SystemMouseCursors.click,
+          onShowFocusHighlight: _handleFocusChanged,
+          shortcuts: _activityActivationShortcuts,
+          actions: <Type, Action<Intent>>{
+            ActivateIntent: CallbackAction<Intent>(
+              onInvoke: (_) {
+                _activate();
+                return null;
+              },
+            ),
+          },
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: _activate,
+            child: content,
+          ),
+        ),
       ),
     );
   }
@@ -564,7 +646,7 @@ class _PaginationIconButtonState extends State<_PaginationIconButton> {
     return _PaginationItemShell(
       enabled: enabled,
       backgroundColor: enabled && _hovered
-          ? _paginationHoverBackgroundColor(context)
+          ? _neutralHoverBackgroundColor(context)
           : null,
       border: border,
       onTap: widget.onTap,
@@ -632,7 +714,7 @@ class _PaginationPageButtonState extends State<_PaginationPageButton> {
     final backgroundColor = selected
         ? colors.background.brandCrimsonStrong
         : _hovered
-        ? _paginationHoverBackgroundColor(context)
+        ? _neutralHoverBackgroundColor(context)
         : null;
     final textColor = selected ? colors.text.inverse : colors.text.accent;
     final border = !selected && _focused
@@ -718,7 +800,7 @@ class _PaginationItemShell extends StatelessWidget {
                 : MouseCursor.defer,
             onShowFocusHighlight: onFocusChanged,
             includeFocusSemantics: false,
-            shortcuts: canActivate ? _paginationActivationShortcuts : null,
+            shortcuts: canActivate ? _activityActivationShortcuts : null,
             actions: canActivate
                 ? <Type, Action<Intent>>{
                     ActivateIntent: CallbackAction<Intent>(
@@ -766,7 +848,7 @@ class _PaginationEllipsis extends StatelessWidget {
   }
 }
 
-Color _paginationHoverBackgroundColor(BuildContext context) {
+Color _neutralHoverBackgroundColor(BuildContext context) {
   final colors = context.colors;
   final isDark = AppTheme.of(context) == AppThemeData.dark;
   return isDark ? colors.background.raised : colors.background.base;

--- a/lib/src/features/activity/widgets/activity_table.dart
+++ b/lib/src/features/activity/widgets/activity_table.dart
@@ -487,6 +487,7 @@ class ActivityTablePagination extends StatelessWidget {
             page == null
                 ? const _PaginationEllipsis()
                 : _PaginationPageButton(
+                    key: ValueKey<int>(page),
                     page: page,
                     selected: page == currentPage,
                     onTap: () => onPageChanged?.call(page),
@@ -522,6 +523,15 @@ class _PaginationIconButton extends StatefulWidget {
 class _PaginationIconButtonState extends State<_PaginationIconButton> {
   bool _hovered = false;
   bool _focused = false;
+
+  @override
+  void didUpdateWidget(covariant _PaginationIconButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.enabled != widget.enabled) {
+      _hovered = false;
+      _focused = false;
+    }
+  }
 
   void _handleHoverChanged(bool value) {
     if (_hovered == value) return;
@@ -570,6 +580,7 @@ class _PaginationPageButton extends StatefulWidget {
     required this.page,
     required this.selected,
     required this.onTap,
+    super.key,
   });
 
   final int page;
@@ -583,6 +594,16 @@ class _PaginationPageButton extends StatefulWidget {
 class _PaginationPageButtonState extends State<_PaginationPageButton> {
   bool _hovered = false;
   bool _focused = false;
+
+  @override
+  void didUpdateWidget(covariant _PaginationPageButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.page != widget.page ||
+        oldWidget.selected != widget.selected) {
+      _hovered = false;
+      _focused = false;
+    }
+  }
 
   void _handleHoverChanged(bool value) {
     if (_hovered == value) return;
@@ -665,24 +686,36 @@ class _PaginationItemShell extends StatelessWidget {
       child: child,
     );
 
-    if (!enabled || onTap == null) return content;
+    final tracksPointer = enabled && onHoverChanged != null;
+    final canActivate = enabled && onTap != null;
+
+    if (!tracksPointer && !canActivate) return content;
+
+    final activatableContent = canActivate
+        ? FocusableActionDetector(
+            mouseCursor: SystemMouseCursors.click,
+            onShowFocusHighlight: onFocusChanged,
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () {
+                FocusManager.instance.primaryFocus?.unfocus();
+                onFocusChanged?.call(false);
+                onHoverChanged?.call(false);
+                onTap?.call();
+              },
+              child: content,
+            ),
+          )
+        : content;
 
     return Semantics(
-      button: true,
+      button: canActivate,
       selected: selected,
       child: MouseRegion(
-        cursor: SystemMouseCursors.click,
+        cursor: canActivate ? SystemMouseCursors.click : MouseCursor.defer,
         onEnter: (_) => onHoverChanged?.call(true),
         onExit: (_) => onHoverChanged?.call(false),
-        child: FocusableActionDetector(
-          mouseCursor: SystemMouseCursors.click,
-          onShowFocusHighlight: onFocusChanged,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: onTap,
-            child: content,
-          ),
-        ),
+        child: activatableContent,
       ),
     );
   }

--- a/lib/src/features/activity/widgets/activity_table.dart
+++ b/lib/src/features/activity/widgets/activity_table.dart
@@ -472,33 +472,39 @@ class ActivityTablePagination extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final pages = _visiblePages(currentPage, totalPages);
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        _PaginationIconButton(
-          iconName: AppIcons.chevronBackward,
-          enabled: currentPage > 1,
-          onTap: () => onPageChanged?.call(currentPage - 1),
-        ),
-        for (final page in pages)
-          page == null
-              ? const _PaginationEllipsis()
-              : _PaginationPageButton(
-                  page: page,
-                  selected: page == currentPage,
-                  onTap: () => onPageChanged?.call(page),
-                ),
-        _PaginationIconButton(
-          iconName: AppIcons.chevronForward,
-          enabled: currentPage < totalPages,
-          onTap: () => onPageChanged?.call(currentPage + 1),
-        ),
-      ],
+    return Padding(
+      padding: const EdgeInsets.all(AppSpacing.xxs),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          _PaginationIconButton(
+            iconName: AppIcons.chevronBackward,
+            enabled: currentPage > 1,
+            onTap: () => onPageChanged?.call(currentPage - 1),
+          ),
+          for (final page in pages) ...[
+            const SizedBox(width: AppSpacing.xxs),
+            page == null
+                ? const _PaginationEllipsis()
+                : _PaginationPageButton(
+                    page: page,
+                    selected: page == currentPage,
+                    onTap: () => onPageChanged?.call(page),
+                  ),
+          ],
+          const SizedBox(width: AppSpacing.xxs),
+          _PaginationIconButton(
+            iconName: AppIcons.chevronForward,
+            enabled: currentPage < totalPages,
+            onTap: () => onPageChanged?.call(currentPage + 1),
+          ),
+        ],
+      ),
     );
   }
 }
 
-class _PaginationIconButton extends StatelessWidget {
+class _PaginationIconButton extends StatefulWidget {
   const _PaginationIconButton({
     required this.iconName,
     required this.enabled,
@@ -510,33 +516,56 @@ class _PaginationIconButton extends StatelessWidget {
   final VoidCallback onTap;
 
   @override
+  State<_PaginationIconButton> createState() => _PaginationIconButtonState();
+}
+
+class _PaginationIconButtonState extends State<_PaginationIconButton> {
+  bool _hovered = false;
+  bool _focused = false;
+
+  void _handleHoverChanged(bool value) {
+    if (_hovered == value) return;
+    setState(() {
+      _hovered = value;
+    });
+  }
+
+  void _handleFocusChanged(bool value) {
+    if (_focused == value) return;
+    setState(() {
+      _focused = value;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final child = SizedBox(
-      width: 32,
-      height: 32,
+    final enabled = widget.enabled;
+    final border = enabled && _focused
+        ? Border.all(color: colors.state.focusRing, width: 1.5)
+        : null;
+
+    return _PaginationItemShell(
+      enabled: enabled,
+      backgroundColor: enabled && _hovered
+          ? _paginationHoverBackgroundColor(context)
+          : null,
+      border: border,
+      onTap: widget.onTap,
+      onHoverChanged: _handleHoverChanged,
+      onFocusChanged: _handleFocusChanged,
       child: Center(
         child: AppIcon(
-          iconName,
-          size: 16,
-          color: enabled ? colors.icon.accent : colors.text.disabled,
+          widget.iconName,
+          size: 14,
+          color: enabled ? colors.icon.accent : colors.icon.disabled,
         ),
-      ),
-    );
-
-    if (!enabled) return child;
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: child,
       ),
     );
   }
 }
 
-class _PaginationPageButton extends StatelessWidget {
+class _PaginationPageButton extends StatefulWidget {
   const _PaginationPageButton({
     required this.page,
     required this.selected,
@@ -548,26 +577,112 @@ class _PaginationPageButton extends StatelessWidget {
   final VoidCallback onTap;
 
   @override
+  State<_PaginationPageButton> createState() => _PaginationPageButtonState();
+}
+
+class _PaginationPageButtonState extends State<_PaginationPageButton> {
+  bool _hovered = false;
+  bool _focused = false;
+
+  void _handleHoverChanged(bool value) {
+    if (_hovered == value) return;
+    setState(() {
+      _hovered = value;
+    });
+  }
+
+  void _handleFocusChanged(bool value) {
+    if (_focused == value) return;
+    setState(() {
+      _focused = value;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final child = SizedBox(
-      width: 32,
-      height: 32,
+    final selected = widget.selected;
+    final backgroundColor = selected
+        ? colors.background.brandCrimsonStrong
+        : _hovered
+        ? _paginationHoverBackgroundColor(context)
+        : null;
+    final textColor = selected ? colors.text.inverse : colors.text.accent;
+    final border = !selected && _focused
+        ? Border.all(color: colors.state.focusRing, width: 1.5)
+        : null;
+
+    return _PaginationItemShell(
+      selected: selected,
+      backgroundColor: backgroundColor,
+      border: border,
+      onTap: selected ? null : widget.onTap,
+      onHoverChanged: _handleHoverChanged,
+      onFocusChanged: _handleFocusChanged,
       child: Center(
         child: Text(
-          '$page',
-          style: AppTypography.bodySmall.copyWith(color: colors.text.accent),
+          '${widget.page}',
+          style: AppTypography.labelMedium.copyWith(color: textColor),
         ),
       ),
     );
+  }
+}
 
-    if (selected) return child;
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: child,
+class _PaginationItemShell extends StatelessWidget {
+  const _PaginationItemShell({
+    required this.child,
+    this.selected = false,
+    this.enabled = true,
+    this.backgroundColor,
+    this.border,
+    this.onTap,
+    this.onHoverChanged,
+    this.onFocusChanged,
+  });
+
+  final Widget child;
+  final bool selected;
+  final bool enabled;
+  final Color? backgroundColor;
+  final Border? border;
+  final VoidCallback? onTap;
+  final ValueChanged<bool>? onHoverChanged;
+  final ValueChanged<bool>? onFocusChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final content = AnimatedContainer(
+      duration: const Duration(milliseconds: 120),
+      curve: Curves.easeOutCubic,
+      width: 32,
+      height: 32,
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
+        border: border,
+      ),
+      child: child,
+    );
+
+    if (!enabled || onTap == null) return content;
+
+    return Semantics(
+      button: true,
+      selected: selected,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => onHoverChanged?.call(true),
+        onExit: (_) => onHoverChanged?.call(false),
+        child: FocusableActionDetector(
+          mouseCursor: SystemMouseCursors.click,
+          onShowFocusHighlight: onFocusChanged,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: onTap,
+            child: content,
+          ),
+        ),
       ),
     );
   }
@@ -584,13 +699,19 @@ class _PaginationEllipsis extends StatelessWidget {
       child: Center(
         child: Text(
           '...',
-          style: AppTypography.bodySmall.copyWith(
+          style: AppTypography.labelMedium.copyWith(
             color: context.colors.text.accent,
           ),
         ),
       ),
     );
   }
+}
+
+Color _paginationHoverBackgroundColor(BuildContext context) {
+  final colors = context.colors;
+  final isDark = AppTheme.of(context) == AppThemeData.dark;
+  return isDark ? colors.background.raised : colors.background.base;
 }
 
 List<int?> _visiblePages(int currentPage, int totalPages) {

--- a/lib/src/features/activity/widgets/activity_table.dart
+++ b/lib/src/features/activity/widgets/activity_table.dart
@@ -1,10 +1,16 @@
 import 'dart:math' as math;
 
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../models/activity_row_data.dart';
+
+const _paginationActivationShortcuts = <ShortcutActivator, Intent>{
+  SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+  SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
+};
 
 class ActivityTable extends StatelessWidget {
   const ActivityTable({
@@ -688,25 +694,44 @@ class _PaginationItemShell extends StatelessWidget {
 
     final tracksPointer = enabled && onHoverChanged != null;
     final canActivate = enabled && onTap != null;
+    final canFocus = enabled && onFocusChanged != null;
 
-    if (!tracksPointer && !canActivate) return content;
+    if (!tracksPointer && !canActivate && !canFocus) return content;
 
-    final activatableContent = canActivate
-        ? FocusableActionDetector(
-            mouseCursor: SystemMouseCursors.click,
-            onShowFocusHighlight: onFocusChanged,
-            child: GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: () {
-                FocusManager.instance.primaryFocus?.unfocus();
-                onFocusChanged?.call(false);
-                onHoverChanged?.call(false);
-                onTap?.call();
-              },
-              child: content,
-            ),
+    void activate() {
+      onHoverChanged?.call(false);
+      onTap?.call();
+    }
+
+    final gestureContent = canActivate
+        ? GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: activate,
+            child: content,
           )
         : content;
+
+    final focusableContent = canFocus
+        ? FocusableActionDetector(
+            mouseCursor: canActivate
+                ? SystemMouseCursors.click
+                : MouseCursor.defer,
+            onShowFocusHighlight: onFocusChanged,
+            includeFocusSemantics: false,
+            shortcuts: canActivate ? _paginationActivationShortcuts : null,
+            actions: canActivate
+                ? <Type, Action<Intent>>{
+                    ActivateIntent: CallbackAction<Intent>(
+                      onInvoke: (_) {
+                        activate();
+                        return null;
+                      },
+                    ),
+                  }
+                : null,
+            child: gestureContent,
+          )
+        : gestureContent;
 
     return Semantics(
       button: canActivate,
@@ -715,7 +740,7 @@ class _PaginationItemShell extends StatelessWidget {
         cursor: canActivate ? SystemMouseCursors.click : MouseCursor.defer,
         onEnter: (_) => onHoverChanged?.call(true),
         onExit: (_) => onHoverChanged?.call(false),
-        child: activatableContent,
+        child: focusableContent,
       ),
     );
   }

--- a/lib/src/features/activity/widgets/activity_table.dart
+++ b/lib/src/features/activity/widgets/activity_table.dart
@@ -344,14 +344,7 @@ class ActivityTableRow extends StatelessWidget {
             ),
           ],
         ),
-        amount: Text(
-          row.amountText,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: AppTypography.labelMedium.copyWith(
-            color: row.amountColor ?? colors.text.accent,
-          ),
-        ),
+        amount: _AmountLabel(row: row),
         status: _StatusLabel(row: row),
         timestamp: Text(
           row.timestampText,
@@ -373,6 +366,43 @@ class ActivityTableRow extends StatelessWidget {
         onTap: row.onTap,
         child: content,
       ),
+    );
+  }
+}
+
+class _AmountLabel extends StatelessWidget {
+  const _AmountLabel({required this.row});
+
+  final ActivityRowData row;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final color = row.amountColor ?? colors.text.accent;
+    final text = Text(
+      row.amountText,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: AppTypography.labelMedium.copyWith(color: color),
+    );
+
+    final iconName = row.amountIconName;
+    if (iconName == null) return text;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Transform.translate(
+          offset: const Offset(0, -1),
+          child: AppIcon(
+            iconName,
+            size: 16,
+            color: row.amountIconColor ?? color,
+          ),
+        ),
+        const SizedBox(width: AppSpacing.xxs),
+        Flexible(child: text),
+      ],
     );
   }
 }

--- a/lib/src/features/history/screens/history_screen.dart
+++ b/lib/src/features/history/screens/history_screen.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 
 class HistoryScreen extends ConsumerStatefulWidget {
@@ -24,11 +27,25 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     _loadTransactions();
   }
 
-  Future<void> _loadTransactions() async {
+  Future<void> _loadTransactions({bool showLoading = false}) async {
+    if (showLoading && mounted) {
+      setState(() {
+        _isLoading = true;
+        _error = null;
+      });
+    }
     try {
       final dbPath = await getWalletDbPath();
       final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
-      if (accountUuid == null) return;
+      if (accountUuid == null) {
+        if (mounted) {
+          setState(() {
+            _transactions = const [];
+            _isLoading = false;
+          });
+        }
+        return;
+      }
       final txs = await rust_sync.getTransactionHistory(
         dbPath: dbPath,
         network: 'main',
@@ -51,23 +68,77 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     }
   }
 
-  String _formatZec(int zatoshi) {
-    final zec = zatoshi.abs() / 100000000;
-    final sign = zatoshi >= 0 ? '+' : '-';
-    return '$sign${zec.toStringAsFixed(8)} ZEC';
+  String _formatZec(BigInt zatoshi, {String? sign}) {
+    final abs = zatoshi.abs();
+    final whole = abs ~/ BigInt.from(100000000);
+    final frac = (abs % BigInt.from(100000000)).toString().padLeft(8, '0');
+    final prefix = sign ?? '';
+    return '$prefix$whole.$frac ZEC';
   }
 
-  String _formatDate(int timestamp) {
-    if (timestamp == 0) return 'Pending';
-    final date = DateTime.fromMillisecondsSinceEpoch(timestamp * 1000);
+  String _formatDate(BigInt timestamp) {
+    if (timestamp == BigInt.zero) return 'Pending';
+    final date = DateTime.fromMillisecondsSinceEpoch(timestamp.toInt() * 1000);
     return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')} '
         '${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
   }
 
-  Widget _buildTransactionTile(BuildContext context, rust_sync.TransactionInfo tx) {
+  String _recentSignature(SyncState? sync) {
+    return sync?.recentTransactions
+            .map(
+              (tx) =>
+                  '${tx.txidHex}:${tx.minedHeight}:${tx.expiredUnmined}:${tx.txKind}:${tx.displayAmount}',
+            )
+            .join('|') ??
+        '';
+  }
+
+  String _titleForTx(rust_sync.TransactionInfo tx) {
+    final base = switch (tx.txKind) {
+      'received' => 'Received',
+      'sent' => 'Sent',
+      'shielded' => 'Shielded',
+      'internal' => 'Internal',
+      _ => 'Transaction',
+    };
+    if (!tx.expiredUnmined) return base;
+    return '$base Failed';
+  }
+
+  String? _poolLabel(rust_sync.TransactionInfo tx) {
+    if (tx.txKind != 'received' && tx.txKind != 'sent') return null;
+    return switch (tx.displayPool) {
+      'transparent' => 'Transparent',
+      'shielded' => 'Shielded',
+      'mixed' => 'Mixed',
+      _ => null,
+    };
+  }
+
+  String _amountForTx(rust_sync.TransactionInfo tx) {
+    if (tx.displayAmount == BigInt.zero) return '--';
+    return switch (tx.txKind) {
+      'received' => _formatZec(tx.displayAmount, sign: '+'),
+      'sent' => _formatZec(tx.displayAmount, sign: '-'),
+      'shielded' => _formatZec(tx.displayAmount),
+      'internal' => _formatZec(tx.displayAmount),
+      _ => _formatZec(tx.displayAmount),
+    };
+  }
+
+  BigInt _timestampForTx(rust_sync.TransactionInfo tx) {
+    return tx.blockTime > BigInt.zero ? tx.blockTime : tx.createdTime;
+  }
+
+  Widget _buildTransactionTile(
+    BuildContext context,
+    rust_sync.TransactionInfo tx,
+  ) {
     final colors = Theme.of(context).colorScheme;
     final text = Theme.of(context).textTheme;
-    final isIncoming = tx.accountBalanceDelta.toInt() >= 0;
+    final isIncoming = tx.txKind == 'received';
+    final isSent = tx.txKind == 'sent';
+    final isShielded = tx.txKind == 'shielded';
     final isPending = tx.minedHeight == BigInt.zero && !tx.expiredUnmined;
     final isExpired = tx.expiredUnmined;
 
@@ -80,47 +151,54 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     if (isExpired) {
       icon = Icons.cancel_outlined;
       iconColor = colors.error;
-      title = isIncoming ? 'Receive Expired' : 'Send Expired';
-      status = 'Transaction expired';
+      title = _titleForTx(tx);
+      status = 'Failed';
       amountColor = colors.outline;
     } else if (isPending) {
       icon = Icons.schedule;
       iconColor = colors.secondary;
-      title = isIncoming ? 'Receiving...' : 'Sending...';
-      status = 'Waiting for confirmation';
+      title = _titleForTx(tx);
+      status = 'In progress';
       amountColor = colors.outline;
     } else {
-      icon = isIncoming ? Icons.arrow_downward : Icons.arrow_upward;
+      icon = isShielded
+          ? Icons.shield_outlined
+          : isIncoming
+          ? Icons.arrow_downward
+          : Icons.arrow_upward;
       iconColor = isIncoming ? colors.tertiary : colors.secondary;
-      title = isIncoming ? 'Received' : 'Sent';
-      status = 'Block ${tx.minedHeight} \u2022 ${_formatDate(tx.blockTime.toInt())}';
+      title = _titleForTx(tx);
+      status = 'Block ${tx.minedHeight} • ${_formatDate(_timestampForTx(tx))}';
       amountColor = isIncoming ? colors.tertiary : colors.onSurface;
     }
+
+    final poolLabel = _poolLabel(tx);
 
     return ListTile(
       leading: isPending
           ? SizedBox(
               width: 24,
               height: 24,
-              child: CircularProgressIndicator(strokeWidth: 2, color: iconColor),
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: iconColor,
+              ),
             )
           : Icon(icon, color: iconColor),
       title: Text(title, style: text.titleSmall),
       subtitle: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(status, style: text.bodySmall?.copyWith(color: colors.outline)),
-          if (tx.fee > BigInt.zero)
-            Text(
-              'Fee: ${(tx.fee.toInt() / 100000000).toStringAsFixed(5)} ZEC',
-              style: text.labelSmall?.copyWith(color: colors.outline),
-            ),
+          Text(
+            poolLabel == null ? status : '$poolLabel • $status',
+            style: text.bodySmall?.copyWith(color: colors.outline),
+          ),
         ],
       ),
       trailing: Text(
-        _formatZec(tx.accountBalanceDelta.toInt()),
+        _amountForTx(tx),
         style: text.titleSmall?.copyWith(
-          color: amountColor,
+          color: isSent ? colors.onSurface : amountColor,
           fontWeight: FontWeight.w600,
           decoration: isExpired ? TextDecoration.lineThrough : null,
         ),
@@ -130,14 +208,21 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<AsyncValue<SyncState>>(syncProvider, (previous, next) {
+      final prevSig = _recentSignature(previous?.value);
+      final nextSig = _recentSignature(next.value);
+      if (prevSig != nextSig && nextSig.isNotEmpty) {
+        unawaited(_loadTransactions());
+      }
+    });
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Transaction History'),
         actions: [
           IconButton(
             onPressed: () {
-              setState(() => _isLoading = true);
-              _loadTransactions();
+              unawaited(_loadTransactions(showLoading: true));
             },
             icon: const Icon(Icons.refresh),
           ),
@@ -146,14 +231,14 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
       body: _isLoading
           ? const Center(child: CircularProgressIndicator())
           : _error != null
-              ? Center(child: Text('Error: $_error'))
-              : _transactions == null || _transactions!.isEmpty
-                  ? const Center(child: Text('No transactions yet'))
-                  : ListView.builder(
-                      itemCount: _transactions!.length,
-                      itemBuilder: (context, index) =>
-                          _buildTransactionTile(context, _transactions![index]),
-                    ),
+          ? Center(child: Text('Error: $_error'))
+          : _transactions == null || _transactions!.isEmpty
+          ? const Center(child: Text('No transactions yet'))
+          : ListView.builder(
+              itemCount: _transactions!.length,
+              itemBuilder: (context, index) =>
+                  _buildTransactionTile(context, _transactions![index]),
+            ),
     );
   }
 }

--- a/lib/src/features/history/screens/history_screen.dart
+++ b/lib/src/features/history/screens/history_screen.dart
@@ -197,12 +197,20 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
         .take(_transactionsPerPage);
     final rows = accountUuid == null
         ? const <ActivityRowData>[]
-        : buildActivityRows(
-            context: context,
-            sync: sync,
-            transactions: pageTransactions,
-            onRetrySync: () => ref.read(syncProvider.notifier).startSync(),
-          );
+        : [
+            if (currentPage == 1)
+              buildSyncActivityRow(
+                context: context,
+                sync: sync,
+                onRetrySync: () => ref.read(syncProvider.notifier).startSync(),
+              ),
+            ...pageTransactions.map(
+              (tx) => buildTransactionActivityRow(
+                context: context,
+                transaction: tx,
+              ),
+            ),
+          ];
 
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),

--- a/lib/src/features/history/screens/history_screen.dart
+++ b/lib/src/features/history/screens/history_screen.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart' show Scrollbar;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/config/network_config.dart';
@@ -13,6 +14,7 @@ import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
+import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
@@ -147,6 +149,14 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     }
   }
 
+  void _goBack() {
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      context.go('/home');
+    }
+  }
+
   String _recentSignature(SyncState? sync) {
     return sync?.recentTransactions
             .map(
@@ -197,7 +207,12 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
       pane: AppDesktopPane(
-        padding: const EdgeInsets.fromLTRB(AppSpacing.sm, 0, AppSpacing.sm, 0),
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.sm,
+          AppSpacing.sm,
+          AppSpacing.sm,
+          0,
+        ),
         child: LayoutBuilder(
           builder: (context, constraints) {
             return NotificationListener<ScrollMetricsNotification>(
@@ -243,6 +258,7 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
                         currentPage: currentPage,
                         totalPages: totalPages,
                         onPageChanged: _setPage,
+                        onBack: _goBack,
                       ),
                     ),
                   ),
@@ -264,6 +280,7 @@ class _ActivityPane extends StatelessWidget {
     required this.currentPage,
     required this.totalPages,
     required this.onPageChanged,
+    required this.onBack,
   });
 
   final List<ActivityRowData> rows;
@@ -272,6 +289,7 @@ class _ActivityPane extends StatelessWidget {
   final int currentPage;
   final int totalPages;
   final ValueChanged<int> onPageChanged;
+  final VoidCallback onBack;
 
   @override
   Widget build(BuildContext context) {
@@ -279,6 +297,7 @@ class _ActivityPane extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
+        _ActivityBackRow(onTap: onBack),
         const SizedBox(height: AppSpacing.s),
         Center(
           child: Text(
@@ -303,8 +322,52 @@ class _ActivityPane extends StatelessWidget {
             onPageChanged: onPageChanged,
           ),
         ),
-        const SizedBox(height: AppSpacing.sm),
+        const SizedBox(height: AppSpacing.s),
       ],
+    );
+  }
+}
+
+class _ActivityBackRow extends StatelessWidget {
+  const _ActivityBackRow({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(minWidth: 60),
+            child: SizedBox(
+              height: 32,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  AppIcon(
+                    AppIcons.chevronBackward,
+                    size: 16,
+                    color: colors.icon.accent,
+                  ),
+                  const SizedBox(width: AppSpacing.xxs),
+                  Text(
+                    'Back',
+                    style: AppTypography.labelLarge.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/features/history/screens/history_screen.dart
+++ b/lib/src/features/history/screens/history_screen.dart
@@ -1,13 +1,24 @@
 import 'dart:async';
+import 'dart:math' as math;
 
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' show Scrollbar;
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/config/network_config.dart';
+import '../../../core/layout/app_desktop_shell.dart';
+import '../../../core/layout/app_layout.dart';
+import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/storage/wallet_paths.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
+import '../../activity/activity_row_mapper.dart';
+import '../../activity/models/activity_row_data.dart';
+import '../../activity/widgets/activity_table.dart';
 
 class HistoryScreen extends ConsumerStatefulWidget {
   const HistoryScreen({super.key});
@@ -17,70 +28,123 @@ class HistoryScreen extends ConsumerStatefulWidget {
 }
 
 class _HistoryScreenState extends ConsumerState<HistoryScreen> {
+  static const _transactionsPerPage = 5;
+
+  final ScrollController _scrollController = ScrollController();
   List<rust_sync.TransactionInfo>? _transactions;
   bool _isLoading = true;
   String? _error;
+  int _currentPage = 1;
+  String? _activeAccountUuid;
+  bool _isHovered = false;
+  bool _canScroll = false;
 
   @override
   void initState() {
     super.initState();
-    _loadTransactions();
+    _activeAccountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    _loadTransactions(showLoading: true);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref.read(appLayoutProvider.notifier).setMode(AppLayoutMode.large);
+      _updateCanScroll();
+    });
   }
 
-  Future<void> _loadTransactions({bool showLoading = false}) async {
+  @override
+  void didUpdateWidget(covariant HistoryScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _updateCanScroll();
+    });
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadTransactions({
+    bool showLoading = false,
+    bool resetPage = false,
+  }) async {
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    _activeAccountUuid = accountUuid;
+
     if (showLoading && mounted) {
       setState(() {
         _isLoading = true;
         _error = null;
+        if (resetPage) {
+          _currentPage = 1;
+          _transactions = null;
+        }
       });
     }
+
+    if (accountUuid == null) {
+      if (!mounted) return;
+      setState(() {
+        _transactions = const [];
+        _isLoading = false;
+        _error = null;
+        _currentPage = 1;
+      });
+      return;
+    }
+
     try {
       final dbPath = await getWalletDbPath();
-      final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
-      if (accountUuid == null) {
-        if (mounted) {
-          setState(() {
-            _transactions = const [];
-            _isLoading = false;
-          });
-        }
-        return;
-      }
       final txs = await rust_sync.getTransactionHistory(
         dbPath: dbPath,
-        network: 'main',
+        network: ZcashNetwork.mainnet.name,
         accountUuid: accountUuid,
       );
-      if (mounted) {
-        setState(() {
-          _transactions = txs;
-          _isLoading = false;
-        });
+      if (!mounted) return;
+      if (accountUuid != ref.read(accountProvider).value?.activeAccountUuid) {
+        return;
       }
-    } catch (e) {
-      log('History: ERROR: $e');
-      if (mounted) {
-        setState(() {
-          _error = e.toString();
-          _isLoading = false;
-        });
-      }
+      setState(() {
+        _transactions = txs;
+        _isLoading = false;
+        _error = null;
+        if (resetPage) _currentPage = 1;
+      });
+    } catch (e, st) {
+      log('Activity: history load failed: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _error = 'Activity could not be loaded.';
+        _isLoading = false;
+      });
     }
   }
 
-  String _formatZec(BigInt zatoshi, {String? sign}) {
-    final abs = zatoshi.abs();
-    final whole = abs ~/ BigInt.from(100000000);
-    final frac = (abs % BigInt.from(100000000)).toString().padLeft(8, '0');
-    final prefix = sign ?? '';
-    return '$prefix$whole.$frac ZEC';
+  void _updateCanScroll() {
+    if (!_scrollController.hasClients) return;
+    final canScroll = _scrollController.position.maxScrollExtent > 0;
+    if (canScroll == _canScroll) return;
+    setState(() {
+      _canScroll = canScroll;
+    });
   }
 
-  String _formatDate(BigInt timestamp) {
-    if (timestamp == BigInt.zero) return 'Pending';
-    final date = DateTime.fromMillisecondsSinceEpoch(timestamp.toInt() * 1000);
-    return '${date.year}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')} '
-        '${date.hour.toString().padLeft(2, '0')}:${date.minute.toString().padLeft(2, '0')}';
+  void _setPage(int page) {
+    if (page == _currentPage) return;
+    setState(() {
+      _currentPage = page;
+    });
+    if (_scrollController.hasClients) {
+      unawaited(
+        _scrollController.animateTo(
+          0,
+          duration: const Duration(milliseconds: 180),
+          curve: Curves.easeOutCubic,
+        ),
+      );
+    }
   }
 
   String _recentSignature(SyncState? sync) {
@@ -93,152 +157,154 @@ class _HistoryScreenState extends ConsumerState<HistoryScreen> {
         '';
   }
 
-  String _titleForTx(rust_sync.TransactionInfo tx) {
-    final base = switch (tx.txKind) {
-      'received' => 'Received',
-      'sent' => 'Sent',
-      'shielded' => 'Shielded',
-      'internal' => 'Internal',
-      _ => 'Transaction',
-    };
-    if (!tx.expiredUnmined) return base;
-    return '$base Failed';
-  }
-
-  String? _poolLabel(rust_sync.TransactionInfo tx) {
-    if (tx.txKind != 'received' && tx.txKind != 'sent') return null;
-    return switch (tx.displayPool) {
-      'transparent' => 'Transparent',
-      'shielded' => 'Shielded',
-      'mixed' => 'Mixed',
-      _ => null,
-    };
-  }
-
-  String _amountForTx(rust_sync.TransactionInfo tx) {
-    if (tx.displayAmount == BigInt.zero) return '--';
-    return switch (tx.txKind) {
-      'received' => _formatZec(tx.displayAmount, sign: '+'),
-      'sent' => _formatZec(tx.displayAmount, sign: '-'),
-      'shielded' => _formatZec(tx.displayAmount),
-      'internal' => _formatZec(tx.displayAmount),
-      _ => _formatZec(tx.displayAmount),
-    };
-  }
-
-  BigInt _timestampForTx(rust_sync.TransactionInfo tx) {
-    return tx.blockTime > BigInt.zero ? tx.blockTime : tx.createdTime;
-  }
-
-  Widget _buildTransactionTile(
-    BuildContext context,
-    rust_sync.TransactionInfo tx,
-  ) {
-    final colors = Theme.of(context).colorScheme;
-    final text = Theme.of(context).textTheme;
-    final isIncoming = tx.txKind == 'received';
-    final isSent = tx.txKind == 'sent';
-    final isShielded = tx.txKind == 'shielded';
-    final isPending = tx.minedHeight == BigInt.zero && !tx.expiredUnmined;
-    final isExpired = tx.expiredUnmined;
-
-    final IconData icon;
-    final Color iconColor;
-    final String title;
-    final String status;
-    final Color amountColor;
-
-    if (isExpired) {
-      icon = Icons.cancel_outlined;
-      iconColor = colors.error;
-      title = _titleForTx(tx);
-      status = 'Failed';
-      amountColor = colors.outline;
-    } else if (isPending) {
-      icon = Icons.schedule;
-      iconColor = colors.secondary;
-      title = _titleForTx(tx);
-      status = 'In progress';
-      amountColor = colors.outline;
-    } else {
-      icon = isShielded
-          ? Icons.shield_outlined
-          : isIncoming
-          ? Icons.arrow_downward
-          : Icons.arrow_upward;
-      iconColor = isIncoming ? colors.tertiary : colors.secondary;
-      title = _titleForTx(tx);
-      status = 'Block ${tx.minedHeight} • ${_formatDate(_timestampForTx(tx))}';
-      amountColor = isIncoming ? colors.tertiary : colors.onSurface;
-    }
-
-    final poolLabel = _poolLabel(tx);
-
-    return ListTile(
-      leading: isPending
-          ? SizedBox(
-              width: 24,
-              height: 24,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: iconColor,
-              ),
-            )
-          : Icon(icon, color: iconColor),
-      title: Text(title, style: text.titleSmall),
-      subtitle: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            poolLabel == null ? status : '$poolLabel • $status',
-            style: text.bodySmall?.copyWith(color: colors.outline),
-          ),
-        ],
-      ),
-      trailing: Text(
-        _amountForTx(tx),
-        style: text.titleSmall?.copyWith(
-          color: isSent ? colors.onSurface : amountColor,
-          fontWeight: FontWeight.w600,
-          decoration: isExpired ? TextDecoration.lineThrough : null,
-        ),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
+    ref.listen<AsyncValue<AccountState>>(accountProvider, (previous, next) {
+      final nextUuid = next.value?.activeAccountUuid;
+      if (nextUuid != _activeAccountUuid) {
+        unawaited(_loadTransactions(showLoading: true, resetPage: true));
+      }
+    });
     ref.listen<AsyncValue<SyncState>>(syncProvider, (previous, next) {
       final prevSig = _recentSignature(previous?.value);
       final nextSig = _recentSignature(next.value);
       if (prevSig != nextSig && nextSig.isNotEmpty) {
-        unawaited(_loadTransactions());
+        unawaited(_loadTransactions(resetPage: true));
       }
     });
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Transaction History'),
-        actions: [
-          IconButton(
-            onPressed: () {
-              unawaited(_loadTransactions(showLoading: true));
-            },
-            icon: const Icon(Icons.refresh),
-          ),
-        ],
+    final sync = ref.watch(syncProvider).value ?? SyncState();
+    final accountUuid = ref.watch(accountProvider).value?.activeAccountUuid;
+    final transactions = _transactions ?? sync.recentTransactions;
+    final totalPages = math.max(
+      1,
+      (transactions.length / _transactionsPerPage).ceil(),
+    );
+    final currentPage = math.min(math.max(_currentPage, 1), totalPages);
+    final firstTxIndex = (currentPage - 1) * _transactionsPerPage;
+    final pageTransactions = transactions
+        .skip(firstTxIndex)
+        .take(_transactionsPerPage);
+    final rows = accountUuid == null
+        ? const <ActivityRowData>[]
+        : buildActivityRows(
+            context: context,
+            sync: sync,
+            transactions: pageTransactions,
+            onRetrySync: () => ref.read(syncProvider.notifier).startSync(),
+          );
+
+    return AppDesktopShell(
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: const EdgeInsets.fromLTRB(AppSpacing.sm, 0, AppSpacing.sm, 0),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return NotificationListener<ScrollMetricsNotification>(
+              onNotification: (_) {
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (!mounted) return;
+                  _updateCanScroll();
+                });
+                return false;
+              },
+              child: MouseRegion(
+                onEnter: (_) {
+                  if (!_isHovered) {
+                    setState(() {
+                      _isHovered = true;
+                    });
+                  }
+                },
+                onExit: (_) {
+                  if (_isHovered) {
+                    setState(() {
+                      _isHovered = false;
+                    });
+                  }
+                },
+                child: Scrollbar(
+                  controller: _scrollController,
+                  thumbVisibility:
+                      isDesktopLayoutPlatform && _isHovered && _canScroll,
+                  child: SingleChildScrollView(
+                    controller: _scrollController,
+                    child: ConstrainedBox(
+                      constraints: BoxConstraints(
+                        minHeight: constraints.maxHeight,
+                      ),
+                      child: _ActivityPane(
+                        rows: rows,
+                        isLoading:
+                            _isLoading &&
+                            _transactions == null &&
+                            sync.recentTransactions.isEmpty,
+                        errorText: _transactions == null ? _error : null,
+                        currentPage: currentPage,
+                        totalPages: totalPages,
+                        onPageChanged: _setPage,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
       ),
-      body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : _error != null
-          ? Center(child: Text('Error: $_error'))
-          : _transactions == null || _transactions!.isEmpty
-          ? const Center(child: Text('No transactions yet'))
-          : ListView.builder(
-              itemCount: _transactions!.length,
-              itemBuilder: (context, index) =>
-                  _buildTransactionTile(context, _transactions![index]),
+    );
+  }
+}
+
+class _ActivityPane extends StatelessWidget {
+  const _ActivityPane({
+    required this.rows,
+    required this.isLoading,
+    required this.errorText,
+    required this.currentPage,
+    required this.totalPages,
+    required this.onPageChanged,
+  });
+
+  final List<ActivityRowData> rows;
+  final bool isLoading;
+  final String? errorText;
+  final int currentPage;
+  final int totalPages;
+  final ValueChanged<int> onPageChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const SizedBox(height: AppSpacing.s),
+        Center(
+          child: Text(
+            'Activity',
+            style: AppTypography.displaySmall.copyWith(
+              color: colors.text.accent,
             ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+        const Center(child: AppDecorativeDivider(width: 256)),
+        const SizedBox(height: AppSpacing.sm),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+          child: ActivityTable(
+            rows: rows,
+            isLoading: isLoading,
+            errorText: errorText,
+            showPagination: true,
+            currentPage: currentPage,
+            totalPages: totalPages,
+            onPageChanged: onPageChanged,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.sm),
+      ],
     );
   }
 }

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart'
-    show CircularProgressIndicator, Scrollbar, Theme;
+    show CircularProgressIndicator, Scrollbar;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -461,14 +461,13 @@ class _HomePaneState extends State<_HomePane> {
 
   _HomeActivityRowData _syncActivityRow(BuildContext context) {
     final colors = context.colors;
-    final successColor = Theme.of(context).colorScheme.tertiary;
 
     if (widget.sync.error != null) {
       return _HomeActivityRowData(
         title: 'Wallet Synced',
-        leadingIconName: AppIcons.warning,
-        leadingBackgroundColor: colors.background.base,
-        leadingIconColor: colors.icon.warning,
+        leadingIconName: AppIcons.sync,
+        leadingBackgroundColor: colors.background.neutralSubtleOpacity,
+        leadingIconColor: colors.icon.regular,
         amountText: 'Retry',
         amountColor: colors.text.warning,
         statusText: 'Failed',
@@ -483,9 +482,9 @@ class _HomePaneState extends State<_HomePane> {
       final pct = (widget.sync.percentage * 100).toStringAsFixed(0);
       return _HomeActivityRowData(
         title: 'Wallet Synced',
-        leadingIconName: AppIcons.renew,
-        leadingBackgroundColor: colors.background.base,
-        leadingIconColor: colors.icon.accent,
+        leadingIconName: AppIcons.sync,
+        leadingBackgroundColor: colors.background.neutralSubtleOpacity,
+        leadingIconColor: colors.icon.regular,
         subtitle: widget.sync.phase.isEmpty
             ? null
             : _capitalize(widget.sync.phase),
@@ -501,8 +500,8 @@ class _HomePaneState extends State<_HomePane> {
     return _HomeActivityRowData(
       title: 'Wallet Synced',
       leadingIconName: AppIcons.sync,
-      leadingBackgroundColor: successColor.withValues(alpha: 0.16),
-      leadingIconColor: successColor,
+      leadingBackgroundColor: colors.background.neutralSubtleOpacity,
+      leadingIconColor: colors.icon.regular,
       amountText: widget.formatZec(widget.sync.totalBalance),
       amountColor: colors.text.accent,
       statusText: 'Completed',
@@ -529,8 +528,8 @@ class _HomePaneState extends State<_HomePane> {
     return _HomeActivityRowData(
       title: _txTitle(kind),
       leadingIconName: _txIcon(kind),
-      leadingBackgroundColor: colors.background.base,
-      leadingIconColor: _txIconColor(colors, kind),
+      leadingBackgroundColor: colors.background.neutralSubtleOpacity,
+      leadingIconColor: colors.icon.regular,
       subtitle: subtitle,
       subtitleIconName: tx.displayPool == 'shielded'
           ? AppIcons.shieldKeyholeOutline
@@ -577,16 +576,6 @@ class _HomePaneState extends State<_HomePane> {
       'shielded' => AppIcons.shieldAsset,
       'internal' => AppIcons.sync,
       _ => AppIcons.history,
-    };
-  }
-
-  Color _txIconColor(AppColors colors, String kind) {
-    return switch (kind) {
-      'received' => colors.icon.accent,
-      'sent' => colors.icon.brandCrimson,
-      'shielded' => colors.icon.brandCrimson,
-      'internal' => colors.icon.muted,
-      _ => colors.icon.regular,
     };
   }
 
@@ -1145,44 +1134,51 @@ class _HomeActivitySection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        MouseRegion(
-          cursor: SystemMouseCursors.click,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: () => context.push('/history'),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    'Recent Activity',
-                    style: AppTypography.headlineSmall.copyWith(
-                      color: colors.text.accent,
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: () => context.push('/history'),
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.xxs),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Recent Activity',
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.text.accent,
+                      ),
                     ),
-                  ),
-                  const SizedBox(width: AppSpacing.xxs),
-                  AppIcon(
-                    AppIcons.chevronForward,
-                    size: 16,
-                    color: colors.icon.accent,
-                  ),
-                ],
+                    const SizedBox(width: AppSpacing.xxs),
+                    AppIcon(
+                      AppIcons.chevronForward,
+                      size: 16,
+                      color: colors.icon.accent,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
-        ),
-        const SizedBox(height: AppSpacing.s),
-        const _HomeActivityTableHeader(),
-        const SizedBox(height: AppSpacing.xs),
-        for (var i = 0; i < rows.length; i++) ...[
-          _HomeActivityRow(row: rows[i]),
-          if (i != rows.length - 1) const _HomeActivityDivider(),
+          const SizedBox(height: AppSpacing.xs),
+          const _HomeActivityTableHeader(),
+          const SizedBox(height: AppSpacing.s),
+          for (var i = 0; i < rows.length; i++) ...[
+            _HomeActivityRow(row: rows[i]),
+            if (i != rows.length - 1) ...[
+              const SizedBox(height: AppSpacing.xs),
+              const _HomeActivityDivider(),
+              const SizedBox(height: AppSpacing.xs),
+            ],
+          ],
         ],
-      ],
+      ),
     );
   }
 }
@@ -1194,56 +1190,119 @@ class _HomeActivityTableHeader extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final style = AppTypography.labelMedium.copyWith(color: colors.text.muted);
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
-      child: Row(
-        children: [
-          Expanded(flex: 30, child: Text('Tx Type', style: style)),
-          Expanded(flex: 22, child: Text('Amount', style: style)),
-          Expanded(flex: 22, child: Text('Status', style: style)),
-          Expanded(
-            flex: 26,
-            child: Text('Time Stamp', textAlign: TextAlign.end, style: style),
-          ),
-        ],
+    return SizedBox(
+      height: 32,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+        child: _HomeActivityColumnLayout(
+          txType: Text('Tx Type', style: style),
+          amount: Text('Amount', style: style),
+          status: Text('Status', style: style),
+          timestamp: Text('Time Stamp', textAlign: TextAlign.end, style: style),
+        ),
       ),
     );
   }
 }
+
+const double _homeActivityLeftCellWidth = 190;
+const double _homeActivityMiddleCellWidth = 160;
+const double _homeActivityRightCellWidth = 140;
+const double _homeActivityFixedColumnsWidth =
+    _homeActivityLeftCellWidth +
+    (_homeActivityMiddleCellWidth * 2) +
+    _homeActivityRightCellWidth;
 
 class _HomeActivityDivider extends StatelessWidget {
   const _HomeActivityDivider();
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: 1,
-      margin: const EdgeInsets.symmetric(vertical: AppSpacing.xxs),
-      color: context.colors.border.subtle,
+    return Container(height: 1, color: context.colors.border.subtle);
+  }
+}
+
+class _HomeActivityColumnLayout extends StatelessWidget {
+  const _HomeActivityColumnLayout({
+    required this.txType,
+    required this.amount,
+    required this.status,
+    required this.timestamp,
+  });
+
+  final Widget txType;
+  final Widget amount;
+  final Widget status;
+  final Widget timestamp;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final useFixedColumns =
+            constraints.maxWidth >= _homeActivityFixedColumnsWidth;
+        if (useFixedColumns) {
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              _HomeActivityCell(
+                width: _homeActivityLeftCellWidth,
+                child: txType,
+              ),
+              _HomeActivityCell(
+                width: _homeActivityMiddleCellWidth,
+                child: amount,
+              ),
+              _HomeActivityCell(
+                width: _homeActivityMiddleCellWidth,
+                child: status,
+              ),
+              _HomeActivityCell(
+                width: _homeActivityRightCellWidth,
+                alignEnd: true,
+                child: timestamp,
+              ),
+            ],
+          );
+        }
+
+        return Row(
+          children: [
+            _HomeActivityCell(flex: 190, child: txType),
+            _HomeActivityCell(flex: 160, child: amount),
+            _HomeActivityCell(flex: 160, child: status),
+            _HomeActivityCell(flex: 140, alignEnd: true, child: timestamp),
+          ],
+        );
+      },
     );
   }
 }
 
 class _HomeActivityCell extends StatelessWidget {
   const _HomeActivityCell({
-    required this.flex,
     required this.child,
+    this.width,
+    this.flex,
     this.alignEnd = false,
   });
 
-  final int flex;
   final Widget child;
+  final double? width;
+  final int? flex;
   final bool alignEnd;
 
   @override
   Widget build(BuildContext context) {
-    return Expanded(
-      flex: flex,
-      child: Align(
-        alignment: alignEnd ? Alignment.centerRight : Alignment.centerLeft,
-        child: child,
-      ),
+    final content = Align(
+      alignment: alignEnd ? Alignment.centerRight : Alignment.centerLeft,
+      child: child,
     );
+    final width = this.width;
+    if (width != null) {
+      return SizedBox(width: width, child: content);
+    }
+    return Expanded(flex: flex ?? 1, child: content);
   }
 }
 
@@ -1320,90 +1379,78 @@ class _HomeActivityRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final content = Container(
-      height: 40,
-      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+      height: 48,
+      padding: const EdgeInsets.all(AppSpacing.xxs),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(AppRadii.xSmall),
       ),
-      child: Row(
-        children: [
-          _HomeActivityCell(
-            flex: 30,
-            child: Row(
-              children: [
-                _ActivityAvatar(row: row),
-                const SizedBox(width: AppSpacing.xs),
-                Flexible(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      Text(
-                        row.title,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: AppTypography.bodyMedium.copyWith(
-                          color: colors.text.accent,
-                        ),
-                      ),
-                      if (row.subtitle != null)
-                        Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            if (row.subtitleIconName != null) ...[
-                              AppIcon(
-                                row.subtitleIconName!,
-                                size: 16,
-                                color: colors.icon.brandCrimson,
-                              ),
-                              const SizedBox(width: AppSpacing.xxs),
-                            ],
-                            Flexible(
-                              child: Text(
-                                row.subtitle!,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                style: AppTypography.labelMedium.copyWith(
-                                  color: row.subtitleIconName == null
-                                      ? colors.text.secondary
-                                      : colors.text.brandCrimson,
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                    ],
+      child: _HomeActivityColumnLayout(
+        txType: Row(
+          children: [
+            _ActivityAvatar(row: row),
+            const SizedBox(width: AppSpacing.s),
+            Flexible(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(
+                    row.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.accent,
+                    ),
                   ),
-                ),
-              ],
-            ),
-          ),
-          _HomeActivityCell(
-            flex: 22,
-            child: Text(
-              row.amountText,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: AppTypography.labelLarge.copyWith(
-                color: row.amountColor ?? colors.text.accent,
+                  if (row.subtitle != null)
+                    Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (row.subtitleIconName != null) ...[
+                          AppIcon(
+                            row.subtitleIconName!,
+                            size: 16,
+                            color: colors.icon.brandCrimson,
+                          ),
+                          const SizedBox(width: AppSpacing.xxs),
+                        ],
+                        Flexible(
+                          child: Text(
+                            row.subtitle!,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: AppTypography.labelMedium.copyWith(
+                              color: row.subtitleIconName == null
+                                  ? colors.text.secondary
+                                  : colors.text.brandCrimson,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                ],
               ),
             ),
+          ],
+        ),
+        amount: Text(
+          row.amountText,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTypography.labelMedium.copyWith(
+            color: row.amountColor ?? colors.text.accent,
           ),
-          _HomeActivityCell(flex: 22, child: _StatusLabel(row: row)),
-          _HomeActivityCell(
-            flex: 26,
-            alignEnd: true,
-            child: Text(
-              row.timestampText,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.end,
-              style: AppTypography.labelMedium.copyWith(
-                color: colors.text.secondary,
-              ),
-            ),
+        ),
+        status: _StatusLabel(row: row),
+        timestamp: Text(
+          row.timestampText,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.end,
+          style: AppTypography.labelMedium.copyWith(
+            color: colors.text.secondary,
           ),
-        ],
+        ),
       ),
     );
 

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -428,7 +428,7 @@ class _HomePaneState extends State<_HomePane> {
     return buildActivityRows(
       context: context,
       sync: widget.sync,
-      transactions: widget.sync.recentTransactions.take(8),
+      transactions: widget.sync.recentTransactions.take(9),
       onRetrySync: widget.onRetrySync,
       onTransactionTap: _openTransactionStatus,
     );

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -76,6 +76,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     return '$sign$whole.$digits ZEC';
   }
 
+  String _formatZecWithUnit(BigInt zatoshi) => '${_formatZec(zatoshi)} ZEC';
+
   void _toggleBalanceVisibility() {
     setState(() {
       _isBalanceVisible = !_isBalanceVisible;
@@ -180,21 +182,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     return 'Shield balance failed. Please try again.';
   }
 
-  String _groupLabelForTx(rust_sync.TransactionInfo tx) {
-    if (tx.minedHeight == BigInt.zero && !tx.expiredUnmined) {
-      return 'Today';
-    }
-
-    final date = DateTime.fromMillisecondsSinceEpoch(
-      tx.blockTime.toInt() * 1000,
-    );
-    final now = DateTime.now();
-    final isToday =
-        date.year == now.year && date.month == now.month && date.day == now.day;
-    if (isToday) return 'Today';
-    return '${_monthName(date.month)}, ${date.day}';
-  }
-
   @override
   Widget build(BuildContext context) {
     final walletAsync = ref.watch(walletProvider);
@@ -234,8 +221,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               canShieldBalance: canShieldTransparentBalance,
               isShieldingBalance: _isShieldingBalance,
               shieldBalanceError: _shieldBalanceError,
+              formatZec: _formatZecWithUnit,
               formatSignedZec: _formatSignedZec,
-              groupLabelForTx: _groupLabelForTx,
               onToggleBalanceVisibility: _toggleBalanceVisibility,
               onShieldBalancePressed: () =>
                   unawaited(_shieldTransparentBalance()),
@@ -283,8 +270,8 @@ class _HomePane extends StatefulWidget {
     required this.canShieldBalance,
     required this.isShieldingBalance,
     required this.shieldBalanceError,
+    required this.formatZec,
     required this.formatSignedZec,
-    required this.groupLabelForTx,
     required this.onToggleBalanceVisibility,
     required this.onShieldBalancePressed,
     required this.onDismissShieldBalanceError,
@@ -302,8 +289,8 @@ class _HomePane extends StatefulWidget {
   final bool canShieldBalance;
   final bool isShieldingBalance;
   final String? shieldBalanceError;
+  final String Function(BigInt zatoshi) formatZec;
   final String Function(BigInt zatoshi) formatSignedZec;
-  final String Function(rust_sync.TransactionInfo tx) groupLabelForTx;
   final VoidCallback onToggleBalanceVisibility;
   final VoidCallback onShieldBalancePressed;
   final VoidCallback onDismissShieldBalanceError;
@@ -356,7 +343,7 @@ class _HomePaneState extends State<_HomePane> {
   @override
   Widget build(BuildContext context) {
     final notice = _noticeData();
-    final groups = _activityGroups(context);
+    final rows = _activityRows(context);
     final showHoverScrollbar = isDesktopLayoutPlatform;
 
     return LayoutBuilder(
@@ -413,7 +400,7 @@ class _HomePaneState extends State<_HomePane> {
                           _HomeNoticeCard(data: notice),
                         ],
                         const SizedBox(height: AppSpacing.sm),
-                        _HomeActivitySection(groups: groups),
+                        _HomeActivitySection(rows: rows),
                         const SizedBox(height: AppSpacing.sm),
                       ],
                     ),
@@ -463,108 +450,180 @@ class _HomePaneState extends State<_HomePane> {
     return null;
   }
 
-  List<_HomeActivityGroupData> _activityGroups(BuildContext context) {
-    final grouped = <String, List<_HomeActivityRowData>>{};
-    final todayRows = <_HomeActivityRowData>[];
+  List<_HomeActivityRowData> _activityRows(BuildContext context) {
+    return [
+      _syncActivityRow(context),
+      ...widget.sync.recentTransactions
+          .take(6)
+          .map((tx) => _transactionActivityRow(context, tx)),
+    ];
+  }
+
+  _HomeActivityRowData _syncActivityRow(BuildContext context) {
     final colors = context.colors;
     final successColor = Theme.of(context).colorScheme.tertiary;
 
     if (widget.sync.error != null) {
-      todayRows.add(
-        _HomeActivityRowData(
-          title: 'Sync Error',
-          leadingIconName: AppIcons.warning,
-          leadingBackgroundColor: colors.background.base,
-          leadingIconColor: colors.icon.warning,
-          amountText: 'Retry',
-          amountColor: colors.text.warning,
-          onTap: widget.onRetrySync,
-        ),
+      return _HomeActivityRowData(
+        title: 'Wallet Synced',
+        leadingIconName: AppIcons.warning,
+        leadingBackgroundColor: colors.background.base,
+        leadingIconColor: colors.icon.warning,
+        amountText: 'Retry',
+        amountColor: colors.text.warning,
+        statusText: 'Failed',
+        statusIconName: AppIcons.skull,
+        statusColor: colors.text.destructive,
+        timestampText: _formatTimestamp(widget.sync.lastSyncFailedAt),
+        onTap: widget.onRetrySync,
       );
-    } else if (widget.sync.isSyncing) {
+    }
+
+    if (widget.sync.isSyncing) {
       final pct = (widget.sync.percentage * 100).toStringAsFixed(0);
-      todayRows.add(
-        _HomeActivityRowData(
-          title: widget.sync.isBackgroundMode
-              ? 'Background Syncing...'
-              : 'Syncing...',
-          leadingIconName: AppIcons.renew,
-          leadingBackgroundColor: colors.background.base,
-          leadingIconColor: colors.icon.accent,
-          subtitle: widget.sync.phase.isEmpty
-              ? null
-              : '${widget.sync.phase[0].toUpperCase()}${widget.sync.phase.substring(1)}',
-          amountText: '$pct%',
-          amountColor: colors.text.secondary,
-        ),
-      );
-    } else {
-      todayRows.add(
-        _HomeActivityRowData(
-          title: 'Wallet Synced',
-          leadingIconName: AppIcons.check,
-          leadingBackgroundColor: successColor.withValues(alpha: 0.16),
-          leadingIconColor: successColor,
-        ),
+      return _HomeActivityRowData(
+        title: 'Wallet Synced',
+        leadingIconName: AppIcons.renew,
+        leadingBackgroundColor: colors.background.base,
+        leadingIconColor: colors.icon.accent,
+        subtitle: widget.sync.phase.isEmpty
+            ? null
+            : _capitalize(widget.sync.phase),
+        amountText: '$pct%',
+        amountColor: colors.text.secondary,
+        statusText: 'In progress',
+        statusIconName: AppIcons.loader,
+        statusColor: colors.text.secondary,
+        timestampText: _formatTimestamp(widget.sync.lastSyncStartedAt),
       );
     }
 
-    for (final tx in widget.sync.recentTransactions.take(6)) {
-      final groupLabel = widget.groupLabelForTx(tx);
-      final rows = grouped.putIfAbsent(groupLabel, () => []);
-      final isIncoming = tx.accountBalanceDelta >= 0;
-      final isPending = tx.minedHeight == BigInt.zero && !tx.expiredUnmined;
-      final isExpired = tx.expiredUnmined;
-      final subtitle = tx.isTransparent ? 'Transparent' : 'Shielded';
-      final subtitleIconName = tx.isTransparent
-          ? null
-          : AppIcons.shieldKeyholeOutline;
-      rows.add(
-        _HomeActivityRowData(
-          title: isExpired
-              ? (isIncoming ? 'Receive Expired' : 'Send Expired')
-              : isPending
-              ? (isIncoming ? 'Receiving...' : 'Sending...')
-              : isIncoming
-              ? 'Received'
-              : 'Sent',
-          subtitle: subtitle,
-          subtitleIconName: subtitleIconName,
-          leadingIconName: isIncoming
-              ? AppIcons.arrowDownCircle
-              : AppIcons.plane,
-          leadingBackgroundColor: colors.background.base,
-          leadingIconColor: isIncoming
-              ? colors.icon.accent
-              : colors.icon.brandCrimson,
-          subIconName: isPending ? AppIcons.loader : null,
-          subIconBackgroundColor: isPending
-              ? colors.background.overlay.withValues(alpha: 0.5)
-              : colors.background.brandCrimsonStrong,
-          amountText: widget.formatSignedZec(
-            BigInt.from(tx.accountBalanceDelta),
-          ),
-          amountColor: isExpired
-              ? colors.text.muted
-              : isIncoming
-              ? colors.text.accent
-              : colors.text.brandCrimson,
-        ),
-      );
-    }
+    return _HomeActivityRowData(
+      title: 'Wallet Synced',
+      leadingIconName: AppIcons.sync,
+      leadingBackgroundColor: successColor.withValues(alpha: 0.16),
+      leadingIconColor: successColor,
+      amountText: widget.formatZec(widget.sync.totalBalance),
+      amountColor: colors.text.accent,
+      statusText: 'Completed',
+      statusColor: colors.text.secondary,
+      timestampText: _formatTimestamp(widget.sync.lastSyncCompletedAt),
+    );
+  }
 
-    final results = <_HomeActivityGroupData>[];
-    final mergedToday = [
-      ...todayRows,
-      ...(grouped.remove('Today') ?? const <_HomeActivityRowData>[]),
-    ];
-    if (mergedToday.isNotEmpty) {
-      results.add(_HomeActivityGroupData(label: 'Today', rows: mergedToday));
+  _HomeActivityRowData _transactionActivityRow(
+    BuildContext context,
+    rust_sync.TransactionInfo tx,
+  ) {
+    final colors = context.colors;
+    final isPending = tx.minedHeight == BigInt.zero && !tx.expiredUnmined;
+    final isFailed = tx.expiredUnmined;
+    final kind = tx.txKind;
+    final amount = tx.displayAmount;
+    final isReceived = kind == 'received';
+    final isSent = kind == 'sent';
+    final isShielded = kind == 'shielded';
+    final signedAmount = isSent ? -amount : amount;
+    final subtitle = isReceived || isSent ? _poolLabel(tx.displayPool) : null;
+
+    return _HomeActivityRowData(
+      title: _txTitle(kind),
+      leadingIconName: _txIcon(kind),
+      leadingBackgroundColor: colors.background.base,
+      leadingIconColor: _txIconColor(colors, kind),
+      subtitle: subtitle,
+      subtitleIconName: tx.displayPool == 'shielded'
+          ? AppIcons.shieldKeyholeOutline
+          : null,
+      amountText: amount == BigInt.zero
+          ? '--'
+          : isShielded || kind == 'internal'
+          ? widget.formatZec(amount)
+          : widget.formatSignedZec(signedAmount),
+      amountColor: isFailed
+          ? colors.text.muted
+          : isReceived
+          ? colors.text.brandCrimson
+          : colors.text.accent,
+      statusText: isFailed
+          ? 'Failed'
+          : isPending
+          ? 'In progress'
+          : 'Completed',
+      statusIconName: isFailed
+          ? AppIcons.skull
+          : isPending
+          ? AppIcons.loader
+          : null,
+      statusColor: isFailed ? colors.text.destructive : colors.text.secondary,
+      timestampText: _formatTimestamp(_txTimestamp(tx)),
+    );
+  }
+
+  String _txTitle(String kind) {
+    return switch (kind) {
+      'received' => 'Received',
+      'sent' => 'Sent',
+      'shielded' => 'Shielded',
+      'internal' => 'Internal',
+      _ => 'Transaction',
+    };
+  }
+
+  String _txIcon(String kind) {
+    return switch (kind) {
+      'received' => AppIcons.arrowDownCircle,
+      'sent' => AppIcons.plane,
+      'shielded' => AppIcons.shieldAsset,
+      'internal' => AppIcons.sync,
+      _ => AppIcons.history,
+    };
+  }
+
+  Color _txIconColor(AppColors colors, String kind) {
+    return switch (kind) {
+      'received' => colors.icon.accent,
+      'sent' => colors.icon.brandCrimson,
+      'shielded' => colors.icon.brandCrimson,
+      'internal' => colors.icon.muted,
+      _ => colors.icon.regular,
+    };
+  }
+
+  String? _poolLabel(String pool) {
+    return switch (pool) {
+      'transparent' => 'Transparent',
+      'shielded' => 'Shielded',
+      'mixed' => 'Mixed',
+      _ => null,
+    };
+  }
+
+  DateTime? _txTimestamp(rust_sync.TransactionInfo tx) {
+    final seconds = tx.blockTime > BigInt.zero ? tx.blockTime : tx.createdTime;
+    if (seconds <= BigInt.zero) return null;
+    return DateTime.fromMillisecondsSinceEpoch(seconds.toInt() * 1000);
+  }
+
+  String _formatTimestamp(DateTime? timestamp) {
+    if (timestamp == null) return '--';
+    final now = DateTime.now();
+    final local = timestamp.toLocal();
+    final today = DateTime(now.year, now.month, now.day);
+    final date = DateTime(local.year, local.month, local.day);
+    final time =
+        '${local.hour.toString().padLeft(2, '0')}:${local.minute.toString().padLeft(2, '0')}';
+
+    if (date == today) return 'Today, $time';
+    if (date == today.subtract(const Duration(days: 1))) {
+      return 'Yesterday, $time';
     }
-    grouped.forEach((label, rows) {
-      results.add(_HomeActivityGroupData(label: label, rows: rows));
-    });
-    return results;
+    return '${_HomeScreenState._monthName(local.month)} ${local.day}, $time';
+  }
+
+  String _capitalize(String value) {
+    if (value.isEmpty) return value;
+    return '${value[0].toUpperCase()}${value.substring(1)}';
   }
 }
 
@@ -1079,9 +1138,9 @@ class _HomeNoticeCard extends StatelessWidget {
 }
 
 class _HomeActivitySection extends StatelessWidget {
-  const _HomeActivitySection({required this.groups});
+  const _HomeActivitySection({required this.rows});
 
-  final List<_HomeActivityGroupData> groups;
+  final List<_HomeActivityRowData> rows;
 
   @override
   Widget build(BuildContext context) {
@@ -1117,47 +1176,104 @@ class _HomeActivitySection extends StatelessWidget {
           ),
         ),
         const SizedBox(height: AppSpacing.s),
-        for (var i = 0; i < groups.length; i++) ...[
-          _HomeActivityGroup(group: groups[i]),
-          if (i != groups.length - 1) const SizedBox(height: AppSpacing.s),
+        const _HomeActivityTableHeader(),
+        const SizedBox(height: AppSpacing.xs),
+        for (var i = 0; i < rows.length; i++) ...[
+          _HomeActivityRow(row: rows[i]),
+          if (i != rows.length - 1) const _HomeActivityDivider(),
         ],
       ],
     );
   }
 }
 
-class _HomeActivityGroupData {
-  const _HomeActivityGroupData({required this.label, required this.rows});
-
-  final String label;
-  final List<_HomeActivityRowData> rows;
-}
-
-class _HomeActivityGroup extends StatelessWidget {
-  const _HomeActivityGroup({required this.group});
-
-  final _HomeActivityGroupData group;
+class _HomeActivityTableHeader extends StatelessWidget {
+  const _HomeActivityTableHeader();
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
+    final style = AppTypography.labelMedium.copyWith(color: colors.text.muted);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+      child: Row(
+        children: [
+          Expanded(flex: 30, child: Text('Tx Type', style: style)),
+          Expanded(flex: 22, child: Text('Amount', style: style)),
+          Expanded(flex: 22, child: Text('Status', style: style)),
+          Expanded(
+            flex: 26,
+            child: Text('Time Stamp', textAlign: TextAlign.end, style: style),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HomeActivityDivider extends StatelessWidget {
+  const _HomeActivityDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 1,
+      margin: const EdgeInsets.symmetric(vertical: AppSpacing.xxs),
+      color: context.colors.border.subtle,
+    );
+  }
+}
+
+class _HomeActivityCell extends StatelessWidget {
+  const _HomeActivityCell({
+    required this.flex,
+    required this.child,
+    this.alignEnd = false,
+  });
+
+  final int flex;
+  final Widget child;
+  final bool alignEnd;
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      flex: flex,
+      child: Align(
+        alignment: alignEnd ? Alignment.centerRight : Alignment.centerLeft,
+        child: child,
+      ),
+    );
+  }
+}
+
+class _StatusLabel extends StatelessWidget {
+  const _StatusLabel({required this.row});
+
+  final _HomeActivityRowData row;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
       children: [
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
-          child: Text(
-            group.label,
-            style: AppTypography.labelMedium.copyWith(
-              color: colors.text.secondary,
-            ),
+        if (row.statusIconName != null) ...[
+          AppIcon(
+            row.statusIconName!,
+            size: 16,
+            color: row.statusColor ?? colors.text.secondary,
+          ),
+          const SizedBox(width: AppSpacing.xxs),
+        ],
+        Text(
+          row.statusText,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTypography.labelMedium.copyWith(
+            color: row.statusColor ?? colors.text.secondary,
           ),
         ),
-        const SizedBox(height: AppSpacing.xs),
-        for (var i = 0; i < group.rows.length; i++) ...[
-          _HomeActivityRow(row: group.rows[i]),
-          if (i != group.rows.length - 1) const SizedBox(height: AppSpacing.xs),
-        ],
       ],
     );
   }
@@ -1171,10 +1287,12 @@ class _HomeActivityRowData {
     required this.leadingIconColor,
     this.subtitle,
     this.subtitleIconName,
-    this.subIconName,
-    this.subIconBackgroundColor,
-    this.amountText,
+    required this.amountText,
     this.amountColor,
+    required this.statusText,
+    required this.timestampText,
+    this.statusIconName,
+    this.statusColor,
     this.onTap,
   });
 
@@ -1184,10 +1302,12 @@ class _HomeActivityRowData {
   final Color leadingIconColor;
   final String? subtitle;
   final String? subtitleIconName;
-  final String? subIconName;
-  final Color? subIconBackgroundColor;
-  final String? amountText;
+  final String amountText;
   final Color? amountColor;
+  final String statusText;
+  final String timestampText;
+  final String? statusIconName;
+  final Color? statusColor;
   final VoidCallback? onTap;
 }
 
@@ -1207,51 +1327,82 @@ class _HomeActivityRow extends StatelessWidget {
       ),
       child: Row(
         children: [
-          _ActivityAvatar(row: row),
-          const SizedBox(width: AppSpacing.xs),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisAlignment: MainAxisAlignment.center,
+          _HomeActivityCell(
+            flex: 30,
+            child: Row(
               children: [
-                Text(
-                  row.title,
-                  style: AppTypography.labelLarge.copyWith(
-                    color: colors.text.accent,
-                  ),
-                ),
-                if (row.subtitle != null)
-                  Row(
-                    mainAxisSize: MainAxisSize.min,
+                _ActivityAvatar(row: row),
+                const SizedBox(width: AppSpacing.xs),
+                Flexible(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Text(
-                        row.subtitle!,
-                        style: AppTypography.labelMedium.copyWith(
-                          color: row.subtitleIconName == null
-                              ? colors.text.secondary
-                              : colors.text.brandCrimson,
+                        row.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTypography.bodyMedium.copyWith(
+                          color: colors.text.accent,
                         ),
                       ),
-                      if (row.subtitleIconName != null) ...[
-                        const SizedBox(width: AppSpacing.xxs),
-                        AppIcon(
-                          row.subtitleIconName!,
-                          size: 16,
-                          color: colors.icon.brandCrimson,
+                      if (row.subtitle != null)
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (row.subtitleIconName != null) ...[
+                              AppIcon(
+                                row.subtitleIconName!,
+                                size: 16,
+                                color: colors.icon.brandCrimson,
+                              ),
+                              const SizedBox(width: AppSpacing.xxs),
+                            ],
+                            Flexible(
+                              child: Text(
+                                row.subtitle!,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: AppTypography.labelMedium.copyWith(
+                                  color: row.subtitleIconName == null
+                                      ? colors.text.secondary
+                                      : colors.text.brandCrimson,
+                                ),
+                              ),
+                            ),
+                          ],
                         ),
-                      ],
                     ],
                   ),
+                ),
               ],
             ),
           ),
-          if (row.amountText != null)
-            Text(
-              row.amountText!,
+          _HomeActivityCell(
+            flex: 22,
+            child: Text(
+              row.amountText,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
               style: AppTypography.labelLarge.copyWith(
                 color: row.amountColor ?? colors.text.accent,
               ),
             ),
+          ),
+          _HomeActivityCell(flex: 22, child: _StatusLabel(row: row)),
+          _HomeActivityCell(
+            flex: 26,
+            alignEnd: true,
+            child: Text(
+              row.timestampText,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.end,
+              style: AppTypography.labelMedium.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+          ),
         ],
       ),
     );
@@ -1296,26 +1447,6 @@ class _ActivityAvatar extends StatelessWidget {
               ),
             ),
           ),
-          if (row.subIconName != null && row.subIconBackgroundColor != null)
-            Positioned(
-              right: -4,
-              bottom: -2,
-              child: Container(
-                width: 16,
-                height: 16,
-                decoration: BoxDecoration(
-                  color: row.subIconBackgroundColor,
-                  borderRadius: BorderRadius.circular(AppRadii.xSmall),
-                ),
-                child: Center(
-                  child: AppIcon(
-                    row.subIconName!,
-                    size: 12,
-                    color: context.colors.icon.accent,
-                  ),
-                ),
-              ),
-            ),
         ],
       ),
     );

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -429,8 +429,11 @@ class _HomePaneState extends State<_HomePane> {
       sync: widget.sync,
       transactions: widget.sync.recentTransactions.take(8),
       onRetrySync: widget.onRetrySync,
+      onTransactionTap: _handleActivityRowAction,
     );
   }
+
+  void _handleActivityRowAction() {}
 }
 
 class _HomeBalanceCard extends StatelessWidget {

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -427,7 +427,7 @@ class _HomePaneState extends State<_HomePane> {
     return buildActivityRows(
       context: context,
       sync: widget.sync,
-      transactions: widget.sync.recentTransactions.take(6),
+      transactions: widget.sync.recentTransactions.take(8),
       onRetrySync: widget.onRetrySync,
     );
   }

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -22,6 +22,7 @@ import '../../../rust/api/sync.dart' as rust_sync;
 import '../../../rust/api/wallet.dart' as rust_wallet;
 import '../../activity/activity_row_mapper.dart';
 import '../../activity/models/activity_row_data.dart';
+import '../../activity/screens/activity_transaction_status_screen.dart';
 import '../../activity/widgets/activity_table.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
@@ -429,11 +430,19 @@ class _HomePaneState extends State<_HomePane> {
       sync: widget.sync,
       transactions: widget.sync.recentTransactions.take(8),
       onRetrySync: widget.onRetrySync,
-      onTransactionTap: _handleActivityRowAction,
+      onTransactionTap: _openTransactionStatus,
     );
   }
 
-  void _handleActivityRowAction() {}
+  void _openTransactionStatus(rust_sync.TransactionInfo transaction) {
+    context.push(
+      '/activity/tx/${transaction.txidHex}',
+      extra: ActivityTransactionStatusArgs(
+        txidHex: transaction.txidHex,
+        initialTransaction: transaction,
+      ),
+    );
+  }
 }
 
 class _HomeBalanceCard extends StatelessWidget {

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -20,6 +20,9 @@ import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../../rust/api/wallet.dart' as rust_wallet;
+import '../../activity/activity_row_mapper.dart';
+import '../../activity/models/activity_row_data.dart';
+import '../../activity/widgets/activity_table.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -63,20 +66,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     }
     return '$whole.${frac.substring(0, 2)}';
   }
-
-  String _formatSignedZec(BigInt zatoshi) {
-    final isPositive = zatoshi >= BigInt.zero;
-    final abs = zatoshi.abs();
-    final whole = abs ~/ BigInt.from(100000000);
-    final frac = (abs % BigInt.from(100000000)).toString().padLeft(8, '0');
-    final digits = whole == BigInt.zero && int.parse(frac) < 1000000
-        ? frac
-        : frac.substring(0, 2);
-    final sign = isPositive ? '+' : '-';
-    return '$sign$whole.$digits ZEC';
-  }
-
-  String _formatZecWithUnit(BigInt zatoshi) => '${_formatZec(zatoshi)} ZEC';
 
   void _toggleBalanceVisibility() {
     setState(() {
@@ -221,8 +210,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               canShieldBalance: canShieldTransparentBalance,
               isShieldingBalance: _isShieldingBalance,
               shieldBalanceError: _shieldBalanceError,
-              formatZec: _formatZecWithUnit,
-              formatSignedZec: _formatSignedZec,
               onToggleBalanceVisibility: _toggleBalanceVisibility,
               onShieldBalancePressed: () =>
                   unawaited(_shieldTransparentBalance()),
@@ -238,25 +225,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       ),
     );
   }
-
-  static String _monthName(int month) {
-    const months = [
-      '',
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec',
-    ];
-    return months[month];
-  }
 }
 
 class _HomePane extends StatefulWidget {
@@ -270,8 +238,6 @@ class _HomePane extends StatefulWidget {
     required this.canShieldBalance,
     required this.isShieldingBalance,
     required this.shieldBalanceError,
-    required this.formatZec,
-    required this.formatSignedZec,
     required this.onToggleBalanceVisibility,
     required this.onShieldBalancePressed,
     required this.onDismissShieldBalanceError,
@@ -289,8 +255,6 @@ class _HomePane extends StatefulWidget {
   final bool canShieldBalance;
   final bool isShieldingBalance;
   final String? shieldBalanceError;
-  final String Function(BigInt zatoshi) formatZec;
-  final String Function(BigInt zatoshi) formatSignedZec;
   final VoidCallback onToggleBalanceVisibility;
   final VoidCallback onShieldBalancePressed;
   final VoidCallback onDismissShieldBalanceError;
@@ -400,7 +364,16 @@ class _HomePaneState extends State<_HomePane> {
                           _HomeNoticeCard(data: notice),
                         ],
                         const SizedBox(height: AppSpacing.sm),
-                        _HomeActivitySection(rows: rows),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: AppSpacing.xs,
+                          ),
+                          child: ActivityTable(
+                            rows: rows,
+                            title: 'Recent Activity',
+                            onTitleTap: () => context.push('/history'),
+                          ),
+                        ),
                         const SizedBox(height: AppSpacing.sm),
                       ],
                     ),
@@ -450,169 +423,13 @@ class _HomePaneState extends State<_HomePane> {
     return null;
   }
 
-  List<_HomeActivityRowData> _activityRows(BuildContext context) {
-    return [
-      _syncActivityRow(context),
-      ...widget.sync.recentTransactions
-          .take(6)
-          .map((tx) => _transactionActivityRow(context, tx)),
-    ];
-  }
-
-  _HomeActivityRowData _syncActivityRow(BuildContext context) {
-    final colors = context.colors;
-
-    if (widget.sync.error != null) {
-      return _HomeActivityRowData(
-        title: 'Wallet Synced',
-        leadingIconName: AppIcons.sync,
-        leadingBackgroundColor: colors.background.neutralSubtleOpacity,
-        leadingIconColor: colors.icon.regular,
-        amountText: 'Retry',
-        amountColor: colors.text.warning,
-        statusText: 'Failed',
-        statusIconName: AppIcons.skull,
-        statusColor: colors.text.destructive,
-        timestampText: _formatTimestamp(widget.sync.lastSyncFailedAt),
-        onTap: widget.onRetrySync,
-      );
-    }
-
-    if (widget.sync.isSyncing) {
-      final pct = (widget.sync.percentage * 100).toStringAsFixed(0);
-      return _HomeActivityRowData(
-        title: 'Wallet Synced',
-        leadingIconName: AppIcons.sync,
-        leadingBackgroundColor: colors.background.neutralSubtleOpacity,
-        leadingIconColor: colors.icon.regular,
-        subtitle: widget.sync.phase.isEmpty
-            ? null
-            : _capitalize(widget.sync.phase),
-        amountText: '$pct%',
-        amountColor: colors.text.secondary,
-        statusText: 'In progress',
-        statusIconName: AppIcons.loader,
-        statusColor: colors.text.secondary,
-        timestampText: _formatTimestamp(widget.sync.lastSyncStartedAt),
-      );
-    }
-
-    return _HomeActivityRowData(
-      title: 'Wallet Synced',
-      leadingIconName: AppIcons.sync,
-      leadingBackgroundColor: colors.background.neutralSubtleOpacity,
-      leadingIconColor: colors.icon.regular,
-      amountText: widget.formatZec(widget.sync.totalBalance),
-      amountColor: colors.text.accent,
-      statusText: 'Completed',
-      statusColor: colors.text.secondary,
-      timestampText: _formatTimestamp(widget.sync.lastSyncCompletedAt),
+  List<ActivityRowData> _activityRows(BuildContext context) {
+    return buildActivityRows(
+      context: context,
+      sync: widget.sync,
+      transactions: widget.sync.recentTransactions.take(6),
+      onRetrySync: widget.onRetrySync,
     );
-  }
-
-  _HomeActivityRowData _transactionActivityRow(
-    BuildContext context,
-    rust_sync.TransactionInfo tx,
-  ) {
-    final colors = context.colors;
-    final isPending = tx.minedHeight == BigInt.zero && !tx.expiredUnmined;
-    final isFailed = tx.expiredUnmined;
-    final kind = tx.txKind;
-    final amount = tx.displayAmount;
-    final isReceived = kind == 'received';
-    final isSent = kind == 'sent';
-    final isShielded = kind == 'shielded';
-    final signedAmount = isSent ? -amount : amount;
-    final subtitle = isReceived || isSent ? _poolLabel(tx.displayPool) : null;
-
-    return _HomeActivityRowData(
-      title: _txTitle(kind),
-      leadingIconName: _txIcon(kind),
-      leadingBackgroundColor: colors.background.neutralSubtleOpacity,
-      leadingIconColor: colors.icon.regular,
-      subtitle: subtitle,
-      subtitleIconName: tx.displayPool == 'shielded'
-          ? AppIcons.shieldKeyholeOutline
-          : null,
-      amountText: amount == BigInt.zero
-          ? '--'
-          : isShielded || kind == 'internal'
-          ? widget.formatZec(amount)
-          : widget.formatSignedZec(signedAmount),
-      amountColor: isFailed
-          ? colors.text.muted
-          : isReceived
-          ? colors.text.brandCrimson
-          : colors.text.accent,
-      statusText: isFailed
-          ? 'Failed'
-          : isPending
-          ? 'In progress'
-          : 'Completed',
-      statusIconName: isFailed
-          ? AppIcons.skull
-          : isPending
-          ? AppIcons.loader
-          : null,
-      statusColor: isFailed ? colors.text.destructive : colors.text.secondary,
-      timestampText: _formatTimestamp(_txTimestamp(tx)),
-    );
-  }
-
-  String _txTitle(String kind) {
-    return switch (kind) {
-      'received' => 'Received',
-      'sent' => 'Sent',
-      'shielded' => 'Shielded',
-      'internal' => 'Internal',
-      _ => 'Transaction',
-    };
-  }
-
-  String _txIcon(String kind) {
-    return switch (kind) {
-      'received' => AppIcons.arrowDownCircle,
-      'sent' => AppIcons.plane,
-      'shielded' => AppIcons.shieldAsset,
-      'internal' => AppIcons.sync,
-      _ => AppIcons.history,
-    };
-  }
-
-  String? _poolLabel(String pool) {
-    return switch (pool) {
-      'transparent' => 'Transparent',
-      'shielded' => 'Shielded',
-      'mixed' => 'Mixed',
-      _ => null,
-    };
-  }
-
-  DateTime? _txTimestamp(rust_sync.TransactionInfo tx) {
-    final seconds = tx.blockTime > BigInt.zero ? tx.blockTime : tx.createdTime;
-    if (seconds <= BigInt.zero) return null;
-    return DateTime.fromMillisecondsSinceEpoch(seconds.toInt() * 1000);
-  }
-
-  String _formatTimestamp(DateTime? timestamp) {
-    if (timestamp == null) return '--';
-    final now = DateTime.now();
-    final local = timestamp.toLocal();
-    final today = DateTime(now.year, now.month, now.day);
-    final date = DateTime(local.year, local.month, local.day);
-    final time =
-        '${local.hour.toString().padLeft(2, '0')}:${local.minute.toString().padLeft(2, '0')}';
-
-    if (date == today) return 'Today, $time';
-    if (date == today.subtract(const Duration(days: 1))) {
-      return 'Yesterday, $time';
-    }
-    return '${_HomeScreenState._monthName(local.month)} ${local.day}, $time';
-  }
-
-  String _capitalize(String value) {
-    if (value.isEmpty) return value;
-    return '${value[0].toUpperCase()}${value.substring(1)}';
   }
 }
 
@@ -1119,380 +936,6 @@ class _HomeNoticeCard extends StatelessWidget {
             size: AppButtonSize.small,
             trailing: const AppIcon(AppIcons.chevronForward),
             child: Text(data.actionLabel),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _HomeActivitySection extends StatelessWidget {
-  const _HomeActivitySection({required this.rows});
-
-  final List<_HomeActivityRowData> rows;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          MouseRegion(
-            cursor: SystemMouseCursors.click,
-            child: GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: () => context.push('/history'),
-              child: Padding(
-                padding: const EdgeInsets.all(AppSpacing.xxs),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      'Recent Activity',
-                      style: AppTypography.labelLarge.copyWith(
-                        color: colors.text.accent,
-                      ),
-                    ),
-                    const SizedBox(width: AppSpacing.xxs),
-                    AppIcon(
-                      AppIcons.chevronForward,
-                      size: 16,
-                      color: colors.icon.accent,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(height: AppSpacing.xs),
-          const _HomeActivityTableHeader(),
-          const SizedBox(height: AppSpacing.s),
-          for (var i = 0; i < rows.length; i++) ...[
-            _HomeActivityRow(row: rows[i]),
-            if (i != rows.length - 1) ...[
-              const SizedBox(height: AppSpacing.xs),
-              const _HomeActivityDivider(),
-              const SizedBox(height: AppSpacing.xs),
-            ],
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _HomeActivityTableHeader extends StatelessWidget {
-  const _HomeActivityTableHeader();
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    final style = AppTypography.labelMedium.copyWith(color: colors.text.muted);
-    return SizedBox(
-      height: 32,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
-        child: _HomeActivityColumnLayout(
-          txType: Text('Tx Type', style: style),
-          amount: Text('Amount', style: style),
-          status: Text('Status', style: style),
-          timestamp: Text('Time Stamp', textAlign: TextAlign.end, style: style),
-        ),
-      ),
-    );
-  }
-}
-
-const double _homeActivityLeftCellWidth = 190;
-const double _homeActivityMiddleCellWidth = 160;
-const double _homeActivityRightCellWidth = 140;
-const double _homeActivityFixedColumnsWidth =
-    _homeActivityLeftCellWidth +
-    (_homeActivityMiddleCellWidth * 2) +
-    _homeActivityRightCellWidth;
-
-class _HomeActivityDivider extends StatelessWidget {
-  const _HomeActivityDivider();
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(height: 1, color: context.colors.border.subtle);
-  }
-}
-
-class _HomeActivityColumnLayout extends StatelessWidget {
-  const _HomeActivityColumnLayout({
-    required this.txType,
-    required this.amount,
-    required this.status,
-    required this.timestamp,
-  });
-
-  final Widget txType;
-  final Widget amount;
-  final Widget status;
-  final Widget timestamp;
-
-  @override
-  Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final useFixedColumns =
-            constraints.maxWidth >= _homeActivityFixedColumnsWidth;
-        if (useFixedColumns) {
-          return Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              _HomeActivityCell(
-                width: _homeActivityLeftCellWidth,
-                child: txType,
-              ),
-              _HomeActivityCell(
-                width: _homeActivityMiddleCellWidth,
-                child: amount,
-              ),
-              _HomeActivityCell(
-                width: _homeActivityMiddleCellWidth,
-                child: status,
-              ),
-              _HomeActivityCell(
-                width: _homeActivityRightCellWidth,
-                alignEnd: true,
-                child: timestamp,
-              ),
-            ],
-          );
-        }
-
-        return Row(
-          children: [
-            _HomeActivityCell(flex: 190, child: txType),
-            _HomeActivityCell(flex: 160, child: amount),
-            _HomeActivityCell(flex: 160, child: status),
-            _HomeActivityCell(flex: 140, alignEnd: true, child: timestamp),
-          ],
-        );
-      },
-    );
-  }
-}
-
-class _HomeActivityCell extends StatelessWidget {
-  const _HomeActivityCell({
-    required this.child,
-    this.width,
-    this.flex,
-    this.alignEnd = false,
-  });
-
-  final Widget child;
-  final double? width;
-  final int? flex;
-  final bool alignEnd;
-
-  @override
-  Widget build(BuildContext context) {
-    final content = Align(
-      alignment: alignEnd ? Alignment.centerRight : Alignment.centerLeft,
-      child: child,
-    );
-    final width = this.width;
-    if (width != null) {
-      return SizedBox(width: width, child: content);
-    }
-    return Expanded(flex: flex ?? 1, child: content);
-  }
-}
-
-class _StatusLabel extends StatelessWidget {
-  const _StatusLabel({required this.row});
-
-  final _HomeActivityRowData row;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        if (row.statusIconName != null) ...[
-          AppIcon(
-            row.statusIconName!,
-            size: 16,
-            color: row.statusColor ?? colors.text.secondary,
-          ),
-          const SizedBox(width: AppSpacing.xxs),
-        ],
-        Text(
-          row.statusText,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: AppTypography.labelMedium.copyWith(
-            color: row.statusColor ?? colors.text.secondary,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _HomeActivityRowData {
-  const _HomeActivityRowData({
-    required this.title,
-    required this.leadingIconName,
-    required this.leadingBackgroundColor,
-    required this.leadingIconColor,
-    this.subtitle,
-    this.subtitleIconName,
-    required this.amountText,
-    this.amountColor,
-    required this.statusText,
-    required this.timestampText,
-    this.statusIconName,
-    this.statusColor,
-    this.onTap,
-  });
-
-  final String title;
-  final String leadingIconName;
-  final Color leadingBackgroundColor;
-  final Color leadingIconColor;
-  final String? subtitle;
-  final String? subtitleIconName;
-  final String amountText;
-  final Color? amountColor;
-  final String statusText;
-  final String timestampText;
-  final String? statusIconName;
-  final Color? statusColor;
-  final VoidCallback? onTap;
-}
-
-class _HomeActivityRow extends StatelessWidget {
-  const _HomeActivityRow({required this.row});
-
-  final _HomeActivityRowData row;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    final content = Container(
-      height: 48,
-      padding: const EdgeInsets.all(AppSpacing.xxs),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(AppRadii.xSmall),
-      ),
-      child: _HomeActivityColumnLayout(
-        txType: Row(
-          children: [
-            _ActivityAvatar(row: row),
-            const SizedBox(width: AppSpacing.s),
-            Flexible(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    row.title,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: AppTypography.bodyMedium.copyWith(
-                      color: colors.text.accent,
-                    ),
-                  ),
-                  if (row.subtitle != null)
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (row.subtitleIconName != null) ...[
-                          AppIcon(
-                            row.subtitleIconName!,
-                            size: 16,
-                            color: colors.icon.brandCrimson,
-                          ),
-                          const SizedBox(width: AppSpacing.xxs),
-                        ],
-                        Flexible(
-                          child: Text(
-                            row.subtitle!,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: AppTypography.labelMedium.copyWith(
-                              color: row.subtitleIconName == null
-                                  ? colors.text.secondary
-                                  : colors.text.brandCrimson,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                ],
-              ),
-            ),
-          ],
-        ),
-        amount: Text(
-          row.amountText,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: AppTypography.labelMedium.copyWith(
-            color: row.amountColor ?? colors.text.accent,
-          ),
-        ),
-        status: _StatusLabel(row: row),
-        timestamp: Text(
-          row.timestampText,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          textAlign: TextAlign.end,
-          style: AppTypography.labelMedium.copyWith(
-            color: colors.text.secondary,
-          ),
-        ),
-      ),
-    );
-
-    if (row.onTap == null) return content;
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: row.onTap,
-        child: content,
-      ),
-    );
-  }
-}
-
-class _ActivityAvatar extends StatelessWidget {
-  const _ActivityAvatar({required this.row});
-
-  final _HomeActivityRowData row;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 32,
-      height: 32,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          Positioned.fill(
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                color: row.leadingBackgroundColor,
-                shape: BoxShape.circle,
-              ),
-              child: Center(
-                child: AppIcon(
-                  row.leadingIconName,
-                  size: 16,
-                  color: row.leadingIconColor,
-                ),
-              ),
-            ),
           ),
         ],
       ),

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -371,7 +371,7 @@ class _HomePaneState extends State<_HomePane> {
                           child: ActivityTable(
                             rows: rows,
                             title: 'Recent Activity',
-                            onTitleTap: () => context.push('/history'),
+                            onTitleTap: () => context.push('/activity'),
                           ),
                         ),
                         const SizedBox(height: AppSpacing.sm),

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -14,13 +14,12 @@ import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
-import '../../../core/widgets/app_button.dart';
-import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../../rust/api/wallet.dart' as rust_wallet;
 import '../../../services/keystone_transport.dart';
+import '../widgets/transaction_receipt_view.dart';
 import 'send_review_screen.dart';
 
 const _saplingSpendHash = 'a15ab54c2888880e53c823a3063820c728444126';
@@ -457,6 +456,11 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   @override
   Widget build(BuildContext context) {
     final addressLines = _splitAddress();
+    final receiptPhase = switch (_phase) {
+      _SendStatusPhase.sending => TransactionReceiptPhase.sending,
+      _SendStatusPhase.succeeded => TransactionReceiptPhase.succeeded,
+      _SendStatusPhase.failed => TransactionReceiptPhase.failed,
+    };
 
     return PopScope<void>(
       canPop: false,
@@ -472,7 +476,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
           child: Stack(
             children: [
               const Positioned.fill(
-                child: IgnorePointer(child: _SendStatusIllustration()),
+                child: IgnorePointer(child: TransactionReceiptIllustration()),
               ),
               Positioned.fill(
                 child: Padding(
@@ -484,24 +488,39 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
                   ),
                   child: Column(
                     children: [
-                      _SendStatusBackRow(onTap: _goHome),
+                      TransactionReceiptBackRow(onTap: _goHome),
                       Expanded(
                         child: Padding(
                           padding: const EdgeInsets.only(right: 255),
                           child: Align(
                             alignment: Alignment.centerLeft,
-                            child: _SendStatusContent(
-                              phase: _phase,
+                            child: TransactionReceiptView(
+                              phase: receiptPhase,
                               amountText: _formatReceiptAmount(
                                 widget.args.amountZatoshi,
                               ),
-                              addressLines: addressLines,
-                              addressSpanBuilder: (line) =>
-                                  _addressSpans(context, line),
+                              primaryBlock: TransactionReceiptBlockData(
+                                title: 'To',
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    for (final line in addressLines)
+                                      RichText(
+                                        text: TextSpan(
+                                          children: _addressSpans(
+                                            context,
+                                            line,
+                                          ),
+                                        ),
+                                      ),
+                                  ],
+                                ),
+                              ),
                               feeText:
                                   '${_formatFee(widget.args.feeZatoshi)} ZEC',
                               dateText: _formatDate(_completedAt ?? _startedAt),
                               error: _error,
+                              failureFallbackText: 'Send failed',
                               onCopyTxid: _phase == _SendStatusPhase.succeeded
                                   ? _copyTransactionHash
                                   : null,
@@ -520,310 +539,6 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
           ),
         ),
       ),
-    );
-  }
-}
-
-class _SendStatusBackRow extends StatelessWidget {
-  const _SendStatusBackRow({required this.onTap});
-
-  final Future<void> Function() onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: () => unawaited(onTap()),
-          child: SizedBox(
-            height: 32,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                AppIcon(
-                  AppIcons.chevronBackward,
-                  size: 16,
-                  color: colors.icon.accent,
-                ),
-                const SizedBox(width: AppSpacing.xxs),
-                Text(
-                  'Back',
-                  style: AppTypography.labelLarge.copyWith(
-                    color: colors.text.accent,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _SendStatusContent extends StatelessWidget {
-  const _SendStatusContent({
-    required this.phase,
-    required this.amountText,
-    required this.addressLines,
-    required this.addressSpanBuilder,
-    required this.feeText,
-    required this.dateText,
-    required this.error,
-    required this.onCopyTxid,
-    required this.onBackToWallet,
-  });
-
-  final _SendStatusPhase phase;
-  final String amountText;
-  final List<String> addressLines;
-  final List<TextSpan> Function(String line) addressSpanBuilder;
-  final String feeText;
-  final String dateText;
-  final String? error;
-  final VoidCallback? onCopyTxid;
-  final VoidCallback? onBackToWallet;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        SizedBox(
-          width: 328,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _SendStatusHeadline(phase: phase, amountText: amountText),
-              const SizedBox(height: AppSpacing.md),
-              _SendStatusBlock(
-                title: 'To',
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    for (final line in addressLines)
-                      RichText(
-                        text: TextSpan(children: addressSpanBuilder(line)),
-                      ),
-                  ],
-                ),
-              ),
-              const SizedBox(height: AppSpacing.md),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  Expanded(
-                    child: _SendStatusBlock(
-                      title: 'Date',
-                      child: Text(
-                        dateText,
-                        style: AppTypography.labelLarge.copyWith(
-                          color: context.colors.text.accent,
-                        ),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: AppSpacing.sm),
-                  Expanded(
-                    child: _SendStatusBlock(
-                      title: 'Tx Fee',
-                      child: Text(
-                        feeText,
-                        style: AppTypography.labelLarge.copyWith(
-                          color: context.colors.text.accent,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: AppSpacing.md),
-        SizedBox(
-          width: 256,
-          child: switch (phase) {
-            _SendStatusPhase.sending => const SizedBox(height: 40),
-            _SendStatusPhase.succeeded => AppButton(
-              onPressed: onCopyTxid,
-              variant: AppButtonVariant.secondary,
-              minWidth: 256,
-              trailing: AppIcon(
-                AppIcons.arrowTopRight,
-                color: context.colors.button.secondary.label,
-              ),
-              child: const Text('Transaction Hash'),
-            ),
-            _SendStatusPhase.failed => Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _SendStatusFailureMessage(message: error ?? 'Send failed'),
-                const SizedBox(height: AppSpacing.xs),
-                AppButton(
-                  onPressed: onBackToWallet,
-                  variant: AppButtonVariant.secondary,
-                  minWidth: 256,
-                  child: const Text('Back to Wallet'),
-                ),
-              ],
-            ),
-          },
-        ),
-      ],
-    );
-  }
-}
-
-class _SendStatusHeadline extends StatelessWidget {
-  const _SendStatusHeadline({required this.phase, required this.amountText});
-
-  final _SendStatusPhase phase;
-  final String amountText;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    final icon = switch (phase) {
-      _SendStatusPhase.sending => AppIcons.loader,
-      _SendStatusPhase.succeeded => AppIcons.check,
-      _SendStatusPhase.failed => AppIcons.warning,
-    };
-    final label = switch (phase) {
-      _SendStatusPhase.sending => 'Sending...',
-      _SendStatusPhase.succeeded => 'Succeeded',
-      _SendStatusPhase.failed => 'Failed',
-    };
-    final labelColor = switch (phase) {
-      _SendStatusPhase.sending => colors.text.accent,
-      _SendStatusPhase.succeeded => colors.text.success,
-      _SendStatusPhase.failed => colors.text.destructive,
-    };
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.all(AppSpacing.xxs),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AppIcon(icon, size: 16, color: labelColor),
-              const SizedBox(width: AppSpacing.xxs),
-              Text(
-                label,
-                style: AppTypography.labelMedium.copyWith(color: labelColor),
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: AppSpacing.xs),
-        Text(
-          amountText,
-          style: AppTypography.displayMedium.copyWith(
-            color: colors.text.accent,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _SendStatusBlock extends StatelessWidget {
-  const _SendStatusBlock({required this.title, required this.child});
-
-  final String title;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Row(
-          children: [
-            Expanded(
-              child: Text(
-                title,
-                style: AppTypography.labelMedium.copyWith(
-                  color: colors.text.secondary,
-                ),
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: AppSpacing.xs),
-        child,
-      ],
-    );
-  }
-}
-
-class _SendStatusFailureMessage extends StatelessWidget {
-  const _SendStatusFailureMessage({required this.message});
-
-  final String message;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        AppIcon(
-          AppIcons.warning,
-          size: 16,
-          color: context.colors.text.destructive,
-        ),
-        const SizedBox(width: AppSpacing.xxs),
-        Expanded(
-          child: Text(
-            message,
-            style: AppTypography.labelMedium.copyWith(
-              color: context.colors.text.destructive,
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _SendStatusIllustration extends StatelessWidget {
-  const _SendStatusIllustration();
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final assetPath = isDark
-        ? 'assets/illustrations/send_status_illustration_dark.png'
-        : 'assets/illustrations/send_status_illustration_light.png';
-    return Stack(
-      children: [
-        Positioned.fill(
-          child: Align(
-            alignment: Alignment.centerRight,
-            child: Image.asset(
-              assetPath,
-              fit: BoxFit.fitHeight,
-              alignment: Alignment.centerRight,
-              height: double.infinity,
-            ),
-          ),
-        ),
-        Positioned.fill(
-          child: DecoratedBox(
-            decoration: BoxDecoration(color: colors.fade.illustration),
-          ),
-        ),
-      ],
     );
   }
 }

--- a/lib/src/features/send/widgets/transaction_receipt_view.dart
+++ b/lib/src/features/send/widgets/transaction_receipt_view.dart
@@ -1,0 +1,345 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart' show Theme;
+import 'package:flutter/widgets.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+
+enum TransactionReceiptPhase { loading, sending, pending, succeeded, failed }
+
+class TransactionReceiptBlockData {
+  const TransactionReceiptBlockData({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+}
+
+class TransactionReceiptBackRow extends StatelessWidget {
+  const TransactionReceiptBackRow({required this.onTap, super.key});
+
+  final FutureOr<void> Function() onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () => unawaited(Future<void>.value(onTap())),
+          child: SizedBox(
+            height: 32,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AppIcon(
+                  AppIcons.chevronBackward,
+                  size: 16,
+                  color: colors.icon.accent,
+                ),
+                const SizedBox(width: AppSpacing.xxs),
+                Text(
+                  'Back',
+                  style: AppTypography.labelLarge.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class TransactionReceiptView extends StatelessWidget {
+  const TransactionReceiptView({
+    required this.phase,
+    required this.amountText,
+    required this.primaryBlock,
+    required this.dateText,
+    required this.feeText,
+    this.error,
+    this.failureFallbackText = 'Transaction failed',
+    this.onCopyTxid,
+    this.onBackToWallet,
+    super.key,
+  });
+
+  final TransactionReceiptPhase phase;
+  final String amountText;
+  final TransactionReceiptBlockData primaryBlock;
+  final String dateText;
+  final String feeText;
+  final String? error;
+  final String failureFallbackText;
+  final VoidCallback? onCopyTxid;
+  final VoidCallback? onBackToWallet;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 328,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _TransactionReceiptHeadline(phase: phase, amountText: amountText),
+              const SizedBox(height: AppSpacing.md),
+              _TransactionReceiptBlock(
+                title: primaryBlock.title,
+                child: primaryBlock.child,
+              ),
+              const SizedBox(height: AppSpacing.md),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Expanded(
+                    child: _TransactionReceiptBlock(
+                      title: 'Date',
+                      child: Text(
+                        dateText,
+                        style: AppTypography.labelLarge.copyWith(
+                          color: context.colors.text.accent,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.sm),
+                  Expanded(
+                    child: _TransactionReceiptBlock(
+                      title: 'Tx Fee',
+                      child: Text(
+                        feeText,
+                        style: AppTypography.labelLarge.copyWith(
+                          color: context.colors.text.accent,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        SizedBox(width: 256, child: _TransactionReceiptActions(view: this)),
+      ],
+    );
+  }
+}
+
+class TransactionReceiptIllustration extends StatelessWidget {
+  const TransactionReceiptIllustration({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final assetPath = isDark
+        ? 'assets/illustrations/send_status_illustration_dark.png'
+        : 'assets/illustrations/send_status_illustration_light.png';
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: Align(
+            alignment: Alignment.centerRight,
+            child: Image.asset(
+              assetPath,
+              fit: BoxFit.fitHeight,
+              alignment: Alignment.centerRight,
+              height: double.infinity,
+            ),
+          ),
+        ),
+        Positioned.fill(
+          child: DecoratedBox(
+            decoration: BoxDecoration(color: colors.fade.illustration),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TransactionReceiptActions extends StatelessWidget {
+  const _TransactionReceiptActions({required this.view});
+
+  final TransactionReceiptView view;
+
+  @override
+  Widget build(BuildContext context) {
+    final copyButton = view.onCopyTxid == null
+        ? null
+        : AppButton(
+            onPressed: view.onCopyTxid,
+            variant: AppButtonVariant.secondary,
+            minWidth: 256,
+            trailing: AppIcon(
+              AppIcons.arrowTopRight,
+              color: context.colors.button.secondary.label,
+            ),
+            child: const Text('Transaction Hash'),
+          );
+
+    return switch (view.phase) {
+      TransactionReceiptPhase.loading ||
+      TransactionReceiptPhase.sending => const SizedBox(height: 40),
+      TransactionReceiptPhase.pending || TransactionReceiptPhase.succeeded =>
+        copyButton ?? const SizedBox(height: 40),
+      TransactionReceiptPhase.failed => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _TransactionReceiptFailureMessage(
+            message: view.error ?? view.failureFallbackText,
+          ),
+          if (copyButton != null) ...[
+            const SizedBox(height: AppSpacing.xs),
+            copyButton,
+          ],
+          if (view.onBackToWallet != null) ...[
+            const SizedBox(height: AppSpacing.xs),
+            AppButton(
+              onPressed: view.onBackToWallet,
+              variant: AppButtonVariant.secondary,
+              minWidth: 256,
+              child: const Text('Back to Wallet'),
+            ),
+          ],
+        ],
+      ),
+    };
+  }
+}
+
+class _TransactionReceiptHeadline extends StatelessWidget {
+  const _TransactionReceiptHeadline({
+    required this.phase,
+    required this.amountText,
+  });
+
+  final TransactionReceiptPhase phase;
+  final String amountText;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final icon = switch (phase) {
+      TransactionReceiptPhase.loading ||
+      TransactionReceiptPhase.sending ||
+      TransactionReceiptPhase.pending => AppIcons.loader,
+      TransactionReceiptPhase.succeeded => AppIcons.check,
+      TransactionReceiptPhase.failed => AppIcons.warning,
+    };
+    final label = switch (phase) {
+      TransactionReceiptPhase.loading => 'Loading...',
+      TransactionReceiptPhase.sending => 'Sending...',
+      TransactionReceiptPhase.pending => 'In progress',
+      TransactionReceiptPhase.succeeded => 'Succeeded',
+      TransactionReceiptPhase.failed => 'Failed',
+    };
+    final labelColor = switch (phase) {
+      TransactionReceiptPhase.loading ||
+      TransactionReceiptPhase.sending ||
+      TransactionReceiptPhase.pending => colors.text.accent,
+      TransactionReceiptPhase.succeeded => colors.text.success,
+      TransactionReceiptPhase.failed => colors.text.destructive,
+    };
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(AppSpacing.xxs),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AppIcon(icon, size: 16, color: labelColor),
+              const SizedBox(width: AppSpacing.xxs),
+              Text(
+                label,
+                style: AppTypography.labelMedium.copyWith(color: labelColor),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          amountText,
+          style: AppTypography.displayMedium.copyWith(
+            color: colors.text.accent,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TransactionReceiptBlock extends StatelessWidget {
+  const _TransactionReceiptBlock({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                title,
+                style: AppTypography.labelMedium.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        child,
+      ],
+    );
+  }
+}
+
+class _TransactionReceiptFailureMessage extends StatelessWidget {
+  const _TransactionReceiptFailureMessage({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        AppIcon(
+          AppIcons.warning,
+          size: 16,
+          color: context.colors.text.destructive,
+        ),
+        const SizedBox(width: AppSpacing.xxs),
+        Expanded(
+          child: Text(
+            message,
+            style: AppTypography.labelMedium.copyWith(
+              color: context.colors.text.destructive,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -36,6 +36,9 @@ class SyncState {
   final BigInt totalBalance;
   final String? error;
   final List<rust_sync.TransactionInfo> recentTransactions;
+  final DateTime? lastSyncStartedAt;
+  final DateTime? lastSyncCompletedAt;
+  final DateTime? lastSyncFailedAt;
 
   /// Current sync phase: `"download"`, `"scan"`, `"enhance"`, or
   /// empty. Widgets can use this to show e.g. "Downloading..."
@@ -64,6 +67,9 @@ class SyncState {
     BigInt? totalBalance,
     this.error,
     this.recentTransactions = const [],
+    this.lastSyncStartedAt,
+    this.lastSyncCompletedAt,
+    this.lastSyncFailedAt,
     this.phase = '',
   }) : transparentBalance = transparentBalance ?? BigInt.zero,
        saplingBalance = saplingBalance ?? BigInt.zero,
@@ -95,6 +101,9 @@ class SyncState {
     BigInt? totalBalance,
     String? error,
     List<rust_sync.TransactionInfo>? recentTransactions,
+    DateTime? lastSyncStartedAt,
+    DateTime? lastSyncCompletedAt,
+    DateTime? lastSyncFailedAt,
     String? phase,
   }) {
     return SyncState(
@@ -121,6 +130,9 @@ class SyncState {
       totalBalance: totalBalance ?? this.totalBalance,
       error: error ?? this.error,
       recentTransactions: recentTransactions ?? this.recentTransactions,
+      lastSyncStartedAt: lastSyncStartedAt ?? this.lastSyncStartedAt,
+      lastSyncCompletedAt: lastSyncCompletedAt ?? this.lastSyncCompletedAt,
+      lastSyncFailedAt: lastSyncFailedAt ?? this.lastSyncFailedAt,
       phase: phase ?? this.phase,
     );
   }
@@ -316,6 +328,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _lastLoggedHeight = 0;
     final gen = ++_syncGen;
     final prev = state.value;
+    final startedAt = DateTime.now();
     state = AsyncData(
       SyncState(
         isSyncing: true,
@@ -335,6 +348,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         spendableBalance: prev?.spendableBalance,
         totalBalance: prev?.totalBalance,
         recentTransactions: prev?.recentTransactions ?? const [],
+        lastSyncStartedAt: startedAt,
+        lastSyncCompletedAt: prev?.lastSyncCompletedAt,
+        lastSyncFailedAt: prev?.lastSyncFailedAt,
         phase: '',
       ),
     );
@@ -412,6 +428,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
                   spendableBalance: prev?.spendableBalance,
                   totalBalance: prev?.totalBalance,
                   recentTransactions: prev?.recentTransactions ?? const [],
+                  lastSyncStartedAt: prev?.lastSyncStartedAt,
+                  lastSyncCompletedAt: prev?.lastSyncCompletedAt,
+                  lastSyncFailedAt: DateTime.now(),
                 ),
               );
               _startPolling();
@@ -446,6 +465,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               spendableBalance: prev?.spendableBalance,
               totalBalance: prev?.totalBalance,
               recentTransactions: prev?.recentTransactions ?? const [],
+              lastSyncStartedAt: prev?.lastSyncStartedAt,
+              lastSyncCompletedAt: prev?.lastSyncCompletedAt,
+              lastSyncFailedAt: DateTime.now(),
             ),
           );
           _startPolling();
@@ -538,6 +560,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         spendableBalance: prev?.spendableBalance,
         totalBalance: prev?.totalBalance,
         recentTransactions: prev?.recentTransactions ?? const [],
+        lastSyncStartedAt: prev?.lastSyncStartedAt,
+        lastSyncCompletedAt: prev?.lastSyncCompletedAt,
+        lastSyncFailedAt: prev?.lastSyncFailedAt,
       ),
     );
   }
@@ -973,6 +998,13 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     // Update delegate BEFORE state so isActive reflects completion
     _bgDelegate.onProgress(event);
 
+    final syncStartedAt =
+        prev?.lastSyncStartedAt ??
+        (event.isSyncing || event.isComplete ? DateTime.now() : null);
+    final syncCompletedAt = event.isComplete
+        ? DateTime.now()
+        : prev?.lastSyncCompletedAt;
+
     state = AsyncData(
       SyncState(
         isSyncing: event.isSyncing && !event.isComplete,
@@ -998,6 +1030,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         spendableBalance: spendable ?? prev?.spendableBalance,
         totalBalance: total ?? prev?.totalBalance,
         recentTransactions: recentTxs,
+        lastSyncStartedAt: syncStartedAt,
+        lastSyncCompletedAt: syncCompletedAt,
+        lastSyncFailedAt: prev?.lastSyncFailedAt,
         phase: event.phase,
       ),
     );
@@ -1125,6 +1160,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         spendableBalance: spendable ?? prev?.spendableBalance,
         totalBalance: total ?? prev?.totalBalance,
         recentTransactions: recentTxs,
+        lastSyncStartedAt: prev?.lastSyncStartedAt,
+        lastSyncCompletedAt: prev?.lastSyncCompletedAt,
+        lastSyncFailedAt: prev?.lastSyncFailedAt,
       ),
     );
   }

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -732,6 +732,10 @@ class TransactionInfo {
   final BigInt fee;
   final BigInt blockTime;
   final bool isTransparent;
+  final String txKind;
+  final BigInt displayAmount;
+  final String displayPool;
+  final BigInt createdTime;
 
   const TransactionInfo({
     required this.txidHex,
@@ -741,6 +745,10 @@ class TransactionInfo {
     required this.fee,
     required this.blockTime,
     required this.isTransparent,
+    required this.txKind,
+    required this.displayAmount,
+    required this.displayPool,
+    required this.createdTime,
   });
 
   @override
@@ -751,7 +759,11 @@ class TransactionInfo {
       accountBalanceDelta.hashCode ^
       fee.hashCode ^
       blockTime.hashCode ^
-      isTransparent.hashCode;
+      isTransparent.hashCode ^
+      txKind.hashCode ^
+      displayAmount.hashCode ^
+      displayPool.hashCode ^
+      createdTime.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -764,7 +776,11 @@ class TransactionInfo {
           accountBalanceDelta == other.accountBalanceDelta &&
           fee == other.fee &&
           blockTime == other.blockTime &&
-          isTransparent == other.isTransparent;
+          isTransparent == other.isTransparent &&
+          txKind == other.txKind &&
+          displayAmount == other.displayAmount &&
+          displayPool == other.displayPool &&
+          createdTime == other.createdTime;
 }
 
 class TxDataRequest {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -2878,8 +2878,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TransactionInfo dco_decode_transaction_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 7)
-      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    if (arr.length != 11)
+      throw Exception('unexpected arr length: expect 11 but see ${arr.length}');
     return TransactionInfo(
       txidHex: dco_decode_String(arr[0]),
       minedHeight: dco_decode_u_64(arr[1]),
@@ -2888,6 +2888,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       fee: dco_decode_u_64(arr[4]),
       blockTime: dco_decode_u_64(arr[5]),
       isTransparent: dco_decode_bool(arr[6]),
+      txKind: dco_decode_String(arr[7]),
+      displayAmount: dco_decode_u_64(arr[8]),
+      displayPool: dco_decode_String(arr[9]),
+      createdTime: dco_decode_u_64(arr[10]),
     );
   }
 
@@ -3433,6 +3437,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_fee = sse_decode_u_64(deserializer);
     var var_blockTime = sse_decode_u_64(deserializer);
     var var_isTransparent = sse_decode_bool(deserializer);
+    var var_txKind = sse_decode_String(deserializer);
+    var var_displayAmount = sse_decode_u_64(deserializer);
+    var var_displayPool = sse_decode_String(deserializer);
+    var var_createdTime = sse_decode_u_64(deserializer);
     return TransactionInfo(
       txidHex: var_txidHex,
       minedHeight: var_minedHeight,
@@ -3441,6 +3449,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       fee: var_fee,
       blockTime: var_blockTime,
       isTransparent: var_isTransparent,
+      txKind: var_txKind,
+      displayAmount: var_displayAmount,
+      displayPool: var_displayPool,
+      createdTime: var_createdTime,
     );
   }
 
@@ -3966,6 +3978,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_u_64(self.fee, serializer);
     sse_encode_u_64(self.blockTime, serializer);
     sse_encode_bool(self.isTransparent, serializer);
+    sse_encode_String(self.txKind, serializer);
+    sse_encode_u_64(self.displayAmount, serializer);
+    sse_encode_String(self.displayPool, serializer);
+    sse_encode_u_64(self.createdTime, serializer);
   }
 
   @protected

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -773,6 +773,10 @@ pub struct TransactionInfo {
     pub fee: u64,
     pub block_time: u64,
     pub is_transparent: bool,
+    pub tx_kind: String,
+    pub display_amount: u64,
+    pub display_pool: String,
+    pub created_time: u64,
 }
 
 pub fn get_transaction_history(
@@ -794,6 +798,10 @@ pub fn get_transaction_history(
                 fee: t.fee,
                 block_time: t.block_time,
                 is_transparent: t.is_transparent,
+                tx_kind: t.tx_kind,
+                display_amount: t.display_amount,
+                display_pool: t.display_pool,
+                created_time: t.created_time,
             })
             .collect())
     })

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -2705,6 +2705,10 @@ impl SseDecode for crate::api::sync::TransactionInfo {
         let mut var_fee = <u64>::sse_decode(deserializer);
         let mut var_blockTime = <u64>::sse_decode(deserializer);
         let mut var_isTransparent = <bool>::sse_decode(deserializer);
+        let mut var_txKind = <String>::sse_decode(deserializer);
+        let mut var_displayAmount = <u64>::sse_decode(deserializer);
+        let mut var_displayPool = <String>::sse_decode(deserializer);
+        let mut var_createdTime = <u64>::sse_decode(deserializer);
         return crate::api::sync::TransactionInfo {
             txid_hex: var_txidHex,
             mined_height: var_minedHeight,
@@ -2713,6 +2717,10 @@ impl SseDecode for crate::api::sync::TransactionInfo {
             fee: var_fee,
             block_time: var_blockTime,
             is_transparent: var_isTransparent,
+            tx_kind: var_txKind,
+            display_amount: var_displayAmount,
+            display_pool: var_displayPool,
+            created_time: var_createdTime,
         };
     }
 }
@@ -3345,6 +3353,10 @@ impl flutter_rust_bridge::IntoDart for crate::api::sync::TransactionInfo {
             self.fee.into_into_dart().into_dart(),
             self.block_time.into_into_dart().into_dart(),
             self.is_transparent.into_into_dart().into_dart(),
+            self.tx_kind.into_into_dart().into_dart(),
+            self.display_amount.into_into_dart().into_dart(),
+            self.display_pool.into_into_dart().into_dart(),
+            self.created_time.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -3813,6 +3825,10 @@ impl SseEncode for crate::api::sync::TransactionInfo {
         <u64>::sse_encode(self.fee, serializer);
         <u64>::sse_encode(self.block_time, serializer);
         <bool>::sse_encode(self.is_transparent, serializer);
+        <String>::sse_encode(self.tx_kind, serializer);
+        <u64>::sse_encode(self.display_amount, serializer);
+        <String>::sse_encode(self.display_pool, serializer);
+        <u64>::sse_encode(self.created_time, serializer);
     }
 }
 

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -217,6 +217,10 @@ pub(crate) struct TransactionInfo {
     pub fee: u64,
     pub block_time: u64,
     pub is_transparent: bool,
+    pub tx_kind: String,
+    pub display_amount: u64,
+    pub display_pool: String,
+    pub created_time: u64,
 }
 
 pub fn get_transaction_history(
@@ -240,8 +244,49 @@ pub fn get_transaction_history(
                  WHERE txo.txid = vt.txid \
                    AND txo.output_pool = 0 \
                    AND (txo.from_account_uuid = vt.account_uuid OR txo.to_account_uuid = vt.account_uuid) \
-             ) AS is_transparent \
+             ) AS is_transparent, \
+             COALESCE(vt.total_spent, 0) AS total_spent, \
+             COALESCE(vt.total_received, 0) AS total_received, \
+             COALESCE(vt.is_shielding, 0) AS is_shielding, \
+             COALESCE(( \
+                 SELECT SUM(txo.value) \
+                 FROM v_tx_outputs txo \
+                 WHERE txo.txid = vt.txid \
+                   AND txo.from_account_uuid = vt.account_uuid \
+                   AND txo.to_account_uuid IS NULL \
+                   AND txo.is_change = 0 \
+             ), 0) AS external_sent_amount, \
+             COALESCE(( \
+                 SELECT SUM(txo.value) \
+                 FROM v_tx_outputs txo \
+                 WHERE txo.txid = vt.txid \
+                   AND txo.to_account_uuid = vt.account_uuid \
+                   AND txo.from_account_uuid IS NULL \
+                   AND txo.is_change = 0 \
+             ), 0) AS external_received_amount, \
+             EXISTS( \
+                 SELECT 1 \
+                 FROM v_tx_outputs txo \
+                 WHERE txo.txid = vt.txid \
+                   AND txo.output_pool = 0 \
+                   AND ( \
+                       (txo.from_account_uuid = vt.account_uuid AND txo.to_account_uuid IS NULL AND txo.is_change = 0) \
+                       OR (txo.to_account_uuid = vt.account_uuid AND txo.from_account_uuid IS NULL AND txo.is_change = 0) \
+                   ) \
+             ) AS display_has_transparent, \
+             EXISTS( \
+                 SELECT 1 \
+                 FROM v_tx_outputs txo \
+                 WHERE txo.txid = vt.txid \
+                   AND txo.output_pool IN (2, 3) \
+                   AND ( \
+                       (txo.from_account_uuid = vt.account_uuid AND txo.to_account_uuid IS NULL AND txo.is_change = 0) \
+                       OR (txo.to_account_uuid = vt.account_uuid AND txo.from_account_uuid IS NULL AND txo.is_change = 0) \
+                   ) \
+             ) AS display_has_shielded, \
+             CAST(COALESCE(strftime('%s', tx.created), 0) AS INTEGER) AS created_time \
              FROM v_transactions vt \
+             LEFT JOIN transactions tx ON tx.txid = vt.txid \
              WHERE vt.account_uuid = ?1 \
              ORDER BY COALESCE(vt.mined_height, 999999999) DESC, vt.tx_index DESC \
              LIMIT ?2"
@@ -255,8 +300,49 @@ pub fn get_transaction_history(
                  WHERE txo.txid = vt.txid \
                    AND txo.output_pool = 0 \
                    AND (txo.from_account_uuid = vt.account_uuid OR txo.to_account_uuid = vt.account_uuid) \
-             ) AS is_transparent \
+             ) AS is_transparent, \
+             COALESCE(vt.total_spent, 0) AS total_spent, \
+             COALESCE(vt.total_received, 0) AS total_received, \
+             COALESCE(vt.is_shielding, 0) AS is_shielding, \
+             COALESCE(( \
+                 SELECT SUM(txo.value) \
+                 FROM v_tx_outputs txo \
+                 WHERE txo.txid = vt.txid \
+                   AND txo.from_account_uuid = vt.account_uuid \
+                   AND txo.to_account_uuid IS NULL \
+                   AND txo.is_change = 0 \
+             ), 0) AS external_sent_amount, \
+             COALESCE(( \
+                 SELECT SUM(txo.value) \
+                 FROM v_tx_outputs txo \
+                 WHERE txo.txid = vt.txid \
+                   AND txo.to_account_uuid = vt.account_uuid \
+                   AND txo.from_account_uuid IS NULL \
+                   AND txo.is_change = 0 \
+             ), 0) AS external_received_amount, \
+             EXISTS( \
+                 SELECT 1 \
+                 FROM v_tx_outputs txo \
+                 WHERE txo.txid = vt.txid \
+                   AND txo.output_pool = 0 \
+                   AND ( \
+                       (txo.from_account_uuid = vt.account_uuid AND txo.to_account_uuid IS NULL AND txo.is_change = 0) \
+                       OR (txo.to_account_uuid = vt.account_uuid AND txo.from_account_uuid IS NULL AND txo.is_change = 0) \
+                   ) \
+             ) AS display_has_transparent, \
+             EXISTS( \
+                 SELECT 1 \
+                 FROM v_tx_outputs txo \
+                 WHERE txo.txid = vt.txid \
+                   AND txo.output_pool IN (2, 3) \
+                   AND ( \
+                       (txo.from_account_uuid = vt.account_uuid AND txo.to_account_uuid IS NULL AND txo.is_change = 0) \
+                       OR (txo.to_account_uuid = vt.account_uuid AND txo.from_account_uuid IS NULL AND txo.is_change = 0) \
+                   ) \
+             ) AS display_has_shielded, \
+             CAST(COALESCE(strftime('%s', tx.created), 0) AS INTEGER) AS created_time \
              FROM v_transactions vt \
+             LEFT JOIN transactions tx ON tx.txid = vt.txid \
              WHERE vt.account_uuid = ?1 \
              ORDER BY COALESCE(vt.mined_height, 999999999) DESC, vt.tx_index DESC"
         }
@@ -271,6 +357,41 @@ pub fn get_transaction_history(
         let fee: u64 = row.get::<_, i64>(4)?.unsigned_abs();
         let block_time: u64 = row.get::<_, i64>(5)?.unsigned_abs();
         let is_transparent: bool = row.get(6)?;
+        let total_spent = row.get::<_, i64>(7)?.unsigned_abs();
+        let total_received = row.get::<_, i64>(8)?.unsigned_abs();
+        let is_shielding: bool = row.get(9)?;
+        let external_sent_amount = row.get::<_, i64>(10)?.unsigned_abs();
+        let external_received_amount = row.get::<_, i64>(11)?.unsigned_abs();
+        let display_has_transparent: bool = row.get(12)?;
+        let display_has_shielded: bool = row.get(13)?;
+        let created_time = row.get::<_, i64>(14)?.unsigned_abs();
+
+        let display_pool = if is_shielding {
+            "shielded"
+        } else {
+            match (display_has_transparent, display_has_shielded) {
+                (true, false) => "transparent",
+                (false, true) => "shielded",
+                (true, true) => "mixed",
+                (false, false) => "unknown",
+            }
+        }
+        .to_string();
+
+        let (tx_kind, display_amount) = if is_shielding {
+            ("shielded", total_received)
+        } else if external_sent_amount > 0 {
+            ("sent", external_sent_amount)
+        } else if external_received_amount > 0 {
+            ("received", external_received_amount)
+        } else if total_spent > 0 && total_received > 0 {
+            ("internal", total_received)
+        } else if balance_delta > 0 {
+            ("received", balance_delta as u64)
+        } else {
+            ("unknown", 0)
+        };
+
         Ok(TransactionInfo {
             txid_hex: hex::encode(&txid_blob),
             mined_height: mined_height.unwrap_or(0) as u64,
@@ -279,6 +400,10 @@ pub fn get_transaction_history(
             fee,
             block_time,
             is_transparent,
+            tx_kind: tx_kind.to_string(),
+            display_amount,
+            display_pool,
+            created_time,
         })
     };
 

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -19,6 +19,8 @@
 //! chain-tip update, scan range management) and the shared
 //! PROPOSAL_STORE used by both the software and PCZT send paths.
 
+use std::collections::{HashMap, HashSet};
+
 use zcash_client_backend::data_api::{wallet::ConfirmationsPolicy, WalletRead, WalletWrite};
 use zcash_protocol::consensus::BlockHeight;
 
@@ -207,7 +209,7 @@ pub fn set_transaction_status(
     })
 }
 
-// ======================== Transaction History (SQL) ========================
+// ======================== Transaction History ========================
 
 pub(crate) struct TransactionInfo {
     pub txid_hex: String,
@@ -223,6 +225,51 @@ pub(crate) struct TransactionInfo {
     pub created_time: u64,
 }
 
+#[derive(Clone)]
+struct TxBase {
+    txid: Vec<u8>,
+    mined_height: Option<u32>,
+    expired_unmined: bool,
+    account_balance_delta: i64,
+    fee: u64,
+    block_time: u64,
+    total_spent: u64,
+    total_received: u64,
+    is_shielding: bool,
+    expiry_height: Option<i64>,
+    tx_index: i64,
+    created: Option<String>,
+    created_time: u64,
+}
+
+struct TxOutput {
+    txid: Vec<u8>,
+    output_pool: i64,
+    from_account_uuid: Option<Vec<u8>>,
+    to_account_uuid: Option<Vec<u8>>,
+    value: u64,
+    is_change: bool,
+}
+
+#[derive(Default, Clone)]
+struct OutputSummary {
+    is_transparent: bool,
+    external_sent_amount: u64,
+    external_received_amount: u64,
+    display_has_transparent: bool,
+    display_has_shielded: bool,
+    has_external_display_output: bool,
+    has_own_transparent_output: bool,
+    has_external_transparent_send: bool,
+}
+
+struct ClassifiedTx {
+    info: TransactionInfo,
+    sort_timestamp: u64,
+    sort_mined_height: u64,
+    tx_index: i64,
+}
+
 pub fn get_transaction_history(
     db_path: &str,
     _network: WalletNetwork,
@@ -234,233 +281,295 @@ pub fn get_transaction_history(
 
     // Open a separate read-only connection (WalletDb.conn is private).
     let conn = open_readonly_conn(db_path)?;
-    // Force materialization so SQLite does not repeatedly inline the SDK views.
-    let sql = r#"
-        WITH
-        base AS MATERIALIZED (
-            SELECT
-                vt.account_uuid,
-                vt.txid,
-                vt.mined_height,
-                vt.expired_unmined,
-                vt.account_balance_delta,
-                COALESCE(vt.fee_paid, 0) AS fee_paid,
-                COALESCE(vt.block_time, 0) AS block_time,
-                COALESCE(vt.total_spent, 0) AS total_spent,
-                COALESCE(vt.total_received, 0) AS total_received,
-                COALESCE(vt.is_shielding, 0) AS is_shielding,
-                vt.expiry_height,
-                vt.tx_index,
-                tx.created,
-                CAST(COALESCE(strftime('%s', tx.created), 0) AS INTEGER) AS created_time
-            FROM v_transactions vt
-            LEFT JOIN transactions tx ON tx.txid = vt.txid
-            WHERE vt.account_uuid = ?1
-        ),
-        base_keys AS MATERIALIZED (
-            SELECT DISTINCT txid, account_uuid
-            FROM base
-        ),
-        account_outputs AS MATERIALIZED (
-            SELECT txo.*
-            FROM v_tx_outputs txo
-            JOIN base_keys bk ON bk.txid = txo.txid
-            WHERE txo.from_account_uuid = bk.account_uuid
-               OR txo.to_account_uuid = bk.account_uuid
-        ),
-        output_summary AS MATERIALIZED (
-            SELECT
-                b.txid,
-                MAX(CASE
-                    WHEN txo.output_pool = 0
-                    THEN 1 ELSE 0
-                END) AS is_transparent,
-                COALESCE(SUM(CASE
-                    WHEN txo.from_account_uuid = b.account_uuid
-                     AND txo.to_account_uuid IS NULL
-                     AND txo.is_change = 0
-                    THEN txo.value ELSE 0
-                END), 0) AS external_sent_amount,
-                COALESCE(SUM(CASE
-                    WHEN txo.to_account_uuid = b.account_uuid
-                     AND txo.from_account_uuid IS NULL
-                     AND txo.is_change = 0
-                    THEN txo.value ELSE 0
-                END), 0) AS external_received_amount,
-                MAX(CASE
-                    WHEN txo.output_pool = 0
-                     AND (
-                         (
-                             txo.from_account_uuid = b.account_uuid
-                             AND txo.to_account_uuid IS NULL
-                             AND txo.is_change = 0
-                         )
-                         OR (
-                             txo.to_account_uuid = b.account_uuid
-                             AND txo.from_account_uuid IS NULL
-                             AND txo.is_change = 0
-                         )
-                     )
-                    THEN 1 ELSE 0
-                END) AS display_has_transparent,
-                MAX(CASE
-                    WHEN txo.output_pool IN (2, 3)
-                     AND (
-                         (
-                             txo.from_account_uuid = b.account_uuid
-                             AND txo.to_account_uuid IS NULL
-                             AND txo.is_change = 0
-                         )
-                         OR (
-                             txo.to_account_uuid = b.account_uuid
-                             AND txo.from_account_uuid IS NULL
-                             AND txo.is_change = 0
-                         )
-                     )
-                    THEN 1 ELSE 0
-                END) AS display_has_shielded,
-                MAX(CASE
-                    WHEN (
-                         txo.from_account_uuid = b.account_uuid
-                         AND txo.to_account_uuid IS NULL
-                         AND txo.is_change = 0
-                    )
-                    OR (
-                         txo.to_account_uuid = b.account_uuid
-                         AND txo.from_account_uuid IS NULL
-                         AND txo.is_change = 0
-                    )
-                    THEN 1 ELSE 0
-                END) AS has_external_display_output,
-                MAX(CASE
-                    WHEN txo.output_pool = 0
-                     AND txo.from_account_uuid = b.account_uuid
-                     AND txo.to_account_uuid = b.account_uuid
-                     AND txo.is_change = 0
-                    THEN 1 ELSE 0
-                END) AS has_own_transparent_output,
-                MAX(CASE
-                    WHEN txo.output_pool = 0
-                     AND txo.from_account_uuid = b.account_uuid
-                     AND txo.to_account_uuid IS NULL
-                     AND txo.is_change = 0
-                    THEN 1 ELSE 0
-                END) AS has_external_transparent_send
-            FROM base b
-            LEFT JOIN account_outputs txo ON txo.txid = b.txid
-            GROUP BY b.txid
-        ),
-        external_send_keys AS MATERIALIZED (
-            SELECT
-                b.created,
-                COALESCE(b.expiry_height, -1) AS expiry_key
-            FROM base b
-            JOIN output_summary os ON os.txid = b.txid
-            WHERE b.created IS NOT NULL
-              AND os.has_external_transparent_send = 1
-            GROUP BY b.created, COALESCE(b.expiry_height, -1)
-        )
-        SELECT
-            b.txid,
-            b.mined_height,
-            b.expired_unmined,
-            b.account_balance_delta,
-            b.fee_paid,
-            b.block_time,
-            COALESCE(os.is_transparent, 0) AS is_transparent,
-            b.total_spent,
-            b.total_received,
-            b.is_shielding,
-            COALESCE(os.external_sent_amount, 0) AS external_sent_amount,
-            COALESCE(os.external_received_amount, 0) AS external_received_amount,
-            COALESCE(os.display_has_transparent, 0) AS display_has_transparent,
-            COALESCE(os.display_has_shielded, 0) AS display_has_shielded,
-            b.created_time
-        FROM base b
-        LEFT JOIN output_summary os ON os.txid = b.txid
-        LEFT JOIN external_send_keys esk
-          ON esk.created = b.created
-         AND esk.expiry_key = COALESCE(b.expiry_height, -1)
-        WHERE NOT (
-            b.is_shielding = 0
-            AND b.total_spent > 0
-            AND b.total_received > 0
-            AND COALESCE(b.account_balance_delta, 0) <= 0
-            AND b.created IS NOT NULL
-            AND COALESCE(os.has_external_display_output, 0) = 0
-            AND COALESCE(os.has_own_transparent_output, 0) = 1
-            AND esk.created IS NOT NULL
-        )
-        ORDER BY COALESCE(b.mined_height, 999999999) DESC, b.tx_index DESC
-        LIMIT ?2
-    "#;
-    let limit_param = limit.map(i64::from).unwrap_or(-1);
-    let mut stmt = conn.prepare(sql).map_err(|e| format!("SQL error: {e}"))?;
+    let read_tx = conn
+        .unchecked_transaction()
+        .map_err(|e| format!("SQL error: {e}"))?;
+    let bases = read_history_bases(&read_tx, &uuid_bytes)?;
+    if bases.is_empty() {
+        return Ok(Vec::new());
+    }
 
-    let map_row = |row: &rusqlite::Row| -> rusqlite::Result<TransactionInfo> {
-        let txid_blob: Vec<u8> = row.get(0)?;
-        let mined_height: Option<u32> = row.get(1)?;
-        let expired_unmined: bool = row.get(2)?;
-        let balance_delta: i64 = row.get(3)?;
-        let fee: u64 = row.get::<_, i64>(4)?.unsigned_abs();
-        let block_time: u64 = row.get::<_, i64>(5)?.unsigned_abs();
-        let is_transparent: bool = row.get(6)?;
-        let total_spent = row.get::<_, i64>(7)?.unsigned_abs();
-        let total_received = row.get::<_, i64>(8)?.unsigned_abs();
-        let is_shielding: bool = row.get(9)?;
-        let external_sent_amount = row.get::<_, i64>(10)?.unsigned_abs();
-        let external_received_amount = row.get::<_, i64>(11)?.unsigned_abs();
-        let display_has_transparent: bool = row.get(12)?;
-        let display_has_shielded: bool = row.get(13)?;
-        let created_time = row.get::<_, i64>(14)?.unsigned_abs();
-
-        let display_pool = if is_shielding {
-            "shielded"
-        } else {
-            match (display_has_transparent, display_has_shielded) {
-                (true, false) => "transparent",
-                (false, true) => "shielded",
-                (true, true) => "mixed",
-                (false, false) => "unknown",
-            }
-        }
-        .to_string();
-
-        let (tx_kind, display_amount) = if is_shielding {
-            ("shielded", total_received)
-        } else if external_sent_amount > 0 {
-            ("sent", external_sent_amount)
-        } else if external_received_amount > 0 {
-            ("received", external_received_amount)
-        } else if total_spent > 0 && total_received > 0 {
-            ("internal", total_received)
-        } else if balance_delta > 0 {
-            ("received", balance_delta as u64)
-        } else {
-            ("unknown", 0)
-        };
-
-        Ok(TransactionInfo {
-            txid_hex: hex::encode(&txid_blob),
-            mined_height: mined_height.unwrap_or(0) as u64,
-            expired_unmined,
-            account_balance_delta: balance_delta,
-            fee,
-            block_time,
-            is_transparent,
-            tx_kind: tx_kind.to_string(),
-            display_amount,
-            display_pool,
-            created_time,
+    let outputs_by_txid = read_history_outputs(&read_tx, &uuid_bytes)?;
+    let summaries: HashMap<Vec<u8>, OutputSummary> = bases
+        .iter()
+        .map(|base| {
+            let outputs = outputs_by_txid
+                .get(&base.txid)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            (
+                base.txid.clone(),
+                summarize_outputs(outputs, uuid_bytes.as_slice()),
+            )
         })
-    };
+        .collect();
+    let external_send_keys = build_external_send_keys(&bases, &summaries);
+
+    let mut visible = bases
+        .iter()
+        .filter_map(|base| {
+            let summary = summaries.get(&base.txid).cloned().unwrap_or_default();
+            if should_suppress_funding_step(base, &summary, &external_send_keys) {
+                None
+            } else {
+                Some(classify_history_tx(base, &summary))
+            }
+        })
+        .collect::<Vec<_>>();
+
+    visible.sort_by(|a, b| {
+        b.sort_timestamp
+            .cmp(&a.sort_timestamp)
+            .then_with(|| b.sort_mined_height.cmp(&a.sort_mined_height))
+            .then_with(|| b.tx_index.cmp(&a.tx_index))
+            .then_with(|| b.info.txid_hex.cmp(&a.info.txid_hex))
+    });
+
+    if let Some(limit) = limit {
+        visible.truncate(limit as usize);
+    }
+
+    Ok(visible.into_iter().map(|tx| tx.info).collect())
+}
+
+fn read_history_bases(
+    conn: &rusqlite::Connection,
+    account_uuid: &[u8],
+) -> Result<Vec<TxBase>, String> {
+    let mut stmt = conn
+        .prepare(
+            r#"
+        SELECT
+            vt.txid,
+            vt.mined_height,
+            vt.expired_unmined,
+            vt.account_balance_delta,
+            COALESCE(vt.fee_paid, 0) AS fee_paid,
+            COALESCE(vt.block_time, 0) AS block_time,
+            COALESCE(vt.total_spent, 0) AS total_spent,
+            COALESCE(vt.total_received, 0) AS total_received,
+            COALESCE(vt.is_shielding, 0) AS is_shielding,
+            vt.expiry_height,
+            COALESCE(vt.tx_index, -1) AS tx_index,
+            tx.created,
+            CAST(COALESCE(strftime('%s', tx.created), 0) AS INTEGER) AS created_time
+        FROM v_transactions vt
+        LEFT JOIN transactions tx ON tx.txid = vt.txid
+        WHERE vt.account_uuid = ?1
+        "#,
+        )
+        .map_err(|e| format!("SQL error: {e}"))?;
 
     let rows = stmt
-        .query_map(rusqlite::params![&uuid_bytes, limit_param], map_row)
+        .query_map(rusqlite::params![account_uuid], |row| {
+            Ok(TxBase {
+                txid: row.get(0)?,
+                mined_height: row.get(1)?,
+                expired_unmined: row.get(2)?,
+                account_balance_delta: row.get(3)?,
+                fee: row.get::<_, i64>(4)?.unsigned_abs(),
+                block_time: row.get::<_, i64>(5)?.unsigned_abs(),
+                total_spent: row.get::<_, i64>(6)?.unsigned_abs(),
+                total_received: row.get::<_, i64>(7)?.unsigned_abs(),
+                is_shielding: row.get(8)?,
+                expiry_height: row.get(9)?,
+                tx_index: row.get(10)?,
+                created: row.get(11)?,
+                created_time: row.get::<_, i64>(12)?.unsigned_abs(),
+            })
+        })
         .map_err(|e| format!("Query error: {e}"))?;
 
     rows.collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("Row error: {e}"))
+}
+
+fn read_history_outputs(
+    conn: &rusqlite::Connection,
+    account_uuid: &[u8],
+) -> Result<HashMap<Vec<u8>, Vec<TxOutput>>, String> {
+    let mut stmt = conn
+        .prepare(
+            r#"
+        SELECT
+            txo.txid,
+            txo.output_pool,
+            txo.from_account_uuid,
+            txo.to_account_uuid,
+            txo.value,
+            txo.is_change
+        FROM v_tx_outputs txo
+        JOIN (
+            SELECT DISTINCT txid
+            FROM v_transactions
+            WHERE account_uuid = ?1
+        ) active_tx ON active_tx.txid = txo.txid
+        WHERE txo.from_account_uuid = ?1
+           OR txo.to_account_uuid = ?1
+        "#,
+        )
+        .map_err(|e| format!("SQL error: {e}"))?;
+
+    let rows = stmt
+        .query_map(rusqlite::params![account_uuid], |row| {
+            Ok(TxOutput {
+                txid: row.get(0)?,
+                output_pool: row.get(1)?,
+                from_account_uuid: row.get(2)?,
+                to_account_uuid: row.get(3)?,
+                value: row.get::<_, i64>(4)?.unsigned_abs(),
+                is_change: row.get(5)?,
+            })
+        })
+        .map_err(|e| format!("Query error: {e}"))?;
+
+    let mut outputs = HashMap::<Vec<u8>, Vec<TxOutput>>::new();
+    for row in rows {
+        let output = row.map_err(|e| format!("Row error: {e}"))?;
+        outputs.entry(output.txid.clone()).or_default().push(output);
+    }
+    Ok(outputs)
+}
+
+fn summarize_outputs(outputs: &[TxOutput], account_uuid: &[u8]) -> OutputSummary {
+    let mut summary = OutputSummary::default();
+
+    for output in outputs {
+        let from_own = output.from_account_uuid.as_deref() == Some(account_uuid);
+        let to_own = output.to_account_uuid.as_deref() == Some(account_uuid);
+        let external_send = from_own && output.to_account_uuid.is_none() && !output.is_change;
+        let external_receive = to_own && output.from_account_uuid.is_none() && !output.is_change;
+        let external_display_output = external_send || external_receive;
+
+        if output.output_pool == 0 {
+            summary.is_transparent = true;
+        }
+        if external_send {
+            summary.external_sent_amount =
+                summary.external_sent_amount.saturating_add(output.value);
+        }
+        if external_receive {
+            summary.external_received_amount = summary
+                .external_received_amount
+                .saturating_add(output.value);
+        }
+        if output.output_pool == 0 && external_display_output {
+            summary.display_has_transparent = true;
+        }
+        if matches!(output.output_pool, 2 | 3) && external_display_output {
+            summary.display_has_shielded = true;
+        }
+        if external_display_output {
+            summary.has_external_display_output = true;
+        }
+        if output.output_pool == 0 && from_own && to_own && !output.is_change {
+            summary.has_own_transparent_output = true;
+        }
+        if output.output_pool == 0 && external_send {
+            summary.has_external_transparent_send = true;
+        }
+    }
+
+    summary
+}
+
+fn build_external_send_keys(
+    bases: &[TxBase],
+    summaries: &HashMap<Vec<u8>, OutputSummary>,
+) -> HashSet<(String, i64)> {
+    bases
+        .iter()
+        .filter_map(|base| {
+            let summary = summaries.get(&base.txid)?;
+            if summary.has_external_transparent_send {
+                base.created
+                    .as_ref()
+                    .map(|created| (created.clone(), base.expiry_key()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn should_suppress_funding_step(
+    base: &TxBase,
+    summary: &OutputSummary,
+    external_send_keys: &HashSet<(String, i64)>,
+) -> bool {
+    !base.is_shielding
+        && base.total_spent > 0
+        && base.total_received > 0
+        && base.account_balance_delta <= 0
+        && base.created.is_some()
+        && !summary.has_external_display_output
+        && summary.has_own_transparent_output
+        && external_send_keys
+            .contains(&(base.created.clone().unwrap_or_default(), base.expiry_key()))
+}
+
+fn classify_history_tx(base: &TxBase, summary: &OutputSummary) -> ClassifiedTx {
+    let display_pool = if base.is_shielding {
+        "shielded"
+    } else {
+        match (
+            summary.display_has_transparent,
+            summary.display_has_shielded,
+        ) {
+            (true, false) => "transparent",
+            (false, true) => "shielded",
+            (true, true) => "mixed",
+            (false, false) => "unknown",
+        }
+    };
+
+    let (tx_kind, display_amount) = if base.is_shielding {
+        ("shielded", base.total_received)
+    } else if summary.external_sent_amount > 0 {
+        ("sent", summary.external_sent_amount)
+    } else if summary.external_received_amount > 0 {
+        ("received", summary.external_received_amount)
+    } else if base.total_spent > 0 && base.total_received > 0 {
+        ("internal", base.total_received)
+    } else if base.account_balance_delta > 0 {
+        ("received", base.account_balance_delta as u64)
+    } else {
+        ("unknown", 0)
+    };
+
+    let sort_timestamp = base.display_timestamp();
+    ClassifiedTx {
+        info: TransactionInfo {
+            txid_hex: hex::encode(&base.txid),
+            mined_height: base.mined_height.unwrap_or(0) as u64,
+            expired_unmined: base.expired_unmined,
+            account_balance_delta: base.account_balance_delta,
+            fee: base.fee,
+            block_time: base.block_time,
+            is_transparent: summary.is_transparent,
+            tx_kind: tx_kind.to_string(),
+            display_amount,
+            display_pool: display_pool.to_string(),
+            created_time: base.created_time,
+        },
+        sort_timestamp,
+        sort_mined_height: base.mined_height.unwrap_or(0) as u64,
+        tx_index: base.tx_index,
+    }
+}
+
+impl TxBase {
+    fn expiry_key(&self) -> i64 {
+        self.expiry_height.unwrap_or(-1)
+    }
+
+    fn display_timestamp(&self) -> u64 {
+        if self.block_time > 0 {
+            self.block_time
+        } else {
+            self.created_time
+        }
+    }
 }
 
 // ======================== Pending TX Tracking ========================
@@ -709,7 +818,7 @@ mod tests {
                  total_received INTEGER,
                  is_shielding INTEGER,
                  expiry_height INTEGER,
-                 tx_index INTEGER NOT NULL
+                 tx_index INTEGER
              );
              CREATE TABLE transactions (
                  txid BLOB PRIMARY KEY,
@@ -786,6 +895,24 @@ mod tests {
                  txid, output_pool, from_account_uuid, to_account_uuid, value, is_change
              ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             rusqlite::params![txid, output_pool, from_bytes, to_bytes, value, is_change],
+        )
+        .unwrap();
+    }
+
+    fn mark_expired_unmined(db: &NamedTempFile, txid: &[u8]) {
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        conn.execute(
+            "UPDATE v_transactions SET expired_unmined = 1 WHERE txid = ?1",
+            rusqlite::params![txid],
+        )
+        .unwrap();
+    }
+
+    fn clear_tx_index(db: &NamedTempFile, txid: &[u8]) {
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        conn.execute(
+            "UPDATE v_transactions SET tx_index = NULL WHERE txid = ?1",
+            rusqlite::params![txid],
         )
         .unwrap();
     }
@@ -899,6 +1026,120 @@ mod tests {
         assert_eq!(got[0].txid_hex, hex::encode(internal_tx));
         assert_eq!(got[0].tx_kind, "internal");
         assert_eq!(got[0].display_amount, 18_262_101);
+    }
+
+    #[test]
+    fn history_sorts_by_display_timestamp_before_limit() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let older_failed = fake_txid(0xC1);
+        let newer_internal = fake_txid(0xC2);
+
+        insert_history_tx(
+            &db,
+            account,
+            &older_failed,
+            None,
+            2,
+            Some(1_000_100),
+            -10_010_000,
+            10_010_000,
+            0,
+            false,
+            Some("2026-04-28T13:04:00Z"),
+        );
+        mark_expired_unmined(&db, &older_failed);
+        insert_output(
+            &db,
+            &older_failed,
+            0,
+            Some(account),
+            None,
+            10_000_000,
+            false,
+        );
+
+        insert_history_tx(
+            &db,
+            account,
+            &newer_internal,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -40_000,
+            17_040_000,
+            17_000_000,
+            false,
+            Some("2026-04-28T16:32:00Z"),
+        );
+        insert_output(
+            &db,
+            &newer_internal,
+            0,
+            Some(account),
+            Some(account),
+            17_000_000,
+            false,
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].txid_hex, hex::encode(newer_internal));
+        assert_eq!(got[1].txid_hex, hex::encode(older_failed));
+        assert!(got[1].expired_unmined);
+
+        let limited = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            Some(1),
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(limited.len(), 1);
+        assert_eq!(limited[0].txid_hex, hex::encode(newer_internal));
+    }
+
+    #[test]
+    fn history_accepts_unmined_tx_with_null_tx_index() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let txid = fake_txid(0xD1);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            None,
+            0,
+            Some(1_000_100),
+            -10_010_000,
+            10_010_000,
+            0,
+            false,
+            Some("2026-04-28T13:04:00Z"),
+        );
+        clear_tx_index(&db, &txid);
+        insert_output(&db, &txid, 0, Some(account), None, 10_000_000, false);
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].txid_hex, hex::encode(txid));
+        assert_eq!(got[0].tx_kind, "sent");
     }
 
     #[test]

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -440,8 +440,8 @@ fn summarize_outputs(outputs: &[TxOutput], account_uuid: &[u8]) -> OutputSummary
     for output in outputs {
         let from_own = output.from_account_uuid.as_deref() == Some(account_uuid);
         let to_own = output.to_account_uuid.as_deref() == Some(account_uuid);
-        let external_send = from_own && output.to_account_uuid.is_none() && !output.is_change;
-        let external_receive = to_own && output.from_account_uuid.is_none() && !output.is_change;
+        let external_send = from_own && !to_own && !output.is_change;
+        let external_receive = to_own && !from_own && !output.is_change;
         let external_display_output = external_send || external_receive;
 
         if output.output_pool == 0 {
@@ -817,6 +817,10 @@ mod tests {
         uuid::Uuid::from_u128(0x7e2b16db08384ddba8026fd48b9e0d02)
     }
 
+    fn second_test_account_uuid() -> uuid::Uuid {
+        uuid::Uuid::from_u128(0x3eb4ded306b74bf2a5393f1b78d792a6)
+    }
+
     fn fresh_history_db() -> NamedTempFile {
         let file = NamedTempFile::new().unwrap();
         let conn = rusqlite::Connection::open(file.path()).unwrap();
@@ -1041,6 +1045,94 @@ mod tests {
         assert_eq!(got[0].txid_hex, hex::encode(internal_tx));
         assert_eq!(got[0].tx_kind, "internal");
         assert_eq!(got[0].display_amount, 18_262_101);
+    }
+
+    #[test]
+    fn history_treats_send_to_other_local_account_as_sent() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let other_account = second_test_account_uuid();
+        let txid = fake_txid(0xB2);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -5_000_000,
+            5_000_000,
+            0,
+            false,
+            Some("2026-04-28T14:03:00Z"),
+        );
+        insert_output(
+            &db,
+            &txid,
+            0,
+            Some(account),
+            Some(other_account),
+            5_000_000,
+            false,
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].txid_hex, hex::encode(txid));
+        assert_eq!(got[0].tx_kind, "sent");
+        assert_eq!(got[0].display_amount, 5_000_000);
+    }
+
+    #[test]
+    fn history_treats_receive_from_other_local_account_as_received() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let other_account = second_test_account_uuid();
+        let txid = fake_txid(0xB3);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            5_000_000,
+            0,
+            5_000_000,
+            false,
+            Some("2026-04-28T14:04:00Z"),
+        );
+        insert_output(
+            &db,
+            &txid,
+            0,
+            Some(other_account),
+            Some(account),
+            5_000_000,
+            false,
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].txid_hex, hex::encode(txid));
+        assert_eq!(got[0].tx_kind, "received");
+        assert_eq!(got[0].display_amount, 5_000_000);
     }
 
     #[test]

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -258,6 +258,7 @@ struct OutputSummary {
     external_received_amount: u64,
     display_has_transparent: bool,
     display_has_shielded: bool,
+    own_non_change_amount: u64,
     has_external_display_output: bool,
     has_own_transparent_output: bool,
     has_external_transparent_send: bool,
@@ -309,7 +310,9 @@ pub fn get_transaction_history(
         .iter()
         .filter_map(|base| {
             let summary = summaries.get(&base.txid).cloned().unwrap_or_default();
-            if should_suppress_funding_step(base, &summary, &external_send_keys) {
+            if should_suppress_funding_step(base, &summary, &external_send_keys)
+                || should_suppress_change_only_internal(base, &summary)
+            {
                 None
             } else {
                 Some(classify_history_tx(base, &summary))
@@ -462,6 +465,10 @@ fn summarize_outputs(outputs: &[TxOutput], account_uuid: &[u8]) -> OutputSummary
         if external_display_output {
             summary.has_external_display_output = true;
         }
+        if from_own && to_own && !output.is_change {
+            summary.own_non_change_amount =
+                summary.own_non_change_amount.saturating_add(output.value);
+        }
         if output.output_pool == 0 && from_own && to_own && !output.is_change {
             summary.has_own_transparent_output = true;
         }
@@ -508,6 +515,14 @@ fn should_suppress_funding_step(
             .contains(&(base.created.clone().unwrap_or_default(), base.expiry_key()))
 }
 
+fn should_suppress_change_only_internal(base: &TxBase, summary: &OutputSummary) -> bool {
+    !base.is_shielding
+        && base.total_spent > 0
+        && base.total_received > 0
+        && !summary.has_external_display_output
+        && summary.own_non_change_amount == 0
+}
+
 fn classify_history_tx(base: &TxBase, summary: &OutputSummary) -> ClassifiedTx {
     let display_pool = if base.is_shielding {
         "shielded"
@@ -530,7 +545,7 @@ fn classify_history_tx(base: &TxBase, summary: &OutputSummary) -> ClassifiedTx {
     } else if summary.external_received_amount > 0 {
         ("received", summary.external_received_amount)
     } else if base.total_spent > 0 && base.total_received > 0 {
-        ("internal", base.total_received)
+        ("internal", summary.own_non_change_amount)
     } else if base.account_balance_delta > 0 {
         ("received", base.account_balance_delta as u64)
     } else {
@@ -1026,6 +1041,107 @@ mod tests {
         assert_eq!(got[0].txid_hex, hex::encode(internal_tx));
         assert_eq!(got[0].tx_kind, "internal");
         assert_eq!(got[0].display_amount, 18_262_101);
+    }
+
+    #[test]
+    fn history_internal_amount_excludes_change_outputs() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let internal_tx = fake_txid(0xC0);
+
+        insert_history_tx(
+            &db,
+            account,
+            &internal_tx,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -15_000,
+            17_252_101,
+            17_237_101,
+            false,
+            Some("2026-04-28T16:32:00Z"),
+        );
+        insert_output(
+            &db,
+            &internal_tx,
+            0,
+            Some(account),
+            Some(account),
+            1_000_000,
+            false,
+        );
+        insert_output(
+            &db,
+            &internal_tx,
+            3,
+            Some(account),
+            Some(account),
+            16_237_101,
+            true,
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].txid_hex, hex::encode(internal_tx));
+        assert_eq!(got[0].tx_kind, "internal");
+        assert_eq!(got[0].display_amount, 1_000_000);
+    }
+
+    #[test]
+    fn history_hides_change_only_internal_tx() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let change_only_tx = fake_txid(0xC3);
+
+        insert_history_tx(
+            &db,
+            account,
+            &change_only_tx,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -10_000,
+            17_252_102,
+            17_242_102,
+            false,
+            Some("2026-04-28T15:43:00Z"),
+        );
+        insert_output(
+            &db,
+            &change_only_tx,
+            3,
+            Some(account),
+            Some(account),
+            7_242_102,
+            true,
+        );
+        insert_output(
+            &db,
+            &change_only_tx,
+            3,
+            Some(account),
+            Some(account),
+            10_000_000,
+            true,
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert!(got.is_empty());
     }
 
     #[test]

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -234,205 +234,167 @@ pub fn get_transaction_history(
 
     // Open a separate read-only connection (WalletDb.conn is private).
     let conn = open_readonly_conn(db_path)?;
-    let sql = match limit {
-        Some(_) => {
-            "SELECT vt.txid, vt.mined_height, vt.expired_unmined, vt.account_balance_delta, \
-             COALESCE(vt.fee_paid, 0), COALESCE(vt.block_time, 0), \
-             EXISTS( \
-                 SELECT 1 \
-                 FROM v_tx_outputs txo \
-                 WHERE txo.txid = vt.txid \
-                   AND txo.output_pool = 0 \
-                   AND (txo.from_account_uuid = vt.account_uuid OR txo.to_account_uuid = vt.account_uuid) \
-             ) AS is_transparent, \
-             COALESCE(vt.total_spent, 0) AS total_spent, \
-             COALESCE(vt.total_received, 0) AS total_received, \
-             COALESCE(vt.is_shielding, 0) AS is_shielding, \
-             COALESCE(( \
-                 SELECT SUM(txo.value) \
-                 FROM v_tx_outputs txo \
-                 WHERE txo.txid = vt.txid \
-                   AND txo.from_account_uuid = vt.account_uuid \
-                   AND txo.to_account_uuid IS NULL \
-                   AND txo.is_change = 0 \
-             ), 0) AS external_sent_amount, \
-             COALESCE(( \
-                 SELECT SUM(txo.value) \
-                 FROM v_tx_outputs txo \
-                 WHERE txo.txid = vt.txid \
-                   AND txo.to_account_uuid = vt.account_uuid \
-                   AND txo.from_account_uuid IS NULL \
-                   AND txo.is_change = 0 \
-             ), 0) AS external_received_amount, \
-             EXISTS( \
-                 SELECT 1 \
-                 FROM v_tx_outputs txo \
-                 WHERE txo.txid = vt.txid \
-                   AND txo.output_pool = 0 \
-                   AND ( \
-                       (txo.from_account_uuid = vt.account_uuid AND txo.to_account_uuid IS NULL AND txo.is_change = 0) \
-                       OR (txo.to_account_uuid = vt.account_uuid AND txo.from_account_uuid IS NULL AND txo.is_change = 0) \
-                   ) \
-             ) AS display_has_transparent, \
-             EXISTS( \
-                 SELECT 1 \
-                 FROM v_tx_outputs txo \
-                 WHERE txo.txid = vt.txid \
-                   AND txo.output_pool IN (2, 3) \
-                   AND ( \
-                       (txo.from_account_uuid = vt.account_uuid AND txo.to_account_uuid IS NULL AND txo.is_change = 0) \
-                       OR (txo.to_account_uuid = vt.account_uuid AND txo.from_account_uuid IS NULL AND txo.is_change = 0) \
-                   ) \
-             ) AS display_has_shielded, \
-             CAST(COALESCE(strftime('%s', tx.created), 0) AS INTEGER) AS created_time \
-             FROM v_transactions vt \
-             LEFT JOIN transactions tx ON tx.txid = vt.txid \
-             WHERE vt.account_uuid = ?1 \
-               AND NOT ( \
-                   COALESCE(vt.is_shielding, 0) = 0 \
-                   AND COALESCE(vt.total_spent, 0) > 0 \
-                   AND COALESCE(vt.total_received, 0) > 0 \
-                   AND COALESCE(vt.account_balance_delta, 0) <= 0 \
-                   AND tx.created IS NOT NULL \
-                   AND NOT EXISTS ( \
-                       SELECT 1 \
-                       FROM v_tx_outputs txo \
-                       WHERE txo.txid = vt.txid \
-                         AND ( \
-                             (txo.from_account_uuid = vt.account_uuid AND txo.to_account_uuid IS NULL AND txo.is_change = 0) \
-                             OR (txo.to_account_uuid = vt.account_uuid AND txo.from_account_uuid IS NULL AND txo.is_change = 0) \
-                         ) \
-                   ) \
-                   AND EXISTS ( \
-                       SELECT 1 \
-                       FROM v_tx_outputs txo \
-                       WHERE txo.txid = vt.txid \
-                         AND txo.output_pool = 0 \
-                         AND txo.from_account_uuid = vt.account_uuid \
-                         AND txo.to_account_uuid = vt.account_uuid \
-                         AND txo.is_change = 0 \
-                   ) \
-                   AND EXISTS ( \
-                       SELECT 1 \
-                       FROM v_transactions sibling_vt \
-                       JOIN transactions sibling_tx ON sibling_tx.txid = sibling_vt.txid \
-                       WHERE sibling_vt.account_uuid = vt.account_uuid \
-                         AND sibling_vt.txid != vt.txid \
-                         AND sibling_tx.created = tx.created \
-                         AND COALESCE(sibling_vt.expiry_height, -1) = COALESCE(vt.expiry_height, -1) \
-                         AND EXISTS ( \
-                             SELECT 1 \
-                             FROM v_tx_outputs sibling_txo \
-                             WHERE sibling_txo.txid = sibling_vt.txid \
-                               AND sibling_txo.output_pool = 0 \
-                               AND sibling_txo.from_account_uuid = sibling_vt.account_uuid \
-                               AND sibling_txo.to_account_uuid IS NULL \
-                               AND sibling_txo.is_change = 0 \
-                         ) \
-                   ) \
-               ) \
-             ORDER BY COALESCE(vt.mined_height, 999999999) DESC, vt.tx_index DESC \
-             LIMIT ?2"
-        }
-        None => {
-            "SELECT vt.txid, vt.mined_height, vt.expired_unmined, vt.account_balance_delta, \
-             COALESCE(vt.fee_paid, 0), COALESCE(vt.block_time, 0), \
-             EXISTS( \
-                 SELECT 1 \
-                 FROM v_tx_outputs txo \
-                 WHERE txo.txid = vt.txid \
-                   AND txo.output_pool = 0 \
-                   AND (txo.from_account_uuid = vt.account_uuid OR txo.to_account_uuid = vt.account_uuid) \
-             ) AS is_transparent, \
-             COALESCE(vt.total_spent, 0) AS total_spent, \
-             COALESCE(vt.total_received, 0) AS total_received, \
-             COALESCE(vt.is_shielding, 0) AS is_shielding, \
-             COALESCE(( \
-                 SELECT SUM(txo.value) \
-                 FROM v_tx_outputs txo \
-                 WHERE txo.txid = vt.txid \
-                   AND txo.from_account_uuid = vt.account_uuid \
-                   AND txo.to_account_uuid IS NULL \
-                   AND txo.is_change = 0 \
-             ), 0) AS external_sent_amount, \
-             COALESCE(( \
-                 SELECT SUM(txo.value) \
-                 FROM v_tx_outputs txo \
-                 WHERE txo.txid = vt.txid \
-                   AND txo.to_account_uuid = vt.account_uuid \
-                   AND txo.from_account_uuid IS NULL \
-                   AND txo.is_change = 0 \
-             ), 0) AS external_received_amount, \
-             EXISTS( \
-                 SELECT 1 \
-                 FROM v_tx_outputs txo \
-                 WHERE txo.txid = vt.txid \
-                   AND txo.output_pool = 0 \
-                   AND ( \
-                       (txo.from_account_uuid = vt.account_uuid AND txo.to_account_uuid IS NULL AND txo.is_change = 0) \
-                       OR (txo.to_account_uuid = vt.account_uuid AND txo.from_account_uuid IS NULL AND txo.is_change = 0) \
-                   ) \
-             ) AS display_has_transparent, \
-             EXISTS( \
-                 SELECT 1 \
-                 FROM v_tx_outputs txo \
-                 WHERE txo.txid = vt.txid \
-                   AND txo.output_pool IN (2, 3) \
-                   AND ( \
-                       (txo.from_account_uuid = vt.account_uuid AND txo.to_account_uuid IS NULL AND txo.is_change = 0) \
-                       OR (txo.to_account_uuid = vt.account_uuid AND txo.from_account_uuid IS NULL AND txo.is_change = 0) \
-                   ) \
-             ) AS display_has_shielded, \
-             CAST(COALESCE(strftime('%s', tx.created), 0) AS INTEGER) AS created_time \
-             FROM v_transactions vt \
-             LEFT JOIN transactions tx ON tx.txid = vt.txid \
-             WHERE vt.account_uuid = ?1 \
-               AND NOT ( \
-                   COALESCE(vt.is_shielding, 0) = 0 \
-                   AND COALESCE(vt.total_spent, 0) > 0 \
-                   AND COALESCE(vt.total_received, 0) > 0 \
-                   AND COALESCE(vt.account_balance_delta, 0) <= 0 \
-                   AND tx.created IS NOT NULL \
-                   AND NOT EXISTS ( \
-                       SELECT 1 \
-                       FROM v_tx_outputs txo \
-                       WHERE txo.txid = vt.txid \
-                         AND ( \
-                             (txo.from_account_uuid = vt.account_uuid AND txo.to_account_uuid IS NULL AND txo.is_change = 0) \
-                             OR (txo.to_account_uuid = vt.account_uuid AND txo.from_account_uuid IS NULL AND txo.is_change = 0) \
-                         ) \
-                   ) \
-                   AND EXISTS ( \
-                       SELECT 1 \
-                       FROM v_tx_outputs txo \
-                       WHERE txo.txid = vt.txid \
-                         AND txo.output_pool = 0 \
-                         AND txo.from_account_uuid = vt.account_uuid \
-                         AND txo.to_account_uuid = vt.account_uuid \
-                         AND txo.is_change = 0 \
-                   ) \
-                   AND EXISTS ( \
-                       SELECT 1 \
-                       FROM v_transactions sibling_vt \
-                       JOIN transactions sibling_tx ON sibling_tx.txid = sibling_vt.txid \
-                       WHERE sibling_vt.account_uuid = vt.account_uuid \
-                         AND sibling_vt.txid != vt.txid \
-                         AND sibling_tx.created = tx.created \
-                         AND COALESCE(sibling_vt.expiry_height, -1) = COALESCE(vt.expiry_height, -1) \
-                         AND EXISTS ( \
-                             SELECT 1 \
-                             FROM v_tx_outputs sibling_txo \
-                             WHERE sibling_txo.txid = sibling_vt.txid \
-                               AND sibling_txo.output_pool = 0 \
-                               AND sibling_txo.from_account_uuid = sibling_vt.account_uuid \
-                               AND sibling_txo.to_account_uuid IS NULL \
-                               AND sibling_txo.is_change = 0 \
-                         ) \
-                   ) \
-               ) \
-             ORDER BY COALESCE(vt.mined_height, 999999999) DESC, vt.tx_index DESC"
-        }
-    };
+    // Force materialization so SQLite does not repeatedly inline the SDK views.
+    let sql = r#"
+        WITH
+        base AS MATERIALIZED (
+            SELECT
+                vt.account_uuid,
+                vt.txid,
+                vt.mined_height,
+                vt.expired_unmined,
+                vt.account_balance_delta,
+                COALESCE(vt.fee_paid, 0) AS fee_paid,
+                COALESCE(vt.block_time, 0) AS block_time,
+                COALESCE(vt.total_spent, 0) AS total_spent,
+                COALESCE(vt.total_received, 0) AS total_received,
+                COALESCE(vt.is_shielding, 0) AS is_shielding,
+                vt.expiry_height,
+                vt.tx_index,
+                tx.created,
+                CAST(COALESCE(strftime('%s', tx.created), 0) AS INTEGER) AS created_time
+            FROM v_transactions vt
+            LEFT JOIN transactions tx ON tx.txid = vt.txid
+            WHERE vt.account_uuid = ?1
+        ),
+        base_keys AS MATERIALIZED (
+            SELECT DISTINCT txid, account_uuid
+            FROM base
+        ),
+        account_outputs AS MATERIALIZED (
+            SELECT txo.*
+            FROM v_tx_outputs txo
+            JOIN base_keys bk ON bk.txid = txo.txid
+            WHERE txo.from_account_uuid = bk.account_uuid
+               OR txo.to_account_uuid = bk.account_uuid
+        ),
+        output_summary AS MATERIALIZED (
+            SELECT
+                b.txid,
+                MAX(CASE
+                    WHEN txo.output_pool = 0
+                    THEN 1 ELSE 0
+                END) AS is_transparent,
+                COALESCE(SUM(CASE
+                    WHEN txo.from_account_uuid = b.account_uuid
+                     AND txo.to_account_uuid IS NULL
+                     AND txo.is_change = 0
+                    THEN txo.value ELSE 0
+                END), 0) AS external_sent_amount,
+                COALESCE(SUM(CASE
+                    WHEN txo.to_account_uuid = b.account_uuid
+                     AND txo.from_account_uuid IS NULL
+                     AND txo.is_change = 0
+                    THEN txo.value ELSE 0
+                END), 0) AS external_received_amount,
+                MAX(CASE
+                    WHEN txo.output_pool = 0
+                     AND (
+                         (
+                             txo.from_account_uuid = b.account_uuid
+                             AND txo.to_account_uuid IS NULL
+                             AND txo.is_change = 0
+                         )
+                         OR (
+                             txo.to_account_uuid = b.account_uuid
+                             AND txo.from_account_uuid IS NULL
+                             AND txo.is_change = 0
+                         )
+                     )
+                    THEN 1 ELSE 0
+                END) AS display_has_transparent,
+                MAX(CASE
+                    WHEN txo.output_pool IN (2, 3)
+                     AND (
+                         (
+                             txo.from_account_uuid = b.account_uuid
+                             AND txo.to_account_uuid IS NULL
+                             AND txo.is_change = 0
+                         )
+                         OR (
+                             txo.to_account_uuid = b.account_uuid
+                             AND txo.from_account_uuid IS NULL
+                             AND txo.is_change = 0
+                         )
+                     )
+                    THEN 1 ELSE 0
+                END) AS display_has_shielded,
+                MAX(CASE
+                    WHEN (
+                         txo.from_account_uuid = b.account_uuid
+                         AND txo.to_account_uuid IS NULL
+                         AND txo.is_change = 0
+                    )
+                    OR (
+                         txo.to_account_uuid = b.account_uuid
+                         AND txo.from_account_uuid IS NULL
+                         AND txo.is_change = 0
+                    )
+                    THEN 1 ELSE 0
+                END) AS has_external_display_output,
+                MAX(CASE
+                    WHEN txo.output_pool = 0
+                     AND txo.from_account_uuid = b.account_uuid
+                     AND txo.to_account_uuid = b.account_uuid
+                     AND txo.is_change = 0
+                    THEN 1 ELSE 0
+                END) AS has_own_transparent_output,
+                MAX(CASE
+                    WHEN txo.output_pool = 0
+                     AND txo.from_account_uuid = b.account_uuid
+                     AND txo.to_account_uuid IS NULL
+                     AND txo.is_change = 0
+                    THEN 1 ELSE 0
+                END) AS has_external_transparent_send
+            FROM base b
+            LEFT JOIN account_outputs txo ON txo.txid = b.txid
+            GROUP BY b.txid
+        ),
+        external_send_keys AS MATERIALIZED (
+            SELECT
+                b.created,
+                COALESCE(b.expiry_height, -1) AS expiry_key
+            FROM base b
+            JOIN output_summary os ON os.txid = b.txid
+            WHERE b.created IS NOT NULL
+              AND os.has_external_transparent_send = 1
+            GROUP BY b.created, COALESCE(b.expiry_height, -1)
+        )
+        SELECT
+            b.txid,
+            b.mined_height,
+            b.expired_unmined,
+            b.account_balance_delta,
+            b.fee_paid,
+            b.block_time,
+            COALESCE(os.is_transparent, 0) AS is_transparent,
+            b.total_spent,
+            b.total_received,
+            b.is_shielding,
+            COALESCE(os.external_sent_amount, 0) AS external_sent_amount,
+            COALESCE(os.external_received_amount, 0) AS external_received_amount,
+            COALESCE(os.display_has_transparent, 0) AS display_has_transparent,
+            COALESCE(os.display_has_shielded, 0) AS display_has_shielded,
+            b.created_time
+        FROM base b
+        LEFT JOIN output_summary os ON os.txid = b.txid
+        LEFT JOIN external_send_keys esk
+          ON esk.created = b.created
+         AND esk.expiry_key = COALESCE(b.expiry_height, -1)
+        WHERE NOT (
+            b.is_shielding = 0
+            AND b.total_spent > 0
+            AND b.total_received > 0
+            AND COALESCE(b.account_balance_delta, 0) <= 0
+            AND b.created IS NOT NULL
+            AND COALESCE(os.has_external_display_output, 0) = 0
+            AND COALESCE(os.has_own_transparent_output, 0) = 1
+            AND esk.created IS NOT NULL
+        )
+        ORDER BY COALESCE(b.mined_height, 999999999) DESC, b.tx_index DESC
+        LIMIT ?2
+    "#;
+    let limit_param = limit.map(i64::from).unwrap_or(-1);
     let mut stmt = conn.prepare(sql).map_err(|e| format!("SQL error: {e}"))?;
 
     let map_row = |row: &rusqlite::Row| -> rusqlite::Result<TransactionInfo> {
@@ -493,12 +455,9 @@ pub fn get_transaction_history(
         })
     };
 
-    let rows = if let Some(n) = limit {
-        stmt.query_map(rusqlite::params![&uuid_bytes, n], map_row)
-    } else {
-        stmt.query_map(rusqlite::params![&uuid_bytes], map_row)
-    }
-    .map_err(|e| format!("Query error: {e}"))?;
+    let rows = stmt
+        .query_map(rusqlite::params![&uuid_bytes, limit_param], map_row)
+        .map_err(|e| format!("Query error: {e}"))?;
 
     rows.collect::<Result<Vec<_>, _>>()
         .map_err(|e| format!("Row error: {e}"))
@@ -728,6 +687,218 @@ mod tests {
 
     fn fake_raw() -> Vec<u8> {
         vec![0xDE, 0xAD, 0xBE, 0xEF]
+    }
+
+    fn test_account_uuid() -> uuid::Uuid {
+        uuid::Uuid::from_u128(0x7e2b16db08384ddba8026fd48b9e0d02)
+    }
+
+    fn fresh_history_db() -> NamedTempFile {
+        let file = NamedTempFile::new().unwrap();
+        let conn = rusqlite::Connection::open(file.path()).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE v_transactions (
+                 account_uuid BLOB NOT NULL,
+                 txid BLOB NOT NULL,
+                 mined_height INTEGER,
+                 expired_unmined INTEGER NOT NULL,
+                 account_balance_delta INTEGER NOT NULL,
+                 fee_paid INTEGER,
+                 block_time INTEGER,
+                 total_spent INTEGER,
+                 total_received INTEGER,
+                 is_shielding INTEGER,
+                 expiry_height INTEGER,
+                 tx_index INTEGER NOT NULL
+             );
+             CREATE TABLE transactions (
+                 txid BLOB PRIMARY KEY,
+                 created TEXT
+             );
+             CREATE TABLE v_tx_outputs (
+                 txid BLOB NOT NULL,
+                 output_pool INTEGER NOT NULL,
+                 from_account_uuid BLOB,
+                 to_account_uuid BLOB,
+                 value INTEGER NOT NULL,
+                 is_change INTEGER NOT NULL
+             );",
+        )
+        .unwrap();
+        file
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_history_tx(
+        db: &NamedTempFile,
+        account: uuid::Uuid,
+        txid: &[u8],
+        mined_height: Option<i64>,
+        tx_index: i64,
+        expiry_height: Option<i64>,
+        account_balance_delta: i64,
+        total_spent: i64,
+        total_received: i64,
+        is_shielding: bool,
+        created: Option<&str>,
+    ) {
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        conn.execute(
+            "INSERT INTO transactions (txid, created) VALUES (?1, ?2)",
+            rusqlite::params![txid, created],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO v_transactions (
+                 account_uuid, txid, mined_height, expired_unmined,
+                 account_balance_delta, fee_paid, block_time, total_spent,
+                 total_received, is_shielding, expiry_height, tx_index
+             ) VALUES (?1, ?2, ?3, 0, ?4, 0, 0, ?5, ?6, ?7, ?8, ?9)",
+            rusqlite::params![
+                account.as_bytes().as_slice(),
+                txid,
+                mined_height,
+                account_balance_delta,
+                total_spent,
+                total_received,
+                is_shielding,
+                expiry_height,
+                tx_index,
+            ],
+        )
+        .unwrap();
+    }
+
+    fn insert_output(
+        db: &NamedTempFile,
+        txid: &[u8],
+        output_pool: i64,
+        from_account: Option<uuid::Uuid>,
+        to_account: Option<uuid::Uuid>,
+        value: i64,
+        is_change: bool,
+    ) {
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        let from_bytes = from_account.map(|uuid| uuid.as_bytes().to_vec());
+        let to_bytes = to_account.map(|uuid| uuid.as_bytes().to_vec());
+        conn.execute(
+            "INSERT INTO v_tx_outputs (
+                 txid, output_pool, from_account_uuid, to_account_uuid, value, is_change
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            rusqlite::params![txid, output_pool, from_bytes, to_bytes, value, is_change],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn history_suppresses_funding_step_after_limit_filtering() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let external_send = fake_txid(0xA1);
+        let funding_step = fake_txid(0xA2);
+        let created = "2026-04-28T13:03:00Z";
+
+        insert_history_tx(
+            &db,
+            account,
+            &funding_step,
+            None,
+            2,
+            Some(1_000_100),
+            -40_000,
+            18_302_101,
+            18_262_101,
+            false,
+            Some(created),
+        );
+        insert_output(
+            &db,
+            &funding_step,
+            0,
+            Some(account),
+            Some(account),
+            10_010_000,
+            false,
+        );
+
+        insert_history_tx(
+            &db,
+            account,
+            &external_send,
+            None,
+            1,
+            Some(1_000_100),
+            -10_010_000,
+            10_010_000,
+            0,
+            false,
+            Some(created),
+        );
+        insert_output(
+            &db,
+            &external_send,
+            0,
+            Some(account),
+            None,
+            10_000_000,
+            false,
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            Some(1),
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].txid_hex, hex::encode(external_send));
+        assert_eq!(got[0].tx_kind, "sent");
+        assert_eq!(got[0].display_amount, 10_000_000);
+    }
+
+    #[test]
+    fn history_keeps_internal_transfer_without_external_send_sibling() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let internal_tx = fake_txid(0xB1);
+
+        insert_history_tx(
+            &db,
+            account,
+            &internal_tx,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -40_000,
+            18_302_101,
+            18_262_101,
+            false,
+            Some("2026-04-28T13:03:00Z"),
+        );
+        insert_output(
+            &db,
+            &internal_tx,
+            0,
+            Some(account),
+            Some(account),
+            18_262_101,
+            false,
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].txid_hex, hex::encode(internal_tx));
+        assert_eq!(got[0].tx_kind, "internal");
+        assert_eq!(got[0].display_amount, 18_262_101);
     }
 
     #[test]

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -288,6 +288,49 @@ pub fn get_transaction_history(
              FROM v_transactions vt \
              LEFT JOIN transactions tx ON tx.txid = vt.txid \
              WHERE vt.account_uuid = ?1 \
+               AND NOT ( \
+                   COALESCE(vt.is_shielding, 0) = 0 \
+                   AND COALESCE(vt.total_spent, 0) > 0 \
+                   AND COALESCE(vt.total_received, 0) > 0 \
+                   AND COALESCE(vt.account_balance_delta, 0) <= 0 \
+                   AND tx.created IS NOT NULL \
+                   AND NOT EXISTS ( \
+                       SELECT 1 \
+                       FROM v_tx_outputs txo \
+                       WHERE txo.txid = vt.txid \
+                         AND ( \
+                             (txo.from_account_uuid = vt.account_uuid AND txo.to_account_uuid IS NULL AND txo.is_change = 0) \
+                             OR (txo.to_account_uuid = vt.account_uuid AND txo.from_account_uuid IS NULL AND txo.is_change = 0) \
+                         ) \
+                   ) \
+                   AND EXISTS ( \
+                       SELECT 1 \
+                       FROM v_tx_outputs txo \
+                       WHERE txo.txid = vt.txid \
+                         AND txo.output_pool = 0 \
+                         AND txo.from_account_uuid = vt.account_uuid \
+                         AND txo.to_account_uuid = vt.account_uuid \
+                         AND txo.is_change = 0 \
+                   ) \
+                   AND EXISTS ( \
+                       SELECT 1 \
+                       FROM v_transactions sibling_vt \
+                       JOIN transactions sibling_tx ON sibling_tx.txid = sibling_vt.txid \
+                       WHERE sibling_vt.account_uuid = vt.account_uuid \
+                         AND sibling_vt.txid != vt.txid \
+                         AND sibling_tx.created = tx.created \
+                         AND COALESCE(sibling_vt.expiry_height, -1) = COALESCE(vt.expiry_height, -1) \
+                         AND EXISTS ( \
+                             SELECT 1 \
+                             FROM v_tx_outputs sibling_txo \
+                             WHERE sibling_txo.txid = sibling_vt.txid \
+                               AND sibling_txo.output_pool = 0 \
+                               AND sibling_txo.from_account_uuid = sibling_vt.account_uuid \
+                               AND sibling_txo.to_account_uuid IS NULL \
+                               AND sibling_txo.is_change = 0 \
+                         ) \
+                   ) \
+               ) \
              ORDER BY COALESCE(vt.mined_height, 999999999) DESC, vt.tx_index DESC \
              LIMIT ?2"
         }
@@ -344,6 +387,49 @@ pub fn get_transaction_history(
              FROM v_transactions vt \
              LEFT JOIN transactions tx ON tx.txid = vt.txid \
              WHERE vt.account_uuid = ?1 \
+               AND NOT ( \
+                   COALESCE(vt.is_shielding, 0) = 0 \
+                   AND COALESCE(vt.total_spent, 0) > 0 \
+                   AND COALESCE(vt.total_received, 0) > 0 \
+                   AND COALESCE(vt.account_balance_delta, 0) <= 0 \
+                   AND tx.created IS NOT NULL \
+                   AND NOT EXISTS ( \
+                       SELECT 1 \
+                       FROM v_tx_outputs txo \
+                       WHERE txo.txid = vt.txid \
+                         AND ( \
+                             (txo.from_account_uuid = vt.account_uuid AND txo.to_account_uuid IS NULL AND txo.is_change = 0) \
+                             OR (txo.to_account_uuid = vt.account_uuid AND txo.from_account_uuid IS NULL AND txo.is_change = 0) \
+                         ) \
+                   ) \
+                   AND EXISTS ( \
+                       SELECT 1 \
+                       FROM v_tx_outputs txo \
+                       WHERE txo.txid = vt.txid \
+                         AND txo.output_pool = 0 \
+                         AND txo.from_account_uuid = vt.account_uuid \
+                         AND txo.to_account_uuid = vt.account_uuid \
+                         AND txo.is_change = 0 \
+                   ) \
+                   AND EXISTS ( \
+                       SELECT 1 \
+                       FROM v_transactions sibling_vt \
+                       JOIN transactions sibling_tx ON sibling_tx.txid = sibling_vt.txid \
+                       WHERE sibling_vt.account_uuid = vt.account_uuid \
+                         AND sibling_vt.txid != vt.txid \
+                         AND sibling_tx.created = tx.created \
+                         AND COALESCE(sibling_vt.expiry_height, -1) = COALESCE(vt.expiry_height, -1) \
+                         AND EXISTS ( \
+                             SELECT 1 \
+                             FROM v_tx_outputs sibling_txo \
+                             WHERE sibling_txo.txid = sibling_vt.txid \
+                               AND sibling_txo.output_pool = 0 \
+                               AND sibling_txo.from_account_uuid = sibling_vt.account_uuid \
+                               AND sibling_txo.to_account_uuid IS NULL \
+                               AND sibling_txo.is_change = 0 \
+                         ) \
+                   ) \
+               ) \
              ORDER BY COALESCE(vt.mined_height, 999999999) DESC, vt.tx_index DESC"
         }
     };

--- a/test/activity_table_pagination_test.dart
+++ b/test/activity_table_pagination_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/activity/widgets/activity_table.dart';
+
+void main() {
+  testWidgets('pagination keeps tab traversal after focused page is selected', (
+    tester,
+  ) async {
+    var currentPage = 1;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: StatefulBuilder(
+            builder: (context, setState) {
+              return ActivityTablePagination(
+                currentPage: currentPage,
+                totalPages: 3,
+                onPageChanged: (page) {
+                  setState(() {
+                    currentPage = page;
+                  });
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    expect(_primaryFocusContainsText('2'), isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+    expect(currentPage, 2);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    expect(_primaryFocusContainsText('3'), isTrue);
+  });
+}
+
+bool _primaryFocusContainsText(String value) {
+  final context = FocusManager.instance.primaryFocus?.context;
+  if (context == null) return false;
+
+  var found = false;
+  void visit(Element element) {
+    if (found) return;
+    final widget = element.widget;
+    if (widget is Text && widget.data == value) {
+      found = true;
+      return;
+    }
+    element.visitChildren(visit);
+  }
+
+  (context as Element).visitChildren(visit);
+  return found;
+}

--- a/test/activity_table_row_test.dart
+++ b/test/activity_table_row_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/features/activity/models/activity_row_data.dart';
+import 'package:zcash_wallet/src/features/activity/widgets/activity_table.dart';
+
+void main() {
+  testWidgets('transaction rows are keyboard activatable but sync row is not', (
+    tester,
+  ) async {
+    var txActivations = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: ActivityTable(
+            rows: [
+              _row(title: 'Wallet Synced'),
+              _row(
+                title: 'Sent',
+                subtitle: 'Shielded',
+                onTap: () {
+                  txActivations += 1;
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    expect(_primaryFocusContainsText('Wallet Synced'), isFalse);
+    expect(_primaryFocusContainsText('Sent'), isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+    expect(txActivations, 1);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pump();
+    expect(txActivations, 2);
+  });
+}
+
+ActivityRowData _row({
+  required String title,
+  String? subtitle,
+  VoidCallback? onTap,
+}) {
+  return ActivityRowData(
+    title: title,
+    leadingIconName: AppIcons.sync,
+    leadingBackgroundColor: const Color(0xFFE1E1E1),
+    leadingIconColor: const Color(0xFF4D5252),
+    subtitle: subtitle,
+    amountText: '1.00 ZEC',
+    statusText: 'Completed',
+    timestampText: 'Today, 13:11',
+    onTap: onTap,
+  );
+}
+
+bool _primaryFocusContainsText(String value) {
+  final context = FocusManager.instance.primaryFocus?.context;
+  if (context == null) return false;
+
+  var found = false;
+  void visit(Element element) {
+    if (found) return;
+    final widget = element.widget;
+    if (widget is Text && widget.data == value) {
+      found = true;
+      return;
+    }
+    element.visitChildren(visit);
+  }
+
+  (context as Element).visitChildren(visit);
+  return found;
+}

--- a/test/app_loading_icon_test.dart
+++ b/test/app_loading_icon_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/widgets/app_loading_icon.dart';
+
+void main() {
+  test('loader progress is derived from absolute frame time', () {
+    expect(
+      AppLoadingIconTiming.progressForFrameTime(Duration.zero),
+      moreOrLessEquals(0),
+    );
+    expect(
+      AppLoadingIconTiming.progressForFrameTime(
+        AppLoadingIconTiming.period ~/ 2,
+      ),
+      moreOrLessEquals(0.5),
+    );
+    expect(
+      AppLoadingIconTiming.progressForFrameTime(AppLoadingIconTiming.period),
+      moreOrLessEquals(0),
+    );
+    expect(
+      AppLoadingIconTiming.progressForFrameTime(
+        AppLoadingIconTiming.period + AppLoadingIconTiming.period ~/ 2,
+      ),
+      moreOrLessEquals(0.5),
+    );
+  });
+
+  test('loader opacity is deterministic for a shared frame time', () {
+    final progress = AppLoadingIconTiming.progressForFrameTime(
+      const Duration(milliseconds: 1234),
+    );
+
+    final firstLoaderOpacities = List.generate(
+      AppLoadingIconTiming.spokeCount,
+      (index) =>
+          AppLoadingIconTiming.opacityForSpokeAtProgress(index, progress),
+    );
+    final secondLoaderOpacities = List.generate(
+      AppLoadingIconTiming.spokeCount,
+      (index) =>
+          AppLoadingIconTiming.opacityForSpokeAtProgress(index, progress),
+    );
+
+    expect(secondLoaderOpacities, firstLoaderOpacities);
+  });
+}


### PR DESCRIPTION
## Summary
- Replace the old History screen with the Activity screen and shared Activity table used by Home.
- Add synced-wallet row, pagination, row interaction states, failed transaction styling, and transaction-status navigation from Activity/Home rows.
- Move transaction history display classification into Rust so UI receives tx kind, display amount, pool, and created timestamp.
- Refine internal/change handling so own change-only rows are hidden, internal amounts exclude change, and transfers to a different local account are shown as sent/received for the active account.
- Keep loading icon animation timing globally aligned across simultaneous loaders.

## Why
The previous history display mixed raw balance deltas with row-level output details, which made transparent send funding steps and internal/change outputs appear confusingly in the UI. The Activity screen also needed to match the Figma table behavior and reuse the send-status receipt UI for historical transactions.

## Validation
- `fvm flutter test`
- `fvm flutter analyze` (reports existing issues in integration_test imports and background_sync_delegate visible-for-testing use)
- `cd rust && cargo test`
- `cd rust && cargo test history_ -- --nocapture`