### PR TITLE
[codex] Improve send flow

### DIFF
--- a/lib/src/core/formatting/zec_amount.dart
+++ b/lib/src/core/formatting/zec_amount.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/services.dart';
+
+final BigInt zatoshiPerZec = BigInt.from(100000000);
+
+String formatZecAmount(BigInt zatoshi, {int minFractionDigits = 0}) {
+  assert(minFractionDigits >= 0 && minFractionDigits <= 8);
+
+  final sign = zatoshi < BigInt.zero ? '-' : '';
+  final abs = zatoshi.abs();
+  final whole = abs ~/ zatoshiPerZec;
+  var fraction = (abs % zatoshiPerZec).toString().padLeft(8, '0');
+
+  fraction = fraction.replaceFirst(RegExp(r'0+$'), '');
+  if (fraction.length < minFractionDigits) {
+    fraction = fraction.padRight(minFractionDigits, '0');
+  }
+
+  return fraction.isEmpty ? '$sign$whole' : '$sign$whole.$fraction';
+}
+
+BigInt? parseZecAmount(String input) {
+  var value = input.trim();
+  if (value.isEmpty || value == '.' || value.contains(',')) return null;
+  if (value.startsWith('.')) value = '0$value';
+
+  final parts = value.split('.');
+  if (parts.length > 2) return null;
+
+  final wholePart = parts[0];
+  final fractionPart = parts.length > 1 ? parts[1] : '';
+  if (!_digitsOnly(wholePart) || !_digitsOnly(fractionPart)) return null;
+  if (fractionPart.length > 8) return null;
+
+  final whole = BigInt.parse(wholePart.isEmpty ? '0' : wholePart);
+  final fraction = BigInt.parse(fractionPart.padRight(8, '0'));
+  return (whole * zatoshiPerZec) + fraction;
+}
+
+bool _digitsOnly(String value) => RegExp(r'^\d*$').hasMatch(value);
+
+class ZecAmountInputFormatter extends TextInputFormatter {
+  const ZecAmountInputFormatter();
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final text = newValue.text.replaceAll(',', '.');
+    if (text.isEmpty) return newValue.copyWith(text: text);
+    if (!RegExp(r'^[0-9.]*$').hasMatch(text)) return oldValue;
+    if ('.'.allMatches(text).length > 1) return oldValue;
+
+    final dotIndex = text.indexOf('.');
+    if (dotIndex != -1 && text.length - dotIndex - 1 > 8) return oldValue;
+
+    return newValue.copyWith(text: text);
+  }
+}

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/config/network_config.dart';
+import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
@@ -59,13 +60,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   String _formatZec(BigInt zatoshi) {
-    if (zatoshi == BigInt.zero) return '0.00';
-    final whole = zatoshi ~/ BigInt.from(100000000);
-    final frac = (zatoshi % BigInt.from(100000000)).toString().padLeft(8, '0');
-    if (whole == BigInt.zero && int.parse(frac) < 1000000) {
-      return '0.$frac';
-    }
-    return '$whole.${frac.substring(0, 2)}';
+    return formatZecAmount(zatoshi, minFractionDigits: 2);
   }
 
   void _toggleBalanceVisibility() {

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
@@ -83,22 +84,11 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   }
 
   String _formatReceiptAmount(BigInt zatoshi) {
-    final whole = zatoshi ~/ BigInt.from(100000000);
-    final fraction =
-        ((zatoshi % BigInt.from(100000000)) ~/ BigInt.from(1000000))
-            .toString()
-            .padLeft(2, '0');
-    return '$whole,$fraction zec';
+    return '${formatZecAmount(zatoshi, minFractionDigits: 2)} zec';
   }
 
   String _formatFee(BigInt zatoshi) {
-    final whole = zatoshi ~/ BigInt.from(100000000);
-    var fraction = (zatoshi % BigInt.from(100000000)).toString().padLeft(
-      8,
-      '0',
-    );
-    fraction = fraction.replaceFirst(RegExp(r'0+$'), '');
-    return fraction.isEmpty ? '$whole' : '$whole.$fraction';
+    return formatZecAmount(zatoshi);
   }
 
   List<TextSpan> _addressSpans(BuildContext context, String line) {

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -18,6 +18,7 @@ import '../../../rust/api/sync.dart' as rust_sync;
 class SendReviewArgs {
   const SendReviewArgs({
     required this.proposalId,
+    required this.sendFlowId,
     required this.proposalAccountUuid,
     required this.address,
     required this.addressType,
@@ -28,6 +29,7 @@ class SendReviewArgs {
   });
 
   final BigInt proposalId;
+  final String sendFlowId;
   final String proposalAccountUuid;
   final String address;
   final String addressType;
@@ -71,7 +73,10 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     _discardScheduled = true;
     unawaited(
       rust_sync
-          .discardProposal(proposalId: widget.args.proposalId)
+          .discardProposal(
+            proposalId: widget.args.proposalId,
+            sendFlowId: widget.args.sendFlowId,
+          )
           .then((_) {
             log('SendReview: released proposal ${widget.args.proposalId}');
           })

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -81,6 +82,14 @@ class _MaxQuote {
   final BigInt amountZatoshi;
 }
 
+String _newSendFlowId() {
+  final random = math.Random.secure();
+  return List<int>.generate(
+    16,
+    (_) => random.nextInt(256),
+  ).map((byte) => byte.toRadixString(16).padLeft(2, '0')).join();
+}
+
 class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   static const _singleLineFieldOverlayReserve = 20.0;
   static const _singleLineFieldGap = AppSpacing.xs;
@@ -93,6 +102,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   final _amountFocusNode = FocusNode();
   final _memoFocusNode = FocusNode();
   final _memoScrollController = ScrollController();
+  late final String _sendFlowId = _newSendFlowId();
   bool _isSending = false;
   bool _messageExpanded = false;
   String? _error;
@@ -479,7 +489,8 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     if (lower.contains('broadcast rejected')) {
       return 'Transaction was rejected by the network. Please try again.';
     }
-    if (lower.contains('proposal not found')) {
+    if (lower.contains('proposal not found') ||
+        lower.contains('send flow mismatch')) {
       return 'Transaction expired. Please try again.';
     }
     return 'Send failed. Please try again.';
@@ -558,6 +569,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         dbPath: dbPath,
         network: 'main',
         accountUuid: accountUuid,
+        sendFlowId: _sendFlowId,
         toAddress: address,
         amountZatoshi: amountZatoshi,
         memo: memo.isNotEmpty ? memo : null,
@@ -573,6 +585,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         '/send/review',
         extra: SendReviewArgs(
           proposalId: proposal.proposalId,
+          sendFlowId: _sendFlowId,
           proposalAccountUuid: accountUuid,
           address: address,
           addressType: _addressType,
@@ -592,7 +605,10 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     } finally {
       if (activeProposalId != null && !pushedReview) {
         try {
-          await rust_sync.discardProposal(proposalId: activeProposalId);
+          await rust_sync.discardProposal(
+            proposalId: activeProposalId,
+            sendFlowId: _sendFlowId,
+          );
           log('Send: released proposal $activeProposalId (review not opened)');
         } catch (e) {
           log('Send: discardProposal cleanup failed (non-critical): $e');

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -202,7 +202,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     // Quick balance pre-check
     final spendable = widget.spendableBalance;
     if (zatoshi > spendable) {
-      setState(() => _amountError = 'Insufficient balance');
+      setState(() => _amountError = 'Insufficient shielded balance');
       return;
     }
 
@@ -241,7 +241,8 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       if (totalNeeded > spendable) {
         final feeZec = formatZecAmount(fee);
         setState(
-          () => _amountError = 'Insufficient balance (fee: $feeZec ZEC)',
+          () =>
+              _amountError = 'Insufficient shielded balance (fee: $feeZec ZEC)',
         );
       } else {
         setState(() => _amountError = null);
@@ -250,7 +251,9 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       if (!mounted || seq != _validateSeq) return;
       final msg = e.toString();
       if (msg.contains('InsufficientFunds') || msg.contains('insufficient')) {
-        setState(() => _amountError = 'Insufficient balance including fee');
+        setState(
+          () => _amountError = 'Insufficient shielded balance including fee',
+        );
       } else {
         log('Send: fee estimation failed (non-blocking): $e');
         setState(() => _amountError = null);
@@ -263,7 +266,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   String _friendlyError(String raw) {
     final lower = raw.toLowerCase();
     if (lower.contains('insufficientfunds') || lower.contains('insufficient')) {
-      return 'Insufficient balance to cover amount and fee.';
+      return 'Insufficient shielded balance to cover amount and fee.';
     }
     if (lower.contains('grpc connect failed') ||
         lower.contains('connection refused') ||
@@ -327,7 +330,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       final spendable = widget.spendableBalance;
       if (amountZatoshi > spendable) {
         setState(() {
-          _error = 'Insufficient balance.';
+          _error = 'Insufficient shielded balance.';
           _isSending = false;
         });
         return;

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -1,11 +1,11 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
@@ -183,19 +183,6 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       _memoError == null &&
       (_isShieldedAddress || _memoController.text.trim().isEmpty);
 
-  String _formatSpendableLabel(BigInt zatoshi) {
-    final whole = zatoshi ~/ BigInt.from(100000000);
-    final frac = (zatoshi % BigInt.from(100000000)).toString().padLeft(8, '0');
-
-    if (frac == '00000000') return whole.toString();
-    if (whole == BigInt.zero && int.parse(frac) < 1000000) {
-      return '0.${frac.replaceFirst(RegExp(r'0+$'), '')}';
-    }
-
-    final short = frac.substring(0, 2).replaceFirst(RegExp(r'0+$'), '');
-    return short.isEmpty ? whole.toString() : '$whole.$short';
-  }
-
   Future<void> _validateAmount() async {
     final seq = ++_validateSeq;
     final text = _amountController.text.trim();
@@ -206,15 +193,15 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       return;
     }
 
-    final zatoshi = _parseZecToZatoshi(text);
-    if (zatoshi == null || zatoshi <= 0) {
+    final zatoshi = parseZecAmount(text);
+    if (zatoshi == null || zatoshi <= BigInt.zero) {
       setState(() => _amountError = 'Invalid amount');
       return;
     }
 
     // Quick balance pre-check
     final spendable = widget.spendableBalance;
-    if (BigInt.from(zatoshi) > spendable) {
+    if (zatoshi > spendable) {
       setState(() => _amountError = 'Insufficient balance');
       return;
     }
@@ -243,16 +230,16 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         network: 'main',
         accountUuid: accountUuid,
         toAddress: address,
-        amountZatoshi: BigInt.from(zatoshi),
+        amountZatoshi: zatoshi,
         memo: memo.isNotEmpty ? memo : null,
       );
 
       // Stale check — new input arrived while awaiting
       if (!mounted || seq != _validateSeq) return;
 
-      final totalNeeded = BigInt.from(zatoshi) + fee;
+      final totalNeeded = zatoshi + fee;
       if (totalNeeded > spendable) {
-        final feeZec = _formatZec(fee);
+        final feeZec = formatZecAmount(fee);
         setState(
           () => _amountError = 'Insufficient balance (fee: $feeZec ZEC)',
         );
@@ -299,37 +286,6 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     return 'Send failed. Please try again.';
   }
 
-  String _formatZec(BigInt zatoshi) {
-    final abs = zatoshi.abs();
-    final whole = abs ~/ BigInt.from(100000000);
-    final frac = (abs % BigInt.from(100000000)).toString().padLeft(8, '0');
-    final sign = zatoshi < BigInt.zero ? '-' : '';
-    return '$sign$whole.$frac';
-  }
-
-  /// Parse a ZEC string to zatoshi without floating-point.
-  /// Handles: "1.5", ".01", "100", "0.00000001"
-  int? _parseZecToZatoshi(String input) {
-    var s = input.trim();
-    if (s.isEmpty) return null;
-    if (s.startsWith('.')) s = '0$s';
-
-    final parts = s.split('.');
-    if (parts.length > 2) return null;
-
-    final whole = int.tryParse(parts[0].isEmpty ? '0' : parts[0]);
-    if (whole == null || whole < 0) return null;
-
-    String frac = parts.length > 1 ? parts[1] : '';
-    if (frac.length > 8) frac = frac.substring(0, 8);
-    frac = frac.padRight(8, '0');
-
-    final fracInt = int.tryParse(frac);
-    if (fracInt == null) return null;
-
-    return whole * 100000000 + fracInt;
-  }
-
   Future<void> _openReview() async {
     setState(() {
       _isSending = true;
@@ -341,7 +297,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
 
     try {
       final address = _addressController.text.trim();
-      final amountZatoshi = _parseZecToZatoshi(_amountController.text.trim());
+      final amountZatoshi = parseZecAmount(_amountController.text.trim());
 
       if (!_hasValidAddress) {
         setState(() {
@@ -351,7 +307,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         return;
       }
 
-      if (amountZatoshi == null || amountZatoshi <= 0) {
+      if (amountZatoshi == null || amountZatoshi <= BigInt.zero) {
         setState(() {
           _error = 'Invalid amount';
           _isSending = false;
@@ -369,7 +325,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
 
       // Check balance before proposing
       final spendable = widget.spendableBalance;
-      if (BigInt.from(amountZatoshi) > spendable) {
+      if (amountZatoshi > spendable) {
         setState(() {
           _error = 'Insufficient balance.';
           _isSending = false;
@@ -396,7 +352,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         network: 'main',
         accountUuid: accountUuid,
         toAddress: address,
-        amountZatoshi: BigInt.from(amountZatoshi),
+        amountZatoshi: amountZatoshi,
         memo: memo.isNotEmpty ? memo : null,
       );
       activeProposalId = proposal.proposalId;
@@ -413,7 +369,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
           proposalAccountUuid: accountUuid,
           address: address,
           addressType: _addressType,
-          amountZatoshi: BigInt.from(amountZatoshi),
+          amountZatoshi: amountZatoshi,
           feeZatoshi: proposal.feeZatoshi,
           memo: memo.isNotEmpty ? memo : null,
           needsSaplingParams: proposal.needsSaplingParams,
@@ -589,7 +545,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                                     : colors.icon.regular,
                                               ),
                                               rightSlot: Text(
-                                                'Max: ${_formatSpendableLabel(spendable)} ZEC',
+                                                'Max: ${formatZecAmount(spendable)} ZEC',
                                                 style: AppTypography.labelMedium
                                                     .copyWith(
                                                       color:
@@ -613,10 +569,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                                     decimal: true,
                                                   ),
                                               inputFormatters: [
-                                                FilteringTextInputFormatter.allow(
-                                                  RegExp(r'[\d.]'),
-                                                ),
-                                                _ZecAmountFormatter(),
+                                                const ZecAmountInputFormatter(),
                                               ],
                                               onChanged: (_) =>
                                                   _validateAmount(),
@@ -909,28 +862,5 @@ class _SendGlobalError extends StatelessWidget {
         ),
       ],
     );
-  }
-}
-
-/// Enforces: one decimal point max, up to 8 fractional digits.
-class _ZecAmountFormatter extends TextInputFormatter {
-  @override
-  TextEditingValue formatEditUpdate(
-    TextEditingValue oldValue,
-    TextEditingValue newValue,
-  ) {
-    final text = newValue.text;
-
-    // Allow empty
-    if (text.isEmpty) return newValue;
-
-    // Only one decimal point
-    if ('.'.allMatches(text).length > 1) return oldValue;
-
-    // Limit fractional digits to 8
-    final dotIndex = text.indexOf('.');
-    if (dotIndex != -1 && text.length - dotIndex - 1 > 8) return oldValue;
-
-    return newValue;
   }
 }

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -66,10 +67,25 @@ class _SendComposeBody extends ConsumerStatefulWidget {
   ConsumerState<_SendComposeBody> createState() => _SendComposeBodyState();
 }
 
+class _MaxQuote {
+  const _MaxQuote({
+    required this.accountUuid,
+    required this.address,
+    required this.memo,
+    required this.amountZatoshi,
+  });
+
+  final String accountUuid;
+  final String address;
+  final String memo;
+  final BigInt amountZatoshi;
+}
+
 class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   static const _singleLineFieldOverlayReserve = 20.0;
   static const _singleLineFieldGap = AppSpacing.xs;
   static const _multilineFieldOverlayReserve = 24.0;
+  static const _maxDebounceDuration = Duration(milliseconds: 300);
   final _addressController = TextEditingController();
   final _amountController = TextEditingController();
   final _memoController = TextEditingController();
@@ -83,6 +99,13 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   String _addressType = '';
   String?
   _amountError; // null = no error, empty string = silent invalid (empty/dot)
+  bool _isMaxMode = false;
+  bool _isResolvingMax = false;
+  bool _programmaticAmountEdit = false;
+  _MaxQuote? _maxQuote;
+  Timer? _maxDebounceTimer;
+  int _addressSeq = 0;
+  int _maxSeq = 0;
   int _validateSeq = 0;
 
   @override
@@ -100,6 +123,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
 
   @override
   void dispose() {
+    _maxDebounceTimer?.cancel();
     _memoController.removeListener(_handleMemoChanged);
     _addressFocusNode.removeListener(_handleFieldVisualStateChanged);
     _amountFocusNode.removeListener(_handleFieldVisualStateChanged);
@@ -118,7 +142,11 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     if (_memoController.text.isNotEmpty && !_messageExpanded) {
       _messageExpanded = true;
     }
-    _validateAmount();
+    if (_isMaxMode) {
+      _scheduleMaxEstimate();
+    } else {
+      _validateAmount();
+    }
     if (mounted) setState(() {});
   }
 
@@ -129,29 +157,80 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   @override
   void didUpdateWidget(covariant _SendComposeBody oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.spendableBalance != widget.spendableBalance &&
-        _amountController.text.trim().isNotEmpty) {
-      _validateAmount();
+    if (oldWidget.spendableBalance != widget.spendableBalance) {
+      if (_isMaxMode) {
+        _scheduleMaxEstimate(immediate: true);
+      } else if (_amountController.text.trim().isNotEmpty) {
+        _validateAmount();
+      }
     }
   }
 
   Future<void> _validateAddress() async {
+    final seq = ++_addressSeq;
     final addr = _addressController.text.trim();
     if (addr.isEmpty) {
+      if (!mounted || seq != _addressSeq) return;
       setState(() => _addressType = '');
+      _handleAddressValidationSettled();
       return;
     }
     try {
       final result = await rust_sync.validateAddress(address: addr);
-      if (!mounted) return;
+      if (!mounted || seq != _addressSeq) return;
       setState(
         () => _addressType = result.isValid ? result.addressType : 'invalid',
       );
+      _handleAddressValidationSettled();
     } catch (e) {
       log('Send: address validation error: $e');
-      if (!mounted) return;
+      if (!mounted || seq != _addressSeq) return;
       setState(() => _addressType = 'error');
+      _handleAddressValidationSettled();
     }
+  }
+
+  void _handleAddressValidationSettled() {
+    if (_isMaxMode) {
+      _scheduleMaxEstimate();
+    } else {
+      _validateAmount();
+    }
+  }
+
+  void _handleAddressChanged() {
+    _addressSeq++;
+    _maxDebounceTimer?.cancel();
+    setState(() {
+      _addressType = '';
+      _error = null;
+      if (_isMaxMode) {
+        _validateSeq++;
+        _maxSeq++;
+        _maxQuote = null;
+        _isResolvingMax = false;
+        _amountError = '';
+      }
+    });
+    unawaited(_validateAddress());
+    if (!_isMaxMode) {
+      _validateAmount();
+    }
+  }
+
+  void _handleAmountChanged() {
+    if (_programmaticAmountEdit) return;
+    if (_isMaxMode) {
+      _maxDebounceTimer?.cancel();
+      _maxSeq++;
+      setState(() {
+        _isMaxMode = false;
+        _isResolvingMax = false;
+        _maxQuote = null;
+        _error = null;
+      });
+    }
+    _validateAmount();
   }
 
   bool get _hasValidAddress =>
@@ -166,6 +245,15 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   bool get _showAmountError =>
       _amountError != null && _amountError!.trim().isNotEmpty;
 
+  bool get _hasCurrentMaxQuote {
+    final quote = _maxQuote;
+    if (quote == null) return false;
+    return quote.accountUuid == widget.activeAccountUuid &&
+        quote.address == _addressController.text.trim() &&
+        quote.memo == _memoController.text.trim() &&
+        parseZecAmount(_amountController.text.trim()) == quote.amountZatoshi;
+  }
+
   int get _memoLength => utf8.encode(_memoController.text).length;
 
   String? get _memoError {
@@ -178,10 +266,118 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
 
   bool get _canReview =>
       !_isSending &&
+      !_isResolvingMax &&
       _hasValidAddress &&
       _isAmountValid &&
+      (!_isMaxMode || _hasCurrentMaxQuote) &&
       _memoError == null &&
       (_isShieldedAddress || _memoController.text.trim().isEmpty);
+
+  void _activateMaxMode() {
+    if (_isResolvingMax) return;
+    setState(() {
+      _isMaxMode = true;
+      _maxQuote = null;
+      _error = null;
+    });
+    _scheduleMaxEstimate(immediate: true);
+  }
+
+  String? _maxEstimatePreconditionError() {
+    if (widget.activeAccountUuid == null) return 'No active account';
+    if (!_hasValidAddress) return 'Enter a valid address to use Max';
+    return _memoError;
+  }
+
+  void _scheduleMaxEstimate({bool immediate = false}) {
+    _maxDebounceTimer?.cancel();
+    _validateSeq++;
+    final seq = ++_maxSeq;
+    if (!_isMaxMode) return;
+
+    final preconditionError = _maxEstimatePreconditionError();
+    setState(() {
+      _maxQuote = null;
+      _isResolvingMax = preconditionError == null;
+      _amountError = preconditionError ?? '';
+      _error = null;
+    });
+
+    if (preconditionError != null) return;
+
+    if (immediate) {
+      unawaited(_resolveMaxEstimate(seq));
+    } else {
+      _maxDebounceTimer = Timer(
+        _maxDebounceDuration,
+        () => unawaited(_resolveMaxEstimate(seq)),
+      );
+    }
+  }
+
+  Future<void> _resolveMaxEstimate(int seq) async {
+    final accountUuid = widget.activeAccountUuid;
+    final address = _addressController.text.trim();
+    final memo = _memoController.text.trim();
+    if (accountUuid == null || !_isMaxMode || seq != _maxSeq) return;
+
+    try {
+      final dbPath = await getWalletDbPath();
+      if (!mounted || !_isMaxMode || seq != _maxSeq) return;
+
+      final estimate = await rust_sync.estimateSendMax(
+        dbPath: dbPath,
+        network: 'main',
+        accountUuid: accountUuid,
+        toAddress: address,
+        memo: memo.isNotEmpty ? memo : null,
+      );
+
+      if (!mounted || !_isMaxMode || seq != _maxSeq) return;
+
+      if (estimate.amountZatoshi <= BigInt.zero) {
+        setState(() {
+          _isResolvingMax = false;
+          _maxQuote = null;
+          _amountError = 'Insufficient shielded balance to cover fee';
+        });
+        return;
+      }
+
+      final amountText = formatZecAmount(estimate.amountZatoshi);
+      _programmaticAmountEdit = true;
+      _amountController.value = TextEditingValue(
+        text: amountText,
+        selection: TextSelection.collapsed(offset: amountText.length),
+      );
+      _programmaticAmountEdit = false;
+
+      setState(() {
+        _isResolvingMax = false;
+        _amountError = null;
+        _maxQuote = _MaxQuote(
+          accountUuid: accountUuid,
+          address: address,
+          memo: memo,
+          amountZatoshi: estimate.amountZatoshi,
+        );
+      });
+    } catch (e) {
+      if (!mounted || !_isMaxMode || seq != _maxSeq) return;
+      final msg = e.toString().toLowerCase();
+      setState(() {
+        _isResolvingMax = false;
+        _maxQuote = null;
+        if (msg.contains('insufficient')) {
+          _amountError = 'Insufficient shielded balance to cover fee';
+        } else {
+          _amountError = 'Max amount unavailable';
+        }
+      });
+    } finally {
+      _programmaticAmountEdit = false;
+    }
+  }
 
   Future<void> _validateAmount() async {
     final seq = ++_validateSeq;
@@ -301,6 +497,14 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     try {
       final address = _addressController.text.trim();
       final amountZatoshi = parseZecAmount(_amountController.text.trim());
+
+      if (_isResolvingMax) {
+        setState(() {
+          _error = 'Calculating max amount';
+          _isSending = false;
+        });
+        return;
+      }
 
       if (!_hasValidAddress) {
         setState(() {
@@ -508,18 +712,27 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                               messageText: addressMessage,
                                               messageIcon: addressMessageIcon,
                                               messageStyle: addressMessageStyle,
-                                              onChanged: (_) {
-                                                _validateAddress();
-                                                _validateAmount();
-                                              },
+                                              onChanged: (_) =>
+                                                  _handleAddressChanged(),
                                               keyboardType: TextInputType.text,
                                               showClearButton: true,
                                               onClear: () {
+                                                _addressSeq++;
+                                                _maxDebounceTimer?.cancel();
                                                 setState(() {
                                                   _addressType = '';
                                                   _error = null;
+                                                  if (_isMaxMode) {
+                                                    _validateSeq++;
+                                                    _maxSeq++;
+                                                    _maxQuote = null;
+                                                    _isResolvingMax = false;
+                                                    _amountError = '';
+                                                  }
                                                 });
-                                                _validateAmount();
+                                                if (!_isMaxMode) {
+                                                  _validateAmount();
+                                                }
                                               },
                                             ),
                                             const SizedBox(
@@ -547,13 +760,27 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                                     ? colors.icon.accent
                                                     : colors.icon.regular,
                                               ),
-                                              rightSlot: Text(
-                                                'Max: ${formatZecAmount(spendable)} ZEC',
-                                                style: AppTypography.labelMedium
-                                                    .copyWith(
-                                                      color:
-                                                          colors.text.secondary,
-                                                    ),
+                                              rightSlot: MouseRegion(
+                                                cursor: _isResolvingMax
+                                                    ? SystemMouseCursors.basic
+                                                    : SystemMouseCursors.click,
+                                                child: GestureDetector(
+                                                  behavior:
+                                                      HitTestBehavior.opaque,
+                                                  onTap: _isResolvingMax
+                                                      ? null
+                                                      : _activateMaxMode,
+                                                  child: Text(
+                                                    'Max: ${formatZecAmount(spendable)} ZEC',
+                                                    style: AppTypography
+                                                        .labelMedium
+                                                        .copyWith(
+                                                          color: colors
+                                                              .text
+                                                              .secondary,
+                                                        ),
+                                                  ),
+                                                ),
                                               ),
                                               messageText: _showAmountError
                                                   ? _amountError
@@ -575,10 +802,16 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                                 const ZecAmountInputFormatter(),
                                               ],
                                               onChanged: (_) =>
-                                                  _validateAmount(),
+                                                  _handleAmountChanged(),
                                               showClearButton: true,
                                               onClear: () {
+                                                _maxDebounceTimer?.cancel();
+                                                _validateSeq++;
+                                                _maxSeq++;
                                                 setState(() {
+                                                  _isMaxMode = false;
+                                                  _isResolvingMax = false;
+                                                  _maxQuote = null;
                                                   _amountError = '';
                                                   _error = null;
                                                 });
@@ -678,7 +911,11 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                                     _messageExpanded = false;
                                                     _error = null;
                                                   });
-                                                  _validateAmount();
+                                                  if (_isMaxMode) {
+                                                    _scheduleMaxEstimate();
+                                                  } else {
+                                                    _validateAmount();
+                                                  }
                                                 },
                                               ),
                                               const SizedBox(

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -9,6 +9,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/config/network_config.dart';
+import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
@@ -108,22 +109,11 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   }
 
   String _formatReceiptAmount(BigInt zatoshi) {
-    final whole = zatoshi ~/ BigInt.from(100000000);
-    final fraction =
-        ((zatoshi % BigInt.from(100000000)) ~/ BigInt.from(1000000))
-            .toString()
-            .padLeft(2, '0');
-    return '$whole,$fraction zec';
+    return '${formatZecAmount(zatoshi, minFractionDigits: 2)} zec';
   }
 
   String _formatFee(BigInt zatoshi) {
-    final whole = zatoshi ~/ BigInt.from(100000000);
-    var fraction = (zatoshi % BigInt.from(100000000)).toString().padLeft(
-      8,
-      '0',
-    );
-    fraction = fraction.replaceFirst(RegExp(r'0+$'), '');
-    return fraction.isEmpty ? '$whole' : '$whole.$fraction';
+    return formatZecAmount(zatoshi);
   }
 
   String _formatDate(DateTime value) {

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -87,7 +87,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   String _friendlyError(String raw) {
     final lower = raw.toLowerCase();
     if (lower.contains('insufficientfunds') || lower.contains('insufficient')) {
-      return 'Insufficient balance to cover amount and fee.';
+      return 'Insufficient shielded balance to cover amount and fee.';
     }
     if (lower.contains('grpc connect failed') ||
         lower.contains('connection refused') ||

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -70,7 +70,10 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     _discardScheduled = true;
     unawaited(
       rust_sync
-          .discardProposal(proposalId: widget.args.proposalId)
+          .discardProposal(
+            proposalId: widget.args.proposalId,
+            sendFlowId: widget.args.sendFlowId,
+          )
           .then((_) {
             log(
               'SendStatus: released proposal ${widget.args.proposalId} on dispose',
@@ -102,7 +105,8 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     if (lower.contains('broadcast rejected')) {
       return 'Transaction was rejected by the network. Please try again later.';
     }
-    if (lower.contains('proposal not found')) {
+    if (lower.contains('proposal not found') ||
+        lower.contains('send flow mismatch')) {
       return 'Transaction expired before it could be sent.';
     }
     return 'Transaction could not be sent. Please return to your wallet and verify the latest status.';
@@ -264,7 +268,10 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     if (!_proposalConsumed && !_discardScheduled) {
       _discardScheduled = true;
       try {
-        await rust_sync.discardProposal(proposalId: widget.args.proposalId);
+        await rust_sync.discardProposal(
+          proposalId: widget.args.proposalId,
+          sendFlowId: widget.args.sendFlowId,
+        );
       } catch (e) {
         log(
           'SendStatus: discardProposal cleanup failed after unmount (non-critical): $e',
@@ -335,6 +342,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
           dbPath: dbPath,
           network: ZcashNetwork.mainnet.name,
           proposalId: widget.args.proposalId,
+          sendFlowId: widget.args.sendFlowId,
         );
         _proposalConsumed = true;
 
@@ -393,6 +401,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
           dbPath: dbPath,
           lightwalletdUrl: ZcashNetwork.mainnet.lightwalletdUrl,
           proposalId: widget.args.proposalId,
+          sendFlowId: widget.args.sendFlowId,
           seed: seedBytes,
           spendParamsPath: widget.args.needsSaplingParams ? spendPath : null,
           outputParamsPath: widget.args.needsSaplingParams ? outputPath : null,
@@ -431,7 +440,10 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
       if (!mounted) {
         if (!_proposalConsumed) {
           try {
-            await rust_sync.discardProposal(proposalId: widget.args.proposalId);
+            await rust_sync.discardProposal(
+              proposalId: widget.args.proposalId,
+              sendFlowId: widget.args.sendFlowId,
+            );
           } catch (_) {}
         }
         return;

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -29,10 +29,10 @@ class SyncState {
   final BigInt shieldTransparentFee;
   final BigInt shieldTransparentAmount;
 
-  /// Sum of spendable balances across all pools. Use for "available to send".
+  /// Spendable shielded balance. Use for "available to send".
   final BigInt spendableBalance;
 
-  /// Sum of spendable + pending across all pools. Use for "total holdings".
+  /// Sum of spendable + pending balances across all pools. Use for "total holdings".
   final BigInt totalBalance;
   final String? error;
   final List<rust_sync.TransactionInfo> recentTransactions;
@@ -46,7 +46,8 @@ class SyncState {
   final String phase;
 
   /// Amount waiting for confirmations (e.g. change from a recently sent tx).
-  BigInt get pendingBalance => totalBalance - spendableBalance;
+  BigInt get pendingBalance =>
+      transparentPendingBalance + saplingPendingBalance + orchardPendingBalance;
 
   SyncState({
     this.isSyncing = false,

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -205,6 +205,7 @@ Future<ProposalResult> proposeSend({
   required String dbPath,
   required String network,
   required String accountUuid,
+  required String sendFlowId,
   required String toAddress,
   required BigInt amountZatoshi,
   String? memo,
@@ -212,6 +213,7 @@ Future<ProposalResult> proposeSend({
   dbPath: dbPath,
   network: network,
   accountUuid: accountUuid,
+  sendFlowId: sendFlowId,
   toAddress: toAddress,
   amountZatoshi: amountZatoshi,
   memo: memo,
@@ -255,6 +257,7 @@ Future<String> executeProposal({
   required String dbPath,
   required String lightwalletdUrl,
   required BigInt proposalId,
+  required String sendFlowId,
   required List<int> seed,
   String? spendParamsPath,
   String? outputParamsPath,
@@ -262,6 +265,7 @@ Future<String> executeProposal({
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
   proposalId: proposalId,
+  sendFlowId: sendFlowId,
   seed: seed,
   spendParamsPath: spendParamsPath,
   outputParamsPath: outputParamsPath,
@@ -357,17 +361,24 @@ Future<Uint8List> createPcztFromProposal({
   required String dbPath,
   required String network,
   required BigInt proposalId,
+  required String sendFlowId,
 }) => RustLib.instance.api.crateApiSyncCreatePcztFromProposal(
   dbPath: dbPath,
   network: network,
   proposalId: proposalId,
+  sendFlowId: sendFlowId,
 );
 
 /// Release a stored proposal without executing it. Called by the Dart send
 /// flow when the user cancels before `create_pczt_from_proposal` so the
 /// proposal ID cannot be replayed. Idempotent.
-Future<void> discardProposal({required BigInt proposalId}) =>
-    RustLib.instance.api.crateApiSyncDiscardProposal(proposalId: proposalId);
+Future<void> discardProposal({
+  required BigInt proposalId,
+  required String sendFlowId,
+}) => RustLib.instance.api.crateApiSyncDiscardProposal(
+  proposalId: proposalId,
+  sendFlowId: sendFlowId,
+);
 
 /// Add Orchard (and Sapling if needed) proofs to a PCZT locally. The output
 /// is the "PCZT with proofs" half that is later combined with the signed PCZT

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -826,10 +826,10 @@ class WalletBalance {
   final BigInt saplingPending;
   final BigInt orchardPending;
 
-  /// Sum of spendable balances across all pools. Use this for "available to send".
+  /// Sum of spendable shielded balances. Use this for "available to send".
   final BigInt spendable;
 
-  /// Sum of spendable + pending across all pools. Use this for "total holdings".
+  /// Sum of spendable + pending balances across all pools. Use this for "total holdings".
   final BigInt total;
 
   const WalletBalance({

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -234,6 +234,21 @@ Future<BigInt> estimateFee({
   memo: memo,
 );
 
+/// Estimate the maximum recipient amount for the current recipient and memo.
+Future<SendMaxEstimateResult> estimateSendMax({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+  required String toAddress,
+  String? memo,
+}) => RustLib.instance.api.crateApiSyncEstimateSendMax(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+  toAddress: toAddress,
+  memo: memo,
+);
+
 /// Step 2: Execute a previously proposed transfer and broadcast to the network.
 /// spend_params_path and output_params_path are required only if needs_sapling_params was true.
 Future<String> executeProposal({
@@ -602,6 +617,33 @@ class ScanResult {
       other is ScanResult &&
           runtimeType == other.runtimeType &&
           blocksScanned == other.blocksScanned;
+}
+
+class SendMaxEstimateResult {
+  final BigInt amountZatoshi;
+  final BigInt feeZatoshi;
+  final bool needsSaplingParams;
+
+  const SendMaxEstimateResult({
+    required this.amountZatoshi,
+    required this.feeZatoshi,
+    required this.needsSaplingParams,
+  });
+
+  @override
+  int get hashCode =>
+      amountZatoshi.hashCode ^
+      feeZatoshi.hashCode ^
+      needsSaplingParams.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SendMaxEstimateResult &&
+          runtimeType == other.runtimeType &&
+          amountZatoshi == other.amountZatoshi &&
+          feeZatoshi == other.feeZatoshi &&
+          needsSaplingParams == other.needsSaplingParams;
 }
 
 class ShieldTransparentResult {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -101,6 +101,7 @@ abstract class RustLibApi extends BaseApi {
     required String dbPath,
     required String network,
     required BigInt proposalId,
+    required String sendFlowId,
   });
 
   Future<WalletCreationResult> crateApiWalletCreateWallet({
@@ -138,7 +139,10 @@ abstract class RustLibApi extends BaseApi {
 
   Future<Uint8List> crateApiWalletDeriveSeed({required String mnemonic});
 
-  Future<void> crateApiSyncDiscardProposal({required BigInt proposalId});
+  Future<void> crateApiSyncDiscardProposal({
+    required BigInt proposalId,
+    required String sendFlowId,
+  });
 
   Future<String> crateApiKeystoneEncodePcztToUr({required List<int> pcztBytes});
 
@@ -168,6 +172,7 @@ abstract class RustLibApi extends BaseApi {
     required String dbPath,
     required String lightwalletdUrl,
     required BigInt proposalId,
+    required String sendFlowId,
     required List<int> seed,
     String? spendParamsPath,
     String? outputParamsPath,
@@ -288,6 +293,7 @@ abstract class RustLibApi extends BaseApi {
     required String dbPath,
     required String network,
     required String accountUuid,
+    required String sendFlowId,
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
@@ -504,6 +510,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String dbPath,
     required String network,
     required BigInt proposalId,
+    required String sendFlowId,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -512,6 +519,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(dbPath, serializer);
           sse_encode_String(network, serializer);
           sse_encode_u_64(proposalId, serializer);
+          sse_encode_String(sendFlowId, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -524,7 +532,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncCreatePcztFromProposalConstMeta,
-        argValues: [dbPath, network, proposalId],
+        argValues: [dbPath, network, proposalId, sendFlowId],
         apiImpl: this,
       ),
     );
@@ -533,7 +541,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiSyncCreatePcztFromProposalConstMeta =>
       const TaskConstMeta(
         debugName: "create_pczt_from_proposal",
-        argNames: ["dbPath", "network", "proposalId"],
+        argNames: ["dbPath", "network", "proposalId", "sendFlowId"],
       );
 
   @override
@@ -807,12 +815,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "derive_seed", argNames: ["mnemonic"]);
 
   @override
-  Future<void> crateApiSyncDiscardProposal({required BigInt proposalId}) {
+  Future<void> crateApiSyncDiscardProposal({
+    required BigInt proposalId,
+    required String sendFlowId,
+  }) {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_64(proposalId, serializer);
+          sse_encode_String(sendFlowId, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -825,7 +837,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: null,
         ),
         constMeta: kCrateApiSyncDiscardProposalConstMeta,
-        argValues: [proposalId],
+        argValues: [proposalId, sendFlowId],
         apiImpl: this,
       ),
     );
@@ -834,7 +846,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiSyncDiscardProposalConstMeta =>
       const TaskConstMeta(
         debugName: "discard_proposal",
-        argNames: ["proposalId"],
+        argNames: ["proposalId", "sendFlowId"],
       );
 
   @override
@@ -1007,6 +1019,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String dbPath,
     required String lightwalletdUrl,
     required BigInt proposalId,
+    required String sendFlowId,
     required List<int> seed,
     String? spendParamsPath,
     String? outputParamsPath,
@@ -1018,6 +1031,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(dbPath, serializer);
           sse_encode_String(lightwalletdUrl, serializer);
           sse_encode_u_64(proposalId, serializer);
+          sse_encode_String(sendFlowId, serializer);
           sse_encode_list_prim_u_8_loose(seed, serializer);
           sse_encode_opt_String(spendParamsPath, serializer);
           sse_encode_opt_String(outputParamsPath, serializer);
@@ -1037,6 +1051,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dbPath,
           lightwalletdUrl,
           proposalId,
+          sendFlowId,
           seed,
           spendParamsPath,
           outputParamsPath,
@@ -1053,6 +1068,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "dbPath",
           "lightwalletdUrl",
           "proposalId",
+          "sendFlowId",
           "seed",
           "spendParamsPath",
           "outputParamsPath",
@@ -1872,6 +1888,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String dbPath,
     required String network,
     required String accountUuid,
+    required String sendFlowId,
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
@@ -1883,6 +1900,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(dbPath, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
+          sse_encode_String(sendFlowId, serializer);
           sse_encode_String(toAddress, serializer);
           sse_encode_u_64(amountZatoshi, serializer);
           sse_encode_opt_String(memo, serializer);
@@ -1902,6 +1920,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           dbPath,
           network,
           accountUuid,
+          sendFlowId,
           toAddress,
           amountZatoshi,
           memo,
@@ -1917,6 +1936,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       "dbPath",
       "network",
       "accountUuid",
+      "sendFlowId",
       "toAddress",
       "amountZatoshi",
       "memo",

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -70,7 +70,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1901376488;
+  int get rustContentHash => -467375400;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -153,6 +153,14 @@ abstract class RustLibApi extends BaseApi {
     required String accountUuid,
     required String toAddress,
     required BigInt amountZatoshi,
+    String? memo,
+  });
+
+  Future<SendMaxEstimateResult> crateApiSyncEstimateSendMax({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String toAddress,
     String? memo,
   });
 
@@ -954,6 +962,47 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<SendMaxEstimateResult> crateApiSyncEstimateSendMax({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String toAddress,
+    String? memo,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
+          sse_encode_String(toAddress, serializer);
+          sse_encode_opt_String(memo, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 17,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_send_max_estimate_result,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSyncEstimateSendMaxConstMeta,
+        argValues: [dbPath, network, accountUuid, toAddress, memo],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncEstimateSendMaxConstMeta =>
+      const TaskConstMeta(
+        debugName: "estimate_send_max",
+        argNames: ["dbPath", "network", "accountUuid", "toAddress", "memo"],
+      );
+
+  @override
   Future<String> crateApiSyncExecuteProposal({
     required String dbPath,
     required String lightwalletdUrl,
@@ -975,7 +1024,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 18,
             port: port_,
           );
         },
@@ -1034,7 +1083,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 19,
             port: port_,
           );
         },
@@ -1077,7 +1126,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 19)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 20)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1109,7 +1158,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 21,
             port: port_,
           );
         },
@@ -1136,7 +1185,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cachePath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1164,7 +1213,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 23,
             port: port_,
           );
         },
@@ -1201,7 +1250,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 24,
             port: port_,
           );
         },
@@ -1236,7 +1285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1273,7 +1322,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 25,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1300,7 +1349,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -1330,7 +1379,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1364,7 +1413,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1403,7 +1452,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1440,7 +1489,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1477,7 +1526,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1505,7 +1554,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1545,7 +1594,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -1602,7 +1651,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1637,7 +1686,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1664,7 +1713,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1688,7 +1737,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 37)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1713,7 +1762,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1735,7 +1784,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1763,7 +1812,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1798,7 +1847,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -1840,7 +1889,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1896,7 +1945,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -1943,7 +1992,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -1970,7 +2019,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2002,7 +2051,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -2040,7 +2089,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -2093,7 +2142,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -2144,7 +2193,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2178,7 +2227,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 51,
             port: port_,
           );
         },
@@ -2219,7 +2268,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -2267,7 +2316,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 52,
+              funcId: 53,
               port: port_,
             );
           },
@@ -2308,7 +2357,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 53,
+              funcId: 54,
               port: port_,
             );
           },
@@ -2337,7 +2386,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2367,7 +2416,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2404,7 +2453,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 57,
             port: port_,
           );
         },
@@ -2436,7 +2485,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2461,7 +2510,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(mnemonic, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2487,7 +2536,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2517,7 +2566,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2808,6 +2857,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     if (arr.length != 1)
       throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
     return ScanResult(blocksScanned: dco_decode_u_64(arr[0]));
+  }
+
+  @protected
+  SendMaxEstimateResult dco_decode_send_max_estimate_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return SendMaxEstimateResult(
+      amountZatoshi: dco_decode_u_64(arr[0]),
+      feeZatoshi: dco_decode_u_64(arr[1]),
+      needsSaplingParams: dco_decode_bool(arr[2]),
+    );
   }
 
   @protected
@@ -3358,6 +3420,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_blocksScanned = sse_decode_u_64(deserializer);
     return ScanResult(blocksScanned: var_blocksScanned);
+  }
+
+  @protected
+  SendMaxEstimateResult sse_decode_send_max_estimate_result(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_amountZatoshi = sse_decode_u_64(deserializer);
+    var var_feeZatoshi = sse_decode_u_64(deserializer);
+    var var_needsSaplingParams = sse_decode_bool(deserializer);
+    return SendMaxEstimateResult(
+      amountZatoshi: var_amountZatoshi,
+      feeZatoshi: var_feeZatoshi,
+      needsSaplingParams: var_needsSaplingParams,
+    );
   }
 
   @protected
@@ -3915,6 +3992,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_scan_result(ScanResult self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self.blocksScanned, serializer);
+  }
+
+  @protected
+  void sse_encode_send_max_estimate_result(
+    SendMaxEstimateResult self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_64(self.amountZatoshi, serializer);
+    sse_encode_u_64(self.feeZatoshi, serializer);
+    sse_encode_bool(self.needsSaplingParams, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -124,6 +124,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ScanResult dco_decode_scan_result(dynamic raw);
 
   @protected
+  SendMaxEstimateResult dco_decode_send_max_estimate_result(dynamic raw);
+
+  @protected
   ShieldTransparentResult dco_decode_shield_transparent_result(dynamic raw);
 
   @protected
@@ -293,6 +296,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ScanResult sse_decode_scan_result(SseDeserializer deserializer);
+
+  @protected
+  SendMaxEstimateResult sse_decode_send_max_estimate_result(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ShieldTransparentResult sse_decode_shield_transparent_result(
@@ -505,6 +513,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_scan_result(ScanResult self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_send_max_estimate_result(
+    SendMaxEstimateResult self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_shield_transparent_result(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -126,6 +126,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ScanResult dco_decode_scan_result(dynamic raw);
 
   @protected
+  SendMaxEstimateResult dco_decode_send_max_estimate_result(dynamic raw);
+
+  @protected
   ShieldTransparentResult dco_decode_shield_transparent_result(dynamic raw);
 
   @protected
@@ -295,6 +298,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ScanResult sse_decode_scan_result(SseDeserializer deserializer);
+
+  @protected
+  SendMaxEstimateResult sse_decode_send_max_estimate_result(
+    SseDeserializer deserializer,
+  );
 
   @protected
   ShieldTransparentResult sse_decode_shield_transparent_result(
@@ -507,6 +515,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_scan_result(ScanResult self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_send_max_estimate_result(
+    SendMaxEstimateResult self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_shield_transparent_result(

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -590,6 +590,7 @@ pub fn propose_send(
     db_path: String,
     network: String,
     account_uuid: String,
+    send_flow_id: String,
     to_address: String,
     amount_zatoshi: u64,
     memo: Option<String>,
@@ -600,6 +601,7 @@ pub fn propose_send(
             &db_path,
             network,
             &account_uuid,
+            &send_flow_id,
             &to_address,
             amount_zatoshi,
             memo.as_deref(),
@@ -665,6 +667,7 @@ pub fn execute_proposal(
     db_path: String,
     lightwalletd_url: String,
     proposal_id: u64,
+    send_flow_id: String,
     seed: Vec<u8>,
     spend_params_path: Option<String>,
     output_params_path: Option<String>,
@@ -675,6 +678,7 @@ pub fn execute_proposal(
             &db_path,
             &lightwalletd_url,
             proposal_id,
+            &send_flow_id,
             &seed,
             spend_params_path.as_deref(),
             output_params_path.as_deref(),
@@ -853,18 +857,19 @@ pub fn create_pczt_from_proposal(
     db_path: String,
     network: String,
     proposal_id: u64,
+    send_flow_id: String,
 ) -> Result<Vec<u8>, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
-        wallet_sync::create_pczt_from_proposal(&db_path, network, proposal_id)
+        wallet_sync::create_pczt_from_proposal(&db_path, network, proposal_id, &send_flow_id)
     })
 }
 
 /// Release a stored proposal without executing it. Called by the Dart send
 /// flow when the user cancels before `create_pczt_from_proposal` so the
 /// proposal ID cannot be replayed. Idempotent.
-pub fn discard_proposal(proposal_id: u64) {
-    wallet_sync::discard_proposal(proposal_id);
+pub fn discard_proposal(proposal_id: u64, send_flow_id: String) {
+    wallet_sync::discard_proposal(proposal_id, &send_flow_id);
 }
 
 /// Add Orchard (and Sapling if needed) proofs to a PCZT locally. The output

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -325,9 +325,9 @@ pub struct WalletBalance {
     pub transparent_pending: u64,
     pub sapling_pending: u64,
     pub orchard_pending: u64,
-    /// Sum of spendable balances across all pools. Use this for "available to send".
+    /// Sum of spendable shielded balances. Use this for "available to send".
     pub spendable: u64,
-    /// Sum of spendable + pending across all pools. Use this for "total holdings".
+    /// Sum of spendable + pending balances across all pools. Use this for "total holdings".
     pub total: u64,
 }
 
@@ -518,7 +518,8 @@ pub fn get_balance(
     catch(|| {
         let network = keys::parse_network(&network)?;
         let b = wallet_sync::get_wallet_balance(&db_path, network, &account_uuid)?;
-        let spendable = b.transparent + b.sapling + b.orchard;
+        let spendable = b.sapling + b.orchard;
+        let total_spendable = b.transparent + b.sapling + b.orchard;
         let pending = b.transparent_pending + b.sapling_pending + b.orchard_pending;
         Ok(WalletBalance {
             transparent: b.transparent,
@@ -528,7 +529,7 @@ pub fn get_balance(
             sapling_pending: b.sapling_pending,
             orchard_pending: b.orchard_pending,
             spendable,
-            total: spendable + pending,
+            total: total_spendable + pending,
         })
     })
 }

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -566,6 +566,12 @@ pub struct ProposalResult {
     pub fee_zatoshi: u64,
 }
 
+pub struct SendMaxEstimateResult {
+    pub amount_zatoshi: u64,
+    pub fee_zatoshi: u64,
+    pub needs_sapling_params: bool,
+}
+
 pub struct ShieldTransparentResult {
     pub txids: String,
     pub fee_zatoshi: u64,
@@ -625,6 +631,31 @@ pub fn estimate_fee(
             amount_zatoshi,
             memo.as_deref(),
         )
+    })
+}
+
+/// Estimate the maximum recipient amount for the current recipient and memo.
+pub fn estimate_send_max(
+    db_path: String,
+    network: String,
+    account_uuid: String,
+    to_address: String,
+    memo: Option<String>,
+) -> Result<SendMaxEstimateResult, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        let r = wallet_sync::estimate_send_max(
+            &db_path,
+            network,
+            &account_uuid,
+            &to_address,
+            memo.as_deref(),
+        )?;
+        Ok(SendMaxEstimateResult {
+            amount_zatoshi: r.amount_zatoshi,
+            fee_zatoshi: r.fee_zatoshi,
+            needs_sapling_params: r.needs_sapling_params,
+        })
     })
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -183,6 +183,7 @@ fn wire__crate__api__sync__create_pczt_from_proposal_impl(
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_proposal_id = <u64>::sse_decode(&mut deserializer);
+            let api_send_flow_id = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -190,6 +191,7 @@ fn wire__crate__api__sync__create_pczt_from_proposal_impl(
                         api_db_path,
                         api_network,
                         api_proposal_id,
+                        api_send_flow_id,
                     )?;
                     Ok(output_ok)
                 })())
@@ -502,11 +504,12 @@ fn wire__crate__api__sync__discard_proposal_impl(
             let mut deserializer =
                 flutter_rust_bridge::for_generated::SseDeserializer::new(message);
             let api_proposal_id = <u64>::sse_decode(&mut deserializer);
+            let api_send_flow_id = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, ()>((move || {
                     let output_ok = Result::<_, ()>::Ok({
-                        crate::api::sync::discard_proposal(api_proposal_id);
+                        crate::api::sync::discard_proposal(api_proposal_id, api_send_flow_id);
                     })?;
                     Ok(output_ok)
                 })())
@@ -697,6 +700,7 @@ fn wire__crate__api__sync__execute_proposal_impl(
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
             let api_proposal_id = <u64>::sse_decode(&mut deserializer);
+            let api_send_flow_id = <String>::sse_decode(&mut deserializer);
             let api_seed = <Vec<u8>>::sse_decode(&mut deserializer);
             let api_spend_params_path = <Option<String>>::sse_decode(&mut deserializer);
             let api_output_params_path = <Option<String>>::sse_decode(&mut deserializer);
@@ -707,6 +711,7 @@ fn wire__crate__api__sync__execute_proposal_impl(
                         api_db_path,
                         api_lightwalletd_url,
                         api_proposal_id,
+                        api_send_flow_id,
                         api_seed,
                         api_spend_params_path,
                         api_output_params_path,
@@ -1603,6 +1608,7 @@ fn wire__crate__api__sync__propose_send_impl(
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_send_flow_id = <String>::sse_decode(&mut deserializer);
             let api_to_address = <String>::sse_decode(&mut deserializer);
             let api_amount_zatoshi = <u64>::sse_decode(&mut deserializer);
             let api_memo = <Option<String>>::sse_decode(&mut deserializer);
@@ -1613,6 +1619,7 @@ fn wire__crate__api__sync__propose_send_impl(
                         api_db_path,
                         api_network,
                         api_account_uuid,
+                        api_send_flow_id,
                         api_to_address,
                         api_amount_zatoshi,
                         api_memo,

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1901376488;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -467375400;
 
 // Section: executor
 
@@ -621,6 +621,49 @@ fn wire__crate__api__sync__estimate_fee_impl(
                         api_account_uuid,
                         api_to_address,
                         api_amount_zatoshi,
+                        api_memo,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__sync__estimate_send_max_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "estimate_send_max",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_to_address = <String>::sse_decode(&mut deserializer);
+            let api_memo = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::sync::estimate_send_max(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                        api_to_address,
                         api_memo,
                     )?;
                     Ok(output_ok)
@@ -2627,6 +2670,20 @@ impl SseDecode for crate::api::sync::ScanResult {
     }
 }
 
+impl SseDecode for crate::api::sync::SendMaxEstimateResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_amountZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_feeZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_needsSaplingParams = <bool>::sse_decode(deserializer);
+        return crate::api::sync::SendMaxEstimateResult {
+            amount_zatoshi: var_amountZatoshi,
+            fee_zatoshi: var_feeZatoshi,
+            needs_sapling_params: var_needsSaplingParams,
+        };
+    }
+}
+
 impl SseDecode for crate::api::sync::ShieldTransparentResult {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2895,100 +2952,101 @@ fn pde_ffi_dispatcher_primary_impl(
             wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len)
         }
         16 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(
+        17 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        20 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__wallet__get_latest_block_height_impl(
+        21 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__wallet__get_latest_block_height_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        23 => wire__crate__api__sync__get_next_available_address_impl(
+        24 => wire__crate__api__sync__get_next_available_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        24 => {
+        25 => {
             wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len)
         }
-        25 => wire__crate__api__sync__get_shield_transparent_status_impl(
+        26 => wire__crate__api__sync__get_shield_transparent_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        27 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__sync__get_transaction_data_requests_impl(
+        28 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__sync__get_transaction_data_requests_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        29 => {
+        30 => {
             wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len)
         }
-        30 => wire__crate__api__wallet__get_transparent_address_impl(
+        31 => wire__crate__api__wallet__get_transparent_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        31 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__wallet__import_hardware_account_impl(
+        32 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__wallet__import_hardware_account_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        34 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__keystone__is_keystone_connected_impl(
+        35 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+        36 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__keystone__is_keystone_connected_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        40 => wire__crate__api__keystone__keystone_usb_sign_pczt_impl(
+        41 => wire__crate__api__keystone__keystone_usb_sign_pczt_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-        44 => {
+        42 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+        45 => {
             wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len)
         }
-        46 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-        47 => {
+        47 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+        48 => {
             wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len)
         }
-        48 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-        50 => {
+        49 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+        51 => {
             wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len)
         }
-        51 => wire__crate__api__sync__shield_transparent_balance_impl(
+        52 => wire__crate__api__sync__shield_transparent_balance_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        52 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-        53 => {
+        53 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+        54 => {
             wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len)
         }
-        55 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-        56 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3002,18 +3060,18 @@ fn pde_ffi_dispatcher_sync_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         3 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        49 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        54 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        27 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        55 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3233,6 +3291,28 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ScanResult>
     for crate::api::sync::ScanResult
 {
     fn into_into_dart(self) -> crate::api::sync::ScanResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sync::SendMaxEstimateResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.amount_zatoshi.into_into_dart().into_dart(),
+            self.fee_zatoshi.into_into_dart().into_dart(),
+            self.needs_sapling_params.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sync::SendMaxEstimateResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::SendMaxEstimateResult>
+    for crate::api::sync::SendMaxEstimateResult
+{
+    fn into_into_dart(self) -> crate::api::sync::SendMaxEstimateResult {
         self
     }
 }
@@ -3768,6 +3848,15 @@ impl SseEncode for crate::api::sync::ScanResult {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u64>::sse_encode(self.blocks_scanned, serializer);
+    }
+}
+
+impl SseEncode for crate::api::sync::SendMaxEstimateResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u64>::sse_encode(self.amount_zatoshi, serializer);
+        <u64>::sse_encode(self.fee_zatoshi, serializer);
+        <bool>::sse_encode(self.needs_sapling_params, serializer);
     }
 }
 

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -364,6 +364,7 @@ pub(super) struct StoredProposal {
     >,
     pub network: WalletNetwork,
     pub account_id: AccountUuid,
+    pub send_flow_id: String,
 }
 
 pub(super) static PROPOSAL_STORE: std::sync::LazyLock<Mutex<ProposalStore>> =
@@ -377,6 +378,49 @@ pub(super) static PROPOSAL_STORE: std::sync::LazyLock<Mutex<ProposalStore>> =
 pub(super) struct ProposalStore {
     pub proposals: HashMap<u64, StoredProposal>,
     pub next_id: u64,
+}
+
+pub(super) fn consume_stored_proposal(
+    proposal_id: u64,
+    send_flow_id: &str,
+    not_found_message: &str,
+) -> Result<StoredProposal, String> {
+    let mut store = PROPOSAL_STORE
+        .lock()
+        .map_err(|e| format!("Lock error: {e}"))?;
+
+    match store.proposals.get(&proposal_id) {
+        Some(stored) if stored.send_flow_id == send_flow_id => {}
+        Some(_) => {
+            log::warn!("proposal store: send flow mismatch for proposal_id={proposal_id}");
+            return Err("Send flow mismatch".to_string());
+        }
+        None => return Err(not_found_message.to_string()),
+    }
+
+    store
+        .proposals
+        .remove(&proposal_id)
+        .ok_or_else(|| not_found_message.to_string())
+}
+
+pub(super) fn discard_stored_proposal(proposal_id: u64, send_flow_id: &str) {
+    match PROPOSAL_STORE.lock() {
+        Ok(mut store) => match store.proposals.get(&proposal_id) {
+            Some(stored) if stored.send_flow_id == send_flow_id => {
+                store.proposals.remove(&proposal_id);
+            }
+            Some(_) => {
+                log::warn!(
+                    "proposal store: discard ignored for send flow mismatch proposal_id={proposal_id}"
+                );
+            }
+            None => {}
+        },
+        Err(e) => {
+            log::warn!("proposal store: discard lock failed: {e}");
+        }
+    }
 }
 
 // ======================== Helpers ========================
@@ -422,8 +466,8 @@ mod tests {
     fn discard_proposal_is_idempotent_for_missing_id() {
         // Should not panic, should not poison the mutex.
         let id = unique_proposal_id();
-        discard_proposal(id);
-        discard_proposal(id); // second call must also be a no-op
+        discard_proposal(id, "missing-flow");
+        discard_proposal(id, "missing-flow"); // second call must also be a no-op
     }
 
     #[test]
@@ -439,6 +483,7 @@ mod tests {
             "/nonexistent/path/that/should/not/exist.db",
             WalletNetwork::Main,
             id,
+            "missing-flow",
         );
 
         match result {
@@ -463,7 +508,8 @@ mod tests {
             "/nonexistent/path/that/should/not/exist.db",
             WalletNetwork::Main,
             id,
+            "missing-flow",
         );
-        discard_proposal(id); // cleanup must not panic
+        discard_proposal(id, "missing-flow"); // cleanup must not panic
     }
 }

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -41,6 +41,7 @@ pub use pczt::{
     add_proofs_to_pczt, create_pczt_from_proposal, discard_proposal, extract_and_broadcast_pczt,
     redact_pczt_for_signer,
 };
+pub(crate) use send::estimate_send_max;
 pub use send::{estimate_fee, execute_proposal, propose_send};
 pub(crate) use send::{get_shield_transparent_status, shield_transparent_balance};
 // Internal-only re-export for `sync_engine::run_sync_impl`'s
@@ -48,6 +49,8 @@ pub(crate) use send::{get_shield_transparent_status, shield_transparent_balance}
 pub(crate) use send::resubmit_pending_transactions;
 #[allow(unused_imports)] // names reachable via `crate::wallet::sync::*`; pre-refactor surface
 pub(crate) use send::ProposalResult;
+#[allow(unused_imports)] // names reachable via `crate::wallet::sync::*`; pre-refactor surface
+pub(crate) use send::SendMaxEstimateResult;
 #[allow(unused_imports)] // names reachable via `crate::wallet::sync::*`; pre-refactor surface
 pub(crate) use send::ShieldTransparentResult;
 #[allow(unused_imports)] // names reachable via `crate::wallet::sync::*`; pre-refactor surface

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -75,7 +75,7 @@ use zcash_proofs::prover::LocalTxProver;
 use crate::wallet::db::with_wallet_db_write_lock;
 use crate::wallet::network::WalletNetwork;
 
-use super::{open_wallet_db, PROPOSAL_STORE};
+use super::{consume_stored_proposal, discard_stored_proposal, open_wallet_db};
 
 /// Create a PCZT from a stored proposal (for hardware wallet signing).
 ///
@@ -91,20 +91,18 @@ pub fn create_pczt_from_proposal(
     db_path: &str,
     network: WalletNetwork,
     proposal_id: u64,
+    send_flow_id: &str,
 ) -> Result<Vec<u8>, String> {
     use zcash_client_backend::data_api::wallet::create_pczt_from_proposal as zcb_create_pczt;
     use zcash_client_backend::wallet::OvkPolicy;
 
     // Consume the proposal up-front (matches execute_proposal), so
     // that any later failure path leaves the PROPOSAL_STORE clean.
-    let stored = {
-        let mut store = PROPOSAL_STORE.lock().map_err(|e| format!("Lock: {e}"))?;
-        store
-            .proposals
-            .remove(&proposal_id)
-            .ok_or("Proposal not found (expired or already consumed)")?
-        // lock dropped here, before heavy work
-    };
+    let stored = consume_stored_proposal(
+        proposal_id,
+        send_flow_id,
+        "Proposal not found (expired or already consumed)",
+    )?;
 
     let pczt = with_wallet_db_write_lock("pczt.create_pczt_from_proposal", || {
         let mut db = open_wallet_db(db_path, network)?;
@@ -127,10 +125,8 @@ pub fn create_pczt_from_proposal(
 /// dialog, cancels the Sapling params download prompt). Idempotent:
 /// safe to call for a proposal that has already been consumed or
 /// never existed.
-pub fn discard_proposal(proposal_id: u64) {
-    if let Ok(mut store) = PROPOSAL_STORE.lock() {
-        store.proposals.remove(&proposal_id);
-    }
+pub fn discard_proposal(proposal_id: u64, send_flow_id: &str) {
+    discard_stored_proposal(proposal_id, send_flow_id);
 }
 
 /// Add Orchard (and, if needed, Sapling) proofs to a PCZT locally.

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -68,8 +68,8 @@ use crate::wallet::keys::parse_account_uuid;
 use crate::wallet::network::WalletNetwork;
 
 use super::{
-    open_readonly_conn, open_wallet_db, open_wallet_db_for_read, StoredProposal, WalletDatabase,
-    PROPOSAL_STORE,
+    consume_stored_proposal, open_readonly_conn, open_wallet_db, open_wallet_db_for_read,
+    StoredProposal, WalletDatabase, PROPOSAL_STORE,
 };
 
 /// Result of a successful [`propose_send`]. `proposal_id` is the
@@ -109,11 +109,16 @@ pub fn propose_send(
     db_path: &str,
     network: WalletNetwork,
     account_uuid: &str,
+    send_flow_id: &str,
     to_address: &str,
     amount_zatoshi: u64,
     memo_str: Option<&str>,
 ) -> Result<ProposalResult, String> {
     use zcash_protocol::{PoolType, ShieldedProtocol as SP};
+
+    if send_flow_id.is_empty() {
+        return Err("Send flow id is required".to_string());
+    }
 
     let mut db = open_wallet_db_for_read(db_path, network)?;
     let account_id = parse_account_uuid(account_uuid)?;
@@ -171,6 +176,7 @@ pub fn propose_send(
             proposal,
             network,
             account_id,
+            send_flow_id: send_flow_id.to_string(),
         },
     );
 
@@ -355,19 +361,17 @@ pub async fn execute_proposal(
     db_path: &str,
     lightwalletd_url: &str,
     proposal_id: u64,
+    send_flow_id: &str,
     seed_bytes: &[u8],
     spend_params_path: Option<&str>,
     output_params_path: Option<&str>,
 ) -> Result<String, String> {
-    let mut store = PROPOSAL_STORE
-        .lock()
-        .map_err(|e| format!("Lock error: {e}"))?;
-    let stored = store
-        .proposals
-        .remove(&proposal_id)
-        .ok_or("Proposal not found (expired or already executed)")?;
+    let stored = consume_stored_proposal(
+        proposal_id,
+        send_flow_id,
+        "Proposal not found (expired or already executed)",
+    )?;
     let network = stored.network;
-    drop(store);
 
     // Scope DB writes and seed/USK so they are dropped before network I/O (broadcast).
     let txids = with_wallet_db_write_lock("send.execute_proposal.create_transactions", || {

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -43,10 +43,10 @@ use zcash_client_backend::data_api::wallet::input_selection::GreedyInputSelector
 use zcash_client_backend::{
     data_api::{
         wallet::{
-            self, create_proposed_transactions, propose_shielding, propose_transfer,
-            ConfirmationsPolicy,
+            self, create_proposed_transactions, propose_send_max_transfer, propose_shielding,
+            propose_transfer, ConfirmationsPolicy,
         },
-        Account as _, Balance, InputSource, WalletRead,
+        Account as _, Balance, InputSource, MaxSpendMode, WalletRead,
     },
     fees::{zip317::MultiOutputChangeStrategy, DustOutputPolicy, SplitPolicy, StandardFeeRule},
     proposal::Proposal,
@@ -60,7 +60,7 @@ use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
     memo::{Memo, MemoBytes},
     value::Zatoshis,
-    ShieldedProtocol,
+    PoolType, ShieldedProtocol,
 };
 
 use crate::wallet::db::with_wallet_db_write_lock;
@@ -82,6 +82,12 @@ pub(crate) struct ProposalResult {
     pub proposal_id: u64,
     pub needs_sapling_params: bool,
     pub fee_zatoshi: u64,
+}
+
+pub(crate) struct SendMaxEstimateResult {
+    pub amount_zatoshi: u64,
+    pub fee_zatoshi: u64,
+    pub needs_sapling_params: bool,
 }
 
 pub(crate) struct ShieldTransparentResult {
@@ -226,6 +232,25 @@ pub fn estimate_fee(
         .sum();
 
     Ok(fee)
+}
+
+/// Estimate the maximum recipient amount for the current destination and memo.
+///
+/// This uses librustzcash's max-spend proposal path instead of subtracting a
+/// guessed fee from the aggregate balance. That keeps note selection, ZIP-317
+/// fees, recipient pool choice, and ZIP-315 confirmation policy aligned with
+/// the actual send flow.
+pub(crate) fn estimate_send_max(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    to_address: &str,
+    memo_str: Option<&str>,
+) -> Result<SendMaxEstimateResult, String> {
+    let mut db = open_wallet_db_for_read(db_path, network)?;
+    let account_id = parse_account_uuid(account_uuid)?;
+    let proposal = build_send_max_proposal(&mut db, network, account_id, to_address, memo_str)?;
+    summarize_send_max_proposal(&proposal)
 }
 
 /// Dry-run the transparent shielding proposal path without creating or
@@ -438,6 +463,63 @@ fn build_shielding_proposal(
     Ok((proposal, selected_value))
 }
 
+fn build_send_max_proposal(
+    db: &mut WalletDatabase,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    to_address: &str,
+    memo_str: Option<&str>,
+) -> Result<Proposal<StandardFeeRule, <WalletDatabase as InputSource>::NoteRef>, String> {
+    let to: zcash_address::ZcashAddress = to_address
+        .parse()
+        .map_err(|e| format!("Bad address: {e}"))?;
+    let memo_bytes = match memo_str {
+        Some(m) => {
+            let bytes = MemoBytes::from(
+                Memo::from_bytes(m.as_bytes()).map_err(|e| format!("Bad memo: {e}"))?,
+            );
+            Some(bytes)
+        }
+        None => None,
+    };
+    let fee_rule = StandardFeeRule::Zip317;
+    propose_send_max_transfer::<_, _, _, Infallible>(
+        db,
+        &network,
+        account_id,
+        &[ShieldedProtocol::Sapling, ShieldedProtocol::Orchard],
+        &fee_rule,
+        to,
+        memo_bytes,
+        MaxSpendMode::MaxSpendable,
+        ConfirmationsPolicy::default(),
+    )
+    .map_err(|e| format!("Propose max failed: {e}"))
+}
+
+fn summarize_send_max_proposal<NoteRef>(
+    proposal: &Proposal<StandardFeeRule, NoteRef>,
+) -> Result<SendMaxEstimateResult, String> {
+    let amount_zatoshi = proposal.steps().iter().try_fold(0u64, |acc, step| {
+        let step_total = step
+            .transaction_request()
+            .total()
+            .map_err(|e| format!("Max amount calculation failed: {e}"))?;
+        acc.checked_add(u64::from(step_total))
+            .ok_or_else(|| "Max amount overflow".to_string())
+    })?;
+    let needs_sapling_params = proposal
+        .steps()
+        .iter()
+        .any(|step| step.involves(PoolType::Shielded(ShieldedProtocol::Sapling)));
+
+    Ok(SendMaxEstimateResult {
+        amount_zatoshi,
+        fee_zatoshi: proposal_fee_zatoshi(proposal),
+        needs_sapling_params,
+    })
+}
+
 fn select_shielding_sources(
     account_receivers: HashMap<TransparentAddress, (TransparentKeyScope, Balance)>,
     shielding_threshold: Zatoshis,
@@ -483,7 +565,7 @@ fn select_shielding_sources(
     Ok((addresses, total))
 }
 
-fn proposal_fee_zatoshi(proposal: &Proposal<StandardFeeRule, Infallible>) -> u64 {
+fn proposal_fee_zatoshi<NoteRef>(proposal: &Proposal<StandardFeeRule, NoteRef>) -> u64 {
     proposal
         .steps()
         .iter()

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -174,10 +174,12 @@ pub fn execute_send(
     to_address: &str,
     amount_zatoshi: u64,
 ) -> String {
+    let send_flow_id = "regtest-send-flow";
     let proposal = sync_api::propose_send(
         path_str(db_path),
         REGTEST_NETWORK.into(),
         sender_account_uuid.into(),
+        send_flow_id.into(),
         to_address.into(),
         amount_zatoshi,
         None,
@@ -199,6 +201,7 @@ pub fn execute_send(
         path_str(db_path),
         LIGHTWALLETD_URL.into(),
         proposal.proposal_id,
+        send_flow_id.into(),
         seed,
         sapling_params.as_ref().map(|p| p.spend_path.clone()),
         sapling_params.as_ref().map(|p| p.output_path.clone()),

--- a/test/sync_state_test.dart
+++ b/test/sync_state_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+void main() {
+  test('pendingBalance is the explicit pending pool sum', () {
+    final state = SyncState(
+      transparentBalance: BigInt.from(100),
+      saplingBalance: BigInt.from(20),
+      orchardBalance: BigInt.from(30),
+      transparentPendingBalance: BigInt.from(3),
+      saplingPendingBalance: BigInt.from(4),
+      orchardPendingBalance: BigInt.from(5),
+      spendableBalance: BigInt.from(50),
+      totalBalance: BigInt.from(162),
+    );
+
+    expect(state.pendingBalance, BigInt.from(12));
+  });
+}

--- a/test/zec_amount_test.dart
+++ b/test/zec_amount_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/formatting/zec_amount.dart';
+
+void main() {
+  group('formatZecAmount', () {
+    test('uses a period as the decimal separator', () {
+      expect(
+        formatZecAmount(BigInt.from(1000000), minFractionDigits: 2),
+        '0.01',
+      );
+      expect(
+        formatZecAmount(BigInt.from(100000000), minFractionDigits: 2),
+        '1.00',
+      );
+    });
+
+    test('preserves exact zatoshi precision when needed', () {
+      expect(formatZecAmount(BigInt.one, minFractionDigits: 2), '0.00000001');
+      expect(formatZecAmount(BigInt.from(123450000)), '1.2345');
+    });
+  });
+
+  group('parseZecAmount', () {
+    test('parses canonical period-separated amounts', () {
+      expect(parseZecAmount('0.01'), BigInt.from(1000000));
+      expect(parseZecAmount('.01'), BigInt.from(1000000));
+      expect(parseZecAmount('1.'), BigInt.from(100000000));
+      expect(parseZecAmount('0.00000001'), BigInt.one);
+    });
+
+    test('rejects commas and non-canonical decimals', () {
+      expect(parseZecAmount('0,01'), isNull);
+      expect(parseZecAmount('1,2.3'), isNull);
+      expect(parseZecAmount('1.2.3'), isNull);
+      expect(parseZecAmount('0.000000001'), isNull);
+    });
+  });
+
+  group('ZecAmountInputFormatter', () {
+    const formatter = ZecAmountInputFormatter();
+
+    test('normalizes comma input to period before parsing', () {
+      final value = formatter.formatEditUpdate(
+        const TextEditingValue(text: ''),
+        const TextEditingValue(
+          text: '0,01',
+          selection: TextSelection.collapsed(offset: 4),
+        ),
+      );
+
+      expect(value.text, '0.01');
+      expect(parseZecAmount(value.text), BigInt.from(1000000));
+    });
+
+    test('rejects invalid characters and ambiguous separators', () {
+      const oldValue = TextEditingValue(text: '1.2');
+
+      expect(
+        formatter
+            .formatEditUpdate(oldValue, const TextEditingValue(text: '1.2a'))
+            .text,
+        oldValue.text,
+      );
+      expect(
+        formatter
+            .formatEditUpdate(oldValue, const TextEditingValue(text: '1,2.3'))
+            .text,
+        oldValue.text,
+      );
+      expect(
+        formatter
+            .formatEditUpdate(
+              oldValue,
+              const TextEditingValue(text: '1.123456789'),
+            )
+            .text,
+        oldValue.text,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Use locale-independent ZEC amount formatting/parsing with `.` as the decimal separator across send, review, status, and home balance displays.
- Restrict sendable balance and send validation to shielded funds, while preserving total balance display semantics.
- Add fee-aware Max amount estimation through Rust/librustzcash and wire it into the amount input.
- Guard stored send proposals with a per-screen send flow ID across compose, review, and status execution paths.

## Validation
- `fvm flutter analyze`
- `fvm flutter test test/zec_amount_test.dart test/sync_state_test.dart`
- `cd rust && cargo test`
- `git diff --check`