### PR TITLE
[codex] Add persisted privacy mode

### DIFF
--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -34,6 +34,7 @@ class AppBootstrapState {
     required this.network,
     required this.rpcEndpointConfig,
     required this.themeMode,
+    required this.privacyModeEnabled,
     required this.isPasswordConfigured,
     required this.isUnlocked,
     required this.passwordRotationRecoveryFailed,
@@ -45,6 +46,7 @@ class AppBootstrapState {
   final String network;
   final RpcEndpointConfig rpcEndpointConfig;
   final ThemeMode themeMode;
+  final bool privacyModeEnabled;
   final bool isPasswordConfigured;
   final bool isUnlocked;
   final bool passwordRotationRecoveryFailed;
@@ -59,6 +61,7 @@ class AppBootstrapState {
     network: 'main',
     rpcEndpointConfig: defaultRpcEndpointConfig('main'),
     themeMode: ThemeMode.system,
+    privacyModeEnabled: false,
     isPasswordConfigured: false,
     isUnlocked: false,
     passwordRotationRecoveryFailed: false,
@@ -140,6 +143,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
     final rpcEndpointConfig = await _readRpcEndpointConfig(storage, network);
     await _seedNativeRpcEndpointMirror(rpcEndpointConfig);
     final themeMode = await _readThemeMode(storage);
+    final privacyModeEnabled = await _readPrivacyModeEnabled(storage);
     final isPasswordConfigured = await storage.isPasswordConfigured();
     final isUnlocked = storage.hasSessionPassword;
     final dbPath = await _getDbPath();
@@ -221,6 +225,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       network: network,
       rpcEndpointConfig: rpcEndpointConfig,
       themeMode: themeMode,
+      privacyModeEnabled: privacyModeEnabled,
       isPasswordConfigured: isPasswordConfigured,
       isUnlocked: isUnlocked,
       passwordRotationRecoveryFailed: passwordRotationRecoveryFailed,
@@ -307,6 +312,15 @@ ThemeMode _decodeThemeMode(String? raw) {
     'dark' => ThemeMode.dark,
     _ => ThemeMode.system,
   };
+}
+
+Future<bool> _readPrivacyModeEnabled(AppSecureStore storage) async {
+  try {
+    return (await storage.readString(kPrivacyModeEnabledKey)) == 'true';
+  } catch (e) {
+    log('bootstrap: failed to read privacy mode: $e');
+    return false;
+  }
 }
 
 Future<List<AccountInfo>> _readStoredAccounts(AppSecureStore storage) async {

--- a/lib/src/core/privacy/privacy_mask.dart
+++ b/lib/src/core/privacy/privacy_mask.dart
@@ -1,0 +1,29 @@
+const kDefaultPrivacyMaskLength = 6;
+
+String fixedPrivacyMask({int length = kDefaultPrivacyMaskLength}) {
+  return '*' * length;
+}
+
+String hideIfPrivacyMode(
+  String visibleText, {
+  required bool privacyModeEnabled,
+  int maskLength = kDefaultPrivacyMaskLength,
+  String suffix = '',
+}) {
+  if (!privacyModeEnabled) return visibleText;
+  return '${fixedPrivacyMask(length: maskLength)}$suffix';
+}
+
+String hideAmountIfPrivacyMode(
+  String visibleText, {
+  required bool privacyModeEnabled,
+  int maskLength = kDefaultPrivacyMaskLength,
+  String denomination = 'ZEC',
+}) {
+  return hideIfPrivacyMode(
+    visibleText,
+    privacyModeEnabled: privacyModeEnabled,
+    maskLength: maskLength,
+    suffix: denomination.isEmpty ? '' : ' $denomination',
+  );
+}

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -10,6 +10,7 @@ import '../security/password_policy.dart';
 
 const kWalletDbNameKey = 'zcash_wallet_db_name';
 const kThemeModeKey = 'zcash_theme_mode';
+const kPrivacyModeEnabledKey = 'zcash_privacy_mode_enabled';
 const kRpcEndpointUrlKey = 'zcash_rpc_endpoint_url';
 const kRpcEndpointPresetKey = 'zcash_rpc_endpoint_preset';
 const _secureStoreSaltKey = 'zcash_secure_store_salt';

--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -1,16 +1,20 @@
 import 'package:flutter/widgets.dart';
 
 import '../../core/formatting/zec_amount.dart';
+import '../../core/privacy/privacy_mask.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/widgets/app_icon.dart';
 import '../../providers/sync_provider.dart';
 import '../../rust/api/sync.dart' as rust_sync;
 import 'models/activity_row_data.dart';
 
+const _activityAmountPrivacyMaskLength = 3;
+
 List<ActivityRowData> buildActivityRows({
   required BuildContext context,
   required SyncState sync,
   required Iterable<rust_sync.TransactionInfo> transactions,
+  bool privacyModeEnabled = false,
   VoidCallback? onRetrySync,
   ValueChanged<rust_sync.TransactionInfo>? onTransactionTap,
 }) {
@@ -18,12 +22,14 @@ List<ActivityRowData> buildActivityRows({
     buildSyncActivityRow(
       context: context,
       sync: sync,
+      privacyModeEnabled: privacyModeEnabled,
       onRetrySync: onRetrySync,
     ),
     ...transactions.map(
       (tx) => buildTransactionActivityRow(
         context: context,
         transaction: tx,
+        privacyModeEnabled: privacyModeEnabled,
         onTap: onTransactionTap == null ? null : () => onTransactionTap(tx),
       ),
     ),
@@ -33,6 +39,7 @@ List<ActivityRowData> buildActivityRows({
 ActivityRowData buildSyncActivityRow({
   required BuildContext context,
   required SyncState sync,
+  bool privacyModeEnabled = false,
   VoidCallback? onRetrySync,
 }) {
   final colors = context.colors;
@@ -74,7 +81,11 @@ ActivityRowData buildSyncActivityRow({
     leadingIconName: AppIcons.sync,
     leadingBackgroundColor: colors.background.neutralSubtleOpacity,
     leadingIconColor: colors.icon.regular,
-    amountText: ZecAmount.fromZatoshi(sync.totalBalance).activity.toString(),
+    amountText: hideAmountIfPrivacyMode(
+      ZecAmount.fromZatoshi(sync.totalBalance).activity.toString(),
+      privacyModeEnabled: privacyModeEnabled,
+      maskLength: _activityAmountPrivacyMaskLength,
+    ),
     amountColor: colors.text.accent,
     statusText: 'Completed',
     statusColor: colors.text.secondary,
@@ -90,6 +101,7 @@ String _formatInProgressSyncPercentage(double progress) {
 ActivityRowData buildTransactionActivityRow({
   required BuildContext context,
   required rust_sync.TransactionInfo transaction,
+  bool privacyModeEnabled = false,
   VoidCallback? onTap,
 }) {
   final colors = context.colors;
@@ -121,6 +133,7 @@ ActivityRowData buildTransactionActivityRow({
       isFailed: isFailed,
       isShielded: isShielded,
       kind: kind,
+      privacyModeEnabled: privacyModeEnabled,
     ),
     amountIconName: isFailed && amount != BigInt.zero
         ? AppIcons.arrowBack
@@ -153,7 +166,15 @@ String _transactionAmountText({
   required bool isFailed,
   required bool isShielded,
   required String kind,
+  required bool privacyModeEnabled,
 }) {
+  if (privacyModeEnabled) {
+    return hideAmountIfPrivacyMode(
+      '',
+      privacyModeEnabled: true,
+      maskLength: _activityAmountPrivacyMaskLength,
+    );
+  }
   if (amount == BigInt.zero) return '--';
   if (isFailed || isShielded) {
     return ZecAmount.fromZatoshi(amount).activity.toString();

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -15,6 +15,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/privacy_mode_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
@@ -237,6 +238,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
 
     final sync = ref.watch(syncProvider).value ?? SyncState();
     final accountUuid = ref.watch(accountProvider).value?.activeAccountUuid;
+    final privacyModeEnabled = ref.watch(privacyModeProvider);
     final transactions = _transactions ?? sync.recentTransactions;
     final transactionsAfterFirstPage = math.max(
       0,
@@ -262,12 +264,14 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
               buildSyncActivityRow(
                 context: context,
                 sync: sync,
+                privacyModeEnabled: privacyModeEnabled,
                 onRetrySync: () => ref.read(syncProvider.notifier).startSync(),
               ),
             ...pageTransactions.map(
               (tx) => buildTransactionActivityRow(
                 context: context,
                 transaction: tx,
+                privacyModeEnabled: privacyModeEnabled,
                 onTap: () => _openTransactionStatus(tx),
               ),
             ),

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -11,9 +11,11 @@ import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/privacy/privacy_mask.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/privacy_mode_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
@@ -234,10 +236,19 @@ class _ActivityTransactionStatusScreenState
     return TransactionReceiptPhase.succeeded;
   }
 
-  String _amountText(rust_sync.TransactionInfo? tx) {
+  String _amountText(
+    rust_sync.TransactionInfo? tx, {
+    required bool privacyModeEnabled,
+  }) {
     if (tx == null) return '--';
+    if (privacyModeEnabled) {
+      return hideAmountIfPrivacyMode('', privacyModeEnabled: true);
+    }
     if (tx.displayAmount == BigInt.zero) return '--';
-    return ZecAmount.fromZatoshi(tx.displayAmount).activity.toString();
+    return hideAmountIfPrivacyMode(
+      ZecAmount.fromZatoshi(tx.displayAmount).activity.toString(),
+      privacyModeEnabled: privacyModeEnabled,
+    );
   }
 
   String _dateText(rust_sync.TransactionInfo? tx) {
@@ -249,9 +260,15 @@ class _ActivityTransactionStatusScreenState
     );
   }
 
-  String _feeText(rust_sync.TransactionInfo? tx) {
+  String _feeText(
+    rust_sync.TransactionInfo? tx, {
+    required bool privacyModeEnabled,
+  }) {
     if (tx == null || tx.fee <= BigInt.zero) return '--';
-    return ZecAmount.fromZatoshi(tx.fee).fee.toString();
+    return hideAmountIfPrivacyMode(
+      ZecAmount.fromZatoshi(tx.fee).fee.toString(),
+      privacyModeEnabled: privacyModeEnabled,
+    );
   }
 
   String _formatDate(DateTime value) {
@@ -423,6 +440,7 @@ class _ActivityTransactionStatusScreenState
 
     final tx = _transaction;
     final detail = _matchingDetailFor(tx);
+    final privacyModeEnabled = ref.watch(privacyModeProvider);
     final useFailedReceiptLayout = tx?.expiredUnmined == true;
     final error = useFailedReceiptLayout
         ? 'Transaction expired before it was mined.'
@@ -459,11 +477,17 @@ class _ActivityTransactionStatusScreenState
                           alignment: Alignment.centerLeft,
                           child: TransactionReceiptView(
                             phase: _phaseFor(tx),
-                            amountText: _amountText(tx),
+                            amountText: _amountText(
+                              tx,
+                              privacyModeEnabled: privacyModeEnabled,
+                            ),
                             primaryBlock: _primaryBlockFor(context, tx, detail),
                             extraBlocks: _extraBlocksFor(context, detail),
                             dateText: _dateText(tx),
-                            feeText: _feeText(tx),
+                            feeText: _feeText(
+                              tx,
+                              privacyModeEnabled: privacyModeEnabled,
+                            ),
                             error: error,
                             useFailedReceiptLayout: useFailedReceiptLayout,
                             onCopyTxid: _copyTransactionHash,

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -12,11 +12,13 @@ import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
+import '../../../core/privacy/privacy_mask.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/privacy_mode_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
@@ -36,7 +38,6 @@ class HomeScreen extends ConsumerStatefulWidget {
 
 class _HomeScreenState extends ConsumerState<HomeScreen> {
   bool _canBackgroundSync = false;
-  bool _isBalanceVisible = true;
   bool _isShieldingBalance = false;
   String? _shieldBalanceError;
 
@@ -62,12 +63,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   String _formatZec(BigInt zatoshi) {
     return ZecAmount.fromZatoshi(zatoshi).balance.amountText;
-  }
-
-  void _toggleBalanceVisibility() {
-    setState(() {
-      _isBalanceVisible = !_isBalanceVisible;
-    });
   }
 
   void _dismissShieldBalanceError() {
@@ -175,6 +170,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final bootstrap = ref.watch(appBootstrapProvider);
     final syncAsync = ref.watch(syncProvider);
     final sync = syncAsync.value ?? SyncState();
+    final privacyModeEnabled = ref.watch(privacyModeProvider);
     final shieldedBalance =
         sync.saplingBalance +
         sync.orchardBalance +
@@ -204,14 +200,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
               passwordRotationRecoveryFailed:
                   bootstrap.passwordRotationRecoveryFailed,
               canBackgroundSync: _canBackgroundSync,
-              isBalanceVisible: _isBalanceVisible,
+              privacyModeEnabled: privacyModeEnabled,
               shieldedBalanceText: _formatZec(shieldedBalance),
               transparentBalanceText: _formatZec(transparentBalance),
               hasTransparentBalance: transparentBalance > BigInt.zero,
               canShieldBalance: canShieldTransparentBalance,
               isShieldingBalance: _isShieldingBalance,
               shieldBalanceError: _shieldBalanceError,
-              onToggleBalanceVisibility: _toggleBalanceVisibility,
+              onTogglePrivacyMode: () =>
+                  ref.read(privacyModeProvider.notifier).toggle(),
               onShieldBalancePressed: () =>
                   unawaited(_shieldTransparentBalance()),
               onDismissShieldBalanceError: _dismissShieldBalanceError,
@@ -233,14 +230,14 @@ class _HomePane extends ConsumerStatefulWidget {
     required this.sync,
     required this.passwordRotationRecoveryFailed,
     required this.canBackgroundSync,
-    required this.isBalanceVisible,
+    required this.privacyModeEnabled,
     required this.shieldedBalanceText,
     required this.transparentBalanceText,
     required this.hasTransparentBalance,
     required this.canShieldBalance,
     required this.isShieldingBalance,
     required this.shieldBalanceError,
-    required this.onToggleBalanceVisibility,
+    required this.onTogglePrivacyMode,
     required this.onShieldBalancePressed,
     required this.onDismissShieldBalanceError,
     required this.onSyncInBackground,
@@ -251,14 +248,14 @@ class _HomePane extends ConsumerStatefulWidget {
   final SyncState sync;
   final bool passwordRotationRecoveryFailed;
   final bool canBackgroundSync;
-  final bool isBalanceVisible;
+  final bool privacyModeEnabled;
   final String shieldedBalanceText;
   final String transparentBalanceText;
   final bool hasTransparentBalance;
   final bool canShieldBalance;
   final bool isShieldingBalance;
   final String? shieldBalanceError;
-  final VoidCallback onToggleBalanceVisibility;
+  final VoidCallback onTogglePrivacyMode;
   final VoidCallback onShieldBalancePressed;
   final VoidCallback onDismissShieldBalanceError;
   final VoidCallback onSyncInBackground;
@@ -357,9 +354,8 @@ class _HomePaneState extends ConsumerState<_HomePane> {
                           hasTransparentBalance: widget.hasTransparentBalance,
                           canShieldBalance: widget.canShieldBalance,
                           isShieldingBalance: widget.isShieldingBalance,
-                          isBalanceVisible: widget.isBalanceVisible,
-                          onToggleBalanceVisibility:
-                              widget.onToggleBalanceVisibility,
+                          privacyModeEnabled: widget.privacyModeEnabled,
+                          onTogglePrivacyMode: widget.onTogglePrivacyMode,
                           onShieldBalancePressed: widget.onShieldBalancePressed,
                         ),
                         if (notice != null) ...[
@@ -439,6 +435,7 @@ class _HomePaneState extends ConsumerState<_HomePane> {
       context: context,
       sync: widget.sync,
       transactions: widget.sync.recentTransactions.take(9),
+      privacyModeEnabled: widget.privacyModeEnabled,
       onRetrySync: widget.onRetrySync,
       onTransactionTap: _openTransactionStatus,
     );
@@ -501,8 +498,8 @@ class _HomeBalanceCard extends StatelessWidget {
     required this.hasTransparentBalance,
     required this.canShieldBalance,
     required this.isShieldingBalance,
-    required this.isBalanceVisible,
-    required this.onToggleBalanceVisibility,
+    required this.privacyModeEnabled,
+    required this.onTogglePrivacyMode,
     required this.onShieldBalancePressed,
   });
 
@@ -511,8 +508,8 @@ class _HomeBalanceCard extends StatelessWidget {
   final bool hasTransparentBalance;
   final bool canShieldBalance;
   final bool isShieldingBalance;
-  final bool isBalanceVisible;
-  final VoidCallback onToggleBalanceVisibility;
+  final bool privacyModeEnabled;
+  final VoidCallback onTogglePrivacyMode;
   final VoidCallback onShieldBalancePressed;
 
   static const _shieldedCardHeight = 216.0;
@@ -526,9 +523,11 @@ class _HomeBalanceCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final displayedShieldedBalance = isBalanceVisible
-        ? '$shieldedBalanceText zec'
-        : '•••••• zec';
+    final displayedShieldedBalance = hideIfPrivacyMode(
+      '$shieldedBalanceText zec',
+      privacyModeEnabled: privacyModeEnabled,
+      suffix: ' zec',
+    );
     final isDark = AppTheme.of(context) == AppThemeData.dark;
     final targetStripHeight = hasTransparentBalance
         ? _transparentStripHeight
@@ -539,7 +538,7 @@ class _HomeBalanceCard extends StatelessWidget {
             balanceText: transparentBalanceText,
             canShieldBalance: canShieldBalance,
             isShieldingBalance: isShieldingBalance,
-            isBalanceVisible: isBalanceVisible,
+            privacyModeEnabled: privacyModeEnabled,
             onShieldBalancePressed: onShieldBalancePressed,
           )
         : const SizedBox.shrink(key: ValueKey('transparent-balance-empty'));
@@ -742,11 +741,10 @@ class _HomeBalanceCard extends StatelessWidget {
                                               ),
                                               const Spacer(),
                                               _IconPillButton(
-                                                iconName: isBalanceVisible
-                                                    ? AppIcons.eye
-                                                    : AppIcons.eyeClosed,
-                                                onPressed:
-                                                    onToggleBalanceVisibility,
+                                                iconName: privacyModeEnabled
+                                                    ? AppIcons.eyeClosed
+                                                    : AppIcons.eye,
+                                                onPressed: onTogglePrivacyMode,
                                               ),
                                             ],
                                           ),
@@ -853,7 +851,7 @@ class _HomeTransparentBalanceStrip extends StatelessWidget {
     required this.balanceText,
     required this.canShieldBalance,
     required this.isShieldingBalance,
-    required this.isBalanceVisible,
+    required this.privacyModeEnabled,
     required this.onShieldBalancePressed,
     super.key,
   });
@@ -861,7 +859,7 @@ class _HomeTransparentBalanceStrip extends StatelessWidget {
   final String balanceText;
   final bool canShieldBalance;
   final bool isShieldingBalance;
-  final bool isBalanceVisible;
+  final bool privacyModeEnabled;
   final VoidCallback onShieldBalancePressed;
 
   static const _itemGap = 10.0;
@@ -869,9 +867,10 @@ class _HomeTransparentBalanceStrip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final displayedBalance = isBalanceVisible
-        ? '$balanceText ZEC'
-        : '•••••• ZEC';
+    final displayedBalance = hideAmountIfPrivacyMode(
+      '$balanceText ZEC',
+      privacyModeEnabled: privacyModeEnabled,
+    );
 
     return SizedBox(
       height: 56,

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -11,6 +11,7 @@ import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/privacy/privacy_mask.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
@@ -18,6 +19,7 @@ import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_text_field.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/privacy_mode_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
@@ -625,9 +627,13 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   @override
   Widget build(BuildContext context) {
     final spendable = widget.spendableBalance;
-    final spendableText = ZecAmount.fromZatoshi(
+    final visibleSpendableText = ZecAmount.fromZatoshi(
       spendable,
     ).pretty(denomStyle: ZecDenomStyle.upper).toString();
+    final spendableText = hideAmountIfPrivacyMode(
+      visibleSpendableText,
+      privacyModeEnabled: ref.watch(privacyModeProvider),
+    );
     final colors = context.colors;
 
     final addressTone = switch (_addressType) {

--- a/lib/src/providers/privacy_mode_provider.dart
+++ b/lib/src/providers/privacy_mode_provider.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../app_bootstrap.dart';
+import '../core/storage/app_secure_store.dart';
+
+class PrivacyModeNotifier extends Notifier<bool> {
+  static final _store = AppSecureStore.instance;
+
+  @override
+  bool build() => ref.watch(appBootstrapProvider).privacyModeEnabled;
+
+  Future<void> set(bool enabled) async {
+    await _store.writePlain(kPrivacyModeEnabledKey, enabled ? 'true' : 'false');
+    state = enabled;
+  }
+
+  Future<void> toggle() => set(!state);
+}
+
+final privacyModeProvider = NotifierProvider<PrivacyModeNotifier, bool>(
+  PrivacyModeNotifier.new,
+);

--- a/test/activity_table_row_test.dart
+++ b/test/activity_table_row_test.dart
@@ -98,6 +98,55 @@ void main() {
     expect(find.text('+1.23 ZEC'), findsOneWidget);
     expect(find.text('-1.00 ZEC'), findsOneWidget);
   });
+
+  testWidgets('activity rows hide asset amounts with a fixed mask', (
+    tester,
+  ) async {
+    late final List<ActivityRowData> rows;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: Builder(
+            builder: (context) {
+              rows = buildActivityRows(
+                context: context,
+                sync: SyncState(totalBalance: BigInt.from(10000)),
+                privacyModeEnabled: true,
+                transactions: [
+                  _tx(
+                    txidHex: 'received',
+                    kind: 'received',
+                    amount: BigInt.from(123450000),
+                  ),
+                  _tx(
+                    txidHex: 'sent',
+                    kind: 'sent',
+                    amount: BigInt.from(100000000),
+                  ),
+                  _tx(
+                    txidHex: 'shielded',
+                    kind: 'shielded',
+                    amount: BigInt.from(10000),
+                  ),
+                ],
+              );
+              return ActivityTable(rows: rows);
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(rows[0].amountText, '*** ZEC');
+    expect(rows[1].amountText, '*** ZEC');
+    expect(rows[2].amountText, '*** ZEC');
+    expect(rows[3].amountText, '*** ZEC');
+    expect(find.text('*** ZEC'), findsNWidgets(4));
+    expect(find.text('+1.23 ZEC'), findsNothing);
+    expect(find.text('-1.00 ZEC'), findsNothing);
+  });
 }
 
 rust_sync.TransactionInfo _tx({

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -52,4 +52,8 @@ void main() {
   test('empty bootstrap has no password rotation recovery failure', () {
     expect(AppBootstrapState.empty.passwordRotationRecoveryFailed, isFalse);
   });
+
+  test('empty bootstrap starts with privacy mode disabled', () {
+    expect(AppBootstrapState.empty.privacyModeEnabled, isFalse);
+  });
 }

--- a/test/core/privacy/privacy_mask_test.dart
+++ b/test/core/privacy/privacy_mask_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/privacy/privacy_mask.dart';
+
+void main() {
+  test('privacy mask does not depend on source text length', () {
+    expect(
+      hideAmountIfPrivacyMode('0.01 ZEC', privacyModeEnabled: true),
+      '****** ZEC',
+    );
+    expect(
+      hideAmountIfPrivacyMode(
+        '123456789.12345678 ZEC',
+        privacyModeEnabled: true,
+      ),
+      '****** ZEC',
+    );
+  });
+
+  test('privacy mask keeps caller-selected context suffix', () {
+    expect(
+      hideAmountIfPrivacyMode(
+        '1.23 zec',
+        privacyModeEnabled: true,
+        denomination: 'zec',
+      ),
+      '****** zec',
+    );
+    expect(
+      hideIfPrivacyMode('0.0001', privacyModeEnabled: true, suffix: ' ZEC'),
+      '****** ZEC',
+    );
+  });
+
+  test('privacy helper preserves visible text when disabled', () {
+    expect(
+      hideAmountIfPrivacyMode(
+        '123456789.12345678 ZEC',
+        privacyModeEnabled: false,
+      ),
+      '123456789.12345678 ZEC',
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Add a persisted global privacy mode provider restored during app bootstrap.
- Replace the home balance-card local visibility flag with app-wide privacy state.
- Mask wallet asset values on home, activity rows, transaction details, and the send compose Max balance with fixed-length masks.

## Validation
- `fvm flutter analyze`
- `fvm flutter test`