### PR TITLE
[codex] Match Sapling download modal to Figma

### DIFF
--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui' as ui;
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
@@ -15,6 +16,8 @@ import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
@@ -46,6 +49,8 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   String? _txid;
   late final DateTime _startedAt = DateTime.now();
   DateTime? _completedAt;
+  bool _showSaplingParamsPrompt = false;
+  Completer<bool>? _saplingParamsPromptCompleter;
 
   @override
   void initState() {
@@ -59,6 +64,11 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
 
   @override
   void dispose() {
+    final promptCompleter = _saplingParamsPromptCompleter;
+    _saplingParamsPromptCompleter = null;
+    if (promptCompleter != null && !promptCompleter.isCompleted) {
+      promptCompleter.complete(false);
+    }
     if (_phase != _SendStatusPhase.sending) {
       _scheduleDiscardIfNeeded();
     }
@@ -182,29 +192,31 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     return [address.substring(0, midpoint), address.substring(midpoint)];
   }
 
-  Future<bool> _showSaplingParamsDialog() async {
-    return await showDialog<bool>(
-          context: context,
-          builder: (context) => AlertDialog(
-            title: const Text('Download Required'),
-            content: const Text(
-              'This transaction uses Sapling shielded notes, which require '
-              'proving parameters (~50MB) to generate zero-knowledge proofs.\n\n'
-              'This is a one-time download. Network data charges may apply.',
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(false),
-                child: const Text('Cancel'),
-              ),
-              FilledButton(
-                onPressed: () => Navigator.of(context).pop(true),
-                child: const Text('Download'),
-              ),
-            ],
-          ),
-        ) ??
-        false;
+  Future<bool> _showSaplingParamsDialog() {
+    if (!mounted) return Future.value(false);
+
+    final existingCompleter = _saplingParamsPromptCompleter;
+    if (existingCompleter != null && !existingCompleter.isCompleted) {
+      return existingCompleter.future;
+    }
+
+    final completer = Completer<bool>();
+    setState(() {
+      _saplingParamsPromptCompleter = completer;
+      _showSaplingParamsPrompt = true;
+    });
+    return completer.future;
+  }
+
+  void _resolveSaplingParamsDialog(bool confirmed) {
+    final completer = _saplingParamsPromptCompleter;
+    if (completer == null || completer.isCompleted) return;
+
+    setState(() {
+      _showSaplingParamsPrompt = false;
+      _saplingParamsPromptCompleter = null;
+    });
+    completer.complete(confirmed);
   }
 
   Future<void> _downloadAndVerify(
@@ -537,9 +549,140 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
                   ),
                 ),
               ),
+              if (_showSaplingParamsPrompt)
+                Positioned.fill(
+                  child: _SaplingParamsPrompt(
+                    onDownload: () => _resolveSaplingParamsDialog(true),
+                    onCancel: () => _resolveSaplingParamsDialog(false),
+                  ),
+                ),
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _SaplingParamsPrompt extends StatelessWidget {
+  const _SaplingParamsPrompt({
+    required this.onDownload,
+    required this.onCancel,
+  });
+
+  final VoidCallback onDownload;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Material(
+      type: MaterialType.transparency,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: onCancel,
+              child: BackdropFilter(
+                filter: ui.ImageFilter.blur(sigmaX: 15, sigmaY: 15),
+                child: ColoredBox(color: colors.background.neutralScrim),
+              ),
+            ),
+          ),
+          Center(
+            child: Container(
+              width: 312,
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.sm,
+                AppSpacing.md,
+                AppSpacing.sm,
+                AppSpacing.md,
+              ),
+              decoration: BoxDecoration(
+                color: colors.background.ground,
+                borderRadius: BorderRadius.circular(AppRadii.large),
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    children: [
+                      Container(
+                        width: 32,
+                        height: 32,
+                        decoration: BoxDecoration(
+                          color: colors.background.neutralSubtleOpacity,
+                          shape: BoxShape.circle,
+                        ),
+                        child: Center(
+                          child: AppIcon(
+                            AppIcons.importWallet,
+                            size: AppIconSize.medium,
+                            color: colors.icon.regular,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.xs),
+                      Expanded(
+                        child: Text(
+                          'Download Required',
+                          style: AppTypography.bodyLarge.copyWith(
+                            color: colors.text.accent,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.xxs,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text(
+                          'This transaction uses Sapling shielded notes, '
+                          'which require proving parameters (~50MB) to '
+                          'generate zero-knowledge proofs.',
+                          style: AppTypography.bodyMedium.copyWith(
+                            color: colors.text.accent,
+                          ),
+                        ),
+                        const SizedBox(height: AppSpacing.xs),
+                        Text(
+                          'This is a one-time download.\n'
+                          'Network data charges may apply.',
+                          style: AppTypography.bodyMedium.copyWith(
+                            color: colors.text.secondary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  AppButton(
+                    onPressed: onDownload,
+                    minWidth: 280,
+                    child: const Text('Download'),
+                  ),
+                  const SizedBox(height: AppSpacing.s),
+                  AppButton(
+                    onPressed: onCancel,
+                    variant: AppButtonVariant.ghost,
+                    minWidth: 280,
+                    child: const Text('Cancel'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui' as ui;
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter/material.dart';
@@ -16,13 +15,12 @@ import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
-import '../../../core/widgets/app_button.dart';
-import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../../rust/api/wallet.dart' as rust_wallet;
 import '../../../services/keystone_transport.dart';
+import '../widgets/sapling_params_prompt.dart';
 import '../widgets/transaction_receipt_view.dart';
 import 'send_review_screen.dart';
 
@@ -551,7 +549,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
               ),
               if (_showSaplingParamsPrompt)
                 Positioned.fill(
-                  child: _SaplingParamsPrompt(
+                  child: SaplingParamsPrompt(
                     onDownload: () => _resolveSaplingParamsDialog(true),
                     onCancel: () => _resolveSaplingParamsDialog(false),
                   ),
@@ -559,130 +557,6 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
             ],
           ),
         ),
-      ),
-    );
-  }
-}
-
-class _SaplingParamsPrompt extends StatelessWidget {
-  const _SaplingParamsPrompt({
-    required this.onDownload,
-    required this.onCancel,
-  });
-
-  final VoidCallback onDownload;
-  final VoidCallback onCancel;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-
-    return Material(
-      type: MaterialType.transparency,
-      child: Stack(
-        fit: StackFit.expand,
-        children: [
-          Positioned.fill(
-            child: GestureDetector(
-              behavior: HitTestBehavior.opaque,
-              onTap: onCancel,
-              child: BackdropFilter(
-                filter: ui.ImageFilter.blur(sigmaX: 15, sigmaY: 15),
-                child: ColoredBox(color: colors.background.neutralScrim),
-              ),
-            ),
-          ),
-          Center(
-            child: Container(
-              width: 312,
-              padding: const EdgeInsets.fromLTRB(
-                AppSpacing.sm,
-                AppSpacing.md,
-                AppSpacing.sm,
-                AppSpacing.md,
-              ),
-              decoration: BoxDecoration(
-                color: colors.background.ground,
-                borderRadius: BorderRadius.circular(AppRadii.large),
-              ),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Row(
-                    children: [
-                      Container(
-                        width: 32,
-                        height: 32,
-                        decoration: BoxDecoration(
-                          color: colors.background.neutralSubtleOpacity,
-                          shape: BoxShape.circle,
-                        ),
-                        child: Center(
-                          child: AppIcon(
-                            AppIcons.importWallet,
-                            size: AppIconSize.medium,
-                            color: colors.icon.regular,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: AppSpacing.xs),
-                      Expanded(
-                        child: Text(
-                          'Download Required',
-                          style: AppTypography.bodyLarge.copyWith(
-                            color: colors.text.accent,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: AppSpacing.md),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: AppSpacing.xxs,
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Text(
-                          'This transaction uses Sapling shielded notes, '
-                          'which require proving parameters (~50MB) to '
-                          'generate zero-knowledge proofs.',
-                          style: AppTypography.bodyMedium.copyWith(
-                            color: colors.text.accent,
-                          ),
-                        ),
-                        const SizedBox(height: AppSpacing.xs),
-                        Text(
-                          'This is a one-time download.\n'
-                          'Network data charges may apply.',
-                          style: AppTypography.bodyMedium.copyWith(
-                            color: colors.text.secondary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  const SizedBox(height: AppSpacing.md),
-                  AppButton(
-                    onPressed: onDownload,
-                    minWidth: 280,
-                    child: const Text('Download'),
-                  ),
-                  const SizedBox(height: AppSpacing.s),
-                  AppButton(
-                    onPressed: onCancel,
-                    variant: AppButtonVariant.ghost,
-                    minWidth: 280,
-                    child: const Text('Cancel'),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ],
       ),
     );
   }

--- a/lib/src/features/send/widgets/sapling_params_prompt.dart
+++ b/lib/src/features/send/widgets/sapling_params_prompt.dart
@@ -1,0 +1,132 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+
+class SaplingParamsPrompt extends StatelessWidget {
+  const SaplingParamsPrompt({
+    required this.onDownload,
+    required this.onCancel,
+    super.key,
+  });
+
+  final VoidCallback onDownload;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Material(
+      type: MaterialType.transparency,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: onCancel,
+              child: BackdropFilter(
+                filter: ui.ImageFilter.blur(sigmaX: 15, sigmaY: 15),
+                child: ColoredBox(color: colors.background.neutralScrim),
+              ),
+            ),
+          ),
+          Center(
+            child: Container(
+              width: 312,
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.sm,
+                AppSpacing.md,
+                AppSpacing.sm,
+                AppSpacing.md,
+              ),
+              decoration: BoxDecoration(
+                color: colors.background.ground,
+                borderRadius: BorderRadius.circular(AppRadii.large),
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    children: [
+                      Container(
+                        width: 32,
+                        height: 32,
+                        decoration: BoxDecoration(
+                          color: colors.background.neutralSubtleOpacity,
+                          shape: BoxShape.circle,
+                        ),
+                        child: Center(
+                          child: AppIcon(
+                            AppIcons.importWallet,
+                            size: AppIconSize.medium,
+                            color: colors.icon.regular,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.xs),
+                      Expanded(
+                        child: Text(
+                          'Download Required',
+                          style: AppTypography.bodyLarge.copyWith(
+                            color: colors.text.accent,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.xxs,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text(
+                          'This transaction uses Sapling shielded notes, '
+                          'which require proving parameters (~50MB) to '
+                          'generate zero-knowledge proofs.',
+                          style: AppTypography.bodyMedium.copyWith(
+                            color: colors.text.accent,
+                          ),
+                        ),
+                        const SizedBox(height: AppSpacing.xs),
+                        Text(
+                          'This is a one-time download.\n'
+                          'Network data charges may apply.',
+                          style: AppTypography.bodyMedium.copyWith(
+                            color: colors.text.secondary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  AppButton(
+                    onPressed: onDownload,
+                    minWidth: 280,
+                    child: const Text('Download'),
+                  ),
+                  const SizedBox(height: AppSpacing.s),
+                  AppButton(
+                    onPressed: onCancel,
+                    variant: AppButtonVariant.ghost,
+                    minWidth: 280,
+                    child: const Text('Cancel'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Replace the Sapling params AlertDialog with a Figma-matched custom prompt overlay.
- Extract the prompt into a reusable send widget.

## Validation
- fvm dart analyze lib/src/features/send/screens/send_status_screen.dart lib/src/features/send/widgets/sapling_params_prompt.dart
- git merge-tree --write-tree origin/main HEAD