### PR TITLE
[codex] Split internal activity rows

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -300,12 +300,21 @@ final _routerProvider = Provider<GoRouter>((ref) {
           if (txid == null || txid.isEmpty) {
             return const ActivityScreen();
           }
+          final txKind = state.uri.queryParameters['kind'];
           final extra = state.extra;
           if (extra is ActivityTransactionStatusArgs) {
-            return ActivityTransactionStatusScreen(args: extra);
+            final args = extra.txKind == null && txKind != null
+                ? ActivityTransactionStatusArgs(
+                    txidHex: extra.txidHex,
+                    txKind: txKind,
+                    initialTransaction: extra.initialTransaction,
+                    initialDetail: extra.initialDetail,
+                  )
+                : extra;
+            return ActivityTransactionStatusScreen(args: args);
           }
           return ActivityTransactionStatusScreen(
-            args: ActivityTransactionStatusArgs(txidHex: txid),
+            args: ActivityTransactionStatusArgs(txidHex: txid, txKind: txKind),
           );
         },
       ),

--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -149,7 +149,7 @@ String _transactionAmountText({
   required String kind,
 }) {
   if (amount == BigInt.zero) return '--';
-  if (isFailed || isShielded || kind == 'internal') {
+  if (isFailed || isShielded) {
     return formatActivityZec(amount);
   }
   return formatSignedActivityZec(signedAmount);
@@ -191,7 +191,6 @@ String _txTitle(String kind) {
     'received' => 'Received',
     'sent' => 'Sent',
     'shielded' => 'Shielded',
-    'internal' => 'Internal',
     _ => 'Transaction',
   };
 }
@@ -201,7 +200,6 @@ String _txIcon(String kind) {
     'received' => AppIcons.arrowDownCircle,
     'sent' => AppIcons.plane,
     'shielded' => AppIcons.shieldAsset,
-    'internal' => AppIcons.sync,
     _ => AppIcons.history,
   };
 }

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -169,9 +169,13 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
     final detail = await _loadTransactionDetail(transaction);
     if (!mounted) return;
     context.push(
-      '/activity/tx/${transaction.txidHex}',
+      Uri(
+        path: '/activity/tx/${transaction.txidHex}',
+        queryParameters: {'kind': transaction.txKind},
+      ).toString(),
       extra: ActivityTransactionStatusArgs(
         txidHex: transaction.txidHex,
+        txKind: transaction.txKind,
         initialTransaction: transaction,
         initialDetail: detail,
       ),

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -160,13 +160,47 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
   }
 
   void _openTransactionStatus(rust_sync.TransactionInfo transaction) {
+    unawaited(_pushTransactionStatus(transaction));
+  }
+
+  Future<void> _pushTransactionStatus(
+    rust_sync.TransactionInfo transaction,
+  ) async {
+    final detail = await _loadTransactionDetail(transaction);
+    if (!mounted) return;
     context.push(
       '/activity/tx/${transaction.txidHex}',
       extra: ActivityTransactionStatusArgs(
         txidHex: transaction.txidHex,
         initialTransaction: transaction,
+        initialDetail: detail,
       ),
     );
+  }
+
+  Future<rust_sync.TransactionDetail?> _loadTransactionDetail(
+    rust_sync.TransactionInfo transaction,
+  ) async {
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    if (accountUuid == null) return null;
+
+    try {
+      final dbPath = await getWalletDbPath();
+      if (!mounted ||
+          accountUuid != ref.read(accountProvider).value?.activeAccountUuid) {
+        return null;
+      }
+      return rust_sync.getTransactionDetail(
+        dbPath: dbPath,
+        network: ZcashNetwork.mainnet.name,
+        accountUuid: accountUuid,
+        txidHex: transaction.txidHex,
+        txKind: transaction.txKind,
+      );
+    } catch (e, st) {
+      log('Activity: transaction detail load failed: $e\n$st');
+      return null;
+    }
   }
 
   String _recentSignature(SyncState? sync) {

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -22,11 +22,13 @@ import '../activity_row_mapper.dart';
 class ActivityTransactionStatusArgs {
   const ActivityTransactionStatusArgs({
     required this.txidHex,
+    this.txKind,
     this.initialTransaction,
     this.initialDetail,
   });
 
   final String txidHex;
+  final String? txKind;
   final rust_sync.TransactionInfo? initialTransaction;
   final rust_sync.TransactionDetail? initialDetail;
 }
@@ -97,7 +99,10 @@ class _ActivityTransactionStatusScreenState
       final tx = _findTransaction(
         txs,
         widget.args.txidHex,
-        txKind: _transaction?.txKind ?? widget.args.initialTransaction?.txKind,
+        txKind:
+            _transaction?.txKind ??
+            widget.args.initialTransaction?.txKind ??
+            widget.args.txKind,
       );
       rust_sync.TransactionDetail? detail;
       if (tx != null) {
@@ -155,6 +160,7 @@ class _ActivityTransactionStatusScreenState
           return tx;
         }
       }
+      return null;
     }
     for (final tx in transactions) {
       if (tx.txidHex.toLowerCase() == normalized) return tx;
@@ -165,7 +171,9 @@ class _ActivityTransactionStatusScreenState
   String _recentTxSignature(SyncState? sync) {
     final txid = widget.args.txidHex.toLowerCase();
     final txKind =
-        _transaction?.txKind ?? widget.args.initialTransaction?.txKind;
+        _transaction?.txKind ??
+        widget.args.initialTransaction?.txKind ??
+        widget.args.txKind;
     if (txKind != null) {
       for (final tx in sync?.recentTransactions ?? const []) {
         if (tx.txidHex.toLowerCase() == txid && tx.txKind == txKind) {
@@ -178,6 +186,7 @@ class _ActivityTransactionStatusScreenState
           ].join(':');
         }
       }
+      return '';
     }
     for (final tx in sync?.recentTransactions ?? const []) {
       if (tx.txidHex.toLowerCase() == txid) {

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -90,7 +90,11 @@ class _ActivityTransactionStatusScreenState
         return;
       }
 
-      final tx = _findTransaction(txs, widget.args.txidHex);
+      final tx = _findTransaction(
+        txs,
+        widget.args.txidHex,
+        txKind: _transaction?.txKind ?? widget.args.initialTransaction?.txKind,
+      );
       setState(() {
         if (tx != null) {
           _transaction = tx;
@@ -116,9 +120,17 @@ class _ActivityTransactionStatusScreenState
 
   rust_sync.TransactionInfo? _findTransaction(
     Iterable<rust_sync.TransactionInfo> transactions,
-    String txidHex,
-  ) {
+    String txidHex, {
+    String? txKind,
+  }) {
     final normalized = txidHex.toLowerCase();
+    if (txKind != null) {
+      for (final tx in transactions) {
+        if (tx.txidHex.toLowerCase() == normalized && tx.txKind == txKind) {
+          return tx;
+        }
+      }
+    }
     for (final tx in transactions) {
       if (tx.txidHex.toLowerCase() == normalized) return tx;
     }
@@ -127,6 +139,21 @@ class _ActivityTransactionStatusScreenState
 
   String _recentTxSignature(SyncState? sync) {
     final txid = widget.args.txidHex.toLowerCase();
+    final txKind =
+        _transaction?.txKind ?? widget.args.initialTransaction?.txKind;
+    if (txKind != null) {
+      for (final tx in sync?.recentTransactions ?? const []) {
+        if (tx.txidHex.toLowerCase() == txid && tx.txKind == txKind) {
+          return [
+            tx.txidHex,
+            tx.minedHeight,
+            tx.expiredUnmined,
+            tx.txKind,
+            tx.displayAmount,
+          ].join(':');
+        }
+      }
+    }
     for (final tx in sync?.recentTransactions ?? const []) {
       if (tx.txidHex.toLowerCase() == txid) {
         return [

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -42,6 +42,7 @@ class ActivityTransactionStatusScreen extends ConsumerStatefulWidget {
 class _ActivityTransactionStatusScreenState
     extends ConsumerState<ActivityTransactionStatusScreen> {
   rust_sync.TransactionInfo? _transaction;
+  rust_sync.TransactionDetail? _detail;
   bool _isLoading = false;
   String? _error;
   String? _activeAccountUuid;
@@ -95,11 +96,31 @@ class _ActivityTransactionStatusScreenState
         widget.args.txidHex,
         txKind: _transaction?.txKind ?? widget.args.initialTransaction?.txKind,
       );
+      rust_sync.TransactionDetail? detail;
+      if (tx != null) {
+        try {
+          detail = await rust_sync.getTransactionDetail(
+            dbPath: dbPath,
+            network: ZcashNetwork.mainnet.name,
+            accountUuid: accountUuid,
+            txidHex: tx.txidHex,
+            txKind: tx.txKind,
+          );
+        } catch (e, st) {
+          log('ActivityTransactionStatus: detail load failed: $e\n$st');
+        }
+        if (!mounted) return;
+        if (accountUuid != ref.read(accountProvider).value?.activeAccountUuid) {
+          return;
+        }
+      }
       setState(() {
         if (tx != null) {
           _transaction = tx;
+          _detail = detail;
           _error = null;
         } else {
+          _detail = null;
           _error = _transaction == null
               ? 'Transaction could not be loaded.'
               : 'Latest transaction status could not be refreshed.';
@@ -110,6 +131,7 @@ class _ActivityTransactionStatusScreenState
       log('ActivityTransactionStatus: transaction load failed: $e\n$st');
       if (!mounted) return;
       setState(() {
+        _detail = null;
         _error = _transaction == null
             ? 'Transaction could not be loaded.'
             : 'Latest transaction status could not be refreshed.';
@@ -252,6 +274,106 @@ class _ActivityTransactionStatusScreenState
     return [txid.substring(0, 32), txid.substring(32)];
   }
 
+  List<String> _splitAddress(String address) {
+    final trimmed = address.trim();
+    if (trimmed.length <= 16) return [trimmed];
+    final midpoint = (trimmed.length / 2).ceil();
+    return [trimmed.substring(0, midpoint), trimmed.substring(midpoint)];
+  }
+
+  rust_sync.TransactionDetail? _matchingDetailFor(
+    rust_sync.TransactionInfo? tx,
+  ) {
+    final detail = _detail;
+    if (tx == null || detail == null) return null;
+    if (detail.txidHex.toLowerCase() != tx.txidHex.toLowerCase()) {
+      return null;
+    }
+    if (detail.txKind != tx.txKind) return null;
+    return detail;
+  }
+
+  TransactionReceiptBlockData _transactionHashBlock(BuildContext context) {
+    final colors = context.colors;
+    final txidLines = _splitTxid(widget.args.txidHex);
+    return TransactionReceiptBlockData(
+      title: 'Transaction Hash',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (final line in txidLines)
+            Text(
+              line,
+              style: AppTypography.codeSmall.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  TransactionReceiptBlockData _addressBlock(
+    BuildContext context, {
+    required String title,
+    required String address,
+  }) {
+    final colors = context.colors;
+    return TransactionReceiptBlockData(
+      title: title,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (final line in _splitAddress(address))
+            Text(
+              line,
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  TransactionReceiptBlockData _primaryBlockFor(
+    BuildContext context,
+    rust_sync.TransactionInfo? tx,
+    rust_sync.TransactionDetail? detail,
+  ) {
+    final primaryAddress = detail?.primaryAddress?.trim();
+    if (tx?.txKind == 'sent' &&
+        primaryAddress != null &&
+        primaryAddress.isNotEmpty) {
+      return _addressBlock(context, title: 'To', address: primaryAddress);
+    }
+    if (tx?.txKind == 'received' &&
+        primaryAddress != null &&
+        primaryAddress.isNotEmpty) {
+      return _addressBlock(context, title: 'From', address: primaryAddress);
+    }
+    return _transactionHashBlock(context);
+  }
+
+  List<TransactionReceiptBlockData> _extraBlocksFor(
+    BuildContext context,
+    rust_sync.TransactionDetail? detail,
+  ) {
+    final memo = detail?.memo?.trim();
+    if (memo == null || memo.isEmpty) return const [];
+    return [
+      TransactionReceiptBlockData(
+        title: 'Message',
+        child: Text(
+          memo,
+          style: AppTypography.labelLarge.copyWith(
+            color: context.colors.text.accent,
+          ),
+        ),
+      ),
+    ];
+  }
+
   @override
   Widget build(BuildContext context) {
     ref.listen<AsyncValue<AccountState>>(accountProvider, (previous, next) {
@@ -269,8 +391,7 @@ class _ActivityTransactionStatusScreenState
     });
 
     final tx = _transaction;
-    final colors = context.colors;
-    final txidLines = _splitTxid(widget.args.txidHex);
+    final detail = _matchingDetailFor(tx);
     final error = tx?.expiredUnmined == true
         ? 'Transaction expired before it was mined.'
         : _error;
@@ -303,21 +424,8 @@ class _ActivityTransactionStatusScreenState
                           child: TransactionReceiptView(
                             phase: _phaseFor(tx),
                             amountText: _amountText(tx),
-                            primaryBlock: TransactionReceiptBlockData(
-                              title: 'Transaction Hash',
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  for (final line in txidLines)
-                                    Text(
-                                      line,
-                                      style: AppTypography.codeSmall.copyWith(
-                                        color: colors.text.accent,
-                                      ),
-                                    ),
-                                ],
-                              ),
-                            ),
+                            primaryBlock: _primaryBlockFor(context, tx, detail),
+                            extraBlocks: _extraBlocksFor(context, detail),
                             dateText: _dateText(tx),
                             feeText: _feeText(tx),
                             error: error,

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -23,10 +23,12 @@ class ActivityTransactionStatusArgs {
   const ActivityTransactionStatusArgs({
     required this.txidHex,
     this.initialTransaction,
+    this.initialDetail,
   });
 
   final String txidHex;
   final rust_sync.TransactionInfo? initialTransaction;
+  final rust_sync.TransactionDetail? initialDetail;
 }
 
 class ActivityTransactionStatusScreen extends ConsumerStatefulWidget {
@@ -51,6 +53,7 @@ class _ActivityTransactionStatusScreenState
   void initState() {
     super.initState();
     _transaction = widget.args.initialTransaction;
+    _detail = widget.args.initialDetail;
     _activeAccountUuid = ref.read(accountProvider).value?.activeAccountUuid;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -99,7 +102,7 @@ class _ActivityTransactionStatusScreenState
       rust_sync.TransactionDetail? detail;
       if (tx != null) {
         try {
-          detail = await rust_sync.getTransactionDetail(
+          detail = rust_sync.getTransactionDetail(
             dbPath: dbPath,
             network: ZcashNetwork.mainnet.name,
             accountUuid: accountUuid,

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -223,7 +223,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 }
 
-class _HomePane extends StatefulWidget {
+class _HomePane extends ConsumerStatefulWidget {
   const _HomePane({
     required this.sync,
     required this.canBackgroundSync,
@@ -259,10 +259,10 @@ class _HomePane extends StatefulWidget {
   final VoidCallback onRetrySync;
 
   @override
-  State<_HomePane> createState() => _HomePaneState();
+  ConsumerState<_HomePane> createState() => _HomePaneState();
 }
 
-class _HomePaneState extends State<_HomePane> {
+class _HomePaneState extends ConsumerState<_HomePane> {
   final ScrollController _scrollController = ScrollController();
   bool _isHovered = false;
   bool _canScroll = false;
@@ -430,13 +430,47 @@ class _HomePaneState extends State<_HomePane> {
   }
 
   void _openTransactionStatus(rust_sync.TransactionInfo transaction) {
+    unawaited(_pushTransactionStatus(transaction));
+  }
+
+  Future<void> _pushTransactionStatus(
+    rust_sync.TransactionInfo transaction,
+  ) async {
+    final detail = await _loadTransactionDetail(transaction);
+    if (!mounted) return;
     context.push(
       '/activity/tx/${transaction.txidHex}',
       extra: ActivityTransactionStatusArgs(
         txidHex: transaction.txidHex,
         initialTransaction: transaction,
+        initialDetail: detail,
       ),
     );
+  }
+
+  Future<rust_sync.TransactionDetail?> _loadTransactionDetail(
+    rust_sync.TransactionInfo transaction,
+  ) async {
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    if (accountUuid == null) return null;
+
+    try {
+      final dbPath = await getWalletDbPath();
+      if (!mounted ||
+          accountUuid != ref.read(accountProvider).value?.activeAccountUuid) {
+        return null;
+      }
+      return rust_sync.getTransactionDetail(
+        dbPath: dbPath,
+        network: ZcashNetwork.mainnet.name,
+        accountUuid: accountUuid,
+        txidHex: transaction.txidHex,
+        txKind: transaction.txKind,
+      );
+    } catch (e, st) {
+      log('HomeScreen: transaction detail load failed: $e\n$st');
+      return null;
+    }
   }
 }
 

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -439,9 +439,13 @@ class _HomePaneState extends ConsumerState<_HomePane> {
     final detail = await _loadTransactionDetail(transaction);
     if (!mounted) return;
     context.push(
-      '/activity/tx/${transaction.txidHex}',
+      Uri(
+        path: '/activity/tx/${transaction.txidHex}',
+        queryParameters: {'kind': transaction.txKind},
+      ).toString(),
       extra: ActivityTransactionStatusArgs(
         txidHex: transaction.txidHex,
+        txKind: transaction.txKind,
         initialTransaction: transaction,
         initialDetail: detail,
       ),

--- a/lib/src/features/send/widgets/transaction_receipt_view.dart
+++ b/lib/src/features/send/widgets/transaction_receipt_view.dart
@@ -64,6 +64,7 @@ class TransactionReceiptView extends StatelessWidget {
     required this.primaryBlock,
     required this.dateText,
     required this.feeText,
+    this.extraBlocks = const [],
     this.error,
     this.failureFallbackText = 'Transaction failed',
     this.onCopyTxid,
@@ -74,6 +75,7 @@ class TransactionReceiptView extends StatelessWidget {
   final TransactionReceiptPhase phase;
   final String amountText;
   final TransactionReceiptBlockData primaryBlock;
+  final List<TransactionReceiptBlockData> extraBlocks;
   final String dateText;
   final String feeText;
   final String? error;
@@ -99,6 +101,13 @@ class TransactionReceiptView extends StatelessWidget {
                 title: primaryBlock.title,
                 child: primaryBlock.child,
               ),
+              for (final block in extraBlocks) ...[
+                const SizedBox(height: AppSpacing.md),
+                _TransactionReceiptBlock(
+                  title: block.title,
+                  child: block.child,
+                ),
+              ],
               const SizedBox(height: AppSpacing.md),
               Row(
                 crossAxisAlignment: CrossAxisAlignment.end,

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -353,7 +353,7 @@ Future<List<TransactionInfo>> getTransactionHistory({
   accountUuid: accountUuid,
 );
 
-Future<TransactionDetail> getTransactionDetail({
+TransactionDetail getTransactionDetail({
   required String dbPath,
   required String network,
   required String accountUuid,

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -353,6 +353,20 @@ Future<List<TransactionInfo>> getTransactionHistory({
   accountUuid: accountUuid,
 );
 
+Future<TransactionDetail> getTransactionDetail({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+  required String txidHex,
+  required String txKind,
+}) => RustLib.instance.api.crateApiSyncGetTransactionDetail(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+  txidHex: txidHex,
+  txKind: txKind,
+);
+
 String getBlocksDir({required String cachePath}) =>
     RustLib.instance.api.crateApiSyncGetBlocksDir(cachePath: cachePath);
 
@@ -775,6 +789,65 @@ class SyncProgress {
           scannedHeight == other.scannedHeight &&
           chainTipHeight == other.chainTipHeight &&
           isSyncing == other.isSyncing;
+}
+
+class TransactionDetail {
+  final String txidHex;
+  final String txKind;
+  final String? primaryAddress;
+  final String? memo;
+  final List<TransactionDetailOutput> outputs;
+
+  const TransactionDetail({
+    required this.txidHex,
+    required this.txKind,
+    this.primaryAddress,
+    this.memo,
+    required this.outputs,
+  });
+
+  @override
+  int get hashCode =>
+      txidHex.hashCode ^
+      txKind.hashCode ^
+      primaryAddress.hashCode ^
+      memo.hashCode ^
+      outputs.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TransactionDetail &&
+          runtimeType == other.runtimeType &&
+          txidHex == other.txidHex &&
+          txKind == other.txKind &&
+          primaryAddress == other.primaryAddress &&
+          memo == other.memo &&
+          outputs == other.outputs;
+}
+
+class TransactionDetailOutput {
+  final String? address;
+  final BigInt amountZatoshi;
+  final String pool;
+
+  const TransactionDetailOutput({
+    this.address,
+    required this.amountZatoshi,
+    required this.pool,
+  });
+
+  @override
+  int get hashCode => address.hashCode ^ amountZatoshi.hashCode ^ pool.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TransactionDetailOutput &&
+          runtimeType == other.runtimeType &&
+          address == other.address &&
+          amountZatoshi == other.amountZatoshi &&
+          pool == other.pool;
 }
 
 class TransactionInfo {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -70,7 +70,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -467375400;
+  int get rustContentHash => 1485024666;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -229,6 +229,14 @@ abstract class RustLibApi extends BaseApi {
   Future<List<TxDataRequest>> crateApiSyncGetTransactionDataRequests({
     required String dbPath,
     required String network,
+  });
+
+  Future<TransactionDetail> crateApiSyncGetTransactionDetail({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String txidHex,
+    required String txKind,
   });
 
   Future<List<TransactionInfo>> crateApiSyncGetTransactionHistory({
@@ -1451,6 +1459,47 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<TransactionDetail> crateApiSyncGetTransactionDetail({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String txidHex,
+    required String txKind,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(accountUuid, serializer);
+          sse_encode_String(txidHex, serializer);
+          sse_encode_String(txKind, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 30,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_transaction_detail,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiSyncGetTransactionDetailConstMeta,
+        argValues: [dbPath, network, accountUuid, txidHex, txKind],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiSyncGetTransactionDetailConstMeta =>
+      const TaskConstMeta(
+        debugName: "get_transaction_detail",
+        argNames: ["dbPath", "network", "accountUuid", "txidHex", "txKind"],
+      );
+
+  @override
   Future<List<TransactionInfo>> crateApiSyncGetTransactionHistory({
     required String dbPath,
     required String network,
@@ -1468,7 +1517,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1505,7 +1554,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1542,7 +1591,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1570,7 +1619,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 33)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1610,7 +1659,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1667,7 +1716,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1702,7 +1751,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1729,7 +1778,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -1753,7 +1802,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1778,7 +1827,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1800,7 +1849,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 40)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 41)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1828,7 +1877,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -1863,7 +1912,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -1907,7 +1956,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -1965,7 +2014,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -2012,7 +2061,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -2039,7 +2088,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2071,7 +2120,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -2109,7 +2158,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -2162,7 +2211,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -2213,7 +2262,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2247,7 +2296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -2288,7 +2337,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -2336,7 +2385,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 53,
+              funcId: 54,
               port: port_,
             );
           },
@@ -2377,7 +2426,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 54,
+              funcId: 55,
               port: port_,
             );
           },
@@ -2406,7 +2455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2436,7 +2485,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 57,
             port: port_,
           );
         },
@@ -2473,7 +2522,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 58,
             port: port_,
           );
         },
@@ -2505,7 +2554,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 59,
             port: port_,
           );
         },
@@ -2530,7 +2579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(mnemonic, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2556,7 +2605,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2586,7 +2635,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 62,
             port: port_,
           );
         },
@@ -2809,6 +2858,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<TransactionDetailOutput> dco_decode_list_transaction_detail_output(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_transaction_detail_output)
+        .toList();
+  }
+
+  @protected
   List<TransactionInfo> dco_decode_list_transaction_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_transaction_info).toList();
@@ -2953,6 +3012,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       scannedHeight: dco_decode_u_64(arr[0]),
       chainTipHeight: dco_decode_u_64(arr[1]),
       isSyncing: dco_decode_bool(arr[2]),
+    );
+  }
+
+  @protected
+  TransactionDetail dco_decode_transaction_detail(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    return TransactionDetail(
+      txidHex: dco_decode_String(arr[0]),
+      txKind: dco_decode_String(arr[1]),
+      primaryAddress: dco_decode_opt_String(arr[2]),
+      memo: dco_decode_opt_String(arr[3]),
+      outputs: dco_decode_list_transaction_detail_output(arr[4]),
+    );
+  }
+
+  @protected
+  TransactionDetailOutput dco_decode_transaction_detail_output(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return TransactionDetailOutput(
+      address: dco_decode_opt_String(arr[0]),
+      amountZatoshi: dco_decode_u_64(arr[1]),
+      pool: dco_decode_String(arr[2]),
     );
   }
 
@@ -3338,6 +3425,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<TransactionDetailOutput> sse_decode_list_transaction_detail_output(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <TransactionDetailOutput>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_transaction_detail_output(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<TransactionInfo> sse_decode_list_transaction_info(
     SseDeserializer deserializer,
   ) {
@@ -3521,6 +3622,40 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       scannedHeight: var_scannedHeight,
       chainTipHeight: var_chainTipHeight,
       isSyncing: var_isSyncing,
+    );
+  }
+
+  @protected
+  TransactionDetail sse_decode_transaction_detail(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_txidHex = sse_decode_String(deserializer);
+    var var_txKind = sse_decode_String(deserializer);
+    var var_primaryAddress = sse_decode_opt_String(deserializer);
+    var var_memo = sse_decode_opt_String(deserializer);
+    var var_outputs = sse_decode_list_transaction_detail_output(deserializer);
+    return TransactionDetail(
+      txidHex: var_txidHex,
+      txKind: var_txKind,
+      primaryAddress: var_primaryAddress,
+      memo: var_memo,
+      outputs: var_outputs,
+    );
+  }
+
+  @protected
+  TransactionDetailOutput sse_decode_transaction_detail_output(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_address = sse_decode_opt_String(deserializer);
+    var var_amountZatoshi = sse_decode_u_64(deserializer);
+    var var_pool = sse_decode_String(deserializer);
+    return TransactionDetailOutput(
+      address: var_address,
+      amountZatoshi: var_amountZatoshi,
+      pool: var_pool,
     );
   }
 
@@ -3920,6 +4055,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_transaction_detail_output(
+    List<TransactionDetailOutput> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_transaction_detail_output(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_transaction_info(
     List<TransactionInfo> self,
     SseSerializer serializer,
@@ -4071,6 +4218,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_u_64(self.scannedHeight, serializer);
     sse_encode_u_64(self.chainTipHeight, serializer);
     sse_encode_bool(self.isSyncing, serializer);
+  }
+
+  @protected
+  void sse_encode_transaction_detail(
+    TransactionDetail self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.txidHex, serializer);
+    sse_encode_String(self.txKind, serializer);
+    sse_encode_opt_String(self.primaryAddress, serializer);
+    sse_encode_opt_String(self.memo, serializer);
+    sse_encode_list_transaction_detail_output(self.outputs, serializer);
+  }
+
+  @protected
+  void sse_encode_transaction_detail_output(
+    TransactionDetailOutput self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_opt_String(self.address, serializer);
+    sse_encode_u_64(self.amountZatoshi, serializer);
+    sse_encode_String(self.pool, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -231,7 +231,7 @@ abstract class RustLibApi extends BaseApi {
     required String network,
   });
 
-  Future<TransactionDetail> crateApiSyncGetTransactionDetail({
+  TransactionDetail crateApiSyncGetTransactionDetail({
     required String dbPath,
     required String network,
     required String accountUuid,
@@ -1459,28 +1459,23 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<TransactionDetail> crateApiSyncGetTransactionDetail({
+  TransactionDetail crateApiSyncGetTransactionDetail({
     required String dbPath,
     required String network,
     required String accountUuid,
     required String txidHex,
     required String txKind,
   }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(txidHex, serializer);
           sse_encode_String(txKind, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 30,
-            port: port_,
-          );
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 30)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_transaction_detail,

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -97,6 +97,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<SubtreeRoot> dco_decode_list_subtree_root(dynamic raw);
 
   @protected
+  List<TransactionDetailOutput> dco_decode_list_transaction_detail_output(
+    dynamic raw,
+  );
+
+  @protected
   List<TransactionInfo> dco_decode_list_transaction_info(dynamic raw);
 
   @protected
@@ -140,6 +145,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SyncProgress dco_decode_sync_progress(dynamic raw);
+
+  @protected
+  TransactionDetail dco_decode_transaction_detail(dynamic raw);
+
+  @protected
+  TransactionDetailOutput dco_decode_transaction_detail_output(dynamic raw);
 
   @protected
   TransactionInfo dco_decode_transaction_info(dynamic raw);
@@ -267,6 +278,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<SubtreeRoot> sse_decode_list_subtree_root(SseDeserializer deserializer);
 
   @protected
+  List<TransactionDetailOutput> sse_decode_list_transaction_detail_output(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<TransactionInfo> sse_decode_list_transaction_info(
     SseDeserializer deserializer,
   );
@@ -320,6 +336,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SyncProgress sse_decode_sync_progress(SseDeserializer deserializer);
+
+  @protected
+  TransactionDetail sse_decode_transaction_detail(SseDeserializer deserializer);
+
+  @protected
+  TransactionDetailOutput sse_decode_transaction_detail_output(
+    SseDeserializer deserializer,
+  );
 
   @protected
   TransactionInfo sse_decode_transaction_info(SseDeserializer deserializer);
@@ -476,6 +500,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_transaction_detail_output(
+    List<TransactionDetailOutput> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_transaction_info(
     List<TransactionInfo> self,
     SseSerializer serializer,
@@ -543,6 +573,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_sync_progress(SyncProgress self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_transaction_detail(
+    TransactionDetail self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_transaction_detail_output(
+    TransactionDetailOutput self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_transaction_info(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -99,6 +99,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<SubtreeRoot> dco_decode_list_subtree_root(dynamic raw);
 
   @protected
+  List<TransactionDetailOutput> dco_decode_list_transaction_detail_output(
+    dynamic raw,
+  );
+
+  @protected
   List<TransactionInfo> dco_decode_list_transaction_info(dynamic raw);
 
   @protected
@@ -142,6 +147,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SyncProgress dco_decode_sync_progress(dynamic raw);
+
+  @protected
+  TransactionDetail dco_decode_transaction_detail(dynamic raw);
+
+  @protected
+  TransactionDetailOutput dco_decode_transaction_detail_output(dynamic raw);
 
   @protected
   TransactionInfo dco_decode_transaction_info(dynamic raw);
@@ -269,6 +280,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<SubtreeRoot> sse_decode_list_subtree_root(SseDeserializer deserializer);
 
   @protected
+  List<TransactionDetailOutput> sse_decode_list_transaction_detail_output(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<TransactionInfo> sse_decode_list_transaction_info(
     SseDeserializer deserializer,
   );
@@ -322,6 +338,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SyncProgress sse_decode_sync_progress(SseDeserializer deserializer);
+
+  @protected
+  TransactionDetail sse_decode_transaction_detail(SseDeserializer deserializer);
+
+  @protected
+  TransactionDetailOutput sse_decode_transaction_detail_output(
+    SseDeserializer deserializer,
+  );
 
   @protected
   TransactionInfo sse_decode_transaction_info(SseDeserializer deserializer);
@@ -478,6 +502,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_transaction_detail_output(
+    List<TransactionDetailOutput> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_transaction_info(
     List<TransactionInfo> self,
     SseSerializer serializer,
@@ -545,6 +575,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_sync_progress(SyncProgress self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_transaction_detail(
+    TransactionDetail self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_transaction_detail_output(
+    TransactionDetailOutput self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_transaction_info(

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -815,6 +815,20 @@ pub struct TransactionInfo {
     pub created_time: u64,
 }
 
+pub struct TransactionDetail {
+    pub txid_hex: String,
+    pub tx_kind: String,
+    pub primary_address: Option<String>,
+    pub memo: Option<String>,
+    pub outputs: Vec<TransactionDetailOutput>,
+}
+
+pub struct TransactionDetailOutput {
+    pub address: Option<String>,
+    pub amount_zatoshi: u64,
+    pub pool: String,
+}
+
 pub fn get_transaction_history(
     db_path: String,
     network: String,
@@ -840,6 +854,40 @@ pub fn get_transaction_history(
                 created_time: t.created_time,
             })
             .collect())
+    })
+}
+
+pub fn get_transaction_detail(
+    db_path: String,
+    network: String,
+    account_uuid: String,
+    txid_hex: String,
+    tx_kind: String,
+) -> Result<TransactionDetail, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        let detail = wallet_sync::get_transaction_detail(
+            &db_path,
+            network,
+            &account_uuid,
+            &txid_hex,
+            &tx_kind,
+        )?;
+        Ok(TransactionDetail {
+            txid_hex: detail.txid_hex,
+            tx_kind: detail.tx_kind,
+            primary_address: detail.primary_address,
+            memo: detail.memo,
+            outputs: detail
+                .outputs
+                .into_iter()
+                .map(|output| TransactionDetailOutput {
+                    address: output.address,
+                    amount_zatoshi: output.amount_zatoshi,
+                    pool: output.pool,
+                })
+                .collect(),
+        })
     })
 }
 

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -857,6 +857,7 @@ pub fn get_transaction_history(
     })
 }
 
+#[frb(sync)]
 pub fn get_transaction_detail(
     db_path: String,
     network: String,

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -467375400;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1485024666;
 
 // Section: executor
 
@@ -1108,6 +1108,49 @@ fn wire__crate__api__sync__get_transaction_data_requests_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok =
                         crate::api::sync::get_transaction_data_requests(api_db_path, api_network)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__sync__get_transaction_detail_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_transaction_detail",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_txid_hex = <String>::sse_decode(&mut deserializer);
+            let api_tx_kind = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::sync::get_transaction_detail(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                        api_txid_hex,
+                        api_tx_kind,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -2569,6 +2612,20 @@ impl SseDecode for Vec<crate::api::sync::SubtreeRoot> {
     }
 }
 
+impl SseDecode for Vec<crate::api::sync::TransactionDetailOutput> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::sync::TransactionDetailOutput>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::api::sync::TransactionInfo> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2755,6 +2812,39 @@ impl SseDecode for crate::api::sync::SyncProgress {
             scanned_height: var_scannedHeight,
             chain_tip_height: var_chainTipHeight,
             is_syncing: var_isSyncing,
+        };
+    }
+}
+
+impl SseDecode for crate::api::sync::TransactionDetail {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_txidHex = <String>::sse_decode(deserializer);
+        let mut var_txKind = <String>::sse_decode(deserializer);
+        let mut var_primaryAddress = <Option<String>>::sse_decode(deserializer);
+        let mut var_memo = <Option<String>>::sse_decode(deserializer);
+        let mut var_outputs =
+            <Vec<crate::api::sync::TransactionDetailOutput>>::sse_decode(deserializer);
+        return crate::api::sync::TransactionDetail {
+            txid_hex: var_txidHex,
+            tx_kind: var_txKind,
+            primary_address: var_primaryAddress,
+            memo: var_memo,
+            outputs: var_outputs,
+        };
+    }
+}
+
+impl SseDecode for crate::api::sync::TransactionDetailOutput {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_address = <Option<String>>::sse_decode(deserializer);
+        let mut var_amountZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_pool = <String>::sse_decode(deserializer);
+        return crate::api::sync::TransactionDetailOutput {
+            address: var_address,
+            amount_zatoshi: var_amountZatoshi,
+            pool: var_pool,
         };
     }
 }
@@ -2997,63 +3087,66 @@ fn pde_ffi_dispatcher_primary_impl(
             data_len,
         ),
         30 => {
+            wire__crate__api__sync__get_transaction_detail_impl(port, ptr, rust_vec_len, data_len)
+        }
+        31 => {
             wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len)
         }
-        31 => wire__crate__api__wallet__get_transparent_address_impl(
+        32 => wire__crate__api__wallet__get_transparent_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        32 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__wallet__import_hardware_account_impl(
+        33 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__wallet__import_hardware_account_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        35 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__keystone__is_keystone_connected_impl(
+        36 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+        37 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__keystone__is_keystone_connected_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__api__keystone__keystone_usb_sign_pczt_impl(
+        42 => wire__crate__api__keystone__keystone_usb_sign_pczt_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        42 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-        45 => {
+        43 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+        46 => {
             wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len)
         }
-        47 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-        48 => {
+        48 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+        49 => {
             wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len)
         }
-        49 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-        51 => {
+        50 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+        52 => {
             wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len)
         }
-        52 => wire__crate__api__sync__shield_transparent_balance_impl(
+        53 => wire__crate__api__sync__shield_transparent_balance_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        53 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-        54 => {
+        54 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+        55 => {
             wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len)
         }
-        56 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-        61 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3070,15 +3163,15 @@ fn pde_ffi_dispatcher_sync_impl(
         20 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
         22 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
         27 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        33 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        50 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        51 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3430,6 +3523,52 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::SyncProgress>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sync::TransactionDetail {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.txid_hex.into_into_dart().into_dart(),
+            self.tx_kind.into_into_dart().into_dart(),
+            self.primary_address.into_into_dart().into_dart(),
+            self.memo.into_into_dart().into_dart(),
+            self.outputs.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sync::TransactionDetail
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::TransactionDetail>
+    for crate::api::sync::TransactionDetail
+{
+    fn into_into_dart(self) -> crate::api::sync::TransactionDetail {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sync::TransactionDetailOutput {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.address.into_into_dart().into_dart(),
+            self.amount_zatoshi.into_into_dart().into_dart(),
+            self.pool.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sync::TransactionDetailOutput
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::TransactionDetailOutput>
+    for crate::api::sync::TransactionDetailOutput
+{
+    fn into_into_dart(self) -> crate::api::sync::TransactionDetailOutput {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::sync::TransactionInfo {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -3773,6 +3912,16 @@ impl SseEncode for Vec<crate::api::sync::SubtreeRoot> {
     }
 }
 
+impl SseEncode for Vec<crate::api::sync::TransactionDetailOutput> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::sync::TransactionDetailOutput>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<crate::api::sync::TransactionInfo> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -3908,6 +4057,26 @@ impl SseEncode for crate::api::sync::SyncProgress {
         <u64>::sse_encode(self.scanned_height, serializer);
         <u64>::sse_encode(self.chain_tip_height, serializer);
         <bool>::sse_encode(self.is_syncing, serializer);
+    }
+}
+
+impl SseEncode for crate::api::sync::TransactionDetail {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.txid_hex, serializer);
+        <String>::sse_encode(self.tx_kind, serializer);
+        <Option<String>>::sse_encode(self.primary_address, serializer);
+        <Option<String>>::sse_encode(self.memo, serializer);
+        <Vec<crate::api::sync::TransactionDetailOutput>>::sse_encode(self.outputs, serializer);
+    }
+}
+
+impl SseEncode for crate::api::sync::TransactionDetailOutput {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Option<String>>::sse_encode(self.address, serializer);
+        <u64>::sse_encode(self.amount_zatoshi, serializer);
+        <String>::sse_encode(self.pool, serializer);
     }
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -1115,16 +1115,15 @@ fn wire__crate__api__sync__get_transaction_data_requests_impl(
     )
 }
 fn wire__crate__api__sync__get_transaction_detail_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
     data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "get_transaction_detail",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
         },
         move || {
             let message = unsafe {
@@ -1142,18 +1141,16 @@ fn wire__crate__api__sync__get_transaction_detail_impl(
             let api_txid_hex = <String>::sse_decode(&mut deserializer);
             let api_tx_kind = <String>::sse_decode(&mut deserializer);
             deserializer.end();
-            move |context| {
-                transform_result_sse::<_, String>((move || {
-                    let output_ok = crate::api::sync::get_transaction_detail(
-                        api_db_path,
-                        api_network,
-                        api_account_uuid,
-                        api_txid_hex,
-                        api_tx_kind,
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
+            transform_result_sse::<_, String>((move || {
+                let output_ok = crate::api::sync::get_transaction_detail(
+                    api_db_path,
+                    api_network,
+                    api_account_uuid,
+                    api_txid_hex,
+                    api_tx_kind,
+                )?;
+                Ok(output_ok)
+            })())
         },
     )
 }
@@ -3086,9 +3083,6 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        30 => {
-            wire__crate__api__sync__get_transaction_detail_impl(port, ptr, rust_vec_len, data_len)
-        }
         31 => {
             wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len)
         }
@@ -3163,6 +3157,7 @@ fn pde_ffi_dispatcher_sync_impl(
         20 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
         22 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
         27 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
         34 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
         39 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
         40 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -57,11 +57,14 @@ pub(crate) use send::ShieldTransparentResult;
 pub(crate) use send::ShieldTransparentStatus;
 pub use transactions::{
     check_tx_mined, decrypt_and_store_transaction, get_next_available_address,
-    get_pending_transactions, get_transaction_data_requests, get_transaction_history,
-    get_wallet_balance, set_transaction_status,
+    get_pending_transactions, get_transaction_data_requests, get_transaction_detail,
+    get_transaction_history, get_wallet_balance, set_transaction_status,
 };
 #[allow(unused_imports)] // ditto
-pub(crate) use transactions::{PendingTxInfo, TransactionInfo, TxDataRequest, WalletBalance};
+pub(crate) use transactions::{
+    PendingTxInfo, TransactionDetail, TransactionDetailOutput, TransactionInfo, TxDataRequest,
+    WalletBalance,
+};
 
 pub(super) fn open_wallet_db(
     db_path: &str,

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -247,19 +247,43 @@ struct TxOutput {
     output_pool: i64,
     from_account_uuid: Option<Vec<u8>>,
     to_account_uuid: Option<Vec<u8>>,
+    to_address: Option<String>,
+    to_key_scope: Option<i64>,
     value: u64,
-    is_change: bool,
 }
 
 #[derive(Default, Clone)]
-struct OutputSummary {
-    is_transparent: bool,
-    external_sent_amount: u64,
-    external_received_amount: u64,
-    display_has_transparent: bool,
-    display_has_shielded: bool,
-    own_non_change_amount: u64,
-    has_external_display_output: bool,
+struct ActivityAmounts {
+    amount: u64,
+    has_transparent: bool,
+    has_shielded: bool,
+}
+
+impl ActivityAmounts {
+    fn add_output(&mut self, output: &TxOutput) {
+        self.amount = self.amount.saturating_add(output.value);
+        match output.output_pool {
+            0 => self.has_transparent = true,
+            2 | 3 => self.has_shielded = true,
+            _ => {}
+        }
+    }
+
+    fn display_pool(&self) -> &'static str {
+        match (self.has_transparent, self.has_shielded) {
+            (true, false) => "transparent",
+            (false, true) => "shielded",
+            (true, true) => "mixed",
+            (false, false) => "unknown",
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+struct ActivitySummary {
+    sent: ActivityAmounts,
+    received: ActivityAmounts,
+    shielded: ActivityAmounts,
     has_own_transparent_output: bool,
     has_external_transparent_send: bool,
 }
@@ -269,6 +293,7 @@ struct ClassifiedTx {
     sort_timestamp: u64,
     sort_mined_height: u64,
     tx_index: i64,
+    row_order: u8,
 }
 
 pub fn get_transaction_history(
@@ -291,7 +316,7 @@ pub fn get_transaction_history(
     }
 
     let outputs_by_txid = read_history_outputs(&read_tx, &uuid_bytes)?;
-    let summaries: HashMap<Vec<u8>, OutputSummary> = bases
+    let summaries: HashMap<Vec<u8>, ActivitySummary> = bases
         .iter()
         .map(|base| {
             let outputs = outputs_by_txid
@@ -300,25 +325,25 @@ pub fn get_transaction_history(
                 .unwrap_or(&[]);
             (
                 base.txid.clone(),
-                summarize_outputs(outputs, uuid_bytes.as_slice()),
+                summarize_activity_outputs(base, outputs, uuid_bytes.as_slice()),
             )
         })
         .collect();
     let external_send_keys = build_external_send_keys(&bases, &summaries);
 
-    let mut visible = bases
-        .iter()
-        .filter_map(|base| {
-            let summary = summaries.get(&base.txid).cloned().unwrap_or_default();
-            if should_suppress_funding_step(base, &summary, &external_send_keys)
-                || should_suppress_change_only_internal(base, &summary)
-            {
-                None
-            } else {
-                Some(classify_history_tx(base, &summary))
-            }
-        })
-        .collect::<Vec<_>>();
+    let mut visible = Vec::new();
+    for base in &bases {
+        let summary = summaries.get(&base.txid).cloned().unwrap_or_default();
+        if should_suppress_funding_step(base, &summary, &external_send_keys) {
+            continue;
+        }
+
+        visible.extend(classify_history_tx(base, &summary));
+    }
+
+    visible.retain(|tx| {
+        tx.info.display_amount > 0 || tx.info.tx_kind == "unknown" || tx.info.tx_kind == "shielded"
+    });
 
     visible.sort_by(|a, b| {
         b.sort_timestamp
@@ -326,6 +351,7 @@ pub fn get_transaction_history(
             .then_with(|| b.sort_mined_height.cmp(&a.sort_mined_height))
             .then_with(|| b.tx_index.cmp(&a.tx_index))
             .then_with(|| b.info.txid_hex.cmp(&a.info.txid_hex))
+            .then_with(|| a.row_order.cmp(&b.row_order))
     });
 
     if let Some(limit) = limit {
@@ -399,8 +425,19 @@ fn read_history_outputs(
             txo.output_pool,
             txo.from_account_uuid,
             txo.to_account_uuid,
-            txo.value,
-            txo.is_change
+            txo.to_address,
+            (
+                SELECT a.key_scope
+                FROM accounts acc
+                JOIN addresses a ON a.account_id = acc.id
+                WHERE acc.uuid = txo.to_account_uuid
+                  AND (
+                      a.address = txo.to_address
+                      OR a.cached_transparent_receiver_address = txo.to_address
+                  )
+                LIMIT 1
+            ) AS to_key_scope,
+            txo.value
         FROM v_tx_outputs txo
         JOIN (
             SELECT DISTINCT txid
@@ -420,8 +457,9 @@ fn read_history_outputs(
                 output_pool: row.get(1)?,
                 from_account_uuid: row.get(2)?,
                 to_account_uuid: row.get(3)?,
-                value: row.get::<_, i64>(4)?.unsigned_abs(),
-                is_change: row.get(5)?,
+                to_address: row.get(4)?,
+                to_key_scope: row.get(5)?,
+                value: row.get::<_, i64>(6)?.unsigned_abs(),
             })
         })
         .map_err(|e| format!("Query error: {e}"))?;
@@ -434,55 +472,66 @@ fn read_history_outputs(
     Ok(outputs)
 }
 
-fn summarize_outputs(outputs: &[TxOutput], account_uuid: &[u8]) -> OutputSummary {
-    let mut summary = OutputSummary::default();
+fn summarize_activity_outputs(
+    base: &TxBase,
+    outputs: &[TxOutput],
+    account_uuid: &[u8],
+) -> ActivitySummary {
+    let mut summary = ActivitySummary::default();
 
     for output in outputs {
         let from_own = output.from_account_uuid.as_deref() == Some(account_uuid);
         let to_own = output.to_account_uuid.as_deref() == Some(account_uuid);
-        let external_send = from_own && !to_own && !output.is_change;
-        let external_receive = to_own && !from_own && !output.is_change;
-        let external_display_output = external_send || external_receive;
 
-        if output.output_pool == 0 {
-            summary.is_transparent = true;
+        if base.is_shielding {
+            if to_own && is_shielded_pool(output.output_pool) {
+                summary.shielded.add_output(output);
+            }
+            continue;
         }
-        if external_send {
-            summary.external_sent_amount =
-                summary.external_sent_amount.saturating_add(output.value);
-        }
-        if external_receive {
-            summary.external_received_amount = summary
-                .external_received_amount
-                .saturating_add(output.value);
-        }
-        if output.output_pool == 0 && external_display_output {
-            summary.display_has_transparent = true;
-        }
-        if matches!(output.output_pool, 2 | 3) && external_display_output {
-            summary.display_has_shielded = true;
-        }
-        if external_display_output {
-            summary.has_external_display_output = true;
-        }
-        if from_own && to_own && !output.is_change {
-            summary.own_non_change_amount =
-                summary.own_non_change_amount.saturating_add(output.value);
-        }
-        if output.output_pool == 0 && from_own && to_own && !output.is_change {
+
+        if output.output_pool == 0 && from_own && to_own {
             summary.has_own_transparent_output = true;
         }
-        if output.output_pool == 0 && external_send {
-            summary.has_external_transparent_send = true;
+
+        let visible_self_output = from_own && to_own && is_user_visible_self_output(output);
+        let visible_sent = from_own && (!to_own || visible_self_output);
+        let visible_received = to_own && (!from_own || visible_self_output);
+
+        if visible_sent {
+            summary.sent.add_output(output);
+            if output.output_pool == 0 && !to_own {
+                summary.has_external_transparent_send = true;
+            }
+        }
+        if visible_received {
+            summary.received.add_output(output);
         }
     }
 
     summary
 }
 
+fn is_shielded_pool(output_pool: i64) -> bool {
+    matches!(output_pool, 2 | 3)
+}
+
+fn is_user_visible_self_output(output: &TxOutput) -> bool {
+    match output.output_pool {
+        // Transparent self outputs are user-visible only when they land on a
+        // normal external/foreign receiver. Internal and ephemeral receivers
+        // are change/funding mechanics.
+        0 => matches!(output.to_key_scope, Some(0) | Some(-1)),
+        // Shielded explicit self-sends preserve the recipient address in
+        // sent_notes. Wallet-internal change does not.
+        2 | 3 => output.to_address.is_some() || matches!(output.to_key_scope, Some(0) | Some(-1)),
+        _ => false,
+    }
+}
+
 fn build_external_send_keys(
     bases: &[TxBase],
-    summaries: &HashMap<Vec<u8>, OutputSummary>,
+    summaries: &HashMap<Vec<u8>, ActivitySummary>,
 ) -> HashSet<(String, i64)> {
     bases
         .iter()
@@ -501,7 +550,7 @@ fn build_external_send_keys(
 
 fn should_suppress_funding_step(
     base: &TxBase,
-    summary: &OutputSummary,
+    summary: &ActivitySummary,
     external_send_keys: &HashSet<(String, i64)>,
 ) -> bool {
     !base.is_shielding
@@ -509,49 +558,76 @@ fn should_suppress_funding_step(
         && base.total_received > 0
         && base.account_balance_delta <= 0
         && base.created.is_some()
-        && !summary.has_external_display_output
+        && summary.sent.amount == 0
+        && summary.received.amount == 0
         && summary.has_own_transparent_output
         && external_send_keys
             .contains(&(base.created.clone().unwrap_or_default(), base.expiry_key()))
 }
 
-fn should_suppress_change_only_internal(base: &TxBase, summary: &OutputSummary) -> bool {
-    !base.is_shielding
-        && base.total_spent > 0
-        && base.total_received > 0
-        && !summary.has_external_display_output
-        && summary.own_non_change_amount == 0
+fn classify_history_tx(base: &TxBase, summary: &ActivitySummary) -> Vec<ClassifiedTx> {
+    if base.is_shielding {
+        let amount = if summary.shielded.amount > 0 {
+            summary.shielded.amount
+        } else {
+            base.total_received
+        };
+        return vec![build_classified_tx(
+            base, "shielded", amount, "shielded", false, 0,
+        )];
+    }
+
+    let mut rows = Vec::new();
+    if summary.sent.amount > 0 {
+        rows.push(build_classified_tx(
+            base,
+            "sent",
+            summary.sent.amount,
+            summary.sent.display_pool(),
+            summary.sent.has_transparent,
+            1,
+        ));
+    }
+    if summary.received.amount > 0 {
+        rows.push(build_classified_tx(
+            base,
+            "received",
+            summary.received.amount,
+            summary.received.display_pool(),
+            summary.received.has_transparent,
+            2,
+        ));
+    }
+
+    if rows.is_empty() {
+        if base.total_spent > 0 && base.total_received > 0 {
+            return rows;
+        }
+        if base.account_balance_delta > 0 {
+            rows.push(build_classified_tx(
+                base,
+                "received",
+                base.account_balance_delta as u64,
+                "unknown",
+                false,
+                2,
+            ));
+        } else {
+            rows.push(build_classified_tx(base, "unknown", 0, "unknown", false, 3));
+        }
+    }
+
+    rows
 }
 
-fn classify_history_tx(base: &TxBase, summary: &OutputSummary) -> ClassifiedTx {
-    let display_pool = if base.is_shielding {
-        "shielded"
-    } else {
-        match (
-            summary.display_has_transparent,
-            summary.display_has_shielded,
-        ) {
-            (true, false) => "transparent",
-            (false, true) => "shielded",
-            (true, true) => "mixed",
-            (false, false) => "unknown",
-        }
-    };
-
-    let (tx_kind, display_amount) = if base.is_shielding {
-        ("shielded", base.total_received)
-    } else if summary.external_sent_amount > 0 {
-        ("sent", summary.external_sent_amount)
-    } else if summary.external_received_amount > 0 {
-        ("received", summary.external_received_amount)
-    } else if base.total_spent > 0 && base.total_received > 0 {
-        ("internal", summary.own_non_change_amount)
-    } else if base.account_balance_delta > 0 {
-        ("received", base.account_balance_delta as u64)
-    } else {
-        ("unknown", 0)
-    };
-
+fn build_classified_tx(
+    base: &TxBase,
+    tx_kind: &str,
+    display_amount: u64,
+    display_pool: &str,
+    is_transparent: bool,
+    row_order: u8,
+) -> ClassifiedTx {
     let sort_timestamp = base.display_timestamp();
     ClassifiedTx {
         info: TransactionInfo {
@@ -561,7 +637,7 @@ fn classify_history_tx(base: &TxBase, summary: &OutputSummary) -> ClassifiedTx {
             account_balance_delta: base.account_balance_delta,
             fee: base.fee,
             block_time: base.block_time,
-            is_transparent: summary.is_transparent,
+            is_transparent,
             tx_kind: tx_kind.to_string(),
             display_amount,
             display_pool: display_pool.to_string(),
@@ -570,6 +646,7 @@ fn classify_history_tx(base: &TxBase, summary: &OutputSummary) -> ClassifiedTx {
         sort_timestamp,
         sort_mined_height: base.mined_height.unwrap_or(0) as u64,
         tx_index: base.tx_index,
+        row_order,
     }
 }
 
@@ -825,7 +902,18 @@ mod tests {
         let file = NamedTempFile::new().unwrap();
         let conn = rusqlite::Connection::open(file.path()).unwrap();
         conn.execute_batch(
-            "CREATE TABLE v_transactions (
+            "CREATE TABLE accounts (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 uuid BLOB NOT NULL UNIQUE
+             );
+             CREATE TABLE addresses (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 account_id INTEGER NOT NULL,
+                 key_scope INTEGER NOT NULL,
+                 address TEXT NOT NULL,
+                 cached_transparent_receiver_address TEXT
+             );
+             CREATE TABLE v_transactions (
                  account_uuid BLOB NOT NULL,
                  txid BLOB NOT NULL,
                  mined_height INTEGER,
@@ -846,8 +934,10 @@ mod tests {
              CREATE TABLE v_tx_outputs (
                  txid BLOB NOT NULL,
                  output_pool INTEGER NOT NULL,
+                 output_index INTEGER NOT NULL,
                  from_account_uuid BLOB,
                  to_account_uuid BLOB,
+                 to_address TEXT,
                  value INTEGER NOT NULL,
                  is_change INTEGER NOT NULL
              );",
@@ -871,6 +961,7 @@ mod tests {
         created: Option<&str>,
     ) {
         let conn = rusqlite::Connection::open(db.path()).unwrap();
+        ensure_account_row(&conn, account);
         conn.execute(
             "INSERT INTO transactions (txid, created) VALUES (?1, ?2)",
             rusqlite::params![txid, created],
@@ -897,6 +988,20 @@ mod tests {
         .unwrap();
     }
 
+    fn ensure_account_row(conn: &rusqlite::Connection, account: uuid::Uuid) -> i64 {
+        conn.execute(
+            "INSERT OR IGNORE INTO accounts (uuid) VALUES (?1)",
+            rusqlite::params![account.as_bytes().as_slice()],
+        )
+        .unwrap();
+        conn.query_row(
+            "SELECT id FROM accounts WHERE uuid = ?1",
+            rusqlite::params![account.as_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .unwrap()
+    }
+
     fn insert_output(
         db: &NamedTempFile,
         txid: &[u8],
@@ -906,14 +1011,73 @@ mod tests {
         value: i64,
         is_change: bool,
     ) {
+        insert_output_with_address(
+            db,
+            txid,
+            output_pool,
+            from_account,
+            to_account,
+            value,
+            is_change,
+            None,
+            None,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_output_with_address(
+        db: &NamedTempFile,
+        txid: &[u8],
+        output_pool: i64,
+        from_account: Option<uuid::Uuid>,
+        to_account: Option<uuid::Uuid>,
+        value: i64,
+        is_change: bool,
+        to_address: Option<&str>,
+        to_key_scope: Option<i64>,
+    ) {
         let conn = rusqlite::Connection::open(db.path()).unwrap();
+        if let Some(account) = from_account {
+            ensure_account_row(&conn, account);
+        }
+        if let Some(account) = to_account {
+            let account_id = ensure_account_row(&conn, account);
+            if let (Some(address), Some(key_scope)) = (to_address, to_key_scope) {
+                conn.execute(
+                    "INSERT INTO addresses (
+                         account_id, key_scope, address, cached_transparent_receiver_address
+                     ) VALUES (?1, ?2, ?3, ?3)",
+                    rusqlite::params![account_id, key_scope, address],
+                )
+                .unwrap();
+            }
+        }
+        let output_index = conn
+            .query_row(
+                "SELECT COALESCE(MAX(output_index) + 1, 0)
+                 FROM v_tx_outputs
+                 WHERE txid = ?1 AND output_pool = ?2",
+                rusqlite::params![txid, output_pool],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap();
         let from_bytes = from_account.map(|uuid| uuid.as_bytes().to_vec());
         let to_bytes = to_account.map(|uuid| uuid.as_bytes().to_vec());
         conn.execute(
             "INSERT INTO v_tx_outputs (
-                 txid, output_pool, from_account_uuid, to_account_uuid, value, is_change
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-            rusqlite::params![txid, output_pool, from_bytes, to_bytes, value, is_change],
+                 txid, output_pool, output_index, from_account_uuid,
+                 to_account_uuid, to_address, value, is_change
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![
+                txid,
+                output_pool,
+                output_index,
+                from_bytes,
+                to_bytes,
+                to_address,
+                value,
+                is_change,
+            ],
         )
         .unwrap();
     }
@@ -957,7 +1121,7 @@ mod tests {
             false,
             Some(created),
         );
-        insert_output(
+        insert_output_with_address(
             &db,
             &funding_step,
             0,
@@ -965,6 +1129,8 @@ mod tests {
             Some(account),
             10_010_000,
             false,
+            Some("t-ephemeral"),
+            Some(2),
         );
 
         insert_history_tx(
@@ -1005,15 +1171,15 @@ mod tests {
     }
 
     #[test]
-    fn history_keeps_internal_transfer_without_external_send_sibling() {
+    fn history_splits_same_account_transparent_self_send() {
         let db = fresh_history_db();
         let account = test_account_uuid();
-        let internal_tx = fake_txid(0xB1);
+        let self_tx = fake_txid(0xB1);
 
         insert_history_tx(
             &db,
             account,
-            &internal_tx,
+            &self_tx,
             Some(1_000_000),
             1,
             Some(1_000_100),
@@ -1023,14 +1189,16 @@ mod tests {
             false,
             Some("2026-04-28T13:03:00Z"),
         );
-        insert_output(
+        insert_output_with_address(
             &db,
-            &internal_tx,
+            &self_tx,
             0,
             Some(account),
             Some(account),
             18_262_101,
             false,
+            Some("t-self"),
+            Some(0),
         );
 
         let got = get_transaction_history(
@@ -1041,10 +1209,15 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(got.len(), 1);
-        assert_eq!(got[0].txid_hex, hex::encode(internal_tx));
-        assert_eq!(got[0].tx_kind, "internal");
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].txid_hex, hex::encode(self_tx));
+        assert_eq!(got[0].tx_kind, "sent");
         assert_eq!(got[0].display_amount, 18_262_101);
+        assert_eq!(got[0].display_pool, "transparent");
+        assert_eq!(got[1].txid_hex, hex::encode(self_tx));
+        assert_eq!(got[1].tx_kind, "received");
+        assert_eq!(got[1].display_amount, 18_262_101);
+        assert_eq!(got[1].display_pool, "transparent");
     }
 
     #[test]
@@ -1136,15 +1309,15 @@ mod tests {
     }
 
     #[test]
-    fn history_internal_amount_excludes_change_outputs() {
+    fn history_splits_same_account_shielded_self_send_and_hides_change() {
         let db = fresh_history_db();
         let account = test_account_uuid();
-        let internal_tx = fake_txid(0xC0);
+        let self_tx = fake_txid(0xC0);
 
         insert_history_tx(
             &db,
             account,
-            &internal_tx,
+            &self_tx,
             Some(1_000_000),
             1,
             Some(1_000_100),
@@ -1154,18 +1327,20 @@ mod tests {
             false,
             Some("2026-04-28T16:32:00Z"),
         );
-        insert_output(
+        insert_output_with_address(
             &db,
-            &internal_tx,
-            0,
+            &self_tx,
+            3,
             Some(account),
             Some(account),
             1_000_000,
-            false,
+            true,
+            Some("u-self"),
+            Some(0),
         );
         insert_output(
             &db,
-            &internal_tx,
+            &self_tx,
             3,
             Some(account),
             Some(account),
@@ -1181,10 +1356,15 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(got.len(), 1);
-        assert_eq!(got[0].txid_hex, hex::encode(internal_tx));
-        assert_eq!(got[0].tx_kind, "internal");
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].txid_hex, hex::encode(self_tx));
+        assert_eq!(got[0].tx_kind, "sent");
         assert_eq!(got[0].display_amount, 1_000_000);
+        assert_eq!(got[0].display_pool, "shielded");
+        assert_eq!(got[1].txid_hex, hex::encode(self_tx));
+        assert_eq!(got[1].tx_kind, "received");
+        assert_eq!(got[1].display_amount, 1_000_000);
+        assert_eq!(got[1].display_pool, "shielded");
     }
 
     #[test]
@@ -1237,11 +1417,55 @@ mod tests {
     }
 
     #[test]
+    fn history_keeps_shielding_tx_as_single_shielded_row() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let shielding_tx = fake_txid(0xC4);
+
+        insert_history_tx(
+            &db,
+            account,
+            &shielding_tx,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -10_000,
+            10_010_000,
+            10_000_000,
+            true,
+            Some("2026-04-28T15:44:00Z"),
+        );
+        insert_output(
+            &db,
+            &shielding_tx,
+            3,
+            Some(account),
+            Some(account),
+            10_000_000,
+            true,
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].txid_hex, hex::encode(shielding_tx));
+        assert_eq!(got[0].tx_kind, "shielded");
+        assert_eq!(got[0].display_amount, 10_000_000);
+        assert_eq!(got[0].display_pool, "shielded");
+    }
+
+    #[test]
     fn history_sorts_by_display_timestamp_before_limit() {
         let db = fresh_history_db();
         let account = test_account_uuid();
         let older_failed = fake_txid(0xC1);
-        let newer_internal = fake_txid(0xC2);
+        let newer_self_send = fake_txid(0xC2);
 
         insert_history_tx(
             &db,
@@ -1270,7 +1494,7 @@ mod tests {
         insert_history_tx(
             &db,
             account,
-            &newer_internal,
+            &newer_self_send,
             Some(1_000_000),
             1,
             Some(1_000_100),
@@ -1280,14 +1504,16 @@ mod tests {
             false,
             Some("2026-04-28T16:32:00Z"),
         );
-        insert_output(
+        insert_output_with_address(
             &db,
-            &newer_internal,
+            &newer_self_send,
             0,
             Some(account),
             Some(account),
             17_000_000,
             false,
+            Some("t-newer-self"),
+            Some(0),
         );
 
         let got = get_transaction_history(
@@ -1298,10 +1524,13 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(got.len(), 2);
-        assert_eq!(got[0].txid_hex, hex::encode(newer_internal));
-        assert_eq!(got[1].txid_hex, hex::encode(older_failed));
-        assert!(got[1].expired_unmined);
+        assert_eq!(got.len(), 3);
+        assert_eq!(got[0].txid_hex, hex::encode(newer_self_send));
+        assert_eq!(got[0].tx_kind, "sent");
+        assert_eq!(got[1].txid_hex, hex::encode(newer_self_send));
+        assert_eq!(got[1].tx_kind, "received");
+        assert_eq!(got[2].txid_hex, hex::encode(older_failed));
+        assert!(got[2].expired_unmined);
 
         let limited = get_transaction_history(
             db.path().to_str().unwrap(),
@@ -1312,7 +1541,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(limited.len(), 1);
-        assert_eq!(limited[0].txid_hex, hex::encode(newer_internal));
+        assert_eq!(limited[0].txid_hex, hex::encode(newer_self_send));
+        assert_eq!(limited[0].tx_kind, "sent");
     }
 
     #[test]

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -21,8 +21,12 @@
 
 use std::collections::{HashMap, HashSet};
 
+use rusqlite::OptionalExtension;
 use zcash_client_backend::data_api::{wallet::ConfirmationsPolicy, WalletRead, WalletWrite};
-use zcash_protocol::consensus::BlockHeight;
+use zcash_protocol::{
+    consensus::BlockHeight,
+    memo::{Memo, MemoBytes},
+};
 
 use crate::wallet::db::with_wallet_db_write_lock;
 use crate::wallet::keys::parse_account_uuid;
@@ -225,6 +229,20 @@ pub(crate) struct TransactionInfo {
     pub created_time: u64,
 }
 
+pub(crate) struct TransactionDetail {
+    pub txid_hex: String,
+    pub tx_kind: String,
+    pub primary_address: Option<String>,
+    pub memo: Option<String>,
+    pub outputs: Vec<TransactionDetailOutput>,
+}
+
+pub(crate) struct TransactionDetailOutput {
+    pub address: Option<String>,
+    pub amount_zatoshi: u64,
+    pub pool: String,
+}
+
 #[derive(Clone)]
 struct TxBase {
     txid: Vec<u8>,
@@ -245,11 +263,13 @@ struct TxBase {
 struct TxOutput {
     txid: Vec<u8>,
     output_pool: i64,
+    output_index: i64,
     from_account_uuid: Option<Vec<u8>>,
     to_account_uuid: Option<Vec<u8>>,
     to_address: Option<String>,
     to_key_scope: Option<i64>,
     value: u64,
+    memo: Option<Vec<u8>>,
 }
 
 #[derive(Default, Clone)]
@@ -361,6 +381,121 @@ pub fn get_transaction_history(
     Ok(visible.into_iter().map(|tx| tx.info).collect())
 }
 
+pub fn get_transaction_detail(
+    db_path: &str,
+    _network: WalletNetwork,
+    account_uuid: &str,
+    txid_hex: &str,
+    tx_kind: &str,
+) -> Result<TransactionDetail, String> {
+    let uuid = uuid::Uuid::parse_str(account_uuid).map_err(|e| format!("Invalid UUID: {e}"))?;
+    let uuid_bytes = uuid.as_bytes().to_vec();
+    let txid = hex::decode(txid_hex).map_err(|e| format!("Invalid txid: {e}"))?;
+    if txid.len() != 32 {
+        return Err("Invalid txid length".to_string());
+    }
+
+    let conn = open_readonly_conn(db_path)?;
+    let read_tx = conn
+        .unchecked_transaction()
+        .map_err(|e| format!("SQL error: {e}"))?;
+    let Some(base) = read_history_base_by_txid(&read_tx, &uuid_bytes, &txid)? else {
+        return Err("Transaction not found".to_string());
+    };
+    let mut outputs = read_outputs_for_tx(&read_tx, &uuid_bytes, &txid)?;
+    outputs.sort_by(|a, b| {
+        a.output_index
+            .cmp(&b.output_index)
+            .then_with(|| a.output_pool.cmp(&b.output_pool))
+    });
+
+    let visible_outputs = outputs
+        .iter()
+        .filter(|output| detail_includes_output(&base, output, uuid_bytes.as_slice(), tx_kind))
+        .collect::<Vec<_>>();
+    let memo = visible_outputs
+        .iter()
+        .find_map(|output| decode_text_memo(output.memo.as_deref()));
+    let primary_address = if tx_kind == "sent" {
+        visible_outputs
+            .iter()
+            .find_map(|output| output.to_address.clone())
+    } else {
+        None
+    };
+    let outputs = visible_outputs
+        .into_iter()
+        .map(|output| TransactionDetailOutput {
+            address: output.to_address.clone(),
+            amount_zatoshi: output.value,
+            pool: output_pool_label(output.output_pool).to_string(),
+        })
+        .collect();
+
+    Ok(TransactionDetail {
+        txid_hex: hex::encode(&base.txid),
+        tx_kind: tx_kind.to_string(),
+        primary_address,
+        memo,
+        outputs,
+    })
+}
+
+fn read_history_base_by_txid(
+    conn: &rusqlite::Connection,
+    account_uuid: &[u8],
+    txid: &[u8],
+) -> Result<Option<TxBase>, String> {
+    let mut stmt = conn
+        .prepare(
+            r#"
+        SELECT
+            vt.txid,
+            vt.mined_height,
+            vt.expired_unmined,
+            vt.account_balance_delta,
+            COALESCE(vt.fee_paid, 0) AS fee_paid,
+            COALESCE(vt.block_time, 0) AS block_time,
+            COALESCE(vt.total_spent, 0) AS total_spent,
+            COALESCE(vt.total_received, 0) AS total_received,
+            COALESCE(vt.is_shielding, 0) AS is_shielding,
+            vt.expiry_height,
+            COALESCE(vt.tx_index, -1) AS tx_index,
+            tx.created,
+            CAST(COALESCE(strftime('%s', tx.created), 0) AS INTEGER) AS created_time
+        FROM v_transactions vt
+        LEFT JOIN transactions tx ON tx.txid = vt.txid
+        WHERE vt.account_uuid = ?1
+          AND vt.txid = ?2
+        LIMIT 1
+        "#,
+        )
+        .map_err(|e| format!("SQL error: {e}"))?;
+
+    let row = stmt
+        .query_row(rusqlite::params![account_uuid, txid], |row| {
+            Ok(TxBase {
+                txid: row.get(0)?,
+                mined_height: row.get(1)?,
+                expired_unmined: row.get(2)?,
+                account_balance_delta: row.get(3)?,
+                fee: row.get::<_, i64>(4)?.unsigned_abs(),
+                block_time: row.get::<_, i64>(5)?.unsigned_abs(),
+                total_spent: row.get::<_, i64>(6)?.unsigned_abs(),
+                total_received: row.get::<_, i64>(7)?.unsigned_abs(),
+                is_shielding: row.get(8)?,
+                expiry_height: row.get(9)?,
+                tx_index: row.get(10)?,
+                created: row.get(11)?,
+                created_time: row.get::<_, i64>(12)?.unsigned_abs(),
+            })
+        })
+        .optional()
+        .map_err(|e| format!("Query error: {e}"))?;
+
+    Ok(row)
+}
+
 fn read_history_bases(
     conn: &rusqlite::Connection,
     account_uuid: &[u8],
@@ -423,6 +558,7 @@ fn read_history_outputs(
         SELECT
             txo.txid,
             txo.output_pool,
+            txo.output_index,
             txo.from_account_uuid,
             txo.to_account_uuid,
             txo.to_address,
@@ -437,7 +573,8 @@ fn read_history_outputs(
                   )
                 LIMIT 1
             ) AS to_key_scope,
-            txo.value
+            txo.value,
+            txo.memo
         FROM v_tx_outputs txo
         JOIN (
             SELECT DISTINCT txid
@@ -455,11 +592,13 @@ fn read_history_outputs(
             Ok(TxOutput {
                 txid: row.get(0)?,
                 output_pool: row.get(1)?,
-                from_account_uuid: row.get(2)?,
-                to_account_uuid: row.get(3)?,
-                to_address: row.get(4)?,
-                to_key_scope: row.get(5)?,
-                value: row.get::<_, i64>(6)?.unsigned_abs(),
+                output_index: row.get(2)?,
+                from_account_uuid: row.get(3)?,
+                to_account_uuid: row.get(4)?,
+                to_address: row.get(5)?,
+                to_key_scope: row.get(6)?,
+                value: row.get::<_, i64>(7)?.unsigned_abs(),
+                memo: row.get(8)?,
             })
         })
         .map_err(|e| format!("Query error: {e}"))?;
@@ -470,6 +609,64 @@ fn read_history_outputs(
         outputs.entry(output.txid.clone()).or_default().push(output);
     }
     Ok(outputs)
+}
+
+fn read_outputs_for_tx(
+    conn: &rusqlite::Connection,
+    account_uuid: &[u8],
+    txid: &[u8],
+) -> Result<Vec<TxOutput>, String> {
+    let mut stmt = conn
+        .prepare(
+            r#"
+        SELECT
+            txo.txid,
+            txo.output_pool,
+            txo.output_index,
+            txo.from_account_uuid,
+            txo.to_account_uuid,
+            txo.to_address,
+            (
+                SELECT a.key_scope
+                FROM accounts acc
+                JOIN addresses a ON a.account_id = acc.id
+                WHERE acc.uuid = txo.to_account_uuid
+                  AND (
+                      a.address = txo.to_address
+                      OR a.cached_transparent_receiver_address = txo.to_address
+                  )
+                LIMIT 1
+            ) AS to_key_scope,
+            txo.value,
+            txo.memo
+        FROM v_tx_outputs txo
+        WHERE txo.txid = ?2
+          AND (
+              txo.from_account_uuid = ?1
+              OR txo.to_account_uuid = ?1
+          )
+        "#,
+        )
+        .map_err(|e| format!("SQL error: {e}"))?;
+
+    let rows = stmt
+        .query_map(rusqlite::params![account_uuid, txid], |row| {
+            Ok(TxOutput {
+                txid: row.get(0)?,
+                output_pool: row.get(1)?,
+                output_index: row.get(2)?,
+                from_account_uuid: row.get(3)?,
+                to_account_uuid: row.get(4)?,
+                to_address: row.get(5)?,
+                to_key_scope: row.get(6)?,
+                value: row.get::<_, i64>(7)?.unsigned_abs(),
+                memo: row.get(8)?,
+            })
+        })
+        .map_err(|e| format!("Query error: {e}"))?;
+
+    rows.collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Row error: {e}"))
 }
 
 fn summarize_activity_outputs(
@@ -512,8 +709,37 @@ fn summarize_activity_outputs(
     summary
 }
 
+fn detail_includes_output(
+    base: &TxBase,
+    output: &TxOutput,
+    account_uuid: &[u8],
+    tx_kind: &str,
+) -> bool {
+    let from_own = output.from_account_uuid.as_deref() == Some(account_uuid);
+    let to_own = output.to_account_uuid.as_deref() == Some(account_uuid);
+
+    match tx_kind {
+        "shielded" => base.is_shielding && to_own && is_shielded_pool(output.output_pool),
+        "sent" => {
+            !base.is_shielding && from_own && (!to_own || is_user_visible_self_output(output))
+        }
+        "received" => {
+            !base.is_shielding && to_own && (!from_own || is_user_visible_self_output(output))
+        }
+        _ => false,
+    }
+}
+
 fn is_shielded_pool(output_pool: i64) -> bool {
     matches!(output_pool, 2 | 3)
+}
+
+fn output_pool_label(output_pool: i64) -> &'static str {
+    match output_pool {
+        0 => "transparent",
+        2 | 3 => "shielded",
+        _ => "unknown",
+    }
 }
 
 fn is_user_visible_self_output(output: &TxOutput) -> bool {
@@ -526,6 +752,22 @@ fn is_user_visible_self_output(output: &TxOutput) -> bool {
         // sent_notes. Wallet-internal change does not.
         2 | 3 => output.to_address.is_some() || matches!(output.to_key_scope, Some(0) | Some(-1)),
         _ => false,
+    }
+}
+
+fn decode_text_memo(memo: Option<&[u8]>) -> Option<String> {
+    let memo = memo?;
+    let memo_bytes = MemoBytes::from_bytes(memo).ok()?;
+    match Memo::try_from(&memo_bytes).ok()? {
+        Memo::Text(text) => {
+            let text = String::from(text);
+            if text.trim().is_empty() {
+                None
+            } else {
+                Some(text)
+            }
+        }
+        Memo::Empty | Memo::Future(_) | Memo::Arbitrary(_) => None,
     }
 }
 
@@ -939,7 +1181,8 @@ mod tests {
                  to_account_uuid BLOB,
                  to_address TEXT,
                  value INTEGER NOT NULL,
-                 is_change INTEGER NOT NULL
+                 is_change INTEGER NOT NULL,
+                 memo BLOB
              );",
         )
         .unwrap();
@@ -1036,6 +1279,33 @@ mod tests {
         to_address: Option<&str>,
         to_key_scope: Option<i64>,
     ) {
+        insert_output_with_address_and_memo(
+            db,
+            txid,
+            output_pool,
+            from_account,
+            to_account,
+            value,
+            is_change,
+            to_address,
+            to_key_scope,
+            None,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_output_with_address_and_memo(
+        db: &NamedTempFile,
+        txid: &[u8],
+        output_pool: i64,
+        from_account: Option<uuid::Uuid>,
+        to_account: Option<uuid::Uuid>,
+        value: i64,
+        is_change: bool,
+        to_address: Option<&str>,
+        to_key_scope: Option<i64>,
+        memo: Option<&[u8]>,
+    ) {
         let conn = rusqlite::Connection::open(db.path()).unwrap();
         if let Some(account) = from_account {
             ensure_account_row(&conn, account);
@@ -1066,8 +1336,8 @@ mod tests {
         conn.execute(
             "INSERT INTO v_tx_outputs (
                  txid, output_pool, output_index, from_account_uuid,
-                 to_account_uuid, to_address, value, is_change
-             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                 to_account_uuid, to_address, value, is_change, memo
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             rusqlite::params![
                 txid,
                 output_pool,
@@ -1077,6 +1347,7 @@ mod tests {
                 to_address,
                 value,
                 is_change,
+                memo,
             ],
         )
         .unwrap();
@@ -1458,6 +1729,257 @@ mod tests {
         assert_eq!(got[0].tx_kind, "shielded");
         assert_eq!(got[0].display_amount, 10_000_000);
         assert_eq!(got[0].display_pool, "shielded");
+    }
+
+    #[test]
+    fn detail_sent_row_returns_recipient_address_and_memo() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let txid = fake_txid(0xD1);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -1_010_000,
+            1_010_000,
+            0,
+            false,
+            Some("2026-04-28T17:00:00Z"),
+        );
+        insert_output_with_address_and_memo(
+            &db,
+            &txid,
+            3,
+            Some(account),
+            None,
+            1_000_000,
+            false,
+            Some("u-recipient"),
+            None,
+            Some(b"hello from activity"),
+        );
+
+        let got = get_transaction_detail(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            &account.to_string(),
+            &hex::encode(txid),
+            "sent",
+        )
+        .unwrap();
+
+        assert_eq!(got.txid_hex, hex::encode(txid));
+        assert_eq!(got.tx_kind, "sent");
+        assert_eq!(got.primary_address.as_deref(), Some("u-recipient"));
+        assert_eq!(got.memo.as_deref(), Some("hello from activity"));
+        assert_eq!(got.outputs.len(), 1);
+        assert_eq!(got.outputs[0].address.as_deref(), Some("u-recipient"));
+        assert_eq!(got.outputs[0].amount_zatoshi, 1_000_000);
+        assert_eq!(got.outputs[0].pool, "shielded");
+    }
+
+    #[test]
+    fn detail_received_row_does_not_invent_from_address() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let txid = fake_txid(0xD2);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            2_000_000,
+            0,
+            2_000_000,
+            false,
+            Some("2026-04-28T17:01:00Z"),
+        );
+        insert_output_with_address_and_memo(
+            &db,
+            &txid,
+            3,
+            None,
+            Some(account),
+            2_000_000,
+            false,
+            Some("u-my-receiver"),
+            Some(0),
+            Some(b"incoming memo"),
+        );
+
+        let got = get_transaction_detail(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            &account.to_string(),
+            &hex::encode(txid),
+            "received",
+        )
+        .unwrap();
+
+        assert_eq!(got.tx_kind, "received");
+        assert_eq!(got.primary_address, None);
+        assert_eq!(got.memo.as_deref(), Some("incoming memo"));
+        assert_eq!(got.outputs.len(), 1);
+        assert_eq!(got.outputs[0].address.as_deref(), Some("u-my-receiver"));
+    }
+
+    #[test]
+    fn detail_separates_same_account_self_send_by_kind() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let txid = fake_txid(0xD3);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -10_000,
+            1_010_000,
+            1_000_000,
+            false,
+            Some("2026-04-28T17:02:00Z"),
+        );
+        insert_output_with_address_and_memo(
+            &db,
+            &txid,
+            3,
+            Some(account),
+            Some(account),
+            1_000_000,
+            true,
+            Some("u-self"),
+            Some(0),
+            Some(b"self memo"),
+        );
+        insert_output(&db, &txid, 3, Some(account), Some(account), 500_000, true);
+
+        let sent = get_transaction_detail(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            &account.to_string(),
+            &hex::encode(txid),
+            "sent",
+        )
+        .unwrap();
+        let received = get_transaction_detail(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            &account.to_string(),
+            &hex::encode(txid),
+            "received",
+        )
+        .unwrap();
+
+        assert_eq!(sent.primary_address.as_deref(), Some("u-self"));
+        assert_eq!(sent.memo.as_deref(), Some("self memo"));
+        assert_eq!(sent.outputs.len(), 1);
+        assert_eq!(sent.outputs[0].amount_zatoshi, 1_000_000);
+        assert_eq!(received.primary_address, None);
+        assert_eq!(received.memo.as_deref(), Some("self memo"));
+        assert_eq!(received.outputs.len(), 1);
+        assert_eq!(received.outputs[0].amount_zatoshi, 1_000_000);
+    }
+
+    #[test]
+    fn detail_hides_change_only_outputs_and_empty_memos() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let txid = fake_txid(0xD4);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -10_000,
+            1_010_000,
+            1_000_000,
+            false,
+            Some("2026-04-28T17:03:00Z"),
+        );
+        insert_output_with_address_and_memo(
+            &db,
+            &txid,
+            3,
+            Some(account),
+            Some(account),
+            1_000_000,
+            true,
+            None,
+            None,
+            Some(&[0xF6]),
+        );
+
+        let got = get_transaction_detail(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            &account.to_string(),
+            &hex::encode(txid),
+            "sent",
+        )
+        .unwrap();
+
+        assert_eq!(got.primary_address, None);
+        assert_eq!(got.memo, None);
+        assert!(got.outputs.is_empty());
+    }
+
+    #[test]
+    fn detail_shielding_row_has_no_primary_address() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let txid = fake_txid(0xD5);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -10_000,
+            1_010_000,
+            1_000_000,
+            true,
+            Some("2026-04-28T17:04:00Z"),
+        );
+        insert_output_with_address(
+            &db,
+            &txid,
+            3,
+            Some(account),
+            Some(account),
+            1_000_000,
+            true,
+            Some("u-shielded-self"),
+            Some(0),
+        );
+
+        let got = get_transaction_detail(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            &account.to_string(),
+            &hex::encode(txid),
+            "shielded",
+        )
+        .unwrap();
+
+        assert_eq!(got.tx_kind, "shielded");
+        assert_eq!(got.primary_address, None);
+        assert_eq!(got.outputs.len(), 1);
+        assert_eq!(got.outputs[0].amount_zatoshi, 1_000_000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Replace internal activity rows with separate sent and received rows for user-visible same-account transfers.
- Keep shielding transactions as a single Shielded row and hide change-only mechanics.
- Add transaction detail loading for activity status screens, including recipient address and memo display when available.
- Preserve `txKind` in the activity transaction route so split rows remain distinguishable after route restoration.

## Why
Confirmed Sapling and Unified Address self-sends could disappear from activity after commit because change-only/internal classification depended on library metadata that differs by pool/address type. The activity feed now derives display rows from user-visible inputs and outputs instead of exposing an `internal` row concept.

## Validation
- `fvm flutter analyze`
- `fvm flutter test`
- `cd rust && cargo test wallet::sync::transactions`
- `git diff --check`