### PR TITLE
Implement Vizor utility pages

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,6 +11,7 @@ import 'src/core/theme/legacy_material_theme.dart';
 import 'src/features/activity/screens/activity_screen.dart';
 import 'src/features/activity/screens/activity_transaction_status_screen.dart';
 import 'src/features/home/screens/home_screen.dart';
+import 'src/features/about/screens/about_screen.dart';
 import 'src/features/onboarding/create/address_types_screen.dart';
 import 'src/features/onboarding/create/intro_zcash_screen.dart';
 import 'src/features/onboarding/create/onboarding_split_view.dart';
@@ -67,6 +68,9 @@ final _routerProvider = Provider<GoRouter>((ref) {
           state.matchedLocation == '/add-account' ||
           state.matchedLocation.startsWith('/onboarding/') ||
           state.matchedLocation.startsWith('/import');
+      final isPublicLegal =
+          state.matchedLocation == '/terms' ||
+          state.matchedLocation == '/privacy';
       final isUnlock = state.matchedLocation == '/unlock';
       final isLostPassword = state.matchedLocation == '/lost-password';
       final isUnlockFlow = isUnlock || isLostPassword;
@@ -77,13 +81,13 @@ final _routerProvider = Provider<GoRouter>((ref) {
       );
 
       if (!hasWallet && isUnlockFlow) return '/welcome';
-      if (!hasWallet && !isOnboarding) return '/welcome';
+      if (!hasWallet && !isOnboarding && !isPublicLegal) return '/welcome';
       if (!hasWallet && state.matchedLocation == '/add-account') {
         return '/welcome';
       }
       // `/lost-password` is intentionally part of the unlock flow: a locked
       // wallet must be able to reach its local reset path from `/unlock`.
-      if (requiresUnlock && !isUnlockFlow) return '/unlock';
+      if (requiresUnlock && !isUnlockFlow && !isPublicLegal) return '/unlock';
       if (!requiresUnlock && isUnlockFlow) {
         return hasWallet ? '/home' : '/welcome';
       }
@@ -292,7 +296,10 @@ final _routerProvider = Provider<GoRouter>((ref) {
         path: '/lost-password',
         builder: (_, _) => const LostPasswordScreen(),
       ),
+      GoRoute(path: '/terms', builder: (_, _) => const TermsScreen()),
+      GoRoute(path: '/privacy', builder: (_, _) => const PrivacyPolicyScreen()),
       GoRoute(path: '/home', builder: (_, _) => const HomeScreen()),
+      GoRoute(path: '/about', builder: (_, _) => const AboutScreen()),
       GoRoute(path: '/activity', builder: (_, _) => const ActivityScreen()),
       GoRoute(
         path: '/activity/tx/:txid',

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -183,9 +183,13 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                               : () => context.go('/settings'),
                         ),
                         const SizedBox(height: AppSpacing.xs),
-                        const AppSidebarItem(
+                        AppSidebarItem(
                           label: 'About Vizor',
                           iconName: AppIcons.vizor,
+                          active: _matches('/about'),
+                          onTap: _matches('/about')
+                              ? null
+                              : () => context.go('/about'),
                         ),
                         const SizedBox(height: AppSpacing.xs),
                         AppSidebarItem(

--- a/lib/src/core/widgets/app_back_link.dart
+++ b/lib/src/core/widgets/app_back_link.dart
@@ -11,12 +11,16 @@ class AppBackLink extends StatefulWidget {
     required this.label,
     required this.onTap,
     this.minWidth = 0,
+    this.semanticsLabel,
     super.key,
   });
+
+  static const height = 32.0;
 
   final String label;
   final FutureOr<void> Function() onTap;
   final double minWidth;
+  final String? semanticsLabel;
 
   @override
   State<AppBackLink> createState() => _AppBackLinkState();
@@ -31,7 +35,7 @@ class _AppBackLinkState extends State<AppBackLink> {
 
     return Semantics(
       button: true,
-      label: 'Back to ${widget.label}',
+      label: widget.semanticsLabel ?? 'Back to ${widget.label}',
       child: ExcludeSemantics(
         child: MouseRegion(
           cursor: SystemMouseCursors.click,
@@ -46,7 +50,7 @@ class _AppBackLinkState extends State<AppBackLink> {
               child: ConstrainedBox(
                 constraints: BoxConstraints(minWidth: widget.minWidth),
                 child: SizedBox(
-                  height: 32,
+                  height: AppBackLink.height,
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [

--- a/lib/src/features/about/screens/about_screen.dart
+++ b/lib/src/features/about/screens/about_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart'
     show
         Colors,
@@ -14,6 +16,7 @@ import '../../../app_bootstrap.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/wallet_provider.dart';
@@ -49,27 +52,8 @@ class AboutScreen extends StatelessWidget {
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
       pane: AppDesktopPane(
-        padding: const EdgeInsets.all(AppSpacing.md),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            const Align(
-              alignment: Alignment.centerLeft,
-              child: _UtilityBackButton(fallbackPath: '/home'),
-            ),
-            const SizedBox(height: AppSpacing.s),
-            Expanded(
-              child: Center(
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(
-                    maxWidth: _maxSidebarPaneContentWidth,
-                  ),
-                  child: const _AboutContent(),
-                ),
-              ),
-            ),
-          ],
-        ),
+        padding: EdgeInsets.zero,
+        child: const _AboutScrollView(),
       ),
     );
   }
@@ -131,19 +115,7 @@ class _LegalScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return _FullPaneShell(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          const Align(
-            alignment: Alignment.centerLeft,
-            child: _UtilityBackButton(),
-          ),
-          const SizedBox(height: AppSpacing.s),
-          Expanded(
-            child: _LegalScrollView(title: title, paragraphs: paragraphs),
-          ),
-        ],
-      ),
+      child: _LegalScrollView(title: title, paragraphs: paragraphs),
     );
   }
 }
@@ -160,11 +132,74 @@ class _FullPaneShell extends StatelessWidget {
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(AppSpacing.xs),
-          child: AppDesktopPane(
-            padding: const EdgeInsets.all(AppSpacing.md),
-            child: child,
-          ),
+          child: AppDesktopPane(padding: EdgeInsets.zero, child: child),
         ),
+      ),
+    );
+  }
+}
+
+class _AboutScrollView extends StatefulWidget {
+  const _AboutScrollView();
+
+  @override
+  State<_AboutScrollView> createState() => _AboutScrollViewState();
+}
+
+class _AboutScrollViewState extends State<_AboutScrollView> {
+  final _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _UtilityScrollbar(
+      controller: _scrollController,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            controller: _scrollController,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.md),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Align(
+                      alignment: Alignment.centerLeft,
+                      child: AppRouteBackLink(),
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    ConstrainedBox(
+                      constraints: BoxConstraints(
+                        minHeight: math.max(
+                          0,
+                          constraints.maxHeight -
+                              (AppSpacing.md * 2) -
+                              32 -
+                              AppSpacing.s,
+                        ),
+                      ),
+                      child: Center(
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(
+                            maxWidth: _maxSidebarPaneContentWidth,
+                          ),
+                          child: const _AboutContent(),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
       ),
     );
   }
@@ -191,6 +226,58 @@ class _LegalScrollViewState extends State<_LegalScrollView> {
 
   @override
   Widget build(BuildContext context) {
+    return _UtilityScrollbar(
+      controller: _scrollController,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            controller: _scrollController,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.md),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Align(
+                      alignment: Alignment.centerLeft,
+                      child: _UtilityBackButton(),
+                    ),
+                    const SizedBox(height: AppSpacing.s),
+                    Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          _UtilityPageTitle(
+                            title: widget.title,
+                            subtitle: _legalUpdatedLabel,
+                          ),
+                          const SizedBox(height: AppSpacing.md),
+                          const AppDecorativeDivider(width: 256),
+                          const SizedBox(height: AppSpacing.md),
+                          _UtilityParagraphList(paragraphs: widget.paragraphs),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _UtilityScrollbar extends StatelessWidget {
+  const _UtilityScrollbar({required this.controller, required this.child});
+
+  final ScrollController controller;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
     final colors = context.colors;
     return ScrollbarTheme(
       data: ScrollbarThemeData(
@@ -202,35 +289,13 @@ class _LegalScrollViewState extends State<_LegalScrollView> {
         crossAxisMargin: 3,
         mainAxisMargin: 3,
       ),
-      child: Scrollbar(
-        controller: _scrollController,
-        child: SingleChildScrollView(
-          controller: _scrollController,
-          child: Padding(
-            padding: const EdgeInsets.only(top: AppSpacing.s),
-            child: Column(
-              children: [
-                _UtilityPageTitle(
-                  title: widget.title,
-                  subtitle: _legalUpdatedLabel,
-                ),
-                const SizedBox(height: AppSpacing.md),
-                const AppDecorativeDivider(width: 256),
-                const SizedBox(height: AppSpacing.md),
-                _UtilityParagraphList(paragraphs: widget.paragraphs),
-              ],
-            ),
-          ),
-        ),
-      ),
+      child: Scrollbar(controller: controller, child: child),
     );
   }
 }
 
 class _UtilityBackButton extends ConsumerWidget {
-  const _UtilityBackButton({this.fallbackPath});
-
-  final String? fallbackPath;
+  const _UtilityBackButton();
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -275,7 +340,7 @@ class _UtilityBackButton extends ConsumerWidget {
       context.pop();
       return;
     }
-    context.go(fallbackPath ?? _defaultFallbackPath(ref));
+    context.go(_defaultFallbackPath(ref));
   }
 
   String _defaultFallbackPath(WidgetRef ref) {

--- a/lib/src/features/about/screens/about_screen.dart
+++ b/lib/src/features/about/screens/about_screen.dart
@@ -18,10 +18,12 @@ import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
-import '../../../core/widgets/app_icon.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../onboarding/shared/onboarding_welcome_art.dart';
 
+const _utilityPageScrollbarKey = ValueKey('utility-page-scrollbar');
+const _backLinkContentGap = AppSpacing.s;
+// TODO(version-metadata): Replace Figma placeholder copy with runtime app metadata.
 const _aboutVersionLabel = 'Version: 0.1.24 Public Beta';
 const _legalUpdatedLabel = 'Last Update:  ';
 const _paragraphWidth = 352.0;
@@ -174,15 +176,15 @@ class _AboutScrollViewState extends State<_AboutScrollView> {
                       alignment: Alignment.centerLeft,
                       child: AppRouteBackLink(),
                     ),
-                    const SizedBox(height: AppSpacing.s),
+                    const SizedBox(height: _backLinkContentGap),
                     ConstrainedBox(
                       constraints: BoxConstraints(
                         minHeight: math.max(
                           0,
                           constraints.maxHeight -
                               (AppSpacing.md * 2) -
-                              32 -
-                              AppSpacing.s,
+                              AppBackLink.height -
+                              _backLinkContentGap,
                         ),
                       ),
                       child: Center(
@@ -243,7 +245,7 @@ class _LegalScrollViewState extends State<_LegalScrollView> {
                       alignment: Alignment.centerLeft,
                       child: _UtilityBackButton(),
                     ),
-                    const SizedBox(height: AppSpacing.s),
+                    const SizedBox(height: _backLinkContentGap),
                     Center(
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
@@ -289,7 +291,11 @@ class _UtilityScrollbar extends StatelessWidget {
         crossAxisMargin: 3,
         mainAxisMargin: 3,
       ),
-      child: Scrollbar(controller: controller, child: child),
+      child: Scrollbar(
+        key: _utilityPageScrollbarKey,
+        controller: controller,
+        child: child,
+      ),
     );
   }
 }
@@ -299,39 +305,12 @@ class _UtilityBackButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final colors = context.colors;
-    return Semantics(
-      button: true,
+    return AppBackLink(
       label: 'Back',
-      child: ExcludeSemantics(
-        child: MouseRegion(
-          cursor: SystemMouseCursors.click,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: () => _navigateBack(context, ref),
-            child: SizedBox(
-              height: 32,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  AppIcon(
-                    AppIcons.chevronBackward,
-                    size: 16,
-                    color: colors.icon.accent,
-                  ),
-                  const SizedBox(width: AppSpacing.xxs),
-                  Text(
-                    'Back',
-                    style: AppTypography.labelLarge.copyWith(
-                      color: colors.text.accent,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      ),
+      semanticsLabel: context.canPop()
+          ? 'Back'
+          : 'Back to ${_defaultFallbackLabel(ref)}',
+      onTap: () => _navigateBack(context, ref),
     );
   }
 
@@ -344,10 +323,17 @@ class _UtilityBackButton extends ConsumerWidget {
   }
 
   String _defaultFallbackPath(WidgetRef ref) {
+    return _hasWallet(ref) ? '/home' : '/welcome';
+  }
+
+  String _defaultFallbackLabel(WidgetRef ref) {
+    return _hasWallet(ref) ? 'Home' : 'Welcome';
+  }
+
+  bool _hasWallet(WidgetRef ref) {
     final bootstrap = ref.read(appBootstrapProvider);
     final wallet = ref.read(walletProvider).value;
-    final hasWallet = wallet?.hasWallet ?? bootstrap.hasWallet;
-    return hasWallet ? '/home' : '/welcome';
+    return wallet?.hasWallet ?? bootstrap.hasWallet;
   }
 }
 

--- a/lib/src/features/about/screens/about_screen.dart
+++ b/lib/src/features/about/screens/about_screen.dart
@@ -1,0 +1,375 @@
+import 'package:flutter/material.dart'
+    show
+        Colors,
+        Scaffold,
+        Scrollbar,
+        ScrollbarTheme,
+        ScrollbarThemeData,
+        WidgetStatePropertyAll;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../app_bootstrap.dart';
+import '../../../core/layout/app_desktop_shell.dart';
+import '../../../core/layout/app_main_sidebar.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_decorative_divider.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../providers/wallet_provider.dart';
+import '../../onboarding/shared/onboarding_welcome_art.dart';
+
+const _aboutVersionLabel = 'Version: 0.1.24 Public Beta';
+const _legalUpdatedLabel = 'Last Update:  ';
+const _paragraphWidth = 352.0;
+const _maxSidebarPaneContentWidth = 752.0;
+
+const _placeholderParagraph = _UtilityParagraphData(
+  heading: 'From the team that brought you Keplr Wallet.',
+  body:
+      'Unlike Bitcoin or Ethereum, shielded Zcash transactions hide the sender, recipient, and amount - verified by cryptography, not trust.',
+);
+
+const _aboutParagraphs = [_placeholderParagraph, _placeholderParagraph];
+
+const _legalParagraphs = [
+  _placeholderParagraph,
+  _placeholderParagraph,
+  _placeholderParagraph,
+  _placeholderParagraph,
+  _placeholderParagraph,
+  _placeholderParagraph,
+];
+
+class AboutScreen extends StatelessWidget {
+  const AboutScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AppDesktopShell(
+      sidebar: const AppMainSidebar(),
+      pane: AppDesktopPane(
+        padding: const EdgeInsets.all(AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Align(
+              alignment: Alignment.centerLeft,
+              child: _UtilityBackButton(fallbackPath: '/home'),
+            ),
+            const SizedBox(height: AppSpacing.s),
+            Expanded(
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    maxWidth: _maxSidebarPaneContentWidth,
+                  ),
+                  child: const _AboutContent(),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class TermsScreen extends StatelessWidget {
+  const TermsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const _LegalScreen(
+      title: 'Terms of Use',
+      paragraphs: _legalParagraphs,
+    );
+  }
+}
+
+class PrivacyPolicyScreen extends StatelessWidget {
+  const PrivacyPolicyScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const _LegalScreen(
+      title: 'Privacy Policy',
+      paragraphs: _legalParagraphs,
+    );
+  }
+}
+
+class _AboutContent extends StatelessWidget {
+  const _AboutContent();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        _UtilityPageTitle(
+          title: 'About Vizor Wallet',
+          subtitle: _aboutVersionLabel,
+        ),
+        SizedBox(height: AppSpacing.md),
+        AppDecorativeDivider(width: 256),
+        SizedBox(height: AppSpacing.md),
+        _UtilityParagraphList(paragraphs: _aboutParagraphs),
+        SizedBox(height: AppSpacing.md),
+        VizorWordmark(width: 74, height: 27.925),
+      ],
+    );
+  }
+}
+
+class _LegalScreen extends StatelessWidget {
+  const _LegalScreen({required this.title, required this.paragraphs});
+
+  final String title;
+  final List<_UtilityParagraphData> paragraphs;
+
+  @override
+  Widget build(BuildContext context) {
+    return _FullPaneShell(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const Align(
+            alignment: Alignment.centerLeft,
+            child: _UtilityBackButton(),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Expanded(
+            child: _LegalScrollView(title: title, paragraphs: paragraphs),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FullPaneShell extends StatelessWidget {
+  const _FullPaneShell({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.xs),
+          child: AppDesktopPane(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: child,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LegalScrollView extends StatefulWidget {
+  const _LegalScrollView({required this.title, required this.paragraphs});
+
+  final String title;
+  final List<_UtilityParagraphData> paragraphs;
+
+  @override
+  State<_LegalScrollView> createState() => _LegalScrollViewState();
+}
+
+class _LegalScrollViewState extends State<_LegalScrollView> {
+  final _scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return ScrollbarTheme(
+      data: ScrollbarThemeData(
+        thumbColor: WidgetStatePropertyAll(colors.background.overlay),
+        thickness: const WidgetStatePropertyAll(6),
+        radius: const Radius.circular(AppRadii.full),
+        thumbVisibility: const WidgetStatePropertyAll(true),
+        trackVisibility: const WidgetStatePropertyAll(false),
+        crossAxisMargin: 3,
+        mainAxisMargin: 3,
+      ),
+      child: Scrollbar(
+        controller: _scrollController,
+        child: SingleChildScrollView(
+          controller: _scrollController,
+          child: Padding(
+            padding: const EdgeInsets.only(top: AppSpacing.s),
+            child: Column(
+              children: [
+                _UtilityPageTitle(
+                  title: widget.title,
+                  subtitle: _legalUpdatedLabel,
+                ),
+                const SizedBox(height: AppSpacing.md),
+                const AppDecorativeDivider(width: 256),
+                const SizedBox(height: AppSpacing.md),
+                _UtilityParagraphList(paragraphs: widget.paragraphs),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _UtilityBackButton extends ConsumerWidget {
+  const _UtilityBackButton({this.fallbackPath});
+
+  final String? fallbackPath;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.colors;
+    return Semantics(
+      button: true,
+      label: 'Back',
+      child: ExcludeSemantics(
+        child: MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () => _navigateBack(context, ref),
+            child: SizedBox(
+              height: 32,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  AppIcon(
+                    AppIcons.chevronBackward,
+                    size: 16,
+                    color: colors.icon.accent,
+                  ),
+                  const SizedBox(width: AppSpacing.xxs),
+                  Text(
+                    'Back',
+                    style: AppTypography.labelLarge.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _navigateBack(BuildContext context, WidgetRef ref) {
+    if (context.canPop()) {
+      context.pop();
+      return;
+    }
+    context.go(fallbackPath ?? _defaultFallbackPath(ref));
+  }
+
+  String _defaultFallbackPath(WidgetRef ref) {
+    final bootstrap = ref.read(appBootstrapProvider);
+    final wallet = ref.read(walletProvider).value;
+    final hasWallet = wallet?.hasWallet ?? bootstrap.hasWallet;
+    return hasWallet ? '/home' : '/welcome';
+  }
+}
+
+class _UtilityPageTitle extends StatelessWidget {
+  const _UtilityPageTitle({required this.title, required this.subtitle});
+
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          title,
+          textAlign: TextAlign.center,
+          style: AppTypography.displaySmall.copyWith(color: colors.text.accent),
+        ),
+        const SizedBox(height: AppSpacing.s),
+        Text(
+          subtitle,
+          textAlign: TextAlign.center,
+          style: AppTypography.bodyMedium.copyWith(color: colors.text.primary),
+        ),
+      ],
+    );
+  }
+}
+
+class _UtilityParagraphList extends StatelessWidget {
+  const _UtilityParagraphList({required this.paragraphs});
+
+  final List<_UtilityParagraphData> paragraphs;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: _paragraphWidth,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.md),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            for (var i = 0; i < paragraphs.length; i++) ...[
+              _UtilityParagraph(paragraph: paragraphs[i]),
+              if (i < paragraphs.length - 1)
+                const SizedBox(height: AppSpacing.md),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UtilityParagraph extends StatelessWidget {
+  const _UtilityParagraph({required this.paragraph});
+
+  final _UtilityParagraphData paragraph;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          paragraph.heading,
+          style: AppTypography.bodyMediumStrong.copyWith(
+            color: colors.text.accent,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          paragraph.body,
+          style: AppTypography.bodyMedium.copyWith(color: colors.text.primary),
+        ),
+      ],
+    );
+  }
+}
+
+class _UtilityParagraphData {
+  const _UtilityParagraphData({required this.heading, required this.body});
+
+  final String heading;
+  final String body;
+}

--- a/lib/src/features/onboarding/welcome.dart
+++ b/lib/src/features/onboarding/welcome.dart
@@ -324,8 +324,7 @@ class _LegalFooter extends StatelessWidget {
     // hardcoded `#4D5252` — in light mode the token resolves to
     // `#626767`, one step lighter than the literal, but this preserves
     // legibility in dark mode where the literal would disappear into
-    // the background. Navigation handlers are intentionally stubbed
-    // until the Terms / Privacy destinations exist.
+    // the background.
     final bodyStyle = AppTypography.bodySmall.copyWith(
       color: colors.text.muted,
     );
@@ -339,13 +338,56 @@ class _LegalFooter extends StatelessWidget {
       TextSpan(
         children: [
           const TextSpan(text: 'By using Vizor you agree to our '),
-          TextSpan(text: 'Terms', style: linkStyle),
+          WidgetSpan(
+            alignment: PlaceholderAlignment.baseline,
+            baseline: TextBaseline.alphabetic,
+            child: _LegalFooterLink(
+              label: 'Terms',
+              style: linkStyle,
+              onTap: () => context.push('/terms'),
+            ),
+          ),
           const TextSpan(text: ' and '),
-          TextSpan(text: 'Privacy', style: linkStyle),
+          WidgetSpan(
+            alignment: PlaceholderAlignment.baseline,
+            baseline: TextBaseline.alphabetic,
+            child: _LegalFooterLink(
+              label: 'Privacy',
+              style: linkStyle,
+              onTap: () => context.push('/privacy'),
+            ),
+          ),
         ],
         style: bodyStyle,
       ),
       textAlign: TextAlign.center,
+    );
+  }
+}
+
+class _LegalFooterLink extends StatelessWidget {
+  const _LegalFooterLink({
+    required this.label,
+    required this.style,
+    required this.onTap,
+  });
+
+  final String label;
+  final TextStyle style;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      link: true,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: Text(label, style: style),
+        ),
+      ),
     );
   }
 }

--- a/test/features/about/about_legal_pages_test.dart
+++ b/test/features/about/about_legal_pages_test.dart
@@ -14,6 +14,8 @@ import 'package:zcash_wallet/src/features/about/screens/about_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/welcome.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 
+const _utilityPageScrollbarKey = ValueKey('utility-page-scrollbar');
+
 void main() {
   testWidgets('About Vizor sidebar item opens the About page', (tester) async {
     await _setDesktopViewport(tester);
@@ -180,6 +182,34 @@ void main() {
     expect(backTopAfterScroll, lessThan(backTopBeforeScroll));
   });
 
+  testWidgets('legal back link reuses shared back link style', (tester) async {
+    await _setDesktopViewport(tester);
+
+    final router = GoRouter(
+      initialLocation: '/terms',
+      routes: [
+        GoRoute(path: '/terms', builder: (_, _) => const TermsScreen()),
+        GoRoute(path: '/welcome', builder: (_, _) => const Text('welcome')),
+      ],
+    );
+
+    await tester.pumpWidget(_routerHarness(router, _emptyBootstrap('/terms')));
+    await tester.pumpAndSettle();
+
+    final backLink = find.byType(AppBackLink);
+    expect(
+      find.descendant(of: backLink, matching: find.text('Back')),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.descendant(of: backLink, matching: find.text('Back')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('welcome'), findsOneWidget);
+  });
+
   testWidgets('Terms and Privacy are public before wallet creation', (
     tester,
   ) async {
@@ -259,7 +289,7 @@ Widget _routerHarness(GoRouter router, AppBootstrapState bootstrap) {
 }
 
 void _expectScrollbarFillsPaneEdge(WidgetTester tester, Size viewport) {
-  final scrollbarRect = tester.getRect(find.byType(Scrollbar).last);
+  final scrollbarRect = tester.getRect(find.byKey(_utilityPageScrollbarKey));
   expect(scrollbarRect.top, moreOrLessEquals(AppSpacing.xs));
   expect(scrollbarRect.right, moreOrLessEquals(viewport.width - AppSpacing.xs));
   expect(
@@ -269,7 +299,7 @@ void _expectScrollbarFillsPaneEdge(WidgetTester tester, Size viewport) {
 }
 
 void _expectUtilityContentCentered(WidgetTester tester, Size viewport) {
-  final scrollbarRect = tester.getRect(find.byType(Scrollbar).last);
+  final scrollbarRect = tester.getRect(find.byKey(_utilityPageScrollbarKey));
   final dividerRect = tester.getRect(find.byType(AppDecorativeDivider).last);
   expect(dividerRect.width, moreOrLessEquals(256));
   expect(dividerRect.center.dx, moreOrLessEquals(scrollbarRect.center.dx));

--- a/test/features/about/about_legal_pages_test.dart
+++ b/test/features/about/about_legal_pages_test.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
+import 'package:zcash_wallet/src/core/layout/app_main_sidebar.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/about/screens/about_screen.dart';
+import 'package:zcash_wallet/src/features/onboarding/welcome.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+
+void main() {
+  testWidgets('About Vizor sidebar item opens the About page', (tester) async {
+    await _setDesktopViewport(tester);
+
+    final router = GoRouter(
+      initialLocation: '/home',
+      routes: [
+        GoRoute(
+          path: '/home',
+          builder: (_, _) => AppDesktopShell(
+            sidebar: const AppMainSidebar(),
+            pane: AppDesktopPane(
+              child: Text(
+                'home route',
+                style: AppTypography.bodyMedium.copyWith(
+                  color: AppThemeData.light.colors.text.primary,
+                ),
+              ),
+            ),
+          ),
+        ),
+        GoRoute(path: '/about', builder: (_, _) => const AboutScreen()),
+        GoRoute(path: '/send', builder: (_, _) => const Text('send route')),
+        GoRoute(
+          path: '/receive',
+          builder: (_, _) => const Text('receive route'),
+        ),
+        GoRoute(
+          path: '/activity',
+          builder: (_, _) => const Text('activity route'),
+        ),
+        GoRoute(path: '/settings', builder: (_, _) => const Text('settings')),
+      ],
+    );
+
+    await tester.pumpWidget(_routerHarness(router, _walletBootstrap('/home')));
+
+    await tester.tap(find.text('About Vizor'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('About Vizor Wallet'), findsOneWidget);
+    expect(find.text('Version: 0.1.24 Public Beta'), findsOneWidget);
+  });
+
+  testWidgets('Terms and Privacy are public before wallet creation', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(_appHarness(_emptyBootstrap('/terms')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Terms of Use'), findsOneWidget);
+    expect(find.text('Private Money.\nFor the New Internet'), findsNothing);
+
+    await tester.pumpWidget(_appHarness(_emptyBootstrap('/privacy')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Privacy Policy'), findsOneWidget);
+    expect(find.text('Private Money.\nFor the New Internet'), findsNothing);
+  });
+
+  testWidgets('welcome footer links open legal pages', (tester) async {
+    await _setDesktopViewport(tester);
+
+    final router = GoRouter(
+      initialLocation: '/welcome',
+      routes: [
+        GoRoute(path: '/welcome', builder: (_, _) => const WelcomeScreen()),
+        GoRoute(path: '/terms', builder: (_, _) => const TermsScreen()),
+        GoRoute(
+          path: '/privacy',
+          builder: (_, _) => const PrivacyPolicyScreen(),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      _routerHarness(router, _emptyBootstrap('/welcome')),
+    );
+
+    await tester.tap(find.text('Terms'));
+    await tester.pumpAndSettle();
+    expect(find.text('Terms of Use'), findsOneWidget);
+
+    router.go('/welcome');
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Privacy'));
+    await tester.pumpAndSettle();
+    expect(find.text('Privacy Policy'), findsOneWidget);
+  });
+}
+
+Future<void> _setDesktopViewport(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(1280, 900));
+  addTearDown(() async {
+    await tester.binding.setSurfaceSize(null);
+  });
+}
+
+Widget _appHarness(AppBootstrapState bootstrap) {
+  return ProviderScope(
+    overrides: [appBootstrapProvider.overrideWithValue(bootstrap)],
+    child: const ZcashWalletApp(),
+  );
+}
+
+Widget _routerHarness(GoRouter router, AppBootstrapState bootstrap) {
+  return ProviderScope(
+    overrides: [appBootstrapProvider.overrideWithValue(bootstrap)],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+    ),
+  );
+}
+
+AppBootstrapState _emptyBootstrap(String initialLocation) {
+  return AppBootstrapState(
+    initialLocation: initialLocation,
+    initialAccountState: const AccountState(),
+    initialSyncSnapshot: AppSyncSnapshot.empty,
+    network: 'main',
+    rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+    themeMode: ThemeMode.system,
+    privacyModeEnabled: false,
+    isPasswordConfigured: false,
+    isUnlocked: false,
+    passwordRotationRecoveryFailed: false,
+  );
+}
+
+AppBootstrapState _walletBootstrap(String initialLocation) {
+  return AppBootstrapState(
+    initialLocation: initialLocation,
+    initialAccountState: const AccountState(
+      accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+      activeAccountUuid: 'account-1',
+      activeAddress: 'u1aboutscreenaddress',
+    ),
+    initialSyncSnapshot: AppSyncSnapshot.empty,
+    network: 'main',
+    rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+    themeMode: ThemeMode.system,
+    privacyModeEnabled: false,
+    isPasswordConfigured: true,
+    isUnlocked: true,
+    passwordRotationRecoveryFailed: false,
+  );
+}

--- a/test/features/about/about_legal_pages_test.dart
+++ b/test/features/about/about_legal_pages_test.dart
@@ -8,6 +8,8 @@ import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
 import 'package:zcash_wallet/src/core/layout/app_main_sidebar.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_back_link.dart';
+import 'package:zcash_wallet/src/core/widgets/app_decorative_divider.dart';
 import 'package:zcash_wallet/src/features/about/screens/about_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/welcome.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
@@ -54,6 +56,128 @@ void main() {
 
     expect(find.text('About Vizor Wallet'), findsOneWidget);
     expect(find.text('Version: 0.1.24 Public Beta'), findsOneWidget);
+  });
+
+  testWidgets('About sidebar navigation uses the standard Home back target', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    final router = GoRouter(
+      initialLocation: '/send',
+      routes: [
+        GoRoute(
+          path: '/send',
+          builder: (_, _) => AppDesktopShell(
+            sidebar: const AppMainSidebar(),
+            pane: AppDesktopPane(
+              child: Text(
+                'send route',
+                style: AppTypography.bodyMedium.copyWith(
+                  color: AppThemeData.light.colors.text.primary,
+                ),
+              ),
+            ),
+          ),
+        ),
+        GoRoute(path: '/about', builder: (_, _) => const AboutScreen()),
+        GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
+        GoRoute(
+          path: '/receive',
+          builder: (_, _) => const Text('receive route'),
+        ),
+        GoRoute(
+          path: '/activity',
+          builder: (_, _) => const Text('activity route'),
+        ),
+        GoRoute(path: '/settings', builder: (_, _) => const Text('settings')),
+      ],
+    );
+
+    await tester.pumpWidget(_routerHarness(router, _walletBootstrap('/send')));
+
+    await tester.tap(find.text('About Vizor'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('About Vizor Wallet'), findsOneWidget);
+    final backLink = find.byType(AppRouteBackLink);
+    expect(
+      find.descendant(of: backLink, matching: find.text('Home')),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.descendant(of: backLink, matching: find.text('Home')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('home route'), findsOneWidget);
+  });
+
+  testWidgets('utility scrollbars fill the pane edge', (tester) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/terms',
+          routes: [
+            GoRoute(path: '/terms', builder: (_, _) => const TermsScreen()),
+          ],
+        ),
+        _emptyBootstrap('/terms'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    _expectScrollbarFillsPaneEdge(tester, const Size(1280, 900));
+    _expectUtilityContentCentered(tester, const Size(1280, 900));
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/about',
+          routes: [
+            GoRoute(path: '/about', builder: (_, _) => const AboutScreen()),
+          ],
+        ),
+        _walletBootstrap('/about'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    _expectScrollbarFillsPaneEdge(tester, const Size(1280, 900));
+    _expectUtilityContentCentered(tester, const Size(1280, 900));
+  });
+
+  testWidgets('legal back row scrolls with the page content', (tester) async {
+    const viewport = Size(1280, 520);
+    await _setViewport(tester, viewport);
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/terms',
+          routes: [
+            GoRoute(path: '/terms', builder: (_, _) => const TermsScreen()),
+          ],
+        ),
+        _emptyBootstrap('/terms'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    _expectScrollbarFillsPaneEdge(tester, viewport);
+
+    final backTopBeforeScroll = tester.getTopLeft(find.text('Back')).dy;
+    await tester.drag(
+      find.byType(SingleChildScrollView),
+      const Offset(0, -160),
+    );
+    await tester.pumpAndSettle();
+    final backTopAfterScroll = tester.getTopLeft(find.text('Back')).dy;
+
+    expect(backTopAfterScroll, lessThan(backTopBeforeScroll));
   });
 
   testWidgets('Terms and Privacy are public before wallet creation', (
@@ -107,7 +231,11 @@ void main() {
 }
 
 Future<void> _setDesktopViewport(WidgetTester tester) async {
-  await tester.binding.setSurfaceSize(const Size(1280, 900));
+  await _setViewport(tester, const Size(1280, 900));
+}
+
+Future<void> _setViewport(WidgetTester tester, Size size) async {
+  await tester.binding.setSurfaceSize(size);
   addTearDown(() async {
     await tester.binding.setSurfaceSize(null);
   });
@@ -128,6 +256,28 @@ Widget _routerHarness(GoRouter router, AppBootstrapState bootstrap) {
       builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
     ),
   );
+}
+
+void _expectScrollbarFillsPaneEdge(WidgetTester tester, Size viewport) {
+  final scrollbarRect = tester.getRect(find.byType(Scrollbar).last);
+  expect(scrollbarRect.top, moreOrLessEquals(AppSpacing.xs));
+  expect(scrollbarRect.right, moreOrLessEquals(viewport.width - AppSpacing.xs));
+  expect(
+    scrollbarRect.bottom,
+    moreOrLessEquals(viewport.height - AppSpacing.xs),
+  );
+}
+
+void _expectUtilityContentCentered(WidgetTester tester, Size viewport) {
+  final scrollbarRect = tester.getRect(find.byType(Scrollbar).last);
+  final dividerRect = tester.getRect(find.byType(AppDecorativeDivider).last);
+  expect(dividerRect.width, moreOrLessEquals(256));
+  expect(dividerRect.center.dx, moreOrLessEquals(scrollbarRect.center.dx));
+
+  final headingRect = tester.getRect(
+    find.text('From the team that brought you Keplr Wallet.').first,
+  );
+  expect(headingRect.left, greaterThan(scrollbarRect.left + 100));
 }
 
 AppBootstrapState _emptyBootstrap(String initialLocation) {


### PR DESCRIPTION
## Summary

Implements the Vizor utility page group from the Figma spec:

- Adds `/about`, `/terms`, and `/privacy` routes.
- Wires the existing `About Vizor` sidebar item to `/about`.
- Makes Terms and Privacy public legal routes so they can be opened before wallet creation.
- Connects the Welcome footer `Terms` and `Privacy` links.
- Adds shared About/Legal page layout pieces for titles, dividers, placeholder paragraphs, and pane-edge scrollbars.
- Adds widget coverage for sidebar navigation, public legal access, welcome footer links, scrollbar sizing, and legal-page scroll behavior.

## Notes

- Legal copy and dates remain placeholder Figma content.
- About version text remains Figma copy for now, not runtime app metadata.
- Goal-board files are intentionally not included in this PR.

## Validation

- `fvm flutter analyze lib/src/core/layout/app_main_sidebar.dart lib/src/features/about/screens/about_screen.dart test/features/about/about_legal_pages_test.dart`
- `fvm flutter test test/features/about/about_legal_pages_test.dart test/features/onboarding/welcome_screen_test.dart`
- `git diff --check`

Flutter dependency resolution still emits non-fatal pub advisory decode warnings for `http` and `shared_preferences_android`, but the validation commands exited successfully.