### PR TITLE
Fix account-scoped activity sync state

### DIFF
--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -70,6 +70,7 @@ class AppBootstrapState {
 
 class AppSyncSnapshot {
   const AppSyncSnapshot({
+    this.accountUuid,
     required this.scannedHeight,
     required this.chainTipHeight,
     required this.percentage,
@@ -87,6 +88,7 @@ class AppSyncSnapshot {
     required this.recentTransactions,
   });
 
+  final String? accountUuid;
   final int scannedHeight;
   final int chainTipHeight;
   final double percentage;
@@ -104,6 +106,25 @@ class AppSyncSnapshot {
   final List<rust_sync.TransactionInfo> recentTransactions;
 
   static final empty = AppSyncSnapshot(
+    scannedHeight: 0,
+    chainTipHeight: 0,
+    percentage: 0,
+    transparentBalance: BigInt.zero,
+    saplingBalance: BigInt.zero,
+    orchardBalance: BigInt.zero,
+    transparentPendingBalance: BigInt.zero,
+    saplingPendingBalance: BigInt.zero,
+    orchardPendingBalance: BigInt.zero,
+    canShieldTransparentBalance: false,
+    shieldTransparentFee: BigInt.zero,
+    shieldTransparentAmount: BigInt.zero,
+    spendableBalance: BigInt.zero,
+    totalBalance: BigInt.zero,
+    recentTransactions: [],
+  );
+
+  static AppSyncSnapshot emptyForAccount(String accountUuid) => AppSyncSnapshot(
+    accountUuid: accountUuid,
     scannedHeight: 0,
     chainTipHeight: 0,
     percentage: 0,
@@ -400,6 +421,7 @@ Future<AppSyncSnapshot> _loadInitialSyncSnapshot({
     );
 
     return AppSyncSnapshot(
+      accountUuid: accountUuid,
       scannedHeight: scannedHeight,
       chainTipHeight: chainTipHeight,
       percentage: percentage,
@@ -418,6 +440,6 @@ Future<AppSyncSnapshot> _loadInitialSyncSnapshot({
     );
   } catch (e) {
     log('bootstrap: failed to load initial sync snapshot: $e');
-    return AppSyncSnapshot.empty;
+    return AppSyncSnapshot.emptyForAccount(accountUuid);
   }
 }

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -71,6 +71,7 @@ class AppBootstrapState {
 class AppSyncSnapshot {
   const AppSyncSnapshot({
     this.accountUuid,
+    this.hasAccountScopedData = false,
     required this.scannedHeight,
     required this.chainTipHeight,
     required this.percentage,
@@ -89,6 +90,7 @@ class AppSyncSnapshot {
   });
 
   final String? accountUuid;
+  final bool hasAccountScopedData;
   final int scannedHeight;
   final int chainTipHeight;
   final double percentage;
@@ -422,6 +424,7 @@ Future<AppSyncSnapshot> _loadInitialSyncSnapshot({
 
     return AppSyncSnapshot(
       accountUuid: accountUuid,
+      hasAccountScopedData: true,
       scannedHeight: scannedHeight,
       chainTipHeight: chainTipHeight,
       percentage: percentage,

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -244,25 +244,32 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
     final accountUuid = ref.watch(accountProvider).value?.activeAccountUuid;
     final sync = (syncState ?? SyncState()).scopedToAccount(accountUuid);
     final hasSyncForActiveAccount =
-        syncState?.belongsToAccount(accountUuid) ?? false;
+        syncState?.hasDataForAccount(accountUuid) ?? false;
     final loadedTransactions = _transactionsAccountUuid == accountUuid
         ? _transactions
         : null;
     final privacyModeEnabled = ref.watch(privacyModeProvider);
-    final transactions = loadedTransactions ?? sync.recentTransactions;
+    final transactions =
+        loadedTransactions ??
+        (hasSyncForActiveAccount
+            ? sync.recentTransactions
+            : const <rust_sync.TransactionInfo>[]);
+    final firstPageTransactionCount = hasSyncForActiveAccount
+        ? _firstPageTransactionCount
+        : _activityRowsPerPage;
     final transactionsAfterFirstPage = math.max(
       0,
-      transactions.length - _firstPageTransactionCount,
+      transactions.length - firstPageTransactionCount,
     );
     final totalPages =
         1 + (transactionsAfterFirstPage / _activityRowsPerPage).ceil();
     final currentPage = math.min(math.max(_currentPage, 1), totalPages);
     final firstTxIndex = currentPage == 1
         ? 0
-        : _firstPageTransactionCount +
+        : firstPageTransactionCount +
               ((currentPage - 2) * _activityRowsPerPage);
     final transactionCount = currentPage == 1
-        ? _firstPageTransactionCount
+        ? firstPageTransactionCount
         : _activityRowsPerPage;
     final pageTransactions = transactions
         .skip(firstTxIndex)
@@ -273,7 +280,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
     final rows = !canRenderRows
         ? const <ActivityRowData>[]
         : [
-            if (currentPage == 1)
+            if (currentPage == 1 && hasSyncForActiveAccount)
               buildSyncActivityRow(
                 context: context,
                 sync: sync,
@@ -337,10 +344,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
                       ),
                       child: _ActivityPane(
                         rows: rows,
-                        isLoading:
-                            _isLoading &&
-                            loadedTransactions == null &&
-                            sync.recentTransactions.isEmpty,
+                        isLoading: _isLoading && !canRenderRows,
                         errorText: loadedTransactions == null ? _error : null,
                         currentPage: currentPage,
                         totalPages: totalPages,

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -39,6 +39,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
 
   final ScrollController _scrollController = ScrollController();
   List<rust_sync.TransactionInfo>? _transactions;
+  String? _transactionsAccountUuid;
   bool _isLoading = true;
   String? _error;
   int _currentPage = 1;
@@ -80,13 +81,16 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
     final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
     _activeAccountUuid = accountUuid;
 
-    if (showLoading && mounted) {
+    if ((showLoading || resetPage) && mounted) {
       setState(() {
-        _isLoading = true;
-        _error = null;
+        if (showLoading) {
+          _isLoading = true;
+          _error = null;
+        }
         if (resetPage) {
           _currentPage = 1;
           _transactions = null;
+          _transactionsAccountUuid = accountUuid;
         }
       });
     }
@@ -95,6 +99,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
       if (!mounted) return;
       setState(() {
         _transactions = const [];
+        _transactionsAccountUuid = null;
         _isLoading = false;
         _error = null;
         _currentPage = 1;
@@ -116,6 +121,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
       }
       setState(() {
         _transactions = txs;
+        _transactionsAccountUuid = accountUuid;
         _isLoading = false;
         _error = null;
         if (resetPage) _currentPage = 1;
@@ -123,7 +129,11 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
     } catch (e, st) {
       log('Activity: transaction load failed: $e\n$st');
       if (!mounted) return;
+      if (accountUuid != ref.read(accountProvider).value?.activeAccountUuid) {
+        return;
+      }
       setState(() {
+        _transactionsAccountUuid = accountUuid;
         _error = 'Activity could not be loaded.';
         _isLoading = false;
       });
@@ -230,10 +240,16 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
       }
     });
 
-    final sync = ref.watch(syncProvider).value ?? SyncState();
+    final syncState = ref.watch(syncProvider).value;
     final accountUuid = ref.watch(accountProvider).value?.activeAccountUuid;
+    final sync = (syncState ?? SyncState()).scopedToAccount(accountUuid);
+    final hasSyncForActiveAccount =
+        syncState?.belongsToAccount(accountUuid) ?? false;
+    final loadedTransactions = _transactionsAccountUuid == accountUuid
+        ? _transactions
+        : null;
     final privacyModeEnabled = ref.watch(privacyModeProvider);
-    final transactions = _transactions ?? sync.recentTransactions;
+    final transactions = loadedTransactions ?? sync.recentTransactions;
     final transactionsAfterFirstPage = math.max(
       0,
       transactions.length - _firstPageTransactionCount,
@@ -251,7 +267,10 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
     final pageTransactions = transactions
         .skip(firstTxIndex)
         .take(transactionCount);
-    final rows = accountUuid == null
+    final canRenderRows =
+        accountUuid != null &&
+        (loadedTransactions != null || hasSyncForActiveAccount);
+    final rows = !canRenderRows
         ? const <ActivityRowData>[]
         : [
             if (currentPage == 1)
@@ -320,9 +339,9 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
                         rows: rows,
                         isLoading:
                             _isLoading &&
-                            _transactions == null &&
+                            loadedTransactions == null &&
                             sync.recentTransactions.isEmpty,
-                        errorText: _transactions == null ? _error : null,
+                        errorText: loadedTransactions == null ? _error : null,
                         currentPage: currentPage,
                         totalPages: totalPages,
                         onPageChanged: _setPage,

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -87,7 +87,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       }
 
       final accountNotifier = ref.read(accountProvider.notifier);
-      final sync = ref.read(syncProvider).value ?? SyncState();
+      final sync = (ref.read(syncProvider).value ?? SyncState())
+          .scopedToAccount(accountUuid);
       if (!sync.canShieldTransparentBalance) {
         throw Exception(
           'Transparent balance is too small to shield after fees.',
@@ -160,7 +161,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final walletAsync = ref.watch(walletProvider);
     final bootstrap = ref.watch(appBootstrapProvider);
     final syncAsync = ref.watch(syncProvider);
-    final sync = syncAsync.value ?? SyncState();
+    final activeAccountUuid = ref.watch(
+      accountProvider.select((value) => value.value?.activeAccountUuid),
+    );
+    final sync = (syncAsync.value ?? SyncState()).scopedToAccount(
+      activeAccountUuid,
+    );
     final privacyModeEnabled = ref.watch(privacyModeProvider);
     final shieldedBalance =
         sync.saplingBalance +

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -164,9 +164,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final activeAccountUuid = ref.watch(
       accountProvider.select((value) => value.value?.activeAccountUuid),
     );
-    final sync = (syncAsync.value ?? SyncState()).scopedToAccount(
-      activeAccountUuid,
-    );
+    final syncState = syncAsync.value;
+    final sync = (syncState ?? SyncState()).scopedToAccount(activeAccountUuid);
+    final hasActivitySyncData =
+        syncState?.hasDataForAccount(activeAccountUuid) ?? false;
+    final isActivityLoading =
+        activeAccountUuid != null && !hasActivitySyncData && sync.error == null;
     final privacyModeEnabled = ref.watch(privacyModeProvider);
     final shieldedBalance =
         sync.saplingBalance +
@@ -194,6 +197,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             ),
             data: (_) => _HomePane(
               sync: sync,
+              hasActivitySyncData: hasActivitySyncData,
+              isActivityLoading: isActivityLoading,
               passwordRotationRecoveryFailed:
                   bootstrap.passwordRotationRecoveryFailed,
               canBackgroundSync: _canBackgroundSync,
@@ -225,6 +230,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 class _HomePane extends ConsumerStatefulWidget {
   const _HomePane({
     required this.sync,
+    required this.hasActivitySyncData,
+    required this.isActivityLoading,
     required this.passwordRotationRecoveryFailed,
     required this.canBackgroundSync,
     required this.privacyModeEnabled,
@@ -243,6 +250,8 @@ class _HomePane extends ConsumerStatefulWidget {
   });
 
   final SyncState sync;
+  final bool hasActivitySyncData;
+  final bool isActivityLoading;
   final bool passwordRotationRecoveryFailed;
   final bool canBackgroundSync;
   final bool privacyModeEnabled;
@@ -367,6 +376,7 @@ class _HomePaneState extends ConsumerState<_HomePane> {
                           child: ActivityTable(
                             rows: rows,
                             title: 'Recent Activity',
+                            isLoading: widget.isActivityLoading,
                             onTitleTap: () => context.push('/activity'),
                           ),
                         ),
@@ -428,6 +438,9 @@ class _HomePaneState extends ConsumerState<_HomePane> {
   }
 
   List<ActivityRowData> _activityRows(BuildContext context) {
+    if (!widget.hasActivitySyncData) {
+      return const [];
+    }
     return buildActivityRows(
       context: context,
       sync: widget.sync,

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -41,11 +41,13 @@ class _SendScreenState extends ConsumerState<SendScreen> {
     final activeAccountUuid = ref.watch(
       accountProvider.select((value) => value.value?.activeAccountUuid),
     );
-    final spendableBalance = ref.watch(
+    final sync = ref.watch(
       syncProvider.select(
-        (value) => value.value?.spendableBalance ?? BigInt.zero,
+        (value) =>
+            (value.value ?? SyncState()).scopedToAccount(activeAccountUuid),
       ),
     );
+    final spendableBalance = sync.spendableBalance;
 
     return _SendComposeBody(
       key: ValueKey(activeAccountUuid),

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -20,10 +20,16 @@ class SyncState {
   /// fields below. Sync progress itself is wallet-wide.
   final String? accountUuid;
 
-  /// True only after balance/history data has been loaded for [accountUuid].
-  /// A state can be scoped to an account while this is false during account
-  /// switches or after the first account-scoped refresh fails.
-  final bool hasAccountScopedData;
+  /// True after balance fields have been loaded for [accountUuid].
+  final bool hasBalanceData;
+
+  /// True after recent transaction history has been loaded for [accountUuid].
+  final bool hasRecentTransactionsData;
+
+  /// True only after both balance and history have been loaded for
+  /// [accountUuid]. Activity UIs should use this instead of treating a scoped
+  /// placeholder or partial refresh as renderable account data.
+  bool get hasAccountScopedData => hasBalanceData && hasRecentTransactionsData;
   final bool isSyncing;
   final bool isBackgroundMode;
   final double percentage;
@@ -62,7 +68,9 @@ class SyncState {
 
   SyncState({
     this.accountUuid,
-    this.hasAccountScopedData = false,
+    bool hasAccountScopedData = false,
+    bool? hasBalanceData,
+    bool? hasRecentTransactionsData,
     this.isSyncing = false,
     this.isBackgroundMode = false,
     this.percentage = 0,
@@ -86,7 +94,10 @@ class SyncState {
     this.lastSyncCompletedAt,
     this.lastSyncFailedAt,
     this.phase = '',
-  }) : displayPercentage = displayPercentage ?? percentage,
+  }) : hasBalanceData = hasBalanceData ?? hasAccountScopedData,
+       hasRecentTransactionsData =
+           hasRecentTransactionsData ?? hasAccountScopedData,
+       displayPercentage = displayPercentage ?? percentage,
        transparentBalance = transparentBalance ?? BigInt.zero,
        saplingBalance = saplingBalance ?? BigInt.zero,
        orchardBalance = orchardBalance ?? BigInt.zero,
@@ -101,6 +112,8 @@ class SyncState {
   SyncState copyWith({
     String? accountUuid,
     bool? hasAccountScopedData,
+    bool? hasBalanceData,
+    bool? hasRecentTransactionsData,
     bool? isSyncing,
     bool? isBackgroundMode,
     double? percentage,
@@ -127,7 +140,12 @@ class SyncState {
   }) {
     return SyncState(
       accountUuid: accountUuid ?? this.accountUuid,
-      hasAccountScopedData: hasAccountScopedData ?? this.hasAccountScopedData,
+      hasBalanceData:
+          hasBalanceData ?? hasAccountScopedData ?? this.hasBalanceData,
+      hasRecentTransactionsData:
+          hasRecentTransactionsData ??
+          hasAccountScopedData ??
+          this.hasRecentTransactionsData,
       isSyncing: isSyncing ?? this.isSyncing,
       isBackgroundMode: isBackgroundMode ?? this.isBackgroundMode,
       percentage: percentage ?? this.percentage,
@@ -175,7 +193,8 @@ class SyncState {
   SyncState withoutAccountScopedData({String? accountUuid}) {
     return SyncState(
       accountUuid: accountUuid,
-      hasAccountScopedData: false,
+      hasBalanceData: false,
+      hasRecentTransactionsData: false,
       isSyncing: isSyncing,
       isBackgroundMode: isBackgroundMode,
       percentage: percentage,
@@ -361,9 +380,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   }
 
   SyncState? _previousScopedState(SyncState? prev, String? accountUuid) {
-    if (accountUuid == null ||
-        prev?.accountUuid != accountUuid ||
-        prev?.hasAccountScopedData != true) {
+    if (accountUuid == null || prev?.accountUuid != accountUuid) {
       return null;
     }
     return prev;
@@ -444,7 +461,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     state = AsyncData(
       SyncState(
         accountUuid: accountUuid,
-        hasAccountScopedData: scopedPrev != null,
+        hasBalanceData: scopedPrev?.hasBalanceData ?? false,
+        hasRecentTransactionsData:
+            scopedPrev?.hasRecentTransactionsData ?? false,
         isSyncing: true,
         isBackgroundMode: false,
         percentage: 0.0,
@@ -536,7 +555,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               state = AsyncData(
                 SyncState(
                   accountUuid: accountUuid,
-                  hasAccountScopedData: scopedPrev != null,
+                  hasBalanceData: scopedPrev?.hasBalanceData ?? false,
+                  hasRecentTransactionsData:
+                      scopedPrev?.hasRecentTransactionsData ?? false,
                   error: e.toString(),
                   transparentBalance: scopedPrev?.transparentBalance,
                   saplingBalance: scopedPrev?.saplingBalance,
@@ -580,7 +601,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
           state = AsyncData(
             SyncState(
               accountUuid: accountUuid,
-              hasAccountScopedData: scopedPrev != null,
+              hasBalanceData: scopedPrev?.hasBalanceData ?? false,
+              hasRecentTransactionsData:
+                  scopedPrev?.hasRecentTransactionsData ?? false,
               error: e.toString(),
               transparentBalance: scopedPrev?.transparentBalance,
               saplingBalance: scopedPrev?.saplingBalance,
@@ -677,7 +700,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     state = AsyncData(
       SyncState(
         accountUuid: accountUuid,
-        hasAccountScopedData: scopedPrev != null,
+        hasBalanceData: scopedPrev?.hasBalanceData ?? false,
+        hasRecentTransactionsData:
+            scopedPrev?.hasRecentTransactionsData ?? false,
         isSyncing: false,
         isBackgroundMode: false,
         percentage: prev?.percentage ?? 0.0,
@@ -1220,10 +1245,13 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     final stateAccountUuid = _getActiveAccountUuid();
     final useFetchedAccountData = accountUuid == stateAccountUuid;
     final stateScopedPrev = _previousScopedState(state.value, stateAccountUuid);
-    final hasAccountScopedData = useFetchedAccountData
-        ? (didFetchBalance && didFetchRecentTxs) ||
-              (stateScopedPrev?.hasAccountScopedData ?? false)
-        : stateScopedPrev?.hasAccountScopedData ?? false;
+    final hasBalanceData = useFetchedAccountData
+        ? didFetchBalance || (stateScopedPrev?.hasBalanceData ?? false)
+        : stateScopedPrev?.hasBalanceData ?? false;
+    final hasRecentTransactionsData = useFetchedAccountData
+        ? didFetchRecentTxs ||
+              (stateScopedPrev?.hasRecentTransactionsData ?? false)
+        : stateScopedPrev?.hasRecentTransactionsData ?? false;
     if (!useFetchedAccountData) {
       log(
         'SyncNotifier: discarding account-scoped sync data after account transition',
@@ -1250,7 +1278,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     state = AsyncData(
       SyncState(
         accountUuid: stateAccountUuid,
-        hasAccountScopedData: hasAccountScopedData,
+        hasBalanceData: hasBalanceData,
+        hasRecentTransactionsData: hasRecentTransactionsData,
         isSyncing: event.isSyncing && !event.isComplete,
         isBackgroundMode: event.isBackground || _bgDelegate.isActive,
         percentage: actualPercentage,
@@ -1424,9 +1453,11 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     state = AsyncData(
       SyncState(
         accountUuid: accountUuid,
-        hasAccountScopedData:
-            (didFetchBalance && didFetchRecentTxs) ||
-            (scopedPrev?.hasAccountScopedData ?? false),
+        hasBalanceData:
+            didFetchBalance || (scopedPrev?.hasBalanceData ?? false),
+        hasRecentTransactionsData:
+            didFetchRecentTxs ||
+            (scopedPrev?.hasRecentTransactionsData ?? false),
         isSyncing: prev?.isSyncing ?? false,
         isBackgroundMode: _bgDelegate.isActive,
         percentage: prev?.percentage ?? 0.0,

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -16,6 +16,9 @@ import 'app_security_provider.dart';
 import 'rpc_endpoint_provider.dart';
 
 class SyncState {
+  /// Account UUID that owns the balance, shield status, and recent transaction
+  /// fields below. Sync progress itself is wallet-wide.
+  final String? accountUuid;
   final bool isSyncing;
   final bool isBackgroundMode;
   final double percentage;
@@ -53,6 +56,7 @@ class SyncState {
       transparentPendingBalance + saplingPendingBalance + orchardPendingBalance;
 
   SyncState({
+    this.accountUuid,
     this.isSyncing = false,
     this.isBackgroundMode = false,
     this.percentage = 0,
@@ -89,6 +93,7 @@ class SyncState {
        totalBalance = totalBalance ?? BigInt.zero;
 
   SyncState copyWith({
+    String? accountUuid,
     bool? isSyncing,
     bool? isBackgroundMode,
     double? percentage,
@@ -114,6 +119,7 @@ class SyncState {
     String? phase,
   }) {
     return SyncState(
+      accountUuid: accountUuid ?? this.accountUuid,
       isSyncing: isSyncing ?? this.isSyncing,
       isBackgroundMode: isBackgroundMode ?? this.isBackgroundMode,
       percentage: percentage ?? this.percentage,
@@ -142,6 +148,32 @@ class SyncState {
       lastSyncCompletedAt: lastSyncCompletedAt ?? this.lastSyncCompletedAt,
       lastSyncFailedAt: lastSyncFailedAt ?? this.lastSyncFailedAt,
       phase: phase ?? this.phase,
+    );
+  }
+
+  bool belongsToAccount(String? accountUuid) {
+    return accountUuid != null && this.accountUuid == accountUuid;
+  }
+
+  SyncState scopedToAccount(String? accountUuid) {
+    if (belongsToAccount(accountUuid)) return this;
+    return withoutAccountScopedData(accountUuid: accountUuid);
+  }
+
+  SyncState withoutAccountScopedData({String? accountUuid}) {
+    return SyncState(
+      accountUuid: accountUuid,
+      isSyncing: isSyncing,
+      isBackgroundMode: isBackgroundMode,
+      percentage: percentage,
+      displayPercentage: displayPercentage,
+      scannedHeight: scannedHeight,
+      chainTipHeight: chainTipHeight,
+      error: error,
+      lastSyncStartedAt: lastSyncStartedAt,
+      lastSyncCompletedAt: lastSyncCompletedAt,
+      lastSyncFailedAt: lastSyncFailedAt,
+      phase: phase,
     );
   }
 }
@@ -242,6 +274,11 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     ref.listen(accountProvider, (prev, next) {
       final prevCount = prev?.value?.accounts.length ?? 0;
       final nextCount = next.value?.accounts.length ?? 0;
+      final prevAccountUuid = prev?.value?.activeAccountUuid;
+      final nextAccountUuid = next.value?.activeAccountUuid;
+      if (prevAccountUuid != nextAccountUuid) {
+        _clearAccountScopedStateFor(nextAccountUuid);
+      }
       if (nextCount > prevCount) {
         startSync();
         _startPolling();
@@ -257,26 +294,66 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     }
 
     final initial = bootstrap.initialSyncSnapshot;
+    final initialAccountUuid = accountState?.activeAccountUuid;
+    final initialBelongsToActiveAccount =
+        initial.accountUuid != null &&
+        initial.accountUuid == initialAccountUuid;
     return SyncState(
+      accountUuid: initialAccountUuid,
       isSyncing: false,
       isBackgroundMode: false,
       percentage: initial.percentage,
       scannedHeight: initial.scannedHeight,
       chainTipHeight: initial.chainTipHeight,
-      transparentBalance: initial.transparentBalance,
-      saplingBalance: initial.saplingBalance,
-      orchardBalance: initial.orchardBalance,
-      transparentPendingBalance: initial.transparentPendingBalance,
-      saplingPendingBalance: initial.saplingPendingBalance,
-      orchardPendingBalance: initial.orchardPendingBalance,
-      canShieldTransparentBalance: initial.canShieldTransparentBalance,
-      shieldTransparentFee: initial.shieldTransparentFee,
-      shieldTransparentAmount: initial.shieldTransparentAmount,
-      spendableBalance: initial.spendableBalance,
-      totalBalance: initial.totalBalance,
-      recentTransactions: initial.recentTransactions,
+      transparentBalance: initialBelongsToActiveAccount
+          ? initial.transparentBalance
+          : BigInt.zero,
+      saplingBalance: initialBelongsToActiveAccount
+          ? initial.saplingBalance
+          : BigInt.zero,
+      orchardBalance: initialBelongsToActiveAccount
+          ? initial.orchardBalance
+          : BigInt.zero,
+      transparentPendingBalance: initialBelongsToActiveAccount
+          ? initial.transparentPendingBalance
+          : BigInt.zero,
+      saplingPendingBalance: initialBelongsToActiveAccount
+          ? initial.saplingPendingBalance
+          : BigInt.zero,
+      orchardPendingBalance: initialBelongsToActiveAccount
+          ? initial.orchardPendingBalance
+          : BigInt.zero,
+      canShieldTransparentBalance: initialBelongsToActiveAccount
+          ? initial.canShieldTransparentBalance
+          : false,
+      shieldTransparentFee: initialBelongsToActiveAccount
+          ? initial.shieldTransparentFee
+          : BigInt.zero,
+      shieldTransparentAmount: initialBelongsToActiveAccount
+          ? initial.shieldTransparentAmount
+          : BigInt.zero,
+      spendableBalance: initialBelongsToActiveAccount
+          ? initial.spendableBalance
+          : BigInt.zero,
+      totalBalance: initialBelongsToActiveAccount
+          ? initial.totalBalance
+          : BigInt.zero,
+      recentTransactions: initialBelongsToActiveAccount
+          ? initial.recentTransactions
+          : const [],
       phase: '',
     );
+  }
+
+  SyncState? _previousScopedState(SyncState? prev, String? accountUuid) {
+    if (accountUuid == null || prev?.accountUuid != accountUuid) return null;
+    return prev;
+  }
+
+  void _clearAccountScopedStateFor(String? accountUuid) {
+    final prev = state.value;
+    if (prev == null) return;
+    state = AsyncData(prev.withoutAccountScopedData(accountUuid: accountUuid));
   }
 
   // ======================== Sync Control ========================
@@ -342,26 +419,30 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _stopDisplayProgressTimer();
     final gen = ++_syncGen;
     final prev = state.value;
+    final accountUuid = _getActiveAccountUuid();
+    final scopedPrev = _previousScopedState(prev, accountUuid);
     final startedAt = DateTime.now();
     state = AsyncData(
       SyncState(
+        accountUuid: accountUuid,
         isSyncing: true,
         isBackgroundMode: false,
         percentage: 0.0,
         scannedHeight: prev?.scannedHeight ?? 0,
         chainTipHeight: prev?.chainTipHeight ?? 0,
-        transparentBalance: prev?.transparentBalance,
-        saplingBalance: prev?.saplingBalance,
-        orchardBalance: prev?.orchardBalance,
-        transparentPendingBalance: prev?.transparentPendingBalance,
-        saplingPendingBalance: prev?.saplingPendingBalance,
-        orchardPendingBalance: prev?.orchardPendingBalance,
-        canShieldTransparentBalance: prev?.canShieldTransparentBalance ?? false,
-        shieldTransparentFee: prev?.shieldTransparentFee,
-        shieldTransparentAmount: prev?.shieldTransparentAmount,
-        spendableBalance: prev?.spendableBalance,
-        totalBalance: prev?.totalBalance,
-        recentTransactions: prev?.recentTransactions ?? const [],
+        transparentBalance: scopedPrev?.transparentBalance,
+        saplingBalance: scopedPrev?.saplingBalance,
+        orchardBalance: scopedPrev?.orchardBalance,
+        transparentPendingBalance: scopedPrev?.transparentPendingBalance,
+        saplingPendingBalance: scopedPrev?.saplingPendingBalance,
+        orchardPendingBalance: scopedPrev?.orchardPendingBalance,
+        canShieldTransparentBalance:
+            scopedPrev?.canShieldTransparentBalance ?? false,
+        shieldTransparentFee: scopedPrev?.shieldTransparentFee,
+        shieldTransparentAmount: scopedPrev?.shieldTransparentAmount,
+        spendableBalance: scopedPrev?.spendableBalance,
+        totalBalance: scopedPrev?.totalBalance,
+        recentTransactions: scopedPrev?.recentTransactions ?? const [],
         lastSyncStartedAt: startedAt,
         lastSyncCompletedAt: prev?.lastSyncCompletedAt,
         lastSyncFailedAt: prev?.lastSyncFailedAt,
@@ -430,22 +511,27 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               // `_refreshBalance()` callbacks with no owning sync.
               _stopMempoolObserver();
               final prev = state.value;
+              final accountUuid = _getActiveAccountUuid();
+              final scopedPrev = _previousScopedState(prev, accountUuid);
               state = AsyncData(
                 SyncState(
+                  accountUuid: accountUuid,
                   error: e.toString(),
-                  transparentBalance: prev?.transparentBalance,
-                  saplingBalance: prev?.saplingBalance,
-                  orchardBalance: prev?.orchardBalance,
-                  transparentPendingBalance: prev?.transparentPendingBalance,
-                  saplingPendingBalance: prev?.saplingPendingBalance,
-                  orchardPendingBalance: prev?.orchardPendingBalance,
+                  transparentBalance: scopedPrev?.transparentBalance,
+                  saplingBalance: scopedPrev?.saplingBalance,
+                  orchardBalance: scopedPrev?.orchardBalance,
+                  transparentPendingBalance:
+                      scopedPrev?.transparentPendingBalance,
+                  saplingPendingBalance: scopedPrev?.saplingPendingBalance,
+                  orchardPendingBalance: scopedPrev?.orchardPendingBalance,
                   canShieldTransparentBalance:
-                      prev?.canShieldTransparentBalance ?? false,
-                  shieldTransparentFee: prev?.shieldTransparentFee,
-                  shieldTransparentAmount: prev?.shieldTransparentAmount,
-                  spendableBalance: prev?.spendableBalance,
-                  totalBalance: prev?.totalBalance,
-                  recentTransactions: prev?.recentTransactions ?? const [],
+                      scopedPrev?.canShieldTransparentBalance ?? false,
+                  shieldTransparentFee: scopedPrev?.shieldTransparentFee,
+                  shieldTransparentAmount: scopedPrev?.shieldTransparentAmount,
+                  spendableBalance: scopedPrev?.spendableBalance,
+                  totalBalance: scopedPrev?.totalBalance,
+                  recentTransactions:
+                      scopedPrev?.recentTransactions ?? const [],
                   lastSyncStartedAt: prev?.lastSyncStartedAt,
                   lastSyncCompletedAt: prev?.lastSyncCompletedAt,
                   lastSyncFailedAt: DateTime.now(),
@@ -468,22 +554,25 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
           // nothing is running.
           _stopMempoolObserver();
           final prev = state.value;
+          final accountUuid = _getActiveAccountUuid();
+          final scopedPrev = _previousScopedState(prev, accountUuid);
           state = AsyncData(
             SyncState(
+              accountUuid: accountUuid,
               error: e.toString(),
-              transparentBalance: prev?.transparentBalance,
-              saplingBalance: prev?.saplingBalance,
-              orchardBalance: prev?.orchardBalance,
-              transparentPendingBalance: prev?.transparentPendingBalance,
-              saplingPendingBalance: prev?.saplingPendingBalance,
-              orchardPendingBalance: prev?.orchardPendingBalance,
+              transparentBalance: scopedPrev?.transparentBalance,
+              saplingBalance: scopedPrev?.saplingBalance,
+              orchardBalance: scopedPrev?.orchardBalance,
+              transparentPendingBalance: scopedPrev?.transparentPendingBalance,
+              saplingPendingBalance: scopedPrev?.saplingPendingBalance,
+              orchardPendingBalance: scopedPrev?.orchardPendingBalance,
               canShieldTransparentBalance:
-                  prev?.canShieldTransparentBalance ?? false,
-              shieldTransparentFee: prev?.shieldTransparentFee,
-              shieldTransparentAmount: prev?.shieldTransparentAmount,
-              spendableBalance: prev?.spendableBalance,
-              totalBalance: prev?.totalBalance,
-              recentTransactions: prev?.recentTransactions ?? const [],
+                  scopedPrev?.canShieldTransparentBalance ?? false,
+              shieldTransparentFee: scopedPrev?.shieldTransparentFee,
+              shieldTransparentAmount: scopedPrev?.shieldTransparentAmount,
+              spendableBalance: scopedPrev?.spendableBalance,
+              totalBalance: scopedPrev?.totalBalance,
+              recentTransactions: scopedPrev?.recentTransactions ?? const [],
               lastSyncStartedAt: prev?.lastSyncStartedAt,
               lastSyncCompletedAt: prev?.lastSyncCompletedAt,
               lastSyncFailedAt: DateTime.now(),
@@ -561,26 +650,30 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       unawaited(_bgDelegate.disable());
     }
     final prev = state.value;
+    final accountUuid = _getActiveAccountUuid();
+    final scopedPrev = _previousScopedState(prev, accountUuid);
     state = AsyncData(
       SyncState(
+        accountUuid: accountUuid,
         isSyncing: false,
         isBackgroundMode: false,
         percentage: prev?.percentage ?? 0.0,
         displayPercentage: prev?.displayPercentage ?? prev?.percentage ?? 0.0,
         scannedHeight: prev?.scannedHeight ?? 0,
         chainTipHeight: prev?.chainTipHeight ?? 0,
-        transparentBalance: prev?.transparentBalance,
-        saplingBalance: prev?.saplingBalance,
-        orchardBalance: prev?.orchardBalance,
-        transparentPendingBalance: prev?.transparentPendingBalance,
-        saplingPendingBalance: prev?.saplingPendingBalance,
-        orchardPendingBalance: prev?.orchardPendingBalance,
-        canShieldTransparentBalance: prev?.canShieldTransparentBalance ?? false,
-        shieldTransparentFee: prev?.shieldTransparentFee,
-        shieldTransparentAmount: prev?.shieldTransparentAmount,
-        spendableBalance: prev?.spendableBalance,
-        totalBalance: prev?.totalBalance,
-        recentTransactions: prev?.recentTransactions ?? const [],
+        transparentBalance: scopedPrev?.transparentBalance,
+        saplingBalance: scopedPrev?.saplingBalance,
+        orchardBalance: scopedPrev?.orchardBalance,
+        transparentPendingBalance: scopedPrev?.transparentPendingBalance,
+        saplingPendingBalance: scopedPrev?.saplingPendingBalance,
+        orchardPendingBalance: scopedPrev?.orchardPendingBalance,
+        canShieldTransparentBalance:
+            scopedPrev?.canShieldTransparentBalance ?? false,
+        shieldTransparentFee: scopedPrev?.shieldTransparentFee,
+        shieldTransparentAmount: scopedPrev?.shieldTransparentAmount,
+        spendableBalance: scopedPrev?.spendableBalance,
+        totalBalance: scopedPrev?.totalBalance,
+        recentTransactions: scopedPrev?.recentTransactions ?? const [],
         lastSyncStartedAt: prev?.lastSyncStartedAt,
         lastSyncCompletedAt: prev?.lastSyncCompletedAt,
         lastSyncFailedAt: prev?.lastSyncFailedAt,
@@ -1032,6 +1125,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       log('SyncNotifier: no active account, skipping refresh');
       return;
     }
+    final scopedPrev = _previousScopedState(prev, accountUuid);
 
     // Only fetch balance/history when there are new transactions or sync is complete.
     // Skipping intermediate batches avoids opening a new DB connection per batch.
@@ -1047,7 +1141,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     BigInt? shieldTransparentFee;
     BigInt? shieldTransparentAmount;
     var recentTxs =
-        prev?.recentTransactions ?? const <rust_sync.TransactionInfo>[];
+        scopedPrev?.recentTransactions ?? const <rust_sync.TransactionInfo>[];
     if (event.hasNewTx || event.isComplete) {
       try {
         final balance = await rust_sync.getBalance(
@@ -1081,7 +1175,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         network: network,
         accountUuid: accountUuid,
         transparentBalance:
-            transparent ?? prev?.transparentBalance ?? BigInt.zero,
+            transparent ?? scopedPrev?.transparentBalance ?? BigInt.zero,
       );
       if (shieldStatus != null) {
         canShieldTransparentBalance = shieldStatus.canShield;
@@ -1095,6 +1189,14 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         'SyncNotifier: discarding sync progress update after lock transition',
       );
       return;
+    }
+    final stateAccountUuid = _getActiveAccountUuid();
+    final useFetchedAccountData = accountUuid == stateAccountUuid;
+    final stateScopedPrev = _previousScopedState(state.value, stateAccountUuid);
+    if (!useFetchedAccountData) {
+      log(
+        'SyncNotifier: discarding account-scoped sync data after account transition',
+      );
     }
 
     // Update delegate BEFORE state so isActive reflects completion
@@ -1116,30 +1218,52 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
     state = AsyncData(
       SyncState(
+        accountUuid: stateAccountUuid,
         isSyncing: event.isSyncing && !event.isComplete,
         isBackgroundMode: event.isBackground || _bgDelegate.isActive,
         percentage: actualPercentage,
         displayPercentage: displayPercentage,
         scannedHeight: event.scannedHeight,
         chainTipHeight: event.chainTipHeight,
-        transparentBalance: transparent ?? prev?.transparentBalance,
-        saplingBalance: sapling ?? prev?.saplingBalance,
-        orchardBalance: orchard ?? prev?.orchardBalance,
-        transparentPendingBalance:
-            transparentPending ?? prev?.transparentPendingBalance,
-        saplingPendingBalance: saplingPending ?? prev?.saplingPendingBalance,
-        orchardPendingBalance: orchardPending ?? prev?.orchardPendingBalance,
-        canShieldTransparentBalance:
-            canShieldTransparentBalance ??
-            prev?.canShieldTransparentBalance ??
-            false,
-        shieldTransparentFee:
-            shieldTransparentFee ?? prev?.shieldTransparentFee,
-        shieldTransparentAmount:
-            shieldTransparentAmount ?? prev?.shieldTransparentAmount,
-        spendableBalance: spendable ?? prev?.spendableBalance,
-        totalBalance: total ?? prev?.totalBalance,
-        recentTransactions: recentTxs,
+        transparentBalance: useFetchedAccountData
+            ? transparent ?? stateScopedPrev?.transparentBalance
+            : stateScopedPrev?.transparentBalance,
+        saplingBalance: useFetchedAccountData
+            ? sapling ?? stateScopedPrev?.saplingBalance
+            : stateScopedPrev?.saplingBalance,
+        orchardBalance: useFetchedAccountData
+            ? orchard ?? stateScopedPrev?.orchardBalance
+            : stateScopedPrev?.orchardBalance,
+        transparentPendingBalance: useFetchedAccountData
+            ? transparentPending ?? stateScopedPrev?.transparentPendingBalance
+            : stateScopedPrev?.transparentPendingBalance,
+        saplingPendingBalance: useFetchedAccountData
+            ? saplingPending ?? stateScopedPrev?.saplingPendingBalance
+            : stateScopedPrev?.saplingPendingBalance,
+        orchardPendingBalance: useFetchedAccountData
+            ? orchardPending ?? stateScopedPrev?.orchardPendingBalance
+            : stateScopedPrev?.orchardPendingBalance,
+        canShieldTransparentBalance: useFetchedAccountData
+            ? canShieldTransparentBalance ??
+                  stateScopedPrev?.canShieldTransparentBalance ??
+                  false
+            : stateScopedPrev?.canShieldTransparentBalance ?? false,
+        shieldTransparentFee: useFetchedAccountData
+            ? shieldTransparentFee ?? stateScopedPrev?.shieldTransparentFee
+            : stateScopedPrev?.shieldTransparentFee,
+        shieldTransparentAmount: useFetchedAccountData
+            ? shieldTransparentAmount ??
+                  stateScopedPrev?.shieldTransparentAmount
+            : stateScopedPrev?.shieldTransparentAmount,
+        spendableBalance: useFetchedAccountData
+            ? spendable ?? stateScopedPrev?.spendableBalance
+            : stateScopedPrev?.spendableBalance,
+        totalBalance: useFetchedAccountData
+            ? total ?? stateScopedPrev?.totalBalance
+            : stateScopedPrev?.totalBalance,
+        recentTransactions: useFetchedAccountData
+            ? recentTxs
+            : stateScopedPrev?.recentTransactions ?? const [],
         lastSyncStartedAt: syncStartedAt,
         lastSyncCompletedAt: syncCompletedAt,
         lastSyncFailedAt: prev?.lastSyncFailedAt,
@@ -1187,6 +1311,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       log('SyncNotifier: no active account, skipping refresh');
       return;
     }
+    final scopedPrev = _previousScopedState(prev, accountUuid);
 
     BigInt? transparent;
     BigInt? sapling;
@@ -1222,7 +1347,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     }
 
     var recentTxs =
-        prev?.recentTransactions ?? const <rust_sync.TransactionInfo>[];
+        scopedPrev?.recentTransactions ?? const <rust_sync.TransactionInfo>[];
     try {
       recentTxs = await rust_sync.getTransactionHistory(
         dbPath: dbPath,
@@ -1243,7 +1368,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       network: network,
       accountUuid: accountUuid,
       transparentBalance:
-          transparent ?? prev?.transparentBalance ?? BigInt.zero,
+          transparent ?? scopedPrev?.transparentBalance ?? BigInt.zero,
     );
     if (shieldStatus != null) {
       canShieldTransparentBalance = shieldStatus.canShield;
@@ -1251,36 +1376,43 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       shieldTransparentAmount = shieldStatus.amount;
     }
 
-    if (epoch != _sensitiveStateEpoch || _requiresUnlock) {
-      log('SyncNotifier: discarding balance refresh after lock transition');
+    if (epoch != _sensitiveStateEpoch ||
+        _requiresUnlock ||
+        accountUuid != _getActiveAccountUuid()) {
+      log(
+        'SyncNotifier: discarding balance refresh after account or lock transition',
+      );
       return;
     }
 
     state = AsyncData(
       SyncState(
+        accountUuid: accountUuid,
         isSyncing: prev?.isSyncing ?? false,
         isBackgroundMode: _bgDelegate.isActive,
         percentage: prev?.percentage ?? 0.0,
         displayPercentage: prev?.displayPercentage ?? prev?.percentage ?? 0.0,
         scannedHeight: prev?.scannedHeight ?? 0,
         chainTipHeight: prev?.chainTipHeight ?? 0,
-        transparentBalance: transparent ?? prev?.transparentBalance,
-        saplingBalance: sapling ?? prev?.saplingBalance,
-        orchardBalance: orchard ?? prev?.orchardBalance,
+        transparentBalance: transparent ?? scopedPrev?.transparentBalance,
+        saplingBalance: sapling ?? scopedPrev?.saplingBalance,
+        orchardBalance: orchard ?? scopedPrev?.orchardBalance,
         transparentPendingBalance:
-            transparentPending ?? prev?.transparentPendingBalance,
-        saplingPendingBalance: saplingPending ?? prev?.saplingPendingBalance,
-        orchardPendingBalance: orchardPending ?? prev?.orchardPendingBalance,
+            transparentPending ?? scopedPrev?.transparentPendingBalance,
+        saplingPendingBalance:
+            saplingPending ?? scopedPrev?.saplingPendingBalance,
+        orchardPendingBalance:
+            orchardPending ?? scopedPrev?.orchardPendingBalance,
         canShieldTransparentBalance:
             canShieldTransparentBalance ??
-            prev?.canShieldTransparentBalance ??
+            scopedPrev?.canShieldTransparentBalance ??
             false,
         shieldTransparentFee:
-            shieldTransparentFee ?? prev?.shieldTransparentFee,
+            shieldTransparentFee ?? scopedPrev?.shieldTransparentFee,
         shieldTransparentAmount:
-            shieldTransparentAmount ?? prev?.shieldTransparentAmount,
-        spendableBalance: spendable ?? prev?.spendableBalance,
-        totalBalance: total ?? prev?.totalBalance,
+            shieldTransparentAmount ?? scopedPrev?.shieldTransparentAmount,
+        spendableBalance: spendable ?? scopedPrev?.spendableBalance,
+        totalBalance: total ?? scopedPrev?.totalBalance,
         recentTransactions: recentTxs,
         lastSyncStartedAt: prev?.lastSyncStartedAt,
         lastSyncCompletedAt: prev?.lastSyncCompletedAt,

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -19,6 +19,11 @@ class SyncState {
   /// Account UUID that owns the balance, shield status, and recent transaction
   /// fields below. Sync progress itself is wallet-wide.
   final String? accountUuid;
+
+  /// True only after balance/history data has been loaded for [accountUuid].
+  /// A state can be scoped to an account while this is false during account
+  /// switches or after the first account-scoped refresh fails.
+  final bool hasAccountScopedData;
   final bool isSyncing;
   final bool isBackgroundMode;
   final double percentage;
@@ -57,6 +62,7 @@ class SyncState {
 
   SyncState({
     this.accountUuid,
+    this.hasAccountScopedData = false,
     this.isSyncing = false,
     this.isBackgroundMode = false,
     this.percentage = 0,
@@ -94,6 +100,7 @@ class SyncState {
 
   SyncState copyWith({
     String? accountUuid,
+    bool? hasAccountScopedData,
     bool? isSyncing,
     bool? isBackgroundMode,
     double? percentage,
@@ -120,6 +127,7 @@ class SyncState {
   }) {
     return SyncState(
       accountUuid: accountUuid ?? this.accountUuid,
+      hasAccountScopedData: hasAccountScopedData ?? this.hasAccountScopedData,
       isSyncing: isSyncing ?? this.isSyncing,
       isBackgroundMode: isBackgroundMode ?? this.isBackgroundMode,
       percentage: percentage ?? this.percentage,
@@ -155,6 +163,10 @@ class SyncState {
     return accountUuid != null && this.accountUuid == accountUuid;
   }
 
+  bool hasDataForAccount(String? accountUuid) {
+    return belongsToAccount(accountUuid) && hasAccountScopedData;
+  }
+
   SyncState scopedToAccount(String? accountUuid) {
     if (belongsToAccount(accountUuid)) return this;
     return withoutAccountScopedData(accountUuid: accountUuid);
@@ -163,6 +175,7 @@ class SyncState {
   SyncState withoutAccountScopedData({String? accountUuid}) {
     return SyncState(
       accountUuid: accountUuid,
+      hasAccountScopedData: false,
       isSyncing: isSyncing,
       isBackgroundMode: isBackgroundMode,
       percentage: percentage,
@@ -297,9 +310,11 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     final initialAccountUuid = accountState?.activeAccountUuid;
     final initialBelongsToActiveAccount =
         initial.accountUuid != null &&
-        initial.accountUuid == initialAccountUuid;
+        initial.accountUuid == initialAccountUuid &&
+        initial.hasAccountScopedData;
     return SyncState(
       accountUuid: initialAccountUuid,
+      hasAccountScopedData: initialBelongsToActiveAccount,
       isSyncing: false,
       isBackgroundMode: false,
       percentage: initial.percentage,
@@ -346,7 +361,11 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   }
 
   SyncState? _previousScopedState(SyncState? prev, String? accountUuid) {
-    if (accountUuid == null || prev?.accountUuid != accountUuid) return null;
+    if (accountUuid == null ||
+        prev?.accountUuid != accountUuid ||
+        prev?.hasAccountScopedData != true) {
+      return null;
+    }
     return prev;
   }
 
@@ -425,6 +444,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     state = AsyncData(
       SyncState(
         accountUuid: accountUuid,
+        hasAccountScopedData: scopedPrev != null,
         isSyncing: true,
         isBackgroundMode: false,
         percentage: 0.0,
@@ -516,6 +536,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               state = AsyncData(
                 SyncState(
                   accountUuid: accountUuid,
+                  hasAccountScopedData: scopedPrev != null,
                   error: e.toString(),
                   transparentBalance: scopedPrev?.transparentBalance,
                   saplingBalance: scopedPrev?.saplingBalance,
@@ -559,6 +580,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
           state = AsyncData(
             SyncState(
               accountUuid: accountUuid,
+              hasAccountScopedData: scopedPrev != null,
               error: e.toString(),
               transparentBalance: scopedPrev?.transparentBalance,
               saplingBalance: scopedPrev?.saplingBalance,
@@ -655,6 +677,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     state = AsyncData(
       SyncState(
         accountUuid: accountUuid,
+        hasAccountScopedData: scopedPrev != null,
         isSyncing: false,
         isBackgroundMode: false,
         percentage: prev?.percentage ?? 0.0,
@@ -1140,6 +1163,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     bool? canShieldTransparentBalance;
     BigInt? shieldTransparentFee;
     BigInt? shieldTransparentAmount;
+    var didFetchBalance = false;
+    var didFetchRecentTxs = false;
     var recentTxs =
         scopedPrev?.recentTransactions ?? const <rust_sync.TransactionInfo>[];
     if (event.hasNewTx || event.isComplete) {
@@ -1157,6 +1182,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         orchardPending = balance.orchardPending;
         spendable = balance.spendable;
         total = balance.total;
+        didFetchBalance = true;
       } catch (e) {
         log('SyncNotifier: balance fetch failed: $e');
       }
@@ -1167,6 +1193,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
           limit: 10,
           accountUuid: accountUuid,
         );
+        didFetchRecentTxs = true;
       } catch (e) {
         log('SyncNotifier: tx history fetch failed: $e');
       }
@@ -1193,6 +1220,10 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     final stateAccountUuid = _getActiveAccountUuid();
     final useFetchedAccountData = accountUuid == stateAccountUuid;
     final stateScopedPrev = _previousScopedState(state.value, stateAccountUuid);
+    final hasAccountScopedData = useFetchedAccountData
+        ? (didFetchBalance && didFetchRecentTxs) ||
+              (stateScopedPrev?.hasAccountScopedData ?? false)
+        : stateScopedPrev?.hasAccountScopedData ?? false;
     if (!useFetchedAccountData) {
       log(
         'SyncNotifier: discarding account-scoped sync data after account transition',
@@ -1219,6 +1250,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     state = AsyncData(
       SyncState(
         accountUuid: stateAccountUuid,
+        hasAccountScopedData: hasAccountScopedData,
         isSyncing: event.isSyncing && !event.isComplete,
         isBackgroundMode: event.isBackground || _bgDelegate.isActive,
         percentage: actualPercentage,
@@ -1324,6 +1356,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     bool? canShieldTransparentBalance;
     BigInt? shieldTransparentFee;
     BigInt? shieldTransparentAmount;
+    var didFetchBalance = false;
+    var didFetchRecentTxs = false;
     try {
       final balance = await rust_sync.getBalance(
         dbPath: dbPath,
@@ -1338,6 +1372,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       orchardPending = balance.orchardPending;
       spendable = balance.spendable;
       total = balance.total;
+      didFetchBalance = true;
     } catch (e) {
       _logRefreshReadError(
         label: 'balance',
@@ -1355,6 +1390,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         limit: 10,
         accountUuid: accountUuid,
       );
+      didFetchRecentTxs = true;
     } catch (e) {
       _logRefreshReadError(
         label: 'tx history',
@@ -1388,6 +1424,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     state = AsyncData(
       SyncState(
         accountUuid: accountUuid,
+        hasAccountScopedData:
+            (didFetchBalance && didFetchRecentTxs) ||
+            (scopedPrev?.hasAccountScopedData ?? false),
         isSyncing: prev?.isSyncing ?? false,
         isBackgroundMode: _bgDelegate.isActive,
         percentage: prev?.percentage ?? 0.0,

--- a/test/sync_state_test.dart
+++ b/test/sync_state_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 void main() {
   test('pendingBalance is the explicit pending pool sum', () {
@@ -42,4 +43,67 @@ void main() {
     expect(reset.percentage, 0.25);
     expect(reset.displayPercentage, 0.25);
   });
+
+  test('scopedToAccount preserves data for the owning account', () {
+    final tx = _tx('a' * 64);
+    final state = SyncState(
+      accountUuid: 'account-a',
+      percentage: 0.75,
+      scannedHeight: 10,
+      chainTipHeight: 20,
+      totalBalance: BigInt.from(123),
+      spendableBalance: BigInt.from(100),
+      recentTransactions: [tx],
+    );
+
+    final scoped = state.scopedToAccount('account-a');
+
+    expect(scoped.accountUuid, 'account-a');
+    expect(scoped.totalBalance, BigInt.from(123));
+    expect(scoped.spendableBalance, BigInt.from(100));
+    expect(scoped.recentTransactions, [tx]);
+    expect(scoped.percentage, 0.75);
+  });
+
+  test('scopedToAccount clears account data for a different account', () {
+    final state = SyncState(
+      accountUuid: 'account-a',
+      isSyncing: true,
+      percentage: 0.75,
+      displayPercentage: 0.50,
+      scannedHeight: 10,
+      chainTipHeight: 20,
+      totalBalance: BigInt.from(123),
+      spendableBalance: BigInt.from(100),
+      recentTransactions: [_tx('a' * 64)],
+    );
+
+    final scoped = state.scopedToAccount('account-b');
+
+    expect(scoped.accountUuid, 'account-b');
+    expect(scoped.totalBalance, BigInt.zero);
+    expect(scoped.spendableBalance, BigInt.zero);
+    expect(scoped.recentTransactions, isEmpty);
+    expect(scoped.isSyncing, isTrue);
+    expect(scoped.percentage, 0.75);
+    expect(scoped.displayPercentage, 0.50);
+    expect(scoped.scannedHeight, 10);
+    expect(scoped.chainTipHeight, 20);
+  });
+}
+
+rust_sync.TransactionInfo _tx(String txidHex) {
+  return rust_sync.TransactionInfo(
+    txidHex: txidHex,
+    minedHeight: BigInt.one,
+    expiredUnmined: false,
+    accountBalanceDelta: 0,
+    fee: BigInt.zero,
+    blockTime: BigInt.from(1800000000),
+    isTransparent: false,
+    txKind: 'received',
+    displayAmount: BigInt.one,
+    displayPool: 'shielded',
+    createdTime: BigInt.from(1800000000),
+  );
 }

--- a/test/sync_state_test.dart
+++ b/test/sync_state_test.dart
@@ -61,6 +61,8 @@ void main() {
 
     expect(scoped.accountUuid, 'account-a');
     expect(scoped.hasDataForAccount('account-a'), isTrue);
+    expect(scoped.hasBalanceData, isTrue);
+    expect(scoped.hasRecentTransactionsData, isTrue);
     expect(scoped.totalBalance, BigInt.from(123));
     expect(scoped.spendableBalance, BigInt.from(100));
     expect(scoped.recentTransactions, [tx]);
@@ -108,8 +110,33 @@ void main() {
 
     expect(cleared.belongsToAccount('account-b'), isTrue);
     expect(cleared.hasDataForAccount('account-b'), isFalse);
+    expect(cleared.hasBalanceData, isFalse);
+    expect(cleared.hasRecentTransactionsData, isFalse);
     expect(cleared.totalBalance, BigInt.zero);
     expect(cleared.recentTransactions, isEmpty);
+  });
+
+  test('partial account state preserves loaded pieces without rendering', () {
+    final state = SyncState(
+      accountUuid: 'account-a',
+      hasBalanceData: true,
+      totalBalance: BigInt.from(123),
+    );
+
+    expect(state.belongsToAccount('account-a'), isTrue);
+    expect(state.hasDataForAccount('account-a'), isFalse);
+    expect(state.hasBalanceData, isTrue);
+    expect(state.hasRecentTransactionsData, isFalse);
+    expect(state.totalBalance, BigInt.from(123));
+
+    final completed = state.copyWith(
+      hasRecentTransactionsData: true,
+      recentTransactions: [_tx('b' * 64)],
+    );
+
+    expect(completed.hasDataForAccount('account-a'), isTrue);
+    expect(completed.totalBalance, BigInt.from(123));
+    expect(completed.recentTransactions, hasLength(1));
   });
 }
 

--- a/test/sync_state_test.dart
+++ b/test/sync_state_test.dart
@@ -48,6 +48,7 @@ void main() {
     final tx = _tx('a' * 64);
     final state = SyncState(
       accountUuid: 'account-a',
+      hasAccountScopedData: true,
       percentage: 0.75,
       scannedHeight: 10,
       chainTipHeight: 20,
@@ -59,6 +60,7 @@ void main() {
     final scoped = state.scopedToAccount('account-a');
 
     expect(scoped.accountUuid, 'account-a');
+    expect(scoped.hasDataForAccount('account-a'), isTrue);
     expect(scoped.totalBalance, BigInt.from(123));
     expect(scoped.spendableBalance, BigInt.from(100));
     expect(scoped.recentTransactions, [tx]);
@@ -68,6 +70,7 @@ void main() {
   test('scopedToAccount clears account data for a different account', () {
     final state = SyncState(
       accountUuid: 'account-a',
+      hasAccountScopedData: true,
       isSyncing: true,
       percentage: 0.75,
       displayPercentage: 0.50,
@@ -81,6 +84,8 @@ void main() {
     final scoped = state.scopedToAccount('account-b');
 
     expect(scoped.accountUuid, 'account-b');
+    expect(scoped.belongsToAccount('account-b'), isTrue);
+    expect(scoped.hasDataForAccount('account-b'), isFalse);
     expect(scoped.totalBalance, BigInt.zero);
     expect(scoped.spendableBalance, BigInt.zero);
     expect(scoped.recentTransactions, isEmpty);
@@ -89,6 +94,22 @@ void main() {
     expect(scoped.displayPercentage, 0.50);
     expect(scoped.scannedHeight, 10);
     expect(scoped.chainTipHeight, 20);
+  });
+
+  test('cleared account state is scoped but not renderable account data', () {
+    final state = SyncState(
+      accountUuid: 'account-a',
+      hasAccountScopedData: true,
+      totalBalance: BigInt.from(123),
+      recentTransactions: [_tx('a' * 64)],
+    );
+
+    final cleared = state.withoutAccountScopedData(accountUuid: 'account-b');
+
+    expect(cleared.belongsToAccount('account-b'), isTrue);
+    expect(cleared.hasDataForAccount('account-b'), isFalse);
+    expect(cleared.totalBalance, BigInt.zero);
+    expect(cleared.recentTransactions, isEmpty);
   });
 }
 


### PR DESCRIPTION
## Summary
- Tag SyncState/App bootstrap snapshots with account ownership and loaded-data flags.
- Gate Activity and Home recent activity rendering so placeholder or stale prior-account sync data is not shown after account switches.
- Scope Home/Send balance reads to the active account and preserve same-account partial refresh data until both balance and history load.

## Validation
- fvm flutter test test/sync_state_test.dart test/activity_row_mapper_test.dart test/activity_table_row_test.dart test/activity_table_pagination_test.dart
- fvm flutter analyze

Note: pub advisory decode warnings were emitted by Flutter tooling, but tests and analyzer passed.