### PR TITLE
Consolidate ZEC amount formatting

### DIFF
--- a/lib/src/core/formatting/zec_amount.dart
+++ b/lib/src/core/formatting/zec_amount.dart
@@ -2,15 +2,27 @@ import 'package:flutter/services.dart';
 
 final BigInt zatoshiPerZec = BigInt.from(100000000);
 
-String formatZecAmount(BigInt zatoshi, {int minFractionDigits = 0}) {
+String _formatZecAmount(
+  BigInt zatoshi, {
+  int minFractionDigits = 0,
+  int maxFractionDigits = 8,
+  bool trimTrailingZeros = true,
+}) {
   assert(minFractionDigits >= 0 && minFractionDigits <= 8);
+  assert(maxFractionDigits >= 0 && maxFractionDigits <= 8);
+  assert(minFractionDigits <= maxFractionDigits);
 
   final sign = zatoshi < BigInt.zero ? '-' : '';
   final abs = zatoshi.abs();
   final whole = abs ~/ zatoshiPerZec;
   var fraction = (abs % zatoshiPerZec).toString().padLeft(8, '0');
 
-  fraction = fraction.replaceFirst(RegExp(r'0+$'), '');
+  if (maxFractionDigits < 8) {
+    fraction = fraction.substring(0, maxFractionDigits);
+  }
+  if (trimTrailingZeros) {
+    fraction = fraction.replaceFirst(RegExp(r'0+$'), '');
+  }
   if (fraction.length < minFractionDigits) {
     fraction = fraction.padRight(minFractionDigits, '0');
   }
@@ -18,7 +30,7 @@ String formatZecAmount(BigInt zatoshi, {int minFractionDigits = 0}) {
   return fraction.isEmpty ? '$sign$whole' : '$sign$whole.$fraction';
 }
 
-BigInt? parseZecAmount(String input) {
+BigInt? _parseZecAmount(String input) {
   var value = input.trim();
   if (value.isEmpty || value == '.' || value.contains(',')) return null;
   if (value.startsWith('.')) value = '0$value';
@@ -37,6 +49,126 @@ BigInt? parseZecAmount(String input) {
 }
 
 bool _digitsOnly(String value) => RegExp(r'^\d*$').hasMatch(value);
+
+/// Formats a raw zatoshi value as ZEC text without appending a denomination.
+String formatZecAmount(BigInt zatoshi, {int minFractionDigits = 0}) {
+  return _formatZecAmount(zatoshi, minFractionDigits: minFractionDigits);
+}
+
+/// Parses user-entered ZEC text into raw zatoshi, returning null when invalid.
+BigInt? parseZecAmount(String input) {
+  return ZecAmount.tryParse(input)?.zatoshi;
+}
+
+enum ZecDenomStyle { none, lower, upper }
+
+/// Typed wrapper for amounts stored in zatoshi, with UI-oriented ZEC presets.
+class ZecAmount {
+  const ZecAmount.fromZatoshi(this.zatoshi);
+
+  static ZecAmount? tryParse(String input) {
+    final zatoshi = _parseZecAmount(input);
+    if (zatoshi == null) return null;
+    return ZecAmount.fromZatoshi(zatoshi);
+  }
+
+  final BigInt zatoshi;
+
+  ZecAmountPretty pretty({
+    int minFractionDigits = 0,
+    int maxFractionDigits = 8,
+    ZecDenomStyle denomStyle = ZecDenomStyle.none,
+    bool signed = false,
+  }) {
+    return ZecAmountPretty._(
+      zatoshi,
+      minFractionDigits: minFractionDigits,
+      maxFractionDigits: maxFractionDigits,
+      denomStyle: denomStyle,
+      signed: signed,
+      trimTrailingZeros: true,
+    );
+  }
+
+  ZecAmountPretty get balance => pretty(minFractionDigits: 2);
+
+  ZecAmountPretty get receipt =>
+      pretty(minFractionDigits: 2, denomStyle: ZecDenomStyle.lower);
+
+  ZecAmountPretty get fee => pretty(denomStyle: ZecDenomStyle.upper);
+
+  ZecAmountPretty get activity => _activity(signed: false);
+
+  ZecAmountPretty get signedActivity => _activity(signed: true);
+
+  ZecAmountPretty _activity({required bool signed}) {
+    final abs = zatoshi.abs();
+    final whole = abs ~/ zatoshiPerZec;
+    final fraction = abs % zatoshiPerZec;
+    // Activity rows show extra precision for non-zero values below 0.01 ZEC.
+    final showFullFraction =
+        whole == BigInt.zero &&
+        fraction > BigInt.zero &&
+        fraction < BigInt.from(1000000);
+
+    return ZecAmountPretty._(
+      signed ? zatoshi : abs,
+      minFractionDigits: showFullFraction ? 0 : 2,
+      maxFractionDigits: showFullFraction ? 8 : 2,
+      denomStyle: ZecDenomStyle.lower,
+      signed: signed,
+      trimTrailingZeros: showFullFraction,
+    );
+  }
+}
+
+/// Immutable formatted ZEC amount; call [toString] for amount plus denom.
+class ZecAmountPretty {
+  const ZecAmountPretty._(
+    this._zatoshi, {
+    required int minFractionDigits,
+    required int maxFractionDigits,
+    required ZecDenomStyle denomStyle,
+    required bool signed,
+    required bool trimTrailingZeros,
+  }) : _minFractionDigits = minFractionDigits,
+       _maxFractionDigits = maxFractionDigits,
+       _denomStyle = denomStyle,
+       _signed = signed,
+       _trimTrailingZeros = trimTrailingZeros;
+
+  final BigInt _zatoshi;
+  final int _minFractionDigits;
+  final int _maxFractionDigits;
+  final ZecDenomStyle _denomStyle;
+  final bool _signed;
+  final bool _trimTrailingZeros;
+
+  String get amountText {
+    final value = _formatZecAmount(
+      _zatoshi,
+      minFractionDigits: _minFractionDigits,
+      maxFractionDigits: _maxFractionDigits,
+      trimTrailingZeros: _trimTrailingZeros,
+    );
+    if (!_signed) return value;
+    return _zatoshi > BigInt.zero ? '+$value' : value;
+  }
+
+  String get denomText {
+    return switch (_denomStyle) {
+      ZecDenomStyle.none => '',
+      ZecDenomStyle.lower => 'zec',
+      ZecDenomStyle.upper => 'ZEC',
+    };
+  }
+
+  @override
+  String toString() {
+    if (_denomStyle == ZecDenomStyle.none) return amountText;
+    return '$amountText $denomText';
+  }
+}
 
 class ZecAmountInputFormatter extends TextInputFormatter {
   const ZecAmountInputFormatter();

--- a/lib/src/core/formatting/zec_amount.dart
+++ b/lib/src/core/formatting/zec_amount.dart
@@ -115,7 +115,7 @@ class ZecAmount {
       signed ? zatoshi : abs,
       minFractionDigits: showFullFraction ? 0 : 2,
       maxFractionDigits: showFullFraction ? 8 : 2,
-      denomStyle: ZecDenomStyle.lower,
+      denomStyle: ZecDenomStyle.upper,
       signed: signed,
       trimTrailingZeros: showFullFraction,
     );

--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 
+import '../../core/formatting/zec_amount.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/widgets/app_icon.dart';
 import '../../providers/sync_provider.dart';
@@ -73,7 +74,7 @@ ActivityRowData buildSyncActivityRow({
     leadingIconName: AppIcons.sync,
     leadingBackgroundColor: colors.background.neutralSubtleOpacity,
     leadingIconColor: colors.icon.regular,
-    amountText: formatActivityZec(sync.totalBalance),
+    amountText: ZecAmount.fromZatoshi(sync.totalBalance).activity.toString(),
     amountColor: colors.text.accent,
     statusText: 'Completed',
     statusColor: colors.text.secondary,
@@ -155,24 +156,9 @@ String _transactionAmountText({
 }) {
   if (amount == BigInt.zero) return '--';
   if (isFailed || isShielded) {
-    return formatActivityZec(amount);
+    return ZecAmount.fromZatoshi(amount).activity.toString();
   }
-  return formatSignedActivityZec(signedAmount);
-}
-
-String formatActivityZec(BigInt zatoshi) {
-  final abs = zatoshi.abs();
-  final whole = abs ~/ BigInt.from(100000000);
-  final frac = (abs % BigInt.from(100000000)).toString().padLeft(8, '0');
-  final digits = whole == BigInt.zero && int.parse(frac) < 1000000
-      ? frac
-      : frac.substring(0, 2);
-  return '$whole.$digits ZEC';
-}
-
-String formatSignedActivityZec(BigInt zatoshi) {
-  final sign = zatoshi >= BigInt.zero ? '+' : '-';
-  return '$sign${formatActivityZec(zatoshi)}';
+  return ZecAmount.fromZatoshi(signedAmount).signedActivity.toString();
 }
 
 String formatActivityTimestamp(DateTime? timestamp) {

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
@@ -17,7 +18,6 @@ import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../send/widgets/transaction_receipt_view.dart';
-import '../activity_row_mapper.dart';
 
 class ActivityTransactionStatusArgs {
   const ActivityTransactionStatusArgs({
@@ -237,7 +237,7 @@ class _ActivityTransactionStatusScreenState
   String _amountText(rust_sync.TransactionInfo? tx) {
     if (tx == null) return '--';
     if (tx.displayAmount == BigInt.zero) return '--';
-    return formatActivityZec(tx.displayAmount);
+    return ZecAmount.fromZatoshi(tx.displayAmount).activity.toString();
   }
 
   String _dateText(rust_sync.TransactionInfo? tx) {
@@ -251,17 +251,7 @@ class _ActivityTransactionStatusScreenState
 
   String _feeText(rust_sync.TransactionInfo? tx) {
     if (tx == null || tx.fee <= BigInt.zero) return '--';
-    return '${_formatZec(tx.fee)} ZEC';
-  }
-
-  String _formatZec(BigInt zatoshi) {
-    final whole = zatoshi ~/ BigInt.from(100000000);
-    var fraction = (zatoshi % BigInt.from(100000000)).toString().padLeft(
-      8,
-      '0',
-    );
-    fraction = fraction.replaceFirst(RegExp(r'0+$'), '');
-    return fraction.isEmpty ? '$whole' : '$whole.$fraction';
+    return ZecAmount.fromZatoshi(tx.fee).fee.toString();
   }
 
   String _formatDate(DateTime value) {

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -61,7 +61,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   String _formatZec(BigInt zatoshi) {
-    return formatZecAmount(zatoshi, minFractionDigits: 2);
+    return ZecAmount.fromZatoshi(zatoshi).balance.amountText;
   }
 
   void _toggleBalanceVisibility() {

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -89,11 +89,11 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   }
 
   String _formatReceiptAmount(BigInt zatoshi) {
-    return '${formatZecAmount(zatoshi, minFractionDigits: 2)} zec';
+    return ZecAmount.fromZatoshi(zatoshi).receipt.toString();
   }
 
   String _formatFee(BigInt zatoshi) {
-    return formatZecAmount(zatoshi);
+    return ZecAmount.fromZatoshi(zatoshi).pretty().amountText;
   }
 
   List<TextSpan> _addressSpans(BuildContext context, String line) {

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -356,7 +356,9 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         return;
       }
 
-      final amountText = formatZecAmount(estimate.amountZatoshi);
+      final amountText = ZecAmount.fromZatoshi(
+        estimate.amountZatoshi,
+      ).pretty().amountText;
       _programmaticAmountEdit = true;
       _amountController.value = TextEditingValue(
         text: amountText,
@@ -448,10 +450,9 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
 
       final totalNeeded = zatoshi + fee;
       if (totalNeeded > spendable) {
-        final feeZec = formatZecAmount(fee);
+        final feeText = ZecAmount.fromZatoshi(fee).fee.toString();
         setState(
-          () =>
-              _amountError = 'Insufficient shielded balance (fee: $feeZec ZEC)',
+          () => _amountError = 'Insufficient shielded balance (fee: $feeText)',
         );
       } else {
         setState(() => _amountError = null);
@@ -624,6 +625,9 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   @override
   Widget build(BuildContext context) {
     final spendable = widget.spendableBalance;
+    final spendableText = ZecAmount.fromZatoshi(
+      spendable,
+    ).pretty(denomStyle: ZecDenomStyle.upper).toString();
     final colors = context.colors;
 
     final addressTone = switch (_addressType) {
@@ -791,7 +795,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                                                       ? null
                                                       : _activateMaxMode,
                                                   child: Text(
-                                                    'Max: ${formatZecAmount(spendable)} ZEC',
+                                                    'Max: $spendableText',
                                                     style: AppTypography
                                                         .labelMedium
                                                         .copyWith(

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -121,11 +121,11 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   }
 
   String _formatReceiptAmount(BigInt zatoshi) {
-    return '${formatZecAmount(zatoshi, minFractionDigits: 2)} zec';
+    return ZecAmount.fromZatoshi(zatoshi).receipt.toString();
   }
 
   String _formatFee(BigInt zatoshi) {
-    return formatZecAmount(zatoshi);
+    return ZecAmount.fromZatoshi(zatoshi).pretty().amountText;
   }
 
   String _formatDate(DateTime value) {

--- a/test/activity_table_row_test.dart
+++ b/test/activity_table_row_test.dart
@@ -4,8 +4,11 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/features/activity/activity_row_mapper.dart';
 import 'package:zcash_wallet/src/features/activity/models/activity_row_data.dart';
 import 'package:zcash_wallet/src/features/activity/widgets/activity_table.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 void main() {
   testWidgets('transaction rows are keyboard activatable but sync row is not', (
@@ -47,6 +50,74 @@ void main() {
     await tester.pump();
     expect(txActivations, 2);
   });
+
+  testWidgets('activity rows render manipulated zatoshi values', (
+    tester,
+  ) async {
+    late final List<ActivityRowData> rows;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: Builder(
+            builder: (context) {
+              rows = buildActivityRows(
+                context: context,
+                sync: SyncState(totalBalance: BigInt.from(10000)),
+                transactions: [
+                  _tx(
+                    txidHex: 'received',
+                    kind: 'received',
+                    amount: BigInt.from(123450000),
+                  ),
+                  _tx(
+                    txidHex: 'sent',
+                    kind: 'sent',
+                    amount: BigInt.from(100000000),
+                  ),
+                  _tx(
+                    txidHex: 'shielded',
+                    kind: 'shielded',
+                    amount: BigInt.from(10000),
+                  ),
+                ],
+              );
+              return ActivityTable(rows: rows);
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(rows[0].amountText, '0.0001 ZEC');
+    expect(rows[1].amountText, '+1.23 ZEC');
+    expect(rows[2].amountText, '-1.00 ZEC');
+    expect(rows[3].amountText, '0.0001 ZEC');
+    expect(find.text('0.0001 ZEC'), findsNWidgets(2));
+    expect(find.text('+1.23 ZEC'), findsOneWidget);
+    expect(find.text('-1.00 ZEC'), findsOneWidget);
+  });
+}
+
+rust_sync.TransactionInfo _tx({
+  required String txidHex,
+  required String kind,
+  required BigInt amount,
+}) {
+  return rust_sync.TransactionInfo(
+    txidHex: txidHex,
+    minedHeight: BigInt.one,
+    expiredUnmined: false,
+    accountBalanceDelta: 0,
+    fee: BigInt.zero,
+    blockTime: BigInt.from(1800000000),
+    isTransparent: false,
+    txKind: kind,
+    displayAmount: amount,
+    displayPool: 'shielded',
+    createdTime: BigInt.from(1800000000),
+  );
 }
 
 ActivityRowData _row({

--- a/test/zec_amount_test.dart
+++ b/test/zec_amount_test.dart
@@ -63,29 +63,29 @@ void main() {
     test('preserves existing activity precision rules', () {
       expect(
         ZecAmount.fromZatoshi(BigInt.from(123450000)).activity.toString(),
-        '1.23 zec',
+        '1.23 ZEC',
       );
       expect(
         ZecAmount.fromZatoshi(BigInt.from(10000)).activity.toString(),
-        '0.0001 zec',
+        '0.0001 ZEC',
       );
       expect(
         ZecAmount.fromZatoshi(BigInt.zero).activity.toString(),
-        '0.00 zec',
+        '0.00 ZEC',
       );
       expect(
         ZecAmount.fromZatoshi(-BigInt.from(100000000)).activity.toString(),
-        '1.00 zec',
+        '1.00 ZEC',
       );
       expect(
         ZecAmount.fromZatoshi(
           -BigInt.from(100000000),
         ).signedActivity.toString(),
-        '-1.00 zec',
+        '-1.00 ZEC',
       );
       expect(
         ZecAmount.fromZatoshi(BigInt.zero).signedActivity.toString(),
-        '0.00 zec',
+        '0.00 ZEC',
       );
     });
   });

--- a/test/zec_amount_test.dart
+++ b/test/zec_amount_test.dart
@@ -3,6 +3,22 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/formatting/zec_amount.dart';
 
 void main() {
+  group('ZecAmount.tryParse', () {
+    test('parses canonical period-separated amounts', () {
+      expect(ZecAmount.tryParse('0.01')?.zatoshi, BigInt.from(1000000));
+      expect(ZecAmount.tryParse('.01')?.zatoshi, BigInt.from(1000000));
+      expect(ZecAmount.tryParse('1.')?.zatoshi, BigInt.from(100000000));
+      expect(ZecAmount.tryParse('0.00000001')?.zatoshi, BigInt.one);
+    });
+
+    test('rejects commas and non-canonical decimals', () {
+      expect(ZecAmount.tryParse('0,01'), isNull);
+      expect(ZecAmount.tryParse('1,2.3'), isNull);
+      expect(ZecAmount.tryParse('1.2.3'), isNull);
+      expect(ZecAmount.tryParse('0.000000001'), isNull);
+    });
+  });
+
   group('formatZecAmount', () {
     test('uses a period as the decimal separator', () {
       expect(
@@ -21,19 +37,56 @@ void main() {
     });
   });
 
-  group('parseZecAmount', () {
-    test('parses canonical period-separated amounts', () {
-      expect(parseZecAmount('0.01'), BigInt.from(1000000));
-      expect(parseZecAmount('.01'), BigInt.from(1000000));
-      expect(parseZecAmount('1.'), BigInt.from(100000000));
-      expect(parseZecAmount('0.00000001'), BigInt.one);
+  group('ZecAmountPretty', () {
+    test('formats balance and receipt presets with existing precision', () {
+      expect(
+        ZecAmount.fromZatoshi(BigInt.from(100000000)).balance.amountText,
+        '1.00',
+      );
+      expect(
+        ZecAmount.fromZatoshi(BigInt.from(100000000)).receipt.toString(),
+        '1.00 zec',
+      );
+      expect(
+        ZecAmount.fromZatoshi(BigInt.one).balance.amountText,
+        '0.00000001',
+      );
     });
 
-    test('rejects commas and non-canonical decimals', () {
-      expect(parseZecAmount('0,01'), isNull);
-      expect(parseZecAmount('1,2.3'), isNull);
-      expect(parseZecAmount('1.2.3'), isNull);
-      expect(parseZecAmount('0.000000001'), isNull);
+    test('formats fee preset with upper-case denom', () {
+      expect(
+        ZecAmount.fromZatoshi(BigInt.from(10000)).fee.toString(),
+        '0.0001 ZEC',
+      );
+    });
+
+    test('preserves existing activity precision rules', () {
+      expect(
+        ZecAmount.fromZatoshi(BigInt.from(123450000)).activity.toString(),
+        '1.23 zec',
+      );
+      expect(
+        ZecAmount.fromZatoshi(BigInt.from(10000)).activity.toString(),
+        '0.0001 zec',
+      );
+      expect(
+        ZecAmount.fromZatoshi(BigInt.zero).activity.toString(),
+        '0.00 zec',
+      );
+      expect(
+        ZecAmount.fromZatoshi(-BigInt.from(100000000)).activity.toString(),
+        '1.00 zec',
+      );
+      expect(
+        ZecAmount.fromZatoshi(
+          -BigInt.from(100000000),
+        ).signedActivity.toString(),
+        '-1.00 zec',
+      );
+      expect(
+        ZecAmount.fromZatoshi(BigInt.zero).signedActivity.toString(),
+        '0.00 zec',
+      );
     });
   });
 
@@ -50,7 +103,7 @@ void main() {
       );
 
       expect(value.text, '0.01');
-      expect(parseZecAmount(value.text), BigInt.from(1000000));
+      expect(ZecAmount.tryParse(value.text)?.zatoshi, BigInt.from(1000000));
     });
 
     test('rejects invalid characters and ambiguous separators', () {


### PR DESCRIPTION
Summary:
- Add a typed ZecAmount/ZecAmountPretty formatter for zatoshi-to-ZEC display.
- Migrate balance, send, fee, and activity amount displays to the shared formatter.
- Keep activity and fee denominations uppercase where the UI expects ZEC.

Tests:
- fvm dart analyze lib test
- fvm flutter test