### PR TITLE
Add macOS-only seed phrase privacy layer

### DIFF
--- a/lib/src/core/privacy/sensitive_privacy_overlay.dart
+++ b/lib/src/core/privacy/sensitive_privacy_overlay.dart
@@ -394,7 +394,7 @@ class _SensitivePrivacyShield extends StatelessWidget {
     return IgnorePointer(
       child: ClipRect(
         child: BackdropFilter(
-          filter: ui.ImageFilter.blur(sigmaX: 15, sigmaY: 15),
+          filter: ui.ImageFilter.blur(sigmaX: 30, sigmaY: 30),
           child: DecoratedBox(
             decoration: BoxDecoration(color: isDark ? _darkScrim : _lightScrim),
             child: Center(

--- a/lib/src/core/privacy/sensitive_privacy_overlay.dart
+++ b/lib/src/core/privacy/sensitive_privacy_overlay.dart
@@ -51,13 +51,14 @@ class MacOSPrivacyExposureEvent {
 
 abstract final class MacOSPrivacyExposureEvents {
   static const _channel = EventChannel('com.zcash.wallet/privacy_exposure');
+  static final Stream<MacOSPrivacyExposureEvent> _stream =
+      kIsWeb || !Platform.isMacOS
+      ? const Stream.empty()
+      : _channel.receiveBroadcastStream().map(
+          MacOSPrivacyExposureEvent.fromPlatformEvent,
+        );
 
-  static Stream<MacOSPrivacyExposureEvent> get stream {
-    if (kIsWeb || !Platform.isMacOS) return const Stream.empty();
-    return _channel.receiveBroadcastStream().map(
-      MacOSPrivacyExposureEvent.fromPlatformEvent,
-    );
-  }
+  static Stream<MacOSPrivacyExposureEvent> get stream => _stream;
 }
 
 abstract final class MacOSSensitiveContentBridge {

--- a/lib/src/core/privacy/sensitive_privacy_overlay.dart
+++ b/lib/src/core/privacy/sensitive_privacy_overlay.dart
@@ -1,0 +1,422 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:window_manager/window_manager.dart';
+
+import '../theme/app_theme.dart';
+import '../widgets/app_icon.dart';
+
+bool get _supportsWindowFocusEvents {
+  if (kIsWeb) return false;
+  return Platform.isMacOS || Platform.isWindows || Platform.isLinux;
+}
+
+class MacOSPrivacyExposureEvent {
+  const MacOSPrivacyExposureEvent({
+    required this.isSafe,
+    required this.reason,
+    this.details = const {},
+  });
+
+  final bool isSafe;
+  final String reason;
+  final Map<String, bool> details;
+
+  static MacOSPrivacyExposureEvent fromPlatformEvent(Object? event) {
+    final map = event as Map<Object?, Object?>? ?? const {};
+    final rawDetails = map['details'] as Map<Object?, Object?>? ?? const {};
+    return MacOSPrivacyExposureEvent(
+      isSafe: map['isSafe'] as bool? ?? true,
+      reason: map['reason'] as String? ?? 'unknown',
+      details: rawDetails.map(
+        (key, value) => MapEntry(key.toString(), value as bool? ?? false),
+      ),
+    );
+  }
+}
+
+abstract final class MacOSPrivacyExposureEvents {
+  static const _channel = EventChannel('com.zcash.wallet/privacy_exposure');
+
+  static Stream<MacOSPrivacyExposureEvent> get stream {
+    if (kIsWeb || !Platform.isMacOS) return const Stream.empty();
+    return _channel.receiveBroadcastStream().map(
+      MacOSPrivacyExposureEvent.fromPlatformEvent,
+    );
+  }
+}
+
+abstract final class MacOSNativePrivacyShield {
+  static const _channel = MethodChannel('com.zcash.wallet/privacy_shield');
+
+  static final Set<int> _visibleTokens = <int>{};
+  static final Map<int, ui.Rect> _tokenRects = <int, ui.Rect>{};
+  static int _nextToken = 0;
+  static bool _lastVisible = false;
+  static ui.Rect? _lastRect;
+
+  static int createToken() => _nextToken++;
+
+  static void updateToken(int token, bool visible, {ui.Rect? globalRect}) {
+    if (visible) {
+      _visibleTokens.add(token);
+      if (globalRect != null && !globalRect.isEmpty) {
+        _tokenRects[token] = globalRect;
+      }
+    } else {
+      _visibleTokens.remove(token);
+      _tokenRects.remove(token);
+    }
+    _syncIfNeeded();
+  }
+
+  static void clearToken(int token) {
+    _visibleTokens.remove(token);
+    _tokenRects.remove(token);
+    _syncIfNeeded();
+  }
+
+  @visibleForTesting
+  static void resetForTesting() {
+    _visibleTokens.clear();
+    _tokenRects.clear();
+    _nextToken = 0;
+    _lastVisible = false;
+    _lastRect = null;
+  }
+
+  static void _syncIfNeeded() {
+    if (kIsWeb || !Platform.isMacOS) return;
+    final visible = _visibleTokens.isNotEmpty;
+    final rect = _combinedVisibleRect();
+    if (_lastVisible == visible && _lastRect == rect) return;
+    _lastVisible = visible;
+    _lastRect = rect;
+    unawaited(_setSensitiveContentVisible(visible, rect));
+  }
+
+  static ui.Rect? _combinedVisibleRect() {
+    ui.Rect? combined;
+    for (final token in _visibleTokens) {
+      final rect = _tokenRects[token];
+      if (rect == null) continue;
+      combined = combined?.expandToInclude(rect) ?? rect;
+    }
+    return combined;
+  }
+
+  static Future<void> _setSensitiveContentVisible(
+    bool visible,
+    ui.Rect? rect,
+  ) async {
+    final arguments = <String, Object?>{'visible': visible};
+    if (rect != null) {
+      arguments['rect'] = <String, double>{
+        'left': rect.left,
+        'top': rect.top,
+        'width': rect.width,
+        'height': rect.height,
+      };
+    }
+
+    try {
+      await _channel.invokeMethod<void>(
+        'setSensitiveContentVisible',
+        arguments,
+      );
+    } catch (_) {
+      // The native shield is a macOS-only fast path. The Flutter overlay still
+      // handles privacy if the native channel is unavailable.
+    }
+  }
+}
+
+class SensitivePrivacyOverlayController extends ChangeNotifier {
+  SensitivePrivacyOverlayController({bool initiallySafe = true})
+    : _isSafe = initiallySafe;
+
+  bool _isSafe;
+
+  bool get isSafe => _isSafe;
+
+  void markSafe() => _setSafe(true);
+
+  void markUnsafe() => _setSafe(false);
+
+  @protected
+  void _setSafe(bool value) {
+    if (_isSafe == value) return;
+    _isSafe = value;
+    notifyListeners();
+  }
+}
+
+class SensitivePrivacyEnvironmentController
+    extends SensitivePrivacyOverlayController
+    with WindowListener {
+  SensitivePrivacyEnvironmentController({
+    Stream<MacOSPrivacyExposureEvent>? macOSExposureEvents,
+  }) {
+    _lifecycleListener = AppLifecycleListener(
+      onResume: () => _setLifecycleSafe(true),
+      onShow: () => _setLifecycleSafe(true),
+      onInactive: () => _setLifecycleSafe(false),
+      onHide: () => _setLifecycleSafe(false),
+      onPause: () => _setLifecycleSafe(false),
+    );
+
+    if (_supportsWindowFocusEvents) {
+      windowManager.addListener(this);
+      windowManager
+          .isFocused()
+          .then((focused) {
+            if (_disposed) return;
+            _setWindowSafe(focused);
+          })
+          .catchError((_) {
+            if (!_disposed) _setWindowSafe(false);
+          });
+    }
+
+    _macOSExposureSub =
+        (macOSExposureEvents ?? MacOSPrivacyExposureEvents.stream).listen(
+          (event) {
+            _setMacOSNativeSafe(event.isSafe);
+            assert(() {
+              final details = event.details.entries
+                  .map((entry) => '${entry.key}=${entry.value}')
+                  .join(', ');
+              debugPrint(
+                'MacOSPrivacyExposure: ${event.isSafe ? 'safe' : 'unsafe'} '
+                '(${event.reason})${details.isEmpty ? '' : ' {$details}'}',
+              );
+              return true;
+            }());
+          },
+          onError: (Object error) {
+            assert(() {
+              debugPrint('MacOSPrivacyExposure: stream error: $error');
+              return true;
+            }());
+          },
+        );
+  }
+
+  AppLifecycleListener? _lifecycleListener;
+  StreamSubscription<MacOSPrivacyExposureEvent>? _macOSExposureSub;
+  bool _lifecycleSafe = true;
+  bool _windowSafe = true;
+  bool _macOSNativeSafe = true;
+  bool _disposed = false;
+
+  @override
+  void onWindowFocus() => _setWindowSafe(true);
+
+  @override
+  void onWindowRestore() => _setWindowSafe(true);
+
+  @override
+  void onWindowBlur() => _setWindowSafe(false);
+
+  @override
+  void onWindowMinimize() => _setWindowSafe(false);
+
+  void _setLifecycleSafe(bool value) {
+    _lifecycleSafe = value;
+    _syncSafety();
+  }
+
+  void _setWindowSafe(bool value) {
+    _windowSafe = value;
+    _syncSafety();
+  }
+
+  void _setMacOSNativeSafe(bool value) {
+    _macOSNativeSafe = value;
+    _syncSafety();
+  }
+
+  void _syncSafety() {
+    _setSafe(_lifecycleSafe && _windowSafe && _macOSNativeSafe);
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _macOSExposureSub?.cancel();
+    _lifecycleListener?.dispose();
+    if (_supportsWindowFocusEvents) {
+      windowManager.removeListener(this);
+    }
+    super.dispose();
+  }
+}
+
+class SensitivePrivacyOverlay extends StatefulWidget {
+  const SensitivePrivacyOverlay({
+    required this.sensitiveContentVisible,
+    required this.child,
+    this.controller,
+    super.key,
+  });
+
+  static const shieldKey = ValueKey('sensitive_privacy_overlay.shield');
+
+  final bool sensitiveContentVisible;
+  final Widget child;
+  final SensitivePrivacyOverlayController? controller;
+
+  @override
+  State<SensitivePrivacyOverlay> createState() =>
+      _SensitivePrivacyOverlayState();
+}
+
+class _SensitivePrivacyOverlayState extends State<SensitivePrivacyOverlay>
+    with WidgetsBindingObserver {
+  final _overlayKey = GlobalKey();
+  late final int _nativeShieldToken = MacOSNativePrivacyShield.createToken();
+  late SensitivePrivacyOverlayController _controller;
+  late bool _ownsController;
+  bool _nativeShieldSyncScheduled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _setController(widget.controller);
+    _scheduleNativeShieldSync();
+  }
+
+  @override
+  void didUpdateWidget(covariant SensitivePrivacyOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      if (_ownsController) _controller.dispose();
+      _setController(widget.controller);
+    }
+    if (oldWidget.sensitiveContentVisible != widget.sensitiveContentVisible) {
+      _scheduleNativeShieldSync();
+    }
+  }
+
+  void _setController(SensitivePrivacyOverlayController? controller) {
+    _ownsController = controller == null;
+    _controller = controller ?? SensitivePrivacyEnvironmentController();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    MacOSNativePrivacyShield.clearToken(_nativeShieldToken);
+    if (_ownsController) _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    _scheduleNativeShieldSync();
+  }
+
+  void _scheduleNativeShieldSync() {
+    if (!widget.sensitiveContentVisible) {
+      _syncNativeShield();
+      return;
+    }
+    if (_nativeShieldSyncScheduled) return;
+    _nativeShieldSyncScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _nativeShieldSyncScheduled = false;
+      if (!mounted) return;
+      _syncNativeShield();
+    });
+  }
+
+  void _syncNativeShield() {
+    MacOSNativePrivacyShield.updateToken(
+      _nativeShieldToken,
+      widget.sensitiveContentVisible,
+      globalRect: _overlayGlobalRect(),
+    );
+  }
+
+  ui.Rect? _overlayGlobalRect() {
+    final renderObject = _overlayKey.currentContext?.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.hasSize) return null;
+    final size = renderObject.size;
+    if (size.isEmpty) return null;
+    return renderObject.localToGlobal(Offset.zero) & size;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _scheduleNativeShieldSync();
+    return ListenableBuilder(
+      listenable: _controller,
+      builder: (context, _) {
+        final showShield =
+            widget.sensitiveContentVisible && !_controller.isSafe;
+        return Stack(
+          key: _overlayKey,
+          fit: StackFit.passthrough,
+          children: [
+            widget.child,
+            if (showShield)
+              const Positioned.fill(
+                child: _SensitivePrivacyShield(
+                  key: SensitivePrivacyOverlay.shieldKey,
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _SensitivePrivacyShield extends StatelessWidget {
+  const _SensitivePrivacyShield({super.key});
+
+  static const _lightScrim = Color(0x33141818);
+  static const _darkScrim = Color(0x33626767);
+  static const _darkSurface = Color(0xFF141818);
+  static const _darkIcon = Color(0xFFE1E1E1);
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = AppTheme.of(context) == AppThemeData.dark;
+    final badgeColor = isDark ? _darkSurface : const Color(0xFFFFFFFF);
+    final iconColor = isDark ? _darkIcon : _darkSurface;
+
+    return IgnorePointer(
+      child: ClipRect(
+        child: BackdropFilter(
+          filter: ui.ImageFilter.blur(sigmaX: 15, sigmaY: 15),
+          child: DecoratedBox(
+            decoration: BoxDecoration(color: isDark ? _darkScrim : _lightScrim),
+            child: Center(
+              child: Container(
+                width: 98,
+                height: 98,
+                decoration: BoxDecoration(
+                  color: badgeColor,
+                  borderRadius: BorderRadius.circular(24),
+                ),
+                alignment: Alignment.center,
+                child: AppIcon(
+                  AppIcons.lock,
+                  size: 50,
+                  color: iconColor,
+                  semanticLabel: 'Sensitive content hidden',
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/core/privacy/sensitive_privacy_overlay.dart
+++ b/lib/src/core/privacy/sensitive_privacy_overlay.dart
@@ -50,78 +50,46 @@ abstract final class MacOSPrivacyExposureEvents {
   }
 }
 
-abstract final class MacOSNativePrivacyShield {
+abstract final class MacOSSensitiveContentBridge {
   static const _channel = MethodChannel('com.zcash.wallet/privacy_shield');
 
   static final Set<int> _visibleTokens = <int>{};
-  static final Map<int, ui.Rect> _tokenRects = <int, ui.Rect>{};
   static int _nextToken = 0;
   static bool _lastVisible = false;
-  static ui.Rect? _lastRect;
 
   static int createToken() => _nextToken++;
 
-  static void updateToken(int token, bool visible, {ui.Rect? globalRect}) {
+  static void updateToken(int token, bool visible) {
     if (visible) {
       _visibleTokens.add(token);
-      if (globalRect != null && !globalRect.isEmpty) {
-        _tokenRects[token] = globalRect;
-      }
     } else {
       _visibleTokens.remove(token);
-      _tokenRects.remove(token);
     }
     _syncIfNeeded();
   }
 
   static void clearToken(int token) {
     _visibleTokens.remove(token);
-    _tokenRects.remove(token);
     _syncIfNeeded();
   }
 
   @visibleForTesting
   static void resetForTesting() {
     _visibleTokens.clear();
-    _tokenRects.clear();
     _nextToken = 0;
     _lastVisible = false;
-    _lastRect = null;
   }
 
   static void _syncIfNeeded() {
     if (kIsWeb || !Platform.isMacOS) return;
     final visible = _visibleTokens.isNotEmpty;
-    final rect = _combinedVisibleRect();
-    if (_lastVisible == visible && _lastRect == rect) return;
+    if (_lastVisible == visible) return;
     _lastVisible = visible;
-    _lastRect = rect;
-    unawaited(_setSensitiveContentVisible(visible, rect));
+    unawaited(_setSensitiveContentVisible(visible));
   }
 
-  static ui.Rect? _combinedVisibleRect() {
-    ui.Rect? combined;
-    for (final token in _visibleTokens) {
-      final rect = _tokenRects[token];
-      if (rect == null) continue;
-      combined = combined?.expandToInclude(rect) ?? rect;
-    }
-    return combined;
-  }
-
-  static Future<void> _setSensitiveContentVisible(
-    bool visible,
-    ui.Rect? rect,
-  ) async {
+  static Future<void> _setSensitiveContentVisible(bool visible) async {
     final arguments = <String, Object?>{'visible': visible};
-    if (rect != null) {
-      arguments['rect'] = <String, double>{
-        'left': rect.left,
-        'top': rect.top,
-        'width': rect.width,
-        'height': rect.height,
-      };
-    }
 
     try {
       await _channel.invokeMethod<void>(
@@ -129,8 +97,8 @@ abstract final class MacOSNativePrivacyShield {
         arguments,
       );
     } catch (_) {
-      // The native shield is a macOS-only fast path. The Flutter overlay still
-      // handles privacy if the native channel is unavailable.
+      // This bridge only controls macOS window policy/exposure events. The
+      // Flutter overlay remains the visual privacy layer if the channel fails.
     }
   }
 }
@@ -164,6 +132,8 @@ class SensitivePrivacyEnvironmentController
     _lifecycleListener = AppLifecycleListener(
       onResume: () => _setLifecycleSafe(true),
       onShow: () => _setLifecycleSafe(true),
+      // iOS snapshots during inactive, before pause. Keep sensitive content
+      // covered as soon as the app starts losing foreground interaction.
       onInactive: () => _setLifecycleSafe(false),
       onHide: () => _setLifecycleSafe(false),
       onPause: () => _setLifecycleSafe(false),
@@ -275,20 +245,17 @@ class SensitivePrivacyOverlay extends StatefulWidget {
       _SensitivePrivacyOverlayState();
 }
 
-class _SensitivePrivacyOverlayState extends State<SensitivePrivacyOverlay>
-    with WidgetsBindingObserver {
-  final _overlayKey = GlobalKey();
-  late final int _nativeShieldToken = MacOSNativePrivacyShield.createToken();
+class _SensitivePrivacyOverlayState extends State<SensitivePrivacyOverlay> {
+  late final int _nativeVisibilityToken =
+      MacOSSensitiveContentBridge.createToken();
   late SensitivePrivacyOverlayController _controller;
   late bool _ownsController;
-  bool _nativeShieldSyncScheduled = false;
 
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
     _setController(widget.controller);
-    _scheduleNativeShieldSync();
+    _syncNativeVisibility();
   }
 
   @override
@@ -299,7 +266,7 @@ class _SensitivePrivacyOverlayState extends State<SensitivePrivacyOverlay>
       _setController(widget.controller);
     }
     if (oldWidget.sensitiveContentVisible != widget.sensitiveContentVisible) {
-      _scheduleNativeShieldSync();
+      _syncNativeVisibility();
     }
   }
 
@@ -310,57 +277,26 @@ class _SensitivePrivacyOverlayState extends State<SensitivePrivacyOverlay>
 
   @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    MacOSNativePrivacyShield.clearToken(_nativeShieldToken);
+    MacOSSensitiveContentBridge.clearToken(_nativeVisibilityToken);
     if (_ownsController) _controller.dispose();
     super.dispose();
   }
 
-  @override
-  void didChangeMetrics() {
-    _scheduleNativeShieldSync();
-  }
-
-  void _scheduleNativeShieldSync() {
-    if (!widget.sensitiveContentVisible) {
-      _syncNativeShield();
-      return;
-    }
-    if (_nativeShieldSyncScheduled) return;
-    _nativeShieldSyncScheduled = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _nativeShieldSyncScheduled = false;
-      if (!mounted) return;
-      _syncNativeShield();
-    });
-  }
-
-  void _syncNativeShield() {
-    MacOSNativePrivacyShield.updateToken(
-      _nativeShieldToken,
+  void _syncNativeVisibility() {
+    MacOSSensitiveContentBridge.updateToken(
+      _nativeVisibilityToken,
       widget.sensitiveContentVisible,
-      globalRect: _overlayGlobalRect(),
     );
-  }
-
-  ui.Rect? _overlayGlobalRect() {
-    final renderObject = _overlayKey.currentContext?.findRenderObject();
-    if (renderObject is! RenderBox || !renderObject.hasSize) return null;
-    final size = renderObject.size;
-    if (size.isEmpty) return null;
-    return renderObject.localToGlobal(Offset.zero) & size;
   }
 
   @override
   Widget build(BuildContext context) {
-    _scheduleNativeShieldSync();
     return ListenableBuilder(
       listenable: _controller,
       builder: (context, _) {
         final showShield =
             widget.sensitiveContentVisible && !_controller.isSafe;
         return Stack(
-          key: _overlayKey,
           fit: StackFit.passthrough,
           children: [
             widget.child,

--- a/lib/src/core/privacy/sensitive_privacy_overlay.dart
+++ b/lib/src/core/privacy/sensitive_privacy_overlay.dart
@@ -10,9 +10,19 @@ import 'package:window_manager/window_manager.dart';
 import '../theme/app_theme.dart';
 import '../widgets/app_icon.dart';
 
-bool get _supportsWindowFocusEvents {
-  if (kIsWeb) return false;
-  return Platform.isMacOS || Platform.isWindows || Platform.isLinux;
+bool get _supportsPlatformPrivacySignals => supportsPlatformPrivacySignals(
+  isWeb: kIsWeb,
+  isMacOS: !kIsWeb && Platform.isMacOS,
+);
+
+@visibleForTesting
+bool supportsPlatformPrivacySignals({
+  required bool isWeb,
+  required bool isMacOS,
+}) {
+  // TODO(privacy-layer): Add a Windows implementation before enabling this on
+  // desktop platforms other than macOS.
+  return !isWeb && isMacOS;
 }
 
 class MacOSPrivacyExposureEvent {
@@ -129,17 +139,16 @@ class SensitivePrivacyEnvironmentController
   SensitivePrivacyEnvironmentController({
     Stream<MacOSPrivacyExposureEvent>? macOSExposureEvents,
   }) {
-    _lifecycleListener = AppLifecycleListener(
-      onResume: () => _setLifecycleSafe(true),
-      onShow: () => _setLifecycleSafe(true),
-      // iOS snapshots during inactive, before pause. Keep sensitive content
-      // covered as soon as the app starts losing foreground interaction.
-      onInactive: () => _setLifecycleSafe(false),
-      onHide: () => _setLifecycleSafe(false),
-      onPause: () => _setLifecycleSafe(false),
-    );
-
-    if (_supportsWindowFocusEvents) {
+    if (_supportsPlatformPrivacySignals) {
+      _lifecycleListener = AppLifecycleListener(
+        onResume: () => _setLifecycleSafe(true),
+        onShow: () => _setLifecycleSafe(true),
+        // iOS snapshots during inactive, before pause. Keep sensitive content
+        // covered as soon as the app starts losing foreground interaction.
+        onInactive: () => _setLifecycleSafe(false),
+        onHide: () => _setLifecycleSafe(false),
+        onPause: () => _setLifecycleSafe(false),
+      );
       windowManager.addListener(this);
       windowManager
           .isFocused()
@@ -219,7 +228,7 @@ class SensitivePrivacyEnvironmentController
     _disposed = true;
     _macOSExposureSub?.cancel();
     _lifecycleListener?.dispose();
-    if (_supportsWindowFocusEvents) {
+    if (_supportsPlatformPrivacySignals) {
       windowManager.removeListener(this);
     }
     super.dispose();

--- a/lib/src/features/onboarding/create/secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/create/secret_passphrase_screen.dart
@@ -8,6 +8,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/layout/app_desktop_shell.dart';
+import '../../../core/privacy/sensitive_privacy_overlay.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_chip.dart';
@@ -20,9 +22,14 @@ import 'onboarding_split_view.dart';
 import '../shared/onboarding_flow_args.dart';
 
 class SecretPassphraseScreen extends ConsumerStatefulWidget {
-  const SecretPassphraseScreen({this.args, super.key});
+  const SecretPassphraseScreen({
+    this.args,
+    this.privacyOverlayController,
+    super.key,
+  });
 
   final CreateSecretPassphraseArgs? args;
+  final SensitivePrivacyOverlayController? privacyOverlayController;
 
   @override
   ConsumerState<SecretPassphraseScreen> createState() =>
@@ -164,25 +171,33 @@ class _SecretPassphraseScreenState
 
   @override
   Widget build(BuildContext context) {
-    return OnboardingTrailingPane(
-      child: Column(
-        children: [
-          const _BackRow(),
-          const SizedBox(height: AppSpacing.xs),
-          Expanded(
-            child: _HeroLayout(
-              mnemonic: _mnemonic,
-              isPreparing: _isPreparing,
-              submitPhase: _submitPhase,
-              revealed: _revealed,
-              copied: _copied,
-              prepareError: _prepareError,
-              submitError: _submitError,
-              onPrimaryPressed: _handlePrimaryAction,
-              onCopyPressed: _copyMnemonic,
-            ),
+    return AppDesktopPane(
+      padding: EdgeInsets.zero,
+      child: SensitivePrivacyOverlay(
+        sensitiveContentVisible: _revealed && _mnemonic != null,
+        controller: widget.privacyOverlayController,
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Column(
+            children: [
+              const _BackRow(),
+              const SizedBox(height: AppSpacing.xs),
+              Expanded(
+                child: _HeroLayout(
+                  mnemonic: _mnemonic,
+                  isPreparing: _isPreparing,
+                  submitPhase: _submitPhase,
+                  revealed: _revealed,
+                  copied: _copied,
+                  prepareError: _prepareError,
+                  submitError: _submitError,
+                  onPrimaryPressed: _handlePrimaryAction,
+                  onCopyPressed: _copyMnemonic,
+                ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -120,12 +120,27 @@ class _ImportSecretPassphraseScreenState
 
   void _handlePrivacySafetyChanged() {
     if (!_privacyOverlayController.isSafe) {
-      _autocompleteSuppressedForPrivacy = true;
+      _suppressAutocompleteForPrivacy();
+      return;
     }
     if (mounted) setState(() {});
   }
 
-  void _reactivateAutocomplete() {
+  void _suppressAutocompleteForPrivacy() {
+    if (!mounted) {
+      _autocompleteSuppressedForPrivacy = true;
+      return;
+    }
+
+    setState(() {
+      _autocompleteSuppressedForPrivacy = true;
+    });
+    for (final controller in _controllers) {
+      _refreshAutocompleteOptions(controller);
+    }
+  }
+
+  void _reactivateAutocomplete(TextEditingController controller) {
     if (!_privacyOverlayController.isSafe ||
         !_autocompleteSuppressedForPrivacy) {
       return;
@@ -133,6 +148,21 @@ class _ImportSecretPassphraseScreenState
     setState(() {
       _autocompleteSuppressedForPrivacy = false;
     });
+    _refreshAutocompleteOptions(controller);
+  }
+
+  void _refreshAutocompleteOptions(TextEditingController controller) {
+    final value = controller.value;
+    final text = value.text;
+    if (text.isEmpty) return;
+
+    // RawAutocomplete only recomputes options when the text value changes.
+    controller.value = value.copyWith(
+      text: '$text ',
+      selection: TextSelection.collapsed(offset: text.length + 1),
+      composing: TextRange.empty,
+    );
+    controller.value = value;
   }
 
   void _restoreMnemonic() {
@@ -380,9 +410,12 @@ class _ImportSecretPassphraseScreenState
                                   controller: _controllers[index],
                                   focusNode: _focusNodes[index],
                                   wordList: _mnemonicWordList,
-                                  autocompleteEnabled: _autocompleteEnabled,
-                                  onAutocompleteReactivationRequested:
-                                      _reactivateAutocomplete,
+                                  autocompleteEnabled: () =>
+                                      _autocompleteEnabled,
+                                  onAutocompleteReactivationRequested: () =>
+                                      _reactivateAutocomplete(
+                                        _controllers[index],
+                                      ),
                                   destructive:
                                       _showValidationError &&
                                       _controllers[index].text
@@ -465,7 +498,7 @@ class _MnemonicWordCell extends StatefulWidget {
   final bool Function() onMoveNext;
   final bool Function() onMovePrevious;
   final ValueChanged<String> onSuggestionSelected;
-  final bool autocompleteEnabled;
+  final bool Function() autocompleteEnabled;
   final VoidCallback onAutocompleteReactivationRequested;
   final bool destructive;
   final bool autofocus;
@@ -551,34 +584,12 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
     _pendingShellTapGlobalPosition = details.globalPosition;
   }
 
-  void _requestAutocompleteReactivation() {
-    widget.onAutocompleteReactivationRequested();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || !widget.autocompleteEnabled) return;
-      _refreshAutocompleteOptions();
-    });
-  }
-
-  void _refreshAutocompleteOptions() {
-    final value = widget.controller.value;
-    final text = value.text;
-    if (text.isEmpty || _optionsForText(text).isEmpty) return;
-
-    // RawAutocomplete only recomputes options when the text value changes.
-    widget.controller.value = value.copyWith(
-      text: '$text ',
-      selection: TextSelection.collapsed(offset: text.length + 1),
-      composing: TextRange.empty,
-    );
-    widget.controller.value = value;
-  }
-
   void _requestFocusFromShell(TextStyle valueStyle) {
     final globalPosition = _pendingShellTapGlobalPosition;
     _pendingShellTapGlobalPosition = null;
     if (globalPosition == null) return;
     if (_positionIsInsideTextFieldRegion(globalPosition)) {
-      _requestAutocompleteReactivation();
+      widget.onAutocompleteReactivationRequested();
       return;
     }
 
@@ -586,7 +597,7 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
     if (!widget.focusNode.hasFocus) {
       widget.focusNode.requestFocus();
     }
-    _requestAutocompleteReactivation();
+    widget.onAutocompleteReactivationRequested();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || !widget.focusNode.hasFocus) return;
       final offset = selection.baseOffset.clamp(
@@ -598,7 +609,7 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
   }
 
   List<String> _optionsForText(String rawValue) {
-    if (!widget.autocompleteEnabled) return const <String>[];
+    if (!widget.autocompleteEnabled()) return const <String>[];
 
     final prefix = rawValue.trim().toLowerCase();
     if (prefix.isEmpty || prefix.contains(RegExp(r'\s'))) {
@@ -825,8 +836,8 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
                                   : null,
                               child: Listener(
                                 behavior: HitTestBehavior.translucent,
-                                onPointerDown: (_) =>
-                                    _requestAutocompleteReactivation(),
+                                onPointerDown: (_) => widget
+                                    .onAutocompleteReactivationRequested(),
                                 child: TextField(
                                   key: _textFieldRegionKey,
                                   controller: controller,
@@ -850,7 +861,8 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
                                         .copyWith(color: colors.text.muted),
                                   ),
                                   onChanged: (value) {
-                                    _requestAutocompleteReactivation();
+                                    widget
+                                        .onAutocompleteReactivationRequested();
                                     widget.onChanged(value);
                                   },
                                   onSubmitted: (_) => _handleTextSubmitted(
@@ -888,10 +900,6 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
           width: _suggestionWidth,
           height: _fieldHeight,
           child: RawAutocomplete<String>(
-            key: ValueKey(
-              'import_mnemonic_autocomplete_${widget.index}_'
-              '${widget.autocompleteEnabled}',
-            ),
             textEditingController: widget.controller,
             focusNode: widget.focusNode,
             displayStringForOption: (word) => word,

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -44,10 +44,13 @@ class _ImportSecretPassphraseScreenState
   late final List<TextEditingController> _controllers;
   late final List<FocusNode> _focusNodes;
   late final List<String> _mnemonicWordList;
+  late SensitivePrivacyOverlayController _privacyOverlayController;
+  late bool _ownsPrivacyOverlayController;
 
   bool _isSubmitting = false;
   bool _showValidationError = false;
   bool _isApplyingProgrammaticChange = false;
+  bool _autocompleteSuppressedForPrivacy = false;
   String? _submitError;
 
   @override
@@ -56,11 +59,28 @@ class _ImportSecretPassphraseScreenState
     _mnemonicWordList = rust_wallet.mnemonicWordList();
     _controllers = List.generate(_wordCount, (_) => TextEditingController());
     _focusNodes = List.generate(_wordCount, (_) => FocusNode());
+    _setPrivacyOverlayController(widget.privacyOverlayController);
     _restoreMnemonic();
   }
 
   @override
+  void didUpdateWidget(covariant ImportSecretPassphraseScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.privacyOverlayController != widget.privacyOverlayController) {
+      _privacyOverlayController.removeListener(_handlePrivacySafetyChanged);
+      if (_ownsPrivacyOverlayController) {
+        _privacyOverlayController.dispose();
+      }
+      _setPrivacyOverlayController(widget.privacyOverlayController);
+    }
+  }
+
+  @override
   void dispose() {
+    _privacyOverlayController.removeListener(_handlePrivacySafetyChanged);
+    if (_ownsPrivacyOverlayController) {
+      _privacyOverlayController.dispose();
+    }
     for (final controller in _controllers) {
       controller.dispose();
     }
@@ -85,6 +105,35 @@ class _ImportSecretPassphraseScreenState
       _hasAllWords && rust_wallet.validateMnemonic(mnemonic: _mnemonic);
 
   bool get _canSubmit => !_isSubmitting && _isMnemonicValid;
+
+  bool get _autocompleteEnabled =>
+      _privacyOverlayController.isSafe && !_autocompleteSuppressedForPrivacy;
+
+  void _setPrivacyOverlayController(
+    SensitivePrivacyOverlayController? controller,
+  ) {
+    _ownsPrivacyOverlayController = controller == null;
+    _privacyOverlayController =
+        controller ?? SensitivePrivacyEnvironmentController();
+    _privacyOverlayController.addListener(_handlePrivacySafetyChanged);
+  }
+
+  void _handlePrivacySafetyChanged() {
+    if (!_privacyOverlayController.isSafe) {
+      _autocompleteSuppressedForPrivacy = true;
+    }
+    if (mounted) setState(() {});
+  }
+
+  void _reactivateAutocomplete() {
+    if (!_privacyOverlayController.isSafe ||
+        !_autocompleteSuppressedForPrivacy) {
+      return;
+    }
+    setState(() {
+      _autocompleteSuppressedForPrivacy = false;
+    });
+  }
 
   void _restoreMnemonic() {
     final mnemonic = widget.args?.mnemonic;
@@ -243,7 +292,7 @@ class _ImportSecretPassphraseScreenState
     return ImportOnboardingTrailingPane(
       overlay: SensitivePrivacyOverlay(
         sensitiveContentVisible: _hasEnteredMnemonicWords,
-        controller: widget.privacyOverlayController,
+        controller: _privacyOverlayController,
         child: const SizedBox.expand(),
       ),
       child: Column(
@@ -331,6 +380,9 @@ class _ImportSecretPassphraseScreenState
                                   controller: _controllers[index],
                                   focusNode: _focusNodes[index],
                                   wordList: _mnemonicWordList,
+                                  autocompleteEnabled: _autocompleteEnabled,
+                                  onAutocompleteReactivationRequested:
+                                      _reactivateAutocomplete,
                                   destructive:
                                       _showValidationError &&
                                       _controllers[index].text
@@ -398,6 +450,8 @@ class _MnemonicWordCell extends StatefulWidget {
     required this.onMoveNext,
     required this.onMovePrevious,
     required this.onSuggestionSelected,
+    required this.autocompleteEnabled,
+    required this.onAutocompleteReactivationRequested,
     this.destructive = false,
     this.autofocus = false,
   });
@@ -411,6 +465,8 @@ class _MnemonicWordCell extends StatefulWidget {
   final bool Function() onMoveNext;
   final bool Function() onMovePrevious;
   final ValueChanged<String> onSuggestionSelected;
+  final bool autocompleteEnabled;
+  final VoidCallback onAutocompleteReactivationRequested;
   final bool destructive;
   final bool autofocus;
 
@@ -495,16 +551,42 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
     _pendingShellTapGlobalPosition = details.globalPosition;
   }
 
+  void _requestAutocompleteReactivation() {
+    widget.onAutocompleteReactivationRequested();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || !widget.autocompleteEnabled) return;
+      _refreshAutocompleteOptions();
+    });
+  }
+
+  void _refreshAutocompleteOptions() {
+    final value = widget.controller.value;
+    final text = value.text;
+    if (text.isEmpty || _optionsForText(text).isEmpty) return;
+
+    // RawAutocomplete only recomputes options when the text value changes.
+    widget.controller.value = value.copyWith(
+      text: '$text ',
+      selection: TextSelection.collapsed(offset: text.length + 1),
+      composing: TextRange.empty,
+    );
+    widget.controller.value = value;
+  }
+
   void _requestFocusFromShell(TextStyle valueStyle) {
     final globalPosition = _pendingShellTapGlobalPosition;
     _pendingShellTapGlobalPosition = null;
     if (globalPosition == null) return;
-    if (_positionIsInsideTextFieldRegion(globalPosition)) return;
+    if (_positionIsInsideTextFieldRegion(globalPosition)) {
+      _requestAutocompleteReactivation();
+      return;
+    }
 
     final selection = _selectionForShellPointer(globalPosition, valueStyle);
     if (!widget.focusNode.hasFocus) {
       widget.focusNode.requestFocus();
     }
+    _requestAutocompleteReactivation();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted || !widget.focusNode.hasFocus) return;
       final offset = selection.baseOffset.clamp(
@@ -516,6 +598,8 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
   }
 
   List<String> _optionsForText(String rawValue) {
+    if (!widget.autocompleteEnabled) return const <String>[];
+
     final prefix = rawValue.trim().toLowerCase();
     if (prefix.isEmpty || prefix.contains(RegExp(r'\s'))) {
       return const <String>[];
@@ -739,32 +823,39 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
                                       'import_mnemonic_first_word_field',
                                     )
                                   : null,
-                              child: TextField(
-                                key: _textFieldRegionKey,
-                                controller: controller,
-                                focusNode: focusNode,
-                                autofocus: widget.autofocus,
-                                keyboardType: TextInputType.text,
-                                textInputAction: TextInputAction.next,
-                                autocorrect: false,
-                                enableSuggestions: false,
-                                inputFormatters: [
-                                  FilteringTextInputFormatter.allow(
-                                    RegExp(r'[A-Za-z\s]'),
+                              child: Listener(
+                                behavior: HitTestBehavior.translucent,
+                                onPointerDown: (_) =>
+                                    _requestAutocompleteReactivation(),
+                                child: TextField(
+                                  key: _textFieldRegionKey,
+                                  controller: controller,
+                                  focusNode: focusNode,
+                                  autofocus: widget.autofocus,
+                                  keyboardType: TextInputType.text,
+                                  textInputAction: TextInputAction.next,
+                                  autocorrect: false,
+                                  enableSuggestions: false,
+                                  inputFormatters: [
+                                    FilteringTextInputFormatter.allow(
+                                      RegExp(r'[A-Za-z\s]'),
+                                    ),
+                                  ],
+                                  style: valueStyle,
+                                  cursorColor: colors.text.accent,
+                                  selectAllOnFocus: false,
+                                  decoration: InputDecoration.collapsed(
+                                    hintText: 'Word',
+                                    hintStyle: AppTypography.labelLarge
+                                        .copyWith(color: colors.text.muted),
                                   ),
-                                ],
-                                style: valueStyle,
-                                cursorColor: colors.text.accent,
-                                selectAllOnFocus: false,
-                                decoration: InputDecoration.collapsed(
-                                  hintText: 'Word',
-                                  hintStyle: AppTypography.labelLarge.copyWith(
-                                    color: colors.text.muted,
+                                  onChanged: (value) {
+                                    _requestAutocompleteReactivation();
+                                    widget.onChanged(value);
+                                  },
+                                  onSubmitted: (_) => _handleTextSubmitted(
+                                    onAutocompleteSubmitted,
                                   ),
-                                ),
-                                onChanged: widget.onChanged,
-                                onSubmitted: (_) => _handleTextSubmitted(
-                                  onAutocompleteSubmitted,
                                 ),
                               ),
                             ),
@@ -797,6 +888,10 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
           width: _suggestionWidth,
           height: _fieldHeight,
           child: RawAutocomplete<String>(
+            key: ValueKey(
+              'import_mnemonic_autocomplete_${widget.index}_'
+              '${widget.autocompleteEnabled}',
+            ),
             textEditingController: widget.controller,
             focusNode: widget.focusNode,
             displayStringForOption: (word) => word,

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -10,6 +10,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../core/privacy/sensitive_privacy_overlay.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -18,9 +19,14 @@ import '../shared/onboarding_flow_args.dart';
 import 'import_split_view.dart';
 
 class ImportSecretPassphraseScreen extends ConsumerStatefulWidget {
-  const ImportSecretPassphraseScreen({this.args, super.key});
+  const ImportSecretPassphraseScreen({
+    this.args,
+    this.privacyOverlayController,
+    super.key,
+  });
 
   final ImportSecretPassphraseArgs? args;
+  final SensitivePrivacyOverlayController? privacyOverlayController;
 
   @override
   ConsumerState<ImportSecretPassphraseScreen> createState() =>
@@ -71,6 +77,9 @@ class _ImportSecretPassphraseScreenState
   String get _mnemonic => _normalizedWords.join(' ');
 
   bool get _hasAllWords => _normalizedWords.every((word) => word.isNotEmpty);
+
+  bool get _hasEnteredMnemonicWords =>
+      _controllers.any((controller) => controller.text.trim().isNotEmpty);
 
   bool get _isMnemonicValid =>
       _hasAllWords && rust_wallet.validateMnemonic(mnemonic: _mnemonic);
@@ -232,6 +241,11 @@ class _ImportSecretPassphraseScreenState
     final colors = context.colors;
 
     return ImportOnboardingTrailingPane(
+      overlay: SensitivePrivacyOverlay(
+        sensitiveContentVisible: _hasEnteredMnemonicWords,
+        controller: widget.privacyOverlayController,
+        child: const SizedBox.expand(),
+      ),
       child: Column(
         children: [
           SizedBox(

--- a/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/privacy/sensitive_privacy_overlay.dart';
 import '../../../core/security/password_policy.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
@@ -23,7 +24,9 @@ import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 
 class SettingsSeedPhraseScreen extends ConsumerStatefulWidget {
-  const SettingsSeedPhraseScreen({super.key});
+  const SettingsSeedPhraseScreen({this.privacyOverlayController, super.key});
+
+  final SensitivePrivacyOverlayController? privacyOverlayController;
 
   @override
   ConsumerState<SettingsSeedPhraseScreen> createState() =>
@@ -349,35 +352,43 @@ class _SettingsSeedPhraseScreenState
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
       pane: AppDesktopPane(
-        padding: const EdgeInsets.all(AppSpacing.md),
-        child: _SettingsSeedPhrasePane(
-          onBeforeNavigateBack: () => _clearSensitiveState(),
-          child: switch (_stage) {
-            _SettingsSeedPhraseStage.password => _PasswordGateView(
-              passwordController: _passwordController,
-              messageText: _passwordError ?? _passwordPolicyMessage,
-              isSubmitting: _isSubmitting,
-              canSubmit: _canSubmit,
-              onChanged: _handlePasswordChanged,
-              onSubmit: _submitPassword,
+        padding: EdgeInsets.zero,
+        child: SensitivePrivacyOverlay(
+          sensitiveContentVisible:
+              _stage == _SettingsSeedPhraseStage.reveal && _mnemonic != null,
+          controller: widget.privacyOverlayController,
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: _SettingsSeedPhrasePane(
+              onBeforeNavigateBack: () => _clearSensitiveState(),
+              child: switch (_stage) {
+                _SettingsSeedPhraseStage.password => _PasswordGateView(
+                  passwordController: _passwordController,
+                  messageText: _passwordError ?? _passwordPolicyMessage,
+                  isSubmitting: _isSubmitting,
+                  canSubmit: _canSubmit,
+                  onChanged: _handlePasswordChanged,
+                  onSubmit: _submitPassword,
+                ),
+                _SettingsSeedPhraseStage.reveal => _SeedPhraseRevealView(
+                  mnemonic: _mnemonic,
+                  birthdayHeight: _birthdayHeight,
+                  birthdayBlockTime: _birthdayBlockTime,
+                  birthdayHeightLoading: _isBirthdayHeightLoading,
+                  birthdayDateLoading: _isBirthdayDateLoading,
+                  errorText: _revealError,
+                  phraseCopied: _copiedTarget == _SeedPhraseCopyTarget.phrase,
+                  birthdayDateCopied:
+                      _copiedTarget == _SeedPhraseCopyTarget.birthdayDate,
+                  birthdayHeightCopied:
+                      _copiedTarget == _SeedPhraseCopyTarget.birthdayHeight,
+                  onCopyPressed: _copyMnemonic,
+                  onCopyBirthdayDatePressed: _copyBirthdayDate,
+                  onCopyBirthdayHeightPressed: _copyBirthdayHeight,
+                ),
+              },
             ),
-            _SettingsSeedPhraseStage.reveal => _SeedPhraseRevealView(
-              mnemonic: _mnemonic,
-              birthdayHeight: _birthdayHeight,
-              birthdayBlockTime: _birthdayBlockTime,
-              birthdayHeightLoading: _isBirthdayHeightLoading,
-              birthdayDateLoading: _isBirthdayDateLoading,
-              errorText: _revealError,
-              phraseCopied: _copiedTarget == _SeedPhraseCopyTarget.phrase,
-              birthdayDateCopied:
-                  _copiedTarget == _SeedPhraseCopyTarget.birthdayDate,
-              birthdayHeightCopied:
-                  _copiedTarget == _SeedPhraseCopyTarget.birthdayHeight,
-              onCopyPressed: _copyMnemonic,
-              onCopyBirthdayDatePressed: _copyBirthdayDate,
-              onCopyBirthdayHeightPressed: _copyBirthdayHeight,
-            ),
-          },
+          ),
         ),
       ),
     );

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -102,6 +102,8 @@ final class WindowAppearanceChannel {
 
 final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
   private static var shared: PrivacyExposureChannel?
+  // Mission Control and occlusion notifications can arrive before the window is
+  // fully key/visible again; wait briefly before marking sensitive content safe.
   private static let safeConfirmationDelay = DispatchTimeInterval.milliseconds(300)
 
   private struct ObserverRegistration {
@@ -191,6 +193,9 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
       if visible {
         publishCurrentState(reason: "sensitiveContentVisible")
       } else {
+        // Dart gates the visual overlay on sensitiveContentVisible as well as
+        // nativeSafe, so clearing sensitive content only needs to restore local
+        // state and Mission Control policy.
         nativeSafe = true
         missionControlPolicySuspended = false
       }

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -371,6 +371,12 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
   }
 
   private func suspendMissionControlPolicy() {
+    // `.transient` keeps the window out of Mission Control, but keeping that
+    // collection behavior through the return transition can leave Vizor behind
+    // another app after Mission Control closes. Once macOS reports an unsafe
+    // transition, restore the original behavior so AppKit can order the window
+    // normally; the Dart privacy overlay remains responsible for the visible
+    // cover during that unsafe interval.
     missionControlPolicySuspended = true
     restoreMissionControlPolicy()
   }

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,5 +1,4 @@
 import Cocoa
-import CoreImage
 import FlutterMacOS
 import desktop_window_bootstrap
 
@@ -101,199 +100,30 @@ final class WindowAppearanceChannel {
   }
 }
 
-private final class NativeLockIconView: NSView {
-  var fillColor = NSColor(calibratedWhite: 0.88, alpha: 1) {
-    didSet {
-      needsDisplay = true
-    }
-  }
-
-  override var isFlipped: Bool {
-    true
-  }
-
-  override func draw(_ dirtyRect: NSRect) {
-    guard let context = NSGraphicsContext.current?.cgContext else {
-      return
-    }
-
-    let scale = min(bounds.width / 24, bounds.height / 24)
-    let xOffset = (bounds.width - 24 * scale) / 2
-    let yOffset = (bounds.height - 24 * scale) / 2
-
-    context.saveGState()
-    context.translateBy(x: xOffset, y: yOffset)
-    context.scaleBy(x: scale, y: scale)
-    context.addPath(Self.iconPath)
-    context.setFillColor(fillColor.cgColor)
-    context.fillPath(using: .evenOdd)
-    context.restoreGState()
-  }
-
-  private static let iconPath: CGPath = {
-    let path = CGMutablePath()
-    path.move(to: CGPoint(x: 12, y: 2.62207))
-    path.addCurve(to: CGPoint(x: 7.22461, y: 7.51074), control1: CGPoint(x: 9.35362, y: 2.62207), control2: CGPoint(x: 7.22461, y: 4.82288))
-    path.addLine(to: CGPoint(x: 7.22461, y: 9.80504))
-    path.addLine(to: CGPoint(x: 6.5, y: 9.80504))
-    path.addCurve(to: CGPoint(x: 4.34961, y: 12), control1: CGPoint(x: 5.3062, y: 9.80504), control2: CGPoint(x: 4.34961, y: 10.8025))
-    path.addLine(to: CGPoint(x: 4.34961, y: 19.1829))
-    path.addLine(to: CGPoint(x: 4.36133, y: 19.4051))
-    path.addCurve(to: CGPoint(x: 6.5, y: 21.3779), control1: CGPoint(x: 4.47091, y: 20.5012), control2: CGPoint(x: 5.38094, y: 21.3779))
-    path.addLine(to: CGPoint(x: 17.5, y: 21.3779))
-    path.addCurve(to: CGPoint(x: 19.6387, y: 19.4051), control1: CGPoint(x: 18.6191, y: 21.3779), control2: CGPoint(x: 19.5291, y: 20.5012))
-    path.addLine(to: CGPoint(x: 19.6504, y: 19.1829))
-    path.addLine(to: CGPoint(x: 19.6504, y: 12))
-    path.addCurve(to: CGPoint(x: 17.5, y: 9.80504), control1: CGPoint(x: 19.6504, y: 10.8025), control2: CGPoint(x: 18.6938, y: 9.80504))
-    path.addLine(to: CGPoint(x: 16.7754, y: 9.80504))
-    path.addLine(to: CGPoint(x: 16.7754, y: 7.51074))
-    path.addCurve(to: CGPoint(x: 12, y: 2.62207), control1: CGPoint(x: 16.7754, y: 4.82288), control2: CGPoint(x: 14.6464, y: 2.62207))
-    path.closeSubpath()
-
-    path.move(to: CGPoint(x: 11.999, y: 12.8982))
-    path.addCurve(to: CGPoint(x: 13.3076, y: 13.4311), control1: CGPoint(x: 12.5087, y: 12.8982), control2: CGPoint(x: 12.9473, y: 13.0761))
-    path.addCurve(to: CGPoint(x: 13.8496, y: 14.722), control1: CGPoint(x: 13.668, y: 13.7861), control2: CGPoint(x: 13.8495, y: 14.2187))
-    path.addLine(to: CGPoint(x: 13.8457, y: 14.8486))
-    path.addCurve(to: CGPoint(x: 13.5908, y: 15.6621), control1: CGPoint(x: 13.8267, y: 15.1403), control2: CGPoint(x: 13.7421, y: 15.4123))
-    path.addLine(to: CGPoint(x: 13.5225, y: 15.7663))
-    path.addCurve(to: CGPoint(x: 12.9434, y: 16.2885), control1: CGPoint(x: 13.3706, y: 15.9823), control2: CGPoint(x: 13.1766, y: 16.1562))
-    path.addLine(to: CGPoint(x: 13.3262, y: 18.3841))
-    path.addCurve(to: CGPoint(x: 13.1943, y: 18.8585), control1: CGPoint(x: 13.3603, y: 18.5584), control2: CGPoint(x: 13.3126, y: 18.7192))
-    path.addCurve(to: CGPoint(x: 12.7432, y: 19.0719), control1: CGPoint(x: 13.0753, y: 18.9984), control2: CGPoint(x: 12.9227, y: 19.0718))
-    path.addLine(to: CGPoint(x: 11.2559, y: 19.0719))
-    path.addCurve(to: CGPoint(x: 10.8047, y: 18.8585), control1: CGPoint(x: 11.0767, y: 19.0716), control2: CGPoint(x: 10.9236, y: 18.9983))
-    path.addCurve(to: CGPoint(x: 10.6748, y: 18.3841), control1: CGPoint(x: 10.6863, y: 18.7189), control2: CGPoint(x: 10.6407, y: 18.5579))
-    path.addLine(to: CGPoint(x: 11.0576, y: 16.2885))
-    path.addCurve(to: CGPoint(x: 10.4092, y: 15.6621), control1: CGPoint(x: 10.7876, y: 16.1355), control2: CGPoint(x: 10.5698, y: 15.9268))
-    path.addLine(to: CGPoint(x: 10.3486, y: 15.5539))
-    path.addCurve(to: CGPoint(x: 10.1543, y: 14.8486), control1: CGPoint(x: 10.235, y: 15.3343), control2: CGPoint(x: 10.1706, y: 15.0988))
-    path.addLine(to: CGPoint(x: 10.1504, y: 14.722))
-    path.addCurve(to: CGPoint(x: 10.6914, y: 13.4311), control1: CGPoint(x: 10.1505, y: 14.219), control2: CGPoint(x: 10.3312, y: 13.7861))
-    path.addCurve(to: CGPoint(x: 11.999, y: 12.8982), control1: CGPoint(x: 11.0515, y: 13.0763), control2: CGPoint(x: 11.4897, y: 12.8984))
-    path.closeSubpath()
-
-    path.move(to: CGPoint(x: 12, y: 5.21643))
-    path.addCurve(to: CGPoint(x: 14.2246, y: 7.51074), control1: CGPoint(x: 13.2121, y: 5.21643), control2: CGPoint(x: 14.2246, y: 6.23883))
-    path.addLine(to: CGPoint(x: 14.2246, y: 9.80504))
-    path.addLine(to: CGPoint(x: 9.77539, y: 9.80504))
-    path.addLine(to: CGPoint(x: 9.77539, y: 7.51074))
-    path.addCurve(to: CGPoint(x: 12, y: 5.21643), control1: CGPoint(x: 9.77539, y: 6.23883), control2: CGPoint(x: 10.7879, y: 5.21643))
-    path.closeSubpath()
-    return path
-  }()
-}
-
-private final class NativePrivacyShieldView: NSView {
-  private static let paneCornerRadius = 8.0
-  private static let blurRadius = 30.0
-
-  private let blurView = NSView()
-  private let scrimView = NSView()
-  private let badge = NSView()
-  private let icon = NativeLockIconView()
-
-  override init(frame frameRect: NSRect) {
-    super.init(frame: frameRect)
-    translatesAutoresizingMaskIntoConstraints = true
-    wantsLayer = true
-    layer?.cornerRadius = Self.paneCornerRadius
-    layer?.masksToBounds = true
-
-    blurView.translatesAutoresizingMaskIntoConstraints = false
-    blurView.wantsLayer = true
-    blurView.layer?.backgroundColor = NSColor.clear.cgColor
-    blurView.layer?.masksToBounds = true
-    if let blurFilter = CIFilter(name: "CIGaussianBlur") {
-      blurFilter.setValue(Self.blurRadius, forKey: kCIInputRadiusKey)
-      blurView.layer?.backgroundFilters = [blurFilter]
-    }
-    addSubview(blurView)
-
-    scrimView.translatesAutoresizingMaskIntoConstraints = false
-    scrimView.wantsLayer = true
-    addSubview(scrimView)
-
-    badge.translatesAutoresizingMaskIntoConstraints = false
-    badge.wantsLayer = true
-    badge.layer?.cornerRadius = 24
-    badge.layer?.masksToBounds = true
-    addSubview(badge)
-
-    icon.translatesAutoresizingMaskIntoConstraints = false
-    badge.addSubview(icon)
-
-    NSLayoutConstraint.activate([
-      blurView.leadingAnchor.constraint(equalTo: leadingAnchor),
-      blurView.trailingAnchor.constraint(equalTo: trailingAnchor),
-      blurView.topAnchor.constraint(equalTo: topAnchor),
-      blurView.bottomAnchor.constraint(equalTo: bottomAnchor),
-
-      scrimView.leadingAnchor.constraint(equalTo: leadingAnchor),
-      scrimView.trailingAnchor.constraint(equalTo: trailingAnchor),
-      scrimView.topAnchor.constraint(equalTo: topAnchor),
-      scrimView.bottomAnchor.constraint(equalTo: bottomAnchor),
-
-      badge.widthAnchor.constraint(equalToConstant: 98),
-      badge.heightAnchor.constraint(equalToConstant: 98),
-      badge.centerXAnchor.constraint(equalTo: centerXAnchor),
-      badge.centerYAnchor.constraint(equalTo: centerYAnchor),
-
-      icon.widthAnchor.constraint(equalToConstant: 50),
-      icon.heightAnchor.constraint(equalToConstant: 50),
-      icon.centerXAnchor.constraint(equalTo: badge.centerXAnchor),
-      icon.centerYAnchor.constraint(equalTo: badge.centerYAnchor),
-    ])
-
-    updateColors()
-  }
-
-  required init?(coder: NSCoder) {
-    nil
-  }
-
-  override func viewDidChangeEffectiveAppearance() {
-    super.viewDidChangeEffectiveAppearance()
-    updateColors()
-  }
-
-  private func updateColors() {
-    let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-
-    scrimView.layer?.backgroundColor =
-      (isDark
-        ? NSColor(calibratedRed: 98 / 255, green: 103 / 255, blue: 103 / 255, alpha: 0.20)
-        : NSColor(calibratedRed: 20 / 255, green: 24 / 255, blue: 24 / 255, alpha: 0.20)
-      ).cgColor
-    badge.layer?.backgroundColor =
-      (isDark ? NSColor(calibratedRed: 0.08, green: 0.09, blue: 0.09, alpha: 1) : NSColor.white).cgColor
-    icon.fillColor =
-      isDark ? NSColor(calibratedWhite: 0.88, alpha: 1) : NSColor(calibratedRed: 0.08, green: 0.09, blue: 0.09, alpha: 1)
-  }
-}
-
 final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
   private static var shared: PrivacyExposureChannel?
+  private static let safeConfirmationDelay = DispatchTimeInterval.milliseconds(300)
+
+  private struct ObserverRegistration {
+    let center: NotificationCenter
+    let observer: NSObjectProtocol
+  }
 
   private weak var window: NSWindow?
-  private weak var containerView: NSView?
   private let methodChannel: FlutterMethodChannel
   private var eventSink: FlutterEventSink?
-  private var observers: [NSObjectProtocol] = []
+  private var observers: [ObserverRegistration] = []
   private var sensitiveContentVisible = false
   private var nativeSafe = true
-  private var shieldFrame: NSRect?
-  private var shieldView: NativePrivacyShieldView?
   private var originalCollectionBehavior: NSWindow.CollectionBehavior?
   private var pendingSafeConfirmation: DispatchWorkItem?
   private var missionControlPolicySuspended = false
 
   private init(
     window: NSWindow,
-    containerView: NSView,
     messenger: FlutterBinaryMessenger
   ) {
     self.window = window
-    self.containerView = containerView
     self.methodChannel = FlutterMethodChannel(
       name: "com.zcash.wallet/privacy_shield",
       binaryMessenger: messenger
@@ -319,12 +149,10 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
 
   static func register(
     window: NSWindow,
-    containerView: NSView,
     messenger: FlutterBinaryMessenger
   ) {
     shared = PrivacyExposureChannel(
       window: window,
-      containerView: containerView,
       messenger: messenger
     )
   }
@@ -357,7 +185,6 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
         return
       }
       sensitiveContentVisible = visible
-      shieldFrame = visible ? parseShieldFrame(from: arguments["rect"]) : nil
       pendingSafeConfirmation?.cancel()
       pendingSafeConfirmation = nil
       updateMissionControlPolicy()
@@ -367,7 +194,6 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
         nativeSafe = true
         missionControlPolicySuspended = false
       }
-      updateNativeShield()
       result(nil)
     default:
       result(FlutterMethodNotImplemented)
@@ -431,13 +257,12 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
       queue: .main,
       using: block
     )
-    observers.append(observer)
+    observers.append(ObserverRegistration(center: center, observer: observer))
   }
 
   private func removeObservers() {
-    for observer in observers {
-      NotificationCenter.default.removeObserver(observer)
-      NSWorkspace.shared.notificationCenter.removeObserver(observer)
+    for registration in observers {
+      registration.center.removeObserver(registration.observer)
     }
     observers.removeAll()
   }
@@ -448,30 +273,13 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
       return
     }
 
-    let appVisible = NSApp.occlusionState.contains(.visible)
-    let windowVisible = window.occlusionState.contains(.visible)
-    let safe =
-      NSApp.isActive &&
-      !NSApp.isHidden &&
-      window.isKeyWindow &&
-      !window.isMiniaturized &&
-      appVisible &&
-      windowVisible
+    let safe = computeIsSafe(window: window)
 
     if !safe && sensitiveContentVisible {
       suspendMissionControlPolicy()
     }
 
-    let details = [
-      "appActive": NSApp.isActive,
-      "appHidden": NSApp.isHidden,
-      "frontmostIsUs": frontmostApplicationIsUs(),
-      "windowKey": window.isKeyWindow,
-      "windowMiniaturized": window.isMiniaturized,
-      "appVisible": appVisible,
-      "windowVisible": windowVisible,
-      "missionControlPolicySuspended": missionControlPolicySuspended,
-    ]
+    let details = windowStateDetails(for: window)
 
     if safe && sensitiveContentVisible && !nativeSafe {
       confirmSafeAfterWindowSettles(reason: reason)
@@ -481,7 +289,6 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
     pendingSafeConfirmation?.cancel()
     pendingSafeConfirmation = nil
     nativeSafe = safe
-    updateNativeShield()
 
     publish(
       isSafe: safe,
@@ -497,7 +304,6 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
       suspendMissionControlPolicy()
     }
     nativeSafe = false
-    updateNativeShield()
     publish(
       isSafe: false,
       reason: reason,
@@ -508,40 +314,22 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
   private func confirmSafeAfterWindowSettles(reason: String) {
     pendingSafeConfirmation?.cancel()
     nativeSafe = false
-    updateNativeShield()
 
     let confirmation = DispatchWorkItem { [weak self] in
       guard let self, let window = self.window else {
         return
       }
 
-      let appVisible = NSApp.occlusionState.contains(.visible)
-      let windowVisible = window.occlusionState.contains(.visible)
-      let safe =
-        NSApp.isActive &&
-        !NSApp.isHidden &&
-        window.isKeyWindow &&
-        !window.isMiniaturized &&
-        appVisible &&
-        windowVisible
-      let details = [
-        "appActive": NSApp.isActive,
-        "appHidden": NSApp.isHidden,
-        "frontmostIsUs": self.frontmostApplicationIsUs(),
-        "windowKey": window.isKeyWindow,
-        "windowMiniaturized": window.isMiniaturized,
-        "appVisible": appVisible,
-        "windowVisible": windowVisible,
-      ]
+      let safe = self.computeIsSafe(window: window)
 
       self.pendingSafeConfirmation = nil
       self.nativeSafe = safe
-      self.updateNativeShield()
 
       if safe && self.sensitiveContentVisible {
         self.missionControlPolicySuspended = false
         self.updateMissionControlPolicy()
       }
+      let details = self.windowStateDetails(for: window)
       self.publish(
         isSafe: safe,
         reason: safe ? "\(reason):confirmed" : "\(reason):notStable",
@@ -550,37 +338,10 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
     }
 
     pendingSafeConfirmation = confirmation
-    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300), execute: confirmation)
-  }
-
-  private func updateNativeShield() {
-    let shouldShow = sensitiveContentVisible && !nativeSafe && currentShieldFrame() != nil
-    if shouldShow {
-      showNativeShield()
-    } else {
-      hideNativeShield()
-    }
-  }
-
-  private func showNativeShield() {
-    guard let containerView, let frame = currentShieldFrame() else {
-      return
-    }
-
-    let shieldView = self.shieldView ?? NativePrivacyShieldView(frame: frame)
-    shieldView.frame = frame
-    if shieldView.superview == nil {
-      containerView.addSubview(shieldView)
-    }
-    self.shieldView = shieldView
-    containerView.layoutSubtreeIfNeeded()
-    containerView.displayIfNeeded()
-    window?.displayIfNeeded()
-  }
-
-  private func hideNativeShield() {
-    shieldView?.removeFromSuperview()
-    shieldView = nil
+    DispatchQueue.main.asyncAfter(
+      deadline: .now() + Self.safeConfirmationDelay,
+      execute: confirmation
+    )
   }
 
   private func updateMissionControlPolicy() {
@@ -621,6 +382,10 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
     guard let window else {
       return nil
     }
+    return windowStateDetails(for: window)
+  }
+
+  private func windowStateDetails(for window: NSWindow) -> [String: Bool] {
     return [
       "appActive": NSApp.isActive,
       "appHidden": NSApp.isHidden,
@@ -633,49 +398,19 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
     ]
   }
 
-  private func parseShieldFrame(from rawRect: Any?) -> NSRect? {
-    guard
-      let rect = rawRect as? [String: Any],
-      let left = doubleValue(rect["left"]),
-      let top = doubleValue(rect["top"]),
-      let width = doubleValue(rect["width"]),
-      let height = doubleValue(rect["height"]),
-      width > 0,
-      height > 0
-    else {
-      return nil
-    }
-    return NSRect(x: left, y: top, width: width, height: height)
-  }
-
-  private func doubleValue(_ value: Any?) -> Double? {
-    if let number = value as? NSNumber {
-      return number.doubleValue
-    }
-    return value as? Double
+  private func computeIsSafe(window: NSWindow) -> Bool {
+    return
+      NSApp.isActive &&
+      !NSApp.isHidden &&
+      window.isKeyWindow &&
+      !window.isMiniaturized &&
+      NSApp.occlusionState.contains(.visible) &&
+      window.occlusionState.contains(.visible)
   }
 
   private func frontmostApplicationIsUs() -> Bool {
     NSWorkspace.shared.frontmostApplication?.processIdentifier ==
       ProcessInfo.processInfo.processIdentifier
-  }
-
-  private func currentShieldFrame() -> NSRect? {
-    guard let containerView, let shieldFrame else {
-      return nil
-    }
-
-    let frame = NSRect(
-      x: shieldFrame.minX,
-      y: containerView.bounds.height - shieldFrame.minY - shieldFrame.height,
-      width: shieldFrame.width,
-      height: shieldFrame.height
-    )
-    let clipped = frame.intersection(containerView.bounds)
-    if clipped.isNull || clipped.width <= 0 || clipped.height <= 0 {
-      return nil
-    }
-    return clipped
   }
 
   private func publish(isSafe: Bool, reason: String, details: [String: Bool]?) {
@@ -716,7 +451,6 @@ class MainFlutterWindow: NSWindow {
     )
     PrivacyExposureChannel.register(
       window: self,
-      containerView: flutterViewController.view,
       messenger: flutterViewController.engine.binaryMessenger
     )
     RegisterGeneratedPlugins(registry: flutterViewController)

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import CoreImage
 import FlutterMacOS
 import desktop_window_bootstrap
 
@@ -100,6 +101,595 @@ final class WindowAppearanceChannel {
   }
 }
 
+private final class NativeLockIconView: NSView {
+  var fillColor = NSColor(calibratedWhite: 0.88, alpha: 1) {
+    didSet {
+      needsDisplay = true
+    }
+  }
+
+  override var isFlipped: Bool {
+    true
+  }
+
+  override func draw(_ dirtyRect: NSRect) {
+    guard let context = NSGraphicsContext.current?.cgContext else {
+      return
+    }
+
+    let scale = min(bounds.width / 24, bounds.height / 24)
+    let xOffset = (bounds.width - 24 * scale) / 2
+    let yOffset = (bounds.height - 24 * scale) / 2
+
+    context.saveGState()
+    context.translateBy(x: xOffset, y: yOffset)
+    context.scaleBy(x: scale, y: scale)
+    context.addPath(Self.iconPath)
+    context.setFillColor(fillColor.cgColor)
+    context.fillPath(using: .evenOdd)
+    context.restoreGState()
+  }
+
+  private static let iconPath: CGPath = {
+    let path = CGMutablePath()
+    path.move(to: CGPoint(x: 12, y: 2.62207))
+    path.addCurve(to: CGPoint(x: 7.22461, y: 7.51074), control1: CGPoint(x: 9.35362, y: 2.62207), control2: CGPoint(x: 7.22461, y: 4.82288))
+    path.addLine(to: CGPoint(x: 7.22461, y: 9.80504))
+    path.addLine(to: CGPoint(x: 6.5, y: 9.80504))
+    path.addCurve(to: CGPoint(x: 4.34961, y: 12), control1: CGPoint(x: 5.3062, y: 9.80504), control2: CGPoint(x: 4.34961, y: 10.8025))
+    path.addLine(to: CGPoint(x: 4.34961, y: 19.1829))
+    path.addLine(to: CGPoint(x: 4.36133, y: 19.4051))
+    path.addCurve(to: CGPoint(x: 6.5, y: 21.3779), control1: CGPoint(x: 4.47091, y: 20.5012), control2: CGPoint(x: 5.38094, y: 21.3779))
+    path.addLine(to: CGPoint(x: 17.5, y: 21.3779))
+    path.addCurve(to: CGPoint(x: 19.6387, y: 19.4051), control1: CGPoint(x: 18.6191, y: 21.3779), control2: CGPoint(x: 19.5291, y: 20.5012))
+    path.addLine(to: CGPoint(x: 19.6504, y: 19.1829))
+    path.addLine(to: CGPoint(x: 19.6504, y: 12))
+    path.addCurve(to: CGPoint(x: 17.5, y: 9.80504), control1: CGPoint(x: 19.6504, y: 10.8025), control2: CGPoint(x: 18.6938, y: 9.80504))
+    path.addLine(to: CGPoint(x: 16.7754, y: 9.80504))
+    path.addLine(to: CGPoint(x: 16.7754, y: 7.51074))
+    path.addCurve(to: CGPoint(x: 12, y: 2.62207), control1: CGPoint(x: 16.7754, y: 4.82288), control2: CGPoint(x: 14.6464, y: 2.62207))
+    path.closeSubpath()
+
+    path.move(to: CGPoint(x: 11.999, y: 12.8982))
+    path.addCurve(to: CGPoint(x: 13.3076, y: 13.4311), control1: CGPoint(x: 12.5087, y: 12.8982), control2: CGPoint(x: 12.9473, y: 13.0761))
+    path.addCurve(to: CGPoint(x: 13.8496, y: 14.722), control1: CGPoint(x: 13.668, y: 13.7861), control2: CGPoint(x: 13.8495, y: 14.2187))
+    path.addLine(to: CGPoint(x: 13.8457, y: 14.8486))
+    path.addCurve(to: CGPoint(x: 13.5908, y: 15.6621), control1: CGPoint(x: 13.8267, y: 15.1403), control2: CGPoint(x: 13.7421, y: 15.4123))
+    path.addLine(to: CGPoint(x: 13.5225, y: 15.7663))
+    path.addCurve(to: CGPoint(x: 12.9434, y: 16.2885), control1: CGPoint(x: 13.3706, y: 15.9823), control2: CGPoint(x: 13.1766, y: 16.1562))
+    path.addLine(to: CGPoint(x: 13.3262, y: 18.3841))
+    path.addCurve(to: CGPoint(x: 13.1943, y: 18.8585), control1: CGPoint(x: 13.3603, y: 18.5584), control2: CGPoint(x: 13.3126, y: 18.7192))
+    path.addCurve(to: CGPoint(x: 12.7432, y: 19.0719), control1: CGPoint(x: 13.0753, y: 18.9984), control2: CGPoint(x: 12.9227, y: 19.0718))
+    path.addLine(to: CGPoint(x: 11.2559, y: 19.0719))
+    path.addCurve(to: CGPoint(x: 10.8047, y: 18.8585), control1: CGPoint(x: 11.0767, y: 19.0716), control2: CGPoint(x: 10.9236, y: 18.9983))
+    path.addCurve(to: CGPoint(x: 10.6748, y: 18.3841), control1: CGPoint(x: 10.6863, y: 18.7189), control2: CGPoint(x: 10.6407, y: 18.5579))
+    path.addLine(to: CGPoint(x: 11.0576, y: 16.2885))
+    path.addCurve(to: CGPoint(x: 10.4092, y: 15.6621), control1: CGPoint(x: 10.7876, y: 16.1355), control2: CGPoint(x: 10.5698, y: 15.9268))
+    path.addLine(to: CGPoint(x: 10.3486, y: 15.5539))
+    path.addCurve(to: CGPoint(x: 10.1543, y: 14.8486), control1: CGPoint(x: 10.235, y: 15.3343), control2: CGPoint(x: 10.1706, y: 15.0988))
+    path.addLine(to: CGPoint(x: 10.1504, y: 14.722))
+    path.addCurve(to: CGPoint(x: 10.6914, y: 13.4311), control1: CGPoint(x: 10.1505, y: 14.219), control2: CGPoint(x: 10.3312, y: 13.7861))
+    path.addCurve(to: CGPoint(x: 11.999, y: 12.8982), control1: CGPoint(x: 11.0515, y: 13.0763), control2: CGPoint(x: 11.4897, y: 12.8984))
+    path.closeSubpath()
+
+    path.move(to: CGPoint(x: 12, y: 5.21643))
+    path.addCurve(to: CGPoint(x: 14.2246, y: 7.51074), control1: CGPoint(x: 13.2121, y: 5.21643), control2: CGPoint(x: 14.2246, y: 6.23883))
+    path.addLine(to: CGPoint(x: 14.2246, y: 9.80504))
+    path.addLine(to: CGPoint(x: 9.77539, y: 9.80504))
+    path.addLine(to: CGPoint(x: 9.77539, y: 7.51074))
+    path.addCurve(to: CGPoint(x: 12, y: 5.21643), control1: CGPoint(x: 9.77539, y: 6.23883), control2: CGPoint(x: 10.7879, y: 5.21643))
+    path.closeSubpath()
+    return path
+  }()
+}
+
+private final class NativePrivacyShieldView: NSView {
+  private static let paneCornerRadius = 8.0
+  private static let blurRadius = 15.0
+
+  private let blurView = NSView()
+  private let scrimView = NSView()
+  private let badge = NSView()
+  private let icon = NativeLockIconView()
+
+  override init(frame frameRect: NSRect) {
+    super.init(frame: frameRect)
+    translatesAutoresizingMaskIntoConstraints = true
+    wantsLayer = true
+    layer?.cornerRadius = Self.paneCornerRadius
+    layer?.masksToBounds = true
+
+    blurView.translatesAutoresizingMaskIntoConstraints = false
+    blurView.wantsLayer = true
+    blurView.layer?.backgroundColor = NSColor.clear.cgColor
+    blurView.layer?.masksToBounds = true
+    if let blurFilter = CIFilter(name: "CIGaussianBlur") {
+      blurFilter.setValue(Self.blurRadius, forKey: kCIInputRadiusKey)
+      blurView.layer?.backgroundFilters = [blurFilter]
+    }
+    addSubview(blurView)
+
+    scrimView.translatesAutoresizingMaskIntoConstraints = false
+    scrimView.wantsLayer = true
+    addSubview(scrimView)
+
+    badge.translatesAutoresizingMaskIntoConstraints = false
+    badge.wantsLayer = true
+    badge.layer?.cornerRadius = 24
+    badge.layer?.masksToBounds = true
+    addSubview(badge)
+
+    icon.translatesAutoresizingMaskIntoConstraints = false
+    badge.addSubview(icon)
+
+    NSLayoutConstraint.activate([
+      blurView.leadingAnchor.constraint(equalTo: leadingAnchor),
+      blurView.trailingAnchor.constraint(equalTo: trailingAnchor),
+      blurView.topAnchor.constraint(equalTo: topAnchor),
+      blurView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+      scrimView.leadingAnchor.constraint(equalTo: leadingAnchor),
+      scrimView.trailingAnchor.constraint(equalTo: trailingAnchor),
+      scrimView.topAnchor.constraint(equalTo: topAnchor),
+      scrimView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+      badge.widthAnchor.constraint(equalToConstant: 98),
+      badge.heightAnchor.constraint(equalToConstant: 98),
+      badge.centerXAnchor.constraint(equalTo: centerXAnchor),
+      badge.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+      icon.widthAnchor.constraint(equalToConstant: 50),
+      icon.heightAnchor.constraint(equalToConstant: 50),
+      icon.centerXAnchor.constraint(equalTo: badge.centerXAnchor),
+      icon.centerYAnchor.constraint(equalTo: badge.centerYAnchor),
+    ])
+
+    updateColors()
+  }
+
+  required init?(coder: NSCoder) {
+    nil
+  }
+
+  override func viewDidChangeEffectiveAppearance() {
+    super.viewDidChangeEffectiveAppearance()
+    updateColors()
+  }
+
+  private func updateColors() {
+    let isDark = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+
+    scrimView.layer?.backgroundColor =
+      (isDark
+        ? NSColor(calibratedRed: 98 / 255, green: 103 / 255, blue: 103 / 255, alpha: 0.20)
+        : NSColor(calibratedRed: 20 / 255, green: 24 / 255, blue: 24 / 255, alpha: 0.20)
+      ).cgColor
+    badge.layer?.backgroundColor =
+      (isDark ? NSColor(calibratedRed: 0.08, green: 0.09, blue: 0.09, alpha: 1) : NSColor.white).cgColor
+    icon.fillColor =
+      isDark ? NSColor(calibratedWhite: 0.88, alpha: 1) : NSColor(calibratedRed: 0.08, green: 0.09, blue: 0.09, alpha: 1)
+  }
+}
+
+final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
+  private static var shared: PrivacyExposureChannel?
+
+  private weak var window: NSWindow?
+  private weak var containerView: NSView?
+  private let methodChannel: FlutterMethodChannel
+  private var eventSink: FlutterEventSink?
+  private var observers: [NSObjectProtocol] = []
+  private var sensitiveContentVisible = false
+  private var nativeSafe = true
+  private var shieldFrame: NSRect?
+  private var shieldView: NativePrivacyShieldView?
+  private var originalCollectionBehavior: NSWindow.CollectionBehavior?
+  private var pendingSafeConfirmation: DispatchWorkItem?
+  private var missionControlPolicySuspended = false
+
+  private init(
+    window: NSWindow,
+    containerView: NSView,
+    messenger: FlutterBinaryMessenger
+  ) {
+    self.window = window
+    self.containerView = containerView
+    self.methodChannel = FlutterMethodChannel(
+      name: "com.zcash.wallet/privacy_shield",
+      binaryMessenger: messenger
+    )
+    super.init()
+
+    methodChannel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call, result: result)
+    }
+
+    let eventChannel = FlutterEventChannel(
+      name: "com.zcash.wallet/privacy_exposure",
+      binaryMessenger: messenger
+    )
+    eventChannel.setStreamHandler(self)
+    installObservers()
+  }
+
+  deinit {
+    removeObservers()
+    restoreMissionControlPolicy()
+  }
+
+  static func register(
+    window: NSWindow,
+    containerView: NSView,
+    messenger: FlutterBinaryMessenger
+  ) {
+    shared = PrivacyExposureChannel(
+      window: window,
+      containerView: containerView,
+      messenger: messenger
+    )
+  }
+
+  func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+    eventSink = events
+    publishCurrentState(reason: "listen")
+    return nil
+  }
+
+  func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    eventSink = nil
+    return nil
+  }
+
+  private func handle(_ call: FlutterMethodCall, result: FlutterResult) {
+    switch call.method {
+    case "setSensitiveContentVisible":
+      guard
+        let arguments = call.arguments as? [String: Any],
+        let visible = arguments["visible"] as? Bool
+      else {
+        result(
+          FlutterError(
+            code: "bad_args",
+            message: "Expected visible argument.",
+            details: nil
+          )
+        )
+        return
+      }
+      sensitiveContentVisible = visible
+      shieldFrame = visible ? parseShieldFrame(from: arguments["rect"]) : nil
+      pendingSafeConfirmation?.cancel()
+      pendingSafeConfirmation = nil
+      updateMissionControlPolicy()
+      if visible {
+        publishCurrentState(reason: "sensitiveContentVisible")
+      } else {
+        nativeSafe = true
+        missionControlPolicySuspended = false
+      }
+      updateNativeShield()
+      result(nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func installObservers() {
+    let defaultCenter = NotificationCenter.default
+    let workspaceCenter = NSWorkspace.shared.notificationCenter
+
+    observe(defaultCenter, name: NSApplication.willResignActiveNotification, object: NSApp) { [weak self] _ in
+      self?.publishUnsafe(reason: "appWillResignActive")
+    }
+    observe(defaultCenter, name: NSApplication.didResignActiveNotification, object: NSApp) { [weak self] _ in
+      self?.publishUnsafe(reason: "appDidResignActive")
+    }
+    observe(defaultCenter, name: NSApplication.didBecomeActiveNotification, object: NSApp) { [weak self] _ in
+      self?.publishCurrentState(reason: "appDidBecomeActive")
+    }
+    observe(defaultCenter, name: NSApplication.didHideNotification, object: NSApp) { [weak self] _ in
+      self?.publishUnsafe(reason: "appDidHide")
+    }
+    observe(defaultCenter, name: NSApplication.didUnhideNotification, object: NSApp) { [weak self] _ in
+      self?.publishCurrentState(reason: "appDidUnhide")
+    }
+    observe(defaultCenter, name: NSApplication.didChangeOcclusionStateNotification, object: NSApp) { [weak self] _ in
+      self?.publishCurrentState(reason: "appOcclusionChanged")
+    }
+    observe(workspaceCenter, name: NSWorkspace.activeSpaceDidChangeNotification, object: NSWorkspace.shared) { [weak self] _ in
+      self?.publishUnsafe(reason: "activeSpaceDidChange")
+    }
+
+    if let window {
+      observe(defaultCenter, name: NSWindow.didResignKeyNotification, object: window) { [weak self] _ in
+        self?.publishUnsafe(reason: "windowDidResignKey")
+      }
+      observe(defaultCenter, name: NSWindow.didBecomeKeyNotification, object: window) { [weak self] _ in
+        self?.publishCurrentState(reason: "windowDidBecomeKey")
+      }
+      observe(defaultCenter, name: NSWindow.didMiniaturizeNotification, object: window) { [weak self] _ in
+        self?.publishUnsafe(reason: "windowDidMiniaturize")
+      }
+      observe(defaultCenter, name: NSWindow.didDeminiaturizeNotification, object: window) { [weak self] _ in
+        self?.publishCurrentState(reason: "windowDidDeminiaturize")
+      }
+      observe(defaultCenter, name: NSWindow.didChangeOcclusionStateNotification, object: window) { [weak self] _ in
+        self?.publishCurrentState(reason: "windowOcclusionChanged")
+      }
+    }
+  }
+
+  private func observe(
+    _ center: NotificationCenter,
+    name: Notification.Name,
+    object: Any?,
+    using block: @escaping (Notification) -> Void
+  ) {
+    let observer = center.addObserver(
+      forName: name,
+      object: object,
+      queue: .main,
+      using: block
+    )
+    observers.append(observer)
+  }
+
+  private func removeObservers() {
+    for observer in observers {
+      NotificationCenter.default.removeObserver(observer)
+      NSWorkspace.shared.notificationCenter.removeObserver(observer)
+    }
+    observers.removeAll()
+  }
+
+  private func publishCurrentState(reason: String) {
+    guard let window else {
+      publishUnsafe(reason: "\(reason):missingWindow")
+      return
+    }
+
+    let appVisible = NSApp.occlusionState.contains(.visible)
+    let windowVisible = window.occlusionState.contains(.visible)
+    let safe =
+      NSApp.isActive &&
+      !NSApp.isHidden &&
+      window.isKeyWindow &&
+      !window.isMiniaturized &&
+      appVisible &&
+      windowVisible
+
+    if !safe && sensitiveContentVisible {
+      suspendMissionControlPolicy()
+    }
+
+    let details = [
+      "appActive": NSApp.isActive,
+      "appHidden": NSApp.isHidden,
+      "frontmostIsUs": frontmostApplicationIsUs(),
+      "windowKey": window.isKeyWindow,
+      "windowMiniaturized": window.isMiniaturized,
+      "appVisible": appVisible,
+      "windowVisible": windowVisible,
+      "missionControlPolicySuspended": missionControlPolicySuspended,
+    ]
+
+    if safe && sensitiveContentVisible && !nativeSafe {
+      confirmSafeAfterWindowSettles(reason: reason)
+      return
+    }
+
+    pendingSafeConfirmation?.cancel()
+    pendingSafeConfirmation = nil
+    nativeSafe = safe
+    updateNativeShield()
+
+    publish(
+      isSafe: safe,
+      reason: reason,
+      details: details
+    )
+  }
+
+  private func publishUnsafe(reason: String) {
+    pendingSafeConfirmation?.cancel()
+    pendingSafeConfirmation = nil
+    if sensitiveContentVisible {
+      suspendMissionControlPolicy()
+    }
+    nativeSafe = false
+    updateNativeShield()
+    publish(
+      isSafe: false,
+      reason: reason,
+      details: windowStateDetails()
+    )
+  }
+
+  private func confirmSafeAfterWindowSettles(reason: String) {
+    pendingSafeConfirmation?.cancel()
+    nativeSafe = false
+    updateNativeShield()
+
+    let confirmation = DispatchWorkItem { [weak self] in
+      guard let self, let window = self.window else {
+        return
+      }
+
+      let appVisible = NSApp.occlusionState.contains(.visible)
+      let windowVisible = window.occlusionState.contains(.visible)
+      let safe =
+        NSApp.isActive &&
+        !NSApp.isHidden &&
+        window.isKeyWindow &&
+        !window.isMiniaturized &&
+        appVisible &&
+        windowVisible
+      let details = [
+        "appActive": NSApp.isActive,
+        "appHidden": NSApp.isHidden,
+        "frontmostIsUs": self.frontmostApplicationIsUs(),
+        "windowKey": window.isKeyWindow,
+        "windowMiniaturized": window.isMiniaturized,
+        "appVisible": appVisible,
+        "windowVisible": windowVisible,
+      ]
+
+      self.pendingSafeConfirmation = nil
+      self.nativeSafe = safe
+      self.updateNativeShield()
+
+      if safe && self.sensitiveContentVisible {
+        self.missionControlPolicySuspended = false
+        self.updateMissionControlPolicy()
+      }
+      self.publish(
+        isSafe: safe,
+        reason: safe ? "\(reason):confirmed" : "\(reason):notStable",
+        details: details
+      )
+    }
+
+    pendingSafeConfirmation = confirmation
+    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300), execute: confirmation)
+  }
+
+  private func updateNativeShield() {
+    let shouldShow = sensitiveContentVisible && !nativeSafe && currentShieldFrame() != nil
+    if shouldShow {
+      showNativeShield()
+    } else {
+      hideNativeShield()
+    }
+  }
+
+  private func showNativeShield() {
+    guard let containerView, let frame = currentShieldFrame() else {
+      return
+    }
+
+    let shieldView = self.shieldView ?? NativePrivacyShieldView(frame: frame)
+    shieldView.frame = frame
+    if shieldView.superview == nil {
+      containerView.addSubview(shieldView)
+    }
+    self.shieldView = shieldView
+    containerView.layoutSubtreeIfNeeded()
+    containerView.displayIfNeeded()
+    window?.displayIfNeeded()
+  }
+
+  private func hideNativeShield() {
+    shieldView?.removeFromSuperview()
+    shieldView = nil
+  }
+
+  private func updateMissionControlPolicy() {
+    guard let window else {
+      return
+    }
+
+    if sensitiveContentVisible {
+      guard !missionControlPolicySuspended else {
+        return
+      }
+      if originalCollectionBehavior == nil {
+        originalCollectionBehavior = window.collectionBehavior
+      }
+      var behavior = window.collectionBehavior
+      behavior.remove(.managed)
+      behavior.insert(.transient)
+      window.collectionBehavior = behavior
+    } else {
+      restoreMissionControlPolicy()
+    }
+  }
+
+  private func suspendMissionControlPolicy() {
+    missionControlPolicySuspended = true
+    restoreMissionControlPolicy()
+  }
+
+  private func restoreMissionControlPolicy() {
+    guard let window, let originalCollectionBehavior else {
+      return
+    }
+    window.collectionBehavior = originalCollectionBehavior
+    self.originalCollectionBehavior = nil
+  }
+
+  private func windowStateDetails() -> [String: Bool]? {
+    guard let window else {
+      return nil
+    }
+    return [
+      "appActive": NSApp.isActive,
+      "appHidden": NSApp.isHidden,
+      "frontmostIsUs": frontmostApplicationIsUs(),
+      "windowKey": window.isKeyWindow,
+      "windowMiniaturized": window.isMiniaturized,
+      "appVisible": NSApp.occlusionState.contains(.visible),
+      "windowVisible": window.occlusionState.contains(.visible),
+      "missionControlPolicySuspended": missionControlPolicySuspended,
+    ]
+  }
+
+  private func parseShieldFrame(from rawRect: Any?) -> NSRect? {
+    guard
+      let rect = rawRect as? [String: Any],
+      let left = doubleValue(rect["left"]),
+      let top = doubleValue(rect["top"]),
+      let width = doubleValue(rect["width"]),
+      let height = doubleValue(rect["height"]),
+      width > 0,
+      height > 0
+    else {
+      return nil
+    }
+    return NSRect(x: left, y: top, width: width, height: height)
+  }
+
+  private func doubleValue(_ value: Any?) -> Double? {
+    if let number = value as? NSNumber {
+      return number.doubleValue
+    }
+    return value as? Double
+  }
+
+  private func frontmostApplicationIsUs() -> Bool {
+    NSWorkspace.shared.frontmostApplication?.processIdentifier ==
+      ProcessInfo.processInfo.processIdentifier
+  }
+
+  private func currentShieldFrame() -> NSRect? {
+    guard let containerView, let shieldFrame else {
+      return nil
+    }
+
+    let frame = NSRect(
+      x: shieldFrame.minX,
+      y: containerView.bounds.height - shieldFrame.minY - shieldFrame.height,
+      width: shieldFrame.width,
+      height: shieldFrame.height
+    )
+    let clipped = frame.intersection(containerView.bounds)
+    if clipped.isNull || clipped.width <= 0 || clipped.height <= 0 {
+      return nil
+    }
+    return clipped
+  }
+
+  private func publish(isSafe: Bool, reason: String, details: [String: Bool]?) {
+    var payload: [String: Any] = [
+      "isSafe": isSafe,
+      "reason": reason,
+    ]
+    if let details {
+      payload["details"] = details
+    }
+    eventSink?(payload)
+  }
+}
+
 private final class TitlebarTitleLabel: NSTextField {
   override func hitTest(_ point: NSPoint) -> NSView? {
     nil
@@ -122,6 +712,11 @@ class MainFlutterWindow: NSWindow {
       window: self,
       visualEffectView: desktopWindowViewController.visualEffectView,
       titleLabel: titleLabel,
+      messenger: flutterViewController.engine.binaryMessenger
+    )
+    PrivacyExposureChannel.register(
+      window: self,
+      containerView: flutterViewController.view,
       messenger: flutterViewController.engine.binaryMessenger
     )
     RegisterGeneratedPlugins(registry: flutterViewController)

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -185,7 +185,7 @@ private final class NativeLockIconView: NSView {
 
 private final class NativePrivacyShieldView: NSView {
   private static let paneCornerRadius = 8.0
-  private static let blurRadius = 15.0
+  private static let blurRadius = 30.0
 
   private let blurView = NSView()
   private let scrimView = NSView()

--- a/test/core/privacy/sensitive_privacy_overlay_test.dart
+++ b/test/core/privacy/sensitive_privacy_overlay_test.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:io' show Platform;
 
-import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/privacy/sensitive_privacy_overlay.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
@@ -123,7 +123,7 @@ void main() {
     expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
   });
 
-  testWidgets('syncs sensitive visibility to the native macOS shield', (
+  testWidgets('syncs sensitive visibility to the native macOS policy bridge', (
     tester,
   ) async {
     if (!Platform.isMacOS) return;
@@ -135,11 +135,11 @@ void main() {
           calls.add(call);
           return null;
         });
-    MacOSNativePrivacyShield.resetForTesting();
+    MacOSSensitiveContentBridge.resetForTesting();
     addTearDown(() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, null);
-      MacOSNativePrivacyShield.resetForTesting();
+      MacOSSensitiveContentBridge.resetForTesting();
     });
 
     await tester.pumpWidget(
@@ -180,66 +180,12 @@ void main() {
     await tester.idle();
 
     expect(calls.single.method, 'setSensitiveContentVisible');
-    expect((calls.single.arguments as Map<Object?, Object?>)['visible'], true);
+    expect(calls.single.arguments, {'visible': true});
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.idle();
 
     expect(calls.last.method, 'setSensitiveContentVisible');
     expect(calls.last.arguments, {'visible': false});
-  });
-
-  testWidgets('syncs the overlay bounds to the native macOS shield', (
-    tester,
-  ) async {
-    if (!Platform.isMacOS) return;
-
-    const channel = MethodChannel('com.zcash.wallet/privacy_shield');
-    final calls = <MethodCall>[];
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(channel, (call) async {
-          calls.add(call);
-          return null;
-        });
-    MacOSNativePrivacyShield.resetForTesting();
-    addTearDown(() {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, null);
-      MacOSNativePrivacyShield.resetForTesting();
-    });
-
-    await tester.pumpWidget(
-      AppTheme(
-        data: AppThemeData.light,
-        child: const Directionality(
-          textDirection: TextDirection.ltr,
-          child: Center(
-            child: SizedBox(
-              width: 320,
-              height: 240,
-              child: SensitivePrivacyOverlay(
-                sensitiveContentVisible: true,
-                child: Text('Seed phrase pane'),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-    await tester.pump();
-    await tester.idle();
-
-    final visibleCalls = calls.where((call) {
-      final args = call.arguments as Map<Object?, Object?>;
-      return call.method == 'setSensitiveContentVisible' &&
-          args['visible'] == true;
-    }).toList();
-    expect(visibleCalls, isNotEmpty);
-
-    final args = visibleCalls.last.arguments as Map<Object?, Object?>;
-    final rect = args['rect'] as Map<Object?, Object?>?;
-    expect(rect, isNotNull);
-    expect(rect!['width'], 320.0);
-    expect(rect['height'], 240.0);
   });
 }

--- a/test/core/privacy/sensitive_privacy_overlay_test.dart
+++ b/test/core/privacy/sensitive_privacy_overlay_test.dart
@@ -1,0 +1,245 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/privacy/sensitive_privacy_overlay.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+
+void main() {
+  testWidgets('shows privacy shield only when sensitive content is unsafe', (
+    tester,
+  ) async {
+    final controller = SensitivePrivacyOverlayController(initiallySafe: true);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      AppTheme(
+        data: AppThemeData.light,
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: SensitivePrivacyOverlay(
+            sensitiveContentVisible: true,
+            controller: controller,
+            child: const SizedBox(
+              width: 320,
+              height: 240,
+              child: Text('Seed phrase pane'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Seed phrase pane'), findsOneWidget);
+    expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+
+    controller.markUnsafe();
+    await tester.pump();
+
+    expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
+
+    controller.markSafe();
+    await tester.pump();
+
+    expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+  });
+
+  testWidgets('does not show privacy shield when no sensitive content exists', (
+    tester,
+  ) async {
+    final controller = SensitivePrivacyOverlayController(initiallySafe: false);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      AppTheme(
+        data: AppThemeData.light,
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: SensitivePrivacyOverlay(
+            sensitiveContentVisible: false,
+            controller: controller,
+            child: const SizedBox(
+              width: 320,
+              height: 240,
+              child: Text('Empty import form'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Empty import form'), findsOneWidget);
+    expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+  });
+
+  testWidgets('environment controller honors native macOS exposure events', (
+    tester,
+  ) async {
+    final exposureEvents = StreamController<MacOSPrivacyExposureEvent>();
+    final controller = SensitivePrivacyEnvironmentController(
+      macOSExposureEvents: exposureEvents.stream,
+    );
+    addTearDown(() async {
+      controller.dispose();
+      await exposureEvents.close();
+    });
+
+    await tester.pumpWidget(
+      AppTheme(
+        data: AppThemeData.light,
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: SensitivePrivacyOverlay(
+            sensitiveContentVisible: true,
+            controller: controller,
+            child: const SizedBox(
+              width: 320,
+              height: 240,
+              child: Text('Seed phrase pane'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+
+    exposureEvents.add(
+      const MacOSPrivacyExposureEvent(isSafe: false, reason: 'missionControl'),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
+
+    exposureEvents.add(
+      const MacOSPrivacyExposureEvent(isSafe: true, reason: 'windowVisible'),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+  });
+
+  testWidgets('syncs sensitive visibility to the native macOS shield', (
+    tester,
+  ) async {
+    if (!Platform.isMacOS) return;
+
+    const channel = MethodChannel('com.zcash.wallet/privacy_shield');
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return null;
+        });
+    MacOSNativePrivacyShield.resetForTesting();
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+      MacOSNativePrivacyShield.resetForTesting();
+    });
+
+    await tester.pumpWidget(
+      AppTheme(
+        data: AppThemeData.light,
+        child: const Directionality(
+          textDirection: TextDirection.ltr,
+          child: SensitivePrivacyOverlay(
+            sensitiveContentVisible: false,
+            child: SizedBox(
+              width: 320,
+              height: 240,
+              child: Text('Seed phrase pane'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(calls, isEmpty);
+
+    await tester.pumpWidget(
+      AppTheme(
+        data: AppThemeData.light,
+        child: const Directionality(
+          textDirection: TextDirection.ltr,
+          child: SensitivePrivacyOverlay(
+            sensitiveContentVisible: true,
+            child: SizedBox(
+              width: 320,
+              height: 240,
+              child: Text('Seed phrase pane'),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.idle();
+
+    expect(calls.single.method, 'setSensitiveContentVisible');
+    expect((calls.single.arguments as Map<Object?, Object?>)['visible'], true);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.idle();
+
+    expect(calls.last.method, 'setSensitiveContentVisible');
+    expect(calls.last.arguments, {'visible': false});
+  });
+
+  testWidgets('syncs the overlay bounds to the native macOS shield', (
+    tester,
+  ) async {
+    if (!Platform.isMacOS) return;
+
+    const channel = MethodChannel('com.zcash.wallet/privacy_shield');
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return null;
+        });
+    MacOSNativePrivacyShield.resetForTesting();
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+      MacOSNativePrivacyShield.resetForTesting();
+    });
+
+    await tester.pumpWidget(
+      AppTheme(
+        data: AppThemeData.light,
+        child: const Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: 320,
+              height: 240,
+              child: SensitivePrivacyOverlay(
+                sensitiveContentVisible: true,
+                child: Text('Seed phrase pane'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.idle();
+
+    final visibleCalls = calls.where((call) {
+      final args = call.arguments as Map<Object?, Object?>;
+      return call.method == 'setSensitiveContentVisible' &&
+          args['visible'] == true;
+    }).toList();
+    expect(visibleCalls, isNotEmpty);
+
+    final args = visibleCalls.last.arguments as Map<Object?, Object?>;
+    final rect = args['rect'] as Map<Object?, Object?>?;
+    expect(rect, isNotNull);
+    expect(rect!['width'], 320.0);
+    expect(rect['height'], 240.0);
+  });
+}

--- a/test/core/privacy/sensitive_privacy_overlay_test.dart
+++ b/test/core/privacy/sensitive_privacy_overlay_test.dart
@@ -8,6 +8,15 @@ import 'package:zcash_wallet/src/core/privacy/sensitive_privacy_overlay.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 
 void main() {
+  test('platform privacy signals are macOS-only', () {
+    expect(supportsPlatformPrivacySignals(isWeb: false, isMacOS: true), isTrue);
+    expect(
+      supportsPlatformPrivacySignals(isWeb: false, isMacOS: false),
+      isFalse,
+    );
+    expect(supportsPlatformPrivacySignals(isWeb: true, isMacOS: true), isFalse);
+  });
+
   testWidgets('shows privacy shield only when sensitive content is unsafe', (
     tester,
   ) async {

--- a/test/core/privacy/sensitive_privacy_overlay_test.dart
+++ b/test/core/privacy/sensitive_privacy_overlay_test.dart
@@ -17,6 +17,13 @@ void main() {
     expect(supportsPlatformPrivacySignals(isWeb: true, isMacOS: true), isFalse);
   });
 
+  test('reuses one native macOS exposure stream instance', () {
+    expect(
+      MacOSPrivacyExposureEvents.stream,
+      same(MacOSPrivacyExposureEvents.stream),
+    );
+  }, skip: !Platform.isMacOS);
+
   testWidgets('shows privacy shield only when sensitive content is unsafe', (
     tester,
   ) async {
@@ -132,69 +139,69 @@ void main() {
     expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
   });
 
-  testWidgets('syncs sensitive visibility to the native macOS policy bridge', (
-    tester,
-  ) async {
-    if (!Platform.isMacOS) return;
-
-    const channel = MethodChannel('com.zcash.wallet/privacy_shield');
-    final calls = <MethodCall>[];
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(channel, (call) async {
-          calls.add(call);
-          return null;
-        });
-    MacOSSensitiveContentBridge.resetForTesting();
-    addTearDown(() {
+  testWidgets(
+    'syncs sensitive visibility to the native macOS policy bridge',
+    (tester) async {
+      const channel = MethodChannel('com.zcash.wallet/privacy_shield');
+      final calls = <MethodCall>[];
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, null);
+          .setMockMethodCallHandler(channel, (call) async {
+            calls.add(call);
+            return null;
+          });
       MacOSSensitiveContentBridge.resetForTesting();
-    });
+      addTearDown(() {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null);
+        MacOSSensitiveContentBridge.resetForTesting();
+      });
 
-    await tester.pumpWidget(
-      AppTheme(
-        data: AppThemeData.light,
-        child: const Directionality(
-          textDirection: TextDirection.ltr,
-          child: SensitivePrivacyOverlay(
-            sensitiveContentVisible: false,
-            child: SizedBox(
-              width: 320,
-              height: 240,
-              child: Text('Seed phrase pane'),
+      await tester.pumpWidget(
+        AppTheme(
+          data: AppThemeData.light,
+          child: const Directionality(
+            textDirection: TextDirection.ltr,
+            child: SensitivePrivacyOverlay(
+              sensitiveContentVisible: false,
+              child: SizedBox(
+                width: 320,
+                height: 240,
+                child: Text('Seed phrase pane'),
+              ),
             ),
           ),
         ),
-      ),
-    );
+      );
 
-    expect(calls, isEmpty);
+      expect(calls, isEmpty);
 
-    await tester.pumpWidget(
-      AppTheme(
-        data: AppThemeData.light,
-        child: const Directionality(
-          textDirection: TextDirection.ltr,
-          child: SensitivePrivacyOverlay(
-            sensitiveContentVisible: true,
-            child: SizedBox(
-              width: 320,
-              height: 240,
-              child: Text('Seed phrase pane'),
+      await tester.pumpWidget(
+        AppTheme(
+          data: AppThemeData.light,
+          child: const Directionality(
+            textDirection: TextDirection.ltr,
+            child: SensitivePrivacyOverlay(
+              sensitiveContentVisible: true,
+              child: SizedBox(
+                width: 320,
+                height: 240,
+                child: Text('Seed phrase pane'),
+              ),
             ),
           ),
         ),
-      ),
-    );
-    await tester.idle();
+      );
+      await tester.idle();
 
-    expect(calls.single.method, 'setSensitiveContentVisible');
-    expect(calls.single.arguments, {'visible': true});
+      expect(calls.single.method, 'setSensitiveContentVisible');
+      expect(calls.single.arguments, {'visible': true});
 
-    await tester.pumpWidget(const SizedBox.shrink());
-    await tester.idle();
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.idle();
 
-    expect(calls.last.method, 'setSensitiveContentVisible');
-    expect(calls.last.arguments, {'visible': false});
-  });
+      expect(calls.last.method, 'setSensitiveContentVisible');
+      expect(calls.last.arguments, {'visible': false});
+    },
+    skip: !Platform.isMacOS,
+  );
 }

--- a/test/features/onboarding/import_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/import_secret_passphrase_screen_test.dart
@@ -266,6 +266,53 @@ void main() {
 
     expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
   });
+
+  testWidgets('privacy shield hides active autocomplete suggestions', (
+    tester,
+  ) async {
+    final controller = SensitivePrivacyOverlayController();
+    addTearDown(controller.dispose);
+
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _importPassphraseScreen(privacyOverlayController: controller),
+    );
+    await tester.enterText(_wordField(0), 'cab');
+    await tester.pump();
+
+    expect(find.text('cabbage'), findsOneWidget);
+
+    controller.markUnsafe();
+    await tester.pump();
+
+    expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
+    expect(find.text('cabbage'), findsNothing);
+
+    controller.markSafe();
+    await tester.pump();
+
+    expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+    expect(find.text('cabbage'), findsNothing);
+
+    await tester.tap(_wordField(0));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('cabbage'), findsOneWidget);
+
+    controller.markUnsafe();
+    await tester.pump();
+    controller.markSafe();
+    await tester.pump();
+
+    expect(find.text('cabbage'), findsNothing);
+
+    await tester.tap(_wordField(0));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('cabbage'), findsOneWidget);
+  });
 }
 
 Future<void> _setDesktopViewport(

--- a/test/features/onboarding/import_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/import_secret_passphrase_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart' show MaterialApp, Scaffold, TextField;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart'
     show
+        BackdropFilter,
         Column,
         Expanded,
         Focus,
@@ -219,6 +220,28 @@ void main() {
     expect(_textField(tester, 3).focusNode!.hasFocus, isTrue);
   });
 
+  testWidgets(
+    'privacy shield ignores empty focused words when focus is unsafe',
+    (tester) async {
+      final controller = SensitivePrivacyOverlayController(
+        initiallySafe: false,
+      );
+      addTearDown(controller.dispose);
+
+      await _setDesktopViewport(tester);
+      await tester.pumpWidget(
+        _importPassphraseScreen(privacyOverlayController: controller),
+      );
+
+      _textField(tester, 0).focusNode!.requestFocus();
+      await tester.pump();
+
+      expect(_textField(tester, 0).focusNode!.hasFocus, isTrue);
+      expect(_textField(tester, 0).controller!.text, isEmpty);
+      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+    },
+  );
+
   testWidgets('privacy shield covers entered words when focus is unsafe', (
     tester,
   ) async {
@@ -236,6 +259,7 @@ void main() {
     await tester.pump();
 
     expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
+    expect(find.byType(BackdropFilter), findsOneWidget);
 
     controller.markSafe();
     await tester.pump();

--- a/test/features/onboarding/import_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/import_secret_passphrase_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter/widgets.dart'
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/privacy/sensitive_privacy_overlay.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/onboarding/import/import_secret_passphrase_screen.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
@@ -217,6 +218,30 @@ void main() {
     expect(_textField(tester, 2).controller!.text, 'able');
     expect(_textField(tester, 3).focusNode!.hasFocus, isTrue);
   });
+
+  testWidgets('privacy shield covers entered words when focus is unsafe', (
+    tester,
+  ) async {
+    final controller = SensitivePrivacyOverlayController(initiallySafe: false);
+    addTearDown(controller.dispose);
+
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _importPassphraseScreen(privacyOverlayController: controller),
+    );
+
+    expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+
+    await tester.enterText(_wordField(0), 'abandon');
+    await tester.pump();
+
+    expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
+
+    controller.markSafe();
+    await tester.pump();
+
+    expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+  });
 }
 
 Future<void> _setDesktopViewport(
@@ -229,8 +254,13 @@ Future<void> _setDesktopViewport(
   });
 }
 
-Widget _importPassphraseScreen({FocusNode? afterNode}) {
-  Widget body = const ImportSecretPassphraseScreen();
+Widget _importPassphraseScreen({
+  FocusNode? afterNode,
+  SensitivePrivacyOverlayController? privacyOverlayController,
+}) {
+  Widget body = ImportSecretPassphraseScreen(
+    privacyOverlayController: privacyOverlayController,
+  );
   if (afterNode != null) {
     body = Column(
       children: [


### PR DESCRIPTION
## Summary

- Adds the Flutter privacy overlay for seed phrase exposure states across create, import, and settings/export seed phrase flows.
- Applies privacy signal handling only on macOS for now; Windows/Linux are intentionally disabled until a platform-specific implementation is added.
- Keeps the macOS native side limited to exposure events and Mission Control window policy. Swift does not draw a native overlay view.

## When Privacy Mode Is Active

Privacy mode is tied to whether seed phrase content is actually present, not just whether the user is on a seed phrase route.

- Create seed phrase: active only after the generated mnemonic has been revealed.
- Import seed phrase: active only after at least one mnemonic word has been entered. An empty focused import form is not covered and remains a normal app window because there is no seed data to protect yet.
- Settings/export seed phrase: active only after the password gate succeeds and the mnemonic is revealed.
- Non-seed screens, unrevealed seed screens, empty import forms, and normal app chrome are not covered by this layer.

When privacy mode is active, the Flutter overlay covers the seed phrase pane with blur/scrim/badge whenever the app/window becomes unsafe, such as focus loss, inactive lifecycle, hide/minimize, or macOS exposure events.

## macOS Mission Control Behavior

macOS does not provide a reliable direct Mission Control entry signal to Flutter. While privacy mode is active, the native bridge changes the window collection behavior from managed to transient so Mission Control does not keep a raw seed phrase snapshot in its window list.

There is an AppKit tradeoff here: keeping `.transient` through the whole Mission Control return transition can leave Vizor ordered behind another app when Mission Control closes. For that reason, once macOS reports the unsafe transition, Swift restores the original collection behavior so AppKit can bring the window back normally. During that unsafe interval, the visible protection is the Flutter privacy overlay rather than a Swift-rendered replacement screen.

Practical result:

- If seed content is present, the app should either disappear from Mission Control during entry or be covered by the Flutter privacy overlay during unsafe exposure transitions.
- If seed content is not present, such as an empty import seed phrase form, the window is left as a normal Mission Control window.
- If the user is actively focused on the seed phrase screen, the seed phrase is intentionally visible; this layer only reacts when the app/window starts losing safe foreground exposure.

We also checked the screen-replacement approach and are not relying on it: neither the Dart overlay nor a Swift-rendered replacement screen can reliably swap what Mission Control captures at the point the snapshot is taken. The chosen macOS fallback is a combination of temporary Mission Control window exclusion and the Flutter overlay for unsafe exposure states.

The visible blur/scrim/badge is still rendered by Flutter only. The native bridge is just the macOS policy and exposure signal path.

## Limitations

- This currently covers macOS only. Windows support is explicitly left as a TODO before enabling desktop privacy signals there.
- It does not prevent disclosure while the app is focused and the seed phrase is intentionally visible.
- Mission Control behavior depends on AppKit window state notifications and collection behavior; it is not a true pre-snapshot replacement API.
- Empty import forms and unrevealed seed screens remain visible in Mission Control because they do not contain seed data yet.
- If Flutter `BackdropFilter` ever fails or is unsupported, the remaining fallback is the configured scrim/badge styling.

## Validation

- `fvm dart analyze lib/src/core/privacy/sensitive_privacy_overlay.dart test/core/privacy/sensitive_privacy_overlay_test.dart`
- `fvm flutter test test/core/privacy/sensitive_privacy_overlay_test.dart test/features/onboarding/import_secret_passphrase_screen_test.dart`
- `fvm flutter build macos --debug`

Note: full `fvm flutter analyze` currently reports pre-existing `rust_builder/cargokit/build_tool` package-resolution errors unrelated to this PR.
