### PR TITLE
Show Back on add-account entry

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -133,7 +133,7 @@ final _routerProvider = Provider<GoRouter>((ref) {
           key: state.pageKey,
           transitionDuration: kOnboardingForwardDuration,
           reverseTransitionDuration: kOnboardingReverseDuration,
-          child: const WelcomeScreen(),
+          child: const WelcomeScreen(showBackButton: true),
           transitionsBuilder: _onboardingFadeTransition,
         ),
       ),

--- a/lib/src/features/onboarding/welcome.dart
+++ b/lib/src/features/onboarding/welcome.dart
@@ -27,7 +27,9 @@ const double _welcomeActionWidth = 256;
 /// [AppLayoutMode.large] so a user who had previously toggled the window
 /// into small can still come back through onboarding.
 class WelcomeScreen extends ConsumerStatefulWidget {
-  const WelcomeScreen({super.key});
+  const WelcomeScreen({super.key, this.showBackButton = false});
+
+  final bool showBackButton;
 
   @override
   ConsumerState<WelcomeScreen> createState() => _WelcomeScreenState();
@@ -57,7 +59,10 @@ class _WelcomeScreenState extends ConsumerState<WelcomeScreen> {
           // Only the 8 dp gap around the pane is transparent — this is
           // the strip where the native acrylic is visible.
           padding: const EdgeInsets.all(AppSpacing.xs),
-          child: const _Pane(child: _Content()),
+          child: _Pane(
+            showBackButton: widget.showBackButton,
+            child: const _Content(),
+          ),
         ),
       ),
     );
@@ -99,9 +104,10 @@ class _WelcomeScreenState extends ConsumerState<WelcomeScreen> {
 /// team decided it adds no depth in the transparent-window + acrylic
 /// context the app actually runs in.
 class _Pane extends StatelessWidget {
-  const _Pane({required this.child});
+  const _Pane({required this.child, required this.showBackButton});
 
   final Widget child;
+  final bool showBackButton;
 
   /// Fixed foreground design-canvas dimensions pulled from Figma's Welcome BG
   /// frame (node 1300:34883). The 1080 × 720 desktop window leaves a
@@ -166,7 +172,50 @@ class _Pane extends StatelessWidget {
               },
             ),
           ),
+          if (showBackButton)
+            const Positioned(
+              left: AppSpacing.md,
+              top: AppSpacing.md,
+              child: _BackRow(),
+            ),
         ],
+      ),
+    );
+  }
+}
+
+class _BackRow extends StatelessWidget {
+  const _BackRow();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => context.canPop() ? context.pop() : context.go('/home'),
+        child: SizedBox(
+          height: 32,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              AppIcon(
+                AppIcons.chevronBackward,
+                size: AppIconSize.medium,
+                color: colors.icon.accent,
+              ),
+              const SizedBox(width: AppSpacing.xxs),
+              Text(
+                'Back',
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/test/features/onboarding/welcome_screen_test.dart
+++ b/test/features/onboarding/welcome_screen_test.dart
@@ -1,0 +1,93 @@
+import 'dart:ui' show Size;
+
+import 'package:flutter/material.dart' show MaterialApp, TextButton;
+import 'package:flutter/widgets.dart' show Text, Widget;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/onboarding/welcome.dart';
+
+void main() {
+  testWidgets('hides Back on first wallet creation entry', (tester) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_welcomeScreen());
+
+    expect(find.text('Back'), findsNothing);
+  });
+
+  testWidgets('shows Back when adding an account to an existing wallet', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_welcomeScreen(showBackButton: true));
+
+    expect(find.text('Back'), findsOneWidget);
+  });
+
+  testWidgets('Back returns to the pushed accounts route', (tester) async {
+    await _setDesktopViewport(tester);
+    final router = GoRouter(
+      initialLocation: '/accounts',
+      routes: [
+        GoRoute(
+          path: '/home',
+          builder: (_, _) => const Text('Home'),
+        ),
+        GoRoute(
+          path: '/accounts',
+          builder: (context, _) => TextButton(
+            onPressed: () => context.push('/add-account'),
+            child: const Text('Open add account'),
+          ),
+        ),
+        GoRoute(
+          path: '/add-account',
+          builder: (_, _) => const WelcomeScreen(showBackButton: true),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(_welcomeRouter(router));
+    await tester.tap(find.text('Open add account'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Back'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Open add account'), findsOneWidget);
+    expect(find.text('Home'), findsNothing);
+  });
+}
+
+Future<void> _setDesktopViewport(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(1280, 900));
+  addTearDown(() async {
+    await tester.binding.setSurfaceSize(null);
+  });
+}
+
+Widget _welcomeScreen({bool showBackButton = false}) {
+  return ProviderScope(
+    overrides: [appBootstrapProvider.overrideWithValue(AppBootstrapState.empty)],
+    child: MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: WelcomeScreen(showBackButton: showBackButton),
+      ),
+    ),
+  );
+}
+
+Widget _welcomeRouter(GoRouter router) {
+  return ProviderScope(
+    overrides: [appBootstrapProvider.overrideWithValue(AppBootstrapState.empty)],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, child) => AppTheme(
+        data: AppThemeData.light,
+        child: child!,
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## Summary
- show the onboarding welcome Back affordance only on the add-account entry route
- keep first-wallet creation free of the Back button
- preserve push-stack history when returning from add-account and fall back to Home when there is no stack
- add widget coverage for first-run visibility, add-account visibility, and pushed-route Back navigation

## Tests
- fvm flutter test test/features/onboarding/welcome_screen_test.dart
- fvm dart analyze lib/app.dart lib/src/features/onboarding/welcome.dart test/features/onboarding/welcome_screen_test.dart