### PR TITLE
Add regtest integration E2E coverage

### DIFF
--- a/integration_test/regtest_import_sync_test.dart
+++ b/integration_test/regtest_import_sync_test.dart
@@ -1,0 +1,221 @@
+import 'dart:io';
+
+import 'package:desktop_window_bootstrap/desktop_window_bootstrap.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/layout/app_layout.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+import 'package:zcash_wallet/src/rust/frb_generated.dart';
+
+const _mnemonic =
+    'winter shiver fetch refuse absurd mail pistol eight market lounge manual '
+    'roast miracle ethics found child scare curve congress renew salute pig '
+    'better used';
+const _password = 'Vizor123!';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    FlutterForegroundTask.initCommunicationPort();
+    await RustLib.init();
+    await initializeDesktopWindow();
+    if (isDesktopLayoutPlatform) {
+      await DesktopWindowBootstrap.initialize();
+      await showDesktopWindow();
+    }
+  });
+
+  testWidgets(
+    'imports a funded regtest wallet, syncs, and displays balances',
+    (tester) async {
+      addTearDown(() {
+        rust_sync.setSyncMode(mode: 0);
+        rust_sync.cancelFullSync();
+        rust_sync.stopMempoolObserver();
+      });
+
+      await _resetWalletState();
+      final bootstrap = await loadAppBootstrap();
+
+      _log('pumping app');
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [appBootstrapProvider.overrideWithValue(bootstrap)],
+          child: const ZcashWalletApp(),
+        ),
+      );
+
+      _log('opening import flow');
+      await _tapButton(tester, const ValueKey('welcome_import_wallet_button'));
+
+      _log('entering mnemonic');
+      await _enterText(
+        tester,
+        const ValueKey('import_mnemonic_first_word_field'),
+        _mnemonic,
+      );
+      await _tapButton(tester, const ValueKey('import_secret_submit_button'));
+
+      _log('skipping birthday');
+      await _tapButton(tester, const ValueKey('import_birthday_skip_button'));
+
+      _log('setting password');
+      await _enterText(
+        tester,
+        const ValueKey('set_password_password_field'),
+        _password,
+      );
+      await _enterText(
+        tester,
+        const ValueKey('set_password_confirm_field'),
+        _password,
+      );
+      await _tapButton(tester, const ValueKey('set_password_submit_button'));
+
+      await _pumpUntil(
+        tester,
+        () => tester.any(
+          find.byKey(const ValueKey('home_shielded_balance_text')),
+        ),
+        description: 'home balance card to render',
+        timeout: const Duration(minutes: 1),
+      );
+      _log(
+        'home rendered with shielded='
+        '${_textForKey(tester, const ValueKey('home_shielded_balance_text'))}',
+      );
+
+      await _pumpUntil(
+        tester,
+        () => _keyedTextEquals(
+          tester,
+          const ValueKey('home_shielded_balance_text'),
+          '1.25 zec',
+        ),
+        description: 'shielded balance to show 1.25 zec',
+        timeout: const Duration(minutes: 4),
+      );
+      _log('shielded balance matched');
+
+      await _pumpUntil(
+        tester,
+        () => _keyedTextEquals(
+          tester,
+          const ValueKey('home_transparent_balance_text'),
+          'Transparent balance: 0.75 ZEC',
+        ),
+        description: 'transparent balance to show 0.75 ZEC',
+        timeout: const Duration(minutes: 1),
+      );
+      _log('transparent balance matched');
+    },
+    timeout: const Timeout(Duration(minutes: 5)),
+  );
+}
+
+Future<void> _resetWalletState() async {
+  _log('resetting wallet state');
+  rust_sync.setSyncMode(mode: 0);
+  rust_sync.cancelFullSync();
+  rust_sync.stopMempoolObserver();
+
+  await AppSecureStore.instance.deleteAll();
+
+  final supportDir = await getWalletSupportDirectory();
+  if (!supportDir.existsSync()) return;
+
+  for (final entity in supportDir.listSync()) {
+    final name = entity.uri.pathSegments.isEmpty
+        ? entity.path
+        : entity.uri.pathSegments.last;
+    if (!name.startsWith('zcash_wallet') || !name.contains('.db')) continue;
+    if (entity is File) {
+      entity.deleteSync();
+    } else if (entity is Directory) {
+      entity.deleteSync(recursive: true);
+    }
+  }
+}
+
+Future<void> _tapButton(WidgetTester tester, Key key) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () =>
+        tester.any(finder) &&
+        tester.widget<AppButton>(finder).onPressed != null,
+    description: '$key button to be enabled',
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _enterText(WidgetTester tester, Key key, String text) async {
+  final editable = find.descendant(
+    of: find.byKey(key),
+    matching: find.byType(EditableText),
+  );
+  await _pumpUntil(
+    tester,
+    () => tester.any(editable),
+    description: '$key editable text field',
+  );
+  await tester.tap(editable);
+  await tester.enterText(editable, text);
+  await tester.pump(const Duration(milliseconds: 100));
+  _log('entered text into $key');
+}
+
+bool _keyedTextEquals(WidgetTester tester, Key key, String expected) {
+  return _textForKey(tester, key) == expected;
+}
+
+String? _textForKey(WidgetTester tester, Key key) {
+  final finder = find.byKey(key);
+  if (!tester.any(finder)) return null;
+  final widget = tester.widget<Text>(finder);
+  return widget.data;
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  required String description,
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final end = DateTime.now().add(timeout);
+  Object? lastError;
+  var polls = 0;
+  while (DateTime.now().isBefore(end)) {
+    try {
+      if (condition()) return;
+    } catch (e) {
+      lastError = e;
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    polls++;
+    if (polls % 25 == 0) {
+      _log('still waiting for $description');
+    }
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail('Timed out waiting for $description.$error');
+}
+
+void _log(String message) {
+  debugPrint('[regtest-e2e] $message');
+}

--- a/integration_test/regtest_import_sync_test.dart
+++ b/integration_test/regtest_import_sync_test.dart
@@ -25,13 +25,11 @@ void main() {
   testWidgets(
     'imports a funded regtest wallet, syncs, and displays balances',
     (tester) async {
-      addTearDown(() {
-        rust_sync.setSyncMode(mode: 0);
-        rust_sync.cancelFullSync();
-        rust_sync.stopMempoolObserver();
+      addTearDown(() async {
+        await _cleanupE2eWalletState();
       });
 
-      await _resetWalletState();
+      await _cleanupE2eWalletState();
 
       _log('pumping app');
       await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
@@ -104,27 +102,47 @@ void main() {
   );
 }
 
-Future<void> _resetWalletState() async {
-  _log('resetting wallet state');
-  rust_sync.setSyncMode(mode: 0);
-  rust_sync.cancelFullSync();
-  rust_sync.stopMempoolObserver();
+Future<void> _cleanupE2eWalletState() async {
+  final storage = AppSecureStore.instance;
+  if (!storage.isE2eStorage) {
+    throw StateError(
+      'Refusing to clean wallet state without ZCASH_USE_E2E_STORAGE.',
+    );
+  }
 
-  await AppSecureStore.instance.deleteAll();
+  _log('cleaning E2E wallet state');
+  await _stopRustWorkForCleanup();
+
+  await storage.deleteAll();
 
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
-  for (final entity in supportDir.listSync()) {
-    final name = entity.uri.pathSegments.isEmpty
-        ? entity.path
-        : entity.uri.pathSegments.last;
-    if (!name.startsWith('zcash_wallet') || !name.contains('.db')) continue;
-    if (entity is File) {
-      entity.deleteSync();
-    } else if (entity is Directory) {
-      entity.deleteSync(recursive: true);
-    }
+  for (final name in [
+    kE2eWalletDbName,
+    '$kE2eWalletDbName-shm',
+    '$kE2eWalletDbName-wal',
+  ]) {
+    final file = File('${supportDir.path}${Platform.pathSeparator}$name');
+    if (file.existsSync()) file.deleteSync();
+  }
+}
+
+Future<void> _stopRustWorkForCleanup() async {
+  rust_sync.setSyncMode(mode: 0);
+  rust_sync.cancelFullSync();
+  rust_sync.stopMempoolObserver();
+
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  while ((rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) &&
+      DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  if (rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) {
+    _log(
+      'timed out waiting for Rust work to stop; continuing E2E storage cleanup',
+    );
   }
 }
 

--- a/integration_test/regtest_import_sync_test.dart
+++ b/integration_test/regtest_import_sync_test.dart
@@ -1,19 +1,13 @@
 import 'dart:io';
 
-import 'package:desktop_window_bootstrap/desktop_window_bootstrap.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:zcash_wallet/app.dart';
-import 'package:zcash_wallet/src/app_bootstrap.dart';
-import 'package:zcash_wallet/src/core/layout/app_layout.dart';
 import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
-import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
 const _mnemonic =
     'winter shiver fetch refuse absurd mail pistol eight market lounge manual '
@@ -25,13 +19,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() async {
-    FlutterForegroundTask.initCommunicationPort();
-    await RustLib.init();
-    await initializeDesktopWindow();
-    if (isDesktopLayoutPlatform) {
-      await DesktopWindowBootstrap.initialize();
-      await showDesktopWindow();
-    }
+    await initializeZcashWalletRuntime();
   });
 
   testWidgets(
@@ -44,15 +32,9 @@ void main() {
       });
 
       await _resetWalletState();
-      final bootstrap = await loadAppBootstrap();
 
       _log('pumping app');
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [appBootstrapProvider.overrideWithValue(bootstrap)],
-          child: const ZcashWalletApp(),
-        ),
-      );
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
 
       _log('opening import flow');
       await _tapButton(tester, const ValueKey('welcome_import_wallet_button'));

--- a/integration_test/regtest_multi_account_send_test.dart
+++ b/integration_test/regtest_multi_account_send_test.dart
@@ -81,7 +81,41 @@ void main() {
         shielded: '0.25 zec',
         timeout: const Duration(minutes: 4),
       );
+      await _expectActivityRow(
+        tester,
+        const ValueKey('home_activity_row_1'),
+        title: 'Received',
+        amount: '+0.25 ZEC',
+        status: 'Completed',
+      );
+      await _openActivity(tester);
+      await _expectActivityRow(
+        tester,
+        const ValueKey('activity_screen_row_1'),
+        title: 'Received',
+        amount: '+0.25 ZEC',
+        status: 'Completed',
+      );
       _log('second account received shielded funds');
+
+      await _openWallet(tester);
+      await _switchAccount(tester, 0);
+      await _expectActivityRow(
+        tester,
+        const ValueKey('home_activity_row_1'),
+        title: 'Sent',
+        amount: '-0.25 ZEC',
+        status: 'Completed',
+      );
+      await _openActivity(tester);
+      await _expectActivityRow(
+        tester,
+        const ValueKey('activity_screen_row_1'),
+        title: 'Sent',
+        amount: '-0.25 ZEC',
+        status: 'Completed',
+      );
+      _log('first account sent activity matched');
     },
     timeout: const Timeout(Duration(minutes: 10)),
   );
@@ -255,6 +289,16 @@ Future<void> _openWallet(WidgetTester tester) async {
   await _waitForHome(tester);
 }
 
+Future<void> _openActivity(WidgetTester tester) async {
+  await _tapWidget(tester, const ValueKey('sidebar_activity_button'));
+  await _pumpUntil(
+    tester,
+    () => tester.any(find.byKey(const ValueKey('activity_screen_row_0'))),
+    description: 'activity screen rows to render',
+    timeout: const Duration(minutes: 1),
+  );
+}
+
 Future<void> _switchAccount(WidgetTester tester, int accountOrder) async {
   _log('switching to account order $accountOrder');
   await _tapWidget(tester, const ValueKey('sidebar_account_selector_button'));
@@ -303,6 +347,27 @@ Future<void> _waitForBalance(
     );
     _log('transparent balance matched: $transparent');
   }
+}
+
+Future<void> _expectActivityRow(
+  WidgetTester tester,
+  Key key, {
+  required String title,
+  required String amount,
+  required String status,
+}) async {
+  await _pumpUntil(
+    tester,
+    () {
+      final texts = _textSetIn(tester, find.byKey(key));
+      return texts.contains(title) &&
+          texts.contains(amount) &&
+          texts.contains(status);
+    },
+    description: '$key activity row to show $title $amount $status',
+    timeout: const Duration(minutes: 2),
+  );
+  _log('activity row matched: $title $amount $status');
 }
 
 Future<void> _cleanupE2eWalletState() async {
@@ -414,6 +479,16 @@ String? _textForKey(WidgetTester tester, Key key) {
   if (!tester.any(finder)) return null;
   final widget = tester.widget<Text>(finder);
   return widget.data;
+}
+
+Set<String> _textSetIn(WidgetTester tester, Finder finder) {
+  if (!tester.any(finder)) return const {};
+  final texts = find.descendant(of: finder, matching: find.byType(Text));
+  return tester
+      .widgetList<Text>(texts)
+      .map((text) => text.data)
+      .whereType<String>()
+      .toSet();
 }
 
 Future<void> _pumpUntil(

--- a/integration_test/regtest_multi_account_send_test.dart
+++ b/integration_test/regtest_multi_account_send_test.dart
@@ -1,0 +1,448 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
+
+const _lightwalletdUrl = String.fromEnvironment(
+  'ZCASH_E2E_LIGHTWALLETD_URL',
+  defaultValue: 'http://127.0.0.1:9067',
+);
+const _zcashdRpcUrl = String.fromEnvironment(
+  'ZCASH_E2E_ZCASHD_RPC_URL',
+  defaultValue: 'http://127.0.0.1:18232',
+);
+const _zcashdRpcUser = 'zcash';
+const _zcashdRpcPassword = 'zcash';
+const _firstMnemonic =
+    'winter shiver fetch refuse absurd mail pistol eight market lounge manual '
+    'roast miracle ethics found child scare curve congress renew salute pig '
+    'better used';
+const _secondMnemonic =
+    'return try reason flat civil wolf dwarf announce toddler uphold equip '
+    'range neck proof gauge east rifle swim tray twin venue fossil will '
+    'version';
+const _password = 'Vizor123!';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeZcashWalletRuntime();
+  });
+
+  testWidgets(
+    'sends shielded funds between two imported regtest accounts',
+    (tester) async {
+      addTearDown(() async {
+        await _cleanupE2eWalletState();
+      });
+
+      await _cleanupE2eWalletState();
+
+      _log('pumping app');
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+
+      await _importFirstWallet(tester);
+      await _waitForBalance(
+        tester,
+        shielded: '1.25 zec',
+        transparent: 'Transparent balance: 0.75 ZEC',
+      );
+
+      await _openAddAccountFlow(tester);
+      await _importAdditionalWallet(tester);
+      await _waitForHome(tester);
+
+      _log('copying second account shielded address');
+      final secondAddress = await _copyActiveShieldedAddress(tester);
+      expect(secondAddress, startsWith('uregtest1'));
+      _log('second account shielded address copied');
+
+      await _openWallet(tester);
+      await _switchAccount(tester, 0);
+      await _waitForBalance(tester, shielded: '1.25 zec');
+
+      await _sendToAddress(tester, secondAddress, '0.25');
+      await _mineRegtestBlocks(10);
+
+      await _openWallet(tester);
+      await _switchAccount(tester, 1);
+      await _waitForBalance(
+        tester,
+        shielded: '0.25 zec',
+        timeout: const Duration(minutes: 4),
+      );
+      _log('second account received shielded funds');
+    },
+    timeout: const Timeout(Duration(minutes: 10)),
+  );
+}
+
+Future<void> _importFirstWallet(WidgetTester tester) async {
+  _log('importing first wallet');
+  await _tapAppButton(tester, const ValueKey('welcome_import_wallet_button'));
+  await _enterText(
+    tester,
+    const ValueKey('import_mnemonic_first_word_field'),
+    _firstMnemonic,
+  );
+  await _tapAppButton(tester, const ValueKey('import_secret_submit_button'));
+  await _tapAppButton(tester, const ValueKey('import_birthday_skip_button'));
+  await _enterText(
+    tester,
+    const ValueKey('set_password_password_field'),
+    _password,
+  );
+  await _enterText(
+    tester,
+    const ValueKey('set_password_confirm_field'),
+    _password,
+  );
+  await _tapAppButton(tester, const ValueKey('set_password_submit_button'));
+  await _waitForHome(tester);
+  _log('first wallet imported');
+}
+
+Future<void> _importAdditionalWallet(WidgetTester tester) async {
+  _log('importing second wallet');
+  await _tapAppButton(tester, const ValueKey('welcome_import_wallet_button'));
+  await _enterText(
+    tester,
+    const ValueKey('import_mnemonic_first_word_field'),
+    _secondMnemonic,
+  );
+  await _tapAppButton(tester, const ValueKey('import_secret_submit_button'));
+  await _tapAppButton(tester, const ValueKey('import_birthday_skip_button'));
+  await _waitForHome(tester);
+  _log('second wallet imported');
+}
+
+Future<void> _openAddAccountFlow(WidgetTester tester) async {
+  _log('opening add-account flow');
+  await _tapWidget(tester, const ValueKey('sidebar_account_selector_button'));
+  await _tapAppButton(tester, const ValueKey('sidebar_add_account_button'));
+  await _pumpUntil(
+    tester,
+    () =>
+        tester.any(find.byKey(const ValueKey('welcome_import_wallet_button'))),
+    description: 'add-account welcome import button',
+  );
+}
+
+Future<String> _copyActiveShieldedAddress(WidgetTester tester) async {
+  await _tapWidget(tester, const ValueKey('sidebar_receive_button'));
+  await _pumpUntil(
+    tester,
+    () => tester.any(
+      find.byKey(const ValueKey('receive_copy_shielded_address_button')),
+    ),
+    description: 'shielded receive copy button',
+  );
+  await _tapWidget(
+    tester,
+    const ValueKey('receive_copy_shielded_address_button'),
+  );
+  final data = await Clipboard.getData('text/plain');
+  final address = data?.text?.trim() ?? '';
+  if (address.isEmpty) {
+    fail('Shielded address was not copied to the clipboard.');
+  }
+  return address;
+}
+
+Future<void> _sendToAddress(
+  WidgetTester tester,
+  String address,
+  String amount,
+) async {
+  _log('sending $amount ZEC to second account');
+  await _tapWidget(tester, const ValueKey('sidebar_send_button'));
+  await _enterText(tester, const ValueKey('send_address_field'), address);
+  await _enterText(tester, const ValueKey('send_amount_field'), amount);
+  await _tapAppButton(
+    tester,
+    const ValueKey('send_review_button'),
+    timeout: const Duration(minutes: 1),
+  );
+  await _tapAppButton(
+    tester,
+    const ValueKey('send_confirm_button'),
+    timeout: const Duration(minutes: 1),
+  );
+  await _pumpUntil(
+    tester,
+    () => tester.any(find.byKey(const ValueKey('send_status_succeeded'))),
+    description: 'send status to succeed',
+    timeout: const Duration(minutes: 4),
+  );
+  _log('send succeeded');
+}
+
+Future<void> _mineRegtestBlocks(int blocks) async {
+  _log('mining $blocks regtest blocks');
+
+  final before = await _zcashdRpc<int>('getblockcount');
+  await _zcashdRpc<List<Object?>>('generate', [blocks]);
+  final targetHeight = before + blocks;
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+
+  while (DateTime.now().isBefore(deadline)) {
+    final lightwalletdHeight = await rust_wallet.getLatestBlockHeight(
+      lightwalletdUrl: _lightwalletdUrl,
+    );
+    if (lightwalletdHeight.toInt() >= targetHeight) {
+      _log('lightwalletd reached mined height $targetHeight');
+      return;
+    }
+    await Future<void>.delayed(const Duration(seconds: 1));
+  }
+
+  throw StateError('Timed out waiting for lightwalletd height $targetHeight.');
+}
+
+Future<T> _zcashdRpc<T>(
+  String method, [
+  List<Object?> params = const [],
+]) async {
+  final client = HttpClient();
+  try {
+    final request = await client.postUrl(Uri.parse(_zcashdRpcUrl));
+    final credentials = base64Encode(
+      utf8.encode('$_zcashdRpcUser:$_zcashdRpcPassword'),
+    );
+    request.headers
+      ..set(HttpHeaders.authorizationHeader, 'Basic $credentials')
+      ..contentType = ContentType.json;
+    request.write(
+      jsonEncode({
+        'jsonrpc': '1.0',
+        'id': 'regtest-e2e',
+        'method': method,
+        'params': params,
+      }),
+    );
+
+    final response = await request.close();
+    final body = await utf8.decoder.bind(response).join();
+    if (response.statusCode != HttpStatus.ok) {
+      throw StateError(
+        'zcashd RPC $method failed: HTTP ${response.statusCode}',
+      );
+    }
+
+    final decoded = jsonDecode(body) as Map<String, Object?>;
+    final error = decoded['error'];
+    if (error != null) {
+      throw StateError('zcashd RPC $method failed: $error');
+    }
+    return decoded['result'] as T;
+  } finally {
+    client.close(force: true);
+  }
+}
+
+Future<void> _openWallet(WidgetTester tester) async {
+  await _tapWidget(tester, const ValueKey('sidebar_wallet_button'));
+  await _waitForHome(tester);
+}
+
+Future<void> _switchAccount(WidgetTester tester, int accountOrder) async {
+  _log('switching to account order $accountOrder');
+  await _tapWidget(tester, const ValueKey('sidebar_account_selector_button'));
+  await _tapWidget(tester, ValueKey('sidebar_account_row_$accountOrder'));
+  await _waitForHome(tester);
+}
+
+Future<void> _waitForHome(WidgetTester tester) async {
+  await _pumpUntil(
+    tester,
+    () => tester.any(find.byKey(const ValueKey('home_shielded_balance_text'))),
+    description: 'home balance card to render',
+    timeout: const Duration(minutes: 1),
+  );
+}
+
+Future<void> _waitForBalance(
+  WidgetTester tester, {
+  String? shielded,
+  String? transparent,
+  Duration timeout = const Duration(minutes: 4),
+}) async {
+  if (shielded != null) {
+    await _pumpUntil(
+      tester,
+      () => _keyedTextEquals(
+        tester,
+        const ValueKey('home_shielded_balance_text'),
+        shielded,
+      ),
+      description: 'shielded balance to show $shielded',
+      timeout: timeout,
+    );
+    _log('shielded balance matched: $shielded');
+  }
+  if (transparent != null) {
+    await _pumpUntil(
+      tester,
+      () => _keyedTextEquals(
+        tester,
+        const ValueKey('home_transparent_balance_text'),
+        transparent,
+      ),
+      description: 'transparent balance to show $transparent',
+      timeout: timeout,
+    );
+    _log('transparent balance matched: $transparent');
+  }
+}
+
+Future<void> _cleanupE2eWalletState() async {
+  final storage = AppSecureStore.instance;
+  if (!storage.isE2eStorage) {
+    throw StateError(
+      'Refusing to clean wallet state without ZCASH_USE_E2E_STORAGE.',
+    );
+  }
+
+  _log('cleaning E2E wallet state');
+  await _stopRustWorkForCleanup();
+
+  await storage.deleteAll();
+
+  final supportDir = await getWalletSupportDirectory();
+  if (!supportDir.existsSync()) return;
+
+  for (final name in [
+    kE2eWalletDbName,
+    '$kE2eWalletDbName-shm',
+    '$kE2eWalletDbName-wal',
+  ]) {
+    final file = File('${supportDir.path}${Platform.pathSeparator}$name');
+    if (file.existsSync()) file.deleteSync();
+  }
+}
+
+Future<void> _stopRustWorkForCleanup() async {
+  rust_sync.setSyncMode(mode: 0);
+  rust_sync.cancelFullSync();
+  rust_sync.stopMempoolObserver();
+
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  while ((rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) &&
+      DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  if (rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) {
+    _log(
+      'timed out waiting for Rust work to stop; continuing E2E storage cleanup',
+    );
+  }
+}
+
+Future<void> _tapAppButton(
+  WidgetTester tester,
+  Key key, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () =>
+        tester.any(finder) &&
+        tester.widget<AppButton>(finder).onPressed != null,
+    description: '$key button to be enabled',
+    timeout: timeout,
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _tapWidget(
+  WidgetTester tester,
+  Key key, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () => tester.any(finder),
+    description: '$key widget to render',
+    timeout: timeout,
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _enterText(WidgetTester tester, Key key, String text) async {
+  final editable = find.descendant(
+    of: find.byKey(key),
+    matching: find.byType(EditableText),
+  );
+  await _pumpUntil(
+    tester,
+    () => tester.any(editable),
+    description: '$key editable text field',
+  );
+  await tester.tap(editable);
+  await tester.enterText(editable, text);
+  await tester.pump(const Duration(milliseconds: 100));
+  _log('entered text into $key');
+}
+
+bool _keyedTextEquals(WidgetTester tester, Key key, String expected) {
+  return _textForKey(tester, key) == expected;
+}
+
+String? _textForKey(WidgetTester tester, Key key) {
+  final finder = find.byKey(key);
+  if (!tester.any(finder)) return null;
+  final widget = tester.widget<Text>(finder);
+  return widget.data;
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  required String description,
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final end = DateTime.now().add(timeout);
+  Object? lastError;
+  var polls = 0;
+  while (DateTime.now().isBefore(end)) {
+    try {
+      if (condition()) return;
+    } catch (e) {
+      lastError = e;
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    polls++;
+    if (polls % 25 == 0) {
+      _log('still waiting for $description');
+    }
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail('Timed out waiting for $description.$error');
+}
+
+void _log(String message) {
+  debugPrint('[regtest-multi-account-e2e] $message');
+}

--- a/integration_test/simple_test.dart
+++ b/integration_test/simple_test.dart
@@ -1,35 +1,19 @@
-import 'package:desktop_window_bootstrap/desktop_window_bootstrap.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:zcash_wallet/app.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
-import 'package:zcash_wallet/src/core/layout/app_layout.dart';
-import 'package:zcash_wallet/src/rust/frb_generated.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() async {
-    FlutterForegroundTask.initCommunicationPort();
-    await RustLib.init();
-    await initializeDesktopWindow();
-    if (isDesktopLayoutPlatform) {
-      await DesktopWindowBootstrap.initialize();
-      await showDesktopWindow();
-    }
+    await initializeZcashWalletRuntime();
   });
 
   testWidgets('Welcome screen shows create and import buttons', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
-        ],
-        child: const ZcashWalletApp(),
-      ),
+      buildZcashWalletApp(bootstrap: AppBootstrapState.empty),
     );
     await tester.pumpAndSettle();
 

--- a/integration_test/simple_test.dart
+++ b/integration_test/simple_test.dart
@@ -1,21 +1,39 @@
+import 'package:desktop_window_bootstrap/desktop_window_bootstrap.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/layout/app_layout.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  setUpAll(() async => await RustLib.init());
+  setUpAll(() async {
+    FlutterForegroundTask.initCommunicationPort();
+    await RustLib.init();
+    await initializeDesktopWindow();
+    if (isDesktopLayoutPlatform) {
+      await DesktopWindowBootstrap.initialize();
+      await showDesktopWindow();
+    }
+  });
 
-  testWidgets('Welcome screen shows create and import buttons',
-      (WidgetTester tester) async {
+  testWidgets('Welcome screen shows create and import buttons', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(
-      const ProviderScope(child: ZcashWalletApp()),
+      ProviderScope(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+        ],
+        child: const ZcashWalletApp(),
+      ),
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Create New Wallet'), findsOneWidget);
-    expect(find.text('Import Wallet'), findsOneWidget);
+    expect(find.text('Create a new wallet'), findsOneWidget);
+    expect(find.text('Import a wallet'), findsOneWidget);
   });
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:go_router/go_router.dart';
 import 'package:desktop_window_bootstrap/desktop_window_bootstrap.dart';
 
-import 'main.dart' show log;
 import 'src/app_bootstrap.dart';
+import 'src/core/layout/app_layout.dart';
 import 'src/core/motion/onboarding_motion.dart';
 import 'src/core/theme/app_theme_host.dart';
 import 'src/core/theme/legacy_material_theme.dart';
@@ -37,6 +38,47 @@ import 'src/providers/theme_mode_provider.dart';
 import 'src/providers/app_security_provider.dart';
 import 'src/providers/router_refresh_provider.dart';
 import 'src/providers/wallet_provider.dart';
+import 'src/rust/frb_generated.dart';
+
+void log(String message) => debugPrint('[zcash] $message');
+
+Future<void> initializeZcashWalletRuntime() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  FlutterForegroundTask.initCommunicationPort();
+  log('runtime: initializing RustLib');
+  await RustLib.init();
+
+  // Order matters: window_manager creates and shows the NSWindow inside
+  // `initializeDesktopWindow`; the acrylic setup is only effective once
+  // that window exists.
+  log('runtime: initializing desktop window (no-op on mobile/web)');
+  await initializeDesktopWindow();
+  if (isDesktopLayoutPlatform) {
+    log('runtime: initializing desktop window visuals');
+    await DesktopWindowBootstrap.initialize();
+    await showDesktopWindow();
+  }
+}
+
+Future<Widget> buildBootstrappedZcashWalletApp() async {
+  final bootstrap = await loadAppBootstrap();
+  return buildZcashWalletApp(bootstrap: bootstrap);
+}
+
+Widget buildZcashWalletApp({required AppBootstrapState bootstrap}) {
+  return ProviderScope(
+    overrides: [appBootstrapProvider.overrideWithValue(bootstrap)],
+    child: const ZcashWalletApp(),
+  );
+}
+
+Future<void> runZcashWalletApp() async {
+  log('runtime: starting');
+  await initializeZcashWalletRuntime();
+  final app = await buildBootstrappedZcashWalletApp();
+  log('runtime: launching app');
+  runApp(app);
+}
 
 final _routerProvider = Provider<GoRouter>((ref) {
   final bootstrap = ref.watch(appBootstrapProvider);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,37 +1,5 @@
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_foreground_task/flutter_foreground_task.dart';
-import 'package:desktop_window_bootstrap/desktop_window_bootstrap.dart';
-
 import 'app.dart';
-import 'src/app_bootstrap.dart';
-import 'src/core/layout/app_layout.dart';
-import 'src/rust/frb_generated.dart';
 
-void log(String message) => debugPrint('[zcash] $message');
+export 'app.dart' show log;
 
-Future<void> main() async {
-  log('main: starting');
-  WidgetsFlutterBinding.ensureInitialized();
-  FlutterForegroundTask.initCommunicationPort();
-  log('main: initializing RustLib');
-  await RustLib.init();
-  // Order matters: window_manager creates and shows the NSWindow inside
-  // `initializeDesktopWindow`; the acrylic setup is only effective once
-  // that window exists.
-  log('main: initializing desktop window (no-op on mobile/web)');
-  await initializeDesktopWindow();
-  if (isDesktopLayoutPlatform) {
-    log('main: initializing desktop window visuals');
-    await DesktopWindowBootstrap.initialize();
-    await showDesktopWindow();
-  }
-  final bootstrap = await loadAppBootstrap();
-  log('main: launching app');
-  runApp(
-    ProviderScope(
-      overrides: [appBootstrapProvider.overrideWithValue(bootstrap)],
-      child: const ZcashWalletApp(),
-    ),
-  );
-}
+Future<void> main() => runZcashWalletApp();

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/foundation.dart' show kDebugMode, visibleForTesting;
 import 'package:flutter/material.dart' show ThemeMode;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
@@ -20,6 +20,10 @@ const _activeAccountKey = 'zcash_active_account';
 const _networkKey = 'zcash_wallet_network';
 const _backgroundSyncChannel = MethodChannel(
   'com.zcash.wallet/background_sync',
+);
+const _e2eNetworkOverride = String.fromEnvironment('ZCASH_E2E_NETWORK');
+const _e2eLightwalletdUrlOverride = String.fromEnvironment(
+  'ZCASH_E2E_LIGHTWALLETD_URL',
 );
 
 final appBootstrapProvider = Provider<AppBootstrapState>((_) {
@@ -151,6 +155,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
   try {
     log('bootstrap: loading startup snapshot');
     await storage.ensureWalletDbName();
+    await _applyE2eBootstrapOverrides(storage);
     var passwordRotationRecoveryFailed = false;
     try {
       await storage.recoverInterruptedPasswordRotation();
@@ -257,6 +262,30 @@ Future<AppBootstrapState> loadAppBootstrap() async {
     log('bootstrap: failed, falling back to welcome: $e');
     return AppBootstrapState.empty;
   }
+}
+
+Future<void> _applyE2eBootstrapOverrides(AppSecureStore storage) async {
+  final network = _e2eNetworkOverride.trim();
+  final lightwalletdUrl = _e2eLightwalletdUrlOverride.trim();
+  if (network.isEmpty && lightwalletdUrl.isEmpty) return;
+
+  if (!kDebugMode) {
+    log('bootstrap: ignoring E2E overrides outside debug mode');
+    return;
+  }
+
+  if (network.isNotEmpty) {
+    await storage.writeString(_networkKey, network);
+  }
+  if (lightwalletdUrl.isNotEmpty) {
+    await storage.writePlain(kRpcEndpointUrlKey, lightwalletdUrl);
+    await storage.writePlain(kRpcEndpointPresetKey, kCustomRpcEndpointPresetId);
+  }
+  log(
+    'bootstrap: applied E2E overrides '
+    'network=${network.isEmpty ? "(unchanged)" : network}, '
+    'lightwalletd=${lightwalletdUrl.isEmpty ? "(unchanged)" : lightwalletdUrl}',
+  );
 }
 
 @visibleForTesting

--- a/lib/src/core/config/network_config.dart
+++ b/lib/src/core/config/network_config.dart
@@ -1,52 +1,64 @@
 enum ZcashNetwork {
   mainnet,
-  testnet;
+  testnet,
+  regtest;
 
   String get name => switch (this) {
-        mainnet => 'main',
-        testnet => 'test',
-      };
+    mainnet => 'main',
+    testnet => 'test',
+    regtest => 'regtest',
+  };
 
   int get coinType => switch (this) {
-        mainnet => 133,
-        testnet => 1,
-      };
+    mainnet => 133,
+    testnet => 1,
+    regtest => 1,
+  };
 
   String get tAddrPrefix => switch (this) {
-        mainnet => 't1',
-        testnet => 'tm',
-      };
+    mainnet => 't1',
+    testnet => 'tm',
+    regtest => 'tm',
+  };
 
   String get saplingPrefix => switch (this) {
-        mainnet => 'zs',
-        testnet => 'ztestsapling',
-      };
+    mainnet => 'zs',
+    testnet => 'ztestsapling',
+    regtest => 'zregtestsapling',
+  };
 
   String get uaPrefix => switch (this) {
-        mainnet => 'u1',
-        testnet => 'utest1',
-      };
+    mainnet => 'u1',
+    testnet => 'utest1',
+    regtest => 'uregtest1',
+  };
 
   int get defaultPort => switch (this) {
-        mainnet => 9067,
-        testnet => 18232,
-      };
+    mainnet => 9067,
+    testnet => 18232,
+    regtest => 9067,
+  };
 
   String get lightwalletdHost => switch (this) {
-        mainnet => 'zec.rocks',
-        testnet => 'lightwalletd.testnet.electriccoin.co',
-      };
+    mainnet => 'zec.rocks',
+    testnet => 'lightwalletd.testnet.electriccoin.co',
+    regtest => '127.0.0.1',
+  };
 
   int get lightwalletdPort => switch (this) {
-        mainnet => 443,
-        testnet => 9067,
-      };
+    mainnet => 443,
+    testnet => 9067,
+    regtest => 9067,
+  };
 
-  String get lightwalletdUrl =>
-      'https://$lightwalletdHost:$lightwalletdPort';
+  String get lightwalletdUrl => switch (this) {
+    regtest => 'http://$lightwalletdHost:$lightwalletdPort',
+    _ => 'https://$lightwalletdHost:$lightwalletdPort',
+  };
 
   int get saplingActivationHeight => switch (this) {
-        mainnet => 419200,
-        testnet => 280000,
-      };
+    mainnet => 419200,
+    testnet => 280000,
+    regtest => 1,
+  };
 }

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -132,11 +132,22 @@ final kTestnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
   ),
 ]);
 
+final kRegtestRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
+  RpcEndpointPreset(
+    id: 'default-regtest',
+    region: 'Regtest',
+    label: 'Local Regtest',
+    url: ZcashNetwork.regtest.lightwalletdUrl,
+    isDefault: true,
+  ),
+]);
+
 List<RpcEndpointPreset> rpcEndpointPresetsForNetwork(String networkName) {
   final network = zcashNetworkFromName(networkName);
   return switch (network) {
     ZcashNetwork.mainnet => kMainnetRpcEndpointPresets,
     ZcashNetwork.testnet => kTestnetRpcEndpointPresets,
+    ZcashNetwork.regtest => kRegtestRpcEndpointPresets,
   };
 }
 
@@ -155,9 +166,11 @@ RpcEndpointConfig defaultRpcEndpointConfig(String networkName) {
 }
 
 ZcashNetwork zcashNetworkFromName(String networkName) {
-  return networkName == ZcashNetwork.testnet.name
-      ? ZcashNetwork.testnet
-      : ZcashNetwork.mainnet;
+  return switch (networkName) {
+    'test' => ZcashNetwork.testnet,
+    'regtest' => ZcashNetwork.regtest,
+    _ => ZcashNetwork.mainnet,
+  };
 }
 
 RpcEndpointPreset? findRpcEndpointPresetById(
@@ -229,7 +242,10 @@ String normalizeRpcEndpointUrl(
 
 bool _isLocalhost(String host) {
   final lower = host.toLowerCase();
-  return lower == 'localhost' || lower == '::1' || lower.startsWith('127.');
+  return lower == 'localhost' ||
+      lower == '::1' ||
+      lower == '10.0.2.2' ||
+      lower.startsWith('127.');
 }
 
 bool _hasExplicitPort(String url) {

--- a/lib/src/core/config/zcash_explorer.dart
+++ b/lib/src/core/config/zcash_explorer.dart
@@ -18,6 +18,7 @@ Uri zcashExplorerTransactionUri({
   final host = switch (network) {
     ZcashNetwork.mainnet => 'mainnet.zcashexplorer.app',
     ZcashNetwork.testnet => 'testnet.zcashexplorer.app',
+    ZcashNetwork.regtest => 'testnet.zcashexplorer.app',
   };
   return Uri.https(
     host,

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -132,6 +132,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                     child: Column(
                       children: [
                         AppSidebarItem(
+                          key: const ValueKey('sidebar_wallet_button'),
                           label: 'Wallet',
                           iconName: AppIcons.wallet,
                           active: _matches('/home'),
@@ -141,6 +142,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                         ),
                         const SizedBox(height: AppSpacing.xs),
                         AppSidebarItem(
+                          key: const ValueKey('sidebar_send_button'),
                           label: 'Send',
                           iconName: AppIcons.plane,
                           active: _matches('/send'),
@@ -150,6 +152,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                         ),
                         const SizedBox(height: AppSpacing.xs),
                         AppSidebarItem(
+                          key: const ValueKey('sidebar_receive_button'),
                           label: 'Receive',
                           iconName: AppIcons.arrowDownCircle,
                           active: _matches('/receive'),
@@ -278,6 +281,7 @@ class _SidebarAccountSelectorButton extends StatelessWidget {
       onEnter: (_) => onHoverChanged(true),
       onExit: (_) => onHoverChanged(false),
       child: GestureDetector(
+        key: const ValueKey('sidebar_account_selector_button'),
         behavior: HitTestBehavior.opaque,
         onTap: onTap,
         child: AnimatedContainer(
@@ -457,11 +461,13 @@ class _SidebarAccountRow extends StatelessWidget {
       ),
     );
 
+    final key = ValueKey('sidebar_account_row_${account.order}');
     return onTap == null
-        ? row
+        ? KeyedSubtree(key: key, child: row)
         : MouseRegion(
             cursor: SystemMouseCursors.click,
             child: GestureDetector(
+              key: key,
               behavior: HitTestBehavior.opaque,
               onTap: onTap,
               child: row,
@@ -480,6 +486,7 @@ class _SidebarCreateWalletRow extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) => Center(
         child: AppButton(
+          key: const ValueKey('sidebar_add_account_button'),
           onPressed: onTap,
           variant: AppButtonVariant.ghost,
           minWidth: constraints.maxWidth,

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -162,6 +162,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                         ),
                         const SizedBox(height: AppSpacing.xs),
                         AppSidebarItem(
+                          key: const ValueKey('sidebar_activity_button'),
                           label: 'Activity',
                           iconName: AppIcons.history,
                           active: _matches('/activity'),

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -3,7 +3,8 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:cryptography/cryptography.dart';
-import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
+import 'package:flutter/foundation.dart'
+    show debugPrint, kDebugMode, visibleForTesting;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../security/password_policy.dart';
@@ -20,6 +21,11 @@ const _passwordRotationInProgressKey = 'zcash_rotation_in_progress';
 const _passwordRotationRollbackFailedKind = 'rollbackFailed';
 const _accountMnemonicKeyPrefix = 'zcash_account_mnemonic_';
 const _secureStoreService = 'com.keplr.vizor.secure_store';
+const _e2eSecureStoreService = 'com.keplr.vizor.secure_store.e2e';
+const _useE2eStorage = bool.fromEnvironment('ZCASH_USE_E2E_STORAGE');
+
+@visibleForTesting
+const kE2eWalletDbName = 'zcash_wallet_e2e.db';
 
 class PasswordRotationRecoveryFailedException implements Exception {
   const PasswordRotationRecoveryFailedException();
@@ -30,26 +36,44 @@ class PasswordRotationRecoveryFailedException implements Exception {
 }
 
 class AppSecureStore {
-  AppSecureStore._({FlutterSecureStorage storage = _defaultStorage})
-    : _storage = storage;
+  AppSecureStore._({
+    FlutterSecureStorage? storage,
+    bool useE2eStorage = _useE2eStorage,
+  }) : isE2eStorage = kDebugMode && useE2eStorage,
+       _storage =
+           storage ??
+           _defaultStorage(useE2eStorage: kDebugMode && useE2eStorage);
 
   @visibleForTesting
-  AppSecureStore.testing({required FlutterSecureStorage storage})
-    : _storage = storage;
+  AppSecureStore.testing({
+    required FlutterSecureStorage storage,
+    bool useE2eStorage = false,
+  }) : isE2eStorage = useE2eStorage,
+       _storage = storage;
 
   static final AppSecureStore instance = AppSecureStore._();
 
-  static const _defaultStorage = FlutterSecureStorage(
-    iOptions: IOSOptions(
-      accountName: _secureStoreService,
-      accessibility: KeychainAccessibility.first_unlock,
-    ),
-    mOptions: MacOsOptions(
-      accountName: _secureStoreService,
-      accessibility: KeychainAccessibility.first_unlock,
-      usesDataProtectionKeychain: true,
-    ),
-  );
+  static FlutterSecureStorage _defaultStorage({required bool useE2eStorage}) {
+    final service = useE2eStorage
+        ? _e2eSecureStoreService
+        : _secureStoreService;
+    return FlutterSecureStorage(
+      iOptions: IOSOptions(
+        accountName: service,
+        accessibility: KeychainAccessibility.first_unlock,
+      ),
+      aOptions: useE2eStorage
+          ? AndroidOptions(sharedPreferencesName: service)
+          : AndroidOptions.defaultOptions,
+      mOptions: MacOsOptions(
+        accountName: service,
+        accessibility: KeychainAccessibility.first_unlock,
+        usesDataProtectionKeychain: true,
+      ),
+    );
+  }
+
+  final bool isE2eStorage;
 
   static final Cipher _cipher = AesGcm.with256bits();
   static final Pbkdf2 _kdf = Pbkdf2(
@@ -66,6 +90,11 @@ class AppSecureStore {
   bool get hasSessionPassword => _sessionPassword != null;
 
   Future<String> ensureWalletDbName() async {
+    if (isE2eStorage) {
+      await writePlain(kWalletDbNameKey, kE2eWalletDbName);
+      return kE2eWalletDbName;
+    }
+
     final existing = await readPlain(kWalletDbNameKey);
     if (existing != null && existing.isNotEmpty) {
       return existing;

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -416,6 +416,7 @@ class _ActivityPane extends StatelessWidget {
                     ),
                     child: ActivityTable(
                       rows: rows,
+                      rowKeyPrefix: 'activity_screen',
                       isLoading: isLoading,
                       errorText: errorText,
                       showPagination: true,

--- a/lib/src/features/activity/widgets/activity_table.dart
+++ b/lib/src/features/activity/widgets/activity_table.dart
@@ -17,6 +17,7 @@ class ActivityTable extends StatelessWidget {
     required this.rows,
     this.title,
     this.onTitleTap,
+    this.rowKeyPrefix,
     this.isLoading = false,
     this.errorText,
     this.emptyText = 'No activity yet',
@@ -31,6 +32,7 @@ class ActivityTable extends StatelessWidget {
   final List<ActivityRowData> rows;
   final String? title;
   final VoidCallback? onTitleTap;
+  final String? rowKeyPrefix;
   final bool isLoading;
   final String? errorText;
   final String emptyText;
@@ -69,7 +71,12 @@ class ActivityTable extends StatelessWidget {
               _ActivityTableMessage(text: emptyText)
             else
               for (var i = 0; i < rows.length; i++) ...[
-                ActivityTableRow(row: rows[i]),
+                ActivityTableRow(
+                  key: rowKeyPrefix == null
+                      ? null
+                      : ValueKey('${rowKeyPrefix}_row_$i'),
+                  row: rows[i],
+                ),
                 if (i != rows.length - 1) ...[
                   const SizedBox(height: AppSpacing.xs),
                   const _ActivityTableDivider(),

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -376,6 +376,7 @@ class _HomePaneState extends ConsumerState<_HomePane> {
                           child: ActivityTable(
                             rows: rows,
                             title: 'Recent Activity',
+                            rowKeyPrefix: 'home_activity',
                             isLoading: widget.isActivityLoading,
                             onTitleTap: () => context.push('/activity'),
                           ),

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -867,6 +867,9 @@ class _HomeBalanceCardState extends State<_HomeBalanceCard> {
                                               ),
                                               Text(
                                                 displayedShieldedBalance,
+                                                key: const ValueKey(
+                                                  'home_shielded_balance_text',
+                                                ),
                                                 style: AppTypography
                                                     .displayMedium
                                                     .copyWith(
@@ -1030,6 +1033,7 @@ class _HomeTransparentBalanceStrip extends StatelessWidget {
                     Flexible(
                       child: Text(
                         'Transparent balance: $displayedBalance',
+                        key: const ValueKey('home_transparent_balance_text'),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: AppTypography.labelLarge.copyWith(

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -358,6 +358,7 @@ class _ImportSecretPassphraseScreenState
                 ),
                 const SizedBox(height: AppSpacing.md),
                 AppButton(
+                  key: const ValueKey('import_secret_submit_button'),
                   onPressed: _canSubmit ? _submit : null,
                   minWidth: _buttonWidth,
                   trailing: const AppIcon(AppIcons.chevronForward),
@@ -718,32 +719,40 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
                             horizontal: AppSpacing.xs,
                           ),
                           child: Center(
-                            child: TextField(
-                              key: _textFieldRegionKey,
-                              controller: controller,
-                              focusNode: focusNode,
-                              autofocus: widget.autofocus,
-                              keyboardType: TextInputType.text,
-                              textInputAction: TextInputAction.next,
-                              autocorrect: false,
-                              enableSuggestions: false,
-                              inputFormatters: [
-                                FilteringTextInputFormatter.allow(
-                                  RegExp(r'[A-Za-z\s]'),
+                            child: KeyedSubtree(
+                              key: widget.index == 0
+                                  ? const ValueKey(
+                                      'import_mnemonic_first_word_field',
+                                    )
+                                  : null,
+                              child: TextField(
+                                key: _textFieldRegionKey,
+                                controller: controller,
+                                focusNode: focusNode,
+                                autofocus: widget.autofocus,
+                                keyboardType: TextInputType.text,
+                                textInputAction: TextInputAction.next,
+                                autocorrect: false,
+                                enableSuggestions: false,
+                                inputFormatters: [
+                                  FilteringTextInputFormatter.allow(
+                                    RegExp(r'[A-Za-z\s]'),
+                                  ),
+                                ],
+                                style: valueStyle,
+                                cursorColor: colors.text.accent,
+                                selectAllOnFocus: false,
+                                decoration: InputDecoration.collapsed(
+                                  hintText: 'Word',
+                                  hintStyle: AppTypography.labelLarge.copyWith(
+                                    color: colors.text.muted,
+                                  ),
                                 ),
-                              ],
-                              style: valueStyle,
-                              cursorColor: colors.text.accent,
-                              selectAllOnFocus: false,
-                              decoration: InputDecoration.collapsed(
-                                hintText: 'Word',
-                                hintStyle: AppTypography.labelLarge.copyWith(
-                                  color: colors.text.muted,
+                                onChanged: widget.onChanged,
+                                onSubmitted: (_) => _handleTextSubmitted(
+                                  onAutocompleteSubmitted,
                                 ),
                               ),
-                              onChanged: widget.onChanged,
-                              onSubmitted: (_) =>
-                                  _handleTextSubmitted(onAutocompleteSubmitted),
                             ),
                           ),
                         ),

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -437,6 +437,7 @@ class _ImportWalletBirthdayScreenState
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       AppButton(
+                        key: const ValueKey('import_birthday_submit_button'),
                         onPressed: _isSubmitEnabled ? _submit : null,
                         variant: AppButtonVariant.primary,
                         minWidth: _buttonWidth,
@@ -445,6 +446,7 @@ class _ImportWalletBirthdayScreenState
                       ),
                       const SizedBox(height: AppSpacing.xs),
                       AppButton(
+                        key: const ValueKey('import_birthday_skip_button'),
                         onPressed: _isSubmitting
                             ? null
                             : () => _submit(

--- a/lib/src/features/onboarding/shared/set_password_screen.dart
+++ b/lib/src/features/onboarding/shared/set_password_screen.dart
@@ -247,6 +247,9 @@ class _SetPasswordContent extends StatelessWidget {
                                 reserveMessageSpace:
                                     _fieldReservedMessageHeight,
                                 child: PasswordTextField(
+                                  key: const ValueKey(
+                                    'set_password_password_field',
+                                  ),
                                   label: 'Password',
                                   controller: passwordController,
                                   messageText: passwordMessage,
@@ -266,6 +269,9 @@ class _SetPasswordContent extends StatelessWidget {
                                 reserveMessageSpace:
                                     _fieldReservedMessageHeight,
                                 child: PasswordTextField(
+                                  key: const ValueKey(
+                                    'set_password_confirm_field',
+                                  ),
                                   label: 'Confirm Password',
                                   controller: confirmController,
                                   messageText: confirmMessage,
@@ -307,6 +313,7 @@ class _SetPasswordContent extends StatelessWidget {
                       ),
                     ],
                     AppButton(
+                      key: const ValueKey('set_password_submit_button'),
                       onPressed: canSubmit ? onSubmit : null,
                       variant: AppButtonVariant.primary,
                       minWidth: _buttonWidth,

--- a/lib/src/features/onboarding/welcome.dart
+++ b/lib/src/features/onboarding/welcome.dart
@@ -294,6 +294,7 @@ class _ButtonsStack extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         AppButton(
+          key: const ValueKey('welcome_create_wallet_button'),
           onPressed: () => context.go('/onboarding/intro'),
           variant: AppButtonVariant.primary,
           minWidth: _welcomeActionWidth,
@@ -302,6 +303,7 @@ class _ButtonsStack extends StatelessWidget {
         ),
         const SizedBox(height: AppSpacing.s),
         AppButton(
+          key: const ValueKey('welcome_import_wallet_button'),
           onPressed: () => context.go('/import'),
           variant: AppButtonVariant.secondary,
           minWidth: _welcomeActionWidth,

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -354,6 +354,11 @@ class _ReceivePane extends StatelessWidget {
                       ),
                       const SizedBox(height: AppSpacing.sm),
                       _CopyAddressButton(
+                        key: ValueKey(
+                          _isShielded
+                              ? 'receive_copy_shielded_address_button'
+                              : 'receive_copy_transparent_address_button',
+                        ),
                         label: _isShielded
                             ? 'Copy Shielded Address'
                             : 'Copy Transparent Address',
@@ -1243,6 +1248,7 @@ class _CopyAddressButton extends StatelessWidget {
     required this.primary,
     required this.enabled,
     required this.onTap,
+    super.key,
   });
 
   final String label;

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -226,6 +226,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
                     SizedBox(
                       width: 256,
                       child: AppButton(
+                        key: const ValueKey('send_confirm_button'),
                         onPressed: _handleSend,
                         variant: AppButtonVariant.primary,
                         minWidth: 256,

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -752,6 +752,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                   child: _SendComposeLayout(
                     messageFieldVisible: messageFieldVisible,
                     reviewButton: AppButton(
+                      key: const ValueKey('send_review_button'),
                       onPressed: _canReview ? _openReview : null,
                       variant: AppButtonVariant.primary,
                       minWidth: 256,
@@ -770,6 +771,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         AppTextField(
+                          key: const ValueKey('send_address_field'),
                           label: 'Send to',
                           tone: addressTone,
                           focusNode: _addressFocusNode,
@@ -810,6 +812,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                         const SizedBox(height: _singleLineFieldOverlayReserve),
                         const SizedBox(height: _singleLineFieldGap),
                         AppTextField(
+                          key: const ValueKey('send_amount_field'),
                           label: 'Amount',
                           tone: _showAmountError
                               ? AppTextFieldTone.destructive

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -473,6 +473,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
                           child: Align(
                             alignment: Alignment.centerLeft,
                             child: TransactionReceiptView(
+                              key: ValueKey('send_status_${receiptPhase.name}'),
                               phase: receiptPhase,
                               amountText: _formatReceiptAmount(
                                 widget.args.amountZatoshi,

--- a/rust/examples/regtest_wallet_addresses.rs
+++ b/rust/examples/regtest_wallet_addresses.rs
@@ -1,0 +1,37 @@
+use rust_lib_zcash_wallet::api::wallet;
+use serde_json::json;
+
+fn main() {
+    let mnemonic = std::env::args()
+        .nth(1)
+        .expect("usage: cargo run --example regtest_wallet_addresses -- <mnemonic>");
+
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let db_path = tempdir.path().join("zcash_wallet.db");
+    let db_path = db_path.to_str().expect("utf-8 db path").to_string();
+
+    let result = wallet::import_wallet(
+        mnemonic,
+        Some(1),
+        "regtest".to_string(),
+        db_path.clone(),
+        Some("E2E Account".to_string()),
+    )
+    .expect("import regtest wallet");
+
+    let transparent_address = wallet::get_transparent_address(
+        db_path,
+        "regtest".to_string(),
+        Some(result.account_uuid.clone()),
+    )
+    .expect("transparent address");
+
+    println!(
+        "{}",
+        json!({
+            "accountUuid": result.account_uuid,
+            "unifiedAddress": result.unified_address,
+            "transparentAddress": transparent_address,
+        })
+    );
+}

--- a/scripts/e2e/flutter-macos-regtest-full.sh
+++ b/scripts/e2e/flutter-macos-regtest-full.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-RESET_EACH_TEST="${E2E_RESET_EACH_TEST:-1}"
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -17,7 +16,7 @@ run_test() {
 
   echo
   echo "==> ${name}"
-  RESET_REGTEST="$RESET_EACH_TEST" "$ROOT_DIR/$script"
+  RESET_REGTEST=1 "$ROOT_DIR/$script"
 }
 
 require_cmd cargo

--- a/scripts/e2e/flutter-macos-regtest-full.sh
+++ b/scripts/e2e/flutter-macos-regtest-full.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RESET_EACH_TEST="${E2E_RESET_EACH_TEST:-1}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+run_test() {
+  local name="$1"
+  local script="$2"
+
+  echo
+  echo "==> ${name}"
+  RESET_REGTEST="$RESET_EACH_TEST" "$ROOT_DIR/$script"
+}
+
+require_cmd cargo
+require_cmd docker
+require_cmd fvm
+require_cmd python3
+
+cd "$ROOT_DIR"
+
+# Keep this ordered from the narrowest smoke test to broader user flows.
+run_test "1/2 import funded wallet and sync balances" \
+  "scripts/e2e/flutter-macos-regtest-import-sync.sh"
+
+run_test "2/2 import two accounts and send shielded funds" \
+  "scripts/e2e/flutter-macos-regtest-multi-account-send.sh"
+
+echo
+echo "all macOS regtest E2E tests passed"

--- a/scripts/e2e/flutter-macos-regtest-import-sync.sh
+++ b/scripts/e2e/flutter-macos-regtest-import-sync.sh
@@ -54,4 +54,5 @@ fvm flutter test \
   integration_test/regtest_import_sync_test.dart \
   -d "$FLUTTER_DEVICE" \
   --dart-define=ZCASH_E2E_NETWORK=regtest \
-  --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$LIGHTWALLETD_URL"
+  --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$LIGHTWALLETD_URL" \
+  --dart-define=ZCASH_USE_E2E_STORAGE=true

--- a/scripts/e2e/flutter-macos-regtest-import-sync.sh
+++ b/scripts/e2e/flutter-macos-regtest-import-sync.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-MNEMONIC="${E2E_MNEMONIC:-winter shiver fetch refuse absurd mail pistol eight market lounge manual roast miracle ethics found child scare curve congress renew salute pig better used}"
-SHIELDED_AMOUNT="${E2E_SHIELDED_ZEC:-1.25}"
-TRANSPARENT_AMOUNT="${E2E_TRANSPARENT_ZEC:-0.75}"
+MNEMONIC="winter shiver fetch refuse absurd mail pistol eight market lounge manual roast miracle ethics found child scare curve congress renew salute pig better used"
+SHIELDED_AMOUNT="1.25"
+TRANSPARENT_AMOUNT="0.75"
 CONFIRMING_BLOCKS="${E2E_CONFIRMING_BLOCKS:-10}"
 LIGHTWALLETD_URL="${E2E_LIGHTWALLETD_URL:-http://127.0.0.1:9067}"
 FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"

--- a/scripts/e2e/flutter-macos-regtest-import-sync.sh
+++ b/scripts/e2e/flutter-macos-regtest-import-sync.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MNEMONIC="${E2E_MNEMONIC:-winter shiver fetch refuse absurd mail pistol eight market lounge manual roast miracle ethics found child scare curve congress renew salute pig better used}"
+SHIELDED_AMOUNT="${E2E_SHIELDED_ZEC:-1.25}"
+TRANSPARENT_AMOUNT="${E2E_TRANSPARENT_ZEC:-0.75}"
+CONFIRMING_BLOCKS="${E2E_CONFIRMING_BLOCKS:-10}"
+LIGHTWALLETD_URL="${E2E_LIGHTWALLETD_URL:-http://127.0.0.1:9067}"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+json_field() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+data = json.loads(sys.argv[1])
+print(data[sys.argv[2]])
+PY
+}
+
+require_cmd cargo
+require_cmd docker
+require_cmd fvm
+require_cmd python3
+
+cd "$ROOT_DIR"
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+addresses_json="$(cd rust && cargo run --quiet --example regtest_wallet_addresses -- "$MNEMONIC")"
+unified_address="$(json_field "$addresses_json" unifiedAddress)"
+transparent_address="$(json_field "$addresses_json" transparentAddress)"
+
+echo "funding shielded address with ${SHIELDED_AMOUNT} ZEC"
+scripts/regtest/fund-wallet.sh "$unified_address" "$SHIELDED_AMOUNT" "$CONFIRMING_BLOCKS" >/dev/null
+
+echo "funding transparent address with ${TRANSPARENT_AMOUNT} ZEC"
+scripts/regtest/fund-wallet.sh "$transparent_address" "$TRANSPARENT_AMOUNT" "$CONFIRMING_BLOCKS" >/dev/null
+
+echo "running Flutter macOS integration test"
+fvm flutter test \
+  integration_test/regtest_import_sync_test.dart \
+  -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_E2E_NETWORK=regtest \
+  --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$LIGHTWALLETD_URL"

--- a/scripts/e2e/flutter-macos-regtest-multi-account-send.sh
+++ b/scripts/e2e/flutter-macos-regtest-multi-account-send.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-MNEMONIC="${E2E_MNEMONIC:-winter shiver fetch refuse absurd mail pistol eight market lounge manual roast miracle ethics found child scare curve congress renew salute pig better used}"
-SHIELDED_AMOUNT="${E2E_SHIELDED_ZEC:-1.25}"
-TRANSPARENT_AMOUNT="${E2E_TRANSPARENT_ZEC:-0.75}"
+MNEMONIC="winter shiver fetch refuse absurd mail pistol eight market lounge manual roast miracle ethics found child scare curve congress renew salute pig better used"
+SHIELDED_AMOUNT="1.25"
+TRANSPARENT_AMOUNT="0.75"
 CONFIRMING_BLOCKS="${E2E_CONFIRMING_BLOCKS:-10}"
 LIGHTWALLETD_URL="${E2E_LIGHTWALLETD_URL:-http://127.0.0.1:9067}"
 ZCASHD_RPC_URL="${E2E_ZCASHD_RPC_URL:-http://127.0.0.1:18232}"

--- a/scripts/e2e/flutter-macos-regtest-multi-account-send.sh
+++ b/scripts/e2e/flutter-macos-regtest-multi-account-send.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MNEMONIC="${E2E_MNEMONIC:-winter shiver fetch refuse absurd mail pistol eight market lounge manual roast miracle ethics found child scare curve congress renew salute pig better used}"
+SHIELDED_AMOUNT="${E2E_SHIELDED_ZEC:-1.25}"
+TRANSPARENT_AMOUNT="${E2E_TRANSPARENT_ZEC:-0.75}"
+CONFIRMING_BLOCKS="${E2E_CONFIRMING_BLOCKS:-10}"
+LIGHTWALLETD_URL="${E2E_LIGHTWALLETD_URL:-http://127.0.0.1:9067}"
+ZCASHD_RPC_URL="${E2E_ZCASHD_RPC_URL:-http://127.0.0.1:18232}"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+json_field() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+data = json.loads(sys.argv[1])
+print(data[sys.argv[2]])
+PY
+}
+
+require_cmd cargo
+require_cmd docker
+require_cmd fvm
+require_cmd python3
+
+cd "$ROOT_DIR"
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+addresses_json="$(cd rust && cargo run --quiet --example regtest_wallet_addresses -- "$MNEMONIC")"
+unified_address="$(json_field "$addresses_json" unifiedAddress)"
+transparent_address="$(json_field "$addresses_json" transparentAddress)"
+
+echo "funding shielded address with ${SHIELDED_AMOUNT} ZEC"
+scripts/regtest/fund-wallet.sh "$unified_address" "$SHIELDED_AMOUNT" "$CONFIRMING_BLOCKS" >/dev/null
+
+echo "funding transparent address with ${TRANSPARENT_AMOUNT} ZEC"
+scripts/regtest/fund-wallet.sh "$transparent_address" "$TRANSPARENT_AMOUNT" "$CONFIRMING_BLOCKS" >/dev/null
+
+echo "running Flutter macOS multi-account send integration test"
+fvm flutter test \
+  integration_test/regtest_multi_account_send_test.dart \
+  -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_E2E_NETWORK=regtest \
+  --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$LIGHTWALLETD_URL" \
+  --dart-define=ZCASH_E2E_ZCASHD_RPC_URL="$ZCASHD_RPC_URL" \
+  --dart-define=ZCASH_USE_E2E_STORAGE=true

--- a/scripts/regtest/fund-wallet.sh
+++ b/scripts/regtest/fund-wallet.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
-destination="${1:?usage: fund-wallet.sh <unified-address> [zec-amount] [confirming-blocks]}"
+destination="${1:?usage: fund-wallet.sh <destination-address> [zec-amount] [confirming-blocks]}"
 requested_amount="${2:-1.0}"
 confirming_blocks="${3:-10}"
 
@@ -28,7 +28,12 @@ print(json.dumps([{"address": sys.argv[1], "amount": float(sys.argv[2])}]))
 PY
 )"
 
-opid="$(extract_opid "$(zcash_cli z_sendmany "$faucet_zaddr" "$recipients" 1 0.0001 AllowRevealedAmounts)")"
+privacy_policy="AllowRevealedAmounts"
+if [[ "$destination" == t* ]]; then
+  privacy_policy="AllowRevealedRecipients"
+fi
+
+opid="$(extract_opid "$(zcash_cli z_sendmany "$faucet_zaddr" "$recipients" 1 0.0001 "$privacy_policy")")"
 txid="$(wait_for_operation "$opid")"
 zcash_cli generate "$confirming_blocks" >/dev/null
 wait_for_lightwalletd_tip "$(zcash_cli getblockcount)"

--- a/scripts/regtest/up.sh
+++ b/scripts/regtest/up.sh
@@ -5,6 +5,8 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
 mkdir -p "$STATE_DIR/zcashd" "$STATE_DIR/lightwalletd"
 chmod 0777 "$STATE_DIR/zcashd" "$STATE_DIR/lightwalletd"
+sync
+sleep 1
 compose up -d zcashd lightwalletd
 wait_for_zcashd
 wait_for_lightwalletd

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -48,6 +48,13 @@ void main() {
       );
     });
 
+    test('allows Android emulator host as local http in debug mode', () {
+      expect(
+        normalizeRpcEndpointUrl('http://10.0.2.2:9067'),
+        'http://10.0.2.2:9067',
+      );
+    });
+
     test('preserves bracketed IPv6 host formatting', () {
       expect(
         normalizeRpcEndpointUrl('https://[::1]:9067'),
@@ -116,6 +123,21 @@ void main() {
       );
 
       expect(preset, isNull);
+    });
+
+    test('includes a local regtest default preset', () {
+      final defaultEndpoint = defaultRpcEndpointConfig('regtest');
+
+      expect(defaultEndpoint.networkName, 'regtest');
+      expect(defaultEndpoint.lightwalletdUrl, 'http://127.0.0.1:9067');
+      expect(defaultEndpoint.presetId, 'default-regtest');
+      expect(
+        findRpcEndpointPresetByUrl(
+          'http://127.0.0.1:9067',
+          networkName: 'regtest',
+        )?.id,
+        'default-regtest',
+      );
     });
   });
 

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -32,6 +32,22 @@ void main() {
     await store.deleteAll();
   });
 
+  test('E2E storage uses a fixed wallet DB name', () async {
+    final e2eStore = AppSecureStore.testing(
+      storage: const FlutterSecureStorage(),
+      useE2eStorage: true,
+    );
+
+    final dbName = await e2eStore.ensureWalletDbName();
+
+    expect(e2eStore.isE2eStorage, isTrue);
+    expect(dbName, kE2eWalletDbName);
+    expect(
+      await const FlutterSecureStorage().read(key: kWalletDbNameKey),
+      kE2eWalletDbName,
+    );
+  });
+
   test('changePassword rotates mnemonic payloads and verifier', () async {
     await store.configurePassword(_oldPassword);
     await store.writeSecretString(_mnemonicKey, _mnemonic);

--- a/test/zcash_explorer_test.dart
+++ b/test/zcash_explorer_test.dart
@@ -28,6 +28,19 @@ void main() {
     );
   });
 
+  test('uses testnet explorer host for regtest transaction links', () {
+    expect(
+      zcashExplorerTransactionUri(
+        networkName: 'regtest',
+        txidHex:
+            '6088ad5facf418b825ab83b421af13a444173627b56d626f586976b9a9c8733b',
+        txidOrder: ZcashExplorerTxidOrder.protocol,
+      ).toString(),
+      'https://testnet.zcashexplorer.app/transactions/'
+      '3b73c8a9b97669586f626db527361744a413af21b483ab25b818f4ac5fad8860',
+    );
+  });
+
   test('builds URL for a shielded protocol-order transaction', () {
     expect(
       zcashExplorerTransactionUri(


### PR DESCRIPTION
## Summary
- Add macOS Flutter integration tests for regtest import/sync and multi-account shielded send flows.
- Add fixed E2E storage isolation and debug-only regtest/lightwalletd bootstrap overrides.
- Add regtest funding helpers and a full E2E runner ordered from simpler to broader flows.

## Validation
- `fvm dart analyze lib integration_test test`
- `scripts/e2e/flutter-macos-regtest-full.sh`