### PR TITLE
[codex] Add route-aware back links

### DIFF
--- a/lib/src/core/navigation/app_back_resolver.dart
+++ b/lib/src/core/navigation/app_back_resolver.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+
+class AppBackTarget {
+  const AppBackTarget({
+    required this.label,
+    required this.fallbackPath,
+    required this.preferPop,
+  });
+
+  final String label;
+  final String fallbackPath;
+  final bool preferPop;
+
+  void navigate(BuildContext context) {
+    if (preferPop && context.canPop()) {
+      context.pop();
+      return;
+    }
+    context.go(fallbackPath);
+  }
+}
+
+class _RouteStackEntry {
+  const _RouteStackEntry({required this.routePath, required this.location});
+
+  final String routePath;
+  final String location;
+}
+
+abstract final class AppBackResolver {
+  static const _homeTarget = AppBackTarget(
+    label: 'Home',
+    fallbackPath: '/home',
+    preferPop: false,
+  );
+
+  static const _routeLabels = <String, String>{
+    '/home': 'Home',
+    '/send': 'Send',
+    '/send/review': 'Review',
+    '/send/status': 'Status',
+    '/receive': 'Receive',
+    '/activity': 'Activity',
+    '/activity/tx/:txid': 'Transaction',
+    '/settings': 'Settings',
+    '/settings/secret-passphrase': 'Secret Passphrase',
+    '/settings/change-password': 'Change Password',
+    '/settings/endpoint': 'Endpoint',
+    '/accounts': 'Accounts',
+    '/import-keystone': 'Import Keystone',
+  };
+
+  static AppBackTarget resolve(BuildContext context) {
+    final stack = _routeStackFor(context);
+    final current = stack.isEmpty ? null : stack.last;
+    if (_forcesHome(current)) return _homeTarget;
+    if (!context.canPop()) return _homeTarget;
+
+    final previous = stack.length >= 2 ? stack[stack.length - 2] : null;
+    if (previous == null) {
+      return const AppBackTarget(
+        label: 'Back',
+        fallbackPath: '/home',
+        preferPop: true,
+      );
+    }
+
+    return AppBackTarget(
+      label: _labelFor(previous) ?? 'Back',
+      fallbackPath: previous.location,
+      preferPop: true,
+    );
+  }
+
+  static bool _forcesHome(_RouteStackEntry? current) {
+    if (current == null) return false;
+    return current.routePath == '/send/status' ||
+        current.location == '/send/status';
+  }
+
+  static List<_RouteStackEntry> _routeStackFor(BuildContext context) {
+    final configuration = GoRouter.of(
+      context,
+    ).routerDelegate.currentConfiguration;
+    final entries = <_RouteStackEntry>[];
+    for (final match in configuration.matches) {
+      _appendStackEntry(match, entries);
+    }
+    return entries;
+  }
+
+  static void _appendStackEntry(
+    RouteMatchBase match,
+    List<_RouteStackEntry> entries,
+  ) {
+    if (match is ImperativeRouteMatch) {
+      final leaf = match.matches.lastOrNull;
+      if (leaf != null) entries.add(_entryFor(leaf));
+      return;
+    }
+
+    if (match is ShellRouteMatch) {
+      for (final child in match.matches) {
+        _appendStackEntry(child, entries);
+      }
+      return;
+    }
+
+    if (match is RouteMatch) {
+      entries.add(_entryFor(match));
+    }
+  }
+
+  static _RouteStackEntry _entryFor(RouteMatch match) {
+    return _RouteStackEntry(
+      routePath: match.route.path,
+      location: match.matchedLocation,
+    );
+  }
+
+  static String? _labelFor(_RouteStackEntry entry) {
+    return _routeLabels[entry.routePath] ??
+        _routeLabels[entry.location] ??
+        _dynamicRouteLabel(entry.location);
+  }
+
+  static String? _dynamicRouteLabel(String location) {
+    if (location.startsWith('/activity/tx/')) {
+      return _routeLabels['/activity/tx/:txid'];
+    }
+    return null;
+  }
+}

--- a/lib/src/core/widgets/app_back_link.dart
+++ b/lib/src/core/widgets/app_back_link.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import '../navigation/app_back_resolver.dart';
+import '../theme/app_theme.dart';
+import 'app_icon.dart';
+
+class AppBackLink extends StatefulWidget {
+  const AppBackLink({
+    required this.label,
+    required this.onTap,
+    this.minWidth = 0,
+    super.key,
+  });
+
+  final String label;
+  final FutureOr<void> Function() onTap;
+  final double minWidth;
+
+  @override
+  State<AppBackLink> createState() => _AppBackLinkState();
+}
+
+class _AppBackLinkState extends State<AppBackLink> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Semantics(
+      button: true,
+      label: 'Back to ${widget.label}',
+      child: ExcludeSemantics(
+        child: MouseRegion(
+          cursor: SystemMouseCursors.click,
+          onEnter: (_) => _setHovered(true),
+          onExit: (_) => _setHovered(false),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () => unawaited(Future<void>.value(widget.onTap())),
+            child: AnimatedOpacity(
+              duration: const Duration(milliseconds: 120),
+              opacity: _hovered ? 0.75 : 1,
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minWidth: widget.minWidth),
+                child: SizedBox(
+                  height: 32,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      AppIcon(
+                        AppIcons.chevronBackward,
+                        size: 16,
+                        color: colors.icon.accent,
+                      ),
+                      const SizedBox(width: AppSpacing.xxs),
+                      Text(
+                        widget.label,
+                        style: AppTypography.labelLarge.copyWith(
+                          color: colors.text.accent,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _setHovered(bool hovered) {
+    if (_hovered == hovered) return;
+    setState(() {
+      _hovered = hovered;
+    });
+  }
+}
+
+class AppRouteBackLink extends StatelessWidget {
+  const AppRouteBackLink({this.onBeforeNavigate, this.minWidth = 0, super.key});
+
+  final FutureOr<void> Function()? onBeforeNavigate;
+  final double minWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final target = AppBackResolver.resolve(context);
+    return AppBackLink(
+      label: target.label,
+      minWidth: minWidth,
+      onTap: () async {
+        final before = onBeforeNavigate;
+        if (before != null) {
+          await Future<void>.value(before());
+        }
+        if (!context.mounted) return;
+        target.navigate(context);
+      },
+    );
+  }
+}

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -12,8 +12,8 @@ import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
-import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/privacy_mode_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
@@ -150,14 +150,6 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
           curve: Curves.easeOutCubic,
         ),
       );
-    }
-  }
-
-  void _goBack() {
-    if (context.canPop()) {
-      context.pop();
-    } else {
-      context.go('/home');
     }
   }
 
@@ -331,7 +323,6 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
                         currentPage: currentPage,
                         totalPages: totalPages,
                         onPageChanged: _setPage,
-                        onBack: _goBack,
                       ),
                     ),
                   ),
@@ -353,7 +344,6 @@ class _ActivityPane extends StatelessWidget {
     required this.currentPage,
     required this.totalPages,
     required this.onPageChanged,
-    required this.onBack,
   });
 
   final List<ActivityRowData> rows;
@@ -362,7 +352,6 @@ class _ActivityPane extends StatelessWidget {
   final int currentPage;
   final int totalPages;
   final ValueChanged<int> onPageChanged;
-  final VoidCallback onBack;
 
   @override
   Widget build(BuildContext context) {
@@ -370,7 +359,10 @@ class _ActivityPane extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _ActivityBackRow(onTap: onBack),
+        const Align(
+          alignment: Alignment.centerLeft,
+          child: AppRouteBackLink(minWidth: 60),
+        ),
         const SizedBox(height: AppSpacing.s),
         Center(
           child: Text(
@@ -397,50 +389,6 @@ class _ActivityPane extends StatelessWidget {
         ),
         const SizedBox(height: AppSpacing.s),
       ],
-    );
-  }
-}
-
-class _ActivityBackRow extends StatelessWidget {
-  const _ActivityBackRow({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: onTap,
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(minWidth: 60),
-            child: SizedBox(
-              height: 32,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  AppIcon(
-                    AppIcons.chevronBackward,
-                    size: 16,
-                    color: colors.icon.accent,
-                  ),
-                  const SizedBox(width: AppSpacing.xxs),
-                  Text(
-                    'Back',
-                    style: AppTypography.labelLarge.copyWith(
-                      color: colors.text.accent,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/formatting/zec_amount.dart';
@@ -13,6 +12,7 @@ import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/privacy/privacy_mask.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_toast.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/privacy_mode_provider.dart';
@@ -203,14 +203,6 @@ class _ActivityTransactionStatusScreenState
       }
     }
     return '';
-  }
-
-  void _goBack() {
-    if (context.canPop()) {
-      context.pop();
-    } else {
-      context.go('/activity');
-    }
   }
 
   Future<void> _copyTransactionHash() async {
@@ -467,7 +459,10 @@ class _ActivityTransactionStatusScreenState
                 ),
                 child: Column(
                   children: [
-                    TransactionReceiptBackRow(onTap: _goBack),
+                    const Align(
+                      alignment: Alignment.centerLeft,
+                      child: AppRouteBackLink(),
+                    ),
                     Expanded(
                       child: Padding(
                         padding: const EdgeInsets.only(right: 255),

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -8,7 +8,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:go_router/go_router.dart';
 import 'package:pretty_qr_code/pretty_qr_code.dart';
 
 import '../../../../main.dart' show log;
@@ -16,6 +15,7 @@ import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
@@ -278,13 +278,6 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
               errorText: selectedErrorText,
               isLoading: isLoadingSelectedAddress,
               isRenewingShielded: _isRenewingShielded,
-              onBack: () {
-                if (context.canPop()) {
-                  context.pop();
-                } else {
-                  context.go('/home');
-                }
-              },
               onTypeChanged: _selectAddressType,
               onRenewShielded: isShielded ? _renewShieldedAddress : null,
               onCopy: _copySelectedAddress,
@@ -312,7 +305,6 @@ class _ReceivePane extends StatelessWidget {
     required this.errorText,
     required this.isLoading,
     required this.isRenewingShielded,
-    required this.onBack,
     required this.onTypeChanged,
     required this.onRenewShielded,
     required this.onCopy,
@@ -324,7 +316,6 @@ class _ReceivePane extends StatelessWidget {
   final String? errorText;
   final bool isLoading;
   final bool isRenewingShielded;
-  final VoidCallback onBack;
   final ValueChanged<_ReceiveAddressType> onTypeChanged;
   final VoidCallback? onRenewShielded;
   final VoidCallback onCopy;
@@ -342,10 +333,7 @@ class _ReceivePane extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Align(
-              alignment: Alignment.centerLeft,
-              child: _BackButton(onTap: onBack),
-            ),
+            Align(alignment: Alignment.centerLeft, child: AppRouteBackLink()),
             const SizedBox(height: AppSpacing.s),
             Expanded(
               child: Center(
@@ -636,60 +624,6 @@ class _ReceiveQrMetrics {
       renewSize: _baseRenewSize,
       qrPaddingX: _baseQrPaddingX,
       qrPaddingY: _baseQrPaddingY,
-    );
-  }
-}
-
-class _BackButton extends StatefulWidget {
-  const _BackButton({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  State<_BackButton> createState() => _BackButtonState();
-}
-
-class _BackButtonState extends State<_BackButton> {
-  bool _hovered = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      onEnter: (_) => setState(() => _hovered = true),
-      onExit: (_) => setState(() => _hovered = false),
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: widget.onTap,
-        child: AnimatedOpacity(
-          duration: const Duration(milliseconds: 120),
-          opacity: _hovered ? 0.75 : 1,
-          child: SizedBox(
-            height: 32,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Transform.scale(
-                  scaleX: -1,
-                  child: AppIcon(
-                    AppIcons.chevronForward,
-                    size: AppIconSize.medium,
-                    color: colors.icon.accent,
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.xxs),
-                Text(
-                  'Back',
-                  style: AppTypography.labelLarge.copyWith(
-                    color: colors.text.accent,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -11,6 +11,7 @@ import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -181,12 +182,6 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     });
   }
 
-  Future<void> _handleBack() async {
-    _scheduleDiscard();
-    if (!mounted) return;
-    context.pop();
-  }
-
   Future<void> _handleSend() async {
     await context.push('/send/status', extra: widget.args);
   }
@@ -207,7 +202,10 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
         padding: const EdgeInsets.all(AppSpacing.md),
         child: Column(
           children: [
-            _SendReviewBackRow(onTap: _handleBack),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: AppRouteBackLink(onBeforeNavigate: _scheduleDiscard),
+            ),
             Expanded(
               child: Center(
                 child: Column(
@@ -243,47 +241,6 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
               ),
             ),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-class _SendReviewBackRow extends StatelessWidget {
-  const _SendReviewBackRow({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: onTap,
-          child: SizedBox(
-            height: 32,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                AppIcon(
-                  AppIcons.chevronBackward,
-                  size: 16,
-                  color: colors.icon.accent,
-                ),
-                const SizedBox(width: AppSpacing.xxs),
-                Text(
-                  'Back',
-                  style: AppTypography.labelLarge.copyWith(
-                    color: colors.text.accent,
-                  ),
-                ),
-              ],
-            ),
-          ),
         ),
       ),
     );

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -14,6 +14,7 @@ import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/privacy/privacy_mask.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -743,15 +744,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
             data: (_) => Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                _SendBackRow(
-                  onTap: () {
-                    if (context.canPop()) {
-                      context.pop();
-                    } else {
-                      context.go('/home');
-                    }
-                  },
-                ),
+                const AppRouteBackLink(),
                 const SizedBox(height: AppSpacing.s),
                 Expanded(
                   child: _SendComposeLayout(
@@ -1035,44 +1028,6 @@ class _SendTitle extends StatelessWidget {
         color: context.colors.text.accent,
       ),
       textAlign: TextAlign.center,
-    );
-  }
-}
-
-class _SendBackRow extends StatelessWidget {
-  const _SendBackRow({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: SizedBox(
-          height: 32,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AppIcon(
-                AppIcons.chevronBackward,
-                size: 16,
-                color: colors.icon.accent,
-              ),
-              const SizedBox(width: AppSpacing.xxs),
-              Text(
-                'Back',
-                style: AppTypography.labelLarge.copyWith(
-                  color: colors.text.accent,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
     );
   }
 }

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -14,6 +14,7 @@ import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_toast.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
@@ -513,7 +514,10 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
                   ),
                   child: Column(
                     children: [
-                      TransactionReceiptBackRow(onTap: _goHome),
+                      const Align(
+                        alignment: Alignment.centerLeft,
+                        child: AppRouteBackLink(),
+                      ),
                       Expanded(
                         child: Padding(
                           padding: const EdgeInsets.only(right: 255),

--- a/lib/src/features/send/widgets/transaction_receipt_view.dart
+++ b/lib/src/features/send/widgets/transaction_receipt_view.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart' show Theme;
 import 'package:flutter/widgets.dart';
 
@@ -19,47 +17,6 @@ class TransactionReceiptBlockData {
   final String title;
   final Widget child;
   final VoidCallback? onCopy;
-}
-
-class TransactionReceiptBackRow extends StatelessWidget {
-  const TransactionReceiptBackRow({required this.onTap, super.key});
-
-  final FutureOr<void> Function() onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Align(
-      alignment: Alignment.centerLeft,
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: () => unawaited(Future<void>.value(onTap())),
-          child: SizedBox(
-            height: 32,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                AppIcon(
-                  AppIcons.chevronBackward,
-                  size: 16,
-                  color: colors.icon.accent,
-                ),
-                const SizedBox(width: AppSpacing.xxs),
-                Text(
-                  'Back',
-                  style: AppTypography.labelLarge.copyWith(
-                    color: colors.text.accent,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
 }
 
 class TransactionReceiptView extends StatelessWidget {

--- a/lib/src/features/settings/screens/settings_change_password_screen.dart
+++ b/lib/src/features/settings/screens/settings_change_password_screen.dart
@@ -8,6 +8,7 @@ import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/security/password_policy.dart';
 import '../../../core/storage/app_secure_store.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -76,11 +77,6 @@ class _SettingsChangePasswordScreenState
     _passwordController.dispose();
     _confirmController.dispose();
     super.dispose();
-  }
-
-  void _handleBack() {
-    _clearSensitiveState();
-    context.go('/settings');
   }
 
   void _clearSensitiveState() {
@@ -228,7 +224,7 @@ class _SettingsChangePasswordScreenState
       pane: AppDesktopPane(
         padding: const EdgeInsets.all(AppSpacing.md),
         child: _SettingsChangePasswordPane(
-          onBack: _handleBack,
+          onBeforeNavigateBack: _clearSensitiveState,
           child: switch (_stage) {
             _ChangePasswordStage.currentPassword => _CurrentPasswordView(
               passwordController: _currentPasswordController,
@@ -259,11 +255,11 @@ class _SettingsChangePasswordScreenState
 
 class _SettingsChangePasswordPane extends StatelessWidget {
   const _SettingsChangePasswordPane({
-    required this.onBack,
+    required this.onBeforeNavigateBack,
     required this.child,
   });
 
-  final VoidCallback onBack;
+  final VoidCallback onBeforeNavigateBack;
   final Widget child;
 
   @override
@@ -274,50 +270,11 @@ class _SettingsChangePasswordPane extends StatelessWidget {
         children: [
           Align(
             alignment: Alignment.centerLeft,
-            child: _BackButton(onTap: onBack),
+            child: AppRouteBackLink(onBeforeNavigate: onBeforeNavigateBack),
           ),
           const SizedBox(height: AppSpacing.s),
           Expanded(child: child),
         ],
-      ),
-    );
-  }
-}
-
-class _BackButton extends StatelessWidget {
-  const _BackButton({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: SizedBox(
-          height: 32,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AppIcon(
-                AppIcons.chevronBackward,
-                size: 16,
-                color: colors.icon.accent,
-              ),
-              const SizedBox(width: AppSpacing.xxs),
-              Text(
-                'Back',
-                style: AppTypography.labelLarge.copyWith(
-                  color: colors.text.accent,
-                ),
-              ),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/lib/src/features/settings/screens/settings_endpoint_screen.dart
+++ b/lib/src/features/settings/screens/settings_endpoint_screen.dart
@@ -3,13 +3,13 @@ import 'package:flutter/material.dart'
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/config/rpc_endpoint_config.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_text_field.dart';
@@ -60,10 +60,6 @@ class _SettingsEndpointScreenState
   void dispose() {
     _customController.dispose();
     super.dispose();
-  }
-
-  void _handleBack() {
-    context.go('/settings');
   }
 
   void _selectTab(_EndpointTab tab) {
@@ -197,7 +193,6 @@ class _SettingsEndpointScreenState
           submitError: _submitError,
           isSubmitting: _isSubmitting,
           canUpdate: _canUpdate(current),
-          onBack: _handleBack,
           onSelectTab: _selectTab,
           onSelectPreset: _selectPreset,
           onCustomChanged: (_) => setState(() {
@@ -221,7 +216,6 @@ class _SettingsEndpointPane extends StatelessWidget {
     required this.submitError,
     required this.isSubmitting,
     required this.canUpdate,
-    required this.onBack,
     required this.onSelectTab,
     required this.onSelectPreset,
     required this.onCustomChanged,
@@ -237,7 +231,6 @@ class _SettingsEndpointPane extends StatelessWidget {
   final String? submitError;
   final bool isSubmitting;
   final bool canUpdate;
-  final VoidCallback onBack;
   final ValueChanged<_EndpointTab> onSelectTab;
   final ValueChanged<String> onSelectPreset;
   final ValueChanged<String> onCustomChanged;
@@ -254,10 +247,7 @@ class _SettingsEndpointPane extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Align(
-            alignment: Alignment.centerLeft,
-            child: _BackButton(onTap: onBack),
-          ),
+          Align(alignment: Alignment.centerLeft, child: AppRouteBackLink()),
           const SizedBox(height: AppSpacing.s),
           Expanded(
             child: Center(
@@ -782,45 +772,6 @@ class _CustomEndpointForm extends StatelessWidget {
             ],
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _BackButton extends StatelessWidget {
-  const _BackButton({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: SizedBox(
-          height: 32,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AppIcon(
-                AppIcons.chevronBackward,
-                size: 16,
-                color: colors.icon.accent,
-              ),
-              const SizedBox(width: AppSpacing.xxs),
-              Text(
-                'Back',
-                style: AppTypography.labelLarge.copyWith(
-                  color: colors.text.accent,
-                ),
-              ),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/lib/src/features/settings/screens/settings_screen.dart
+++ b/lib/src/features/settings/screens/settings_screen.dart
@@ -8,6 +8,7 @@ import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/profile_pictures.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -99,10 +100,10 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 activeAccountIsHardware: activeAccountIsHardware,
                 endpointLabel: endpointLabel,
                 themeLabel: _themeLabel(themeMode),
-                onBack: () => _handleBack(context),
-                onSeedPhrase: () => context.go('/settings/secret-passphrase'),
-                onChangePassword: () => context.go('/settings/change-password'),
-                onEndpoint: () => context.go('/settings/endpoint'),
+                onSeedPhrase: () => context.push('/settings/secret-passphrase'),
+                onChangePassword: () =>
+                    context.push('/settings/change-password'),
+                onEndpoint: () => context.push('/settings/endpoint'),
                 onAccountName: hasActiveAccount
                     ? () => _showModal(_SettingsModalType.accountName)
                     : null,
@@ -140,14 +141,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     );
   }
 
-  static void _handleBack(BuildContext context) {
-    if (context.canPop()) {
-      context.pop();
-      return;
-    }
-    context.go('/home');
-  }
-
   static String _themeLabel(ThemeMode mode) {
     return switch (mode) {
       ThemeMode.system => 'System',
@@ -168,7 +161,6 @@ class _SettingsPane extends StatelessWidget {
     required this.activeAccountIsHardware,
     required this.endpointLabel,
     required this.themeLabel,
-    required this.onBack,
     required this.onSeedPhrase,
     required this.onChangePassword,
     required this.onEndpoint,
@@ -182,7 +174,6 @@ class _SettingsPane extends StatelessWidget {
   final bool activeAccountIsHardware;
   final String endpointLabel;
   final String themeLabel;
-  final VoidCallback onBack;
   final VoidCallback onSeedPhrase;
   final VoidCallback onChangePassword;
   final VoidCallback onEndpoint;
@@ -198,10 +189,7 @@ class _SettingsPane extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Align(
-            alignment: Alignment.centerLeft,
-            child: _SettingsBackButton(onTap: onBack),
-          ),
+          Align(alignment: Alignment.centerLeft, child: AppRouteBackLink()),
           const SizedBox(height: AppSpacing.s),
           Expanded(
             child: Padding(
@@ -242,45 +230,6 @@ class _SettingsPane extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _SettingsBackButton extends StatelessWidget {
-  const _SettingsBackButton({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: SizedBox(
-          height: 32,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AppIcon(
-                AppIcons.chevronBackward,
-                size: 16,
-                color: colors.icon.accent,
-              ),
-              const SizedBox(width: AppSpacing.xxs),
-              Text(
-                'Back',
-                style: AppTypography.labelLarge.copyWith(
-                  color: colors.text.accent,
-                ),
-              ),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
@@ -3,13 +3,13 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/security/password_policy.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_chip.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
@@ -57,11 +57,6 @@ class _SettingsSeedPhraseScreenState
     _clearSensitiveState();
     _passwordController.dispose();
     super.dispose();
-  }
-
-  void _handleBack() {
-    _clearSensitiveState();
-    context.go('/settings');
   }
 
   void _clearSensitiveState({String? passwordError}) {
@@ -238,7 +233,7 @@ class _SettingsSeedPhraseScreenState
       pane: AppDesktopPane(
         padding: const EdgeInsets.all(AppSpacing.md),
         child: _SettingsSeedPhrasePane(
-          onBack: _handleBack,
+          onBeforeNavigateBack: () => _clearSensitiveState(),
           child: switch (_stage) {
             _SettingsSeedPhraseStage.password => _PasswordGateView(
               passwordController: _passwordController,
@@ -262,9 +257,12 @@ class _SettingsSeedPhraseScreenState
 }
 
 class _SettingsSeedPhrasePane extends StatelessWidget {
-  const _SettingsSeedPhrasePane({required this.onBack, required this.child});
+  const _SettingsSeedPhrasePane({
+    required this.onBeforeNavigateBack,
+    required this.child,
+  });
 
-  final VoidCallback onBack;
+  final VoidCallback onBeforeNavigateBack;
   final Widget child;
 
   @override
@@ -275,50 +273,11 @@ class _SettingsSeedPhrasePane extends StatelessWidget {
         children: [
           Align(
             alignment: Alignment.centerLeft,
-            child: _BackButton(onTap: onBack),
+            child: AppRouteBackLink(onBeforeNavigate: onBeforeNavigateBack),
           ),
           const SizedBox(height: AppSpacing.s),
           Expanded(child: child),
         ],
-      ),
-    );
-  }
-}
-
-class _BackButton extends StatelessWidget {
-  const _BackButton({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: SizedBox(
-          height: 32,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AppIcon(
-                AppIcons.chevronBackward,
-                size: 16,
-                color: colors.icon.accent,
-              ),
-              const SizedBox(width: AppSpacing.xxs),
-              Text(
-                'Back',
-                style: AppTypography.labelLarge.copyWith(
-                  color: colors.text.accent,
-                ),
-              ),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/test/core/navigation/app_back_resolver_test.dart
+++ b/test/core/navigation/app_back_resolver_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_back_link.dart';
+
+void main() {
+  testWidgets(
+    'falls back to Home when the current route has no previous route',
+    (tester) async {
+      await tester.pumpWidget(
+        _backResolverHarness(initialLocation: '/receive'),
+      );
+      await tester.pump();
+
+      expect(find.text('Home'), findsOneWidget);
+    },
+  );
+
+  testWidgets('uses the actual previous route for pushed transaction details', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_backResolverHarness(initialLocation: '/home'));
+    await tester.pump();
+
+    await tester.tap(find.text('Open Home Tx'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Home'), findsOneWidget);
+    expect(find.text('Activity'), findsNothing);
+  });
+
+  testWidgets('updates the label when the same route is pushed from activity', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_backResolverHarness(initialLocation: '/activity'));
+    await tester.pump();
+
+    await tester.tap(find.text('Open Activity Tx'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Activity'), findsOneWidget);
+  });
+
+  testWidgets('uses Send when review is pushed from send', (tester) async {
+    await tester.pumpWidget(_backResolverHarness(initialLocation: '/send'));
+    await tester.pump();
+
+    await tester.tap(find.text('Open Review'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Send'), findsOneWidget);
+  });
+
+  testWidgets('keeps send status pinned to Home', (tester) async {
+    await tester.pumpWidget(_backResolverHarness(initialLocation: '/send'));
+    await tester.pump();
+
+    await tester.tap(find.text('Open Review'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Open Status'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Home'), findsOneWidget);
+    expect(find.text('Review'), findsNothing);
+  });
+}
+
+Widget _backResolverHarness({required String initialLocation}) {
+  final router = GoRouter(
+    initialLocation: initialLocation,
+    routes: [
+      GoRoute(
+        path: '/home',
+        builder: (_, _) => const _PushRouteButton(
+          label: 'Open Home Tx',
+          location: '/activity/tx/home-tx',
+        ),
+      ),
+      GoRoute(path: '/receive', builder: (_, _) => const AppRouteBackLink()),
+      GoRoute(
+        path: '/activity',
+        builder: (_, _) => const Column(
+          children: [
+            AppRouteBackLink(),
+            _PushRouteButton(
+              label: 'Open Activity Tx',
+              location: '/activity/tx/activity-tx',
+            ),
+          ],
+        ),
+      ),
+      GoRoute(
+        path: '/activity/tx/:txid',
+        builder: (_, _) => const AppRouteBackLink(),
+      ),
+      GoRoute(
+        path: '/send',
+        builder: (_, _) => const Column(
+          children: [
+            AppRouteBackLink(),
+            _PushRouteButton(label: 'Open Review', location: '/send/review'),
+          ],
+        ),
+      ),
+      GoRoute(
+        path: '/send/review',
+        builder: (_, _) => const Column(
+          children: [
+            AppRouteBackLink(),
+            _PushRouteButton(label: 'Open Status', location: '/send/status'),
+          ],
+        ),
+      ),
+      GoRoute(
+        path: '/send/status',
+        builder: (_, _) => const AppRouteBackLink(),
+      ),
+    ],
+  );
+
+  return MaterialApp.router(
+    routerConfig: router,
+    builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+  );
+}
+
+class _PushRouteButton extends StatelessWidget {
+  const _PushRouteButton({required this.label, required this.location});
+
+  final String label;
+  final String location;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: () => context.push(location),
+      child: Text(label),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add a shared back-link component for the non-onboarding custom back controls.
- Resolve the displayed back label from the actual GoRouter route stack, falling back to Home when there is no previous route.
- Keep send status pinned to Home and push settings detail screens so their back links resolve to Settings.

## Validation
- `fvm flutter analyze`
- `fvm flutter test test/core/navigation/app_back_resolver_test.dart`
- `fvm flutter test`