### PR TITLE
[codex] Adjust home receive focus ring

### DIFF
--- a/lib/src/core/widgets/app_button.dart
+++ b/lib/src/core/widgets/app_button.dart
@@ -155,6 +155,7 @@ class AppButton extends StatefulWidget {
     this.leading,
     this.trailing,
     this.minWidth,
+    this.focusRingColor,
     this.focusNode,
     this.autofocus = false,
   });
@@ -181,6 +182,9 @@ class AppButton extends StatefulWidget {
   /// intrinsic — content drives size. Callers opt in to a floor when a
   /// specific screen or layout demands a consistent button width.
   final double? minWidth;
+
+  /// Optional focus ring color override for one-off surface-specific cases.
+  final Color? focusRingColor;
 
   final FocusNode? focusNode;
   final bool autofocus;
@@ -308,6 +312,7 @@ class _AppButtonState extends State<AppButton> {
     );
 
     final focusRingWidth = widget.size == AppButtonSize.small ? 1.5 : 2.0;
+    final focusRingColor = widget.focusRingColor ?? palette.focusRing;
     final focusRingOutset = switch (widget.variant) {
       AppButtonVariant.primary =>
         widget.size == AppButtonSize.large ? 3.5 : 3.0,
@@ -337,7 +342,7 @@ class _AppButtonState extends State<AppButton> {
                 decoration: ShapeDecoration(
                   shape: StadiumBorder(
                     side: BorderSide(
-                      color: palette.focusRing,
+                      color: focusRingColor,
                       width: focusRingWidth,
                       strokeAlign: BorderSide.strokeAlignOutside,
                     ),

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -780,6 +780,12 @@ class _HomeBalanceCard extends StatelessWidget {
                                                 variant:
                                                     AppButtonVariant.secondary,
                                                 minWidth: _actionButtonMinWidth,
+                                                focusRingColor: isDark
+                                                    ? null
+                                                    : colors
+                                                          .button
+                                                          .secondary
+                                                          .bg,
                                                 leading: const AppIcon(
                                                   AppIcons.arrowDownCircle,
                                                 ),


### PR DESCRIPTION
## Summary
- Add an optional `AppButton.focusRingColor` override for surface-specific focus ring cases.
- Apply the override only to the home balance card Receive button in light theme so its focus ring uses the secondary button background token (`#EBEBEB`).
- Keep dark theme and all other buttons on the existing variant focus ring behavior.

## Validation
- `fvm flutter analyze lib/src/core/widgets/app_button.dart lib/src/features/home/screens/home_screen.dart`

Note: full `fvm flutter analyze` is currently blocked by existing `rust_builder/cargokit/build_tool` package resolution errors unrelated to this change.