### PR TITLE
Add RPC endpoint latency checks

### DIFF
--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -62,8 +62,8 @@ class RpcEndpointPreset {
   String get hostPort => rpcEndpointHostPort(url);
 }
 
-// Mirrors the current zodl-android lightwalletd candidate list while keeping
-// this app's existing zec.rocks default unchanged.
+// Additional regional lightwalletd presets while keeping this app's existing
+// zec.rocks default unchanged.
 final kMainnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
   RpcEndpointPreset(
     id: kDefaultRpcEndpointPresetId,

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -50,7 +50,6 @@ class RpcEndpointPreset {
     required this.region,
     required this.label,
     required this.url,
-    this.latencyLabel,
     this.isDefault = false,
   });
 
@@ -58,41 +57,68 @@ class RpcEndpointPreset {
   final String region;
   final String label;
   final String url;
-  final String? latencyLabel;
   final bool isDefault;
 
   String get hostPort => rpcEndpointHostPort(url);
 }
 
+// Mirrors the current zodl-android lightwalletd candidate list while keeping
+// this app's existing zec.rocks default unchanged.
 final kMainnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
   RpcEndpointPreset(
     id: kDefaultRpcEndpointPresetId,
     region: 'Default',
     label: 'Zec Rocks',
     url: ZcashNetwork.mainnet.lightwalletdUrl,
-    latencyLabel: 'Default',
     isDefault: true,
+  ),
+  const RpcEndpointPreset(
+    id: 'us-zec-stardust',
+    region: 'Americas',
+    label: 'Stardust US',
+    url: 'https://us.zec.stardust.rest:443',
+  ),
+  const RpcEndpointPreset(
+    id: 'eu-zec-stardust',
+    region: 'Europe',
+    label: 'Stardust Europe',
+    url: 'https://eu.zec.stardust.rest:443',
+  ),
+  const RpcEndpointPreset(
+    id: 'eu2-zec-stardust',
+    region: 'Europe',
+    label: 'Stardust Europe 2',
+    url: 'https://eu2.zec.stardust.rest:443',
+  ),
+  const RpcEndpointPreset(
+    id: 'jp-zec-stardust',
+    region: 'Asia Pacific',
+    label: 'Stardust Japan',
+    url: 'https://jp.zec.stardust.rest:443',
   ),
   const RpcEndpointPreset(
     id: 'na-zec-rocks',
     region: 'Americas',
     label: 'Zec Rocks North America',
     url: 'https://na.zec.rocks:443',
-    latencyLabel: '75ms',
+  ),
+  const RpcEndpointPreset(
+    id: 'sa-zec-rocks',
+    region: 'Americas',
+    label: 'Zec Rocks South America',
+    url: 'https://sa.zec.rocks:443',
   ),
   const RpcEndpointPreset(
     id: 'eu-zec-rocks',
     region: 'Europe',
     label: 'Zec Rocks Europe',
     url: 'https://eu.zec.rocks:443',
-    latencyLabel: '160ms',
   ),
   const RpcEndpointPreset(
     id: 'ap-zec-rocks',
     region: 'Asia Pacific',
     label: 'Zec Rocks Asia Pacific',
     url: 'https://ap.zec.rocks:443',
-    latencyLabel: '240ms',
   ),
 ]);
 
@@ -102,7 +128,6 @@ final kTestnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
     region: 'Testnet',
     label: 'Zec Rocks Testnet',
     url: 'https://testnet.zec.rocks:443',
-    latencyLabel: 'Default',
     isDefault: true,
   ),
 ]);

--- a/lib/src/features/settings/screens/settings_endpoint_screen.dart
+++ b/lib/src/features/settings/screens/settings_endpoint_screen.dart
@@ -13,6 +13,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_text_field.dart';
+import '../../../providers/rpc_endpoint_latency_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 
@@ -38,6 +39,12 @@ class _SettingsEndpointScreenState
   void initState() {
     super.initState();
     final endpoint = ref.read(rpcEndpointProvider);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref
+          .read(rpcEndpointLatencyProvider.notifier)
+          .refresh(endpoint.networkName);
+    });
     final currentPreset = findRpcEndpointPresetByUrl(
       endpoint.normalizedLightwalletdUrl,
       networkName: endpoint.networkName,
@@ -143,6 +150,7 @@ class _SettingsEndpointScreenState
       await ref.read(syncProvider.notifier).restartSync();
       if (!mounted) return;
       final next = ref.read(rpcEndpointProvider);
+      ref.read(rpcEndpointLatencyProvider.notifier).refresh(next.networkName);
       setState(() {
         _selectedPresetId = findRpcEndpointPresetByUrl(
           next.normalizedLightwalletdUrl,
@@ -173,6 +181,7 @@ class _SettingsEndpointScreenState
   @override
   Widget build(BuildContext context) {
     final current = ref.watch(rpcEndpointProvider);
+    final latencyState = ref.watch(rpcEndpointLatencyProvider);
 
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
@@ -180,6 +189,7 @@ class _SettingsEndpointScreenState
         padding: const EdgeInsets.all(AppSpacing.md),
         child: _SettingsEndpointPane(
           current: current,
+          latencyState: latencyState,
           activeTab: _activeTab,
           selectedPresetId: _selectedPresetId,
           customController: _customController,
@@ -203,6 +213,7 @@ class _SettingsEndpointScreenState
 class _SettingsEndpointPane extends StatelessWidget {
   const _SettingsEndpointPane({
     required this.current,
+    required this.latencyState,
     required this.activeTab,
     required this.selectedPresetId,
     required this.customController,
@@ -218,6 +229,7 @@ class _SettingsEndpointPane extends StatelessWidget {
   });
 
   final RpcEndpointConfig current;
+  final RpcEndpointLatencyState latencyState;
   final _EndpointTab activeTab;
   final String? selectedPresetId;
   final TextEditingController customController;
@@ -260,11 +272,15 @@ class _SettingsEndpointPane extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: AppSpacing.xs),
-                  _CurrentEndpointText(current: current),
+                  _CurrentEndpointText(
+                    current: current,
+                    latencyState: latencyState,
+                  ),
                   const SizedBox(height: AppSpacing.sm),
                   _EndpointSelector(
                     width: _widgetWidth,
                     current: current,
+                    latencyState: latencyState,
                     activeTab: activeTab,
                     selectedPresetId: selectedPresetId,
                     customController: customController,
@@ -306,9 +322,13 @@ class _SettingsEndpointPane extends StatelessWidget {
 }
 
 class _CurrentEndpointText extends StatelessWidget {
-  const _CurrentEndpointText({required this.current});
+  const _CurrentEndpointText({
+    required this.current,
+    required this.latencyState,
+  });
 
   final RpcEndpointConfig current;
+  final RpcEndpointLatencyState latencyState;
 
   @override
   Widget build(BuildContext context) {
@@ -317,8 +337,11 @@ class _CurrentEndpointText extends StatelessWidget {
       current.normalizedLightwalletdUrl,
       networkName: current.networkName,
     );
+    final latency = latencyState.sampleForUrl(
+      current.normalizedLightwalletdUrl,
+    );
     final suffix = [
-      if (preset?.latencyLabel != null) preset!.latencyLabel!,
+      if (latency != null) latency.label,
       if (preset?.isDefault ?? false) '(Default)',
     ].join(' ');
 
@@ -343,6 +366,7 @@ class _EndpointSelector extends StatelessWidget {
   const _EndpointSelector({
     required this.width,
     required this.current,
+    required this.latencyState,
     required this.activeTab,
     required this.selectedPresetId,
     required this.customController,
@@ -355,6 +379,7 @@ class _EndpointSelector extends StatelessWidget {
 
   final double width;
   final RpcEndpointConfig current;
+  final RpcEndpointLatencyState latencyState;
   final _EndpointTab activeTab;
   final String? selectedPresetId;
   final TextEditingController customController;
@@ -394,6 +419,7 @@ class _EndpointSelector extends StatelessWidget {
               child: switch (activeTab) {
                 _EndpointTab.list => _PresetList(
                   networkName: current.networkName,
+                  latencyState: latencyState,
                   selectedPresetId: selectedPresetId,
                   onSelect: onSelectPreset,
                 ),
@@ -490,11 +516,13 @@ class _EndpointTabButton extends StatelessWidget {
 class _PresetList extends StatefulWidget {
   const _PresetList({
     required this.networkName,
+    required this.latencyState,
     required this.selectedPresetId,
     required this.onSelect,
   });
 
   final String networkName;
+  final RpcEndpointLatencyState latencyState;
   final String? selectedPresetId;
   final ValueChanged<String> onSelect;
 
@@ -548,6 +576,7 @@ class _PresetListState extends State<_PresetList> {
                 for (final preset in entry.value) ...[
                   _PresetCard(
                     preset: preset,
+                    latency: widget.latencyState.sampleForUrl(preset.url),
                     selected: preset.id == widget.selectedPresetId,
                     onTap: () => widget.onSelect(preset.id),
                   ),
@@ -585,11 +614,13 @@ class _PresetRegionLabel extends StatelessWidget {
 class _PresetCard extends StatelessWidget {
   const _PresetCard({
     required this.preset,
+    required this.latency,
     required this.selected,
     required this.onTap,
   });
 
   final RpcEndpointPreset preset;
+  final RpcEndpointLatencySample? latency;
   final bool selected;
   final VoidCallback onTap;
 
@@ -627,9 +658,9 @@ class _PresetCard extends StatelessWidget {
                         color: colors.text.accent,
                       ),
                     ),
-                    if (preset.latencyLabel != null)
+                    if (latency != null)
                       Text(
-                        preset.latencyLabel!,
+                        latency!.label,
                         overflow: TextOverflow.ellipsis,
                         style: AppTypography.labelMedium.copyWith(
                           color: colors.text.secondary,

--- a/lib/src/providers/rpc_endpoint_latency_provider.dart
+++ b/lib/src/providers/rpc_endpoint_latency_provider.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/config/rpc_endpoint_config.dart';
+import '../rust/api/wallet.dart' as rust_wallet;
+
+typedef RpcEndpointChainNameGetter =
+    Future<String> Function(String lightwalletdUrl);
+
+enum RpcEndpointLatencyStatus { checking, available, unavailable, wrongNetwork }
+
+class RpcEndpointLatencySample {
+  const RpcEndpointLatencySample._({required this.status, this.latency});
+
+  const RpcEndpointLatencySample.checking()
+    : this._(status: RpcEndpointLatencyStatus.checking);
+
+  const RpcEndpointLatencySample.available(Duration latency)
+    : this._(status: RpcEndpointLatencyStatus.available, latency: latency);
+
+  const RpcEndpointLatencySample.unavailable()
+    : this._(status: RpcEndpointLatencyStatus.unavailable);
+
+  const RpcEndpointLatencySample.wrongNetwork()
+    : this._(status: RpcEndpointLatencyStatus.wrongNetwork);
+
+  final RpcEndpointLatencyStatus status;
+  final Duration? latency;
+
+  String get label {
+    return switch (status) {
+      RpcEndpointLatencyStatus.checking => 'Checking...',
+      RpcEndpointLatencyStatus.available => '${latency!.inMilliseconds}ms',
+      RpcEndpointLatencyStatus.unavailable => 'Unavailable',
+      RpcEndpointLatencyStatus.wrongNetwork => 'Wrong network',
+    };
+  }
+}
+
+class RpcEndpointLatencyState {
+  const RpcEndpointLatencyState({this.samples = const {}});
+
+  final Map<String, RpcEndpointLatencySample> samples;
+
+  RpcEndpointLatencySample? sampleForUrl(String url) {
+    final normalized = normalizeRpcEndpointUrl(url, allowDefaultPort: true);
+    return samples[normalized];
+  }
+
+  RpcEndpointLatencyState copyWithSample(
+    String url,
+    RpcEndpointLatencySample sample,
+  ) {
+    final normalized = normalizeRpcEndpointUrl(url, allowDefaultPort: true);
+    return RpcEndpointLatencyState(samples: {...samples, normalized: sample});
+  }
+}
+
+Future<RpcEndpointLatencySample> measureRpcEndpointLatency({
+  required String lightwalletdUrl,
+  required String expectedNetworkName,
+  required RpcEndpointChainNameGetter getChainName,
+  DateTime Function() now = DateTime.now,
+}) async {
+  // Use the same lightwalletd chain-info call as endpoint saving so the
+  // displayed latency reflects a real gRPC/TLS response, not only TCP reachability.
+  final startedAt = now();
+  try {
+    final chainName = await getChainName(lightwalletdUrl);
+    final elapsed = now().difference(startedAt);
+    if (chainName != expectedNetworkName) {
+      return const RpcEndpointLatencySample.wrongNetwork();
+    }
+    return RpcEndpointLatencySample.available(elapsed);
+  } catch (_) {
+    return const RpcEndpointLatencySample.unavailable();
+  }
+}
+
+final rpcEndpointChainNameGetterProvider = Provider<RpcEndpointChainNameGetter>(
+  (ref) =>
+      (lightwalletdUrl) => rust_wallet.getLightwalletdChainName(
+        lightwalletdUrl: lightwalletdUrl,
+      ),
+);
+
+class RpcEndpointLatencyNotifier extends Notifier<RpcEndpointLatencyState> {
+  var _generation = 0;
+
+  @override
+  RpcEndpointLatencyState build() => const RpcEndpointLatencyState();
+
+  Future<void> refresh(String networkName) async {
+    final generation = ++_generation;
+    final presets = rpcEndpointPresetsForNetwork(networkName);
+    final getChainName = ref.read(rpcEndpointChainNameGetterProvider);
+
+    var nextState = state;
+    for (final preset in presets) {
+      nextState = nextState.copyWithSample(
+        preset.url,
+        const RpcEndpointLatencySample.checking(),
+      );
+    }
+    state = nextState;
+
+    await Future.wait([
+      for (final preset in presets)
+        _measurePreset(
+          preset: preset,
+          networkName: networkName,
+          getChainName: getChainName,
+          generation: generation,
+        ),
+    ]);
+  }
+
+  Future<void> _measurePreset({
+    required RpcEndpointPreset preset,
+    required String networkName,
+    required RpcEndpointChainNameGetter getChainName,
+    required int generation,
+  }) async {
+    final sample = await measureRpcEndpointLatency(
+      lightwalletdUrl: normalizeRpcEndpointUrl(
+        preset.url,
+        allowDefaultPort: true,
+      ),
+      expectedNetworkName: networkName,
+      getChainName: getChainName,
+    );
+    if (generation != _generation) return;
+    state = state.copyWithSample(preset.url, sample);
+  }
+}
+
+final rpcEndpointLatencyProvider =
+    NotifierProvider<RpcEndpointLatencyNotifier, RpcEndpointLatencyState>(
+      RpcEndpointLatencyNotifier.new,
+    );

--- a/lib/src/providers/rpc_endpoint_latency_provider.dart
+++ b/lib/src/providers/rpc_endpoint_latency_provider.dart
@@ -120,16 +120,17 @@ class RpcEndpointLatencyNotifier extends Notifier<RpcEndpointLatencyState> {
     required RpcEndpointChainNameGetter getChainName,
     required int generation,
   }) async {
+    final normalizedUrl = normalizeRpcEndpointUrl(
+      preset.url,
+      allowDefaultPort: true,
+    );
     final sample = await measureRpcEndpointLatency(
-      lightwalletdUrl: normalizeRpcEndpointUrl(
-        preset.url,
-        allowDefaultPort: true,
-      ),
+      lightwalletdUrl: normalizedUrl,
       expectedNetworkName: networkName,
       getChainName: getChainName,
     );
     if (generation != _generation) return;
-    state = state.copyWithSample(preset.url, sample);
+    state = state.copyWithSample(normalizedUrl, sample);
   }
 }
 

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -57,7 +57,7 @@ void main() {
   });
 
   group('preset lookup', () {
-    test('mainnet presets include the zodl endpoint list', () {
+    test('mainnet presets include the regional endpoint list', () {
       final urls = kMainnetRpcEndpointPresets
           .map((preset) => preset.url)
           .map((url) => normalizeRpcEndpointUrl(url, allowDefaultPort: true))

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -57,6 +57,49 @@ void main() {
   });
 
   group('preset lookup', () {
+    test('mainnet presets include the zodl endpoint list', () {
+      final urls = kMainnetRpcEndpointPresets
+          .map((preset) => preset.url)
+          .map((url) => normalizeRpcEndpointUrl(url, allowDefaultPort: true))
+          .toSet();
+
+      expect(urls, {
+        'https://us.zec.stardust.rest:443',
+        'https://eu.zec.stardust.rest:443',
+        'https://eu2.zec.stardust.rest:443',
+        'https://jp.zec.stardust.rest:443',
+        'https://zec.rocks:443',
+        'https://na.zec.rocks:443',
+        'https://sa.zec.rocks:443',
+        'https://eu.zec.rocks:443',
+        'https://ap.zec.rocks:443',
+      });
+    });
+
+    test('mainnet presets are grouped by geography, not provider', () {
+      expect(
+        findRpcEndpointPresetByUrl(
+          'us.zec.stardust.rest:443',
+          networkName: 'main',
+        )?.region,
+        'Americas',
+      );
+      expect(
+        findRpcEndpointPresetByUrl(
+          'eu.zec.stardust.rest:443',
+          networkName: 'main',
+        )?.region,
+        'Europe',
+      );
+      expect(
+        findRpcEndpointPresetByUrl(
+          'jp.zec.stardust.rest:443',
+          networkName: 'main',
+        )?.region,
+        'Asia Pacific',
+      );
+    });
+
     test('matches normalized URLs within the requested network', () {
       final preset = findRpcEndpointPresetByUrl(
         'zec.rocks',
@@ -77,16 +120,19 @@ void main() {
   });
 
   group('RpcEndpointConfig', () {
-    test('derives the effective preset from the URL before stored preset id', () {
-      final defaultEndpoint = defaultRpcEndpointConfig('main');
-      final config = RpcEndpointConfig(
-        networkName: 'main',
-        lightwalletdUrl: defaultEndpoint.lightwalletdUrl,
-        presetId: kCustomRpcEndpointPresetId,
-      );
+    test(
+      'derives the effective preset from the URL before stored preset id',
+      () {
+        final defaultEndpoint = defaultRpcEndpointConfig('main');
+        final config = RpcEndpointConfig(
+          networkName: 'main',
+          lightwalletdUrl: defaultEndpoint.lightwalletdUrl,
+          presetId: kCustomRpcEndpointPresetId,
+        );
 
-      expect(config.effectivePresetId, defaultEndpoint.presetId);
-    });
+        expect(config.effectivePresetId, defaultEndpoint.presetId);
+      },
+    );
   });
 
   group('rpcEndpointHostPort', () {

--- a/test/providers/rpc_endpoint_latency_provider_test.dart
+++ b/test/providers/rpc_endpoint_latency_provider_test.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:zcash_wallet/src/providers/rpc_endpoint_latency_provider.dart';
 
 void main() {
@@ -45,6 +48,97 @@ void main() {
 
       expect(sample.status, RpcEndpointLatencyStatus.unavailable);
       expect(sample.label, 'Unavailable');
+    });
+  });
+
+  group('RpcEndpointLatencyNotifier', () {
+    test('marks presets checking before resolving measured latency', () async {
+      final completer = Completer<String>();
+      final container = ProviderContainer(
+        overrides: [
+          rpcEndpointChainNameGetterProvider.overrideWithValue(
+            (_) => completer.future,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final refresh = container
+          .read(rpcEndpointLatencyProvider.notifier)
+          .refresh('main');
+
+      await Future<void>.delayed(Duration.zero);
+
+      final checkingState = container.read(rpcEndpointLatencyProvider);
+      expect(
+        checkingState.samples.values.every(
+          (sample) => sample.status == RpcEndpointLatencyStatus.checking,
+        ),
+        isTrue,
+      );
+
+      completer.complete('main');
+      await refresh;
+
+      final finalState = container.read(rpcEndpointLatencyProvider);
+      expect(
+        finalState.samples.values.every(
+          (sample) => sample.status == RpcEndpointLatencyStatus.available,
+        ),
+        isTrue,
+      );
+    });
+
+    test('discard stale samples when a newer refresh starts', () async {
+      final completers = <Completer<String>>[];
+      final container = ProviderContainer(
+        overrides: [
+          rpcEndpointChainNameGetterProvider.overrideWithValue((_) {
+            final completer = Completer<String>();
+            completers.add(completer);
+            return completer.future;
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final firstRefresh = container
+          .read(rpcEndpointLatencyProvider.notifier)
+          .refresh('main');
+      await Future<void>.delayed(Duration.zero);
+      final firstCompleters = List<Completer<String>>.of(completers);
+
+      final secondRefresh = container
+          .read(rpcEndpointLatencyProvider.notifier)
+          .refresh('main');
+      await Future<void>.delayed(Duration.zero);
+      final secondCompleters = completers
+          .where((completer) => !firstCompleters.contains(completer))
+          .toList();
+
+      for (final completer in firstCompleters) {
+        completer.complete('test');
+      }
+      await firstRefresh;
+      final afterStale = container.read(rpcEndpointLatencyProvider);
+      expect(
+        afterStale.samples.values.every(
+          (sample) => sample.status == RpcEndpointLatencyStatus.checking,
+        ),
+        isTrue,
+      );
+
+      for (final completer in secondCompleters) {
+        completer.complete('main');
+      }
+      await secondRefresh;
+      final finalState = container.read(rpcEndpointLatencyProvider);
+      expect(
+        finalState.samples.values.every(
+          (sample) => sample.status == RpcEndpointLatencyStatus.available,
+        ),
+        isTrue,
+      );
     });
   });
 }

--- a/test/providers/rpc_endpoint_latency_provider_test.dart
+++ b/test/providers/rpc_endpoint_latency_provider_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/providers/rpc_endpoint_latency_provider.dart';
+
+void main() {
+  group('measureRpcEndpointLatency', () {
+    test('returns an available sample with elapsed milliseconds', () async {
+      final timestamps = [
+        DateTime(2026),
+        DateTime(2026).add(const Duration(milliseconds: 123)),
+      ];
+      var index = 0;
+
+      final sample = await measureRpcEndpointLatency(
+        lightwalletdUrl: 'https://zec.rocks:443',
+        expectedNetworkName: 'main',
+        getChainName: (_) async => 'main',
+        now: () => timestamps[index++],
+      );
+
+      expect(sample.status, RpcEndpointLatencyStatus.available);
+      expect(sample.latency, const Duration(milliseconds: 123));
+      expect(sample.label, '123ms');
+    });
+
+    test(
+      'returns wrongNetwork when the endpoint reports another chain',
+      () async {
+        final sample = await measureRpcEndpointLatency(
+          lightwalletdUrl: 'https://testnet.zec.rocks:443',
+          expectedNetworkName: 'main',
+          getChainName: (_) async => 'test',
+        );
+
+        expect(sample.status, RpcEndpointLatencyStatus.wrongNetwork);
+        expect(sample.label, 'Wrong network');
+      },
+    );
+
+    test('returns unavailable when the endpoint check fails', () async {
+      final sample = await measureRpcEndpointLatency(
+        lightwalletdUrl: 'https://does-not-exist.example:443',
+        expectedNetworkName: 'main',
+        getChainName: (_) async => throw Exception('connect failed'),
+      );
+
+      expect(sample.status, RpcEndpointLatencyStatus.unavailable);
+      expect(sample.label, 'Unavailable');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add more regional RPC endpoint presets for endpoint selection
- Replace hardcoded latency labels with live lightwalletd latency states
- Show checking, unavailable, wrong-network, and measured ms states in Settings
- Add tests for preset coverage, geographic grouping, latency measurement, and refresh state handling

## Tests
- fvm flutter test
- fvm flutter test test/providers/rpc_endpoint_latency_provider_test.dart test/core/config/rpc_endpoint_config_test.dart
- fvm dart analyze lib/src/core/config/rpc_endpoint_config.dart lib/src/providers/rpc_endpoint_latency_provider.dart test/providers/rpc_endpoint_latency_provider_test.dart

Note: full analyzer still reports pre-existing issues under rust_builder/cargokit/build_tool.