### PR TITLE
Refine activity and transaction receipt layouts

### DIFF
--- a/lib/src/core/config/zcash_explorer.dart
+++ b/lib/src/core/config/zcash_explorer.dart
@@ -1,0 +1,71 @@
+import 'package:url_launcher/url_launcher.dart';
+
+import 'network_config.dart';
+import 'rpc_endpoint_config.dart';
+
+enum ZcashExplorerTxidOrder { protocol, display }
+
+typedef ZcashExplorerLauncher = Future<bool> Function(Uri uri);
+
+final _txidHexPattern = RegExp(r'^[0-9a-f]{64}$');
+
+Uri zcashExplorerTransactionUri({
+  required String networkName,
+  required String txidHex,
+  required ZcashExplorerTxidOrder txidOrder,
+}) {
+  final network = zcashNetworkFromName(networkName);
+  final host = switch (network) {
+    ZcashNetwork.mainnet => 'mainnet.zcashexplorer.app',
+    ZcashNetwork.testnet => 'testnet.zcashexplorer.app',
+  };
+  return Uri.https(
+    host,
+    '/transactions/${_explorerTxidHex(txidHex, txidOrder)}',
+  );
+}
+
+String _explorerTxidHex(String txidHex, ZcashExplorerTxidOrder txidOrder) {
+  final normalized = txidHex.trim().toLowerCase();
+  return switch (txidOrder) {
+    ZcashExplorerTxidOrder.display => normalized,
+    ZcashExplorerTxidOrder.protocol => _protocolOrderToDisplayTxidHex(
+      normalized,
+    ),
+  };
+}
+
+String _protocolOrderToDisplayTxidHex(String normalizedTxidHex) {
+  if (!_txidHexPattern.hasMatch(normalizedTxidHex)) {
+    return normalizedTxidHex;
+  }
+
+  // Wallet DB txids are protocol-order bytes; explorers use byte-reversed text.
+  final bytes = <String>[];
+  for (var i = 0; i < normalizedTxidHex.length; i += 2) {
+    bytes.add(normalizedTxidHex.substring(i, i + 2));
+  }
+  return bytes.reversed.join();
+}
+
+Future<bool> launchZcashExplorerTransaction({
+  required String networkName,
+  required String txidHex,
+  required ZcashExplorerTxidOrder txidOrder,
+  ZcashExplorerLauncher? launcher,
+}) async {
+  final uri = zcashExplorerTransactionUri(
+    networkName: networkName,
+    txidHex: txidHex,
+    txidOrder: txidOrder,
+  );
+  try {
+    return await (launcher ?? _launchExternalUrl)(uri);
+  } on Exception {
+    return false;
+  }
+}
+
+Future<bool> _launchExternalUrl(Uri uri) {
+  return launchUrl(uri, mode: LaunchMode.externalApplication);
+}

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -34,6 +34,8 @@ class ActivityScreen extends ConsumerStatefulWidget {
 class _ActivityScreenState extends ConsumerState<ActivityScreen> {
   static const _activityRowsPerPage = 6;
   static const _firstPageTransactionCount = _activityRowsPerPage - 1;
+  // Figma frame keeps a 32px Back row plus a 616px Activity panel.
+  static const double _activityPaneMinHeight = 648;
 
   final ScrollController _scrollController = ScrollController();
   List<rust_sync.TransactionInfo>? _transactions;
@@ -273,9 +275,9 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
       sidebar: const AppMainSidebar(),
       pane: AppDesktopPane(
         padding: const EdgeInsets.fromLTRB(
-          AppSpacing.sm,
-          AppSpacing.sm,
-          AppSpacing.sm,
+          AppSpacing.md,
+          AppSpacing.md,
+          AppSpacing.md,
           0,
         ),
         child: LayoutBuilder(
@@ -309,9 +311,10 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
                       isDesktopLayoutPlatform && _isHovered && _canScroll,
                   child: SingleChildScrollView(
                     controller: _scrollController,
-                    child: ConstrainedBox(
-                      constraints: BoxConstraints(
-                        minHeight: constraints.maxHeight,
+                    child: SizedBox(
+                      height: math.max(
+                        constraints.maxHeight,
+                        _activityPaneMinHeight,
                       ),
                       child: _ActivityPane(
                         rows: rows,
@@ -363,31 +366,47 @@ class _ActivityPane extends StatelessWidget {
           alignment: Alignment.centerLeft,
           child: AppRouteBackLink(minWidth: 60),
         ),
-        const SizedBox(height: AppSpacing.s),
-        Center(
-          child: Text(
-            'Activity',
-            style: AppTypography.displaySmall.copyWith(
-              color: colors.text.accent,
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.only(
+              top: AppSpacing.s,
+              bottom: AppSpacing.s,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Center(
+                  child: Text(
+                    'Activity',
+                    style: AppTypography.displaySmall.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                const Center(child: AppDecorativeDivider(width: 256)),
+                const SizedBox(height: AppSpacing.sm),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.xs,
+                    ),
+                    child: ActivityTable(
+                      rows: rows,
+                      isLoading: isLoading,
+                      errorText: errorText,
+                      showPagination: true,
+                      pinPaginationToBottom: true,
+                      currentPage: currentPage,
+                      totalPages: totalPages,
+                      onPageChanged: onPageChanged,
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
         ),
-        const SizedBox(height: AppSpacing.sm),
-        const Center(child: AppDecorativeDivider(width: 256)),
-        const SizedBox(height: AppSpacing.sm),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
-          child: ActivityTable(
-            rows: rows,
-            isLoading: isLoading,
-            errorText: errorText,
-            showPagination: true,
-            currentPage: currentPage,
-            totalPages: totalPages,
-            onPageChanged: onPageChanged,
-          ),
-        ),
-        const SizedBox(height: AppSpacing.s),
       ],
     );
   }

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -53,6 +53,7 @@ class _ActivityTransactionStatusScreenState
   bool _isLoading = false;
   String? _error;
   String? _activeAccountUuid;
+  bool _messageExpanded = false;
 
   @override
   void initState() {
@@ -227,6 +228,12 @@ class _ActivityTransactionStatusScreenState
     showAppToast(context, message);
   }
 
+  void _toggleMessageExpanded() {
+    setState(() {
+      _messageExpanded = !_messageExpanded;
+    });
+  }
+
   TransactionReceiptPhase _phaseFor(rust_sync.TransactionInfo? tx) {
     if (tx == null) {
       return _isLoading
@@ -300,13 +307,6 @@ class _ActivityTransactionStatusScreenState
     return [txid.substring(0, 32), txid.substring(32)];
   }
 
-  List<String> _splitAddress(String address) {
-    final trimmed = address.trim();
-    if (trimmed.length <= 16) return [trimmed];
-    final midpoint = (trimmed.length / 2).ceil();
-    return [trimmed.substring(0, midpoint), trimmed.substring(midpoint)];
-  }
-
   rust_sync.TransactionDetail? _matchingDetailFor(
     rust_sync.TransactionInfo? tx,
   ) {
@@ -345,29 +345,21 @@ class _ActivityTransactionStatusScreenState
     required String title,
     required String address,
     bool useFailedReceiptLayout = false,
+    bool compactAddress = false,
   }) {
     final colors = context.colors;
     final trimmedAddress = address.trim();
     return TransactionReceiptBlockData(
       title: title,
       onCopy: () => unawaited(_copyText(trimmedAddress, 'Address Copied')),
-      child: useFailedReceiptLayout
-          ? TransactionReceiptAddressText(
-              address: trimmedAddress,
-              highlightEdges: _shouldHighlightAddressEdges(trimmedAddress),
-            )
-          : Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                for (final line in _splitAddress(trimmedAddress))
-                  Text(
-                    line,
-                    style: AppTypography.labelLarge.copyWith(
-                      color: colors.text.accent,
-                    ),
-                  ),
-              ],
-            ),
+      child: TransactionReceiptAddressText(
+        address: trimmedAddress,
+        highlightEdges: _shouldHighlightAddressEdges(trimmedAddress),
+        compact: compactAddress,
+        highlightColor: useFailedReceiptLayout
+            ? colors.text.destructive
+            : colors.text.success,
+      ),
     );
   }
 
@@ -382,6 +374,7 @@ class _ActivityTransactionStatusScreenState
   ) {
     final primaryAddress = detail?.primaryAddress?.trim();
     final useFailedReceiptLayout = tx?.expiredUnmined == true;
+    final compactAddress = detail?.memo?.trim().isNotEmpty == true;
     if (tx?.txKind == 'sent' &&
         primaryAddress != null &&
         primaryAddress.isNotEmpty) {
@@ -390,6 +383,7 @@ class _ActivityTransactionStatusScreenState
         title: 'To',
         address: primaryAddress,
         useFailedReceiptLayout: useFailedReceiptLayout,
+        compactAddress: compactAddress,
       );
     }
     if (tx?.txKind == 'received' &&
@@ -400,13 +394,13 @@ class _ActivityTransactionStatusScreenState
         title: 'From',
         address: primaryAddress,
         useFailedReceiptLayout: useFailedReceiptLayout,
+        compactAddress: compactAddress,
       );
     }
     return _transactionHashBlock(context);
   }
 
   List<TransactionReceiptBlockData> _extraBlocksFor(
-    BuildContext context,
     rust_sync.TransactionDetail? detail,
   ) {
     final memo = detail?.memo?.trim();
@@ -414,11 +408,13 @@ class _ActivityTransactionStatusScreenState
     return [
       TransactionReceiptBlockData(
         title: 'Message',
-        child: Text(
-          memo,
-          style: AppTypography.labelLarge.copyWith(
-            color: context.colors.text.accent,
-          ),
+        titleTrailing: TransactionReceiptMessageToggle(
+          expanded: _messageExpanded,
+          onTap: _toggleMessageExpanded,
+        ),
+        child: TransactionReceiptMessageText(
+          memo: memo,
+          expanded: _messageExpanded,
         ),
       ),
     ];
@@ -475,6 +471,7 @@ class _ActivityTransactionStatusScreenState
                       alignment: Alignment.centerLeft,
                       child: AppRouteBackLink(),
                     ),
+                    const SizedBox(height: AppSpacing.s),
                     Expanded(
                       child: Padding(
                         padding: const EdgeInsets.only(right: 255),
@@ -487,7 +484,7 @@ class _ActivityTransactionStatusScreenState
                               privacyModeEnabled: privacyModeEnabled,
                             ),
                             primaryBlock: _primaryBlockFor(context, tx, detail),
-                            extraBlocks: _extraBlocksFor(context, detail),
+                            extraBlocks: _extraBlocksFor(detail),
                             dateText: _dateText(tx),
                             feeText: _feeText(
                               tx,
@@ -495,6 +492,8 @@ class _ActivityTransactionStatusScreenState
                             ),
                             error: error,
                             useFailedReceiptLayout: useFailedReceiptLayout,
+                            showPrimaryCopyAction: true,
+                            pinActionsToBottom: true,
                             onTransactionHashPressed: _openTransactionExplorer,
                           ),
                         ),

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/formatting/zec_amount.dart';
+import '../../../core/config/zcash_explorer.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
@@ -206,6 +207,17 @@ class _ActivityTransactionStatusScreenState
   }
 
   Future<void> _copyTransactionHash() async {
+    await _copyText(widget.args.txidHex, 'Transaction Hash Copied');
+  }
+
+  Future<void> _openTransactionExplorer() async {
+    final endpoint = ref.read(rpcEndpointProvider);
+    final launched = await launchZcashExplorerTransaction(
+      networkName: endpoint.networkName,
+      txidHex: widget.args.txidHex,
+      txidOrder: ZcashExplorerTxidOrder.protocol,
+    );
+    if (launched || !mounted) return;
     await _copyText(widget.args.txidHex, 'Transaction Hash Copied');
   }
 
@@ -483,7 +495,7 @@ class _ActivityTransactionStatusScreenState
                             ),
                             error: error,
                             useFailedReceiptLayout: useFailedReceiptLayout,
-                            onCopyTxid: _copyTransactionHash,
+                            onTransactionHashPressed: _openTransactionExplorer,
                           ),
                         ),
                       ),

--- a/lib/src/features/activity/widgets/activity_table.dart
+++ b/lib/src/features/activity/widgets/activity_table.dart
@@ -24,6 +24,7 @@ class ActivityTable extends StatelessWidget {
     this.totalPages = 1,
     this.onPageChanged,
     this.showPagination = false,
+    this.pinPaginationToBottom = false,
     super.key,
   });
 
@@ -37,6 +38,7 @@ class ActivityTable extends StatelessWidget {
   final int totalPages;
   final ValueChanged<int>? onPageChanged;
   final bool showPagination;
+  final bool pinPaginationToBottom;
 
   @override
   Widget build(BuildContext context) {
@@ -46,39 +48,49 @@ class ActivityTable extends StatelessWidget {
       effectiveTotalPages,
     );
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        if (title != null) ...[
-          _ActivityTableTitle(title: title!, onTap: onTitleTap),
-          const SizedBox(height: AppSpacing.xs),
-        ],
-        const _ActivityTableHeader(),
-        const SizedBox(height: AppSpacing.s),
-        if (errorText != null && rows.isEmpty)
-          _ActivityTableMessage(text: errorText!, isError: true)
-        else if (isLoading && rows.isEmpty)
-          const _ActivityTableMessage(text: 'Loading activity...')
-        else if (rows.isEmpty)
-          _ActivityTableMessage(text: emptyText)
-        else
-          for (var i = 0; i < rows.length; i++) ...[
-            ActivityTableRow(row: rows[i]),
-            if (i != rows.length - 1) ...[
-              const SizedBox(height: AppSpacing.xs),
-              const _ActivityTableDivider(),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final shouldPinPagination =
+            pinPaginationToBottom && constraints.hasBoundedHeight;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (title != null) ...[
+              _ActivityTableTitle(title: title!, onTap: onTitleTap),
               const SizedBox(height: AppSpacing.xs),
             ],
+            const _ActivityTableHeader(),
+            const SizedBox(height: AppSpacing.s),
+            if (errorText != null && rows.isEmpty)
+              _ActivityTableMessage(text: errorText!, isError: true)
+            else if (isLoading && rows.isEmpty)
+              const _ActivityTableMessage(text: 'Loading activity...')
+            else if (rows.isEmpty)
+              _ActivityTableMessage(text: emptyText)
+            else
+              for (var i = 0; i < rows.length; i++) ...[
+                ActivityTableRow(row: rows[i]),
+                if (i != rows.length - 1) ...[
+                  const SizedBox(height: AppSpacing.xs),
+                  const _ActivityTableDivider(),
+                  const SizedBox(height: AppSpacing.xs),
+                ],
+              ],
+            if (showPagination && effectiveTotalPages > 1) ...[
+              if (shouldPinPagination) ...[
+                const Spacer(),
+                const SizedBox(height: AppSpacing.xs),
+              ] else
+                const SizedBox(height: AppSpacing.lg),
+              ActivityTablePagination(
+                currentPage: effectiveCurrentPage,
+                totalPages: effectiveTotalPages,
+                onPageChanged: onPageChanged,
+              ),
+            ],
           ],
-        if (showPagination) ...[
-          const SizedBox(height: AppSpacing.lg),
-          ActivityTablePagination(
-            currentPage: effectiveCurrentPage,
-            totalPages: effectiveTotalPages,
-            onPageChanged: onPageChanged,
-          ),
-        ],
-      ],
+        );
+      },
     );
   }
 }
@@ -136,9 +148,6 @@ class _ActivityTableHeader extends StatelessWidget {
     final mutedStyle = AppTypography.labelMedium.copyWith(
       color: colors.text.muted,
     );
-    final accentStyle = AppTypography.labelMedium.copyWith(
-      color: colors.text.accent,
-    );
     return SizedBox(
       height: 32,
       child: Padding(
@@ -147,13 +156,10 @@ class _ActivityTableHeader extends StatelessWidget {
           txType: Text('Tx Type', style: mutedStyle),
           amount: Text('Amount', style: mutedStyle),
           status: Text('Status', style: mutedStyle),
-          timestamp: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text('Time Stamp', textAlign: TextAlign.end, style: accentStyle),
-              const SizedBox(width: AppSpacing.xxs),
-              AppIcon(AppIcons.arrowDown, size: 16, color: colors.icon.accent),
-            ],
+          timestamp: Text(
+            'Time Stamp',
+            textAlign: TextAlign.end,
+            style: mutedStyle,
           ),
         ),
       ),
@@ -277,7 +283,7 @@ class _StatusLabel extends StatelessWidget {
             row.statusText,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: AppTypography.labelMedium.copyWith(
+            style: AppTypography.labelLarge.copyWith(
               color: row.statusColor ?? colors.text.secondary,
             ),
           ),
@@ -404,7 +410,7 @@ class _ActivityTableRowState extends State<ActivityTableRow> {
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               textAlign: TextAlign.end,
-              style: AppTypography.labelMedium.copyWith(
+              style: AppTypography.labelLarge.copyWith(
                 color: colors.text.secondary,
               ),
             ),
@@ -471,7 +477,7 @@ class _AmountLabel extends StatelessWidget {
       row.amountText,
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
-      style: AppTypography.labelMedium.copyWith(color: color),
+      style: AppTypography.labelLarge.copyWith(color: color),
     );
 
     final iconName = row.amountIconName;

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -158,7 +158,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
       return [
         TextSpan(
           text: line,
-          style: AppTypography.labelLarge.copyWith(color: colors.text.accent),
+          style: AppTypography.bodyMedium.copyWith(color: colors.text.accent),
         ),
       ];
     }
@@ -168,18 +168,18 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     return [
       TextSpan(
         text: prefix,
-        style: AppTypography.labelLarge.copyWith(
+        style: AppTypography.bodyMedium.copyWith(
           color: colors.text.brandCrimson,
         ),
       ),
       TextSpan(
         text: middle,
-        style: AppTypography.labelLarge.copyWith(color: colors.text.accent),
+        style: AppTypography.bodyMedium.copyWith(color: colors.text.accent),
       ),
       if (suffix.isNotEmpty)
         TextSpan(
           text: suffix,
-          style: AppTypography.labelLarge.copyWith(
+          style: AppTypography.bodyMedium.copyWith(
             color: colors.text.brandCrimson,
           ),
         ),

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/config/zcash_explorer.dart';
 import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
@@ -263,6 +264,19 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     await Clipboard.setData(ClipboardData(text: txid));
     if (!mounted) return;
     showAppToast(context, 'Transaction Hash Copied');
+  }
+
+  Future<void> _openTransactionExplorer() async {
+    final txid = _txid;
+    if (txid == null) return;
+    final endpoint = ref.read(rpcEndpointProvider);
+    final launched = await launchZcashExplorerTransaction(
+      networkName: endpoint.networkName,
+      txidHex: txid,
+      txidOrder: ZcashExplorerTxidOrder.display,
+    );
+    if (launched || !mounted) return;
+    await _copyTransactionHash();
   }
 
   Future<void> _copyRecipientAddress() async {
@@ -560,8 +574,9 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
                               error: _error,
                               failureFallbackText: 'Send failed',
                               useFailedReceiptLayout: useFailedReceiptLayout,
-                              onCopyTxid: _phase == _SendStatusPhase.succeeded
-                                  ? _copyTransactionHash
+                              onTransactionHashPressed:
+                                  _phase == _SendStatusPhase.succeeded
+                                  ? _openTransactionExplorer
                                   : null,
                               onBackToWallet: _phase == _SendStatusPhase.failed
                                   ? _goHome

--- a/lib/src/features/send/widgets/transaction_receipt_view.dart
+++ b/lib/src/features/send/widgets/transaction_receipt_view.dart
@@ -30,7 +30,7 @@ class TransactionReceiptView extends StatelessWidget {
     this.error,
     this.failureFallbackText = 'Transaction failed',
     this.useFailedReceiptLayout = false,
-    this.onCopyTxid,
+    this.onTransactionHashPressed,
     this.onBackToWallet,
     super.key,
   });
@@ -44,7 +44,7 @@ class TransactionReceiptView extends StatelessWidget {
   final String? error;
   final String failureFallbackText;
   final bool useFailedReceiptLayout;
-  final VoidCallback? onCopyTxid;
+  final VoidCallback? onTransactionHashPressed;
   final VoidCallback? onBackToWallet;
 
   @override
@@ -214,10 +214,10 @@ class _TransactionReceiptActions extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final copyButton = view.onCopyTxid == null
+    final transactionHashButton = view.onTransactionHashPressed == null
         ? null
         : AppButton(
-            onPressed: view.onCopyTxid,
+            onPressed: view.onTransactionHashPressed,
             variant: AppButtonVariant.secondary,
             minWidth: 256,
             trailing: AppIcon(
@@ -231,16 +231,16 @@ class _TransactionReceiptActions extends StatelessWidget {
       TransactionReceiptPhase.loading ||
       TransactionReceiptPhase.sending => const SizedBox(height: 40),
       TransactionReceiptPhase.pending || TransactionReceiptPhase.succeeded =>
-        copyButton ?? const SizedBox(height: 40),
+        transactionHashButton ?? const SizedBox(height: 40),
       TransactionReceiptPhase.failed => Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _TransactionReceiptFailureMessage(
             message: view.error ?? view.failureFallbackText,
           ),
-          if (copyButton != null) ...[
+          if (transactionHashButton != null) ...[
             const SizedBox(height: AppSpacing.xs),
-            copyButton,
+            transactionHashButton,
           ],
           if (view.onBackToWallet != null) ...[
             const SizedBox(height: AppSpacing.xs),

--- a/lib/src/features/send/widgets/transaction_receipt_view.dart
+++ b/lib/src/features/send/widgets/transaction_receipt_view.dart
@@ -12,11 +12,18 @@ class TransactionReceiptBlockData {
     required this.title,
     required this.child,
     this.onCopy,
-  });
+    this.titleTrailing,
+  }) : assert(
+         onCopy == null || titleTrailing == null,
+         'Use either onCopy or titleTrailing, not both.',
+       );
 
   final String title;
   final Widget child;
   final VoidCallback? onCopy;
+
+  /// Optional right-side title action. Mutually exclusive with [onCopy].
+  final Widget? titleTrailing;
 }
 
 class TransactionReceiptView extends StatelessWidget {
@@ -30,6 +37,8 @@ class TransactionReceiptView extends StatelessWidget {
     this.error,
     this.failureFallbackText = 'Transaction failed',
     this.useFailedReceiptLayout = false,
+    this.showPrimaryCopyAction = false,
+    this.pinActionsToBottom = false,
     this.onTransactionHashPressed,
     this.onBackToWallet,
     super.key,
@@ -44,6 +53,11 @@ class TransactionReceiptView extends StatelessWidget {
   final String? error;
   final String failureFallbackText;
   final bool useFailedReceiptLayout;
+  final bool showPrimaryCopyAction;
+
+  /// Expands the receipt to its bounded parent height and pins the action
+  /// stack to the bottom. Do not use inside an unbounded vertical scroll view.
+  final bool pinActionsToBottom;
   final VoidCallback? onTransactionHashPressed;
   final VoidCallback? onBackToWallet;
 
@@ -51,72 +65,170 @@ class TransactionReceiptView extends StatelessWidget {
   Widget build(BuildContext context) {
     final showFailedReceipt =
         useFailedReceiptLayout && phase == TransactionReceiptPhase.failed;
+    final content = SizedBox(
+      width: 328,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _TransactionReceiptHeadline(
+            phase: phase,
+            amountText: amountText,
+            useFailedReceiptLayout: showFailedReceipt,
+          ),
+          const SizedBox(height: AppSpacing.md),
+          _TransactionReceiptBlock(
+            title: primaryBlock.title,
+            onCopy: showFailedReceipt || showPrimaryCopyAction
+                ? primaryBlock.onCopy
+                : null,
+            titleTrailing: primaryBlock.titleTrailing,
+            child: primaryBlock.child,
+          ),
+          for (final block in extraBlocks) ...[
+            const SizedBox(height: AppSpacing.md),
+            _TransactionReceiptBlock(
+              title: block.title,
+              onCopy: block.onCopy,
+              titleTrailing: block.titleTrailing,
+              child: block.child,
+            ),
+          ],
+          const SizedBox(height: AppSpacing.md),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Expanded(
+                child: _TransactionReceiptBlock(
+                  title: 'Date',
+                  child: Text(
+                    dateText,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: context.colors.text.accent,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: _TransactionReceiptBlock(
+                  title: 'Tx Fee',
+                  child: Text(
+                    feeText,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: context.colors.text.accent,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+    final actions = showFailedReceipt
+        ? null
+        : SizedBox(width: 256, child: _TransactionReceiptActions(view: this));
+
+    if (pinActionsToBottom) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Align(alignment: Alignment.centerLeft, child: content),
+          ),
+          if (actions != null) ...[
+            const SizedBox(height: AppSpacing.md),
+            actions,
+          ],
+        ],
+      );
+    }
 
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        SizedBox(
-          width: 328,
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _TransactionReceiptHeadline(
-                phase: phase,
-                amountText: amountText,
-                useFailedReceiptLayout: showFailedReceipt,
-              ),
-              const SizedBox(height: AppSpacing.md),
-              _TransactionReceiptBlock(
-                title: primaryBlock.title,
-                onCopy: showFailedReceipt ? primaryBlock.onCopy : null,
-                child: primaryBlock.child,
-              ),
-              for (final block in extraBlocks) ...[
-                const SizedBox(height: AppSpacing.md),
-                _TransactionReceiptBlock(
-                  title: block.title,
-                  child: block.child,
-                ),
-              ],
-              const SizedBox(height: AppSpacing.md),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                children: [
-                  Expanded(
-                    child: _TransactionReceiptBlock(
-                      title: 'Date',
-                      child: Text(
-                        dateText,
-                        style: AppTypography.labelLarge.copyWith(
-                          color: context.colors.text.accent,
-                        ),
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: AppSpacing.sm),
-                  Expanded(
-                    child: _TransactionReceiptBlock(
-                      title: 'Tx Fee',
-                      child: Text(
-                        feeText,
-                        style: AppTypography.labelLarge.copyWith(
-                          color: context.colors.text.accent,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-        if (!showFailedReceipt) ...[
+        content,
+        if (actions != null) ...[
           const SizedBox(height: AppSpacing.md),
-          SizedBox(width: 256, child: _TransactionReceiptActions(view: this)),
+          actions,
         ],
       ],
+    );
+  }
+}
+
+class TransactionReceiptMessageText extends StatelessWidget {
+  const TransactionReceiptMessageText({
+    required this.memo,
+    required this.expanded,
+    this.expandedMaxHeight = 156,
+    super.key,
+  });
+
+  final String memo;
+  final bool expanded;
+
+  /// Figma's expanded message body height; matches the send preview receipt.
+  final double expandedMaxHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Text(
+      memo,
+      maxLines: expanded ? null : 3,
+      overflow: expanded ? TextOverflow.visible : TextOverflow.ellipsis,
+      style: AppTypography.bodyMedium.copyWith(
+        color: context.colors.text.accent,
+      ),
+    );
+
+    if (!expanded) return text;
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: expandedMaxHeight),
+      child: SingleChildScrollView(child: text),
+    );
+  }
+}
+
+class TransactionReceiptMessageToggle extends StatelessWidget {
+  const TransactionReceiptMessageToggle({
+    required this.expanded,
+    required this.onTap,
+    super.key,
+  });
+
+  final bool expanded;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              expanded ? 'Collapse' : 'Expand',
+              style: AppTypography.labelMedium.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+            const SizedBox(width: AppSpacing.xxs),
+            AppIcon(
+              expanded ? AppIcons.collapsed : AppIcons.expand,
+              size: AppIconSize.medium,
+              color: colors.icon.regular,
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -162,11 +274,23 @@ class TransactionReceiptAddressText extends StatelessWidget {
   const TransactionReceiptAddressText({
     required this.address,
     this.highlightEdges = false,
+    this.compact = false,
+    this.highlightColor,
     super.key,
   });
 
+  static const _prefixHighlightLength = 6;
+  static const _compactLeadingPlainLength = 33;
+  static const _compactTrailingPlainLength = 33;
+  static const _suffixHighlightLength = 5;
+
   final String address;
   final bool highlightEdges;
+
+  /// Shortens long shielded-style addresses to the two-line memo layout.
+  /// Shorter addresses keep the regular full-address rendering.
+  final bool compact;
+  final Color? highlightColor;
 
   @override
   Widget build(BuildContext context) {
@@ -180,25 +304,61 @@ class TransactionReceiptAddressText extends StatelessWidget {
       return Text(trimmed, style: baseStyle);
     }
 
-    const prefixLength = 6;
-    const suffixLength = 5;
-    final middle = trimmed.substring(
-      prefixLength,
-      trimmed.length - suffixLength,
+    final highlightStyle = baseStyle.copyWith(
+      color: highlightColor ?? colors.text.destructive,
     );
-    final highlightStyle = baseStyle.copyWith(color: colors.text.destructive);
+
+    if (compact &&
+        trimmed.length >
+            _prefixHighlightLength +
+                _compactLeadingPlainLength +
+                _compactTrailingPlainLength +
+                _suffixHighlightLength) {
+      final leadingEnd = _prefixHighlightLength + _compactLeadingPlainLength;
+      final trailingStart =
+          trimmed.length - _suffixHighlightLength - _compactTrailingPlainLength;
+      final suffixStart = trimmed.length - _suffixHighlightLength;
+
+      return RichText(
+        softWrap: false,
+        overflow: TextOverflow.clip,
+        text: TextSpan(
+          style: baseStyle,
+          children: [
+            TextSpan(
+              text: trimmed.substring(0, _prefixHighlightLength),
+              style: highlightStyle,
+            ),
+            TextSpan(
+              text: trimmed.substring(_prefixHighlightLength, leadingEnd),
+            ),
+            const TextSpan(text: '\n... '),
+            TextSpan(text: trimmed.substring(trailingStart, suffixStart)),
+            TextSpan(
+              text: trimmed.substring(suffixStart),
+              style: highlightStyle,
+            ),
+          ],
+        ),
+      );
+    }
+
+    final middle = trimmed.substring(
+      _prefixHighlightLength,
+      trimmed.length - _suffixHighlightLength,
+    );
 
     return RichText(
       text: TextSpan(
         style: baseStyle,
         children: [
           TextSpan(
-            text: trimmed.substring(0, prefixLength),
+            text: trimmed.substring(0, _prefixHighlightLength),
             style: highlightStyle,
           ),
           TextSpan(text: middle),
           TextSpan(
-            text: trimmed.substring(trimmed.length - suffixLength),
+            text: trimmed.substring(trimmed.length - _suffixHighlightLength),
             style: highlightStyle,
           ),
         ],
@@ -317,11 +477,7 @@ class _TransactionReceiptHeadline extends StatelessWidget {
         const SizedBox(height: AppSpacing.xs),
         Text(
           amountText,
-          style:
-              (useFailedReceiptLayout
-                      ? AppTypography.displayLarge
-                      : AppTypography.displayMedium)
-                  .copyWith(color: colors.text.accent),
+          style: AppTypography.displayLarge.copyWith(color: colors.text.accent),
         ),
         if (useFailedReceiptLayout) ...[
           const SizedBox(height: AppSpacing.xs),
@@ -362,11 +518,13 @@ class _TransactionReceiptBlock extends StatelessWidget {
     required this.title,
     required this.child,
     this.onCopy,
+    this.titleTrailing,
   });
 
   final String title;
   final Widget child;
   final VoidCallback? onCopy;
+  final Widget? titleTrailing;
 
   @override
   Widget build(BuildContext context) {
@@ -384,7 +542,10 @@ class _TransactionReceiptBlock extends StatelessWidget {
                 ),
               ),
             ),
-            if (onCopy != null) _TransactionReceiptCopyAction(onTap: onCopy!),
+            if (titleTrailing != null)
+              titleTrailing!
+            else if (onCopy != null)
+              _TransactionReceiptCopyAction(onTap: onCopy!),
           ],
         ),
         const SizedBox(height: AppSpacing.xs),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1078,7 +1078,7 @@ packages:
     source: hosted
     version: "1.4.0"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
       sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   cryptography: ^2.7.0
   flutter_foreground_task: ^9.2.1
   window_manager: ^0.5.1
+  url_launcher: ^6.3.2
   # Renders the Figma-exported icon SVGs under `assets/icons/`.
   # Paired with `ColorFilter.mode(color, BlendMode.srcIn)` in
   # `AppIcon` so a single single-fill SVG tints to any theme color

--- a/test/activity_table_pagination_test.dart
+++ b/test/activity_table_pagination_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/features/activity/models/activity_row_data.dart';
 import 'package:zcash_wallet/src/features/activity/widgets/activity_table.dart';
 
 void main() {
@@ -46,6 +48,110 @@ void main() {
     await tester.pump();
     expect(_primaryFocusContainsText('3'), isTrue);
   });
+
+  testWidgets('pagination can be pinned to the bottom of full-height table', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(768, 500));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: SizedBox(
+            width: 768,
+            height: 500,
+            child: ActivityTable(
+              rows: [for (var i = 0; i < 6; i++) _row('Sent $i')],
+              showPagination: true,
+              pinPaginationToBottom: true,
+              currentPage: 1,
+              totalPages: 10,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final selectedPageShell = find.ancestor(
+      of: find.text('1'),
+      matching: find.byType(AnimatedContainer),
+    );
+
+    expect(selectedPageShell, findsOneWidget);
+    expect(
+      tester.getTopLeft(selectedPageShell).dy,
+      moreOrLessEquals(464, epsilon: 0.1),
+    );
+  });
+
+  testWidgets('pagination is hidden when there is only one page', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: ActivityTable(
+            rows: [_row('Sent')],
+            showPagination: true,
+            currentPage: 1,
+            totalPages: 1,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(ActivityTablePagination), findsNothing);
+  });
+
+  testWidgets(
+    'headers render without sort indicators while sorting is disabled',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(768, 240));
+      addTearDown(() async {
+        await tester.binding.setSurfaceSize(null);
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: AppTheme(
+            data: AppThemeData.light,
+            child: const SizedBox(width: 752, child: ActivityTable(rows: [])),
+          ),
+        ),
+      );
+
+      final arrowFinder = find.byWidgetPredicate(
+        (widget) => widget is AppIcon && widget.name == AppIcons.arrowDown,
+      );
+
+      expect(arrowFinder, findsNothing);
+
+      final mutedColor = AppThemeData.light.colors.text.muted;
+      for (final label in ['Tx Type', 'Amount', 'Status', 'Time Stamp']) {
+        final text = tester.widget<Text>(find.text(label));
+        expect(text.style?.color, mutedColor);
+      }
+    },
+  );
+}
+
+ActivityRowData _row(String title) {
+  return ActivityRowData(
+    title: title,
+    leadingIconName: AppIcons.plane,
+    leadingBackgroundColor: const Color(0xFFE1E1E1),
+    leadingIconColor: const Color(0xFF4D5252),
+    subtitle: 'Shielded',
+    subtitleIconName: AppIcons.shieldKeyholeOutline,
+    amountText: '-1.00 ZEC',
+    statusText: 'Completed',
+    timestampText: 'Apr, 25 10:25',
+  );
 }
 
 bool _primaryFocusContainsText(String value) {

--- a/test/activity_table_row_test.dart
+++ b/test/activity_table_row_test.dart
@@ -147,6 +147,28 @@ void main() {
     expect(find.text('+1.23 ZEC'), findsNothing);
     expect(find.text('-1.00 ZEC'), findsNothing);
   });
+
+  testWidgets('activity row value cells use label large typography', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: ActivityTable(rows: [_row(title: 'Wallet Synced')]),
+        ),
+      ),
+    );
+
+    for (final value in ['1.00 ZEC', 'Completed', 'Today, 13:11']) {
+      final text = tester.widget<Text>(find.text(value));
+      expect(text.style?.fontFamily, AppTypography.labelLarge.fontFamily);
+      expect(text.style?.fontWeight, AppTypography.labelLarge.fontWeight);
+      expect(text.style?.fontSize, AppTypography.labelLarge.fontSize);
+      expect(text.style?.height, AppTypography.labelLarge.height);
+      expect(text.style?.letterSpacing, AppTypography.labelLarge.letterSpacing);
+    }
+  });
 }
 
 rust_sync.TransactionInfo _tx({

--- a/test/transaction_receipt_view_test.dart
+++ b/test/transaction_receipt_view_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/features/send/widgets/transaction_receipt_view.dart';
+
+void main() {
+  test('block data rejects competing title trailing actions', () {
+    expect(
+      () => TransactionReceiptBlockData(
+        title: 'Message',
+        onCopy: _noop,
+        titleTrailing: const SizedBox.shrink(),
+        child: const Text('memo'),
+      ),
+      throwsAssertionError,
+    );
+  });
+
+  testWidgets('pins transaction hash action to the bottom when requested', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _receiptHarness(
+        const SizedBox(
+          width: 400,
+          height: 500,
+          child: TransactionReceiptView(
+            phase: TransactionReceiptPhase.succeeded,
+            amountText: '15.12 zec',
+            primaryBlock: TransactionReceiptBlockData(
+              title: 'To',
+              child: Text('u1testaddress'),
+            ),
+            dateText: 'April 20, 2026 13:50',
+            feeText: '0.00012 ZEC',
+            pinActionsToBottom: true,
+            onTransactionHashPressed: _noop,
+          ),
+        ),
+      ),
+    );
+
+    final button = find.widgetWithText(AppButton, 'Transaction Hash');
+
+    expect(button, findsOneWidget);
+    expect(tester.getTopLeft(button).dy, moreOrLessEquals(456, epsilon: 0.1));
+  });
+
+  testWidgets('message block toggles between collapsed and expanded text', (
+    tester,
+  ) async {
+    var expanded = false;
+
+    await tester.pumpWidget(
+      _receiptHarness(
+        StatefulBuilder(
+          builder: (context, setState) {
+            return TransactionReceiptView(
+              phase: TransactionReceiptPhase.succeeded,
+              amountText: '15.12 zec',
+              primaryBlock: const TransactionReceiptBlockData(
+                title: 'To',
+                child: Text('u1testaddress'),
+              ),
+              extraBlocks: [
+                TransactionReceiptBlockData(
+                  title: 'Message',
+                  titleTrailing: TransactionReceiptMessageToggle(
+                    expanded: expanded,
+                    onTap: () => setState(() {
+                      expanded = !expanded;
+                    }),
+                  ),
+                  child: TransactionReceiptMessageText(
+                    memo: _longMemo,
+                    expanded: expanded,
+                  ),
+                ),
+              ],
+              dateText: 'April 20, 2026 13:50',
+              feeText: '0.00012 ZEC',
+              onTransactionHashPressed: _noop,
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('Expand'), findsOneWidget);
+    expect(tester.widget<Text>(find.text(_longMemo)).maxLines, 3);
+
+    await tester.tap(find.text('Expand'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Collapse'), findsOneWidget);
+    expect(tester.widget<Text>(find.text(_longMemo)).maxLines, isNull);
+  });
+
+  testWidgets('address block shows the full wrapped address without a memo', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _receiptHarness(
+        const TransactionReceiptAddressText(
+          address: _longAddress,
+          highlightEdges: true,
+        ),
+      ),
+    );
+
+    final addressText = tester.widget<RichText>(find.byType(RichText));
+
+    expect(addressText.text.toPlainText(), _longAddress);
+    expect(addressText.text.toPlainText(), isNot(contains('...')));
+  });
+
+  testWidgets('address block shortens to two lines when memo is present', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _receiptHarness(
+        const TransactionReceiptAddressText(
+          address: _longAddress,
+          highlightEdges: true,
+          compact: true,
+        ),
+      ),
+    );
+
+    final addressText = tester.widget<RichText>(find.byType(RichText));
+    final plainText = addressText.text.toPlainText();
+
+    expect(plainText, startsWith('u1tvg4'));
+    expect(plainText, contains('\n... '));
+    expect(plainText, endsWith('n8fh5'));
+    expect(plainText, isNot(_longAddress));
+  });
+}
+
+Widget _receiptHarness(Widget child) {
+  return MaterialApp(
+    home: MediaQuery(
+      // Widget tests use the wide Ahem font; this keeps fixed Figma-width
+      // receipt controls from reporting test-only overflows.
+      data: const MediaQueryData(textScaler: TextScaler.linear(0.7)),
+      child: AppTheme(
+        data: AppThemeData.light,
+        child: Align(alignment: Alignment.topLeft, child: child),
+      ),
+    ),
+  );
+}
+
+void _noop() {}
+
+const _longMemo =
+    'Zcash is a privacy-focused cryptocurrency which features an encrypted '
+    'ledger using zero-knowledge proofs. Launched in October 2016, Zcash was '
+    'developed by cryptographers at Johns Hopkins University and MIT and '
+    'derived its code from bitcoin.';
+
+const _longAddress =
+    'u1tvg4akwn3gk64hhq6dfe05psw8zr0x4tspgwhkgy8x9yhy6djxjhrawuee0ecuzwm6zcwr8uewd366wefxxwp6tr8q8462lcdgvanwessx3sz87nm6c5mue444uzdumlecth9ncr4yavgtdqwd249nsfz5j3eds7qfhzek6scgcn8fh5';

--- a/test/zcash_explorer_test.dart
+++ b/test/zcash_explorer_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/config/zcash_explorer.dart';
+
+void main() {
+  test('builds mainnet transaction explorer URL from protocol-order txid', () {
+    expect(
+      zcashExplorerTransactionUri(
+        networkName: 'main',
+        txidHex:
+            'd6e03b5276de779d532791a82a28da7fb6b60524bf5996f4d7629cd794682c01',
+        txidOrder: ZcashExplorerTxidOrder.protocol,
+      ).toString(),
+      'https://mainnet.zcashexplorer.app/transactions/'
+      '012c6894d79c62d7f49659bf2405b6b67fda282aa89127539d77de76523be0d6',
+    );
+  });
+
+  test('builds testnet transaction explorer URL from protocol-order txid', () {
+    expect(
+      zcashExplorerTransactionUri(
+        networkName: 'test',
+        txidHex:
+            '6088ad5facf418b825ab83b421af13a444173627b56d626f586976b9a9c8733b',
+        txidOrder: ZcashExplorerTxidOrder.protocol,
+      ).toString(),
+      'https://testnet.zcashexplorer.app/transactions/'
+      '3b73c8a9b97669586f626db527361744a413af21b483ab25b818f4ac5fad8860',
+    );
+  });
+
+  test('builds URL for a shielded protocol-order transaction', () {
+    expect(
+      zcashExplorerTransactionUri(
+        networkName: 'main',
+        txidHex:
+            '1f9180542beb73685e309ec65d023df3e308c2eed26aafa056ea81e078d57a47',
+        txidOrder: ZcashExplorerTxidOrder.protocol,
+      ).toString(),
+      'https://mainnet.zcashexplorer.app/transactions/'
+      '477ad578e081ea56a0af6ad2eec208e3f33d025dc69e305e6873eb2b5480911f',
+    );
+  });
+
+  test('does not reverse display-order transaction IDs', () {
+    expect(
+      zcashExplorerTransactionUri(
+        networkName: 'main',
+        txidHex:
+            '477ad578e081ea56a0af6ad2eec208e3f33d025dc69e305e6873eb2b5480911f',
+        txidOrder: ZcashExplorerTxidOrder.display,
+      ).toString(),
+      'https://mainnet.zcashexplorer.app/transactions/'
+      '477ad578e081ea56a0af6ad2eec208e3f33d025dc69e305e6873eb2b5480911f',
+    );
+  });
+
+  test('does not reverse malformed protocol-order transaction IDs', () {
+    expect(
+      zcashExplorerTransactionUri(
+        networkName: 'main',
+        txidHex:
+            'zz7ad578e081ea56a0af6ad2eec208e3f33d025dc69e305e6873eb2b5480911f',
+        txidOrder: ZcashExplorerTxidOrder.protocol,
+      ).toString(),
+      'https://mainnet.zcashexplorer.app/transactions/'
+      'zz7ad578e081ea56a0af6ad2eec208e3f33d025dc69e305e6873eb2b5480911f',
+    );
+  });
+
+  test('launch returns false when the platform launcher throws', () async {
+    final launched = await launchZcashExplorerTransaction(
+      networkName: 'main',
+      txidHex:
+          '477ad578e081ea56a0af6ad2eec208e3f33d025dc69e305e6873eb2b5480911f',
+      txidOrder: ZcashExplorerTxidOrder.display,
+      launcher: (_) async => throw Exception('no browser'),
+    );
+
+    expect(launched, isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- Align the activity screen/table layout with the updated Figma direction: 256px sidebar shell, no postponed sort arrows, bottom-pinned pagination when needed, and hidden pagination for single-page tables.
- Add transaction explorer support with txid display-order handling and clipboard fallback when external launch fails.
- Refine transaction details receipts: bottom-pinned Transaction Hash action, copyable primary address, memo expand/collapse, and compact two-line address display when a memo is present.

## Verification
- fvm flutter test test/zcash_explorer_test.dart test/activity_table_pagination_test.dart test/activity_table_row_test.dart
- fvm flutter test test/transaction_receipt_view_test.dart test/features/send/send_review_screen_test.dart
- fvm flutter analyze lib test

## Note
- Full repo fvm flutter analyze still reports unrelated rust_builder/cargokit/build_tool dependency-resolution issues, so app/test scoped analysis was used.