### PR TITLE
Settings

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -38,7 +38,13 @@ import UIKit
         #endif
       case "startBackgroundSync":
         if #available(iOS 26.0, *) {
-          let success = BackgroundSyncManager.shared.startBackgroundSync()
+          let args = call.arguments as? [String: Any]
+          let lightwalletdUrl = args?["lightwalletdUrl"] as? String
+          let network = args?["network"] as? String
+          let success = BackgroundSyncManager.shared.startBackgroundSync(
+            lightwalletdUrl: lightwalletdUrl,
+            network: network
+          )
           result(success)
         } else {
           result(false)
@@ -50,9 +56,22 @@ import UIKit
         } else {
           result(false)
         }
+      case "updateEndpoint":
+        let args = call.arguments as? [String: Any]
+        let lightwalletdUrl = args?["lightwalletdUrl"] as? String
+        let network = args?["network"] as? String
+        RpcEndpointConfigStore.save(
+          lightwalletdUrl: lightwalletdUrl,
+          network: network
+        )
+        result(true)
       case "startTxTracking":
         if #available(iOS 26.0, *) {
-          let success = TxTrackManager.shared.startTxTracking()
+          let args = call.arguments as? [String: Any]
+          let lightwalletdUrl = args?["lightwalletdUrl"] as? String
+          let success = TxTrackManager.shared.startTxTracking(
+            lightwalletdUrl: lightwalletdUrl
+          )
           result(success)
         } else {
           result(false)

--- a/ios/Runner/BackgroundSyncManager.swift
+++ b/ios/Runner/BackgroundSyncManager.swift
@@ -124,11 +124,14 @@ class BackgroundSyncManager {
         hb.resume()
         heartbeat = hb
 
+        let lightwalletdUrl = RpcEndpointConfigStore.lightwalletdUrl
+        let network = RpcEndpointConfigStore.network
+
         // C FFI sync — blocks this thread (.utility QoS)
         let result = zcash_run_full_sync(
             dbPath,
-            "https://zec.rocks:443",
-            "main",
+            lightwalletdUrl,
+            network,
             { progress in
                 if #available(iOS 26.0, *) {
                     let mgr = BackgroundSyncManager.shared
@@ -172,7 +175,11 @@ class BackgroundSyncManager {
         try resolveWalletDbPath()
     }
 
-    func startBackgroundSync() -> Bool {
+    func startBackgroundSync(lightwalletdUrl: String? = nil, network: String? = nil) -> Bool {
+        RpcEndpointConfigStore.save(
+            lightwalletdUrl: lightwalletdUrl,
+            network: network
+        )
         print("[BGSync] startBackgroundSync: submitting BGContinuedProcessingTaskRequest")
         let request = BGContinuedProcessingTaskRequest(
             identifier: Self.taskIdentifier,

--- a/ios/Runner/RpcEndpointConfigStore.swift
+++ b/ios/Runner/RpcEndpointConfigStore.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum RpcEndpointConfigStore {
+    // iOS BGTasks cannot read Flutter secure storage directly. These keys are
+    // a native mirror of Dart's RPC endpoint setting; keep defaults in sync
+    // with rpc_endpoint_config.dart.
+    private static let lightwalletdUrlKey = "zcash_rpc_endpoint_url_ios_mirror"
+    private static let networkKey = "zcash_rpc_endpoint_network_ios_mirror"
+    private static let defaultLightwalletdUrl = "https://zec.rocks:443"
+    private static let defaultNetwork = "main"
+
+    static var lightwalletdUrl: String {
+        UserDefaults.standard.string(forKey: lightwalletdUrlKey) ?? defaultLightwalletdUrl
+    }
+
+    static var network: String {
+        UserDefaults.standard.string(forKey: networkKey) ?? defaultNetwork
+    }
+
+    static func save(lightwalletdUrl: String?, network: String? = nil) {
+        if let lightwalletdUrl, !lightwalletdUrl.isEmpty {
+            UserDefaults.standard.set(lightwalletdUrl, forKey: lightwalletdUrlKey)
+        }
+        if let network, !network.isEmpty {
+            UserDefaults.standard.set(network, forKey: networkKey)
+        }
+    }
+}

--- a/ios/Runner/TxTrackManager.swift
+++ b/ios/Runner/TxTrackManager.swift
@@ -11,7 +11,6 @@ class TxTrackManager {
     private let trackQueue = DispatchQueue(label: "com.keplr.vizor.txtrack", qos: .utility)
     private let pollInterval: TimeInterval = 5.0
     private let resultDisplayDelay: TimeInterval = 5.0
-    private let lightwalletdUrl = "https://zec.rocks:443"
     private var cancelled = false
 
     private init() {}
@@ -33,7 +32,8 @@ class TxTrackManager {
         print("[TxTrack] registered")
     }
 
-    func startTxTracking() -> Bool {
+    func startTxTracking(lightwalletdUrl: String? = nil) -> Bool {
+        RpcEndpointConfigStore.save(lightwalletdUrl: lightwalletdUrl)
         print("[TxTrack] submitting task request")
         let request = BGContinuedProcessingTaskRequest(
             identifier: Self.taskIdentifier,
@@ -105,6 +105,7 @@ class TxTrackManager {
         print("[TxTrack] tracking \(pending.count) transaction(s)")
         DynamicIslandManager.shared.showTxTracking(pendingCount: pending.count)
 
+        let lightwalletdUrl = RpcEndpointConfigStore.lightwalletdUrl
         var confirmed = 0
         var expired = 0
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -32,6 +32,7 @@ import 'src/features/send/screens/send_screen.dart';
 import 'src/features/send/screens/send_status_screen.dart';
 import 'src/features/settings/screens/settings_screen.dart';
 import 'src/features/settings/screens/settings_change_password_screen.dart';
+import 'src/features/settings/screens/settings_endpoint_screen.dart';
 import 'src/features/settings/screens/settings_seed_phrase_screen.dart';
 import 'src/providers/theme_mode_provider.dart';
 import 'src/providers/app_security_provider.dart';
@@ -351,6 +352,10 @@ final _routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/settings/change-password',
         builder: (_, _) => const SettingsChangePasswordScreen(),
+      ),
+      GoRoute(
+        path: '/settings/endpoint',
+        builder: (_, _) => const SettingsEndpointScreen(),
       ),
     ],
   );

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,7 +6,7 @@ import 'package:desktop_window_bootstrap/desktop_window_bootstrap.dart';
 import 'main.dart' show log;
 import 'src/app_bootstrap.dart';
 import 'src/core/motion/onboarding_motion.dart';
-import 'src/core/theme/app_theme.dart';
+import 'src/core/theme/app_theme_host.dart';
 import 'src/core/theme/legacy_material_theme.dart';
 import 'src/features/activity/screens/activity_screen.dart';
 import 'src/features/activity/screens/activity_transaction_status_screen.dart';
@@ -407,20 +407,8 @@ class ZcashWalletApp extends ConsumerWidget {
       themeMode: themeMode,
       routerConfig: router,
       builder: (context, child) {
-        // Resolve themeMode intent → concrete brightness using the OS's
-        // current platformBrightness when mode is `system`. Rebuilds when
-        // either themeMode or platform brightness changes.
-        final platformBrightness = MediaQuery.platformBrightnessOf(context);
-        final brightness = switch (themeMode) {
-          ThemeMode.system => platformBrightness,
-          ThemeMode.dark => Brightness.dark,
-          ThemeMode.light => Brightness.light,
-        };
-        final appThemeData = brightness == Brightness.dark
-            ? AppThemeData.dark
-            : AppThemeData.light;
-        return AppTheme(
-          data: appThemeData,
+        return AppThemeHost(
+          themeMode: themeMode,
           // `DesktopWindowTitlebarSafeArea` pads the app content down past the macOS
           // titlebar area when the native full-size content view is
           // enabled, so traffic-light controls don't overlap UI. It is a

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -31,6 +31,7 @@ import 'src/features/send/screens/send_review_screen.dart';
 import 'src/features/send/screens/send_screen.dart';
 import 'src/features/send/screens/send_status_screen.dart';
 import 'src/features/settings/screens/settings_screen.dart';
+import 'src/features/settings/screens/settings_change_password_screen.dart';
 import 'src/features/settings/screens/settings_seed_phrase_screen.dart';
 import 'src/providers/theme_mode_provider.dart';
 import 'src/providers/app_security_provider.dart';
@@ -346,6 +347,10 @@ final _routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/settings/secret-passphrase',
         builder: (_, _) => const SettingsSeedPhraseScreen(),
+      ),
+      GoRoute(
+        path: '/settings/change-password',
+        builder: (_, _) => const SettingsChangePasswordScreen(),
       ),
     ],
   );

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -31,6 +31,7 @@ import 'src/features/send/screens/send_review_screen.dart';
 import 'src/features/send/screens/send_screen.dart';
 import 'src/features/send/screens/send_status_screen.dart';
 import 'src/features/settings/screens/settings_screen.dart';
+import 'src/features/settings/screens/settings_seed_phrase_screen.dart';
 import 'src/providers/theme_mode_provider.dart';
 import 'src/providers/app_security_provider.dart';
 import 'src/providers/router_refresh_provider.dart';
@@ -342,6 +343,10 @@ final _routerProvider = Provider<GoRouter>((ref) {
         builder: (_, _) => const ImportKeystoneScreen(),
       ),
       GoRoute(path: '/settings', builder: (_, _) => const SettingsScreen()),
+      GoRoute(
+        path: '/settings/secret-passphrase',
+        builder: (_, _) => const SettingsSeedPhraseScreen(),
+      ),
     ],
   );
 });

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart' show ThemeMode;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../main.dart' show log;
+import 'core/profile_pictures.dart';
 import 'core/storage/app_secure_store.dart';
 import 'core/storage/wallet_paths.dart';
 import 'providers/account_models.dart';
@@ -144,6 +145,8 @@ Future<AppBootstrapState> loadAppBootstrap() async {
             name: account.name,
             order: index,
             isHardware: stored?.isHardware ?? false,
+            profilePictureId:
+                stored?.profilePictureId ?? kDefaultProfilePictureId,
           );
         }).toList();
         log('bootstrap: rust accounts=${rustAccounts.length}');

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -107,6 +107,11 @@ Future<AppBootstrapState> loadAppBootstrap() async {
   try {
     log('bootstrap: loading startup snapshot');
     await storage.ensureWalletDbName();
+    try {
+      await storage.recoverInterruptedPasswordRotation();
+    } catch (e) {
+      log('bootstrap: failed to recover password rotation: $e');
+    }
     final network = await storage.readString(_networkKey) ?? 'main';
     final isPasswordConfigured = await storage.isPasswordConfigured();
     final isUnlocked = storage.hasSessionPassword;

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/material.dart' show ThemeMode;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
@@ -35,6 +36,7 @@ class AppBootstrapState {
     required this.themeMode,
     required this.isPasswordConfigured,
     required this.isUnlocked,
+    required this.passwordRotationRecoveryFailed,
   });
 
   final String initialLocation;
@@ -45,6 +47,7 @@ class AppBootstrapState {
   final ThemeMode themeMode;
   final bool isPasswordConfigured;
   final bool isUnlocked;
+  final bool passwordRotationRecoveryFailed;
 
   bool get hasWallet => initialAccountState.hasAccounts;
   bool get requiresUnlock => hasWallet && !isUnlocked;
@@ -58,6 +61,7 @@ class AppBootstrapState {
     themeMode: ThemeMode.system,
     isPasswordConfigured: false,
     isUnlocked: false,
+    passwordRotationRecoveryFailed: false,
   );
 }
 
@@ -121,8 +125,14 @@ Future<AppBootstrapState> loadAppBootstrap() async {
   try {
     log('bootstrap: loading startup snapshot');
     await storage.ensureWalletDbName();
+    var passwordRotationRecoveryFailed = false;
     try {
       await storage.recoverInterruptedPasswordRotation();
+    } on PasswordRotationRecoveryFailedException catch (e) {
+      // Fail open so the user can still try either password, but keep the
+      // sticky journal visible to the UI instead of silently clearing it.
+      passwordRotationRecoveryFailed = true;
+      log('bootstrap: unsafe password rotation recovery state: $e');
     } catch (e) {
       log('bootstrap: failed to recover password rotation: $e');
     }
@@ -151,13 +161,14 @@ Future<AppBootstrapState> loadAppBootstrap() async {
           final (index, account) = entry;
           rustAddressesByUuid[account.uuid] = account.unifiedAddress;
           final stored = storedAccountsByUuid[account.uuid];
-          return AccountInfo(
-            uuid: account.uuid,
-            name: account.name,
+          return mergeBootstrappedAccountInfo(
+            rustAccount: AccountInfo(
+              uuid: account.uuid,
+              name: account.name,
+              order: index,
+            ),
+            storedAccount: stored,
             order: index,
-            isHardware: stored?.isHardware ?? false,
-            profilePictureId:
-                stored?.profilePictureId ?? kDefaultProfilePictureId,
           );
         }).toList();
         log('bootstrap: rust accounts=${rustAccounts.length}');
@@ -212,11 +223,30 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       themeMode: themeMode,
       isPasswordConfigured: isPasswordConfigured,
       isUnlocked: isUnlocked,
+      passwordRotationRecoveryFailed: passwordRotationRecoveryFailed,
     );
   } catch (e) {
     log('bootstrap: failed, falling back to welcome: $e');
     return AppBootstrapState.empty;
   }
+}
+
+@visibleForTesting
+AccountInfo mergeBootstrappedAccountInfo({
+  required AccountInfo rustAccount,
+  required AccountInfo? storedAccount,
+  required int order,
+}) {
+  // Rust is authoritative for account existence/address. Dart secure storage
+  // owns UI metadata that Rust does not update, so preserve it across relaunch.
+  return AccountInfo(
+    uuid: rustAccount.uuid,
+    name: storedAccount?.name ?? rustAccount.name,
+    order: order,
+    isHardware: storedAccount?.isHardware ?? false,
+    profilePictureId:
+        storedAccount?.profilePictureId ?? kDefaultProfilePictureId,
+  );
 }
 
 Future<void> _seedNativeRpcEndpointMirror(RpcEndpointConfig endpoint) async {

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/material.dart' show ThemeMode;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../main.dart' show log;
@@ -23,6 +24,7 @@ class AppBootstrapState {
     required this.initialAccountState,
     required this.initialSyncSnapshot,
     required this.network,
+    required this.themeMode,
     required this.isPasswordConfigured,
     required this.isUnlocked,
   });
@@ -31,6 +33,7 @@ class AppBootstrapState {
   final AccountState initialAccountState;
   final AppSyncSnapshot initialSyncSnapshot;
   final String network;
+  final ThemeMode themeMode;
   final bool isPasswordConfigured;
   final bool isUnlocked;
 
@@ -42,6 +45,7 @@ class AppBootstrapState {
     initialAccountState: AccountState(),
     initialSyncSnapshot: AppSyncSnapshot.empty,
     network: 'main',
+    themeMode: ThemeMode.system,
     isPasswordConfigured: false,
     isUnlocked: false,
   );
@@ -113,6 +117,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       log('bootstrap: failed to recover password rotation: $e');
     }
     final network = await storage.readString(_networkKey) ?? 'main';
+    final themeMode = await _readThemeMode(storage);
     final isPasswordConfigured = await storage.isPasswordConfigured();
     final isUnlocked = storage.hasSessionPassword;
     final dbPath = await _getDbPath();
@@ -189,6 +194,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       ),
       initialSyncSnapshot: initialSyncSnapshot,
       network: network,
+      themeMode: themeMode,
       isPasswordConfigured: isPasswordConfigured,
       isUnlocked: isUnlocked,
     );
@@ -196,6 +202,23 @@ Future<AppBootstrapState> loadAppBootstrap() async {
     log('bootstrap: failed, falling back to welcome: $e');
     return AppBootstrapState.empty;
   }
+}
+
+Future<ThemeMode> _readThemeMode(AppSecureStore storage) async {
+  try {
+    return _decodeThemeMode(await storage.readString(kThemeModeKey));
+  } catch (e) {
+    log('bootstrap: failed to read theme mode: $e');
+    return ThemeMode.system;
+  }
+}
+
+ThemeMode _decodeThemeMode(String? raw) {
+  return switch (raw) {
+    'light' => ThemeMode.light,
+    'dark' => ThemeMode.dark,
+    _ => ThemeMode.system,
+  };
 }
 
 Future<List<AccountInfo>> _readStoredAccounts(AppSecureStore storage) async {

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -1,10 +1,13 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart' show ThemeMode;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
 
 import '../main.dart' show log;
 import 'core/profile_pictures.dart';
+import 'core/config/rpc_endpoint_config.dart';
 import 'core/storage/app_secure_store.dart';
 import 'core/storage/wallet_paths.dart';
 import 'providers/account_models.dart';
@@ -14,6 +17,9 @@ import 'rust/api/wallet.dart' as rust_wallet;
 const _accountsKey = 'zcash_accounts';
 const _activeAccountKey = 'zcash_active_account';
 const _networkKey = 'zcash_wallet_network';
+const _backgroundSyncChannel = MethodChannel(
+  'com.zcash.wallet/background_sync',
+);
 
 final appBootstrapProvider = Provider<AppBootstrapState>((_) {
   throw StateError('appBootstrapProvider must be overridden in main()');
@@ -25,6 +31,7 @@ class AppBootstrapState {
     required this.initialAccountState,
     required this.initialSyncSnapshot,
     required this.network,
+    required this.rpcEndpointConfig,
     required this.themeMode,
     required this.isPasswordConfigured,
     required this.isUnlocked,
@@ -34,6 +41,7 @@ class AppBootstrapState {
   final AccountState initialAccountState;
   final AppSyncSnapshot initialSyncSnapshot;
   final String network;
+  final RpcEndpointConfig rpcEndpointConfig;
   final ThemeMode themeMode;
   final bool isPasswordConfigured;
   final bool isUnlocked;
@@ -46,6 +54,7 @@ class AppBootstrapState {
     initialAccountState: AccountState(),
     initialSyncSnapshot: AppSyncSnapshot.empty,
     network: 'main',
+    rpcEndpointConfig: defaultRpcEndpointConfig('main'),
     themeMode: ThemeMode.system,
     isPasswordConfigured: false,
     isUnlocked: false,
@@ -118,6 +127,8 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       log('bootstrap: failed to recover password rotation: $e');
     }
     final network = await storage.readString(_networkKey) ?? 'main';
+    final rpcEndpointConfig = await _readRpcEndpointConfig(storage, network);
+    await _seedNativeRpcEndpointMirror(rpcEndpointConfig);
     final themeMode = await _readThemeMode(storage);
     final isPasswordConfigured = await storage.isPasswordConfigured();
     final isUnlocked = storage.hasSessionPassword;
@@ -197,6 +208,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       ),
       initialSyncSnapshot: initialSyncSnapshot,
       network: network,
+      rpcEndpointConfig: rpcEndpointConfig,
       themeMode: themeMode,
       isPasswordConfigured: isPasswordConfigured,
       isUnlocked: isUnlocked,
@@ -204,6 +216,49 @@ Future<AppBootstrapState> loadAppBootstrap() async {
   } catch (e) {
     log('bootstrap: failed, falling back to welcome: $e');
     return AppBootstrapState.empty;
+  }
+}
+
+Future<void> _seedNativeRpcEndpointMirror(RpcEndpointConfig endpoint) async {
+  if (!Platform.isIOS) return;
+  try {
+    final success = await _backgroundSyncChannel
+        .invokeMethod<bool>('updateEndpoint', {
+          'lightwalletdUrl': endpoint.normalizedLightwalletdUrl,
+          'network': endpoint.networkName,
+        });
+    if (success != true) {
+      log('bootstrap: iOS RPC endpoint mirror seed returned $success');
+    }
+  } catch (e) {
+    log('bootstrap: failed to seed iOS RPC endpoint mirror: $e');
+  }
+}
+
+Future<RpcEndpointConfig> _readRpcEndpointConfig(
+  AppSecureStore storage,
+  String network,
+) async {
+  try {
+    final storedUrl = await storage.readString(kRpcEndpointUrlKey);
+    final storedPreset = await storage.readString(kRpcEndpointPresetKey);
+    if (storedUrl == null || storedUrl.trim().isEmpty) {
+      return defaultRpcEndpointConfig(network);
+    }
+
+    return RpcEndpointConfig(
+      networkName: zcashNetworkFromName(network).name,
+      lightwalletdUrl: normalizeRpcEndpointUrl(
+        storedUrl,
+        allowDefaultPort: true,
+      ),
+      presetId: storedPreset == null || storedPreset.trim().isEmpty
+          ? findRpcEndpointPresetByUrl(storedUrl, networkName: network)?.id
+          : storedPreset,
+    );
+  } catch (e) {
+    log('bootstrap: failed to read RPC endpoint: $e');
+    return defaultRpcEndpointConfig(network);
   }
 }
 

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/foundation.dart' show kDebugMode;
+
+import 'network_config.dart';
+
+const kDefaultRpcEndpointPresetId = 'default-mainnet';
+const kCustomRpcEndpointPresetId = 'custom';
+
+class RpcEndpointConfig {
+  const RpcEndpointConfig({
+    required this.networkName,
+    required this.lightwalletdUrl,
+    this.presetId,
+  });
+
+  final String networkName;
+  final String lightwalletdUrl;
+  final String? presetId;
+
+  ZcashNetwork get network => zcashNetworkFromName(networkName);
+
+  String get normalizedLightwalletdUrl =>
+      normalizeRpcEndpointUrl(lightwalletdUrl, allowDefaultPort: true);
+
+  String get hostPort => rpcEndpointHostPort(lightwalletdUrl);
+
+  String get effectivePresetId =>
+      presetId ??
+      findRpcEndpointPresetByUrl(
+        normalizedLightwalletdUrl,
+        networkName: networkName,
+      )?.id ??
+      kCustomRpcEndpointPresetId;
+
+  RpcEndpointConfig copyWith({
+    String? networkName,
+    String? lightwalletdUrl,
+    String? presetId,
+  }) {
+    return RpcEndpointConfig(
+      networkName: networkName ?? this.networkName,
+      lightwalletdUrl: lightwalletdUrl ?? this.lightwalletdUrl,
+      presetId: presetId ?? this.presetId,
+    );
+  }
+}
+
+class RpcEndpointPreset {
+  const RpcEndpointPreset({
+    required this.id,
+    required this.region,
+    required this.label,
+    required this.url,
+    this.latencyLabel,
+    this.isDefault = false,
+  });
+
+  final String id;
+  final String region;
+  final String label;
+  final String url;
+  final String? latencyLabel;
+  final bool isDefault;
+
+  String get hostPort => rpcEndpointHostPort(url);
+}
+
+final kMainnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
+  RpcEndpointPreset(
+    id: kDefaultRpcEndpointPresetId,
+    region: 'Default',
+    label: 'Zec Rocks',
+    url: ZcashNetwork.mainnet.lightwalletdUrl,
+    latencyLabel: 'Default',
+    isDefault: true,
+  ),
+  const RpcEndpointPreset(
+    id: 'na-zec-rocks',
+    region: 'Americas',
+    label: 'Zec Rocks North America',
+    url: 'https://na.zec.rocks:443',
+    latencyLabel: '75ms',
+  ),
+  const RpcEndpointPreset(
+    id: 'eu-zec-rocks',
+    region: 'Europe',
+    label: 'Zec Rocks Europe',
+    url: 'https://eu.zec.rocks:443',
+    latencyLabel: '160ms',
+  ),
+  const RpcEndpointPreset(
+    id: 'ap-zec-rocks',
+    region: 'Asia Pacific',
+    label: 'Zec Rocks Asia Pacific',
+    url: 'https://ap.zec.rocks:443',
+    latencyLabel: '240ms',
+  ),
+]);
+
+final kTestnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
+  const RpcEndpointPreset(
+    id: 'default-testnet',
+    region: 'Testnet',
+    label: 'Zec Rocks Testnet',
+    url: 'https://testnet.zec.rocks:443',
+    latencyLabel: 'Default',
+    isDefault: true,
+  ),
+]);
+
+List<RpcEndpointPreset> rpcEndpointPresetsForNetwork(String networkName) {
+  final network = zcashNetworkFromName(networkName);
+  return switch (network) {
+    ZcashNetwork.mainnet => kMainnetRpcEndpointPresets,
+    ZcashNetwork.testnet => kTestnetRpcEndpointPresets,
+  };
+}
+
+RpcEndpointConfig defaultRpcEndpointConfig(String networkName) {
+  final network = zcashNetworkFromName(networkName);
+  final presets = rpcEndpointPresetsForNetwork(network.name);
+  final preset = presets.firstWhere(
+    (preset) => preset.isDefault,
+    orElse: () => presets.first,
+  );
+  return RpcEndpointConfig(
+    networkName: network.name,
+    lightwalletdUrl: preset.url,
+    presetId: preset.id,
+  );
+}
+
+ZcashNetwork zcashNetworkFromName(String networkName) {
+  return networkName == ZcashNetwork.testnet.name
+      ? ZcashNetwork.testnet
+      : ZcashNetwork.mainnet;
+}
+
+RpcEndpointPreset? findRpcEndpointPresetById(
+  String networkName,
+  String presetId,
+) {
+  for (final preset in rpcEndpointPresetsForNetwork(networkName)) {
+    if (preset.id == presetId) return preset;
+  }
+  return null;
+}
+
+RpcEndpointPreset? findRpcEndpointPresetByUrl(
+  String url, {
+  String? networkName,
+}) {
+  final normalized = normalizeRpcEndpointUrl(url, allowDefaultPort: true);
+  final presets = networkName == null
+      ? [...kMainnetRpcEndpointPresets, ...kTestnetRpcEndpointPresets]
+      : rpcEndpointPresetsForNetwork(networkName);
+  for (final preset in presets) {
+    if (normalizeRpcEndpointUrl(preset.url, allowDefaultPort: true) ==
+        normalized) {
+      return preset;
+    }
+  }
+  return null;
+}
+
+String normalizeRpcEndpointUrl(
+  String input, {
+  bool allowDefaultPort = false,
+  bool allowLocalHttp = kDebugMode,
+}) {
+  final trimmed = input.trim();
+  if (trimmed.isEmpty) {
+    throw const FormatException('Enter an endpoint.');
+  }
+  if (trimmed.contains(RegExp(r'\s'))) {
+    throw const FormatException('Endpoint cannot contain spaces.');
+  }
+
+  final candidate = trimmed.contains('://') ? trimmed : 'https://$trimmed';
+  final uri = Uri.tryParse(candidate);
+  if (uri == null || uri.host.isEmpty) {
+    throw const FormatException('Enter a valid hostname and port.');
+  }
+  if (uri.scheme != 'https' && uri.scheme != 'http') {
+    throw const FormatException('Use an https:// endpoint.');
+  }
+  if (uri.scheme == 'http' && !(allowLocalHttp && _isLocalhost(uri.host))) {
+    throw const FormatException('Use an https:// endpoint.');
+  }
+  final hasExplicitPort = _hasExplicitPort(candidate);
+  if (!hasExplicitPort && !allowDefaultPort) {
+    throw const FormatException(
+      'Include a valid port, for example zec.rocks:443.',
+    );
+  }
+  final port = hasExplicitPort ? uri.port : _defaultPortForScheme(uri.scheme);
+  if (port <= 0 || port > 65535) {
+    throw const FormatException(
+      'Include a valid port, for example zec.rocks:443.',
+    );
+  }
+
+  return '${uri.scheme}://${_formatRpcHost(uri.host)}:$port';
+}
+
+bool _isLocalhost(String host) {
+  final lower = host.toLowerCase();
+  return lower == 'localhost' || lower == '::1' || lower.startsWith('127.');
+}
+
+bool _hasExplicitPort(String url) {
+  final schemeIndex = url.indexOf('://');
+  if (schemeIndex < 0) return false;
+
+  final afterScheme = url.substring(schemeIndex + 3);
+  final authorityEnd = afterScheme.indexOf(RegExp(r'[/#?]'));
+  final authority = authorityEnd < 0
+      ? afterScheme
+      : afterScheme.substring(0, authorityEnd);
+  final hostPort = authority.contains('@')
+      ? authority.substring(authority.lastIndexOf('@') + 1)
+      : authority;
+
+  if (hostPort.startsWith('[')) {
+    final closeBracket = hostPort.indexOf(']');
+    return closeBracket >= 0 &&
+        closeBracket + 1 < hostPort.length &&
+        hostPort[closeBracket + 1] == ':';
+  }
+
+  return hostPort.lastIndexOf(':') > 0;
+}
+
+String rpcEndpointHostPort(String url) {
+  final uri = Uri.parse(normalizeRpcEndpointUrl(url, allowDefaultPort: true));
+  return '${uri.host}:${uri.port}';
+}
+
+int _defaultPortForScheme(String scheme) {
+  return switch (scheme) {
+    'https' => 443,
+    'http' => 80,
+    _ => 0,
+  };
+}
+
+String _formatRpcHost(String host) {
+  if (host.contains(':') && !host.startsWith('[')) {
+    return '[$host]';
+  }
+  return host;
+}

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -24,11 +24,11 @@ class RpcEndpointConfig {
   String get hostPort => rpcEndpointHostPort(lightwalletdUrl);
 
   String get effectivePresetId =>
-      presetId ??
       findRpcEndpointPresetByUrl(
         normalizedLightwalletdUrl,
         networkName: networkName,
       )?.id ??
+      presetId ??
       kCustomRpcEndpointPresetId;
 
   RpcEndpointConfig copyWith({
@@ -233,6 +233,15 @@ bool _hasExplicitPort(String url) {
 String rpcEndpointHostPort(String url) {
   final uri = Uri.parse(normalizeRpcEndpointUrl(url, allowDefaultPort: true));
   return '${_formatRpcHost(uri.host)}:${uri.port}';
+}
+
+String rpcEndpointInputText(String url) {
+  final normalized = normalizeRpcEndpointUrl(url, allowDefaultPort: true);
+  final uri = Uri.parse(normalized);
+  if (uri.scheme == 'https') {
+    return rpcEndpointHostPort(normalized);
+  }
+  return normalized;
 }
 
 int _defaultPortForScheme(String scheme) {

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -232,7 +232,7 @@ bool _hasExplicitPort(String url) {
 
 String rpcEndpointHostPort(String url) {
   final uri = Uri.parse(normalizeRpcEndpointUrl(url, allowDefaultPort: true));
-  return '${uri.host}:${uri.port}';
+  return '${_formatRpcHost(uri.host)}:${uri.port}';
 }
 
 int _defaultPortForScheme(String scheme) {

--- a/lib/src/core/layout/app_desktop_shell.dart
+++ b/lib/src/core/layout/app_desktop_shell.dart
@@ -8,7 +8,7 @@ class AppDesktopShell extends StatelessWidget {
   const AppDesktopShell({
     required this.sidebar,
     required this.pane,
-    this.sidebarWidth = 240,
+    this.sidebarWidth = 256,
     super.key,
   });
 
@@ -103,23 +103,28 @@ class AppSidebarItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final row = Padding(
-      padding: const EdgeInsets.only(
-        left: AppSpacing.xs,
-        top: AppSpacing.xxs,
-        bottom: AppSpacing.xxs,
+    final row = AnimatedContainer(
+      duration: const Duration(milliseconds: 160),
+      curve: Curves.easeOut,
+      height: 40,
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+      decoration: BoxDecoration(
+        color: active ? colors.state.selectedOpacity : null,
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
       ),
       child: Row(
         children: [
+          AppIcon(iconName, size: 20, color: colors.icon.accent),
+          const SizedBox(width: AppSpacing.s),
           Expanded(
             child: Text(
               label,
+              overflow: TextOverflow.ellipsis,
               style: AppTypography.labelLarge.copyWith(
                 color: colors.text.accent,
               ),
             ),
           ),
-          AppIcon(iconName, size: 20, color: colors.icon.accent),
         ],
       ),
     );

--- a/lib/src/core/layout/app_desktop_shell.dart
+++ b/lib/src/core/layout/app_desktop_shell.dart
@@ -103,6 +103,9 @@ class AppSidebarItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final disabled = onTap == null && !active;
+    final iconColor = disabled ? colors.icon.disabled : colors.icon.accent;
+    final textColor = disabled ? colors.text.disabled : colors.text.accent;
     final row = AnimatedContainer(
       duration: const Duration(milliseconds: 160),
       curve: Curves.easeOut,
@@ -114,34 +117,29 @@ class AppSidebarItem extends StatelessWidget {
       ),
       child: Row(
         children: [
-          AppIcon(iconName, size: 20, color: colors.icon.accent),
+          AppIcon(iconName, size: 20, color: iconColor),
           const SizedBox(width: AppSpacing.s),
           Expanded(
             child: Text(
               label,
               overflow: TextOverflow.ellipsis,
-              style: AppTypography.labelLarge.copyWith(
-                color: colors.text.accent,
-              ),
+              style: AppTypography.labelLarge.copyWith(color: textColor),
             ),
           ),
         ],
       ),
     );
 
-    return Opacity(
-      opacity: active ? 1.0 : 0.5,
-      child: onTap == null
-          ? row
-          : MouseRegion(
-              cursor: SystemMouseCursors.click,
-              child: GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTap: onTap,
-                child: row,
-              ),
+    return onTap == null
+        ? row
+        : MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: onTap,
+              child: row,
             ),
-    );
+          );
   }
 }
 

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -263,7 +263,9 @@ class _SidebarAccountSelectorButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final backgroundColor = (isOpen || isHovered) ? colors.surface.input : null;
+    final backgroundColor = (isOpen || isHovered)
+        ? colors.state.selectedOpacity
+        : null;
     final textColor = colors.text.accent;
     final iconColor = colors.icon.accent;
 

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../providers/account_provider.dart';
 import '../../providers/app_security_provider.dart';
 import '../../providers/sync_provider.dart';
+import '../profile_pictures.dart';
 import '../theme/app_theme.dart';
 import '../widgets/app_icon.dart';
 import '../widgets/app_button.dart';
@@ -205,6 +206,9 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                   children: [
                     _SidebarAccountSelectorButton(
                       label: accountName,
+                      profilePictureId:
+                          activeAccount?.profilePictureId ??
+                          kDefaultProfilePictureId,
                       isOpen: _isDropdownOpen,
                       isHovered: _isSelectorHovered,
                       onHoverChanged: (hovered) {
@@ -242,6 +246,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
 class _SidebarAccountSelectorButton extends StatelessWidget {
   const _SidebarAccountSelectorButton({
     required this.label,
+    required this.profilePictureId,
     required this.isOpen,
     required this.isHovered,
     required this.onHoverChanged,
@@ -249,6 +254,7 @@ class _SidebarAccountSelectorButton extends StatelessWidget {
   });
 
   final String label;
+  final String profilePictureId;
   final bool isOpen;
   final bool isHovered;
   final ValueChanged<bool> onHoverChanged;
@@ -279,7 +285,7 @@ class _SidebarAccountSelectorButton extends StatelessWidget {
           ),
           child: Row(
             children: [
-              const _SidebarAccountAvatar(),
+              _SidebarAccountAvatar(profilePictureId: profilePictureId),
               const SizedBox(width: AppSpacing.xs),
               Expanded(
                 child: Text(
@@ -429,7 +435,7 @@ class _SidebarAccountRow extends StatelessWidget {
           ),
           child: Row(
             children: [
-              const _SidebarAccountAvatar(),
+              _SidebarAccountAvatar(profilePictureId: account.profilePictureId),
               const SizedBox(width: AppSpacing.xs),
               Expanded(
                 child: Text(
@@ -480,13 +486,17 @@ class _SidebarCreateWalletRow extends StatelessWidget {
 }
 
 class _SidebarAccountAvatar extends StatelessWidget {
-  const _SidebarAccountAvatar();
+  const _SidebarAccountAvatar({required this.profilePictureId});
+
+  final String profilePictureId;
 
   @override
   Widget build(BuildContext context) {
+    final option = resolveProfilePictureOption(profilePictureId);
+
     return ClipOval(
       child: Image.asset(
-        'assets/illustrations/sidebar_account_avatar_knight.png',
+        option.assetPath,
         width: 24,
         height: 24,
         fit: BoxFit.cover,

--- a/lib/src/core/profile_pictures.dart
+++ b/lib/src/core/profile_pictures.dart
@@ -1,0 +1,44 @@
+const kDefaultProfilePictureId = 'knight-02';
+const kKnightProfilePictureAsset =
+    'assets/illustrations/sidebar_account_avatar_knight.png';
+
+class ProfilePictureOption {
+  const ProfilePictureOption({
+    required this.id,
+    required this.label,
+    required this.assetPath,
+  });
+
+  final String id;
+  final String label;
+  final String assetPath;
+}
+
+// Figma currently hands off the same Knight image for every slot. Keep stable
+// ids now so each asset can be swapped later without changing stored values.
+final kProfilePictureOptions = List<ProfilePictureOption>.unmodifiable(
+  List.generate(
+    15,
+    (index) => ProfilePictureOption(
+      id: 'knight-${index.toString().padLeft(2, '0')}',
+      label: 'Knight',
+      assetPath: kKnightProfilePictureAsset,
+    ),
+  ),
+);
+
+ProfilePictureOption? findProfilePictureOption(String id) {
+  for (final option in kProfilePictureOptions) {
+    if (option.id == id) return option;
+  }
+  return null;
+}
+
+ProfilePictureOption resolveProfilePictureOption(String id) {
+  return findProfilePictureOption(id) ??
+      findProfilePictureOption(kDefaultProfilePictureId)!;
+}
+
+bool isKnownProfilePictureId(String id) {
+  return findProfilePictureOption(id) != null;
+}

--- a/lib/src/core/security/password_policy.dart
+++ b/lib/src/core/security/password_policy.dart
@@ -3,6 +3,7 @@ const kWalletPasswordMinLengthMessage =
     'Password must be at least 8 characters.';
 const kWalletPasswordAsciiMessage =
     'Use only English letters, numbers, and symbols.';
+const kWalletPasswordMustDifferMessage = 'Use a different password.';
 
 bool isWalletPasswordAsciiOnly(String value) {
   return value.runes.every((rune) => rune >= 0x21 && rune <= 0x7E);
@@ -17,6 +18,11 @@ String? validateWalletPassword(String value) {
     return kWalletPasswordMinLengthMessage;
   }
   return null;
+}
+
+String? validateRequiredWalletPassword(String value) {
+  if (value.isEmpty) return kWalletPasswordMinLengthMessage;
+  return validateWalletPassword(value);
 }
 
 bool isWalletPasswordValid(String value) {

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -9,6 +9,8 @@ import '../security/password_policy.dart';
 
 const kWalletDbNameKey = 'zcash_wallet_db_name';
 const kThemeModeKey = 'zcash_theme_mode';
+const kRpcEndpointUrlKey = 'zcash_rpc_endpoint_url';
+const kRpcEndpointPresetKey = 'zcash_rpc_endpoint_preset';
 const _secureStoreSaltKey = 'zcash_secure_store_salt';
 const _passwordVerifierKey = 'zcash_password_verifier';
 const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:cryptography/cryptography.dart';
+import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../security/password_policy.dart';
@@ -10,14 +11,21 @@ const kWalletDbNameKey = 'zcash_wallet_db_name';
 const _secureStoreSaltKey = 'zcash_secure_store_salt';
 const _passwordVerifierKey = 'zcash_password_verifier';
 const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';
+const _passwordRotationInProgressKey = 'zcash_rotation_in_progress';
+const _accountMnemonicKeyPrefix = 'zcash_account_mnemonic_';
 const _secureStoreService = 'com.keplr.vizor.secure_store';
 
 class AppSecureStore {
-  AppSecureStore._();
+  AppSecureStore._({FlutterSecureStorage storage = _defaultStorage})
+    : _storage = storage;
+
+  @visibleForTesting
+  AppSecureStore.testing({required FlutterSecureStorage storage})
+    : _storage = storage;
 
   static final AppSecureStore instance = AppSecureStore._();
 
-  static const _storage = FlutterSecureStorage(
+  static const _defaultStorage = FlutterSecureStorage(
     iOptions: IOSOptions(
       accountName: _secureStoreService,
       accessibility: KeychainAccessibility.first_unlock,
@@ -36,8 +44,9 @@ class AppSecureStore {
     bits: 256,
   );
 
-  static SecretKey? _cachedSecretKey;
-  static String? _sessionPassword;
+  final FlutterSecureStorage _storage;
+  SecretKey? _cachedSecretKey;
+  String? _sessionPassword;
 
   bool get hasSessionPassword => _sessionPassword != null;
 
@@ -138,7 +147,7 @@ class AppSecureStore {
   }
 
   Future<void> configurePassword(String password) async {
-    final error = validateWalletPassword(password);
+    final error = validateRequiredWalletPassword(password);
     if (error != null) {
       throw ArgumentError(error);
     }
@@ -149,9 +158,111 @@ class AppSecureStore {
     setSessionPassword(password);
   }
 
+  /// Rotates the wallet password and re-encrypts every app-managed encrypted
+  /// secure-storage payload so mnemonic entries remain readable afterwards.
+  Future<bool> changePassword({
+    required String currentPassword,
+    required String newPassword,
+  }) async {
+    if (!isWalletPasswordValid(currentPassword)) {
+      return false;
+    }
+    if (currentPassword == newPassword) {
+      throw ArgumentError(kWalletPasswordMustDifferMessage);
+    }
+    final newPasswordError = validateRequiredWalletPassword(newPassword);
+    if (newPasswordError != null) {
+      throw ArgumentError(newPasswordError);
+    }
+
+    final isCurrentPasswordValid = await verifyPasswordOnly(currentPassword);
+    if (!isCurrentPasswordValid) {
+      return false;
+    }
+
+    final oldVerifierSalt = await readPlain(_passwordVerifierSaltKey);
+    final oldVerifier = await readPlain(_passwordVerifierKey);
+    final currentSecretKey = await _deriveSecretKeyForPassword(currentPassword);
+    final newSecretKey = await _deriveSecretKeyForPassword(newPassword);
+    try {
+      final storedValues = await _storage.readAll();
+      final rotatedSecrets = <_PasswordRotationEntry>[];
+
+      for (final entry in storedValues.entries) {
+        if (!entry.key.startsWith(_accountMnemonicKeyPrefix)) continue;
+
+        final payload = _EncryptedPayload.tryParse(entry.value);
+        if (payload == null) continue;
+
+        final clearText = await _decryptPayloadForKey(
+          entry.key,
+          payload,
+          currentSecretKey,
+        );
+        final rotatedValue = await _encryptStringWithKey(
+          clearText,
+          newSecretKey,
+        );
+        rotatedSecrets.add(
+          _PasswordRotationEntry(
+            key: entry.key,
+            originalValue: entry.value,
+            rotatedValue: rotatedValue,
+          ),
+        );
+      }
+
+      final newVerifierSalt = _randomBytes(16);
+      final newVerifier = await _derivePasswordVerifier(
+        newPassword,
+        newVerifierSalt,
+      );
+
+      final rotation = _PasswordRotationRecord(
+        oldVerifierSalt: oldVerifierSalt,
+        oldVerifier: oldVerifier,
+        newVerifierSalt: base64Encode(newVerifierSalt),
+        newVerifier: newVerifier,
+        entries: rotatedSecrets,
+      );
+      await writePlain(_passwordRotationInProgressKey, rotation.serialize());
+
+      try {
+        await _writeRotatedPasswordState(rotation);
+      } catch (error, stackTrace) {
+        await _rollbackPasswordRotation(rotation, currentPassword);
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+
+      setSessionPassword(newPassword);
+      await _deleteRotationRecordBestEffort();
+    } finally {
+      currentSecretKey.destroy();
+      newSecretKey.destroy();
+    }
+
+    return true;
+  }
+
+  Future<void> recoverInterruptedPasswordRotation() async {
+    final raw = await readPlain(_passwordRotationInProgressKey);
+    if (raw == null || raw.isEmpty) return;
+
+    final rotation = _PasswordRotationRecord.tryParse(raw);
+    if (rotation == null) {
+      await delete(_passwordRotationInProgressKey);
+      throw StateError('Password rotation recovery record is invalid.');
+    }
+
+    await _writeRotatedPasswordState(rotation);
+    await _deleteRotationRecordBestEffort();
+    clearSessionPassword();
+  }
+
   Future<void> clearPasswordConfiguration() async {
     await delete(_passwordVerifierSaltKey);
     await delete(_passwordVerifierKey);
+    await delete(_passwordRotationInProgressKey);
     clearSessionPassword();
   }
 
@@ -214,6 +325,58 @@ class AppSecureStore {
     return key;
   }
 
+  Future<SecretKey> _deriveSecretKeyForPassword(String password) async {
+    final salt = await _getOrCreateSalt();
+    return _kdf.deriveKeyFromPassword(password: password, nonce: salt);
+  }
+
+  Future<String> _decryptPayload(
+    _EncryptedPayload payload,
+    SecretKey secretKey,
+  ) async {
+    final clearText = await _cipher.decrypt(
+      SecretBox(
+        payload.cipherText,
+        nonce: payload.nonce,
+        mac: Mac(payload.mac),
+      ),
+      secretKey: secretKey,
+    );
+    return utf8.decode(clearText);
+  }
+
+  Future<String> _decryptPayloadForKey(
+    String key,
+    _EncryptedPayload payload,
+    SecretKey secretKey,
+  ) async {
+    try {
+      return await _decryptPayload(payload, secretKey);
+    } catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        StateError('Failed to decrypt secure-storage value for "$key": $error'),
+        stackTrace,
+      );
+    }
+  }
+
+  Future<String> _encryptStringWithKey(
+    String value,
+    SecretKey secretKey,
+  ) async {
+    final nonce = _randomBytes(12);
+    final secretBox = await _cipher.encrypt(
+      utf8.encode(value),
+      secretKey: secretKey,
+      nonce: nonce,
+    );
+    return _EncryptedPayload(
+      nonce: secretBox.nonce,
+      cipherText: secretBox.cipherText,
+      mac: secretBox.mac.bytes,
+    ).serialize();
+  }
+
   Future<String> _derivePasswordVerifier(
     String password,
     List<int> salt,
@@ -222,7 +385,65 @@ class AppSecureStore {
       password: password,
       nonce: salt,
     );
-    return base64Encode(await key.extractBytes());
+    try {
+      return base64Encode(await key.extractBytes());
+    } finally {
+      key.destroy();
+    }
+  }
+
+  Future<void> _writeRotatedPasswordState(
+    _PasswordRotationRecord rotation,
+  ) async {
+    for (final entry in rotation.entries) {
+      await writePlain(entry.key, entry.rotatedValue);
+    }
+    await writePlain(_passwordVerifierSaltKey, rotation.newVerifierSalt);
+    await writePlain(_passwordVerifierKey, rotation.newVerifier);
+  }
+
+  Future<void> _rollbackPasswordRotation(
+    _PasswordRotationRecord rotation,
+    String currentPassword,
+  ) async {
+    try {
+      final rollbackRecord = rotation.toRollbackRecord();
+      if (rollbackRecord != null) {
+        await writePlain(
+          _passwordRotationInProgressKey,
+          rollbackRecord.serialize(),
+        );
+      }
+      for (final entry in rotation.entries) {
+        await writePlain(entry.key, entry.originalValue);
+      }
+      if (rotation.oldVerifierSalt == null) {
+        await delete(_passwordVerifierSaltKey);
+      } else {
+        await writePlain(_passwordVerifierSaltKey, rotation.oldVerifierSalt!);
+      }
+      if (rotation.oldVerifier == null) {
+        await delete(_passwordVerifierKey);
+      } else {
+        await writePlain(_passwordVerifierKey, rotation.oldVerifier!);
+      }
+      setSessionPassword(currentPassword);
+      await _deleteRotationRecordBestEffort();
+    } catch (rollbackError, rollbackStackTrace) {
+      debugPrint(
+        'AppSecureStore: rollback failed: $rollbackError\n$rollbackStackTrace',
+      );
+    }
+  }
+
+  Future<void> _deleteRotationRecordBestEffort() async {
+    try {
+      await delete(_passwordRotationInProgressKey);
+    } catch (error, stackTrace) {
+      debugPrint(
+        'AppSecureStore: failed to delete rotation record: $error\n$stackTrace',
+      );
+    }
   }
 
   Future<List<int>> _getOrCreateSalt() async {
@@ -248,6 +469,104 @@ class AppSecureStore {
       buffer.write(byte.toRadixString(16).padLeft(2, '0'));
     }
     return buffer.toString();
+  }
+}
+
+class _PasswordRotationEntry {
+  const _PasswordRotationEntry({
+    required this.key,
+    required this.originalValue,
+    required this.rotatedValue,
+  });
+
+  final String key;
+  final String originalValue;
+  final String rotatedValue;
+}
+
+class _PasswordRotationRecord {
+  const _PasswordRotationRecord({
+    required this.oldVerifierSalt,
+    required this.oldVerifier,
+    required this.newVerifierSalt,
+    required this.newVerifier,
+    required this.entries,
+  });
+
+  final String? oldVerifierSalt;
+  final String? oldVerifier;
+  final String newVerifierSalt;
+  final String newVerifier;
+  final List<_PasswordRotationEntry> entries;
+
+  String serialize() {
+    return jsonEncode({
+      'v': 1,
+      'oldVerifierSalt': oldVerifierSalt,
+      'oldVerifier': oldVerifier,
+      'newVerifierSalt': newVerifierSalt,
+      'newVerifier': newVerifier,
+      'entries': entries
+          .map(
+            (entry) => {
+              'key': entry.key,
+              'originalValue': entry.originalValue,
+              'rotatedValue': entry.rotatedValue,
+            },
+          )
+          .toList(),
+    });
+  }
+
+  static _PasswordRotationRecord? tryParse(String raw) {
+    try {
+      final json = jsonDecode(raw);
+      if (json is! Map<String, dynamic>) return null;
+      if (json['v'] != 1) return null;
+
+      final entriesJson = json['entries'];
+      if (entriesJson is! List) return null;
+
+      return _PasswordRotationRecord(
+        oldVerifierSalt: json['oldVerifierSalt'] as String?,
+        oldVerifier: json['oldVerifier'] as String?,
+        newVerifierSalt: json['newVerifierSalt'] as String,
+        newVerifier: json['newVerifier'] as String,
+        entries: entriesJson
+            .map(
+              (entry) => _PasswordRotationEntry(
+                key: (entry as Map<String, dynamic>)['key'] as String,
+                originalValue: entry['originalValue'] as String,
+                rotatedValue: entry['rotatedValue'] as String,
+              ),
+            )
+            .toList(),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  _PasswordRotationRecord? toRollbackRecord() {
+    final oldSalt = oldVerifierSalt;
+    final oldPasswordVerifier = oldVerifier;
+    if (oldSalt == null || oldPasswordVerifier == null) return null;
+
+    return _PasswordRotationRecord(
+      oldVerifierSalt: newVerifierSalt,
+      oldVerifier: newVerifier,
+      newVerifierSalt: oldSalt,
+      newVerifier: oldPasswordVerifier,
+      entries: entries
+          .map(
+            (entry) => _PasswordRotationEntry(
+              key: entry.key,
+              originalValue: entry.rotatedValue,
+              rotatedValue: entry.originalValue,
+            ),
+          )
+          .toList(),
+    );
   }
 }
 

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -155,7 +155,10 @@ class AppSecureStore {
     clearSessionPassword();
   }
 
-  Future<bool> verifyPassword(String password) async {
+  /// Checks the wallet password without opening or refreshing the encrypted
+  /// storage session. Use this for in-app re-authentication prompts where the
+  /// wallet is already unlocked and callers only need a fresh password check.
+  Future<bool> verifyPasswordOnly(String password) async {
     if (!isWalletPasswordValid(password)) {
       return false;
     }
@@ -172,7 +175,11 @@ class AppSecureStore {
       password,
       base64Decode(encodedSalt),
     );
-    final isMatch = derived == storedVerifier;
+    return derived == storedVerifier;
+  }
+
+  Future<bool> verifyPassword(String password) async {
+    final isMatch = await verifyPasswordOnly(password);
     if (isMatch) {
       setSessionPassword(password);
     }

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -228,7 +228,11 @@ class AppSecureStore {
           if (!entry.key.startsWith(_accountMnemonicKeyPrefix)) continue;
 
           final payload = _EncryptedPayload.tryParse(entry.value);
-          if (payload == null) continue;
+          if (payload == null) {
+            throw StateError(
+              'Failed to parse secure-storage value for "${entry.key}".',
+            );
+          }
 
           final clearText = await _decryptPayloadForKey(
             entry.key,

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
@@ -15,8 +16,17 @@ const _secureStoreSaltKey = 'zcash_secure_store_salt';
 const _passwordVerifierKey = 'zcash_password_verifier';
 const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';
 const _passwordRotationInProgressKey = 'zcash_rotation_in_progress';
+const _passwordRotationRollbackFailedKind = 'rollbackFailed';
 const _accountMnemonicKeyPrefix = 'zcash_account_mnemonic_';
 const _secureStoreService = 'com.keplr.vizor.secure_store';
+
+class PasswordRotationRecoveryFailedException implements Exception {
+  const PasswordRotationRecoveryFailedException();
+
+  @override
+  String toString() =>
+      'Password rotation rollback failed; automatic recovery is unsafe.';
+}
 
 class AppSecureStore {
   AppSecureStore._({FlutterSecureStorage storage = _defaultStorage})
@@ -48,6 +58,7 @@ class AppSecureStore {
   );
 
   final FlutterSecureStorage _storage;
+  final _secretMutationLock = _AsyncLock();
   SecretKey? _cachedSecretKey;
   String? _sessionPassword;
 
@@ -72,57 +83,65 @@ class AppSecureStore {
   Future<String?> readSecretStringWithOptions(
     String key, {
     bool requireUnlockedSession = false,
-  }) async {
-    if (requireUnlockedSession && !hasSessionPassword) {
-      return null;
-    }
-    if (!hasSessionPassword) {
-      throw StateError('Secret storage requires an unlocked session.');
-    }
+  }) {
+    return _secretMutationLock.run(() async {
+      if (requireUnlockedSession && !hasSessionPassword) {
+        return null;
+      }
+      if (!hasSessionPassword) {
+        throw StateError('Secret storage requires an unlocked session.');
+      }
 
-    final raw = await _storage.read(key: key);
-    if (raw == null || raw.isEmpty) return null;
+      final raw = await _storage.read(key: key);
+      if (raw == null || raw.isEmpty) return null;
 
-    final payload = _EncryptedPayload.tryParse(raw);
-    if (payload == null) {
-      return null;
-    }
+      final payload = _EncryptedPayload.tryParse(raw);
+      if (payload == null) {
+        return null;
+      }
 
-    final secretKey = await _getSecretKey();
-    final clearText = await _cipher.decrypt(
-      SecretBox(
-        payload.cipherText,
-        nonce: payload.nonce,
-        mac: Mac(payload.mac),
-      ),
-      secretKey: secretKey,
-    );
-    return utf8.decode(clearText);
+      final secretKey = await _getSecretKey();
+      final clearText = await _cipher.decrypt(
+        SecretBox(
+          payload.cipherText,
+          nonce: payload.nonce,
+          mac: Mac(payload.mac),
+        ),
+        secretKey: secretKey,
+      );
+      return utf8.decode(clearText);
+    });
   }
 
   Future<void> writeString(String key, String value) async {
     await _storage.write(key: key, value: value);
   }
 
-  Future<void> writeSecretString(String key, String value) async {
-    final secretKey = await _getSecretKey();
-    final nonce = _randomBytes(12);
-    final secretBox = await _cipher.encrypt(
-      utf8.encode(value),
-      secretKey: secretKey,
-      nonce: nonce,
-    );
-    await _storage.write(
-      key: key,
-      value: _EncryptedPayload(
-        nonce: secretBox.nonce,
-        cipherText: secretBox.cipherText,
-        mac: secretBox.mac.bytes,
-      ).serialize(),
-    );
+  Future<void> writeSecretString(String key, String value) {
+    return _secretMutationLock.run(() async {
+      final secretKey = await _getSecretKey();
+      final nonce = _randomBytes(12);
+      final secretBox = await _cipher.encrypt(
+        utf8.encode(value),
+        secretKey: secretKey,
+        nonce: nonce,
+      );
+      await _storage.write(
+        key: key,
+        value: _EncryptedPayload(
+          nonce: secretBox.nonce,
+          cipherText: secretBox.cipherText,
+          mac: secretBox.mac.bytes,
+        ).serialize(),
+      );
+    });
   }
 
   Future<void> delete(String key) async {
+    if (key.startsWith(_accountMnemonicKeyPrefix)) {
+      await _secretMutationLock.run(() => _storage.delete(key: key));
+      return;
+    }
     await _storage.delete(key: key);
   }
 
@@ -166,90 +185,108 @@ class AppSecureStore {
   Future<bool> changePassword({
     required String currentPassword,
     required String newPassword,
-  }) async {
-    if (!isWalletPasswordValid(currentPassword)) {
-      return false;
-    }
-    if (currentPassword == newPassword) {
-      throw ArgumentError(kWalletPasswordMustDifferMessage);
-    }
-    final newPasswordError = validateRequiredWalletPassword(newPassword);
-    if (newPasswordError != null) {
-      throw ArgumentError(newPasswordError);
-    }
-
-    final isCurrentPasswordValid = await verifyPasswordOnly(currentPassword);
-    if (!isCurrentPasswordValid) {
-      return false;
-    }
-
-    final oldVerifierSalt = await readPlain(_passwordVerifierSaltKey);
-    final oldVerifier = await readPlain(_passwordVerifierKey);
-    final currentSecretKey = await _deriveSecretKeyForPassword(currentPassword);
-    final newSecretKey = await _deriveSecretKeyForPassword(newPassword);
-    try {
-      final storedValues = await _storage.readAll();
-      final rotatedSecrets = <_PasswordRotationEntry>[];
-
-      for (final entry in storedValues.entries) {
-        if (!entry.key.startsWith(_accountMnemonicKeyPrefix)) continue;
-
-        final payload = _EncryptedPayload.tryParse(entry.value);
-        if (payload == null) continue;
-
-        final clearText = await _decryptPayloadForKey(
-          entry.key,
-          payload,
-          currentSecretKey,
-        );
-        final rotatedValue = await _encryptStringWithKey(
-          clearText,
-          newSecretKey,
-        );
-        rotatedSecrets.add(
-          _PasswordRotationEntry(
-            key: entry.key,
-            originalValue: entry.value,
-            rotatedValue: rotatedValue,
-          ),
-        );
+  }) {
+    // Secret writes and password rotation share one lock so a mnemonic cannot
+    // be encrypted with the old key after rotation has taken its key snapshot.
+    return _secretMutationLock.run(() async {
+      final existingRecoveryRecord = await readPlain(
+        _passwordRotationInProgressKey,
+      );
+      // Defense in depth: bootstrap normally reports this state, but password
+      // changes must still refuse to overwrite the sticky failure marker.
+      if (existingRecoveryRecord != null &&
+          _isRollbackFailedRotationRecord(existingRecoveryRecord)) {
+        throw const PasswordRotationRecoveryFailedException();
+      }
+      if (!isWalletPasswordValid(currentPassword)) {
+        return false;
+      }
+      if (currentPassword == newPassword) {
+        throw ArgumentError(kWalletPasswordMustDifferMessage);
+      }
+      final newPasswordError = validateRequiredWalletPassword(newPassword);
+      if (newPasswordError != null) {
+        throw ArgumentError(newPasswordError);
       }
 
-      final newVerifierSalt = _randomBytes(16);
-      final newVerifier = await _derivePasswordVerifier(
-        newPassword,
-        newVerifierSalt,
-      );
+      final isCurrentPasswordValid = await verifyPasswordOnly(currentPassword);
+      if (!isCurrentPasswordValid) {
+        return false;
+      }
 
-      final rotation = _PasswordRotationRecord(
-        oldVerifierSalt: oldVerifierSalt,
-        oldVerifier: oldVerifier,
-        newVerifierSalt: base64Encode(newVerifierSalt),
-        newVerifier: newVerifier,
-        entries: rotatedSecrets,
+      final oldVerifierSalt = await readPlain(_passwordVerifierSaltKey);
+      final oldVerifier = await readPlain(_passwordVerifierKey);
+      final currentSecretKey = await _deriveSecretKeyForPassword(
+        currentPassword,
       );
-      await writePlain(_passwordRotationInProgressKey, rotation.serialize());
-
+      final newSecretKey = await _deriveSecretKeyForPassword(newPassword);
       try {
-        await _writeRotatedPasswordState(rotation);
-      } catch (error, stackTrace) {
-        await _rollbackPasswordRotation(rotation, currentPassword);
-        Error.throwWithStackTrace(error, stackTrace);
+        final storedValues = await _storage.readAll();
+        final rotatedSecrets = <_PasswordRotationEntry>[];
+
+        for (final entry in storedValues.entries) {
+          if (!entry.key.startsWith(_accountMnemonicKeyPrefix)) continue;
+
+          final payload = _EncryptedPayload.tryParse(entry.value);
+          if (payload == null) continue;
+
+          final clearText = await _decryptPayloadForKey(
+            entry.key,
+            payload,
+            currentSecretKey,
+          );
+          final rotatedValue = await _encryptStringWithKey(
+            clearText,
+            newSecretKey,
+          );
+          rotatedSecrets.add(
+            _PasswordRotationEntry(
+              key: entry.key,
+              originalValue: entry.value,
+              rotatedValue: rotatedValue,
+            ),
+          );
+        }
+
+        final newVerifierSalt = _randomBytes(16);
+        final newVerifier = await _derivePasswordVerifier(
+          newPassword,
+          newVerifierSalt,
+        );
+
+        final rotation = _PasswordRotationRecord(
+          oldVerifierSalt: oldVerifierSalt,
+          oldVerifier: oldVerifier,
+          newVerifierSalt: base64Encode(newVerifierSalt),
+          newVerifier: newVerifier,
+          entries: rotatedSecrets,
+        );
+        await writePlain(_passwordRotationInProgressKey, rotation.serialize());
+
+        try {
+          await _writeRotatedPasswordState(rotation);
+        } catch (error, stackTrace) {
+          await _rollbackPasswordRotation(rotation, currentPassword);
+          Error.throwWithStackTrace(error, stackTrace);
+        }
+
+        setSessionPassword(newPassword);
+        await _deleteRotationRecordBestEffort();
+      } finally {
+        currentSecretKey.destroy();
+        newSecretKey.destroy();
       }
 
-      setSessionPassword(newPassword);
-      await _deleteRotationRecordBestEffort();
-    } finally {
-      currentSecretKey.destroy();
-      newSecretKey.destroy();
-    }
-
-    return true;
+      return true;
+    });
   }
 
   Future<void> recoverInterruptedPasswordRotation() async {
     final raw = await readPlain(_passwordRotationInProgressKey);
     if (raw == null || raw.isEmpty) return;
+    if (_isRollbackFailedRotationRecord(raw)) {
+      throw const PasswordRotationRecoveryFailedException();
+    }
 
     final rotation = _PasswordRotationRecord.tryParse(raw);
     if (rotation == null) {
@@ -433,6 +470,7 @@ class AppSecureStore {
       setSessionPassword(currentPassword);
       await _deleteRotationRecordBestEffort();
     } catch (rollbackError, rollbackStackTrace) {
+      await _markRollbackFailedBestEffort();
       debugPrint(
         'AppSecureStore: rollback failed: $rollbackError\n$rollbackStackTrace',
       );
@@ -445,6 +483,21 @@ class AppSecureStore {
     } catch (error, stackTrace) {
       debugPrint(
         'AppSecureStore: failed to delete rotation record: $error\n$stackTrace',
+      );
+    }
+  }
+
+  Future<void> _markRollbackFailedBestEffort() async {
+    try {
+      // If rollback cannot even replace the forward journal, do not let the
+      // next boot silently roll forward after the UI reported failure.
+      await writePlain(
+        _passwordRotationInProgressKey,
+        jsonEncode({'v': 1, 'kind': _passwordRotationRollbackFailedKind}),
+      );
+    } catch (error, stackTrace) {
+      debugPrint(
+        'AppSecureStore: failed to mark rollback failure: $error\n$stackTrace',
       );
     }
   }
@@ -472,6 +525,20 @@ class AppSecureStore {
       buffer.write(byte.toRadixString(16).padLeft(2, '0'));
     }
     return buffer.toString();
+  }
+}
+
+class _AsyncLock {
+  Future<void> _tail = Future<void>.value();
+
+  Future<T> run<T>(Future<T> Function() action) {
+    final previous = _tail;
+    final completer = Completer<void>();
+    _tail = completer.future;
+
+    return previous
+        .then((_) => Future<T>.sync(action))
+        .whenComplete(() => completer.complete());
   }
 }
 
@@ -570,6 +637,17 @@ class _PasswordRotationRecord {
           )
           .toList(),
     );
+  }
+}
+
+bool _isRollbackFailedRotationRecord(String raw) {
+  try {
+    final json = jsonDecode(raw);
+    return json is Map<String, dynamic> &&
+        json['v'] == 1 &&
+        json['kind'] == _passwordRotationRollbackFailedKind;
+  } catch (_) {
+    return false;
   }
 }
 

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -8,6 +8,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import '../security/password_policy.dart';
 
 const kWalletDbNameKey = 'zcash_wallet_db_name';
+const kThemeModeKey = 'zcash_theme_mode';
 const _secureStoreSaltKey = 'zcash_secure_store_salt';
 const _passwordVerifierKey = 'zcash_password_verifier';
 const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';

--- a/lib/src/core/theme/app_theme_host.dart
+++ b/lib/src/core/theme/app_theme_host.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'app_theme.dart';
+
+/// Resolves the user's [ThemeMode] into the app design-system theme and keeps
+/// the macOS window chrome aligned with that resolved brightness.
+class AppThemeHost extends StatelessWidget {
+  const AppThemeHost({required this.themeMode, required this.child, super.key});
+
+  final ThemeMode themeMode;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final brightness = _resolveBrightness(
+      themeMode,
+      MediaQuery.platformBrightnessOf(context),
+    );
+    final appThemeData = brightness == Brightness.dark
+        ? AppThemeData.dark
+        : AppThemeData.light;
+
+    return AppTheme(
+      data: appThemeData,
+      child: _MacOSWindowAppearanceSync(brightness: brightness, child: child),
+    );
+  }
+
+  static Brightness _resolveBrightness(
+    ThemeMode themeMode,
+    Brightness platformBrightness,
+  ) {
+    return switch (themeMode) {
+      ThemeMode.system => platformBrightness,
+      ThemeMode.dark => Brightness.dark,
+      ThemeMode.light => Brightness.light,
+    };
+  }
+}
+
+class _MacOSWindowAppearanceSync extends StatefulWidget {
+  const _MacOSWindowAppearanceSync({
+    required this.brightness,
+    required this.child,
+  });
+
+  final Brightness brightness;
+  final Widget child;
+
+  @override
+  State<_MacOSWindowAppearanceSync> createState() =>
+      _MacOSWindowAppearanceSyncState();
+}
+
+class _MacOSWindowAppearanceSyncState
+    extends State<_MacOSWindowAppearanceSync> {
+  @override
+  void initState() {
+    super.initState();
+    _MacOSWindowAppearance.sync(widget.brightness);
+  }
+
+  @override
+  void didUpdateWidget(covariant _MacOSWindowAppearanceSync oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.brightness == widget.brightness) return;
+    _MacOSWindowAppearance.sync(widget.brightness);
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+abstract final class _MacOSWindowAppearance {
+  static const _channel = MethodChannel('com.zcash.wallet/window_appearance');
+
+  static Brightness? _lastBrightness;
+
+  static void sync(Brightness brightness) {
+    if (kIsWeb || !Platform.isMacOS) return;
+    if (_lastBrightness == brightness) return;
+    _lastBrightness = brightness;
+    unawaited(_setBrightness(brightness));
+  }
+
+  static Future<void> _setBrightness(Brightness brightness) async {
+    try {
+      await _channel.invokeMethod<void>('setBrightness', {
+        'brightness': brightness == Brightness.dark ? 'dark' : 'light',
+      });
+    } catch (error) {
+      _lastBrightness = null;
+      debugPrint('MacOSWindowAppearance: sync failed: $error');
+    }
+  }
+}

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -7,7 +7,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
-import '../../../core/config/network_config.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
@@ -16,6 +15,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../activity_row_mapper.dart';
@@ -101,9 +101,10 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
 
     try {
       final dbPath = await getWalletDbPath();
+      final endpoint = ref.read(rpcEndpointProvider);
       final txs = await rust_sync.getTransactionHistory(
         dbPath: dbPath,
-        network: ZcashNetwork.mainnet.name,
+        network: endpoint.networkName,
         accountUuid: accountUuid,
       );
       if (!mounted) return;

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -190,13 +190,14 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
 
     try {
       final dbPath = await getWalletDbPath();
+      final endpoint = ref.read(rpcEndpointProvider);
       if (!mounted ||
           accountUuid != ref.read(accountProvider).value?.activeAccountUuid) {
         return null;
       }
       return rust_sync.getTransactionDetail(
         dbPath: dbPath,
-        network: ZcashNetwork.mainnet.name,
+        network: endpoint.networkName,
         accountUuid: accountUuid,
         txidHex: transaction.txidHex,
         txKind: transaction.txKind,

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -7,13 +7,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
-import '../../../core/config/network_config.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../send/widgets/transaction_receipt_view.dart';
@@ -86,9 +86,10 @@ class _ActivityTransactionStatusScreenState
 
     try {
       final dbPath = await getWalletDbPath();
+      final endpoint = ref.read(rpcEndpointProvider);
       final txs = await rust_sync.getTransactionHistory(
         dbPath: dbPath,
-        network: ZcashNetwork.mainnet.name,
+        network: endpoint.networkName,
         accountUuid: accountUuid,
       );
       if (!mounted) return;
@@ -107,7 +108,6 @@ class _ActivityTransactionStatusScreenState
       rust_sync.TransactionDetail? detail;
       if (tx != null) {
         try {
-          final endpoint = ref.read(rpcEndpointProvider);
           detail = rust_sync.getTransactionDetail(
             dbPath: dbPath,
             network: endpoint.networkName,

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -107,9 +107,10 @@ class _ActivityTransactionStatusScreenState
       rust_sync.TransactionDetail? detail;
       if (tx != null) {
         try {
+          final endpoint = ref.read(rpcEndpointProvider);
           detail = rust_sync.getTransactionDetail(
             dbPath: dbPath,
-            network: ZcashNetwork.mainnet.name,
+            network: endpoint.networkName,
             accountUuid: accountUuid,
             txidHex: tx.txidHex,
             txKind: tx.txKind,

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -7,7 +7,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
-import '../../../core/config/network_config.dart';
 import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_desktop_shell.dart';
@@ -17,6 +16,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
@@ -111,10 +111,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
       final seedBytes = await rust_wallet.deriveSeed(mnemonic: mnemonic);
       final dbPath = await getWalletDbPath();
+      final endpoint = ref.read(rpcEndpointProvider);
       final result = await rust_sync.shieldTransparentBalance(
         dbPath: dbPath,
-        lightwalletdUrl: ZcashNetwork.mainnet.lightwalletdUrl,
-        network: ZcashNetwork.mainnet.name,
+        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+        network: endpoint.networkName,
         accountUuid: accountUuid,
         seed: seedBytes,
       );
@@ -460,13 +461,14 @@ class _HomePaneState extends ConsumerState<_HomePane> {
 
     try {
       final dbPath = await getWalletDbPath();
+      final endpoint = ref.read(rpcEndpointProvider);
       if (!mounted ||
           accountUuid != ref.read(accountProvider).value?.activeAccountUuid) {
         return null;
       }
       return rust_sync.getTransactionDetail(
         dbPath: dbPath,
-        network: ZcashNetwork.mainnet.name,
+        network: endpoint.networkName,
         accountUuid: accountUuid,
         txidHex: transaction.txidHex,
         txKind: transaction.txKind,

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../app_bootstrap.dart';
 import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_desktop_shell.dart';
@@ -171,6 +172,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     final walletAsync = ref.watch(walletProvider);
+    final bootstrap = ref.watch(appBootstrapProvider);
     final syncAsync = ref.watch(syncProvider);
     final sync = syncAsync.value ?? SyncState();
     final shieldedBalance =
@@ -199,6 +201,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             ),
             data: (_) => _HomePane(
               sync: sync,
+              passwordRotationRecoveryFailed:
+                  bootstrap.passwordRotationRecoveryFailed,
               canBackgroundSync: _canBackgroundSync,
               isBalanceVisible: _isBalanceVisible,
               shieldedBalanceText: _formatZec(shieldedBalance),
@@ -227,6 +231,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 class _HomePane extends ConsumerStatefulWidget {
   const _HomePane({
     required this.sync,
+    required this.passwordRotationRecoveryFailed,
     required this.canBackgroundSync,
     required this.isBalanceVisible,
     required this.shieldedBalanceText,
@@ -244,6 +249,7 @@ class _HomePane extends ConsumerStatefulWidget {
   });
 
   final SyncState sync;
+  final bool passwordRotationRecoveryFailed;
   final bool canBackgroundSync;
   final bool isBalanceVisible;
   final String shieldedBalanceText;
@@ -385,6 +391,14 @@ class _HomePaneState extends ConsumerState<_HomePane> {
   }
 
   _HomeNoticeData? _noticeData() {
+    if (widget.passwordRotationRecoveryFailed) {
+      return _HomeNoticeData(
+        iconName: AppIcons.warning,
+        message: "We couldn't verify the previous password change.",
+        actionLabel: 'Settings',
+        onTap: () => context.push('/settings'),
+      );
+    }
     if (widget.shieldBalanceError != null) {
       return _HomeNoticeData(
         iconName: AppIcons.warning,

--- a/lib/src/features/onboarding/import/import_birthday_estimator.dart
+++ b/lib/src/features/onboarding/import/import_birthday_estimator.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:fixnum/fixnum.dart';
 import 'package:grpc/grpc.dart';
 
-import '../../../core/config/network_config.dart';
+import '../../../core/config/rpc_endpoint_config.dart';
 import '../../../generated/compact_formats.pb.dart' as compact;
 import '../../../generated/service.pbgrpc.dart' as service;
 
@@ -29,9 +29,9 @@ class ImportBirthdayEstimator {
   );
 
   static Future<ImportBirthdayMetadata> loadMetadata({
-    required ZcashNetwork network,
+    required RpcEndpointConfig endpoint,
   }) async {
-    return _withClient(network, (client) async {
+    return _withClient(endpoint.normalizedLightwalletdUrl, (client) async {
       final info = await client.getLightdInfo(
         service.Empty(),
         options: _rpcOptions,
@@ -55,10 +55,10 @@ class ImportBirthdayEstimator {
   }
 
   static Future<int> estimateBirthdayHeight({
-    required ZcashNetwork network,
+    required RpcEndpointConfig endpoint,
     required DateTime selectedDate,
   }) async {
-    return _withClient(network, (client) async {
+    return _withClient(endpoint.normalizedLightwalletdUrl, (client) async {
       final info = await client.getLightdInfo(
         service.Empty(),
         options: _rpcOptions,
@@ -117,10 +117,10 @@ class ImportBirthdayEstimator {
   }
 
   static Future<T> _withClient<T>(
-    ZcashNetwork network,
+    String lightwalletdUrl,
     Future<T> Function(service.CompactTxStreamerClient client) action,
   ) async {
-    final uri = Uri.parse(network.lightwalletdUrl);
+    final uri = Uri.parse(lightwalletdUrl);
     final credentials = uri.scheme == 'https'
         ? const ChannelCredentials.secure()
         : const ChannelCredentials.insecure();

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -5,13 +5,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
-import '../../../app_bootstrap.dart';
-import '../../../core/config/network_config.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
+import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/wallet_mutation_guard.dart';
 import '../shared/onboarding_flow_args.dart';
 import 'import_birthday_estimator.dart';
@@ -81,14 +80,12 @@ class _ImportWalletBirthdayScreenState
     super.dispose();
   }
 
-  ZcashNetwork get _network {
-    final network = ref.read(appBootstrapProvider).network;
-    return network == 'main' ? ZcashNetwork.mainnet : ZcashNetwork.testnet;
-  }
-
   void _handleFocusChanged() {
     if (mounted) setState(() {});
   }
+
+  int get _minimumBirthdayHeight =>
+      ref.read(rpcEndpointProvider).network.saplingActivationHeight;
 
   Future<void> _loadMetadata() async {
     setState(() {
@@ -97,8 +94,9 @@ class _ImportWalletBirthdayScreenState
     });
 
     try {
+      final endpoint = ref.read(rpcEndpointProvider);
       final metadata = await ImportBirthdayEstimator.loadMetadata(
-        network: _network,
+        endpoint: endpoint,
       );
       if (!mounted) return;
       setState(() {
@@ -129,9 +127,10 @@ class _ImportWalletBirthdayScreenState
     });
 
     try {
+      final endpoint = ref.read(rpcEndpointProvider);
       final estimatedHeight =
           await ImportBirthdayEstimator.estimateBirthdayHeight(
-            network: _network,
+            endpoint: endpoint,
             selectedDate: date,
           );
       if (!mounted || seq != _estimateSeq) return;
@@ -272,7 +271,7 @@ class _ImportWalletBirthdayScreenState
   int? get _validatedManualHeight {
     final value = int.tryParse(_manualHeightController.text.trim());
     if (value == null) return null;
-    final minimumHeight = _network.saplingActivationHeight;
+    final minimumHeight = _minimumBirthdayHeight;
     if (value < minimumHeight) {
       return null;
     }
@@ -288,7 +287,7 @@ class _ImportWalletBirthdayScreenState
     if (text.isEmpty) return null;
     final parsed = int.tryParse(text);
     if (parsed == null) return 'Doesn’t seem like a legit block height';
-    if (parsed < _network.saplingActivationHeight) {
+    if (parsed < _minimumBirthdayHeight) {
       return 'Doesn’t seem like a legit block height';
     }
     final maximumHeight = _metadata?.tipHeight;
@@ -450,7 +449,7 @@ class _ImportWalletBirthdayScreenState
                             ? null
                             : () => _submit(
                                 birthdayHeightOverride:
-                                    _network.saplingActivationHeight,
+                                    _minimumBirthdayHeight,
                               ),
                         variant: AppButtonVariant.ghost,
                         minWidth: _buttonWidth,

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -18,6 +18,7 @@ import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_text_field.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
@@ -424,6 +425,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
 
     try {
       final dbPath = await getWalletDbPath();
+      final endpoint = ref.read(rpcEndpointProvider);
       if (!mounted || seq != _validateSeq) return;
       final memo = _memoController.text.trim();
       final accountUuid = widget.activeAccountUuid;
@@ -433,7 +435,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       }
       final fee = await rust_sync.estimateFee(
         dbPath: dbPath,
-        network: 'main',
+        network: endpoint.networkName,
         accountUuid: accountUuid,
         toAddress: address,
         amountZatoshi: zatoshi,
@@ -553,6 +555,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
 
       final memo = _memoController.text.trim();
       final dbPath = await getWalletDbPath();
+      final endpoint = ref.read(rpcEndpointProvider);
       if (!mounted) return;
 
       // Step 1: Propose transfer
@@ -567,7 +570,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       }
       final proposal = await rust_sync.proposeSend(
         dbPath: dbPath,
-        network: 'main',
+        network: endpoint.networkName,
         accountUuid: accountUuid,
         sendFlowId: _sendFlowId,
         toAddress: address,

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -334,11 +334,12 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
 
     try {
       final dbPath = await getWalletDbPath();
+      final endpoint = ref.read(rpcEndpointProvider);
       if (!mounted || !_isMaxMode || seq != _maxSeq) return;
 
       final estimate = await rust_sync.estimateSendMax(
         dbPath: dbPath,
-        network: 'main',
+        network: endpoint.networkName,
         accountUuid: accountUuid,
         toAddress: address,
         memo: memo.isNotEmpty ? memo : null,

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -8,7 +8,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
-import '../../../core/config/network_config.dart';
 import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
@@ -16,6 +15,7 @@ import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../../rust/api/wallet.dart' as rust_wallet;
@@ -303,6 +303,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     try {
       final supportDir = await getWalletSupportDirectory();
       final dbPath = await getWalletDbPath();
+      final endpoint = ref.read(rpcEndpointProvider);
       final paramsDir =
           '${supportDir.path}${Platform.pathSeparator}sapling_params';
       final spendPath =
@@ -358,7 +359,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
         );
         final pcztBytes = await rust_sync.createPcztFromProposal(
           dbPath: dbPath,
-          network: ZcashNetwork.mainnet.name,
+          network: endpoint.networkName,
           proposalId: widget.args.proposalId,
           sendFlowId: widget.args.sendFlowId,
         );
@@ -394,8 +395,8 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
         );
         txid = await rust_sync.extractAndBroadcastPczt(
           dbPath: dbPath,
-          lightwalletdUrl: ZcashNetwork.mainnet.lightwalletdUrl,
-          network: ZcashNetwork.mainnet.name,
+          lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+          network: endpoint.networkName,
           pcztWithProofsBytes: pcztWithProofs,
           pcztWithSignaturesBytes: pcztWithSignatures,
           spendParamsPath: widget.args.needsSaplingParams ? spendPath : null,
@@ -417,7 +418,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
         final seedBytes = await rust_wallet.deriveSeed(mnemonic: mnemonic);
         txid = await rust_sync.executeProposal(
           dbPath: dbPath,
-          lightwalletdUrl: ZcashNetwork.mainnet.lightwalletdUrl,
+          lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
           proposalId: widget.args.proposalId,
           sendFlowId: widget.args.sendFlowId,
           seed: seedBytes,
@@ -439,7 +440,9 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
           final available =
               await channel.invokeMethod<bool>('isAvailable') ?? false;
           if (available) {
-            await channel.invokeMethod('startTxTracking');
+            await channel.invokeMethod('startTxTracking', {
+              'lightwalletdUrl': endpoint.normalizedLightwalletdUrl,
+            });
           }
         } catch (e) {
           log('SendStatus: iOS TX tracking failed (non-critical): $e');

--- a/lib/src/features/settings/screens/settings_change_password_screen.dart
+++ b/lib/src/features/settings/screens/settings_change_password_screen.dart
@@ -6,6 +6,7 @@ import '../../../../main.dart' show log;
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/security/password_policy.dart';
+import '../../../core/storage/app_secure_store.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
@@ -200,6 +201,14 @@ class _SettingsChangePasswordScreenState
 
       _clearSensitiveState();
       context.go('/settings');
+    } on PasswordRotationRecoveryFailedException {
+      if (!mounted) return;
+      setState(() {
+        _submitError =
+            "We couldn't verify the previous password change. "
+            'Please keep your secret passphrase available before trying again.';
+        _isSubmitting = false;
+      });
     } catch (e, st) {
       log('SettingsChangePasswordScreen._submitNewPassword: ERROR: $e\n$st');
       if (!mounted) return;

--- a/lib/src/features/settings/screens/settings_change_password_screen.dart
+++ b/lib/src/features/settings/screens/settings_change_password_screen.dart
@@ -1,0 +1,570 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/layout/app_desktop_shell.dart';
+import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/security/password_policy.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_decorative_divider.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_text_field.dart';
+import '../../../core/widgets/password_text_field.dart';
+import '../../../providers/app_security_provider.dart';
+
+class SettingsChangePasswordScreen extends ConsumerStatefulWidget {
+  const SettingsChangePasswordScreen({super.key});
+
+  @override
+  ConsumerState<SettingsChangePasswordScreen> createState() =>
+      _SettingsChangePasswordScreenState();
+}
+
+enum _ChangePasswordStage { currentPassword, newPassword }
+
+class _SettingsChangePasswordScreenState
+    extends ConsumerState<SettingsChangePasswordScreen> {
+  final _currentPasswordController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _confirmController = TextEditingController();
+  _ChangePasswordStage _stage = _ChangePasswordStage.currentPassword;
+  String? _verifiedCurrentPassword;
+  String? _currentPasswordError;
+  String? _submitError;
+  bool _isSubmitting = false;
+
+  bool get _canContinue =>
+      !_isSubmitting && isWalletPasswordValid(_currentPasswordController.text);
+
+  String? get _passwordMessage {
+    final policyError = validateWalletPassword(_passwordController.text);
+    if (policyError != null) return policyError;
+    if (_passwordController.text.isNotEmpty &&
+        _verifiedCurrentPassword != null &&
+        _passwordController.text == _verifiedCurrentPassword) {
+      return kWalletPasswordMustDifferMessage;
+    }
+    return null;
+  }
+
+  bool get _matches =>
+      _confirmController.text.isNotEmpty &&
+      _confirmController.text == _passwordController.text;
+
+  bool get _canUpdate =>
+      !_isSubmitting &&
+      _verifiedCurrentPassword != null &&
+      _passwordMessage == null &&
+      _matches;
+
+  String? get _confirmMessage {
+    final value = _confirmController.text;
+    if (value.isEmpty || _passwordMessage != null || _matches) return null;
+    return "Password didn't match";
+  }
+
+  @override
+  void dispose() {
+    _clearSensitiveState();
+    _currentPasswordController.dispose();
+    _passwordController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  void _handleBack() {
+    _clearSensitiveState();
+    context.go('/settings');
+  }
+
+  void _clearSensitiveState() {
+    _currentPasswordController.clear();
+    _passwordController.clear();
+    _confirmController.clear();
+    _verifiedCurrentPassword = null;
+    _currentPasswordError = null;
+    _submitError = null;
+    _isSubmitting = false;
+  }
+
+  void _handleCurrentPasswordChanged() {
+    if (_currentPasswordError == null) {
+      setState(() {});
+      return;
+    }
+    setState(() {
+      _currentPasswordError = null;
+    });
+  }
+
+  void _handleNewPasswordChanged() {
+    setState(() {
+      _submitError = null;
+    });
+  }
+
+  Future<void> _submitCurrentPassword() async {
+    if (_isSubmitting) return;
+    if (!isWalletPasswordValid(_currentPasswordController.text)) {
+      final policyError = validateWalletPassword(
+        _currentPasswordController.text,
+      );
+      if (policyError != null) {
+        setState(() {
+          _currentPasswordError = policyError;
+        });
+      }
+      return;
+    }
+
+    setState(() {
+      _isSubmitting = true;
+      _currentPasswordError = null;
+    });
+
+    try {
+      final currentPassword = _currentPasswordController.text;
+      final isValid = await ref
+          .read(appSecurityProvider.notifier)
+          .confirmPassword(currentPassword);
+      if (!mounted) return;
+      if (!isValid) {
+        setState(() {
+          _currentPasswordError = 'Wrong password';
+          _isSubmitting = false;
+        });
+        return;
+      }
+
+      setState(() {
+        _verifiedCurrentPassword = currentPassword;
+        _currentPasswordController.clear();
+        _stage = _ChangePasswordStage.newPassword;
+        _isSubmitting = false;
+      });
+    } catch (e, st) {
+      log(
+        'SettingsChangePasswordScreen._submitCurrentPassword: ERROR: $e\n$st',
+      );
+      if (!mounted) return;
+      setState(() {
+        _currentPasswordError =
+            "Couldn't check your password. Please try again.";
+        _isSubmitting = false;
+      });
+    }
+  }
+
+  Future<void> _submitNewPassword() async {
+    if (_isSubmitting) return;
+    final currentPassword = _verifiedCurrentPassword;
+    final passwordError = _passwordMessage;
+    if (currentPassword == null) {
+      setState(() {
+        _stage = _ChangePasswordStage.currentPassword;
+        _currentPasswordError = 'Enter your current password again.';
+      });
+      return;
+    }
+    if (passwordError != null || !_matches) {
+      setState(() {});
+      return;
+    }
+
+    setState(() {
+      _isSubmitting = true;
+      _submitError = null;
+    });
+
+    try {
+      final didChange = await ref
+          .read(appSecurityProvider.notifier)
+          .changePassword(
+            currentPassword: currentPassword,
+            newPassword: _passwordController.text,
+          );
+      if (!mounted) return;
+      if (!didChange) {
+        setState(() {
+          _verifiedCurrentPassword = null;
+          _passwordController.clear();
+          _confirmController.clear();
+          _stage = _ChangePasswordStage.currentPassword;
+          _currentPasswordError = 'Wrong password';
+          _isSubmitting = false;
+        });
+        return;
+      }
+
+      _clearSensitiveState();
+      context.go('/settings');
+    } catch (e, st) {
+      log('SettingsChangePasswordScreen._submitNewPassword: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _submitError = e is ArgumentError && e.message != null
+            ? e.message.toString()
+            : "Couldn't update your password. Please try again.";
+        _isSubmitting = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AppDesktopShell(
+      sidebarWidth: 240,
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: _SettingsChangePasswordPane(
+          onBack: _handleBack,
+          child: switch (_stage) {
+            _ChangePasswordStage.currentPassword => _CurrentPasswordView(
+              passwordController: _currentPasswordController,
+              messageText: _currentPasswordError,
+              isSubmitting: _isSubmitting,
+              canSubmit: _canContinue,
+              onChanged: _handleCurrentPasswordChanged,
+              onSubmit: _submitCurrentPassword,
+            ),
+            _ChangePasswordStage.newPassword => _NewPasswordView(
+              passwordController: _passwordController,
+              confirmController: _confirmController,
+              isSubmitting: _isSubmitting,
+              canSubmit: _canUpdate,
+              passwordMessage: _passwordMessage,
+              confirmMessage: _confirmMessage,
+              submitError: _submitError,
+              onChanged: _handleNewPasswordChanged,
+              onSubmit: _submitNewPassword,
+            ),
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsChangePasswordPane extends StatelessWidget {
+  const _SettingsChangePasswordPane({
+    required this.onBack,
+    required this.child,
+  });
+
+  final VoidCallback onBack;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.expand(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: _BackButton(onTap: onBack),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Expanded(child: child),
+        ],
+      ),
+    );
+  }
+}
+
+class _BackButton extends StatelessWidget {
+  const _BackButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: SizedBox(
+          height: 32,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AppIcon(
+                AppIcons.chevronBackward,
+                size: 16,
+                color: colors.icon.accent,
+              ),
+              const SizedBox(width: AppSpacing.xxs),
+              Text(
+                'Back',
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CurrentPasswordView extends StatelessWidget {
+  const _CurrentPasswordView({
+    required this.passwordController,
+    required this.messageText,
+    required this.isSubmitting,
+    required this.canSubmit,
+    required this.onChanged,
+    required this.onSubmit,
+  });
+
+  final TextEditingController passwordController;
+  final String? messageText;
+  final bool isSubmitting;
+  final bool canSubmit;
+  final VoidCallback onChanged;
+  final Future<void> Function() onSubmit;
+
+  static const _contentWidth = 304.0;
+  static const _buttonWidth = 256.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Column(
+      children: [
+        Expanded(
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Current Password',
+                  textAlign: TextAlign.center,
+                  style: AppTypography.displaySmall.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.s),
+                SizedBox(
+                  width: 270,
+                  child: Text(
+                    'Enter your current password\n'
+                    'to update your password.',
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                const AppDecorativeDivider(width: 256),
+                const SizedBox(height: AppSpacing.sm),
+                SizedBox(
+                  width: _contentWidth,
+                  height: 86,
+                  child: PasswordTextField(
+                    label: 'Current Password',
+                    hintText: 'Enter Your Password',
+                    leadingSlotWidth: 32,
+                    trailingSlotWidth: 40,
+                    inputHorizontalPadding: AppSpacing.s,
+                    controller: passwordController,
+                    autofocus: true,
+                    enabled: !isSubmitting,
+                    messageText: messageText,
+                    tone: messageText == null
+                        ? AppTextFieldTone.neutral
+                        : AppTextFieldTone.destructive,
+                    onChanged: (_) => onChanged(),
+                    onSubmitted: (_) => onSubmit(),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AppButton(
+          onPressed: canSubmit ? onSubmit : null,
+          variant: AppButtonVariant.primary,
+          minWidth: _buttonWidth,
+          trailing: const AppIcon(AppIcons.chevronForward),
+          child: Text(isSubmitting ? 'Checking password...' : 'Continue'),
+        ),
+      ],
+    );
+  }
+}
+
+class _NewPasswordView extends StatelessWidget {
+  const _NewPasswordView({
+    required this.passwordController,
+    required this.confirmController,
+    required this.isSubmitting,
+    required this.canSubmit,
+    required this.passwordMessage,
+    required this.confirmMessage,
+    required this.submitError,
+    required this.onChanged,
+    required this.onSubmit,
+  });
+
+  final TextEditingController passwordController;
+  final TextEditingController confirmController;
+  final bool isSubmitting;
+  final bool canSubmit;
+  final String? passwordMessage;
+  final String? confirmMessage;
+  final String? submitError;
+  final VoidCallback onChanged;
+  final Future<void> Function() onSubmit;
+
+  static const _formWidth = 304.0;
+  static const _buttonWidth = 256.0;
+  static const _fieldGroupGap = 12.0;
+  static const _fieldReservedMessageHeight = 20.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Column(
+      children: [
+        Expanded(
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: AppSpacing.s),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'New Password',
+                    textAlign: TextAlign.center,
+                    style: AppTypography.displaySmall.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.s),
+                  SizedBox(
+                    width: 270,
+                    child: Text(
+                      kWalletPasswordMinLengthMessage,
+                      textAlign: TextAlign.center,
+                      style: AppTypography.bodyMedium.copyWith(
+                        color: colors.text.accent,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  const AppDecorativeDivider(width: 256),
+                  const SizedBox(height: AppSpacing.sm),
+                  SizedBox(
+                    width: _formWidth,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        _PasswordFieldBlock(
+                          reserveMessageSpace: _fieldReservedMessageHeight,
+                          child: PasswordTextField(
+                            label: 'Password',
+                            controller: passwordController,
+                            messageText: passwordMessage,
+                            tone: passwordMessage == null
+                                ? AppTextFieldTone.neutral
+                                : AppTextFieldTone.destructive,
+                            leadingSlotWidth: 32,
+                            trailingSlotWidth: 40,
+                            inputHorizontalPadding: AppSpacing.s,
+                            autofocus: true,
+                            enabled: !isSubmitting,
+                            onChanged: (_) => onChanged(),
+                            onSubmitted: (_) => onSubmit(),
+                          ),
+                        ),
+                        const SizedBox(height: _fieldGroupGap),
+                        _PasswordFieldBlock(
+                          reserveMessageSpace: _fieldReservedMessageHeight,
+                          child: PasswordTextField(
+                            label: 'Confirm Password',
+                            controller: confirmController,
+                            messageText: confirmMessage,
+                            tone: confirmMessage == null
+                                ? AppTextFieldTone.neutral
+                                : AppTextFieldTone.destructive,
+                            leadingSlotWidth: 32,
+                            trailingSlotWidth: 40,
+                            inputHorizontalPadding: AppSpacing.s,
+                            showVisibilityToggle: false,
+                            enabled: !isSubmitting,
+                            onChanged: (_) => onChanged(),
+                            onSubmitted: (_) => onSubmit(),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        SizedBox(
+          width: _buttonWidth,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (submitError != null) ...[
+                Padding(
+                  padding: const EdgeInsets.only(bottom: AppSpacing.xs),
+                  child: Text(
+                    submitError!,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.destructive,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ],
+              AppButton(
+                onPressed: canSubmit ? onSubmit : null,
+                variant: AppButtonVariant.primary,
+                minWidth: _buttonWidth,
+                trailing: const AppIcon(AppIcons.chevronForward),
+                child: Text(
+                  isSubmitting ? 'Updating password...' : 'Update Password',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PasswordFieldBlock extends StatelessWidget {
+  const _PasswordFieldBlock({
+    required this.child,
+    required this.reserveMessageSpace,
+  });
+
+  final Widget child;
+  final double reserveMessageSpace;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(bottom: reserveMessageSpace),
+      child: child,
+    );
+  }
+}

--- a/lib/src/features/settings/screens/settings_change_password_screen.dart
+++ b/lib/src/features/settings/screens/settings_change_password_screen.dart
@@ -36,6 +36,9 @@ class _SettingsChangePasswordScreenState
   String? _submitError;
   bool _isSubmitting = false;
 
+  String? get _currentPasswordPolicyMessage =>
+      validateWalletPassword(_currentPasswordController.text);
+
   bool get _canContinue =>
       !_isSubmitting && isWalletPasswordValid(_currentPasswordController.text);
 
@@ -63,7 +66,7 @@ class _SettingsChangePasswordScreenState
   String? get _confirmMessage {
     final value = _confirmController.text;
     if (value.isEmpty || _passwordMessage != null || _matches) return null;
-    return "Password didn't match";
+    return 'Passwords do not match.';
   }
 
   @override
@@ -107,16 +110,13 @@ class _SettingsChangePasswordScreenState
   }
 
   Future<void> _submitCurrentPassword() async {
+    final policyError = _currentPasswordPolicyMessage;
     if (_isSubmitting) return;
     if (!isWalletPasswordValid(_currentPasswordController.text)) {
-      final policyError = validateWalletPassword(
-        _currentPasswordController.text,
-      );
-      if (policyError != null) {
-        setState(() {
-          _currentPasswordError = policyError;
-        });
-      }
+      if (policyError == null) return;
+      setState(() {
+        _currentPasswordError = policyError;
+      });
       return;
     }
 
@@ -133,7 +133,7 @@ class _SettingsChangePasswordScreenState
       if (!mounted) return;
       if (!isValid) {
         setState(() {
-          _currentPasswordError = 'Wrong password';
+          _currentPasswordError = 'Incorrect password. Please try again.';
           _isSubmitting = false;
         });
         return;
@@ -193,7 +193,7 @@ class _SettingsChangePasswordScreenState
           _passwordController.clear();
           _confirmController.clear();
           _stage = _ChangePasswordStage.currentPassword;
-          _currentPasswordError = 'Wrong password';
+          _currentPasswordError = 'Incorrect password. Please try again.';
           _isSubmitting = false;
         });
         return;
@@ -232,7 +232,8 @@ class _SettingsChangePasswordScreenState
           child: switch (_stage) {
             _ChangePasswordStage.currentPassword => _CurrentPasswordView(
               passwordController: _currentPasswordController,
-              messageText: _currentPasswordError,
+              messageText:
+                  _currentPasswordError ?? _currentPasswordPolicyMessage,
               isSubmitting: _isSubmitting,
               canSubmit: _canContinue,
               onChanged: _handleCurrentPasswordChanged,
@@ -464,7 +465,7 @@ class _NewPasswordView extends StatelessWidget {
                   SizedBox(
                     width: 270,
                     child: Text(
-                      kWalletPasswordMinLengthMessage,
+                      'Minimum 8 symbols including characters.',
                       textAlign: TextAlign.center,
                       style: AppTypography.bodyMedium.copyWith(
                         color: colors.text.accent,

--- a/lib/src/features/settings/screens/settings_change_password_screen.dart
+++ b/lib/src/features/settings/screens/settings_change_password_screen.dart
@@ -215,7 +215,6 @@ class _SettingsChangePasswordScreenState
   @override
   Widget build(BuildContext context) {
     return AppDesktopShell(
-      sidebarWidth: 240,
       sidebar: const AppMainSidebar(),
       pane: AppDesktopPane(
         padding: const EdgeInsets.all(AppSpacing.md),

--- a/lib/src/features/settings/screens/settings_endpoint_screen.dart
+++ b/lib/src/features/settings/screens/settings_endpoint_screen.dart
@@ -1,0 +1,796 @@
+import 'package:flutter/material.dart'
+    show Scrollbar, ScrollbarTheme, ScrollbarThemeData;
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/config/rpc_endpoint_config.dart';
+import '../../../core/layout/app_desktop_shell.dart';
+import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_text_field.dart';
+import '../../../providers/rpc_endpoint_provider.dart';
+import '../../../providers/sync_provider.dart';
+
+class SettingsEndpointScreen extends ConsumerStatefulWidget {
+  const SettingsEndpointScreen({super.key});
+
+  @override
+  ConsumerState<SettingsEndpointScreen> createState() =>
+      _SettingsEndpointScreenState();
+}
+
+enum _EndpointTab { list, custom }
+
+class _SettingsEndpointScreenState
+    extends ConsumerState<SettingsEndpointScreen> {
+  final _customController = TextEditingController();
+  _EndpointTab _activeTab = _EndpointTab.list;
+  String? _selectedPresetId;
+  bool _isSubmitting = false;
+  String? _submitError;
+
+  @override
+  void initState() {
+    super.initState();
+    final endpoint = ref.read(rpcEndpointProvider);
+    final currentPreset = findRpcEndpointPresetByUrl(
+      endpoint.normalizedLightwalletdUrl,
+      networkName: endpoint.networkName,
+    );
+    _selectedPresetId = currentPreset?.id;
+    if (currentPreset == null) {
+      _activeTab = _EndpointTab.custom;
+      _customController.text = endpoint.hostPort;
+    }
+  }
+
+  @override
+  void dispose() {
+    _customController.dispose();
+    super.dispose();
+  }
+
+  void _handleBack() {
+    context.go('/settings');
+  }
+
+  void _selectTab(_EndpointTab tab) {
+    if (_isSubmitting) return;
+    if (tab == _EndpointTab.custom && _customController.text.trim().isEmpty) {
+      _customController.text = ref.read(rpcEndpointProvider).hostPort;
+    }
+    setState(() {
+      _activeTab = tab;
+      _submitError = null;
+    });
+  }
+
+  void _selectPreset(String id) {
+    if (_isSubmitting) return;
+    setState(() {
+      _selectedPresetId = id;
+      _submitError = null;
+    });
+  }
+
+  bool _canUpdate(RpcEndpointConfig current) {
+    if (_isSubmitting) return false;
+    return switch (_activeTab) {
+      _EndpointTab.list =>
+        _selectedPresetId != null &&
+            findRpcEndpointPresetById(
+                  current.networkName,
+                  _selectedPresetId!,
+                ) !=
+                null &&
+            _selectedPresetId != current.effectivePresetId,
+      _EndpointTab.custom => _customEndpointChanged(current),
+    };
+  }
+
+  bool _customEndpointChanged(RpcEndpointConfig current) {
+    try {
+      return normalizeRpcEndpointUrl(
+            _customController.text,
+            allowDefaultPort: true,
+          ) !=
+          current.normalizedLightwalletdUrl;
+    } on FormatException {
+      return false;
+    }
+  }
+
+  String? _customMessageText() {
+    if (_activeTab != _EndpointTab.custom) return null;
+    if (_customController.text.trim().isEmpty) return null;
+    try {
+      normalizeRpcEndpointUrl(_customController.text, allowDefaultPort: true);
+      return null;
+    } on FormatException catch (e) {
+      return e.message;
+    }
+  }
+
+  Future<void> _submit() async {
+    final current = ref.read(rpcEndpointProvider);
+    if (!_canUpdate(current)) return;
+
+    setState(() {
+      _isSubmitting = true;
+      _submitError = null;
+    });
+
+    try {
+      final notifier = ref.read(rpcEndpointProvider.notifier);
+      if (_activeTab == _EndpointTab.list) {
+        final preset = findRpcEndpointPresetById(
+          current.networkName,
+          _selectedPresetId!,
+        );
+        if (preset == null) {
+          throw const FormatException('Select an endpoint.');
+        }
+        await notifier.setPreset(preset);
+      } else {
+        await notifier.setCustom(_customController.text);
+      }
+      await ref.read(syncProvider.notifier).restartSync();
+      if (!mounted) return;
+      final next = ref.read(rpcEndpointProvider);
+      setState(() {
+        _selectedPresetId = findRpcEndpointPresetByUrl(
+          next.normalizedLightwalletdUrl,
+          networkName: next.networkName,
+        )?.id;
+        if (_selectedPresetId == null) {
+          _customController.text = next.hostPort;
+        }
+        _isSubmitting = false;
+      });
+    } on FormatException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _submitError = e.message;
+        _isSubmitting = false;
+      });
+    } catch (e, st) {
+      log('SettingsEndpointScreen._submit: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _submitError =
+            "Couldn't connect to that endpoint. Check the host and port.";
+        _isSubmitting = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final current = ref.watch(rpcEndpointProvider);
+
+    return AppDesktopShell(
+      sidebarWidth: 240,
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: _SettingsEndpointPane(
+          current: current,
+          activeTab: _activeTab,
+          selectedPresetId: _selectedPresetId,
+          customController: _customController,
+          customMessageText: _customMessageText(),
+          submitError: _submitError,
+          isSubmitting: _isSubmitting,
+          canUpdate: _canUpdate(current),
+          onBack: _handleBack,
+          onSelectTab: _selectTab,
+          onSelectPreset: _selectPreset,
+          onCustomChanged: (_) => setState(() {
+            _submitError = null;
+          }),
+          onSubmit: _submit,
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsEndpointPane extends StatelessWidget {
+  const _SettingsEndpointPane({
+    required this.current,
+    required this.activeTab,
+    required this.selectedPresetId,
+    required this.customController,
+    required this.customMessageText,
+    required this.submitError,
+    required this.isSubmitting,
+    required this.canUpdate,
+    required this.onBack,
+    required this.onSelectTab,
+    required this.onSelectPreset,
+    required this.onCustomChanged,
+    required this.onSubmit,
+  });
+
+  final RpcEndpointConfig current;
+  final _EndpointTab activeTab;
+  final String? selectedPresetId;
+  final TextEditingController customController;
+  final String? customMessageText;
+  final String? submitError;
+  final bool isSubmitting;
+  final bool canUpdate;
+  final VoidCallback onBack;
+  final ValueChanged<_EndpointTab> onSelectTab;
+  final ValueChanged<String> onSelectPreset;
+  final ValueChanged<String> onCustomChanged;
+  final Future<void> Function() onSubmit;
+
+  static const _widgetWidth = 352.0;
+  static const _buttonWidth = 256.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return SizedBox.expand(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: _BackButton(onTap: onBack),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Expanded(
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Endpoint',
+                    textAlign: TextAlign.center,
+                    style: AppTypography.displaySmall.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  _CurrentEndpointText(current: current),
+                  const SizedBox(height: AppSpacing.sm),
+                  _EndpointSelector(
+                    width: _widgetWidth,
+                    current: current,
+                    activeTab: activeTab,
+                    selectedPresetId: selectedPresetId,
+                    customController: customController,
+                    customMessageText: customMessageText,
+                    onSelectTab: onSelectTab,
+                    onSelectPreset: onSelectPreset,
+                    onCustomChanged: onCustomChanged,
+                    onSubmit: onSubmit,
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  if (submitError != null) ...[
+                    SizedBox(
+                      width: _widgetWidth,
+                      child: Text(
+                        submitError!,
+                        textAlign: TextAlign.center,
+                        style: AppTypography.bodyMedium.copyWith(
+                          color: colors.text.destructive,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                  ],
+                  AppButton(
+                    onPressed: canUpdate ? onSubmit : null,
+                    variant: AppButtonVariant.primary,
+                    minWidth: _buttonWidth,
+                    trailing: const AppIcon(AppIcons.chevronForward),
+                    child: Text(isSubmitting ? 'Updating...' : 'Update'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CurrentEndpointText extends StatelessWidget {
+  const _CurrentEndpointText({required this.current});
+
+  final RpcEndpointConfig current;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final preset = findRpcEndpointPresetByUrl(
+      current.normalizedLightwalletdUrl,
+      networkName: current.networkName,
+    );
+    final suffix = [
+      if (preset?.latencyLabel != null) preset!.latencyLabel!,
+      if (preset?.isDefault ?? false) '(Default)',
+    ].join(' ');
+
+    return Text.rich(
+      TextSpan(
+        text: 'Current: ',
+        children: [
+          TextSpan(
+            text: current.hostPort,
+            style: TextStyle(color: colors.text.brandCrimson),
+          ),
+          if (suffix.isNotEmpty) TextSpan(text: ' $suffix'),
+        ],
+      ),
+      textAlign: TextAlign.center,
+      style: AppTypography.bodyMedium.copyWith(color: colors.text.primary),
+    );
+  }
+}
+
+class _EndpointSelector extends StatelessWidget {
+  const _EndpointSelector({
+    required this.width,
+    required this.current,
+    required this.activeTab,
+    required this.selectedPresetId,
+    required this.customController,
+    required this.customMessageText,
+    required this.onSelectTab,
+    required this.onSelectPreset,
+    required this.onCustomChanged,
+    required this.onSubmit,
+  });
+
+  final double width;
+  final RpcEndpointConfig current;
+  final _EndpointTab activeTab;
+  final String? selectedPresetId;
+  final TextEditingController customController;
+  final String? customMessageText;
+  final ValueChanged<_EndpointTab> onSelectTab;
+  final ValueChanged<String> onSelectPreset;
+  final ValueChanged<String> onCustomChanged;
+  final Future<void> Function() onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Container(
+      width: width,
+      height: 395,
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.xs,
+        AppSpacing.sm,
+        AppSpacing.xs,
+        AppSpacing.xs,
+      ),
+      decoration: BoxDecoration(
+        color: colors.background.base,
+        borderRadius: BorderRadius.circular(AppRadii.xLarge),
+      ),
+      child: Column(
+        children: [
+          _EndpointTabs(activeTab: activeTab, onSelect: onSelectTab),
+          const SizedBox(height: AppSpacing.sm),
+          Expanded(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: colors.background.ground,
+                borderRadius: BorderRadius.circular(AppRadii.large),
+              ),
+              child: switch (activeTab) {
+                _EndpointTab.list => _PresetList(
+                  networkName: current.networkName,
+                  selectedPresetId: selectedPresetId,
+                  onSelect: onSelectPreset,
+                ),
+                _EndpointTab.custom => Padding(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.xs,
+                    AppSpacing.s,
+                    AppSpacing.sm,
+                    AppSpacing.xs,
+                  ),
+                  child: _CustomEndpointForm(
+                    controller: customController,
+                    messageText: customMessageText,
+                    onChanged: onCustomChanged,
+                    onSubmit: onSubmit,
+                  ),
+                ),
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EndpointTabs extends StatelessWidget {
+  const _EndpointTabs({required this.activeTab, required this.onSelect});
+
+  final _EndpointTab activeTab;
+  final ValueChanged<_EndpointTab> onSelect;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 32,
+      child: Row(
+        children: [
+          Expanded(
+            child: _EndpointTabButton(
+              label: 'Select from list',
+              selected: activeTab == _EndpointTab.list,
+              onTap: () => onSelect(_EndpointTab.list),
+            ),
+          ),
+          Expanded(
+            child: _EndpointTabButton(
+              label: 'Custom Endpoint',
+              selected: activeTab == _EndpointTab.custom,
+              onTap: () => onSelect(_EndpointTab.custom),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EndpointTabButton extends StatelessWidget {
+  const _EndpointTabButton({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Center(
+          child: Text(
+            label,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.labelMedium.copyWith(
+              color: selected ? colors.text.accent : colors.text.secondary,
+              fontWeight: selected ? FontWeight.w500 : FontWeight.w400,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PresetList extends StatefulWidget {
+  const _PresetList({
+    required this.networkName,
+    required this.selectedPresetId,
+    required this.onSelect,
+  });
+
+  final String networkName;
+  final String? selectedPresetId;
+  final ValueChanged<String> onSelect;
+
+  @override
+  State<_PresetList> createState() => _PresetListState();
+}
+
+class _PresetListState extends State<_PresetList> {
+  final _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final groups = <String, List<RpcEndpointPreset>>{};
+    for (final preset in rpcEndpointPresetsForNetwork(widget.networkName)) {
+      groups.putIfAbsent(preset.region, () => []).add(preset);
+    }
+
+    return ScrollbarTheme(
+      data: ScrollbarThemeData(
+        thumbColor: WidgetStatePropertyAll(colors.background.overlay),
+        thickness: const WidgetStatePropertyAll(6),
+        radius: const Radius.circular(AppRadii.full),
+        thumbVisibility: const WidgetStatePropertyAll(true),
+        trackVisibility: const WidgetStatePropertyAll(false),
+        crossAxisMargin: 3,
+        mainAxisMargin: 3,
+      ),
+      child: Scrollbar(
+        controller: _scrollController,
+        child: SingleChildScrollView(
+          controller: _scrollController,
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.xs,
+            AppSpacing.s,
+            AppSpacing.sm,
+            AppSpacing.xs,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (final entry in groups.entries) ...[
+                _PresetRegionLabel(label: entry.key),
+                const SizedBox(height: AppSpacing.xs),
+                for (final preset in entry.value) ...[
+                  _PresetCard(
+                    preset: preset,
+                    selected: preset.id == widget.selectedPresetId,
+                    onTap: () => widget.onSelect(preset.id),
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                ],
+                const SizedBox(height: AppSpacing.xs),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PresetRegionLabel extends StatelessWidget {
+  const _PresetRegionLabel({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+      child: Text(
+        label,
+        style: AppTypography.labelMedium.copyWith(
+          color: context.colors.text.secondary,
+        ),
+      ),
+    );
+  }
+}
+
+class _PresetCard extends StatelessWidget {
+  const _PresetCard({
+    required this.preset,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final RpcEndpointPreset preset;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          height: 56,
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(AppRadii.medium),
+            border: Border.all(
+              color: selected ? colors.border.strong : colors.border.regular,
+              width: selected ? 2 : 1.5,
+              strokeAlign: BorderSide.strokeAlignInside,
+            ),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      preset.hostPort,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.text.accent,
+                      ),
+                    ),
+                    if (preset.latencyLabel != null)
+                      Text(
+                        preset.latencyLabel!,
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTypography.labelMedium.copyWith(
+                          color: colors.text.secondary,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xs),
+              _PresetIndicator(selected: selected),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PresetIndicator extends StatelessWidget {
+  const _PresetIndicator({required this.selected});
+
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Container(
+      width: 16,
+      height: 16,
+      decoration: BoxDecoration(
+        color: selected
+            ? colors.background.inverse
+            : colors.background.neutralSubtleOpacity,
+        shape: BoxShape.circle,
+      ),
+      child: selected
+          ? Center(
+              child: AppIcon(
+                AppIcons.check,
+                size: 12,
+                color: colors.background.ground,
+              ),
+            )
+          : null,
+    );
+  }
+}
+
+class _CustomEndpointForm extends StatelessWidget {
+  const _CustomEndpointForm({
+    required this.controller,
+    required this.messageText,
+    required this.onChanged,
+    required this.onSubmit,
+  });
+
+  final TextEditingController controller;
+  final String? messageText;
+  final ValueChanged<String> onChanged;
+  final Future<void> Function() onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            height: 86,
+            child: AppTextField(
+              label: 'Custom Endpoint',
+              hintText: '<hostname>:<port>',
+              controller: controller,
+              autofocus: true,
+              leading: const AppIcon(AppIcons.endpoint),
+              leadingSlotWidth: 32,
+              trailingSlotWidth: 40,
+              inputHorizontalPadding: AppSpacing.s,
+              keyboardType: TextInputType.url,
+              textInputAction: TextInputAction.done,
+              messageText: messageText,
+              tone: messageText == null
+                  ? AppTextFieldTone.neutral
+                  : AppTextFieldTone.destructive,
+              onChanged: onChanged,
+              onSubmitted: (_) => onSubmit(),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              AppIcon(AppIcons.book, size: 20, color: colors.icon.accent),
+              const SizedBox(width: AppSpacing.xs),
+              Expanded(
+                child: Text.rich(
+                  TextSpan(
+                    text:
+                        "If the endpoint is configured wrong, your wallet won't "
+                        'be able to sync with Zcash blockchain.\n',
+                    children: [
+                      TextSpan(
+                        text:
+                            "The wallet will show the balance from the last "
+                            "time it was successfully connected. It won't "
+                            'show any ZEC you recently received.',
+                        style: TextStyle(color: colors.text.primary),
+                      ),
+                    ],
+                  ),
+                  style: AppTypography.bodyMedium.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BackButton extends StatelessWidget {
+  const _BackButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: SizedBox(
+          height: 32,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AppIcon(
+                AppIcons.chevronBackward,
+                size: 16,
+                color: colors.icon.accent,
+              ),
+              const SizedBox(width: AppSpacing.xxs),
+              Text(
+                'Back',
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/settings/screens/settings_endpoint_screen.dart
+++ b/lib/src/features/settings/screens/settings_endpoint_screen.dart
@@ -174,7 +174,6 @@ class _SettingsEndpointScreenState
     final current = ref.watch(rpcEndpointProvider);
 
     return AppDesktopShell(
-      sidebarWidth: 240,
       sidebar: const AppMainSidebar(),
       pane: AppDesktopPane(
         padding: const EdgeInsets.all(AppSpacing.md),

--- a/lib/src/features/settings/screens/settings_endpoint_screen.dart
+++ b/lib/src/features/settings/screens/settings_endpoint_screen.dart
@@ -45,7 +45,7 @@ class _SettingsEndpointScreenState
     _selectedPresetId = currentPreset?.id;
     if (currentPreset == null) {
       _activeTab = _EndpointTab.custom;
-      _customController.text = endpoint.hostPort;
+      _customController.text = rpcEndpointInputText(endpoint.lightwalletdUrl);
     }
   }
 
@@ -62,7 +62,8 @@ class _SettingsEndpointScreenState
   void _selectTab(_EndpointTab tab) {
     if (_isSubmitting) return;
     if (tab == _EndpointTab.custom && _customController.text.trim().isEmpty) {
-      _customController.text = ref.read(rpcEndpointProvider).hostPort;
+      final endpoint = ref.read(rpcEndpointProvider);
+      _customController.text = rpcEndpointInputText(endpoint.lightwalletdUrl);
     }
     setState(() {
       _activeTab = tab;
@@ -148,7 +149,7 @@ class _SettingsEndpointScreenState
           networkName: next.networkName,
         )?.id;
         if (_selectedPresetId == null) {
-          _customController.text = next.hostPort;
+          _customController.text = rpcEndpointInputText(next.lightwalletdUrl);
         }
         _isSubmitting = false;
       });

--- a/lib/src/features/settings/screens/settings_screen.dart
+++ b/lib/src/features/settings/screens/settings_screen.dart
@@ -6,8 +6,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../app_bootstrap.dart';
-import '../../../core/config/network_config.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/profile_pictures.dart';
@@ -17,6 +15,7 @@ import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_text_field.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/theme_mode_provider.dart';
 
 class SettingsScreen extends ConsumerStatefulWidget {
@@ -78,9 +77,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final activeAccountIsHardware =
         accountState?.activeAccount?.isHardware ?? false;
     final themeMode = ref.watch(themeModeProvider);
-    final endpointLabel = _endpointLabel(
-      ref.watch(appBootstrapProvider).network,
-    );
+    final endpointLabel = ref.watch(rpcEndpointProvider).hostPort;
 
     return AppDesktopShell(
       sidebarWidth: 240,
@@ -102,6 +99,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 onBack: () => _handleBack(context),
                 onSeedPhrase: () => context.go('/settings/secret-passphrase'),
                 onChangePassword: () => context.go('/settings/change-password'),
+                onEndpoint: () => context.go('/settings/endpoint'),
                 onAccountName: hasActiveAccount
                     ? () => _showModal(_SettingsModalType.accountName)
                     : null,
@@ -158,13 +156,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   static String _profilePictureLabel(String profilePictureId) {
     return findProfilePictureOption(profilePictureId)?.label ?? 'Custom';
   }
-
-  static String _endpointLabel(String networkName) {
-    final network = networkName == ZcashNetwork.testnet.name
-        ? ZcashNetwork.testnet
-        : ZcashNetwork.mainnet;
-    return network.lightwalletdHost;
-  }
 }
 
 class _SettingsPane extends StatelessWidget {
@@ -177,6 +168,7 @@ class _SettingsPane extends StatelessWidget {
     required this.onBack,
     required this.onSeedPhrase,
     required this.onChangePassword,
+    required this.onEndpoint,
     required this.onAccountName,
     required this.onProfilePicture,
     required this.onTheme,
@@ -190,6 +182,7 @@ class _SettingsPane extends StatelessWidget {
   final VoidCallback onBack;
   final VoidCallback onSeedPhrase;
   final VoidCallback onChangePassword;
+  final VoidCallback onEndpoint;
   final VoidCallback? onAccountName;
   final VoidCallback? onProfilePicture;
   final VoidCallback onTheme;
@@ -234,6 +227,7 @@ class _SettingsPane extends StatelessWidget {
                         themeLabel: themeLabel,
                         onSeedPhrase: onSeedPhrase,
                         onChangePassword: onChangePassword,
+                        onEndpoint: onEndpoint,
                         onAccountName: onAccountName,
                         onProfilePicture: onProfilePicture,
                         onTheme: onTheme,
@@ -298,6 +292,7 @@ class _SettingsList extends StatelessWidget {
     required this.themeLabel,
     required this.onSeedPhrase,
     required this.onChangePassword,
+    required this.onEndpoint,
     required this.onAccountName,
     required this.onProfilePicture,
     required this.onTheme,
@@ -310,6 +305,7 @@ class _SettingsList extends StatelessWidget {
   final String themeLabel;
   final VoidCallback onSeedPhrase;
   final VoidCallback onChangePassword;
+  final VoidCallback onEndpoint;
   final VoidCallback? onAccountName;
   final VoidCallback? onProfilePicture;
   final VoidCallback onTheme;
@@ -359,6 +355,7 @@ class _SettingsList extends StatelessWidget {
               iconName: AppIcons.endpoint,
               label: 'Endpoint',
               value: endpointLabel,
+              onTap: onEndpoint,
             ),
             const _SettingsRowDivider(),
             _SettingsRow(

--- a/lib/src/features/settings/screens/settings_screen.dart
+++ b/lib/src/features/settings/screens/settings_screen.dart
@@ -10,6 +10,7 @@ import '../../../app_bootstrap.dart';
 import '../../../core/config/network_config.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/profile_pictures.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
@@ -25,7 +26,7 @@ class SettingsScreen extends ConsumerStatefulWidget {
   ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
 }
 
-enum _SettingsModalType { accountName, theme }
+enum _SettingsModalType { accountName, profilePicture, theme }
 
 class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   _SettingsModalType? _activeModal;
@@ -56,10 +57,23 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     _closeModal();
   }
 
+  Future<void> _updateProfilePicture(String profilePictureId) async {
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    if (accountUuid == null) return;
+    await ref
+        .read(accountProvider.notifier)
+        .updateProfilePicture(accountUuid, profilePictureId);
+    if (!mounted) return;
+    _closeModal();
+  }
+
   @override
   Widget build(BuildContext context) {
     final accountState = ref.watch(accountProvider).value;
     final activeAccountName = accountState?.activeAccount?.name ?? 'Wallet 1';
+    final activeProfilePictureId =
+        accountState?.activeAccount?.profilePictureId ??
+        kDefaultProfilePictureId;
     final hasActiveAccount = accountState?.activeAccountUuid != null;
     final activeAccountIsHardware =
         accountState?.activeAccount?.isHardware ?? false;
@@ -79,6 +93,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               padding: const EdgeInsets.all(AppSpacing.md),
               child: _SettingsPane(
                 accountName: activeAccountName,
+                profilePictureLabel: _profilePictureLabel(
+                  activeProfilePictureId,
+                ),
                 activeAccountIsHardware: activeAccountIsHardware,
                 endpointLabel: endpointLabel,
                 themeLabel: _themeLabel(themeMode),
@@ -87,6 +104,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 onChangePassword: () => context.go('/settings/change-password'),
                 onAccountName: hasActiveAccount
                     ? () => _showModal(_SettingsModalType.accountName)
+                    : null,
+                onProfilePicture: hasActiveAccount
+                    ? () => _showModal(_SettingsModalType.profilePicture)
                     : null,
                 onTheme: () => _showModal(_SettingsModalType.theme),
               ),
@@ -97,8 +117,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 child: switch (_activeModal!) {
                   _SettingsModalType.accountName => _AccountNameModal(
                     accountName: activeAccountName,
+                    profilePictureId: activeProfilePictureId,
                     onCancel: _closeModal,
                     onUpdate: _updateAccountName,
+                  ),
+                  _SettingsModalType.profilePicture => _ProfilePictureModal(
+                    currentProfilePictureId: activeProfilePictureId,
+                    onCancel: _closeModal,
+                    onUpdate: _updateProfilePicture,
                   ),
                   _SettingsModalType.theme => _ThemeModal(
                     currentMode: themeMode,
@@ -129,6 +155,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     };
   }
 
+  static String _profilePictureLabel(String profilePictureId) {
+    return findProfilePictureOption(profilePictureId)?.label ?? 'Custom';
+  }
+
   static String _endpointLabel(String networkName) {
     final network = networkName == ZcashNetwork.testnet.name
         ? ZcashNetwork.testnet
@@ -140,6 +170,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 class _SettingsPane extends StatelessWidget {
   const _SettingsPane({
     required this.accountName,
+    required this.profilePictureLabel,
     required this.activeAccountIsHardware,
     required this.endpointLabel,
     required this.themeLabel,
@@ -147,10 +178,12 @@ class _SettingsPane extends StatelessWidget {
     required this.onSeedPhrase,
     required this.onChangePassword,
     required this.onAccountName,
+    required this.onProfilePicture,
     required this.onTheme,
   });
 
   final String accountName;
+  final String profilePictureLabel;
   final bool activeAccountIsHardware;
   final String endpointLabel;
   final String themeLabel;
@@ -158,6 +191,7 @@ class _SettingsPane extends StatelessWidget {
   final VoidCallback onSeedPhrase;
   final VoidCallback onChangePassword;
   final VoidCallback? onAccountName;
+  final VoidCallback? onProfilePicture;
   final VoidCallback onTheme;
 
   @override
@@ -194,12 +228,14 @@ class _SettingsPane extends StatelessWidget {
                       const SizedBox(height: AppSpacing.sm),
                       _SettingsList(
                         accountName: accountName,
+                        profilePictureLabel: profilePictureLabel,
                         activeAccountIsHardware: activeAccountIsHardware,
                         endpointLabel: endpointLabel,
                         themeLabel: themeLabel,
                         onSeedPhrase: onSeedPhrase,
                         onChangePassword: onChangePassword,
                         onAccountName: onAccountName,
+                        onProfilePicture: onProfilePicture,
                         onTheme: onTheme,
                       ),
                     ],
@@ -256,22 +292,26 @@ class _SettingsBackButton extends StatelessWidget {
 class _SettingsList extends StatelessWidget {
   const _SettingsList({
     required this.accountName,
+    required this.profilePictureLabel,
     required this.activeAccountIsHardware,
     required this.endpointLabel,
     required this.themeLabel,
     required this.onSeedPhrase,
     required this.onChangePassword,
     required this.onAccountName,
+    required this.onProfilePicture,
     required this.onTheme,
   });
 
   final String accountName;
+  final String profilePictureLabel;
   final bool activeAccountIsHardware;
   final String endpointLabel;
   final String themeLabel;
   final VoidCallback onSeedPhrase;
   final VoidCallback onChangePassword;
   final VoidCallback? onAccountName;
+  final VoidCallback? onProfilePicture;
   final VoidCallback onTheme;
 
   @override
@@ -296,10 +336,11 @@ class _SettingsList extends StatelessWidget {
               onTap: onChangePassword,
             ),
             const _SettingsRowDivider(),
-            const _SettingsRow(
+            _SettingsRow(
               iconName: AppIcons.users,
               label: 'Profile Picture',
-              value: 'Knight',
+              value: profilePictureLabel,
+              onTap: onProfilePicture,
             ),
             const _SettingsRowDivider(),
             _SettingsRow(
@@ -387,10 +428,15 @@ class _SettingsModalOverlay extends StatelessWidget {
 }
 
 class _SettingsModalCard extends StatelessWidget {
-  const _SettingsModalCard({required this.header, required this.child});
+  const _SettingsModalCard({
+    required this.header,
+    required this.child,
+    this.gap = AppSpacing.md,
+  });
 
   final Widget header;
   final Widget child;
+  final double gap;
 
   @override
   Widget build(BuildContext context) {
@@ -408,7 +454,7 @@ class _SettingsModalCard extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           header,
-          const SizedBox(height: AppSpacing.md),
+          SizedBox(height: gap),
           child,
         ],
       ),
@@ -444,15 +490,31 @@ class _ModalHeader extends StatelessWidget {
 }
 
 class _ModalAccountAvatar extends StatelessWidget {
-  const _ModalAccountAvatar();
+  const _ModalAccountAvatar({required this.profilePictureId});
+
+  final String profilePictureId;
+
+  @override
+  Widget build(BuildContext context) {
+    final option = resolveProfilePictureOption(profilePictureId);
+
+    return _ProfilePictureImage(assetPath: option.assetPath, size: 32);
+  }
+}
+
+class _ProfilePictureImage extends StatelessWidget {
+  const _ProfilePictureImage({required this.assetPath, required this.size});
+
+  final String assetPath;
+  final double size;
 
   @override
   Widget build(BuildContext context) {
     return ClipOval(
       child: Image.asset(
-        'assets/illustrations/sidebar_account_avatar_knight.png',
-        width: 32,
-        height: 32,
+        assetPath,
+        width: size,
+        height: size,
         fit: BoxFit.cover,
       ),
     );
@@ -486,14 +548,198 @@ class _ModalUtilityIcon extends StatelessWidget {
   }
 }
 
+class _ProfilePictureModal extends StatefulWidget {
+  const _ProfilePictureModal({
+    required this.currentProfilePictureId,
+    required this.onCancel,
+    required this.onUpdate,
+  });
+
+  final String currentProfilePictureId;
+  final VoidCallback onCancel;
+  final Future<void> Function(String profilePictureId) onUpdate;
+
+  @override
+  State<_ProfilePictureModal> createState() => _ProfilePictureModalState();
+}
+
+class _ProfilePictureModalState extends State<_ProfilePictureModal> {
+  static const _buttonWidth = 280.0;
+  static const _optionSize = 32.0;
+
+  late String _selectedId = _initialSelectedId();
+  bool _isSubmitting = false;
+  String? _submitError;
+
+  bool get _canUpdate =>
+      !_isSubmitting &&
+      isKnownProfilePictureId(_selectedId) &&
+      _selectedId != widget.currentProfilePictureId;
+
+  String _initialSelectedId() {
+    return widget.currentProfilePictureId;
+  }
+
+  Future<void> _submit() async {
+    if (!_canUpdate) return;
+    setState(() {
+      _isSubmitting = true;
+      _submitError = null;
+    });
+    try {
+      await widget.onUpdate(_selectedId);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _submitError = "Couldn't update profile picture.";
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSubmitting = false;
+        });
+      }
+    }
+  }
+
+  void _select(String id) {
+    if (_isSubmitting) return;
+    setState(() {
+      _selectedId = id;
+      _submitError = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final previewOption = resolveProfilePictureOption(_selectedId);
+
+    return _SettingsModalCard(
+      gap: AppSpacing.sm,
+      header: _ModalHeader(
+        leading: _ProfilePictureImage(
+          assetPath: previewOption.assetPath,
+          size: 56,
+        ),
+        title: 'Select Profile Picture',
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: AppSpacing.s),
+            child: Wrap(
+              alignment: WrapAlignment.center,
+              spacing: AppSpacing.s,
+              runSpacing: AppSpacing.s,
+              children: [
+                for (final option in kProfilePictureOptions)
+                  _ProfilePictureOptionButton(
+                    option: option,
+                    size: _optionSize,
+                    selected: option.id == _selectedId,
+                    onTap: () => _select(option.id),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          if (_submitError != null) ...[
+            Text(
+              _submitError!,
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMedium.copyWith(
+                color: context.colors.text.destructive,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+          ],
+          AppButton(
+            onPressed: _canUpdate ? _submit : null,
+            variant: AppButtonVariant.primary,
+            minWidth: _buttonWidth,
+            child: Text(_isSubmitting ? 'Updating...' : 'Update'),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          AppButton(
+            onPressed: _isSubmitting ? null : widget.onCancel,
+            variant: AppButtonVariant.ghost,
+            minWidth: _buttonWidth,
+            child: const Text('Cancel'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfilePictureOptionButton extends StatelessWidget {
+  const _ProfilePictureOptionButton({
+    required this.option,
+    required this.size,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final ProfilePictureOption option;
+  final double size;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: SizedBox(
+          width: size,
+          height: size,
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              _ProfilePictureImage(assetPath: option.assetPath, size: size),
+              if (selected)
+                Positioned(
+                  right: -4,
+                  bottom: -2,
+                  child: Container(
+                    width: 16,
+                    height: 16,
+                    decoration: BoxDecoration(
+                      color: colors.background.inverse,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Center(
+                      child: AppIcon(
+                        AppIcons.check,
+                        size: 12,
+                        color: colors.background.ground,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _AccountNameModal extends StatefulWidget {
   const _AccountNameModal({
     required this.accountName,
+    required this.profilePictureId,
     required this.onCancel,
     required this.onUpdate,
   });
 
   final String accountName;
+  final String profilePictureId;
   final VoidCallback onCancel;
   final Future<void> Function(String name) onUpdate;
 
@@ -567,7 +813,7 @@ class _AccountNameModalState extends State<_AccountNameModal> {
   Widget build(BuildContext context) {
     return _SettingsModalCard(
       header: _ModalHeader(
-        leading: const _ModalAccountAvatar(),
+        leading: _ModalAccountAvatar(profilePictureId: widget.profilePictureId),
         title: widget.accountName,
       ),
       child: Column(

--- a/lib/src/features/settings/screens/settings_screen.dart
+++ b/lib/src/features/settings/screens/settings_screen.dart
@@ -20,20 +20,25 @@ class SettingsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final accountState = ref.watch(accountProvider).value;
     final activeAccountName = accountState?.activeAccount?.name ?? 'Wallet 1';
+    final activeAccountIsHardware =
+        accountState?.activeAccount?.isHardware ?? false;
     final themeMode = ref.watch(themeModeProvider);
     final endpointLabel = _endpointLabel(
       ref.watch(appBootstrapProvider).network,
     );
 
     return AppDesktopShell(
+      sidebarWidth: 240,
       sidebar: const AppMainSidebar(),
       pane: AppDesktopPane(
         padding: const EdgeInsets.all(AppSpacing.md),
         child: _SettingsPane(
           accountName: activeAccountName,
+          activeAccountIsHardware: activeAccountIsHardware,
           endpointLabel: endpointLabel,
           themeLabel: _themeLabel(themeMode),
           onBack: () => _handleBack(context),
+          onSeedPhrase: () => context.go('/settings/secret-passphrase'),
         ),
       ),
     );
@@ -66,15 +71,19 @@ class SettingsScreen extends ConsumerWidget {
 class _SettingsPane extends StatelessWidget {
   const _SettingsPane({
     required this.accountName,
+    required this.activeAccountIsHardware,
     required this.endpointLabel,
     required this.themeLabel,
     required this.onBack,
+    required this.onSeedPhrase,
   });
 
   final String accountName;
+  final bool activeAccountIsHardware;
   final String endpointLabel;
   final String themeLabel;
   final VoidCallback onBack;
+  final VoidCallback onSeedPhrase;
 
   @override
   Widget build(BuildContext context) {
@@ -110,8 +119,10 @@ class _SettingsPane extends StatelessWidget {
                       const SizedBox(height: AppSpacing.sm),
                       _SettingsList(
                         accountName: accountName,
+                        activeAccountIsHardware: activeAccountIsHardware,
                         endpointLabel: endpointLabel,
                         themeLabel: themeLabel,
+                        onSeedPhrase: onSeedPhrase,
                       ),
                     ],
                   ),
@@ -167,13 +178,17 @@ class _SettingsBackButton extends StatelessWidget {
 class _SettingsList extends StatelessWidget {
   const _SettingsList({
     required this.accountName,
+    required this.activeAccountIsHardware,
     required this.endpointLabel,
     required this.themeLabel,
+    required this.onSeedPhrase,
   });
 
   final String accountName;
+  final bool activeAccountIsHardware;
   final String endpointLabel;
   final String themeLabel;
+  final VoidCallback onSeedPhrase;
 
   @override
   Widget build(BuildContext context) {
@@ -183,10 +198,11 @@ class _SettingsList extends StatelessWidget {
         _SettingsBlock(
           title: 'Account',
           rows: [
-            const _SettingsRow(
+            _SettingsRow(
               iconName: AppIcons.key,
               label: 'Secret Passphrase',
-              value: 'View',
+              value: activeAccountIsHardware ? 'Unavailable' : 'View',
+              onTap: activeAccountIsHardware ? null : onSeedPhrase,
             ),
             const _SettingsRowDivider(),
             const _SettingsRow(
@@ -285,16 +301,18 @@ class _SettingsRow extends StatelessWidget {
     required this.iconName,
     required this.label,
     required this.value,
+    this.onTap,
   });
 
   final String iconName;
   final String label;
   final String value;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return Container(
+    final row = Container(
       height: 40,
       padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
       decoration: BoxDecoration(
@@ -328,6 +346,16 @@ class _SettingsRow extends StatelessWidget {
           const SizedBox(width: AppSpacing.xxs),
           AppIcon(AppIcons.chevronForward, size: 16, color: colors.icon.accent),
         ],
+      ),
+    );
+
+    if (onTap == null) return row;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: row,
       ),
     );
   }

--- a/lib/src/features/settings/screens/settings_screen.dart
+++ b/lib/src/features/settings/screens/settings_screen.dart
@@ -80,7 +80,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final endpointLabel = ref.watch(rpcEndpointProvider).hostPort;
 
     return AppDesktopShell(
-      sidebarWidth: 240,
       sidebar: const AppMainSidebar(),
       pane: AppDesktopPane(
         padding: EdgeInsets.zero,

--- a/lib/src/features/settings/screens/settings_screen.dart
+++ b/lib/src/features/settings/screens/settings_screen.dart
@@ -39,6 +39,7 @@ class SettingsScreen extends ConsumerWidget {
           themeLabel: _themeLabel(themeMode),
           onBack: () => _handleBack(context),
           onSeedPhrase: () => context.go('/settings/secret-passphrase'),
+          onChangePassword: () => context.go('/settings/change-password'),
         ),
       ),
     );
@@ -76,6 +77,7 @@ class _SettingsPane extends StatelessWidget {
     required this.themeLabel,
     required this.onBack,
     required this.onSeedPhrase,
+    required this.onChangePassword,
   });
 
   final String accountName;
@@ -84,6 +86,7 @@ class _SettingsPane extends StatelessWidget {
   final String themeLabel;
   final VoidCallback onBack;
   final VoidCallback onSeedPhrase;
+  final VoidCallback onChangePassword;
 
   @override
   Widget build(BuildContext context) {
@@ -123,6 +126,7 @@ class _SettingsPane extends StatelessWidget {
                         endpointLabel: endpointLabel,
                         themeLabel: themeLabel,
                         onSeedPhrase: onSeedPhrase,
+                        onChangePassword: onChangePassword,
                       ),
                     ],
                   ),
@@ -182,6 +186,7 @@ class _SettingsList extends StatelessWidget {
     required this.endpointLabel,
     required this.themeLabel,
     required this.onSeedPhrase,
+    required this.onChangePassword,
   });
 
   final String accountName;
@@ -189,6 +194,7 @@ class _SettingsList extends StatelessWidget {
   final String endpointLabel;
   final String themeLabel;
   final VoidCallback onSeedPhrase;
+  final VoidCallback onChangePassword;
 
   @override
   Widget build(BuildContext context) {
@@ -205,10 +211,11 @@ class _SettingsList extends StatelessWidget {
               onTap: activeAccountIsHardware ? null : onSeedPhrase,
             ),
             const _SettingsRowDivider(),
-            const _SettingsRow(
+            _SettingsRow(
               iconName: AppIcons.lock,
               label: 'Password',
               value: 'Change',
+              onTap: onChangePassword,
             ),
             const _SettingsRowDivider(),
             const _SettingsRow(

--- a/lib/src/features/settings/screens/settings_screen.dart
+++ b/lib/src/features/settings/screens/settings_screen.dart
@@ -1,4 +1,7 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart' show ThemeMode;
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -8,18 +11,56 @@ import '../../../core/config/network_config.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_text_field.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/theme_mode_provider.dart';
 
-class SettingsScreen extends ConsumerWidget {
+class SettingsScreen extends ConsumerStatefulWidget {
   const SettingsScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+enum _SettingsModalType { accountName, theme }
+
+class _SettingsScreenState extends ConsumerState<SettingsScreen> {
+  _SettingsModalType? _activeModal;
+
+  void _showModal(_SettingsModalType modal) {
+    setState(() {
+      _activeModal = modal;
+    });
+  }
+
+  void _closeModal() {
+    setState(() {
+      _activeModal = null;
+    });
+  }
+
+  Future<void> _updateAccountName(String name) async {
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    if (accountUuid == null) return;
+    await ref.read(accountProvider.notifier).renameAccount(accountUuid, name);
+    if (!mounted) return;
+    _closeModal();
+  }
+
+  Future<void> _updateTheme(ThemeMode mode) async {
+    await ref.read(themeModeProvider.notifier).set(mode);
+    if (!mounted) return;
+    _closeModal();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final accountState = ref.watch(accountProvider).value;
     final activeAccountName = accountState?.activeAccount?.name ?? 'Wallet 1';
+    final hasActiveAccount = accountState?.activeAccountUuid != null;
     final activeAccountIsHardware =
         accountState?.activeAccount?.isHardware ?? false;
     final themeMode = ref.watch(themeModeProvider);
@@ -31,15 +72,42 @@ class SettingsScreen extends ConsumerWidget {
       sidebarWidth: 240,
       sidebar: const AppMainSidebar(),
       pane: AppDesktopPane(
-        padding: const EdgeInsets.all(AppSpacing.md),
-        child: _SettingsPane(
-          accountName: activeAccountName,
-          activeAccountIsHardware: activeAccountIsHardware,
-          endpointLabel: endpointLabel,
-          themeLabel: _themeLabel(themeMode),
-          onBack: () => _handleBack(context),
-          onSeedPhrase: () => context.go('/settings/secret-passphrase'),
-          onChangePassword: () => context.go('/settings/change-password'),
+        padding: EdgeInsets.zero,
+        child: Stack(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(AppSpacing.md),
+              child: _SettingsPane(
+                accountName: activeAccountName,
+                activeAccountIsHardware: activeAccountIsHardware,
+                endpointLabel: endpointLabel,
+                themeLabel: _themeLabel(themeMode),
+                onBack: () => _handleBack(context),
+                onSeedPhrase: () => context.go('/settings/secret-passphrase'),
+                onChangePassword: () => context.go('/settings/change-password'),
+                onAccountName: hasActiveAccount
+                    ? () => _showModal(_SettingsModalType.accountName)
+                    : null,
+                onTheme: () => _showModal(_SettingsModalType.theme),
+              ),
+            ),
+            if (_activeModal != null)
+              _SettingsModalOverlay(
+                onDismiss: _closeModal,
+                child: switch (_activeModal!) {
+                  _SettingsModalType.accountName => _AccountNameModal(
+                    accountName: activeAccountName,
+                    onCancel: _closeModal,
+                    onUpdate: _updateAccountName,
+                  ),
+                  _SettingsModalType.theme => _ThemeModal(
+                    currentMode: themeMode,
+                    onCancel: _closeModal,
+                    onUpdate: _updateTheme,
+                  ),
+                },
+              ),
+          ],
         ),
       ),
     );
@@ -78,6 +146,8 @@ class _SettingsPane extends StatelessWidget {
     required this.onBack,
     required this.onSeedPhrase,
     required this.onChangePassword,
+    required this.onAccountName,
+    required this.onTheme,
   });
 
   final String accountName;
@@ -87,6 +157,8 @@ class _SettingsPane extends StatelessWidget {
   final VoidCallback onBack;
   final VoidCallback onSeedPhrase;
   final VoidCallback onChangePassword;
+  final VoidCallback? onAccountName;
+  final VoidCallback onTheme;
 
   @override
   Widget build(BuildContext context) {
@@ -127,6 +199,8 @@ class _SettingsPane extends StatelessWidget {
                         themeLabel: themeLabel,
                         onSeedPhrase: onSeedPhrase,
                         onChangePassword: onChangePassword,
+                        onAccountName: onAccountName,
+                        onTheme: onTheme,
                       ),
                     ],
                   ),
@@ -187,6 +261,8 @@ class _SettingsList extends StatelessWidget {
     required this.themeLabel,
     required this.onSeedPhrase,
     required this.onChangePassword,
+    required this.onAccountName,
+    required this.onTheme,
   });
 
   final String accountName;
@@ -195,6 +271,8 @@ class _SettingsList extends StatelessWidget {
   final String themeLabel;
   final VoidCallback onSeedPhrase;
   final VoidCallback onChangePassword;
+  final VoidCallback? onAccountName;
+  final VoidCallback onTheme;
 
   @override
   Widget build(BuildContext context) {
@@ -228,6 +306,7 @@ class _SettingsList extends StatelessWidget {
               iconName: AppIcons.scroll,
               label: 'Account Name',
               value: accountName,
+              onTap: onAccountName,
             ),
           ],
         ),
@@ -245,10 +324,506 @@ class _SettingsList extends StatelessWidget {
               iconName: AppIcons.theme,
               label: 'Theme',
               value: themeLabel,
+              onTap: onTheme,
             ),
           ],
         ),
       ],
+    );
+  }
+}
+
+class _SettingsModalOverlay extends StatelessWidget {
+  const _SettingsModalOverlay({required this.child, required this.onDismiss});
+
+  final Widget child;
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Positioned.fill(
+      child: PopScope<void>(
+        canPop: false,
+        onPopInvokedWithResult: (didPop, _) {
+          if (!didPop) onDismiss();
+        },
+        child: Focus(
+          autofocus: true,
+          onKeyEvent: (_, event) {
+            if (event is KeyDownEvent &&
+                event.logicalKey == LogicalKeyboardKey.escape) {
+              onDismiss();
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          },
+          child: ClipRect(
+            child: BackdropFilter(
+              filter: ui.ImageFilter.blur(sigmaX: 15, sigmaY: 15),
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: onDismiss,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: colors.background.neutralScrim,
+                  ),
+                  child: Center(
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: () {},
+                      child: child,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsModalCard extends StatelessWidget {
+  const _SettingsModalCard({required this.header, required this.child});
+
+  final Widget header;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 312,
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.sm,
+        vertical: AppSpacing.md,
+      ),
+      decoration: BoxDecoration(
+        color: context.colors.background.ground,
+        borderRadius: BorderRadius.circular(AppRadii.large),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          header,
+          const SizedBox(height: AppSpacing.md),
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _ModalHeader extends StatelessWidget {
+  const _ModalHeader({required this.leading, required this.title});
+
+  final Widget leading;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        leading,
+        const SizedBox(width: AppSpacing.xs),
+        Flexible(
+          child: Text(
+            title,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.bodyLarge.copyWith(
+              color: context.colors.text.accent,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ModalAccountAvatar extends StatelessWidget {
+  const _ModalAccountAvatar();
+
+  @override
+  Widget build(BuildContext context) {
+    return ClipOval(
+      child: Image.asset(
+        'assets/illustrations/sidebar_account_avatar_knight.png',
+        width: 32,
+        height: 32,
+        fit: BoxFit.cover,
+      ),
+    );
+  }
+}
+
+class _ModalUtilityIcon extends StatelessWidget {
+  const _ModalUtilityIcon({required this.iconName});
+
+  final String iconName;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Container(
+      width: 32,
+      height: 32,
+      decoration: BoxDecoration(
+        color: colors.background.neutralSubtleOpacity,
+        shape: BoxShape.circle,
+      ),
+      child: Center(
+        child: AppIcon(
+          iconName,
+          size: AppIconSize.medium,
+          color: colors.icon.accent,
+        ),
+      ),
+    );
+  }
+}
+
+class _AccountNameModal extends StatefulWidget {
+  const _AccountNameModal({
+    required this.accountName,
+    required this.onCancel,
+    required this.onUpdate,
+  });
+
+  final String accountName;
+  final VoidCallback onCancel;
+  final Future<void> Function(String name) onUpdate;
+
+  @override
+  State<_AccountNameModal> createState() => _AccountNameModalState();
+}
+
+class _AccountNameModalState extends State<_AccountNameModal> {
+  static const _fieldHeight = 86.0;
+  static const _buttonWidth = 280.0;
+  static const _minNameLength = 5;
+  static const _maxNameLength = 20;
+
+  final _controller = TextEditingController();
+  bool _isSubmitting = false;
+  String? _submitError;
+
+  String get _trimmedName => _controller.text.trim();
+
+  bool get _isLengthValid =>
+      _trimmedName.length >= _minNameLength &&
+      _trimmedName.length <= _maxNameLength;
+
+  bool get _canUpdate =>
+      !_isSubmitting &&
+      _isLengthValid &&
+      _trimmedName != widget.accountName.trim();
+
+  String? get _messageText {
+    if (_submitError != null) return _submitError;
+    if (_controller.text.isEmpty || _isLengthValid) return null;
+    return 'Use 5-20 characters.';
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_canUpdate) return;
+    setState(() {
+      _isSubmitting = true;
+      _submitError = null;
+    });
+
+    try {
+      await widget.onUpdate(_trimmedName);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _submitError = "Couldn't update account name.";
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSubmitting = false;
+        });
+      }
+    }
+  }
+
+  void _handleChanged() {
+    setState(() {
+      _submitError = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _SettingsModalCard(
+      header: _ModalHeader(
+        leading: const _ModalAccountAvatar(),
+        title: widget.accountName,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            height: _fieldHeight,
+            child: AppTextField(
+              label: 'New Account Name',
+              hintText: '5-20 Characters',
+              controller: _controller,
+              autofocus: true,
+              enabled: !_isSubmitting,
+              trailingSlotWidth: 40,
+              inputHorizontalPadding: AppSpacing.s,
+              inputFormatters: [
+                LengthLimitingTextInputFormatter(_maxNameLength),
+              ],
+              messageText: _messageText,
+              tone: _messageText == null
+                  ? AppTextFieldTone.neutral
+                  : AppTextFieldTone.destructive,
+              onChanged: (_) => _handleChanged(),
+              onSubmitted: (_) => _submit(),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          AppButton(
+            onPressed: _canUpdate ? _submit : null,
+            variant: AppButtonVariant.primary,
+            minWidth: _buttonWidth,
+            child: Text(_isSubmitting ? 'Updating...' : 'Update'),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          AppButton(
+            onPressed: _isSubmitting ? null : widget.onCancel,
+            variant: AppButtonVariant.ghost,
+            minWidth: _buttonWidth,
+            child: const Text('Cancel'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ThemeModal extends StatefulWidget {
+  const _ThemeModal({
+    required this.currentMode,
+    required this.onCancel,
+    required this.onUpdate,
+  });
+
+  final ThemeMode currentMode;
+  final VoidCallback onCancel;
+  final Future<void> Function(ThemeMode mode) onUpdate;
+
+  @override
+  State<_ThemeModal> createState() => _ThemeModalState();
+}
+
+class _ThemeModalState extends State<_ThemeModal> {
+  static const _buttonWidth = 280.0;
+
+  late ThemeMode _selectedMode = widget.currentMode;
+  bool _isSubmitting = false;
+  String? _submitError;
+
+  bool get _canUpdate => !_isSubmitting && _selectedMode != widget.currentMode;
+
+  Future<void> _submit() async {
+    if (!_canUpdate) return;
+    setState(() {
+      _isSubmitting = true;
+      _submitError = null;
+    });
+    try {
+      await widget.onUpdate(_selectedMode);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _submitError = "Couldn't update theme.";
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSubmitting = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _SettingsModalCard(
+      header: const _ModalHeader(
+        leading: _ModalUtilityIcon(iconName: AppIcons.theme),
+        title: 'Theme',
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Column(
+            children: [
+              _ThemeOptionCard(
+                iconName: AppIcons.monitor,
+                label: 'System (Auto)',
+                selected: _selectedMode == ThemeMode.system,
+                onTap: () => setState(() {
+                  _submitError = null;
+                  _selectedMode = ThemeMode.system;
+                }),
+              ),
+              const SizedBox(height: AppSpacing.xs),
+              _ThemeOptionCard(
+                iconName: AppIcons.day,
+                label: 'Light Mode',
+                selected: _selectedMode == ThemeMode.light,
+                onTap: () => setState(() {
+                  _submitError = null;
+                  _selectedMode = ThemeMode.light;
+                }),
+              ),
+              const SizedBox(height: AppSpacing.xs),
+              _ThemeOptionCard(
+                iconName: AppIcons.night,
+                label: 'Dark Mode',
+                selected: _selectedMode == ThemeMode.dark,
+                onTap: () => setState(() {
+                  _submitError = null;
+                  _selectedMode = ThemeMode.dark;
+                }),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.md),
+          if (_submitError != null) ...[
+            Text(
+              _submitError!,
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMedium.copyWith(
+                color: context.colors.text.destructive,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xs),
+          ],
+          AppButton(
+            onPressed: _canUpdate ? _submit : null,
+            variant: AppButtonVariant.primary,
+            minWidth: _buttonWidth,
+            child: Text(_isSubmitting ? 'Updating...' : 'Update'),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          AppButton(
+            onPressed: _isSubmitting ? null : widget.onCancel,
+            variant: AppButtonVariant.ghost,
+            minWidth: _buttonWidth,
+            child: const Text('Cancel'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ThemeOptionCard extends StatelessWidget {
+  const _ThemeOptionCard({
+    required this.iconName,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String iconName;
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          width: 280,
+          height: 40,
+          padding: const EdgeInsets.only(
+            left: AppSpacing.xs,
+            right: AppSpacing.s,
+          ),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(AppRadii.medium),
+            border: Border.all(
+              color: selected ? colors.border.strong : colors.border.regular,
+              width: selected ? 2 : 1.5,
+              strokeAlign: BorderSide.strokeAlignInside,
+            ),
+          ),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 32,
+                height: 32,
+                child: Center(
+                  child: AppIcon(iconName, size: 18, color: colors.icon.accent),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xs),
+              Expanded(
+                child: Text(
+                  label,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTypography.labelLarge.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+              ),
+              _ThemeOptionIndicator(selected: selected),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ThemeOptionIndicator extends StatelessWidget {
+  const _ThemeOptionIndicator({required this.selected});
+
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Container(
+      width: 16,
+      height: 16,
+      decoration: BoxDecoration(
+        color: selected
+            ? colors.background.inverse
+            : colors.background.neutralSubtleOpacity,
+        shape: BoxShape.circle,
+      ),
+      child: selected
+          ? Center(
+              child: AppIcon(
+                AppIcons.check,
+                size: 12,
+                color: colors.background.ground,
+              ),
+            )
+          : null,
     );
   }
 }

--- a/lib/src/features/settings/screens/settings_screen.dart
+++ b/lib/src/features/settings/screens/settings_screen.dart
@@ -1,26 +1,356 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' show ThemeMode;
+import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+
+import '../../../app_bootstrap.dart';
+import '../../../core/config/network_config.dart';
+import '../../../core/layout/app_desktop_shell.dart';
+import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_decorative_divider.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../providers/account_provider.dart';
+import '../../../providers/theme_mode_provider.dart';
 
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Settings'),
-        leading: IconButton(
-          icon: const Icon(Icons.arrow_back),
-          onPressed: () => context.pop(),
+    final accountState = ref.watch(accountProvider).value;
+    final activeAccountName = accountState?.activeAccount?.name ?? 'Wallet 1';
+    final themeMode = ref.watch(themeModeProvider);
+    final endpointLabel = _endpointLabel(
+      ref.watch(appBootstrapProvider).network,
+    );
+
+    return AppDesktopShell(
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: _SettingsPane(
+          accountName: activeAccountName,
+          endpointLabel: endpointLabel,
+          themeLabel: _themeLabel(themeMode),
+          onBack: () => _handleBack(context),
         ),
       ),
-      body: ListView(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        children: const [
-          // Placeholder — settings will be added here as needed.
+    );
+  }
+
+  static void _handleBack(BuildContext context) {
+    if (context.canPop()) {
+      context.pop();
+      return;
+    }
+    context.go('/home');
+  }
+
+  static String _themeLabel(ThemeMode mode) {
+    return switch (mode) {
+      ThemeMode.system => 'System',
+      ThemeMode.light => 'Light',
+      ThemeMode.dark => 'Dark',
+    };
+  }
+
+  static String _endpointLabel(String networkName) {
+    final network = networkName == ZcashNetwork.testnet.name
+        ? ZcashNetwork.testnet
+        : ZcashNetwork.mainnet;
+    return network.lightwalletdHost;
+  }
+}
+
+class _SettingsPane extends StatelessWidget {
+  const _SettingsPane({
+    required this.accountName,
+    required this.endpointLabel,
+    required this.themeLabel,
+    required this.onBack,
+  });
+
+  final String accountName;
+  final String endpointLabel;
+  final String themeLabel;
+  final VoidCallback onBack;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return SizedBox.expand(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: _SettingsBackButton(onTap: onBack),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: AppSpacing.s),
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 752),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        'Settings',
+                        textAlign: TextAlign.center,
+                        style: AppTypography.displaySmall.copyWith(
+                          color: colors.text.accent,
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.sm),
+                      const AppDecorativeDivider(width: 256),
+                      const SizedBox(height: AppSpacing.sm),
+                      _SettingsList(
+                        accountName: accountName,
+                        endpointLabel: endpointLabel,
+                        themeLabel: themeLabel,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
         ],
       ),
+    );
+  }
+}
+
+class _SettingsBackButton extends StatelessWidget {
+  const _SettingsBackButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: SizedBox(
+          height: 32,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AppIcon(
+                AppIcons.chevronBackward,
+                size: 16,
+                color: colors.icon.accent,
+              ),
+              const SizedBox(width: AppSpacing.xxs),
+              Text(
+                'Back',
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsList extends StatelessWidget {
+  const _SettingsList({
+    required this.accountName,
+    required this.endpointLabel,
+    required this.themeLabel,
+  });
+
+  final String accountName;
+  final String endpointLabel;
+  final String themeLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _SettingsBlock(
+          title: 'Account',
+          rows: [
+            const _SettingsRow(
+              iconName: AppIcons.key,
+              label: 'Secret Passphrase',
+              value: 'View',
+            ),
+            const _SettingsRowDivider(),
+            const _SettingsRow(
+              iconName: AppIcons.lock,
+              label: 'Password',
+              value: 'Change',
+            ),
+            const _SettingsRowDivider(),
+            const _SettingsRow(
+              iconName: AppIcons.users,
+              label: 'Profile Picture',
+              value: 'Knight',
+            ),
+            const _SettingsRowDivider(),
+            _SettingsRow(
+              iconName: AppIcons.scroll,
+              label: 'Account Name',
+              value: accountName,
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.s),
+        _SettingsBlock(
+          title: 'System',
+          rows: [
+            _SettingsRow(
+              iconName: AppIcons.endpoint,
+              label: 'Endpoint',
+              value: endpointLabel,
+            ),
+            const _SettingsRowDivider(),
+            _SettingsRow(
+              iconName: AppIcons.theme,
+              label: 'Theme',
+              value: themeLabel,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _SettingsBlock extends StatelessWidget {
+  const _SettingsBlock({required this.title, required this.rows});
+
+  final String title;
+  final List<Widget> rows;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SizedBox(
+          height: 24,
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.xxs),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                title,
+                style: AppTypography.labelMedium.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Column(crossAxisAlignment: CrossAxisAlignment.stretch, children: rows),
+      ],
+    );
+  }
+}
+
+class _SettingsRowDivider extends StatelessWidget {
+  const _SettingsRowDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      child: DecoratedBox(
+        decoration: BoxDecoration(color: context.colors.border.subtle),
+        child: const SizedBox(height: 1),
+      ),
+    );
+  }
+}
+
+class _SettingsRow extends StatelessWidget {
+  const _SettingsRow({
+    required this.iconName,
+    required this.label,
+    required this.value,
+  });
+
+  final String iconName;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Container(
+      height: 40,
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
+      ),
+      child: Row(
+        children: [
+          _SettingsRowIcon(iconName: iconName),
+          const SizedBox(width: AppSpacing.xs),
+          Expanded(
+            child: Text(
+              label,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.xs),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 260),
+            child: Text(
+              value,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.right,
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.xxs),
+          AppIcon(AppIcons.chevronForward, size: 16, color: colors.icon.accent),
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsRowIcon extends StatelessWidget {
+  const _SettingsRowIcon({required this.iconName});
+
+  final String iconName;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Container(
+      width: 32,
+      height: 32,
+      decoration: BoxDecoration(
+        color: colors.background.neutralSubtleOpacity,
+        shape: BoxShape.circle,
+      ),
+      alignment: Alignment.center,
+      child: AppIcon(iconName, size: 16, color: colors.icon.regular),
     );
   }
 }

--- a/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
@@ -232,7 +232,6 @@ class _SettingsSeedPhraseScreenState
     );
 
     return AppDesktopShell(
-      sidebarWidth: 240,
       sidebar: const AppMainSidebar(),
       pane: AppDesktopPane(
         padding: const EdgeInsets.all(AppSpacing.md),

--- a/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
@@ -51,7 +51,7 @@ class _SettingsSeedPhraseScreenState
 
   @override
   void dispose() {
-    _copyResetTimer?.cancel();
+    _clearSensitiveState();
     _passwordController.dispose();
     super.dispose();
   }

--- a/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
@@ -46,6 +46,9 @@ class _SettingsSeedPhraseScreenState
   bool _copied = false;
   Timer? _copyResetTimer;
 
+  String? get _passwordPolicyMessage =>
+      validateWalletPassword(_passwordController.text);
+
   bool get _canSubmit =>
       !_isSubmitting && isWalletPasswordValid(_passwordController.text);
 
@@ -105,14 +108,13 @@ class _SettingsSeedPhraseScreenState
   }
 
   Future<void> _submitPassword() async {
+    final policyError = _passwordPolicyMessage;
     if (_isSubmitting) return;
     if (!isWalletPasswordValid(_passwordController.text)) {
-      final policyError = validateWalletPassword(_passwordController.text);
-      if (policyError != null) {
-        setState(() {
-          _passwordError = policyError;
-        });
-      }
+      if (policyError == null) return;
+      setState(() {
+        _passwordError = policyError;
+      });
       return;
     }
 
@@ -138,7 +140,7 @@ class _SettingsSeedPhraseScreenState
       if (!isValid) {
         if (!mounted) return;
         setState(() {
-          _passwordError = 'Wrong password';
+          _passwordError = 'Incorrect password. Please try again.';
           _isSubmitting = false;
         });
         return;
@@ -240,7 +242,7 @@ class _SettingsSeedPhraseScreenState
           child: switch (_stage) {
             _SettingsSeedPhraseStage.password => _PasswordGateView(
               passwordController: _passwordController,
-              messageText: _passwordError,
+              messageText: _passwordError ?? _passwordPolicyMessage,
               isSubmitting: _isSubmitting,
               canSubmit: _canSubmit,
               onChanged: _handlePasswordChanged,

--- a/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
@@ -1,0 +1,603 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/security/password_policy.dart';
+import '../../../core/layout/app_desktop_shell.dart';
+import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_chip.dart';
+import '../../../core/widgets/app_decorative_divider.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/password_text_field.dart';
+import '../../../core/widgets/app_text_field.dart';
+import '../../../providers/account_provider.dart';
+import '../../../providers/app_security_provider.dart';
+
+class SettingsSeedPhraseScreen extends ConsumerStatefulWidget {
+  const SettingsSeedPhraseScreen({super.key});
+
+  @override
+  ConsumerState<SettingsSeedPhraseScreen> createState() =>
+      _SettingsSeedPhraseScreenState();
+}
+
+enum _SettingsSeedPhraseStage { password, reveal }
+
+class _SeedPhraseUnavailableException implements Exception {
+  const _SeedPhraseUnavailableException(this.message);
+
+  final String message;
+}
+
+class _SettingsSeedPhraseScreenState
+    extends ConsumerState<SettingsSeedPhraseScreen> {
+  final _passwordController = TextEditingController();
+  bool _isSubmitting = false;
+  _SettingsSeedPhraseStage _stage = _SettingsSeedPhraseStage.password;
+  String? _passwordError;
+  String? _mnemonic;
+  String? _revealError;
+  bool _copied = false;
+  Timer? _copyResetTimer;
+
+  bool get _canSubmit =>
+      !_isSubmitting && isWalletPasswordValid(_passwordController.text);
+
+  @override
+  void dispose() {
+    _copyResetTimer?.cancel();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _handleBack() {
+    _clearSensitiveState();
+    context.go('/settings');
+  }
+
+  void _clearSensitiveState({String? passwordError}) {
+    _copyResetTimer?.cancel();
+    _passwordController.clear();
+    _isSubmitting = false;
+    _stage = _SettingsSeedPhraseStage.password;
+    _passwordError = passwordError;
+    _mnemonic = null;
+    _revealError = null;
+    _copied = false;
+  }
+
+  void _handleActiveAccountChanged() {
+    if (_stage == _SettingsSeedPhraseStage.password &&
+        !_isSubmitting &&
+        _mnemonic == null) {
+      return;
+    }
+
+    setState(() {
+      _clearSensitiveState(
+        passwordError: 'Active account changed. Enter your password again.',
+      );
+    });
+  }
+
+  bool _activeAccountChanged(String expectedAccountUuid) {
+    final currentAccountUuid = ref
+        .read(accountProvider)
+        .value
+        ?.activeAccountUuid;
+    return currentAccountUuid != expectedAccountUuid;
+  }
+
+  void _handlePasswordChanged() {
+    if (_passwordError == null) {
+      setState(() {});
+      return;
+    }
+    setState(() {
+      _passwordError = null;
+    });
+  }
+
+  Future<void> _submitPassword() async {
+    if (_isSubmitting) return;
+    if (!isWalletPasswordValid(_passwordController.text)) {
+      final policyError = validateWalletPassword(_passwordController.text);
+      if (policyError != null) {
+        setState(() {
+          _passwordError = policyError;
+        });
+      }
+      return;
+    }
+
+    setState(() {
+      _isSubmitting = true;
+      _passwordError = null;
+      _revealError = null;
+    });
+
+    try {
+      final accountState = ref.read(accountProvider).value;
+      final activeAccount = accountState?.activeAccount;
+      if (activeAccount == null) {
+        throw const _SeedPhraseUnavailableException(
+          'No active account is selected.',
+        );
+      }
+      final activeAccountUuid = activeAccount.uuid;
+
+      final isValid = await ref
+          .read(appSecurityProvider.notifier)
+          .confirmPassword(_passwordController.text);
+      if (!isValid) {
+        if (!mounted) return;
+        setState(() {
+          _passwordError = 'Wrong password';
+          _isSubmitting = false;
+        });
+        return;
+      }
+
+      if (_activeAccountChanged(activeAccountUuid)) {
+        if (!mounted) return;
+        setState(() {
+          _clearSensitiveState(
+            passwordError: 'Active account changed. Enter your password again.',
+          );
+        });
+        return;
+      }
+
+      if (activeAccount.isHardware) {
+        throw const _SeedPhraseUnavailableException(
+          'Secret passphrase is not available for hardware accounts.',
+        );
+      }
+
+      final mnemonic = await ref
+          .read(accountProvider.notifier)
+          .getMnemonicForAccount(activeAccountUuid);
+      if (mnemonic == null || mnemonic.isEmpty) {
+        throw const _SeedPhraseUnavailableException(
+          'Secret passphrase is not available for this account.',
+        );
+      }
+
+      if (!mounted) return;
+      if (_activeAccountChanged(activeAccountUuid)) {
+        setState(() {
+          _clearSensitiveState(
+            passwordError: 'Active account changed. Enter your password again.',
+          );
+        });
+        return;
+      }
+
+      setState(() {
+        _mnemonic = mnemonic;
+        _stage = _SettingsSeedPhraseStage.reveal;
+        _isSubmitting = false;
+        _copied = false;
+      });
+    } on _SeedPhraseUnavailableException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _revealError = e.message;
+        _stage = _SettingsSeedPhraseStage.reveal;
+        _isSubmitting = false;
+      });
+    } catch (e, st) {
+      log('SettingsSeedPhraseScreen._submitPassword: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _revealError =
+            "Couldn't load your secret passphrase. Please try again.";
+        _stage = _SettingsSeedPhraseStage.reveal;
+        _isSubmitting = false;
+      });
+    }
+  }
+
+  Future<void> _copyMnemonic() async {
+    final mnemonic = _mnemonic;
+    if (mnemonic == null || mnemonic.isEmpty) return;
+    await Clipboard.setData(ClipboardData(text: mnemonic));
+    if (!mounted) return;
+    _copyResetTimer?.cancel();
+    setState(() {
+      _copied = true;
+    });
+    _copyResetTimer = Timer(const Duration(seconds: 2), () {
+      if (!mounted) return;
+      setState(() {
+        _copied = false;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<String?>(
+      accountProvider.select((state) => state.value?.activeAccountUuid),
+      (previous, next) {
+        if (previous == next) return;
+        _handleActiveAccountChanged();
+      },
+    );
+
+    return AppDesktopShell(
+      sidebarWidth: 240,
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: _SettingsSeedPhrasePane(
+          onBack: _handleBack,
+          child: switch (_stage) {
+            _SettingsSeedPhraseStage.password => _PasswordGateView(
+              passwordController: _passwordController,
+              messageText: _passwordError,
+              isSubmitting: _isSubmitting,
+              canSubmit: _canSubmit,
+              onChanged: _handlePasswordChanged,
+              onSubmit: _submitPassword,
+            ),
+            _SettingsSeedPhraseStage.reveal => _SeedPhraseRevealView(
+              mnemonic: _mnemonic,
+              errorText: _revealError,
+              copied: _copied,
+              onCopyPressed: _copyMnemonic,
+            ),
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _SettingsSeedPhrasePane extends StatelessWidget {
+  const _SettingsSeedPhrasePane({required this.onBack, required this.child});
+
+  final VoidCallback onBack;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.expand(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Align(
+            alignment: Alignment.centerLeft,
+            child: _BackButton(onTap: onBack),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Expanded(child: child),
+        ],
+      ),
+    );
+  }
+}
+
+class _BackButton extends StatelessWidget {
+  const _BackButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: SizedBox(
+          height: 32,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AppIcon(
+                AppIcons.chevronBackward,
+                size: 16,
+                color: colors.icon.accent,
+              ),
+              const SizedBox(width: AppSpacing.xxs),
+              Text(
+                'Back',
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PasswordGateView extends StatelessWidget {
+  const _PasswordGateView({
+    required this.passwordController,
+    required this.messageText,
+    required this.isSubmitting,
+    required this.canSubmit,
+    required this.onChanged,
+    required this.onSubmit,
+  });
+
+  final TextEditingController passwordController;
+  final String? messageText;
+  final bool isSubmitting;
+  final bool canSubmit;
+  final VoidCallback onChanged;
+  final Future<void> Function() onSubmit;
+
+  static const _contentWidth = 304.0;
+  static const _buttonWidth = 256.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Column(
+      children: [
+        Expanded(
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Enter Password',
+                  textAlign: TextAlign.center,
+                  style: AppTypography.displaySmall.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.s),
+                SizedBox(
+                  width: 270,
+                  child: Text(
+                    'Enter your password to continue.',
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                const AppDecorativeDivider(width: 256),
+                const SizedBox(height: AppSpacing.sm),
+                SizedBox(
+                  width: _contentWidth,
+                  height: 86,
+                  child: PasswordTextField(
+                    label: 'Password',
+                    hintText: 'Enter Your Password',
+                    leadingSlotWidth: 32,
+                    trailingSlotWidth: 40,
+                    inputHorizontalPadding: AppSpacing.s,
+                    controller: passwordController,
+                    autofocus: true,
+                    enabled: !isSubmitting,
+                    messageText: messageText,
+                    tone: messageText == null
+                        ? AppTextFieldTone.neutral
+                        : AppTextFieldTone.destructive,
+                    onChanged: (_) => onChanged(),
+                    onSubmitted: (_) {
+                      onSubmit();
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        AppButton(
+          onPressed: canSubmit
+              ? () {
+                  onSubmit();
+                }
+              : null,
+          variant: AppButtonVariant.primary,
+          minWidth: _buttonWidth,
+          trailing: const AppIcon(AppIcons.chevronForward),
+          child: Text(
+            isSubmitting ? 'Checking password...' : 'View Secret Passphrase',
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SeedPhraseRevealView extends StatelessWidget {
+  const _SeedPhraseRevealView({
+    required this.mnemonic,
+    required this.errorText,
+    required this.copied,
+    required this.onCopyPressed,
+  });
+
+  final String? mnemonic;
+  final String? errorText;
+  final bool copied;
+  final Future<void> Function() onCopyPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            'Secret Passphrase',
+            textAlign: TextAlign.center,
+            style: AppTypography.displaySmall.copyWith(
+              color: colors.text.accent,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          SizedBox(
+            width: 197,
+            child: Text(
+              "The Master Key to your wallet.\nDon't share it with anyone.",
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMedium.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          const AppDecorativeDivider(width: 256),
+          const SizedBox(height: AppSpacing.sm),
+          if (errorText == null && mnemonic != null)
+            _SeedPhraseCard(
+              mnemonic: mnemonic!,
+              copied: copied,
+              onCopyPressed: onCopyPressed,
+            )
+          else
+            _SeedPhraseErrorCard(
+              message:
+                  errorText ??
+                  'Secret passphrase is not available for this account.',
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SeedPhraseCard extends StatelessWidget {
+  const _SeedPhraseCard({
+    required this.mnemonic,
+    required this.copied,
+    required this.onCopyPressed,
+  });
+
+  final String mnemonic;
+  final bool copied;
+  final Future<void> Function() onCopyPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final words = mnemonic.split(' ');
+
+    return SizedBox(
+      width: 529,
+      height: 348,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppRadii.large),
+        child: DecoratedBox(
+          decoration: BoxDecoration(color: colors.background.base),
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: Padding(
+                  padding: const EdgeInsets.all(AppSpacing.lg),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Secret Passphrase',
+                        style: AppTypography.bodyLarge.copyWith(
+                          color: colors.text.accent,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.base),
+                      Wrap(
+                        spacing: AppSpacing.xxs,
+                        runSpacing: AppSpacing.xs,
+                        children: [
+                          for (var i = 0; i < words.length; i++)
+                            AppChip(
+                              width: 90,
+                              leadingText: '${i + 1}'.padLeft(2, '0'),
+                              label: words[i],
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Positioned(
+                top: AppSpacing.s,
+                right: AppSpacing.s,
+                child: AppButton(
+                  onPressed: () {
+                    onCopyPressed();
+                  },
+                  variant: AppButtonVariant.primary,
+                  size: AppButtonSize.small,
+                  minWidth: copied ? 72 : 61,
+                  trailing: AppIcon(copied ? AppIcons.check : AppIcons.copy),
+                  child: Text(copied ? 'Copied' : 'Copy'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SeedPhraseErrorCard extends StatelessWidget {
+  const _SeedPhraseErrorCard({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return SizedBox(
+      width: 529,
+      height: 348,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(AppRadii.large),
+        child: DecoratedBox(
+          decoration: BoxDecoration(color: colors.background.base),
+          child: Center(
+            child: SizedBox(
+              width: 320,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  AppIcon(
+                    AppIcons.warning,
+                    size: 24,
+                    color: colors.icon.destructive,
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  Text(
+                    message,
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/providers/account_models.dart
+++ b/lib/src/providers/account_models.dart
@@ -1,28 +1,35 @@
+import '../core/profile_pictures.dart';
+
 class AccountInfo {
   final String uuid;
   final String name;
   final int order;
   final bool isHardware;
+  final String profilePictureId;
 
   const AccountInfo({
     required this.uuid,
     required this.name,
     required this.order,
     this.isHardware = false,
+    this.profilePictureId = kDefaultProfilePictureId,
   });
 
-  AccountInfo copyWith({String? name, int? order}) => AccountInfo(
-    uuid: uuid,
-    name: name ?? this.name,
-    order: order ?? this.order,
-    isHardware: isHardware,
-  );
+  AccountInfo copyWith({String? name, int? order, String? profilePictureId}) =>
+      AccountInfo(
+        uuid: uuid,
+        name: name ?? this.name,
+        order: order ?? this.order,
+        isHardware: isHardware,
+        profilePictureId: profilePictureId ?? this.profilePictureId,
+      );
 
   Map<String, dynamic> toJson() => {
     'uuid': uuid,
     'name': name,
     'order': order,
     'isHardware': isHardware,
+    'profilePictureId': profilePictureId,
   };
 
   factory AccountInfo.fromJson(Map<String, dynamic> json) => AccountInfo(
@@ -30,6 +37,8 @@ class AccountInfo {
     name: json['name'] as String,
     order: json['order'] as int? ?? 0,
     isHardware: json['isHardware'] as bool? ?? false,
+    profilePictureId:
+        json['profilePictureId'] as String? ?? kDefaultProfilePictureId,
   );
 }
 

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -6,13 +6,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../main.dart' show log;
 import '../app_bootstrap.dart';
-import '../core/config/network_config.dart';
 import '../core/profile_pictures.dart';
 import '../core/storage/app_secure_store.dart';
 import '../core/storage/wallet_paths.dart';
 import '../rust/api/wallet.dart' as rust_wallet;
 import 'account_models.dart';
 import 'app_security_provider.dart';
+import 'rpc_endpoint_provider.dart';
 
 export 'account_models.dart';
 
@@ -36,14 +36,12 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   Future<String> createAccount({String? name}) async {
     try {
       final dbPath = await _getDbPath();
-      final network = await _getNetwork();
-      final networkConfig = network == 'main'
-          ? ZcashNetwork.mainnet
-          : ZcashNetwork.testnet;
+      final endpoint = ref.read(rpcEndpointProvider);
+      final network = endpoint.networkName;
 
       // Fetch chain tip as birthday
       final birthday = await rust_wallet.getLatestBlockHeight(
-        lightwalletdUrl: networkConfig.lightwalletdUrl,
+        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
       );
       log('createAccount: birthday=$birthday');
 
@@ -124,13 +122,11 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   }) async {
     try {
       final dbPath = await _getDbPath();
-      final network = await _getNetwork();
-      final networkConfig = network == 'main'
-          ? ZcashNetwork.mainnet
-          : ZcashNetwork.testnet;
+      final endpoint = ref.read(rpcEndpointProvider);
+      final network = endpoint.networkName;
 
       final birthday = await rust_wallet.getLatestBlockHeight(
-        lightwalletdUrl: networkConfig.lightwalletdUrl,
+        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
       );
       log('createAccountFromMnemonic: birthday=$birthday');
 

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../main.dart' show log;
 import '../app_bootstrap.dart';
 import '../core/config/network_config.dart';
+import '../core/profile_pictures.dart';
 import '../core/storage/app_secure_store.dart';
 import '../core/storage/wallet_paths.dart';
 import '../rust/api/wallet.dart' as rust_wallet;
@@ -300,6 +301,32 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     await _saveAccounts(updated);
     state = AsyncData(prev.copyWith(accounts: updated));
     log('renameAccount: $uuid → $newName');
+  }
+
+  /// Update an account profile picture.
+  Future<void> updateProfilePicture(
+    String uuid,
+    String profilePictureId,
+  ) async {
+    if (!isKnownProfilePictureId(profilePictureId)) {
+      throw ArgumentError.value(
+        profilePictureId,
+        'profilePictureId',
+        'Unknown profile picture id',
+      );
+    }
+
+    final prev = state.value ?? const AccountState();
+    final updated = prev.accounts
+        .map(
+          (a) => a.uuid == uuid
+              ? a.copyWith(profilePictureId: profilePictureId)
+              : a,
+        )
+        .toList();
+    await _saveAccounts(updated);
+    state = AsyncData(prev.copyWith(accounts: updated));
+    log('updateProfilePicture: $uuid → $profilePictureId');
   }
 
   /// Delete all wallet data (DB + keychain). Caller must stop sync first.

--- a/lib/src/providers/app_security_provider.dart
+++ b/lib/src/providers/app_security_provider.dart
@@ -88,6 +88,13 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
     return isValid;
   }
 
+  Future<bool> confirmPassword(String password) async {
+    if (!isWalletPasswordValid(password)) {
+      return false;
+    }
+    return _store.verifyPasswordOnly(password);
+  }
+
   void lock() {
     _store.clearSessionPassword();
     state = state.copyWith(isUnlocked: false);

--- a/lib/src/providers/app_security_provider.dart
+++ b/lib/src/providers/app_security_provider.dart
@@ -48,7 +48,7 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
     if (_isPasswordSetupPrepared) {
       throw StateError('Password setup is already pending.');
     }
-    final error = validateWalletPassword(password);
+    final error = validateRequiredWalletPassword(password);
     if (error != null) {
       throw ArgumentError(error);
     }
@@ -93,6 +93,32 @@ class AppSecurityNotifier extends Notifier<AppSecurityState> {
       return false;
     }
     return _store.verifyPasswordOnly(password);
+  }
+
+  /// Changes the wallet password without using the setup path. The store must
+  /// rotate encrypted secure-storage payloads before the verifier is updated.
+  Future<bool> changePassword({
+    required String currentPassword,
+    required String newPassword,
+  }) async {
+    if (!state.isUnlocked) {
+      throw StateError('Wallet must be unlocked to change the password.');
+    }
+    if (currentPassword == newPassword) {
+      throw ArgumentError(kWalletPasswordMustDifferMessage);
+    }
+    final newPasswordError = validateRequiredWalletPassword(newPassword);
+    if (newPasswordError != null) {
+      throw ArgumentError(newPasswordError);
+    }
+    final didChange = await _store.changePassword(
+      currentPassword: currentPassword,
+      newPassword: newPassword,
+    );
+    if (didChange) {
+      state = state.copyWith(isPasswordConfigured: true, isUnlocked: true);
+    }
+    return didChange;
   }
 
   void lock() {

--- a/lib/src/providers/rpc_endpoint_provider.dart
+++ b/lib/src/providers/rpc_endpoint_provider.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../main.dart' show log;
+import '../app_bootstrap.dart';
+import '../core/config/rpc_endpoint_config.dart';
+import '../core/storage/app_secure_store.dart';
+import '../rust/api/wallet.dart' as rust_wallet;
+import '../services/background_sync_service.dart' as bg_sync;
+
+class RpcEndpointNotifier extends Notifier<RpcEndpointConfig> {
+  static final _store = AppSecureStore.instance;
+
+  @override
+  RpcEndpointConfig build() =>
+      ref.watch(appBootstrapProvider).rpcEndpointConfig;
+
+  Future<void> setPreset(RpcEndpointPreset preset) async {
+    final normalized = normalizeRpcEndpointUrl(
+      preset.url,
+      allowDefaultPort: true,
+    );
+    await _verifyNetwork(normalized);
+    await _persist(
+      state.copyWith(lightwalletdUrl: normalized, presetId: preset.id),
+    );
+  }
+
+  Future<void> setCustom(String input) async {
+    final normalized = normalizeRpcEndpointUrl(input, allowDefaultPort: true);
+    await _verifyNetwork(normalized);
+    await _persist(
+      state.copyWith(
+        lightwalletdUrl: normalized,
+        presetId: kCustomRpcEndpointPresetId,
+      ),
+    );
+  }
+
+  Future<void> _persist(RpcEndpointConfig next) async {
+    await _store.writePlain(kRpcEndpointUrlKey, next.normalizedLightwalletdUrl);
+    await _store.writePlain(kRpcEndpointPresetKey, next.effectivePresetId);
+    try {
+      await bg_sync.updateBackgroundSyncEndpoint(endpoint: next);
+    } catch (e) {
+      log('RpcEndpointNotifier: failed to update iOS endpoint mirror: $e');
+    }
+    state = next;
+  }
+
+  Future<void> _verifyNetwork(String lightwalletdUrl) async {
+    final chainName = await rust_wallet.getLightwalletdChainName(
+      lightwalletdUrl: lightwalletdUrl,
+    );
+    if (chainName != state.networkName) {
+      throw FormatException(
+        'Endpoint is for $chainName, but this wallet uses ${state.networkName}.',
+      );
+    }
+  }
+}
+
+final rpcEndpointProvider =
+    NotifierProvider<RpcEndpointNotifier, RpcEndpointConfig>(
+      RpcEndpointNotifier.new,
+    );

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -6,13 +6,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../main.dart' show log;
 import '../app_bootstrap.dart';
-import '../core/config/network_config.dart';
+import '../core/config/rpc_endpoint_config.dart';
 import '../core/storage/wallet_paths.dart';
 import '../rust/api/sync.dart' as rust_sync;
 import '../rust/api/wallet.dart' as rust_wallet;
 import '../services/background_sync_delegate.dart';
 import 'account_provider.dart';
 import 'app_security_provider.dart';
+import 'rpc_endpoint_provider.dart';
 
 class SyncState {
   final bool isSyncing;
@@ -371,17 +372,17 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _getDbPath()
         .then((dbPath) {
           if (gen != _syncGen) return; // stopSync was called, abort
-          final network = ZcashNetwork.mainnet;
-          log('Sync: starting foreground sync');
+          final endpoint = _endpointConfig;
+          log('Sync: starting foreground sync via ${endpoint.hostPort}');
           // Fire up the mempool observer alongside the scan loop.
           // It has its own Rust cancel flag (MEMPOOL_CANCEL) and runs
           // on a separate tokio runtime, so it can accept events while
           // the scan loop is still catching up on old blocks.
-          _startMempoolObserver(dbPath, network);
+          _startMempoolObserver(dbPath, endpoint);
           final stream = rust_sync.startFullSync(
             dbPath: dbPath,
-            lightwalletdUrl: network.lightwalletdUrl,
-            network: network.name,
+            lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+            network: endpoint.networkName,
             mode: 1,
           );
           _syncSub = stream.listen(
@@ -557,7 +558,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _stopDisplayProgressTimer();
     _stopPolling();
     if (_bgDelegate.isActive) {
-      _bgDelegate.disable();
+      unawaited(_bgDelegate.disable());
     }
     final prev = state.value;
     state = AsyncData(
@@ -704,7 +705,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
   Future<void> enableBackgroundSync() async {
     if (_bgDelegate.isActive) return;
-    await _bgDelegate.enable();
+    await _bgDelegate.enable(endpoint: _endpointConfig);
     _stopDisplayProgressTimer();
     log('SyncNotifier: background sync enabled');
   }
@@ -727,7 +728,27 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   /// silent for the rest of the session if the toggle fires while
   /// sync is already idle.
   Future<void> restartSync() async {
-    stopSync();
+    final hadBackgroundSync = _bgDelegate.isActive;
+    ++_syncGen;
+    rust_sync.cancelFullSync();
+    await _syncSub?.cancel();
+    _syncSub = null;
+    _stopMempoolObserver();
+    _isSyncing = false;
+    _stopPolling();
+    if (hadBackgroundSync) {
+      try {
+        await _bgDelegate.disable();
+      } catch (e) {
+        log('SyncNotifier: background disable before restart failed: $e');
+      }
+    }
+    final prev = state.value;
+    if (prev != null) {
+      state = AsyncData(
+        prev.copyWith(isSyncing: false, isBackgroundMode: false, phase: ''),
+      );
+    }
     // `cancelFullSync` / `stopMempoolObserver` set atomics that
     // the Rust loop and the mempool observer check at their own
     // cadence (batch boundaries for sync, the 100ms cancel-aware
@@ -762,6 +783,13 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     );
     startSync();
     _startPolling();
+    if (hadBackgroundSync) {
+      try {
+        await _bgDelegate.enable(endpoint: _endpointConfig);
+      } catch (e) {
+        log('SyncNotifier: background re-enable after restart failed: $e');
+      }
+    }
   }
 
   static Future<bool> isBackgroundSyncAvailable() async {
@@ -808,7 +836,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _stopPolling();
     try {
       final tip = await rust_wallet.getLatestBlockHeight(
-        lightwalletdUrl: ZcashNetwork.mainnet.lightwalletdUrl,
+        lightwalletdUrl: _endpointConfig.normalizedLightwalletdUrl,
       );
       final lastSynced = state.value?.chainTipHeight ?? 0;
       final syncComplete = (state.value?.percentage ?? 0) >= 1.0;
@@ -882,7 +910,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   /// `startMempoolObserver` FRB call is guarded on the Rust side
   /// by the MEMPOOL_RUNNING atomic, so a double-call just logs
   /// and returns an error; we catch and ignore it.
-  void _startMempoolObserver(String dbPath, ZcashNetwork network) {
+  void _startMempoolObserver(String dbPath, RpcEndpointConfig endpoint) {
     if (rust_sync.isMempoolObserverRunning()) {
       // Already up — happens if startSync fires while a previous
       // observer is still winding down. The Rust side will
@@ -893,8 +921,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _mempoolSub?.cancel();
     final stream = rust_sync.startMempoolObserver(
       dbPath: dbPath,
-      network: network.name,
-      lightwalletdUrl: network.lightwalletdUrl,
+      network: endpoint.networkName,
+      lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
     );
     _mempoolSub = stream.listen(
       (event) {
@@ -998,7 +1026,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
     final prev = state.value;
     final dbPath = await _getDbPath();
-    final network = ZcashNetwork.mainnet.name;
+    final network = _endpointConfig.networkName;
     final accountUuid = _getActiveAccountUuid();
     if (accountUuid == null) {
       log('SyncNotifier: no active account, skipping refresh');
@@ -1153,7 +1181,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     final epoch = _sensitiveStateEpoch;
     final prev = state.value;
     final dbPath = await _getDbPath();
-    final network = ZcashNetwork.mainnet.name;
+    final network = _endpointConfig.networkName;
     final accountUuid = _getActiveAccountUuid();
     if (accountUuid == null) {
       log('SyncNotifier: no active account, skipping refresh');
@@ -1327,6 +1355,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   bool get _requiresUnlock {
     return ref.read(appSecurityProvider).requiresUnlock;
   }
+
+  RpcEndpointConfig get _endpointConfig => ref.read(rpcEndpointProvider);
 }
 
 final syncProvider = AsyncNotifierProvider<SyncNotifier, SyncState>(

--- a/lib/src/providers/theme_mode_provider.dart
+++ b/lib/src/providers/theme_mode_provider.dart
@@ -1,19 +1,33 @@
 import 'package:flutter/material.dart' show ThemeMode;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../app_bootstrap.dart';
+import '../core/storage/app_secure_store.dart';
+
 /// Holds the user's selected [ThemeMode] (system / light / dark).
 ///
 /// Defaults to [ThemeMode.system] so the app follows the OS. This provider
 /// owns the *intent*; resolving the intent to a concrete [Brightness] (and
 /// thus to `AppThemeData.dark` or `.light`) happens at the `MaterialApp`
 /// layer where `MediaQuery.platformBrightness` is available.
-///
-/// Persistence is intentionally deferred — add it alongside a settings UI.
 class ThemeModeNotifier extends Notifier<ThemeMode> {
-  @override
-  ThemeMode build() => ThemeMode.system;
+  static final _store = AppSecureStore.instance;
 
-  void set(ThemeMode mode) => state = mode;
+  @override
+  ThemeMode build() => ref.watch(appBootstrapProvider).themeMode;
+
+  Future<void> set(ThemeMode mode) async {
+    await _store.writePlain(kThemeModeKey, _encode(mode));
+    state = mode;
+  }
+
+  static String _encode(ThemeMode mode) {
+    return switch (mode) {
+      ThemeMode.system => 'system',
+      ThemeMode.light => 'light',
+      ThemeMode.dark => 'dark',
+    };
+  }
 }
 
 final themeModeProvider = NotifierProvider<ThemeModeNotifier, ThemeMode>(

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -14,6 +14,12 @@ Future<BigInt> getLatestBlockHeight({required String lightwalletdUrl}) =>
       lightwalletdUrl: lightwalletdUrl,
     );
 
+/// Get the lightwalletd chain name ("main" or "test") for endpoint validation.
+Future<String> getLightwalletdChainName({required String lightwalletdUrl}) =>
+    RustLib.instance.api.crateApiWalletGetLightwalletdChainName(
+      lightwalletdUrl: lightwalletdUrl,
+    );
+
 /// Create a new Zcash wallet with a fresh mnemonic.
 /// birthday_height should be the current chain tip (from get_latest_block_height).
 Future<WalletCreationResult> createWallet({

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -70,7 +70,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1485024666;
+  int get rustContentHash => 861917172;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -199,6 +199,10 @@ abstract class RustLibApi extends BaseApi {
   String crateApiSyncGetBlocksDir({required String cachePath});
 
   Future<BigInt> crateApiWalletGetLatestBlockHeight({
+    required String lightwalletdUrl,
+  });
+
+  Future<String> crateApiWalletGetLightwalletdChainName({
     required String lightwalletdUrl,
   });
 
@@ -1259,6 +1263,39 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<String> crateApiWalletGetLightwalletdChainName({
+    required String lightwalletdUrl,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(lightwalletdUrl, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 24,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_String,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletGetLightwalletdChainNameConstMeta,
+        argValues: [lightwalletdUrl],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletGetLightwalletdChainNameConstMeta =>
+      const TaskConstMeta(
+        debugName: "get_lightwalletd_chain_name",
+        argNames: ["lightwalletdUrl"],
+      );
+
+  @override
   Future<String> crateApiSyncGetNextAvailableAddress({
     required String dbPath,
     required String network,
@@ -1274,7 +1311,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1309,7 +1346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1346,7 +1383,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1373,7 +1410,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -1403,7 +1440,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1437,7 +1474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1475,7 +1512,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(txidHex, serializer);
           sse_encode_String(txKind, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_transaction_detail,
@@ -1512,7 +1549,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1549,7 +1586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1586,7 +1623,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1614,7 +1651,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1654,7 +1691,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1711,7 +1748,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1746,7 +1783,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -1773,7 +1810,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 39,
             port: port_,
           );
         },
@@ -1797,7 +1834,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1822,7 +1859,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1844,7 +1881,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1872,7 +1909,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1907,7 +1944,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -1951,7 +1988,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -2009,7 +2046,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -2056,7 +2093,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -2083,7 +2120,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2115,7 +2152,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -2153,7 +2190,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -2206,7 +2243,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 51,
             port: port_,
           );
         },
@@ -2257,7 +2294,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2291,7 +2328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -2332,7 +2369,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -2380,7 +2417,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 54,
+              funcId: 55,
               port: port_,
             );
           },
@@ -2421,7 +2458,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 55,
+              funcId: 56,
               port: port_,
             );
           },
@@ -2450,7 +2487,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2480,7 +2517,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2517,7 +2554,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 59,
             port: port_,
           );
         },
@@ -2549,7 +2586,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2574,7 +2611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(mnemonic, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2600,7 +2637,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2630,7 +2667,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 63,
             port: port_,
           );
         },

--- a/lib/src/services/background_sync_delegate.dart
+++ b/lib/src/services/background_sync_delegate.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 
 import '../../main.dart' show log;
+import '../core/config/rpc_endpoint_config.dart';
 import '../rust/api/sync.dart' as rust_sync;
 import 'background_sync_service.dart' as bg_sync;
 
@@ -56,7 +57,7 @@ abstract class BackgroundSyncDelegate {
 
   void disposeListeners();
 
-  Future<void> enable();
+  Future<void> enable({required RpcEndpointConfig endpoint});
 
   /// Returns true if foreground sync needs to be restarted after disabling.
   Future<bool> disable();
@@ -115,7 +116,7 @@ class AndroidBackgroundSyncDelegate implements BackgroundSyncDelegate {
   }
 
   @override
-  Future<void> enable() async {
+  Future<void> enable({required RpcEndpointConfig endpoint}) async {
     _active = true;
     await bg_sync.startBackgroundSync();
     log('BackgroundSyncDelegate(Android): enabled');
@@ -216,10 +217,10 @@ class IOSBackgroundSyncDelegate implements BackgroundSyncDelegate {
   }
 
   @override
-  Future<void> enable() async {
+  Future<void> enable({required RpcEndpointConfig endpoint}) async {
     _active = true;
     rust_sync.setSyncMode(mode: 2);
-    await bg_sync.startBackgroundSync();
+    await bg_sync.startBackgroundSync(endpoint: endpoint);
     log('BackgroundSyncDelegate(iOS): enabled');
   }
 
@@ -296,7 +297,7 @@ class NoOpBackgroundSyncDelegate implements BackgroundSyncDelegate {
   void disposeListeners() {}
 
   @override
-  Future<void> enable() async {}
+  Future<void> enable({required RpcEndpointConfig endpoint}) async {}
 
   @override
   Future<bool> disable() async => false;

--- a/lib/src/services/background_sync_service.dart
+++ b/lib/src/services/background_sync_service.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 
 import '../../main.dart' show log;
+import '../core/config/rpc_endpoint_config.dart';
 
 const _iosChannel = MethodChannel('com.zcash.wallet/background_sync');
 
@@ -48,17 +49,38 @@ Future<bool> isBackgroundSyncAvailable() async {
 }
 
 /// Start background sync with platform notification.
-Future<void> startBackgroundSync() async {
+Future<void> startBackgroundSync({RpcEndpointConfig? endpoint}) async {
   if (Platform.isAndroid) {
     await _startAndroidForegroundService();
   } else if (Platform.isIOS) {
     try {
-      final success =
-          await _iosChannel.invokeMethod<bool>('startBackgroundSync');
+      final success = await _iosChannel.invokeMethod<bool>(
+        'startBackgroundSync',
+        endpoint == null
+            ? null
+            : {
+                'lightwalletdUrl': endpoint.normalizedLightwalletdUrl,
+                'network': endpoint.networkName,
+              },
+      );
       log('BackgroundSync: iOS BGTask submitted: $success');
     } catch (e) {
       log('BackgroundSync: iOS BGTask failed: $e');
     }
+  }
+}
+
+/// Mirror the Dart endpoint setting into native storage used by iOS BGTasks.
+Future<void> updateBackgroundSyncEndpoint({
+  required RpcEndpointConfig endpoint,
+}) async {
+  if (!Platform.isIOS) return;
+  final success = await _iosChannel.invokeMethod<bool>('updateEndpoint', {
+    'lightwalletdUrl': endpoint.normalizedLightwalletdUrl,
+    'network': endpoint.networkName,
+  });
+  if (success != true) {
+    throw StateError('iOS endpoint mirror update failed.');
   }
 }
 
@@ -83,8 +105,9 @@ Future<void> stopBackgroundSync() async {
     await FlutterForegroundTask.stopService();
   } else if (Platform.isIOS) {
     try {
-      final success =
-          await _iosChannel.invokeMethod<bool>('stopBackgroundSync');
+      final success = await _iosChannel.invokeMethod<bool>(
+        'stopBackgroundSync',
+      );
       log('BackgroundSync: iOS BGTask cancel requested: $success');
     } catch (e) {
       log('BackgroundSync: iOS BGTask cancel failed: $e');

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -2,12 +2,95 @@ import Cocoa
 import FlutterMacOS
 import desktop_window_bootstrap
 
+final class WindowAppearanceChannel {
+  private static var shared: WindowAppearanceChannel?
+
+  private weak var window: NSWindow?
+  private weak var visualEffectView: NSVisualEffectView?
+  private let channel: FlutterMethodChannel
+
+  private init(
+    window: NSWindow,
+    visualEffectView: NSVisualEffectView,
+    messenger: FlutterBinaryMessenger
+  ) {
+    self.window = window
+    self.visualEffectView = visualEffectView
+    self.channel = FlutterMethodChannel(
+      name: "com.zcash.wallet/window_appearance",
+      binaryMessenger: messenger
+    )
+    channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call, result: result)
+    }
+  }
+
+  static func register(
+    window: NSWindow,
+    visualEffectView: NSVisualEffectView,
+    messenger: FlutterBinaryMessenger
+  ) {
+    shared = WindowAppearanceChannel(
+      window: window,
+      visualEffectView: visualEffectView,
+      messenger: messenger
+    )
+  }
+
+  private func handle(_ call: FlutterMethodCall, result: FlutterResult) {
+    switch call.method {
+    case "setBrightness":
+      guard
+        let arguments = call.arguments as? [String: Any],
+        let brightness = arguments["brightness"] as? String
+      else {
+        result(
+          FlutterError(
+            code: "bad_args",
+            message: "Expected brightness argument.",
+            details: nil
+          )
+        )
+        return
+      }
+      setBrightness(brightness)
+      result(nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func setBrightness(_ brightness: String) {
+    let appearanceName: NSAppearance.Name =
+      brightness == "dark" ? .darkAqua : .aqua
+    let appearance = NSAppearance(named: appearanceName)
+
+    NSApp.appearance = appearance
+    window?.appearance = appearance
+    window?.contentView?.appearance = appearance
+    window?.contentViewController?.view.appearance = appearance
+    visualEffectView?.appearance = appearance
+    // Keep the blur chrome neutral; `.fullScreenUI` can render as a dark
+    // sidebar/titlebar even when Flutter has resolved the app to light mode.
+    visualEffectView?.material = .windowBackground
+    visualEffectView?.state = .active
+    window?.backgroundColor = .clear
+    window?.invalidateShadow()
+  }
+}
+
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
     let desktopWindowViewController = DesktopWindowBootstrapMacOS.start(
       mainFlutterWindow: self
     )
-    RegisterGeneratedPlugins(registry: desktopWindowViewController.flutterViewController)
+    let flutterViewController = desktopWindowViewController.flutterViewController
+    WindowAppearanceChannel.register(
+      window: self,
+      visualEffectView: desktopWindowViewController.visualEffectView,
+      messenger: flutterViewController.engine.binaryMessenger
+    )
+    RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()
   }

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -2,20 +2,39 @@ import Cocoa
 import FlutterMacOS
 import desktop_window_bootstrap
 
+private func titlebarTitleColor(for brightness: String) -> NSColor {
+  if brightness == "dark" {
+    return NSColor.white.withAlphaComponent(0.8)
+  }
+  return NSColor.black.withAlphaComponent(0.8)
+}
+
+private func currentSystemBrightness() -> String {
+  let match = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua])
+  return match == .darkAqua ? "dark" : "light"
+}
+
+private func appTitle() -> String {
+  Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "Vizor"
+}
+
 final class WindowAppearanceChannel {
   private static var shared: WindowAppearanceChannel?
 
   private weak var window: NSWindow?
   private weak var visualEffectView: NSVisualEffectView?
+  private weak var titleLabel: NSTextField?
   private let channel: FlutterMethodChannel
 
   private init(
     window: NSWindow,
     visualEffectView: NSVisualEffectView,
+    titleLabel: NSTextField,
     messenger: FlutterBinaryMessenger
   ) {
     self.window = window
     self.visualEffectView = visualEffectView
+    self.titleLabel = titleLabel
     self.channel = FlutterMethodChannel(
       name: "com.zcash.wallet/window_appearance",
       binaryMessenger: messenger
@@ -28,11 +47,13 @@ final class WindowAppearanceChannel {
   static func register(
     window: NSWindow,
     visualEffectView: NSVisualEffectView,
+    titleLabel: NSTextField,
     messenger: FlutterBinaryMessenger
   ) {
     shared = WindowAppearanceChannel(
       window: window,
       visualEffectView: visualEffectView,
+      titleLabel: titleLabel,
       messenger: messenger
     )
   }
@@ -70,6 +91,8 @@ final class WindowAppearanceChannel {
     window?.contentView?.appearance = appearance
     window?.contentViewController?.view.appearance = appearance
     visualEffectView?.appearance = appearance
+    titleLabel?.appearance = appearance
+    titleLabel?.textColor = titlebarTitleColor(for: brightness)
     // Keep the blur chrome neutral; `.fullScreenUI` can render as a dark
     // sidebar/titlebar even when Flutter has resolved the app to light mode.
     visualEffectView?.material = .windowBackground
@@ -79,20 +102,84 @@ final class WindowAppearanceChannel {
   }
 }
 
+private final class TitlebarTitleLabel: NSTextField {
+  override func hitTest(_ point: NSPoint) -> NSView? {
+    nil
+  }
+}
+
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
     let desktopWindowViewController = DesktopWindowBootstrapMacOS.start(
       mainFlutterWindow: self
     )
     let flutterViewController = desktopWindowViewController.flutterViewController
+    let titleLabel = makeTitleLabel()
+    installTitleLabel(
+      titleLabel,
+      in: desktopWindowViewController.visualEffectView,
+      above: flutterViewController.view
+    )
     WindowAppearanceChannel.register(
       window: self,
       visualEffectView: desktopWindowViewController.visualEffectView,
+      titleLabel: titleLabel,
       messenger: flutterViewController.engine.binaryMessenger
     )
     RegisterGeneratedPlugins(registry: flutterViewController)
 
     super.awakeFromNib()
+  }
+
+  private func makeTitleLabel() -> NSTextField {
+    let label = TitlebarTitleLabel(labelWithString: appTitle())
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.font = NSFont.systemFont(ofSize: 15, weight: .bold)
+    label.textColor = titlebarTitleColor(for: currentSystemBrightness())
+    label.lineBreakMode = .byClipping
+    label.usesSingleLineMode = true
+    return label
+  }
+
+  private func installTitleLabel(
+    _ label: NSTextField,
+    in visualEffectView: NSVisualEffectView,
+    above flutterView: NSView
+  ) {
+    visualEffectView.addSubview(label, positioned: .above, relativeTo: flutterView)
+    let verticalConstraint =
+      titleCenterYConstraint(for: label, in: visualEffectView) ??
+      label.topAnchor.constraint(equalTo: visualEffectView.topAnchor, constant: 6)
+    NSLayoutConstraint.activate([
+      label.leadingAnchor.constraint(equalTo: visualEffectView.leadingAnchor, constant: 84),
+      verticalConstraint,
+    ])
+  }
+
+  private func titleCenterYConstraint(
+    for label: NSTextField,
+    in visualEffectView: NSVisualEffectView
+  ) -> NSLayoutConstraint? {
+    guard
+      let closeButton = standardWindowButton(.closeButton),
+      let closeButtonSuperview = closeButton.superview
+    else {
+      return nil
+    }
+
+    closeButtonSuperview.layoutSubtreeIfNeeded()
+    visualEffectView.layoutSubtreeIfNeeded()
+
+    let closeFrame = closeButtonSuperview.convert(closeButton.frame, to: visualEffectView)
+    guard closeFrame.height > 0, visualEffectView.bounds.height > 0 else {
+      return nil
+    }
+
+    let closeCenterYFromTop = visualEffectView.bounds.height - closeFrame.midY
+    return label.centerYAnchor.constraint(
+      equalTo: visualEffectView.topAnchor,
+      constant: closeCenterYFromTop
+    )
   }
 
   override public func order(_ place: NSWindow.OrderingMode, relativeTo otherWin: Int) {

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -93,9 +93,7 @@ final class WindowAppearanceChannel {
     visualEffectView?.appearance = appearance
     titleLabel?.appearance = appearance
     titleLabel?.textColor = titlebarTitleColor(for: brightness)
-    // Keep the blur chrome neutral; `.fullScreenUI` can render as a dark
-    // sidebar/titlebar even when Flutter has resolved the app to light mode.
-    visualEffectView?.material = .windowBackground
+    visualEffectView?.material = .fullScreenUI
     visualEffectView?.state = .active
     window?.backgroundColor = .clear
     window?.invalidateShadow()

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -68,6 +68,27 @@ pub fn get_latest_block_height(lightwalletd_url: String) -> Result<u64, String> 
     })
 }
 
+/// Get the lightwalletd chain name ("main" or "test") for endpoint validation.
+pub fn get_lightwalletd_chain_name(lightwalletd_url: String) -> Result<String, String> {
+    catch(|| {
+        let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
+        rt.block_on(async {
+            use zcash_client_backend::proto::service::Empty;
+
+            let mut client = crate::wallet::sync_engine::open_lwd_channel(&lightwalletd_url)
+                .await
+                .map_err(|e| e.to_string())?;
+            let info = client
+                .get_lightd_info(Empty {})
+                .await
+                .map_err(|e| format!("get_lightd_info: {e}"))?
+                .into_inner();
+
+            Ok(info.chain_name)
+        })
+    })
+}
+
 /// Create a new Zcash wallet with a fresh mnemonic.
 /// birthday_height should be the current chain tip (from get_latest_block_height).
 pub fn create_wallet(

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -78,11 +78,14 @@ pub fn get_lightwalletd_chain_name(lightwalletd_url: String) -> Result<String, S
             let mut client = crate::wallet::sync_engine::open_lwd_channel(&lightwalletd_url)
                 .await
                 .map_err(|e| e.to_string())?;
-            let info = client
-                .get_lightd_info(Empty {})
-                .await
-                .map_err(|e| format!("get_lightd_info: {e}"))?
-                .into_inner();
+            let info = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                client.get_lightd_info(Empty {}),
+            )
+            .await
+            .map_err(|_| "get_lightd_info: timed out waiting for response".to_string())?
+            .map_err(|e| format!("get_lightd_info: {e}"))?
+            .into_inner();
 
             Ok(info.chain_name)
         })

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1485024666;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 861917172;
 
 // Section: executor
 
@@ -897,6 +897,40 @@ fn wire__crate__api__wallet__get_latest_block_height_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok =
                         crate::api::wallet::get_latest_block_height(api_lightwalletd_url)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet__get_lightwalletd_chain_name_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_lightwalletd_chain_name",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok =
+                        crate::api::wallet::get_lightwalletd_chain_name(api_lightwalletd_url)?;
                     Ok(output_ok)
                 })())
             }
@@ -3065,86 +3099,92 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        24 => wire__crate__api__sync__get_next_available_address_impl(
+        24 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        25 => {
+        25 => wire__crate__api__sync__get_next_available_address_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        26 => {
             wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len)
         }
-        26 => wire__crate__api__sync__get_shield_transparent_status_impl(
+        27 => wire__crate__api__sync__get_shield_transparent_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        28 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__sync__get_transaction_data_requests_impl(
+        29 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__sync__get_transaction_data_requests_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        31 => {
+        32 => {
             wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len)
         }
-        32 => wire__crate__api__wallet__get_transparent_address_impl(
+        33 => wire__crate__api__wallet__get_transparent_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        33 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__wallet__import_hardware_account_impl(
+        34 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__wallet__import_hardware_account_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        36 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__keystone__is_keystone_connected_impl(
+        37 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__keystone__is_keystone_connected_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__keystone__keystone_usb_sign_pczt_impl(
+        43 => wire__crate__api__keystone__keystone_usb_sign_pczt_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        43 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-        46 => {
+        44 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+        47 => {
             wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len)
         }
-        48 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-        49 => {
+        49 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+        50 => {
             wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len)
         }
-        50 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-        52 => {
+        51 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+        53 => {
             wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len)
         }
-        53 => wire__crate__api__sync__shield_transparent_balance_impl(
+        54 => wire__crate__api__sync__shield_transparent_balance_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        54 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-        55 => {
+        55 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+        56 => {
             wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len)
         }
-        57 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+        63 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3160,17 +3200,17 @@ fn pde_ffi_dispatcher_sync_impl(
         3 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
         20 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
         22 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        56 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        61 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        28 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        52 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -14,6 +14,8 @@
 //! failures into `SyncError::net` or `SyncError::parse`, so the outer
 //! loop only ever deals with the typed `SyncError` taxonomy.
 
+use std::time::Duration;
+
 use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
 use zcash_client_backend::{
     data_api::{
@@ -30,6 +32,8 @@ use crate::wallet::db::with_wallet_db_write_lock;
 
 use super::block_source::MemoryBlockSource;
 use super::{elapsed, SyncError, WalletDatabase};
+
+const LIGHTWALLETD_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Opens a tonic gRPC channel to the given lightwalletd URL and
 /// returns a `CompactTxStreamerClient`.
@@ -50,7 +54,8 @@ pub(crate) async fn open_lwd_channel(
     });
 
     let endpoint = Endpoint::from_shared(lightwalletd_url.to_string())
-        .map_err(|e| SyncError::net(format!("invalid URL: {e}")))?;
+        .map_err(|e| SyncError::net(format!("invalid URL: {e}")))?
+        .connect_timeout(LIGHTWALLETD_CONNECT_TIMEOUT);
     let channel = if lightwalletd_url.starts_with("https://") {
         endpoint
             .tls_config(ClientTlsConfig::new().with_webpki_roots())

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+
+void main() {
+  test('mergeBootstrappedAccountInfo keeps stored UI metadata', () {
+    const rustAccount = AccountInfo(
+      uuid: 'account-1',
+      name: 'Rust Name',
+      order: 0,
+    );
+    const storedAccount = AccountInfo(
+      uuid: 'account-1',
+      name: 'Stored Name',
+      order: 9,
+      isHardware: true,
+      profilePictureId: 'knight-04',
+    );
+
+    final merged = mergeBootstrappedAccountInfo(
+      rustAccount: rustAccount,
+      storedAccount: storedAccount,
+      order: 3,
+    );
+
+    expect(merged.uuid, 'account-1');
+    expect(merged.name, 'Stored Name');
+    expect(merged.order, 3);
+    expect(merged.isHardware, isTrue);
+    expect(merged.profilePictureId, 'knight-04');
+  });
+
+  test('mergeBootstrappedAccountInfo falls back to Rust metadata', () {
+    const rustAccount = AccountInfo(
+      uuid: 'account-2',
+      name: 'Rust Name',
+      order: 0,
+    );
+
+    final merged = mergeBootstrappedAccountInfo(
+      rustAccount: rustAccount,
+      storedAccount: null,
+      order: 1,
+    );
+
+    expect(merged.uuid, 'account-2');
+    expect(merged.name, 'Rust Name');
+    expect(merged.order, 1);
+    expect(merged.isHardware, isFalse);
+  });
+
+  test('empty bootstrap has no password rotation recovery failure', () {
+    expect(AppBootstrapState.empty.passwordRotationRecoveryFailed, isFalse);
+  });
+}

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -76,9 +76,35 @@ void main() {
     });
   });
 
+  group('RpcEndpointConfig', () {
+    test('derives the effective preset from the URL before stored preset id', () {
+      final defaultEndpoint = defaultRpcEndpointConfig('main');
+      final config = RpcEndpointConfig(
+        networkName: 'main',
+        lightwalletdUrl: defaultEndpoint.lightwalletdUrl,
+        presetId: kCustomRpcEndpointPresetId,
+      );
+
+      expect(config.effectivePresetId, defaultEndpoint.presetId);
+    });
+  });
+
   group('rpcEndpointHostPort', () {
     test('keeps IPv6 brackets so custom endpoint fields can round-trip', () {
       expect(rpcEndpointHostPort('https://[::1]:9067'), '[::1]:9067');
+    });
+  });
+
+  group('rpcEndpointInputText', () {
+    test('preserves local http schemes for custom endpoint editing', () {
+      expect(
+        rpcEndpointInputText('http://127.0.0.1:9067'),
+        'http://127.0.0.1:9067',
+      );
+    });
+
+    test('keeps https endpoints compact for custom endpoint editing', () {
+      expect(rpcEndpointInputText('https://zec.rocks:443'), 'zec.rocks:443');
     });
   });
 }

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -75,4 +75,10 @@ void main() {
       expect(preset, isNull);
     });
   });
+
+  group('rpcEndpointHostPort', () {
+    test('keeps IPv6 brackets so custom endpoint fields can round-trip', () {
+      expect(rpcEndpointHostPort('https://[::1]:9067'), '[::1]:9067');
+    });
+  });
 }

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+
+void main() {
+  group('normalizeRpcEndpointUrl', () {
+    test('normalizes host and explicit port with an https scheme', () {
+      expect(normalizeRpcEndpointUrl('zec.rocks:443'), 'https://zec.rocks:443');
+      expect(
+        normalizeRpcEndpointUrl('https://zec.rocks:443'),
+        'https://zec.rocks:443',
+      );
+    });
+
+    test('rejects missing ports unless default ports are allowed', () {
+      expect(
+        () => normalizeRpcEndpointUrl('zec.rocks'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        normalizeRpcEndpointUrl('zec.rocks', allowDefaultPort: true),
+        'https://zec.rocks:443',
+      );
+    });
+
+    test('rejects invalid ports and spaces', () {
+      expect(
+        () => normalizeRpcEndpointUrl('zec.rocks:70000'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => normalizeRpcEndpointUrl('zec.rocks:abc'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => normalizeRpcEndpointUrl('zec.rocks :443'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('rejects non-local http endpoints', () {
+      expect(
+        () => normalizeRpcEndpointUrl('http://zec.rocks:443'),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        normalizeRpcEndpointUrl('http://127.0.0.1:9067'),
+        'http://127.0.0.1:9067',
+      );
+    });
+
+    test('preserves bracketed IPv6 host formatting', () {
+      expect(
+        normalizeRpcEndpointUrl('https://[::1]:9067'),
+        'https://[::1]:9067',
+      );
+    });
+  });
+
+  group('preset lookup', () {
+    test('matches normalized URLs within the requested network', () {
+      final preset = findRpcEndpointPresetByUrl(
+        'zec.rocks',
+        networkName: 'main',
+      );
+
+      expect(preset?.id, kDefaultRpcEndpointPresetId);
+    });
+
+    test('does not cross-match testnet URLs when mainnet is requested', () {
+      final preset = findRpcEndpointPresetByUrl(
+        'testnet.zec.rocks:443',
+        networkName: 'main',
+      );
+
+      expect(preset, isNull);
+    });
+  });
+}

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -103,6 +103,24 @@ void main() {
     expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
   });
 
+  test('changePassword rejects unreadable mnemonic payloads', () async {
+    await store.configurePassword(_oldPassword);
+    await store.writeString(_mnemonicKey, 'not encrypted json');
+
+    await expectLater(
+      () => store.changePassword(
+        currentPassword: _oldPassword,
+        newPassword: _newPassword,
+      ),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(await store.readPlain(_rotationInProgressKey), isNull);
+    expect(await store.verifyPasswordOnly(_newPassword), isFalse);
+    expect(await store.verifyPassword(_oldPassword), isTrue);
+    expect(await store.readPlain(_mnemonicKey), 'not encrypted json');
+  });
+
   test('changePassword rolls back if the verifier write fails', () async {
     final failingStorage = _FailingWriteStorage(failKey: _passwordVerifierKey);
     store = AppSecureStore.testing(storage: failingStorage);

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -1,0 +1,217 @@
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/security/password_policy.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+
+const _oldPassword = 'Oldpass1!';
+const _newPassword = 'Newpass1!';
+const _wrongPassword = 'Wrongpass1!';
+const _mnemonicKey = 'zcash_account_mnemonic_test-account';
+const _externalEncryptedKey = 'external_encrypted_key';
+const _mnemonic = 'abandon abandon abandon abandon abandon abandon';
+
+const _passwordVerifierKey = 'zcash_password_verifier';
+const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';
+const _rotationInProgressKey = 'zcash_rotation_in_progress';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppSecureStore store;
+
+  setUp(() async {
+    FlutterSecureStorage.setMockInitialValues({});
+    store = AppSecureStore.instance;
+    await store.deleteAll();
+  });
+
+  tearDown(() async {
+    await store.deleteAll();
+  });
+
+  test('changePassword rotates mnemonic payloads and verifier', () async {
+    await store.configurePassword(_oldPassword);
+    await store.writeSecretString(_mnemonicKey, _mnemonic);
+
+    final didChange = await store.changePassword(
+      currentPassword: _oldPassword,
+      newPassword: _newPassword,
+    );
+
+    expect(didChange, isTrue);
+
+    store.clearSessionPassword();
+    expect(await store.verifyPasswordOnly(_oldPassword), isFalse);
+    expect(await store.verifyPassword(_newPassword), isTrue);
+    expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+  });
+
+  test(
+    'changePassword rejects wrong current password without rotating',
+    () async {
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(_mnemonicKey, _mnemonic);
+      final originalPayload = await store.readPlain(_mnemonicKey);
+
+      final didChange = await store.changePassword(
+        currentPassword: _wrongPassword,
+        newPassword: _newPassword,
+      );
+
+      expect(didChange, isFalse);
+      expect(await store.readPlain(_rotationInProgressKey), isNull);
+      expect(await store.readPlain(_mnemonicKey), originalPayload);
+      expect(await store.verifyPassword(_oldPassword), isTrue);
+      expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+    },
+  );
+
+  test('changePassword rejects invalid or unchanged new passwords', () async {
+    await store.configurePassword(_oldPassword);
+
+    expect(
+      () =>
+          store.changePassword(currentPassword: _oldPassword, newPassword: ''),
+      throwsA(isA<ArgumentError>()),
+    );
+    expect(
+      () => store.changePassword(
+        currentPassword: _oldPassword,
+        newPassword: _oldPassword,
+      ),
+      throwsA(isA<ArgumentError>()),
+    );
+    expect(validateRequiredWalletPassword(''), kWalletPasswordMinLengthMessage);
+  });
+
+  test('changePassword only rotates app-managed mnemonic payloads', () async {
+    await store.configurePassword(_oldPassword);
+    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    await store.writeSecretString(_externalEncryptedKey, 'external secret');
+    final externalPayload = await store.readPlain(_externalEncryptedKey);
+
+    final didChange = await store.changePassword(
+      currentPassword: _oldPassword,
+      newPassword: _newPassword,
+    );
+
+    expect(didChange, isTrue);
+    expect(await store.readPlain(_externalEncryptedKey), externalPayload);
+    expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+  });
+
+  test('changePassword rolls back if the verifier write fails', () async {
+    final failingStorage = _FailingWriteStorage(failKey: _passwordVerifierKey);
+    store = AppSecureStore.testing(storage: failingStorage);
+    await store.configurePassword(_oldPassword);
+    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    final originalPayload = await store.readPlain(_mnemonicKey);
+
+    failingStorage.failNextMatchingWrite = true;
+
+    await expectLater(
+      () => store.changePassword(
+        currentPassword: _oldPassword,
+        newPassword: _newPassword,
+      ),
+      throwsA(
+        isA<StateError>().having(
+          (error) => error.message,
+          'message',
+          'forced write failure',
+        ),
+      ),
+    );
+
+    expect(await store.readPlain(_rotationInProgressKey), isNull);
+    expect(await store.readPlain(_mnemonicKey), originalPayload);
+    expect(await store.verifyPasswordOnly(_newPassword), isFalse);
+    expect(await store.verifyPassword(_oldPassword), isTrue);
+    expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+  });
+
+  test(
+    'recoverInterruptedPasswordRotation rolls forward from sentinel',
+    () async {
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(_mnemonicKey, _mnemonic);
+
+      final oldVerifierSalt = await store.readPlain(_passwordVerifierSaltKey);
+      final oldVerifier = await store.readPlain(_passwordVerifierKey);
+      final originalPayload = await store.readPlain(_mnemonicKey);
+
+      await store.changePassword(
+        currentPassword: _oldPassword,
+        newPassword: _newPassword,
+      );
+      final rotatedPayload = await store.readPlain(_mnemonicKey);
+      final newVerifierSalt = await store.readPlain(_passwordVerifierSaltKey);
+      final newVerifier = await store.readPlain(_passwordVerifierKey);
+
+      await store.writePlain(_mnemonicKey, originalPayload!);
+      await store.writePlain(_passwordVerifierSaltKey, oldVerifierSalt!);
+      await store.writePlain(_passwordVerifierKey, oldVerifier!);
+      await store.writePlain(
+        _rotationInProgressKey,
+        jsonEncode({
+          'v': 1,
+          'oldVerifierSalt': oldVerifierSalt,
+          'oldVerifier': oldVerifier,
+          'newVerifierSalt': newVerifierSalt,
+          'newVerifier': newVerifier,
+          'entries': [
+            {
+              'key': _mnemonicKey,
+              'originalValue': originalPayload,
+              'rotatedValue': rotatedPayload,
+            },
+          ],
+        }),
+      );
+      store.clearSessionPassword();
+
+      await store.recoverInterruptedPasswordRotation();
+
+      expect(await store.readPlain(_rotationInProgressKey), isNull);
+      expect(await store.verifyPasswordOnly(_oldPassword), isFalse);
+      expect(await store.verifyPassword(_newPassword), isTrue);
+      expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+    },
+  );
+}
+
+class _FailingWriteStorage extends FlutterSecureStorage {
+  _FailingWriteStorage({required this.failKey});
+
+  final String failKey;
+  bool failNextMatchingWrite = false;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) {
+    if (failNextMatchingWrite && key == failKey) {
+      failNextMatchingWrite = false;
+      throw StateError('forced write failure');
+    }
+    return super.write(
+      key: key,
+      value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
+}

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -180,6 +181,107 @@ void main() {
       expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
     },
   );
+
+  test('changePassword waits for concurrent mnemonic writes', () async {
+    const lateMnemonicKey = 'zcash_account_mnemonic_late-account';
+    const lateMnemonic = 'legal winner thank year wave sausage worth useful';
+    final blockingStorage = _BlockingWriteStorage(blockKey: lateMnemonicKey);
+    store = AppSecureStore.testing(storage: blockingStorage);
+    await store.configurePassword(_oldPassword);
+    await store.writeSecretString(_mnemonicKey, _mnemonic);
+
+    blockingStorage.blockNextWrite = true;
+    final lateWrite = store.writeSecretString(lateMnemonicKey, lateMnemonic);
+    await blockingStorage.writeStarted.future;
+
+    final rotation = store.changePassword(
+      currentPassword: _oldPassword,
+      newPassword: _newPassword,
+    );
+    final rotationReachedSnapshot = await Future.any([
+      blockingStorage.readAllFinished.future.then((_) => true),
+      Future<void>.delayed(const Duration(seconds: 6)).then((_) => false),
+    ]);
+
+    if (rotationReachedSnapshot) {
+      await rotation;
+    }
+    blockingStorage.release();
+    await lateWrite;
+    if (!rotationReachedSnapshot) {
+      await rotation;
+    }
+
+    store.clearSessionPassword();
+    expect(await store.verifyPassword(_newPassword), isTrue);
+    expect(
+      await store.readSecretStringWithOptions(lateMnemonicKey),
+      lateMnemonic,
+    );
+  });
+
+  test(
+    'rollback sentinel write failure does not roll forward on recovery',
+    () async {
+      final failingStorage = _CountingFailingWriteStorage();
+      store = AppSecureStore.testing(storage: failingStorage);
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(_mnemonicKey, _mnemonic);
+      failingStorage
+        ..failNextWriteFor(_passwordVerifierKey)
+        ..failWriteNumberFor(_rotationInProgressKey, 2);
+
+      await expectLater(
+        () => store.changePassword(
+          currentPassword: _oldPassword,
+          newPassword: _newPassword,
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      final recoveryRecord = await store.readPlain(_rotationInProgressKey);
+      expect(recoveryRecord, contains('rollbackFailed'));
+      await expectLater(
+        () => store.recoverInterruptedPasswordRotation(),
+        throwsA(isA<PasswordRotationRecoveryFailedException>()),
+      );
+      await expectLater(
+        () => store.changePassword(
+          currentPassword: _oldPassword,
+          newPassword: _newPassword,
+        ),
+        throwsA(isA<PasswordRotationRecoveryFailedException>()),
+      );
+    },
+  );
+
+  test(
+    'delete waits for password rotation before deleting mnemonics',
+    () async {
+      final blockingStorage = _BlockingWriteStorage(
+        blockKey: _rotationInProgressKey,
+      );
+      store = AppSecureStore.testing(storage: blockingStorage);
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(_mnemonicKey, _mnemonic);
+
+      blockingStorage.blockNextWrite = true;
+      final rotation = store.changePassword(
+        currentPassword: _oldPassword,
+        newPassword: _newPassword,
+      );
+      await blockingStorage.writeStarted.future;
+
+      final delete = store.delete(_mnemonicKey);
+      blockingStorage.release();
+      await rotation;
+      await delete;
+
+      store.clearSessionPassword();
+      expect(await store.verifyPassword(_newPassword), isTrue);
+      expect(await store.readPlain(_mnemonicKey), isNull);
+    },
+  );
 }
 
 class _FailingWriteStorage extends FlutterSecureStorage {
@@ -202,6 +304,118 @@ class _FailingWriteStorage extends FlutterSecureStorage {
     if (failNextMatchingWrite && key == failKey) {
       failNextMatchingWrite = false;
       throw StateError('forced write failure');
+    }
+    return super.write(
+      key: key,
+      value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
+}
+
+class _BlockingWriteStorage extends FlutterSecureStorage {
+  _BlockingWriteStorage({required this.blockKey});
+
+  final String blockKey;
+  var blockNextWrite = false;
+  Completer<void> writeStarted = Completer<void>();
+  Completer<void> readAllFinished = Completer<void>();
+  final Completer<void> _release = Completer<void>();
+
+  void release() {
+    if (!_release.isCompleted) {
+      _release.complete();
+    }
+  }
+
+  @override
+  Future<Map<String, String>> readAll({
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    final values = await super.readAll(
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+    if (!readAllFinished.isCompleted) {
+      readAllFinished.complete();
+    }
+    return values;
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (blockNextWrite && key == blockKey) {
+      blockNextWrite = false;
+      if (!writeStarted.isCompleted) {
+        writeStarted.complete();
+      }
+      await _release.future;
+    }
+    return super.write(
+      key: key,
+      value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
+}
+
+class _CountingFailingWriteStorage extends FlutterSecureStorage {
+  final _writeCounts = <String, int>{};
+  final _failNext = <String>{};
+  final _failWriteNumbers = <String, Set<int>>{};
+
+  void failNextWriteFor(String key) {
+    _failNext.add(key);
+  }
+
+  void failWriteNumberFor(String key, int writeNumber) {
+    _failWriteNumbers.putIfAbsent(key, () => <int>{}).add(writeNumber);
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) {
+    final count = (_writeCounts[key] ?? 0) + 1;
+    _writeCounts[key] = count;
+    if (_failNext.remove(key) ||
+        (_failWriteNumbers[key]?.remove(count) ?? false)) {
+      throw StateError('forced write failure for $key');
     }
     return super.write(
       key: key,

--- a/test/features/onboarding/import_birthday_estimator_test.dart
+++ b/test/features/onboarding/import_birthday_estimator_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/features/onboarding/import/import_birthday_estimator.dart';
+
+typedef _LoadMetadataWithEndpoint = Future<ImportBirthdayMetadata> Function({
+  required RpcEndpointConfig endpoint,
+});
+
+typedef _EstimateBirthdayWithEndpoint = Future<int> Function({
+  required RpcEndpointConfig endpoint,
+  required DateTime selectedDate,
+});
+
+void main() {
+  test('estimator APIs accept the configured RPC endpoint', () {
+    final _LoadMetadataWithEndpoint loadMetadata =
+        ImportBirthdayEstimator.loadMetadata;
+    final _EstimateBirthdayWithEndpoint estimateBirthdayHeight =
+        ImportBirthdayEstimator.estimateBirthdayHeight;
+
+    expect(loadMetadata, isNotNull);
+    expect(estimateBirthdayHeight, isNotNull);
+  });
+}


### PR DESCRIPTION
## Summary

Adds the Settings area and related wallet-management flows:

- Settings home with account rows/actions, theme selection, profile picture selection, RPC endpoint selection, seed phrase reveal, and change-password entry points.
- Password-gated seed phrase reveal for software accounts, with hardware-account guardrails and active-account-change reset behavior.
- Change-password flow that re-encrypts stored account mnemonics and updates the wallet password verifier.
- User-configurable lightwalletd RPC endpoints with preset/custom endpoint UI, network validation, secure-storage persistence, and sync restart.
- Theme persistence plus macOS titlebar/sidebar appearance sync so app chrome follows the selected theme.
- Account profile picture metadata and sidebar/settings rendering support.

## Security / Recovery

- Added `verifyPasswordOnly` for passive password re-checks without changing unlocked state.
- Added crash-safe password rotation journaling:
  - writes a rotation sentinel before rewriting encrypted mnemonic payloads,
  - supports boot-time recovery from interrupted rotations,
  - preserves rollback-failed state instead of silently rolling forward,
  - serializes mnemonic writes/deletes with password rotation to avoid mixed-key payloads.
- Surfaces password-rotation recovery failure through bootstrap state and a home warning banner.
- Keeps the sensitive-screen protection gap as a release TODO instead of landing an unreliable macOS Mission Control workaround.

## RPC Endpoint

- Added `RpcEndpointConfig`, endpoint presets, URL normalization/validation, and `RpcEndpointNotifier`.
- Added Rust `get_lightwalletd_chain_name` / Dart binding for endpoint network validation before saving.
- Threaded the configured endpoint through wallet creation/import birthday fetch, sync, polling, mempool observer, send/broadcast paths, shield flow, iOS background sync, and tx tracking.
- Added iOS `RpcEndpointConfigStore` mirror so BGTask code can read the selected endpoint outside Dart runtime.
- Bootstrap now reads persisted endpoint config and seeds the native iOS mirror.

## UI / Platform

- Introduced `AppThemeHost` to resolve theme brightness once and sync macOS window appearance.
- Added macOS titlebar app label and kept the native acrylic/translucent shell intact.
- Updated Settings/sidebar layout and modal flows for account name, theme, and profile picture changes.
- Added centralized profile picture option metadata with provider-level validation.

## Tests / Verification

Run locally:

- `fvm flutter test test/app_bootstrap_test.dart test/core/storage/app_secure_store_test.dart test/core/config/rpc_endpoint_config_test.dart`
- `fvm flutter test test/features/onboarding/import_birthday_estimator_test.dart test/core/config/rpc_endpoint_config_test.dart`
- `fvm dart analyze lib/app.dart lib/src/app_bootstrap.dart lib/src/core/storage/app_secure_store.dart lib/src/core/config/rpc_endpoint_config.dart lib/src/features/settings lib/src/features/home/screens/home_screen.dart lib/src/providers`
- `fvm dart analyze lib/src/features/onboarding/import/import_birthday_estimator.dart lib/src/features/onboarding/import/import_wallet_birthday_screen.dart test/features/onboarding/import_birthday_estimator_test.dart`

## Manual Verification Recommended

- Change theme between System / Light / Dark on macOS and confirm the titlebar, sidebar, and pane stay visually consistent.
- Reveal settings seed phrase for a software account, verify wrong-password and hardware-account paths, and switch active accounts while revealed.
- Change wallet password, then unlock again and verify stored software-account seed phrase remains readable.
- Configure a custom RPC endpoint, restart the app, and verify sync/import/send paths use the selected endpoint.
- Enable background sync on iOS, change endpoint, and verify the next background run uses the updated endpoint.
- Import wallet birthday by date with a custom endpoint selected and verify metadata/height estimation goes through that endpoint.

## TODO

- Add reliable sensitive-screen protection for seed phrase surfaces before release. Current Flutter lifecycle overlay does not reliably cover macOS Mission Control, so this needs a follow-up design/implementation pass across Settings seed phrase reveal, onboarding Secret Passphrase reveal, and Import Secret Passphrase entry.
