### PR TITLE
[codex] Add mnemonic import autocomplete

### DIFF
--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -211,7 +211,7 @@ String _txIcon(String kind) {
   return switch (kind) {
     'received' => AppIcons.arrowDownCircle,
     'sent' => AppIcons.plane,
-    'shielded' => AppIcons.shieldAsset,
+    'shielded' => AppIcons.shieldKeyholeOutline,
     _ => AppIcons.history,
   };
 }

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -541,7 +541,17 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
     }
 
     if (event.logicalKey == LogicalKeyboardKey.tab) {
-      if (HardwareKeyboard.instance.isShiftPressed) {
+      final shiftPressed = HardwareKeyboard.instance.isShiftPressed;
+      if (_hasAutocompleteOptions) {
+        final actionContext = node.context;
+        if (actionContext == null) return KeyEventResult.handled;
+        Actions.invoke(
+          actionContext,
+          shiftPressed
+              ? const AutocompletePreviousOptionIntent()
+              : const AutocompleteNextOptionIntent(),
+        );
+      } else if (shiftPressed) {
         widget.onMovePrevious();
       } else {
         widget.onMoveNext();

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -812,6 +812,7 @@ class _MnemonicSuggestionPopoverState
   static const _rowGap = 4.0;
   static const _visibleRows = 4;
   static const _listPadding = 4.0;
+  static const _scrollbarTrackWidth = 12.0;
   static const _outerVerticalPadding = 8.0;
   static const _listViewportHeight =
       _listPadding * 2 + _rowHeight * _visibleRows + _rowGap * 3;
@@ -870,6 +871,7 @@ class _MnemonicSuggestionPopoverState
     final visibleCount = optionCount < _visibleRows
         ? optionCount
         : _visibleRows;
+    final showScrollbar = optionCount > _visibleRows;
     final gapCount = visibleCount > 0 ? visibleCount - 1 : 0;
     final listHeight =
         _listPadding * 2 + visibleCount * _rowHeight + gapCount * _rowGap;
@@ -902,7 +904,7 @@ class _MnemonicSuggestionPopoverState
                 ],
         ),
         child: Padding(
-          padding: const EdgeInsets.fromLTRB(4, 8, 16, 8),
+          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
           child: ScrollbarTheme(
             data: ScrollbarThemeData(
               thumbColor: WidgetStatePropertyAll(
@@ -911,30 +913,38 @@ class _MnemonicSuggestionPopoverState
               radius: const Radius.circular(AppRadii.full),
               thickness: const WidgetStatePropertyAll(6),
               mainAxisMargin: 3,
-              crossAxisMargin: -10,
+              crossAxisMargin: 3,
             ),
             child: Scrollbar(
               controller: _scrollController,
-              thumbVisibility: optionCount > _visibleRows,
-              child: ListView.builder(
-                controller: _scrollController,
-                padding: const EdgeInsets.all(_listPadding),
-                itemCount: optionCount,
-                itemBuilder: (context, index) {
-                  final option = widget.options[index];
-                  final highlighted = index == widget.highlightedIndex;
-                  return Padding(
-                    padding: EdgeInsets.only(
-                      bottom: index == optionCount - 1 ? 0 : _rowGap,
+              thumbVisibility: showScrollbar,
+              child: Row(
+                children: [
+                  Expanded(
+                    child: ListView.builder(
+                      controller: _scrollController,
+                      padding: const EdgeInsets.all(_listPadding),
+                      itemCount: optionCount,
+                      itemBuilder: (context, index) {
+                        final option = widget.options[index];
+                        final highlighted = index == widget.highlightedIndex;
+                        return Padding(
+                          padding: EdgeInsets.only(
+                            bottom: index == optionCount - 1 ? 0 : _rowGap,
+                          ),
+                          child: _MnemonicSuggestionRow(
+                            wordIndex: widget.wordIndex,
+                            word: option,
+                            highlighted: highlighted,
+                            onTap: () => widget.onSelected(option),
+                          ),
+                        );
+                      },
                     ),
-                    child: _MnemonicSuggestionRow(
-                      wordIndex: widget.wordIndex,
-                      word: option,
-                      highlighted: highlighted,
-                      onTap: () => widget.onSelected(option),
-                    ),
-                  );
-                },
+                  ),
+                  if (showScrollbar)
+                    const SizedBox(width: _scrollbarTrackWidth),
+                ],
               ),
             ),
           ),

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -1,4 +1,10 @@
-import 'package:flutter/material.dart' show InputDecoration, TextField;
+import 'package:flutter/material.dart'
+    show
+        InputDecoration,
+        Scrollbar,
+        ScrollbarTheme,
+        ScrollbarThemeData,
+        TextField;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -31,6 +37,7 @@ class _ImportSecretPassphraseScreenState
 
   late final List<TextEditingController> _controllers;
   late final List<FocusNode> _focusNodes;
+  late final List<String> _mnemonicWordList;
 
   bool _isSubmitting = false;
   bool _showValidationError = false;
@@ -40,6 +47,7 @@ class _ImportSecretPassphraseScreenState
   @override
   void initState() {
     super.initState();
+    _mnemonicWordList = rust_wallet.mnemonicWordList();
     _controllers = List.generate(_wordCount, (_) => TextEditingController());
     _focusNodes = List.generate(_wordCount, (_) => FocusNode());
     _restoreMnemonic();
@@ -108,6 +116,35 @@ class _ImportSecretPassphraseScreenState
   void _focusIndex(int index) {
     if (index < 0 || index >= _focusNodes.length) return;
     _focusNodes[index].requestFocus();
+  }
+
+  void _moveToNextWord(int index) {
+    if (index < _wordCount - 1) {
+      _focusIndex(index + 1);
+    }
+  }
+
+  void _moveToPreviousWord(int index) {
+    if (index > 0) {
+      _focusIndex(index - 1);
+    }
+  }
+
+  void _handleSuggestionSelected(int index, String word) {
+    _isApplyingProgrammaticChange = true;
+    _setControllerText(index, word.toLowerCase());
+    _isApplyingProgrammaticChange = false;
+
+    if (mounted) {
+      setState(() {
+        _submitError = null;
+        if (_showValidationError && _isMnemonicValid) {
+          _showValidationError = false;
+        }
+      });
+    }
+
+    _moveToNextWord(index);
   }
 
   void _handleWordChanged(int index, String rawValue) {
@@ -279,19 +316,25 @@ class _ImportSecretPassphraseScreenState
                                   index: index,
                                   controller: _controllers[index],
                                   focusNode: _focusNodes[index],
+                                  wordList: _mnemonicWordList,
                                   destructive:
                                       _showValidationError &&
                                       _controllers[index].text
                                           .trim()
                                           .isNotEmpty,
                                   autofocus: index == 0,
+                                  onMoveNext: () => _moveToNextWord(index),
+                                  onMovePrevious: () =>
+                                      _moveToPreviousWord(index),
+                                  onSuggestionSelected: (word) =>
+                                      _handleSuggestionSelected(index, word),
                                   onChanged: (value) =>
                                       _handleWordChanged(index, value),
-                                  onSubmitted: (_) {
+                                  onSubmitted: () {
                                     if (index == _wordCount - 1) {
                                       _submit();
                                     } else {
-                                      _focusIndex(index + 1);
+                                      _moveToNextWord(index);
                                     }
                                   },
                                 ),
@@ -334,8 +377,12 @@ class _MnemonicWordCell extends StatefulWidget {
     required this.index,
     required this.controller,
     required this.focusNode,
+    required this.wordList,
     required this.onChanged,
     required this.onSubmitted,
+    required this.onMoveNext,
+    required this.onMovePrevious,
+    required this.onSuggestionSelected,
     this.destructive = false,
     this.autofocus = false,
   });
@@ -343,8 +390,12 @@ class _MnemonicWordCell extends StatefulWidget {
   final int index;
   final TextEditingController controller;
   final FocusNode focusNode;
+  final List<String> wordList;
   final ValueChanged<String> onChanged;
-  final ValueChanged<String> onSubmitted;
+  final VoidCallback onSubmitted;
+  final VoidCallback onMoveNext;
+  final VoidCallback onMovePrevious;
+  final ValueChanged<String> onSuggestionSelected;
   final bool destructive;
   final bool autofocus;
 
@@ -353,6 +404,11 @@ class _MnemonicWordCell extends StatefulWidget {
 }
 
 class _MnemonicWordCellState extends State<_MnemonicWordCell> {
+  static const _fieldWidth = 120.0;
+  static const _fieldHeight = 36.0;
+  static const _suggestionWidth = 172.0;
+  static const _maxSuggestionCount = 64;
+
   final GlobalKey _textFieldRegionKey = GlobalKey();
   bool _hovered = false;
   Offset? _pendingShellTapGlobalPosition;
@@ -444,11 +500,97 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
     });
   }
 
-  @override
-  Widget build(BuildContext context) {
+  List<String> _optionsForText(String rawValue) {
+    final prefix = rawValue.trim().toLowerCase();
+    if (prefix.isEmpty || prefix.contains(RegExp(r'\s'))) {
+      return const <String>[];
+    }
+
+    final options = <String>[];
+    for (final word in widget.wordList) {
+      if (!word.startsWith(prefix)) continue;
+      options.add(word);
+      if (options.length >= _maxSuggestionCount) break;
+    }
+
+    if (options.length == 1 && options.first == prefix) {
+      return const <String>[];
+    }
+    return options;
+  }
+
+  Iterable<String> _buildOptions(TextEditingValue value) {
+    return _optionsForText(value.text);
+  }
+
+  bool get _hasAutocompleteOptions {
+    return widget.focusNode.hasFocus &&
+        _optionsForText(widget.controller.text).isNotEmpty;
+  }
+
+  KeyEventResult _handleFieldKeyEvent(
+    FocusNode node,
+    KeyEvent event,
+    VoidCallback onAutocompleteSubmitted,
+  ) {
+    if (event is! KeyDownEvent) return KeyEventResult.ignored;
+    if (event.logicalKey == LogicalKeyboardKey.enter ||
+        event.logicalKey == LogicalKeyboardKey.numpadEnter) {
+      _handleTextSubmitted(onAutocompleteSubmitted);
+      return KeyEventResult.handled;
+    }
+
+    if (event.logicalKey != LogicalKeyboardKey.tab) {
+      return KeyEventResult.ignored;
+    }
+
+    if (HardwareKeyboard.instance.isShiftPressed) {
+      widget.onMovePrevious();
+      return KeyEventResult.handled;
+    }
+
+    if (_hasAutocompleteOptions) {
+      onAutocompleteSubmitted();
+    } else {
+      widget.onMoveNext();
+    }
+    return KeyEventResult.handled;
+  }
+
+  void _handleTextSubmitted(VoidCallback onAutocompleteSubmitted) {
+    if (_hasAutocompleteOptions) {
+      onAutocompleteSubmitted();
+      return;
+    }
+    widget.onSubmitted();
+  }
+
+  Widget _buildOptionsView(
+    BuildContext context,
+    AutocompleteOnSelected<String> onSelected,
+    Iterable<String> options,
+  ) {
+    final highlightedIndex = AutocompleteHighlightedOption.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.xs),
+      child: _MnemonicSuggestionPopover(
+        wordIndex: widget.index,
+        options: options.toList(growable: false),
+        highlightedIndex: highlightedIndex,
+        onSelected: onSelected,
+      ),
+    );
+  }
+
+  Widget _buildFieldShell(
+    BuildContext context,
+    TextEditingController controller,
+    FocusNode focusNode,
+    VoidCallback onAutocompleteSubmitted,
+  ) {
     final colors = context.colors;
-    final isFocused = widget.focusNode.hasFocus;
-    final hasText = widget.controller.text.trim().isNotEmpty;
+    final isFocused = focusNode.hasFocus;
+    final hasText = controller.text.trim().isNotEmpty;
     final valueStyle = AppTypography.labelLarge.copyWith(
       color: colors.text.accent,
     );
@@ -469,8 +611,9 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
         ? colors.text.accent
         : colors.text.secondary;
 
-    return SizedBox(
-      width: 120,
+    return Focus(
+      onKeyEvent: (node, event) =>
+          _handleFieldKeyEvent(node, event, onAutocompleteSubmitted),
       child: MouseRegion(
         cursor: SystemMouseCursors.text,
         onEnter: (_) => setState(() => _hovered = true),
@@ -480,7 +623,7 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
           onTapDown: _handleShellTapDown,
           onTap: () => _requestFocusFromShell(valueStyle),
           child: SizedBox(
-            height: 36,
+            height: _fieldHeight,
             child: Stack(
               clipBehavior: Clip.none,
               children: [
@@ -557,8 +700,8 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
                           child: Center(
                             child: TextField(
                               key: _textFieldRegionKey,
-                              controller: widget.controller,
-                              focusNode: widget.focusNode,
+                              controller: controller,
+                              focusNode: focusNode,
                               autofocus: widget.autofocus,
                               keyboardType: TextInputType.text,
                               textInputAction: TextInputAction.next,
@@ -579,7 +722,8 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
                                 ),
                               ),
                               onChanged: widget.onChanged,
-                              onSubmitted: widget.onSubmitted,
+                              onSubmitted: (_) =>
+                                  _handleTextSubmitted(onAutocompleteSubmitted),
                             ),
                           ),
                         ),
@@ -589,6 +733,275 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
                 ),
               ],
             ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: _fieldWidth,
+      height: _fieldHeight,
+      child: OverflowBox(
+        minWidth: _suggestionWidth,
+        maxWidth: _suggestionWidth,
+        minHeight: _fieldHeight,
+        maxHeight: _fieldHeight,
+        alignment: Alignment.topCenter,
+        child: SizedBox(
+          width: _suggestionWidth,
+          height: _fieldHeight,
+          child: RawAutocomplete<String>(
+            textEditingController: widget.controller,
+            focusNode: widget.focusNode,
+            displayStringForOption: (word) => word,
+            optionsBuilder: _buildOptions,
+            optionsViewOpenDirection: OptionsViewOpenDirection.down,
+            optionsViewBuilder: _buildOptionsView,
+            onSelected: widget.onSuggestionSelected,
+            fieldViewBuilder:
+                (context, controller, focusNode, onAutocompleteSubmitted) {
+                  return Center(
+                    child: SizedBox(
+                      width: _fieldWidth,
+                      height: _fieldHeight,
+                      child: _buildFieldShell(
+                        context,
+                        controller,
+                        focusNode,
+                        onAutocompleteSubmitted,
+                      ),
+                    ),
+                  );
+                },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MnemonicSuggestionPopover extends StatefulWidget {
+  const _MnemonicSuggestionPopover({
+    required this.wordIndex,
+    required this.options,
+    required this.highlightedIndex,
+    required this.onSelected,
+  });
+
+  final int wordIndex;
+  final List<String> options;
+  final int highlightedIndex;
+  final ValueChanged<String> onSelected;
+
+  @override
+  State<_MnemonicSuggestionPopover> createState() =>
+      _MnemonicSuggestionPopoverState();
+}
+
+class _MnemonicSuggestionPopoverState
+    extends State<_MnemonicSuggestionPopover> {
+  static const _rowHeight = 32.0;
+  static const _rowGap = 4.0;
+  static const _visibleRows = 4;
+  static const _listPadding = 4.0;
+  static const _outerVerticalPadding = 8.0;
+  static const _listViewportHeight =
+      _listPadding * 2 + _rowHeight * _visibleRows + _rowGap * 3;
+
+  final ScrollController _scrollController = ScrollController();
+  int? _hoveredIndex;
+
+  @override
+  void didUpdateWidget(covariant _MnemonicSuggestionPopover oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.highlightedIndex != widget.highlightedIndex ||
+        oldWidget.options.length != widget.options.length) {
+      _scheduleHighlightedOptionScroll();
+    }
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _scheduleHighlightedOptionScroll() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scrollController.hasClients) return;
+      if (widget.options.isEmpty) return;
+      final index = widget.highlightedIndex
+          .clamp(0, widget.options.length - 1)
+          .toInt();
+      if (index < 0) return;
+
+      final rowTop = _listPadding + index * (_rowHeight + _rowGap);
+      final rowBottom = rowTop + _rowHeight;
+      final viewportTop = _scrollController.offset;
+      final viewportBottom = viewportTop + _listViewportHeight;
+
+      double? nextOffset;
+      if (rowTop < viewportTop) {
+        nextOffset = rowTop;
+      } else if (rowBottom > viewportBottom) {
+        nextOffset = rowBottom - _listViewportHeight;
+      }
+
+      if (nextOffset == null) return;
+      _scrollController.jumpTo(
+        nextOffset.clamp(0.0, _scrollController.position.maxScrollExtent),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final optionCount = widget.options.length;
+    if (optionCount == 0) return const SizedBox.shrink();
+
+    final visibleCount = optionCount < _visibleRows
+        ? optionCount
+        : _visibleRows;
+    final gapCount = visibleCount > 0 ? visibleCount - 1 : 0;
+    final listHeight =
+        _listPadding * 2 + visibleCount * _rowHeight + gapCount * _rowGap;
+    final popoverHeight = listHeight + _outerVerticalPadding * 2;
+
+    return SizedBox(
+      width: _MnemonicWordCellState._suggestionWidth,
+      height: popoverHeight,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: colors.background.ground,
+          borderRadius: BorderRadius.circular(AppRadii.medium),
+          border: Border.all(
+            color: colors.border.subtle,
+            strokeAlign: BorderSide.strokeAlignInside,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: colors.background.neutralScrim,
+              blurRadius: 2,
+              offset: const Offset(0, 2),
+            ),
+            BoxShadow(
+              color: colors.background.neutralScrim,
+              blurRadius: 15,
+              offset: const Offset(0, 10),
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(4, 8, 16, 8),
+          child: ScrollbarTheme(
+            data: ScrollbarThemeData(
+              thumbColor: WidgetStatePropertyAll(
+                colors.background.overlay.withValues(alpha: 0.5),
+              ),
+              radius: const Radius.circular(AppRadii.full),
+              thickness: const WidgetStatePropertyAll(6),
+              mainAxisMargin: 3,
+              crossAxisMargin: -10,
+            ),
+            child: Scrollbar(
+              controller: _scrollController,
+              thumbVisibility: optionCount > _visibleRows,
+              child: ListView.builder(
+                controller: _scrollController,
+                padding: const EdgeInsets.all(_listPadding),
+                itemCount: optionCount,
+                itemBuilder: (context, index) {
+                  final option = widget.options[index];
+                  return Padding(
+                    padding: EdgeInsets.only(
+                      bottom: index == optionCount - 1 ? 0 : _rowGap,
+                    ),
+                    child: _MnemonicSuggestionRow(
+                      wordIndex: widget.wordIndex,
+                      word: option,
+                      highlighted:
+                          index == widget.highlightedIndex ||
+                          index == _hoveredIndex,
+                      onHoverChanged: (hovered) {
+                        setState(() {
+                          _hoveredIndex = hovered ? index : null;
+                        });
+                      },
+                      onTap: () => widget.onSelected(option),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MnemonicSuggestionRow extends StatelessWidget {
+  const _MnemonicSuggestionRow({
+    required this.wordIndex,
+    required this.word,
+    required this.highlighted,
+    required this.onHoverChanged,
+    required this.onTap,
+  });
+
+  final int wordIndex;
+  final String word;
+  final bool highlighted;
+  final ValueChanged<bool> onHoverChanged;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => onHoverChanged(true),
+      onExit: (_) => onHoverChanged(false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          height: _MnemonicSuggestionPopoverState._rowHeight,
+          decoration: BoxDecoration(
+            color: highlighted ? colors.state.hover : null,
+            borderRadius: BorderRadius.circular(AppRadii.xSmall),
+          ),
+          child: Row(
+            children: [
+              SizedBox(
+                width: 24,
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  child: Text(
+                    '${wordIndex + 1}'.padLeft(2, '0'),
+                    style: AppTypography.codeMedium.copyWith(
+                      fontSize: 14,
+                      height: 21 / 14,
+                      color: colors.text.muted.withValues(alpha: 0.5),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xs),
+              Flexible(
+                child: Text(
+                  word,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTypography.labelLarge.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -858,6 +858,7 @@ class _MnemonicSuggestionPopoverState
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final isDark = AppTheme.of(context) == AppThemeData.dark;
     final optionCount = widget.options.length;
     if (optionCount == 0) return const SizedBox.shrink();
 
@@ -880,18 +881,20 @@ class _MnemonicSuggestionPopoverState
             color: colors.border.subtle,
             strokeAlign: BorderSide.strokeAlignInside,
           ),
-          boxShadow: [
-            BoxShadow(
-              color: colors.background.neutralScrim,
-              blurRadius: 2,
-              offset: const Offset(0, 2),
-            ),
-            BoxShadow(
-              color: colors.background.neutralScrim,
-              blurRadius: 15,
-              offset: const Offset(0, 10),
-            ),
-          ],
+          boxShadow: isDark
+              ? null
+              : [
+                  BoxShadow(
+                    color: colors.background.overlay,
+                    blurRadius: 2,
+                    offset: const Offset(0, 2),
+                  ),
+                  BoxShadow(
+                    color: colors.background.overlay,
+                    blurRadius: 15,
+                    offset: const Offset(0, 10),
+                  ),
+                ],
         ),
         child: Padding(
           padding: const EdgeInsets.fromLTRB(4, 8, 16, 8),

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -812,8 +812,6 @@ class _MnemonicSuggestionPopoverState
       _listPadding * 2 + _rowHeight * _visibleRows + _rowGap * 3;
 
   final ScrollController _scrollController = ScrollController();
-  int? _hoveredIndex;
-
   @override
   void didUpdateWidget(covariant _MnemonicSuggestionPopover oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -916,6 +914,7 @@ class _MnemonicSuggestionPopoverState
                 itemCount: optionCount,
                 itemBuilder: (context, index) {
                   final option = widget.options[index];
+                  final highlighted = index == widget.highlightedIndex;
                   return Padding(
                     padding: EdgeInsets.only(
                       bottom: index == optionCount - 1 ? 0 : _rowGap,
@@ -923,14 +922,7 @@ class _MnemonicSuggestionPopoverState
                     child: _MnemonicSuggestionRow(
                       wordIndex: widget.wordIndex,
                       word: option,
-                      highlighted:
-                          index == widget.highlightedIndex ||
-                          index == _hoveredIndex,
-                      onHoverChanged: (hovered) {
-                        setState(() {
-                          _hoveredIndex = hovered ? index : null;
-                        });
-                      },
+                      highlighted: highlighted,
                       onTap: () => widget.onSelected(option),
                     ),
                   );
@@ -949,30 +941,30 @@ class _MnemonicSuggestionRow extends StatelessWidget {
     required this.wordIndex,
     required this.word,
     required this.highlighted,
-    required this.onHoverChanged,
     required this.onTap,
   });
 
   final int wordIndex;
   final String word;
   final bool highlighted;
-  final ValueChanged<bool> onHoverChanged;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final selectedBackgroundColor = AppTheme.of(context) == AppThemeData.dark
+        ? colors.background.raised
+        : colors.background.base;
+
     return MouseRegion(
       cursor: SystemMouseCursors.click,
-      onEnter: (_) => onHoverChanged(true),
-      onExit: (_) => onHoverChanged(false),
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
         onTap: onTap,
         child: Container(
           height: _MnemonicSuggestionPopoverState._rowHeight,
           decoration: BoxDecoration(
-            color: highlighted ? colors.state.hover : null,
+            color: highlighted ? selectedBackgroundColor : null,
             borderRadius: BorderRadius.circular(AppRadii.xSmall),
           ),
           child: Row(

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -540,21 +540,16 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
       return KeyEventResult.handled;
     }
 
-    if (event.logicalKey != LogicalKeyboardKey.tab) {
-      return KeyEventResult.ignored;
-    }
-
-    if (HardwareKeyboard.instance.isShiftPressed) {
-      widget.onMovePrevious();
+    if (event.logicalKey == LogicalKeyboardKey.tab) {
+      if (HardwareKeyboard.instance.isShiftPressed) {
+        widget.onMovePrevious();
+      } else {
+        widget.onMoveNext();
+      }
       return KeyEventResult.handled;
     }
 
-    if (_hasAutocompleteOptions) {
-      onAutocompleteSubmitted();
-    } else {
-      widget.onMoveNext();
-    }
-    return KeyEventResult.handled;
+    return KeyEventResult.ignored;
   }
 
   void _handleTextSubmitted(VoidCallback onAutocompleteSubmitted) {

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -814,8 +814,6 @@ class _MnemonicSuggestionPopoverState
   static const _listPadding = 4.0;
   static const _scrollbarTrackWidth = 12.0;
   static const _outerVerticalPadding = 8.0;
-  static const _listViewportHeight =
-      _listPadding * 2 + _rowHeight * _visibleRows + _rowGap * 3;
 
   final ScrollController _scrollController = ScrollController();
   @override
@@ -845,13 +843,14 @@ class _MnemonicSuggestionPopoverState
       final rowTop = _listPadding + index * (_rowHeight + _rowGap);
       final rowBottom = rowTop + _rowHeight;
       final viewportTop = _scrollController.offset;
-      final viewportBottom = viewportTop + _listViewportHeight;
+      final viewportHeight = _scrollController.position.viewportDimension;
+      final viewportBottom = viewportTop + viewportHeight;
 
       double? nextOffset;
       if (rowTop < viewportTop) {
         nextOffset = rowTop;
       } else if (rowBottom > viewportBottom) {
-        nextOffset = rowBottom - _listViewportHeight;
+        nextOffset = rowBottom - viewportHeight;
       }
 
       if (nextOffset == null) return;

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -118,16 +118,16 @@ class _ImportSecretPassphraseScreenState
     _focusNodes[index].requestFocus();
   }
 
-  void _moveToNextWord(int index) {
-    if (index < _wordCount - 1) {
-      _focusIndex(index + 1);
-    }
+  bool _moveToNextWord(int index) {
+    if (index >= _wordCount - 1) return false;
+    _focusIndex(index + 1);
+    return true;
   }
 
-  void _moveToPreviousWord(int index) {
-    if (index > 0) {
-      _focusIndex(index - 1);
-    }
+  bool _moveToPreviousWord(int index) {
+    if (index <= 0) return false;
+    _focusIndex(index - 1);
+    return true;
   }
 
   void _handleSuggestionSelected(int index, String word) {
@@ -393,8 +393,8 @@ class _MnemonicWordCell extends StatefulWidget {
   final List<String> wordList;
   final ValueChanged<String> onChanged;
   final VoidCallback onSubmitted;
-  final VoidCallback onMoveNext;
-  final VoidCallback onMovePrevious;
+  final bool Function() onMoveNext;
+  final bool Function() onMovePrevious;
   final ValueChanged<String> onSuggestionSelected;
   final bool destructive;
   final bool autofocus;
@@ -552,9 +552,22 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
               : const AutocompleteNextOptionIntent(),
         );
       } else if (shiftPressed) {
-        widget.onMovePrevious();
+        if (!widget.onMovePrevious()) {
+          final focusContext = node.context;
+          final moved = focusContext == null
+              ? widget.focusNode.previousFocus()
+              : FocusTraversalGroup.of(focusContext).previous(widget.focusNode);
+          if (!moved || widget.focusNode.hasFocus) {
+            widget.focusNode.unfocus();
+          }
+        }
       } else {
-        widget.onMoveNext();
+        if (!widget.onMoveNext()) {
+          final moved = widget.focusNode.nextFocus();
+          if (!moved) {
+            widget.focusNode.unfocus();
+          }
+        }
       }
       return KeyEventResult.handled;
     }
@@ -617,6 +630,8 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
         : colors.text.secondary;
 
     return Focus(
+      canRequestFocus: false,
+      skipTraversal: true,
       onKeyEvent: (node, event) =>
           _handleFieldKeyEvent(node, event, onAutocompleteSubmitted),
       child: MouseRegion(

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -816,19 +816,39 @@ class _MnemonicSuggestionPopoverState
   static const _outerVerticalPadding = 8.0;
 
   final ScrollController _scrollController = ScrollController();
+  bool _canScroll = false;
+
   @override
   void didUpdateWidget(covariant _MnemonicSuggestionPopover oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.highlightedIndex != widget.highlightedIndex ||
         oldWidget.options.length != widget.options.length) {
+      _scheduleCanScrollUpdate();
       _scheduleHighlightedOptionScroll();
     }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _scheduleCanScrollUpdate();
   }
 
   @override
   void dispose() {
     _scrollController.dispose();
     super.dispose();
+  }
+
+  void _scheduleCanScrollUpdate() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !_scrollController.hasClients) return;
+      final nextCanScroll = _scrollController.position.maxScrollExtent > 0;
+      if (_canScroll == nextCanScroll) return;
+      setState(() {
+        _canScroll = nextCanScroll;
+      });
+    });
   }
 
   void _scheduleHighlightedOptionScroll() {
@@ -870,7 +890,6 @@ class _MnemonicSuggestionPopoverState
     final visibleCount = optionCount < _visibleRows
         ? optionCount
         : _visibleRows;
-    final showScrollbar = optionCount > _visibleRows;
     final gapCount = visibleCount > 0 ? visibleCount - 1 : 0;
     final listHeight =
         _listPadding * 2 + visibleCount * _rowHeight + gapCount * _rowGap;
@@ -916,7 +935,7 @@ class _MnemonicSuggestionPopoverState
             ),
             child: Scrollbar(
               controller: _scrollController,
-              thumbVisibility: showScrollbar,
+              thumbVisibility: _canScroll,
               child: Row(
                 children: [
                   Expanded(
@@ -946,8 +965,7 @@ class _MnemonicSuggestionPopoverState
                       ),
                     ),
                   ),
-                  if (showScrollbar)
-                    const SizedBox(width: _scrollbarTrackWidth),
+                  if (_canScroll) const SizedBox(width: _scrollbarTrackWidth),
                 ],
               ),
             ),

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -921,25 +921,30 @@ class _MnemonicSuggestionPopoverState
               child: Row(
                 children: [
                   Expanded(
-                    child: ListView.builder(
-                      controller: _scrollController,
-                      padding: const EdgeInsets.all(_listPadding),
-                      itemCount: optionCount,
-                      itemBuilder: (context, index) {
-                        final option = widget.options[index];
-                        final highlighted = index == widget.highlightedIndex;
-                        return Padding(
-                          padding: EdgeInsets.only(
-                            bottom: index == optionCount - 1 ? 0 : _rowGap,
-                          ),
-                          child: _MnemonicSuggestionRow(
-                            wordIndex: widget.wordIndex,
-                            word: option,
-                            highlighted: highlighted,
-                            onTap: () => widget.onSelected(option),
-                          ),
-                        );
-                      },
+                    child: ScrollConfiguration(
+                      behavior: ScrollConfiguration.of(
+                        context,
+                      ).copyWith(scrollbars: false),
+                      child: ListView.builder(
+                        controller: _scrollController,
+                        padding: const EdgeInsets.all(_listPadding),
+                        itemCount: optionCount,
+                        itemBuilder: (context, index) {
+                          final option = widget.options[index];
+                          final highlighted = index == widget.highlightedIndex;
+                          return Padding(
+                            padding: EdgeInsets.only(
+                              bottom: index == optionCount - 1 ? 0 : _rowGap,
+                            ),
+                            child: _MnemonicSuggestionRow(
+                              wordIndex: widget.wordIndex,
+                              word: option,
+                              highlighted: highlighted,
+                              onTap: () => widget.onSelected(option),
+                            ),
+                          );
+                        },
+                      ),
                     ),
                   ),
                   if (showScrollbar)

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -107,6 +107,10 @@ Future<String> getUnifiedAddress({
 String generateMnemonic() =>
     RustLib.instance.api.crateApiWalletGenerateMnemonic();
 
+/// Get the BIP-39 English word list used for mnemonic validation.
+List<String> mnemonicWordList() =>
+    RustLib.instance.api.crateApiWalletMnemonicWordList();
+
 /// Check if a wallet database exists at the given path.
 bool walletExists({required String dbPath}) =>
     RustLib.instance.api.crateApiWalletWalletExists(dbPath: dbPath);

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -70,7 +70,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 861917172;
+  int get rustContentHash => 1276288732;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -300,6 +300,8 @@ abstract class RustLibApi extends BaseApi {
     required String dbPath,
     required String network,
   });
+
+  List<String> crateApiWalletMnemonicWordList();
 
   Future<ProposalResult> crateApiSyncProposeSend({
     required String dbPath,
@@ -1965,6 +1967,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  List<String> crateApiWalletMnemonicWordList() {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_String,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiWalletMnemonicWordListConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletMnemonicWordListConstMeta =>
+      const TaskConstMeta(debugName: "mnemonic_word_list", argNames: []);
+
+  @override
   Future<ProposalResult> crateApiSyncProposeSend({
     required String dbPath,
     required String network,
@@ -1988,7 +2012,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -2046,7 +2070,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -2093,7 +2117,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -2120,7 +2144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 49)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2152,7 +2176,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -2190,7 +2214,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 51,
             port: port_,
           );
         },
@@ -2243,7 +2267,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -2294,7 +2318,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2328,7 +2352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -2369,7 +2393,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 55,
             port: port_,
           );
         },
@@ -2417,7 +2441,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 55,
+              funcId: 56,
               port: port_,
             );
           },
@@ -2458,7 +2482,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 56,
+              funcId: 57,
               port: port_,
             );
           },
@@ -2487,7 +2511,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2517,7 +2541,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 59,
             port: port_,
           );
         },
@@ -2554,7 +2578,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2586,7 +2610,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2611,7 +2635,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(mnemonic, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2637,7 +2661,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2667,7 +2691,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 64,
             port: port_,
           );
         },

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -226,6 +226,12 @@ pub fn generate_mnemonic() -> String {
     keys::generate_mnemonic()
 }
 
+/// Get the BIP-39 English word list used for mnemonic validation.
+#[flutter_rust_bridge::frb(sync)]
+pub fn mnemonic_word_list() -> Vec<String> {
+    keys::mnemonic_word_list()
+}
+
 /// Check if a wallet database exists at the given path.
 #[flutter_rust_bridge::frb(sync)]
 pub fn wallet_exists(db_path: String) -> bool {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 861917172;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1276288732;
 
 // Section: executor
 
@@ -1657,6 +1657,35 @@ fn wire__crate__api__wallet__list_accounts_impl(
         },
     )
 }
+fn wire__crate__api__wallet__mnemonic_word_list_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "mnemonic_word_list",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok(crate::api::wallet::mnemonic_word_list())?;
+                Ok(output_ok)
+            })())
+        },
+    )
+}
 fn wire__crate__api__sync__propose_send_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -3158,33 +3187,33 @@ fn pde_ffi_dispatcher_primary_impl(
             data_len,
         ),
         44 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-        47 => {
+        46 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+        48 => {
             wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len)
         }
-        49 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-        50 => {
+        50 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+        51 => {
             wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len)
         }
-        51 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-        53 => {
+        52 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+        54 => {
             wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len)
         }
-        54 => wire__crate__api__sync__shield_transparent_balance_impl(
+        55 => wire__crate__api__sync__shield_transparent_balance_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        55 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-        56 => {
+        56 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+        57 => {
             wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len)
         }
-        58 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3206,11 +3235,12 @@ fn pde_ffi_dispatcher_sync_impl(
         40 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
         41 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
         42 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        52 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        61 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        49 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        53 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        63 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use bip0039::{Count, English, Mnemonic};
+use bip0039::{Count, English, Language, Mnemonic};
 use secrecy::{ExposeSecret, SecretVec};
 use zcash_client_backend::data_api::{
     chain::ChainState, Account as _, AccountBirthday, AccountPurpose, AccountSource, WalletRead,
@@ -49,6 +49,14 @@ fn open_wallet_db_for_read(
 pub fn generate_mnemonic() -> String {
     let mnemonic = Mnemonic::<English>::generate(Count::Words24);
     mnemonic.phrase().to_string()
+}
+
+/// Return the BIP-39 English word list used for mnemonic validation.
+pub fn mnemonic_word_list() -> Vec<String> {
+    English::WORD_LIST
+        .iter()
+        .map(|word| (*word).to_string())
+        .collect()
 }
 
 /// Convert a mnemonic phrase to a 64-byte seed wrapped in SecretVec.

--- a/test/activity_table_row_test.dart
+++ b/test/activity_table_row_test.dart
@@ -148,6 +148,38 @@ void main() {
     expect(find.text('-1.00 ZEC'), findsNothing);
   });
 
+  testWidgets('shielded activity rows use the shield keyhole outline icon', (
+    tester,
+  ) async {
+    late final List<ActivityRowData> rows;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: Builder(
+            builder: (context) {
+              rows = buildActivityRows(
+                context: context,
+                sync: SyncState(totalBalance: BigInt.zero),
+                transactions: [
+                  _tx(
+                    txidHex: 'shielded',
+                    kind: 'shielded',
+                    amount: BigInt.from(10000),
+                  ),
+                ],
+              );
+              return ActivityTable(rows: rows);
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(rows[1].leadingIconName, AppIcons.shieldKeyholeOutline);
+  });
+
   testWidgets('activity row value cells use label large typography', (
     tester,
   ) async {

--- a/test/features/onboarding/import_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/import_secret_passphrase_screen_test.dart
@@ -128,6 +128,7 @@ void main() {
         find.byType(Scrollable).last,
       );
       expect(scrollable.position.viewportDimension, lessThan(152));
+      expect(find.text('cage'), findsNothing);
 
       await tester.sendKeyEvent(LogicalKeyboardKey.tab);
       await tester.pump();

--- a/test/features/onboarding/import_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/import_secret_passphrase_screen_test.dart
@@ -60,7 +60,7 @@ void main() {
     expect(_textField(tester, 1).focusNode!.hasFocus, isTrue);
   });
 
-  testWidgets('Tab keeps the typed text and moves focus to the next field', (
+  testWidgets('Tab moves the highlighted suggestion down without selecting', (
     tester,
   ) async {
     await _setDesktopViewport(tester);
@@ -72,6 +72,46 @@ void main() {
     await tester.pump();
 
     expect(_textField(tester, 0).controller!.text, 'cab');
+    expect(_textField(tester, 0).focusNode!.hasFocus, isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+
+    expect(_textField(tester, 0).controller!.text, 'cabin');
+    expect(_textField(tester, 1).focusNode!.hasFocus, isTrue);
+  });
+
+  testWidgets('Shift+Tab moves the highlighted suggestion up', (tester) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_importPassphraseScreen());
+    await tester.enterText(_wordField(0), 'cab');
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.pump();
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+
+    expect(_textField(tester, 0).controller!.text, 'cabin');
+    expect(_textField(tester, 1).focusNode!.hasFocus, isTrue);
+  });
+
+  testWidgets('Tab moves focus when autocomplete is hidden', (tester) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_importPassphraseScreen());
+    await tester.enterText(_wordField(0), 'zzz');
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    expect(_textField(tester, 0).controller!.text, 'zzz');
     expect(_textField(tester, 1).focusNode!.hasFocus, isTrue);
   });
 

--- a/test/features/onboarding/import_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/import_secret_passphrase_screen_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart' show MaterialApp, Scaffold, TextField;
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart' show Widget;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/onboarding/import/import_secret_passphrase_screen.dart';
+import 'package:zcash_wallet/src/rust/frb_generated.dart';
+
+void main() {
+  setUpAll(() {
+    RustLib.initMock(api: _RustApiFake());
+  });
+
+  tearDownAll(RustLib.dispose);
+
+  testWidgets('shows BIP39 prefix suggestions for the focused word', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_importPassphraseScreen());
+    await tester.enterText(_wordField(0), 'ca');
+    await tester.pump();
+
+    expect(find.text('cabbage'), findsOneWidget);
+    expect(find.text('cabin'), findsOneWidget);
+    expect(find.text('cable'), findsOneWidget);
+    expect(find.text('cactus'), findsOneWidget);
+  });
+
+  testWidgets(
+    'tapping a suggestion fills the word and focuses the next field',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      await tester.pumpWidget(_importPassphraseScreen());
+      await tester.enterText(_wordField(0), 'cab');
+      await tester.pump();
+
+      await tester.tap(find.text('cabbage'));
+      await tester.pump();
+
+      expect(_textField(tester, 0).controller!.text, 'cabbage');
+      expect(_textField(tester, 1).focusNode!.hasFocus, isTrue);
+    },
+  );
+
+  testWidgets('Enter accepts the highlighted suggestion and moves next', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_importPassphraseScreen());
+    await tester.enterText(_wordField(0), 'cab');
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+
+    expect(_textField(tester, 0).controller!.text, 'cabbage');
+    expect(_textField(tester, 1).focusNode!.hasFocus, isTrue);
+  });
+
+  testWidgets('Tab accepts the highlighted suggestion and moves next', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_importPassphraseScreen());
+    await tester.enterText(_wordField(0), 'cab');
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    expect(_textField(tester, 0).controller!.text, 'cabbage');
+    expect(_textField(tester, 1).focusNode!.hasFocus, isTrue);
+  });
+
+  testWidgets('keeps existing paste-to-fill behavior', (tester) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_importPassphraseScreen());
+    await tester.enterText(_wordField(0), 'abandon ability able');
+    await tester.pump();
+
+    expect(_textField(tester, 0).controller!.text, 'abandon');
+    expect(_textField(tester, 1).controller!.text, 'ability');
+    expect(_textField(tester, 2).controller!.text, 'able');
+    expect(_textField(tester, 3).focusNode!.hasFocus, isTrue);
+  });
+}
+
+Future<void> _setDesktopViewport(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(1280, 900));
+  addTearDown(() async {
+    await tester.binding.setSurfaceSize(null);
+  });
+}
+
+Widget _importPassphraseScreen() {
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+    ],
+    child: MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: const Scaffold(body: ImportSecretPassphraseScreen()),
+      ),
+    ),
+  );
+}
+
+Finder _wordField(int index) => find.byType(TextField).at(index);
+
+TextField _textField(WidgetTester tester, int index) {
+  return tester.widget<TextField>(_wordField(index));
+}
+
+class _RustApiFake implements RustLibApi {
+  @override
+  List<String> crateApiWalletMnemonicWordList() => _wordList;
+
+  @override
+  bool crateApiWalletValidateMnemonic({required String mnemonic}) {
+    return mnemonic.trim().split(RegExp(r'\s+')).length == 24;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => Future<void>.value();
+}
+
+const _wordList = <String>[
+  'abandon',
+  'ability',
+  'able',
+  'about',
+  'above',
+  'cabbage',
+  'cabin',
+  'cable',
+  'cactus',
+  'cage',
+  'cake',
+  'call',
+  'calm',
+  'camera',
+  'camp',
+];

--- a/test/features/onboarding/import_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/import_secret_passphrase_screen_test.dart
@@ -1,7 +1,16 @@
 import 'package:flutter/material.dart' show MaterialApp, Scaffold, TextField;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart'
-    show Scrollable, ScrollableState, Size, Widget;
+    show
+        Column,
+        Expanded,
+        Focus,
+        FocusNode,
+        Scrollable,
+        ScrollableState,
+        Size,
+        SizedBox,
+        Widget;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
@@ -116,6 +125,57 @@ void main() {
     expect(_textField(tester, 1).focusNode!.hasFocus, isTrue);
   });
 
+  testWidgets('Tab leaves the last word when autocomplete is hidden', (
+    tester,
+  ) async {
+    final afterNode = FocusNode();
+    addTearDown(afterNode.dispose);
+
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_importPassphraseScreen(afterNode: afterNode));
+    await tester.enterText(_wordField(23), 'zzz');
+    _textField(tester, 23).focusNode!.requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    expect(afterNode.hasFocus, isTrue);
+  });
+
+  testWidgets('Tab from the focus cycle end enters the first word', (
+    tester,
+  ) async {
+    final afterNode = FocusNode();
+    addTearDown(afterNode.dispose);
+
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_importPassphraseScreen(afterNode: afterNode));
+    afterNode.requestFocus();
+    await tester.pump();
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pump();
+
+    expect(_textField(tester, 0).focusNode!.hasFocus, isTrue);
+  });
+
+  testWidgets('Shift+Tab leaves the first word when autocomplete is hidden', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_importPassphraseScreen());
+    await tester.enterText(_wordField(0), 'zzz');
+    await tester.pump();
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+    await tester.pump();
+
+    expect(_textField(tester, 0).focusNode!.hasFocus, isFalse);
+  });
+
   testWidgets(
     'Tab scrolls clipped suggestions when highlight moves below view',
     (tester) async {
@@ -169,7 +229,17 @@ Future<void> _setDesktopViewport(
   });
 }
 
-Widget _importPassphraseScreen() {
+Widget _importPassphraseScreen({FocusNode? afterNode}) {
+  Widget body = const ImportSecretPassphraseScreen();
+  if (afterNode != null) {
+    body = Column(
+      children: [
+        Expanded(child: body),
+        Focus(focusNode: afterNode, child: const SizedBox(width: 1, height: 1)),
+      ],
+    );
+  }
+
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
@@ -177,7 +247,7 @@ Widget _importPassphraseScreen() {
     child: MaterialApp(
       home: AppTheme(
         data: AppThemeData.light,
-        child: const Scaffold(body: ImportSecretPassphraseScreen()),
+        child: Scaffold(body: body),
       ),
     ),
   );

--- a/test/features/onboarding/import_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/import_secret_passphrase_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart' show MaterialApp, Scaffold, TextField;
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart' show Widget;
+import 'package:flutter/widgets.dart'
+    show Scrollable, ScrollableState, Size, Widget;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
@@ -115,6 +116,35 @@ void main() {
     expect(_textField(tester, 1).focusNode!.hasFocus, isTrue);
   });
 
+  testWidgets(
+    'Tab scrolls clipped suggestions when highlight moves below view',
+    (tester) async {
+      await _setDesktopViewport(tester, const Size(1280, 720));
+      await tester.pumpWidget(_importPassphraseScreen());
+      await tester.enterText(_wordField(23), 'ca');
+      await tester.pump();
+
+      final scrollable = tester.state<ScrollableState>(
+        find.byType(Scrollable).last,
+      );
+      expect(scrollable.position.viewportDimension, lessThan(152));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      expect(scrollable.position.pixels, greaterThan(0));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      expect(_textField(tester, 23).controller!.text, 'cactus');
+    },
+  );
+
   testWidgets('keeps existing paste-to-fill behavior', (tester) async {
     await _setDesktopViewport(tester);
     await tester.pumpWidget(_importPassphraseScreen());
@@ -128,8 +158,11 @@ void main() {
   });
 }
 
-Future<void> _setDesktopViewport(WidgetTester tester) async {
-  await tester.binding.setSurfaceSize(const Size(1280, 900));
+Future<void> _setDesktopViewport(
+  WidgetTester tester, [
+  Size size = const Size(1280, 900),
+]) async {
+  await tester.binding.setSurfaceSize(size);
   addTearDown(() async {
     await tester.binding.setSurfaceSize(null);
   });

--- a/test/features/onboarding/import_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/import_secret_passphrase_screen_test.dart
@@ -60,7 +60,7 @@ void main() {
     expect(_textField(tester, 1).focusNode!.hasFocus, isTrue);
   });
 
-  testWidgets('Tab accepts the highlighted suggestion and moves next', (
+  testWidgets('Tab keeps the typed text and moves focus to the next field', (
     tester,
   ) async {
     await _setDesktopViewport(tester);
@@ -71,7 +71,7 @@ void main() {
     await tester.sendKeyEvent(LogicalKeyboardKey.tab);
     await tester.pump();
 
-    expect(_textField(tester, 0).controller!.text, 'cabbage');
+    expect(_textField(tester, 0).controller!.text, 'cab');
     expect(_textField(tester, 1).focusNode!.hasFocus, isTrue);
   });
 


### PR DESCRIPTION
## Summary
- Add Rust-backed BIP-39 English word list access for import mnemonic autocomplete.
- Implement RawAutocomplete suggestions on the import secret passphrase screen with desktop keyboard behavior for Enter, Tab, Shift+Tab, and arrow navigation.
- Match the autocomplete popover styling, scrollbar behavior, clipped-list scrolling, and focus traversal behavior.
- Add widget tests covering suggestions, selection, keyboard traversal, clipped scrolling, focus cycle behavior, and paste-to-fill preservation.

## Validation
- `fvm flutter test test/features/onboarding/import_secret_passphrase_screen_test.dart`
- `fvm flutter analyze lib/src/features/onboarding/import/import_secret_passphrase_screen.dart test/features/onboarding/import_secret_passphrase_screen_test.dart`
- `cd rust && cargo test`
- `git diff --check`

## Merge readiness
- Checked against `origin/main`; no merge conflicts detected.