### PR TITLE
Handle wallet-relevant mempool transactions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -578,6 +578,12 @@ Important desktop design rule:
 - Rust unit tests: `cd rust && cargo test` — 11 tests covering key derivation, address encoding / Orchard-only UA derivation, determinism, and PROPOSAL_STORE lifecycle (idempotent discard, consume-on-entry, replay rejection). Tests that need a DB use `tempfile::tempdir()`.
 - Dart unit tests: `fvm flutter test`
 - Integration tests: `fvm flutter test integration_test/` (requires device/simulator)
+- Flutter regtest E2E notes:
+  - Run app tests with `--dart-define=ZCASH_DEFAULT_NETWORK=regtest`; do not use the old `ZCASH_USE_E2E_STORAGE` path. Secure storage and wallet DB names are network-scoped.
+  - Cleanup code should guard on `kZcashDefaultNetworkName == ZcashNetwork.regtest.name`, then delete `getWalletDbName()` plus its `-shm` / `-wal` files.
+  - Use `ZCASH_E2E_LIGHTWALLETD_URL` only as the endpoint override, and keep Rust API calls on the same network as `kZcashDefaultNetworkName`.
+  - Mempool receive E2E should use external zcashd/lightwalletd funding when testing true inbound tx discovery, not another in-app account.
+  - To prove mempool behavior while sync is active, pre-mine enough regtest blocks and pass the debug-only Rust throttle env vars inline: `ZCASH_E2E_SYNC_BATCH_SIZE` and `ZCASH_E2E_SYNC_BATCH_DELAY_MS`.
 - Zcash regtest Rust integration tests:
   - One-shot runner from repo root: `./run-regtest-rust-tests.sh`
   - The runner always starts by tearing down any existing regtest containers and resetting `.regtest/`, so each run starts from the same clean chain/wallet state.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -578,6 +578,12 @@ Important desktop design rule:
 - Rust unit tests: `cd rust && cargo test` — 11 tests covering key derivation, address encoding / Orchard-only UA derivation, determinism, and PROPOSAL_STORE lifecycle (idempotent discard, consume-on-entry, replay rejection). Tests that need a DB use `tempfile::tempdir()`.
 - Dart unit tests: `fvm flutter test`
 - Integration tests: `fvm flutter test integration_test/` (requires device/simulator)
+- Flutter regtest E2E notes:
+  - Run app tests with `--dart-define=ZCASH_DEFAULT_NETWORK=regtest`; do not use the old `ZCASH_USE_E2E_STORAGE` path. Secure storage and wallet DB names are network-scoped.
+  - Cleanup code should guard on `kZcashDefaultNetworkName == ZcashNetwork.regtest.name`, then delete `getWalletDbName()` plus its `-shm` / `-wal` files.
+  - Use `ZCASH_E2E_LIGHTWALLETD_URL` only as the endpoint override, and keep Rust API calls on the same network as `kZcashDefaultNetworkName`.
+  - Mempool receive E2E should use external zcashd/lightwalletd funding when testing true inbound tx discovery, not another in-app account.
+  - To prove mempool behavior while sync is active, pre-mine enough regtest blocks and pass the debug-only Rust throttle env vars inline: `ZCASH_E2E_SYNC_BATCH_SIZE` and `ZCASH_E2E_SYNC_BATCH_DELAY_MS`.
 - Zcash regtest Rust integration tests:
   - One-shot runner from repo root: `./run-regtest-rust-tests.sh`
   - The runner always starts by tearing down any existing regtest containers and resetting `.regtest/`, so each run starts from the same clean chain/wallet state.

--- a/docker-compose.zcash-regtest-expiry.yml
+++ b/docker-compose.zcash-regtest-expiry.yml
@@ -1,0 +1,8 @@
+services:
+  zcashd:
+    command:
+      - "-printtoconsole"
+      - "-conf=/etc/zcash/zcash-expiry.conf"
+      - "-datadir=/var/lib/zcash/.zcash"
+    volumes:
+      - ./scripts/regtest/zcash-expiry.conf:/etc/zcash/zcash-expiry.conf:ro

--- a/integration_test/regtest_mempool_receive_history_test.dart
+++ b/integration_test/regtest_mempool_receive_history_test.dart
@@ -1,0 +1,491 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
+
+const _network = String.fromEnvironment(
+  'ZCASH_E2E_NETWORK',
+  defaultValue: 'regtest',
+);
+const _driverUrl = String.fromEnvironment(
+  'ZCASH_E2E_DRIVER_URL',
+  defaultValue: 'http://127.0.0.1:39067',
+);
+const _firstMnemonic =
+    'winter shiver fetch refuse absurd mail pistol eight market lounge manual '
+    'roast miracle ethics found child scare curve congress renew salute pig '
+    'better used';
+const _password = 'Vizor123!';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeZcashWalletRuntime();
+  });
+
+  testWidgets(
+    'shows shielded receives from the mempool before mining',
+    (tester) async {
+      addTearDown(() async {
+        await _cleanupE2eWalletState();
+      });
+
+      await _cleanupE2eWalletState();
+
+      _log('pumping app');
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+
+      await _importFirstWallet(tester);
+      await _waitForMempoolObserver();
+
+      _log('copying first account shielded address');
+      final firstAddress = await _copyActiveShieldedAddress(tester);
+      expect(firstAddress, startsWith('uregtest1'));
+      final firstAccountUuid = await _accountUuidAtOrder(0);
+      await _openWallet(tester);
+
+      final txid = await _fundUnmined(firstAddress, '0.25');
+      _log('external unmined funding txid=$txid');
+      await _waitForHistoryTx(
+        tester,
+        accountUuid: firstAccountUuid,
+        txidHex: txid,
+        txKind: 'receiving',
+        displayAmount: BigInt.from(25_000_000),
+      );
+      await _expectActivityRow(
+        tester,
+        const ValueKey('home_activity_row_1'),
+        title: 'Receiving',
+        amount: '+0.25 ZEC',
+        status: 'In progress',
+        timeout: const Duration(minutes: 4),
+      );
+
+      await _mineRegtestBlocks(10);
+      await _expectActivityRow(
+        tester,
+        const ValueKey('home_activity_row_1'),
+        title: 'Received',
+        amount: '+0.25 ZEC',
+        status: 'Completed',
+        timeout: const Duration(minutes: 4),
+      );
+      _expectNoActivityRow(
+        tester,
+        rowKeyPrefix: 'home_activity',
+        title: 'Receiving',
+        amount: '+0.25 ZEC',
+        status: 'In progress',
+      );
+      await _openActivity(tester);
+      await _expectActivityRow(
+        tester,
+        const ValueKey('activity_screen_row_1'),
+        title: 'Received',
+        amount: '+0.25 ZEC',
+        status: 'Completed',
+        timeout: const Duration(minutes: 2),
+      );
+      _expectNoActivityRow(
+        tester,
+        rowKeyPrefix: 'activity_screen',
+        title: 'Receiving',
+        amount: '+0.25 ZEC',
+        status: 'In progress',
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 10)),
+  );
+}
+
+Future<void> _importFirstWallet(WidgetTester tester) async {
+  _log('importing first wallet');
+  await _tapAppButton(tester, const ValueKey('welcome_import_wallet_button'));
+  await _enterText(
+    tester,
+    const ValueKey('import_mnemonic_first_word_field'),
+    _firstMnemonic,
+  );
+  await _tapAppButton(tester, const ValueKey('import_secret_submit_button'));
+  await _tapAppButton(tester, const ValueKey('import_birthday_skip_button'));
+  await _enterText(
+    tester,
+    const ValueKey('set_password_password_field'),
+    _password,
+  );
+  await _enterText(
+    tester,
+    const ValueKey('set_password_confirm_field'),
+    _password,
+  );
+  await _tapAppButton(tester, const ValueKey('set_password_submit_button'));
+  await _waitForHome(tester);
+  _log('first wallet imported');
+}
+
+Future<String> _copyActiveShieldedAddress(WidgetTester tester) async {
+  await _tapWidget(tester, const ValueKey('sidebar_receive_button'));
+  await _pumpUntil(
+    tester,
+    () => tester.any(
+      find.byKey(const ValueKey('receive_copy_shielded_address_button')),
+    ),
+    description: 'shielded receive copy button',
+  );
+  await _tapWidget(
+    tester,
+    const ValueKey('receive_copy_shielded_address_button'),
+  );
+  final data = await Clipboard.getData('text/plain');
+  final address = data?.text?.trim() ?? '';
+  if (address.isEmpty) {
+    fail('Shielded address was not copied to the clipboard.');
+  }
+  return address;
+}
+
+Future<String> _fundUnmined(String address, String amount) async {
+  _log('requesting external unmined funding of $amount ZEC to $address');
+  final response = await _postDriver('/fund-unmined', {
+    'address': address,
+    'amount': amount,
+  }, timeout: const Duration(minutes: 5));
+  final txid = response['txid'] as String? ?? '';
+  if (txid.isEmpty) fail('E2E driver did not return a txid.');
+  return txid;
+}
+
+Future<void> _mineRegtestBlocks(int blocks) async {
+  _log('requesting external mining of $blocks regtest blocks');
+  await _postDriver('/mine', {'blocks': blocks});
+}
+
+Future<Map<String, Object?>> _postDriver(
+  String path,
+  Map<String, Object?> payload, {
+  Duration timeout = const Duration(minutes: 2),
+}) async {
+  final client = HttpClient();
+  try {
+    final request = await client
+        .postUrl(Uri.parse('$_driverUrl$path'))
+        .timeout(timeout);
+    final bodyBytes = utf8.encode(jsonEncode(payload));
+    request.headers.contentType = ContentType.json;
+    request.contentLength = bodyBytes.length;
+    request.add(bodyBytes);
+
+    final response = await request.close().timeout(timeout);
+    final body = await utf8.decoder.bind(response).join().timeout(timeout);
+    if (response.statusCode != HttpStatus.ok) {
+      throw StateError(
+        'E2E driver $path failed: HTTP '
+        '${response.statusCode}\n$body',
+      );
+    }
+    final decoded = jsonDecode(body) as Map<String, Object?>;
+    return decoded;
+  } finally {
+    client.close(force: true);
+  }
+}
+
+Future<void> _openWallet(WidgetTester tester) async {
+  await _tapWidget(tester, const ValueKey('sidebar_wallet_button'));
+  await _waitForHome(tester);
+}
+
+Future<void> _openActivity(WidgetTester tester) async {
+  await _tapWidget(tester, const ValueKey('sidebar_activity_button'));
+  await _pumpUntil(
+    tester,
+    () => tester.any(find.byKey(const ValueKey('activity_screen_row_0'))),
+    description: 'activity screen rows to render',
+    timeout: const Duration(minutes: 1),
+  );
+}
+
+Future<void> _waitForHome(WidgetTester tester) async {
+  await _pumpUntil(
+    tester,
+    () => tester.any(find.byKey(const ValueKey('home_shielded_balance_text'))),
+    description: 'home balance card to render',
+    timeout: const Duration(minutes: 1),
+  );
+}
+
+Future<void> _waitForMempoolObserver() async {
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  while (DateTime.now().isBefore(deadline)) {
+    if (rust_sync.isMempoolObserverRunning()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+  fail('Timed out waiting for mempool observer to run.');
+}
+
+Future<String> _accountUuidAtOrder(int order) async {
+  final dbPath = await getWalletDbPath();
+  final accounts = await rust_wallet.listAccounts(
+    dbPath: dbPath,
+    network: _network,
+  );
+  if (order >= accounts.length) {
+    fail('Expected account order $order, got ${accounts.length} accounts.');
+  }
+  return accounts[order].uuid;
+}
+
+Future<void> _waitForHistoryTx(
+  WidgetTester tester, {
+  required String accountUuid,
+  required String txidHex,
+  required String txKind,
+  required BigInt displayAmount,
+}) async {
+  final dbPath = await getWalletDbPath();
+  final deadline = DateTime.now().add(const Duration(minutes: 2));
+  Object? lastError;
+  var lastHistorySummary = '<not read>';
+  final acceptedTxids = {txidHex, _reverseTxidHex(txidHex)};
+
+  while (DateTime.now().isBefore(deadline)) {
+    try {
+      final history = await rust_sync.getTransactionHistory(
+        dbPath: dbPath,
+        network: _network,
+        limit: 20,
+        accountUuid: accountUuid,
+      );
+      lastHistorySummary = history
+          .map(
+            (tx) =>
+                '${tx.txidHex}:${tx.txKind}:${tx.displayAmount}:'
+                'mined=${tx.minedHeight}:expired=${tx.expiredUnmined}',
+          )
+          .join(', ');
+      if (history.any(
+        (tx) =>
+            acceptedTxids.contains(tx.txidHex) &&
+            tx.txKind == txKind &&
+            tx.displayAmount == displayAmount &&
+            tx.minedHeight == BigInt.zero &&
+            !tx.expiredUnmined,
+      )) {
+        _log('history matched pending $txKind tx $txidHex');
+        return;
+      }
+    } catch (e) {
+      lastError = e;
+    }
+
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail(
+    'Timed out waiting for pending history tx $txidHex. '
+    'Observed history: $lastHistorySummary.$error',
+  );
+}
+
+String _reverseTxidHex(String txidHex) {
+  final pairs = <String>[];
+  for (var i = 0; i + 1 < txidHex.length; i += 2) {
+    pairs.add(txidHex.substring(i, i + 2));
+  }
+  return pairs.reversed.join();
+}
+
+Future<void> _expectActivityRow(
+  WidgetTester tester,
+  Key key, {
+  required String title,
+  required String amount,
+  required String status,
+  Duration timeout = const Duration(minutes: 2),
+}) async {
+  await _pumpUntil(
+    tester,
+    () {
+      final texts = _textSetIn(tester, find.byKey(key));
+      return texts.contains(title) &&
+          texts.contains(amount) &&
+          texts.contains(status);
+    },
+    description: '$key activity row to show $title $amount $status',
+    timeout: timeout,
+  );
+  _log('activity row matched: $title $amount $status');
+}
+
+void _expectNoActivityRow(
+  WidgetTester tester, {
+  required String rowKeyPrefix,
+  required String title,
+  required String amount,
+  required String status,
+}) {
+  for (var i = 0; i < 10; i++) {
+    final key = ValueKey('${rowKeyPrefix}_row_$i');
+    final texts = _textSetIn(tester, find.byKey(key));
+    if (texts.contains(title) &&
+        texts.contains(amount) &&
+        texts.contains(status)) {
+      fail('Unexpected stale activity row $key: $title $amount $status');
+    }
+  }
+  _log('no stale activity row matched: $title $amount $status');
+}
+
+Future<void> _cleanupE2eWalletState() async {
+  final storage = AppSecureStore.instance;
+  if (!storage.isE2eStorage) {
+    throw StateError(
+      'Refusing to clean wallet state without ZCASH_USE_E2E_STORAGE.',
+    );
+  }
+
+  _log('cleaning E2E wallet state');
+  await _stopRustWorkForCleanup();
+
+  await storage.deleteAll();
+
+  final supportDir = await getWalletSupportDirectory();
+  if (!supportDir.existsSync()) return;
+
+  for (final name in [
+    kE2eWalletDbName,
+    '$kE2eWalletDbName-shm',
+    '$kE2eWalletDbName-wal',
+  ]) {
+    final file = File('${supportDir.path}${Platform.pathSeparator}$name');
+    if (file.existsSync()) file.deleteSync();
+  }
+}
+
+Future<void> _stopRustWorkForCleanup() async {
+  rust_sync.setSyncMode(mode: 0);
+  rust_sync.cancelFullSync();
+  rust_sync.stopMempoolObserver();
+
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  while ((rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) &&
+      DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  if (rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) {
+    _log(
+      'timed out waiting for Rust work to stop; continuing E2E storage cleanup',
+    );
+  }
+}
+
+Future<void> _tapAppButton(
+  WidgetTester tester,
+  Key key, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () =>
+        tester.any(finder) &&
+        tester.widget<AppButton>(finder).onPressed != null,
+    description: '$key button to be enabled',
+    timeout: timeout,
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _tapWidget(
+  WidgetTester tester,
+  Key key, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () => tester.any(finder),
+    description: '$key widget to render',
+    timeout: timeout,
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _enterText(WidgetTester tester, Key key, String text) async {
+  final editable = find.descendant(
+    of: find.byKey(key),
+    matching: find.byType(EditableText),
+  );
+  await _pumpUntil(
+    tester,
+    () => tester.any(editable),
+    description: '$key editable text field',
+  );
+  await tester.tap(editable);
+  await tester.enterText(editable, text);
+  await tester.pump(const Duration(milliseconds: 100));
+  _log('entered text into $key');
+}
+
+Set<String> _textSetIn(WidgetTester tester, Finder finder) {
+  if (!tester.any(finder)) return const {};
+  final texts = find.descendant(of: finder, matching: find.byType(Text));
+  return tester
+      .widgetList<Text>(texts)
+      .map((text) => text.data)
+      .whereType<String>()
+      .toSet();
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  required String description,
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final end = DateTime.now().add(timeout);
+  Object? lastError;
+  var polls = 0;
+  while (DateTime.now().isBefore(end)) {
+    try {
+      if (condition()) return;
+    } catch (e) {
+      lastError = e;
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    polls++;
+    if (polls % 25 == 0) {
+      _log('still waiting for $description');
+    }
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail('Timed out waiting for $description.$error');
+}
+
+void _log(String message) {
+  debugPrint('[regtest-mempool-e2e] $message');
+}

--- a/integration_test/regtest_mempool_receive_history_test.dart
+++ b/integration_test/regtest_mempool_receive_history_test.dart
@@ -6,16 +6,14 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
 import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
 
-const _network = String.fromEnvironment(
-  'ZCASH_E2E_NETWORK',
-  defaultValue: 'regtest',
-);
+final _network = kZcashDefaultNetworkName;
 const _driverUrl = String.fromEnvironment(
   'ZCASH_E2E_DRIVER_URL',
   defaultValue: 'http://127.0.0.1:39067',
@@ -526,14 +524,16 @@ void _expectNoActivityRow(
 }
 
 Future<void> _cleanupE2eWalletState() async {
-  final storage = AppSecureStore.instance;
-  if (!storage.isE2eStorage) {
+  if (kZcashDefaultNetworkName != ZcashNetwork.regtest.name) {
     throw StateError(
-      'Refusing to clean wallet state without ZCASH_USE_E2E_STORAGE.',
+      'Refusing to clean wallet state without ZCASH_DEFAULT_NETWORK=regtest.',
     );
   }
 
-  _log('cleaning E2E wallet state');
+  final storage = AppSecureStore.instance;
+  final dbName = await getWalletDbName();
+
+  _log('cleaning regtest wallet state');
   await _stopRustWorkForCleanup();
 
   await storage.deleteAll();
@@ -541,11 +541,7 @@ Future<void> _cleanupE2eWalletState() async {
   final supportDir = await getWalletSupportDirectory();
   if (!supportDir.existsSync()) return;
 
-  for (final name in [
-    kE2eWalletDbName,
-    '$kE2eWalletDbName-shm',
-    '$kE2eWalletDbName-wal',
-  ]) {
+  for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
     final file = File('${supportDir.path}${Platform.pathSeparator}$name');
     if (file.existsSync()) file.deleteSync();
   }

--- a/integration_test/regtest_mempool_receive_history_test.dart
+++ b/integration_test/regtest_mempool_receive_history_test.dart
@@ -20,6 +20,10 @@ const _driverUrl = String.fromEnvironment(
   'ZCASH_E2E_DRIVER_URL',
   defaultValue: 'http://127.0.0.1:39067',
 );
+const _testMode = String.fromEnvironment(
+  'ZCASH_E2E_MEMPOOL_TEST_MODE',
+  defaultValue: 'steady',
+);
 const _firstMnemonic =
     'winter shiver fetch refuse absurd mail pistol eight market lounge manual '
     'roast miracle ethics found child scare curve congress renew salute pig '
@@ -33,80 +37,155 @@ void main() {
     await initializeZcashWalletRuntime();
   });
 
-  testWidgets(
-    'shows shielded receives from the mempool before mining',
-    (tester) async {
-      addTearDown(() async {
+  if (_testMode == 'steady') {
+    testWidgets(
+      'shows shielded receives from the mempool before mining',
+      (tester) async {
+        addTearDown(() async {
+          await _cleanupE2eWalletState();
+        });
+
         await _cleanupE2eWalletState();
-      });
 
-      await _cleanupE2eWalletState();
+        _log('pumping app');
+        await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
 
-      _log('pumping app');
-      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+        await _importFirstWallet(tester);
+        await _waitForMempoolObserver();
 
-      await _importFirstWallet(tester);
-      await _waitForMempoolObserver();
+        _log('copying first account shielded address');
+        final firstAddress = await _copyActiveShieldedAddress(tester);
+        expect(firstAddress, startsWith('uregtest1'));
+        final firstAccountUuid = await _accountUuidAtOrder(0);
+        await _openWallet(tester);
 
-      _log('copying first account shielded address');
-      final firstAddress = await _copyActiveShieldedAddress(tester);
-      expect(firstAddress, startsWith('uregtest1'));
-      final firstAccountUuid = await _accountUuidAtOrder(0);
-      await _openWallet(tester);
+        final txid = await _fundUnmined(firstAddress, '0.25');
+        _log('external unmined funding txid=$txid');
+        await _waitForHistoryTx(
+          tester,
+          accountUuid: firstAccountUuid,
+          txidHex: txid,
+          txKind: 'receiving',
+          displayAmount: BigInt.from(25_000_000),
+        );
+        await _expectActivityRow(
+          tester,
+          const ValueKey('home_activity_row_1'),
+          title: 'Receiving',
+          amount: '+0.25 ZEC',
+          status: 'In progress',
+          timeout: const Duration(minutes: 4),
+        );
 
-      final txid = await _fundUnmined(firstAddress, '0.25');
-      _log('external unmined funding txid=$txid');
-      await _waitForHistoryTx(
-        tester,
-        accountUuid: firstAccountUuid,
-        txidHex: txid,
-        txKind: 'receiving',
-        displayAmount: BigInt.from(25_000_000),
-      );
-      await _expectActivityRow(
-        tester,
-        const ValueKey('home_activity_row_1'),
-        title: 'Receiving',
-        amount: '+0.25 ZEC',
-        status: 'In progress',
-        timeout: const Duration(minutes: 4),
-      );
+        await _mineRegtestBlocks(10);
+        await _expectActivityRow(
+          tester,
+          const ValueKey('home_activity_row_1'),
+          title: 'Received',
+          amount: '+0.25 ZEC',
+          status: 'Completed',
+          timeout: const Duration(minutes: 4),
+        );
+        _expectNoActivityRow(
+          tester,
+          rowKeyPrefix: 'home_activity',
+          title: 'Receiving',
+          amount: '+0.25 ZEC',
+          status: 'In progress',
+        );
+        await _openActivity(tester);
+        await _expectActivityRow(
+          tester,
+          const ValueKey('activity_screen_row_1'),
+          title: 'Received',
+          amount: '+0.25 ZEC',
+          status: 'Completed',
+          timeout: const Duration(minutes: 2),
+        );
+        _expectNoActivityRow(
+          tester,
+          rowKeyPrefix: 'activity_screen',
+          title: 'Receiving',
+          amount: '+0.25 ZEC',
+          status: 'In progress',
+        );
+      },
+      timeout: const Timeout(Duration(minutes: 10)),
+    );
+  }
 
-      await _mineRegtestBlocks(10);
-      await _expectActivityRow(
-        tester,
-        const ValueKey('home_activity_row_1'),
-        title: 'Received',
-        amount: '+0.25 ZEC',
-        status: 'Completed',
-        timeout: const Duration(minutes: 4),
-      );
-      _expectNoActivityRow(
-        tester,
-        rowKeyPrefix: 'home_activity',
-        title: 'Receiving',
-        amount: '+0.25 ZEC',
-        status: 'In progress',
-      );
-      await _openActivity(tester);
-      await _expectActivityRow(
-        tester,
-        const ValueKey('activity_screen_row_1'),
-        title: 'Received',
-        amount: '+0.25 ZEC',
-        status: 'Completed',
-        timeout: const Duration(minutes: 2),
-      );
-      _expectNoActivityRow(
-        tester,
-        rowKeyPrefix: 'activity_screen',
-        title: 'Receiving',
-        amount: '+0.25 ZEC',
-        status: 'In progress',
-      );
-    },
-    timeout: const Timeout(Duration(minutes: 10)),
-  );
+  if (_testMode == 'during-sync') {
+    testWidgets(
+      'shows shielded receives from the mempool while sync is running',
+      (tester) async {
+        addTearDown(() async {
+          await _cleanupE2eWalletState();
+        });
+
+        await _cleanupE2eWalletState();
+
+        _log('pumping app');
+        await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+
+        await _importFirstWallet(tester);
+        final firstAccountUuid = await _accountUuidAtOrder(0);
+        final firstAddress = await _unifiedAddressForAccount(firstAccountUuid);
+        expect(firstAddress, startsWith('uregtest1'));
+
+        await _waitForActiveSyncAndMempool(tester);
+        final beforeFunding = await _syncStatusSummary();
+        _log('sync active before external funding: $beforeFunding');
+
+        final txid = await _fundPreparedUnmined(firstAddress, '0.25');
+        _log('external prepared unmined funding txid=$txid');
+        await _expectForegroundSyncStillRunning();
+
+        await _waitForHistoryTx(
+          tester,
+          accountUuid: firstAccountUuid,
+          txidHex: txid,
+          txKind: 'receiving',
+          displayAmount: BigInt.from(25_000_000),
+        );
+        await _expectActivityRow(
+          tester,
+          const ValueKey('home_activity_row_1'),
+          title: 'Receiving',
+          amount: '+0.25 ZEC',
+          status: 'In progress',
+          timeout: const Duration(minutes: 4),
+        );
+
+        await _waitForForegroundSyncToFinish(tester);
+        await _expectActivityRow(
+          tester,
+          const ValueKey('home_activity_row_1'),
+          title: 'Receiving',
+          amount: '+0.25 ZEC',
+          status: 'In progress',
+          timeout: const Duration(minutes: 1),
+        );
+
+        await _mineRegtestBlocks(10);
+        await _expectActivityRow(
+          tester,
+          const ValueKey('home_activity_row_1'),
+          title: 'Received',
+          amount: '+0.25 ZEC',
+          status: 'Completed',
+          timeout: const Duration(minutes: 4),
+        );
+        _expectNoActivityRow(
+          tester,
+          rowKeyPrefix: 'home_activity',
+          title: 'Receiving',
+          amount: '+0.25 ZEC',
+          status: 'In progress',
+        );
+      },
+      timeout: const Timeout(Duration(minutes: 12)),
+    );
+  }
 }
 
 Future<void> _importFirstWallet(WidgetTester tester) async {
@@ -155,12 +234,34 @@ Future<String> _copyActiveShieldedAddress(WidgetTester tester) async {
   return address;
 }
 
+Future<String> _unifiedAddressForAccount(String accountUuid) async {
+  final dbPath = await getWalletDbPath();
+  return rust_wallet.getUnifiedAddress(
+    dbPath: dbPath,
+    network: _network,
+    accountUuid: accountUuid,
+  );
+}
+
 Future<String> _fundUnmined(String address, String amount) async {
   _log('requesting external unmined funding of $amount ZEC to $address');
   final response = await _postDriver('/fund-unmined', {
     'address': address,
     'amount': amount,
   }, timeout: const Duration(minutes: 5));
+  final txid = response['txid'] as String? ?? '';
+  if (txid.isEmpty) fail('E2E driver did not return a txid.');
+  return txid;
+}
+
+Future<String> _fundPreparedUnmined(String address, String amount) async {
+  _log(
+    'requesting prepared external unmined funding of $amount ZEC to $address',
+  );
+  final response = await _postDriver('/fund-unmined-prepared', {
+    'address': address,
+    'amount': amount,
+  }, timeout: const Duration(minutes: 2));
   final txid = response['txid'] as String? ?? '';
   if (txid.isEmpty) fail('E2E driver did not return a txid.');
   return txid;
@@ -232,6 +333,81 @@ Future<void> _waitForMempoolObserver() async {
     await Future<void>.delayed(const Duration(milliseconds: 100));
   }
   fail('Timed out waiting for mempool observer to run.');
+}
+
+Future<void> _waitForActiveSyncAndMempool(WidgetTester tester) async {
+  final deadline = DateTime.now().add(const Duration(minutes: 2));
+  var lastStatus = '<not read>';
+
+  while (DateTime.now().isBefore(deadline)) {
+    try {
+      lastStatus = await _syncStatusSummary();
+      if (rust_sync.isSyncRunning() &&
+          rust_sync.isMempoolObserverRunning() &&
+          await _isBehindChainTip()) {
+        return;
+      }
+    } catch (e) {
+      lastStatus = 'error: $e';
+    }
+
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  fail(
+    'Timed out waiting for active sync and mempool observer. '
+    'Last status: $lastStatus, syncRunning=${rust_sync.isSyncRunning()}, '
+    'mempoolRunning=${rust_sync.isMempoolObserverRunning()}',
+  );
+}
+
+Future<void> _expectForegroundSyncStillRunning() async {
+  if (rust_sync.isSyncRunning()) return;
+  fail(
+    'Expected foreground sync to still be running when prepared mempool tx '
+    'was submitted. Last status: ${await _syncStatusSummary()}, '
+    'mempoolRunning=${rust_sync.isMempoolObserverRunning()}',
+  );
+}
+
+Future<void> _waitForForegroundSyncToFinish(WidgetTester tester) async {
+  final deadline = DateTime.now().add(const Duration(minutes: 4));
+  var lastStatus = '<not read>';
+
+  while (DateTime.now().isBefore(deadline)) {
+    lastStatus = await _syncStatusSummary();
+    if (!rust_sync.isSyncRunning()) {
+      _log('foreground sync finished: $lastStatus');
+      return;
+    }
+
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  fail(
+    'Timed out waiting for foreground sync to finish. Last status: $lastStatus',
+  );
+}
+
+Future<bool> _isBehindChainTip() async {
+  final dbPath = await getWalletDbPath();
+  final status = await rust_sync.getSyncStatus(
+    dbPath: dbPath,
+    network: _network,
+  );
+  return status.scannedHeight < status.chainTipHeight;
+}
+
+Future<String> _syncStatusSummary() async {
+  final dbPath = await getWalletDbPath();
+  final status = await rust_sync.getSyncStatus(
+    dbPath: dbPath,
+    network: _network,
+  );
+  return 'scanned=${status.scannedHeight}, tip=${status.chainTipHeight}, '
+      'isSyncing=${status.isSyncing}';
 }
 
 Future<String> _accountUuidAtOrder(int order) async {

--- a/integration_test/regtest_mempool_receive_history_test.dart
+++ b/integration_test/regtest_mempool_receive_history_test.dart
@@ -27,6 +27,24 @@ const _firstMnemonic =
     'roast miracle ethics found child scare curve congress renew salute pig '
     'better used';
 const _password = 'Vizor123!';
+final _receiveAmountZatoshi = BigInt.from(25_000_000);
+
+class _ExpiringFunding {
+  const _ExpiringFunding({required this.txid, required this.expiryHeight});
+
+  final String txid;
+  final int expiryHeight;
+}
+
+class _ShieldedBalanceSnapshot {
+  const _ShieldedBalanceSnapshot({
+    required this.pending,
+    required this.spendable,
+  });
+
+  final BigInt pending;
+  final BigInt spendable;
+}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -184,6 +202,108 @@ void main() {
       timeout: const Timeout(Duration(minutes: 12)),
     );
   }
+
+  if (_testMode == 'expiry') {
+    testWidgets(
+      'removes expired shielded mempool receives from pending balance',
+      (tester) async {
+        addTearDown(() async {
+          await _cleanupE2eWalletState();
+        });
+
+        await _cleanupE2eWalletState();
+
+        _log('pumping app');
+        await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+
+        await _importFirstWallet(tester);
+        await _waitForMempoolObserver();
+
+        _log('copying first account shielded address');
+        final firstAddress = await _copyActiveShieldedAddress(tester);
+        expect(firstAddress, startsWith('uregtest1'));
+        final firstAccountUuid = await _accountUuidAtOrder(0);
+        await _openWallet(tester);
+
+        final before = await _shieldedBalance(firstAccountUuid);
+        final funding = await _fundExpiringUnmined(firstAddress, '0.25');
+        _log(
+          'external expiring unmined funding txid=${funding.txid} '
+          'expiry=${funding.expiryHeight}',
+        );
+
+        await _waitForHistoryTx(
+          tester,
+          accountUuid: firstAccountUuid,
+          txidHex: funding.txid,
+          txKind: 'receiving',
+          displayAmount: _receiveAmountZatoshi,
+        );
+        await _waitForShieldedBalance(
+          tester,
+          accountUuid: firstAccountUuid,
+          pending: before.pending + _receiveAmountZatoshi,
+          spendable: before.spendable,
+        );
+        await _expectActivityRow(
+          tester,
+          const ValueKey('home_activity_row_1'),
+          title: 'Receiving',
+          amount: '+0.25 ZEC',
+          status: 'In progress',
+          timeout: const Duration(minutes: 4),
+        );
+
+        await _mineToExpiry(funding.txid, funding.expiryHeight);
+        await _waitForExpiredHistoryTx(
+          tester,
+          accountUuid: firstAccountUuid,
+          txidHex: funding.txid,
+          displayAmount: _receiveAmountZatoshi,
+        );
+        await _waitForShieldedBalance(
+          tester,
+          accountUuid: firstAccountUuid,
+          pending: before.pending,
+          spendable: before.spendable,
+          timeout: const Duration(minutes: 4),
+        );
+        await _expectAnyActivityRow(
+          tester,
+          rowKeyPrefix: 'home_activity',
+          title: 'Received',
+          amount: '0.25 ZEC',
+          status: 'Failed',
+          timeout: const Duration(minutes: 4),
+        );
+        _expectNoActivityRow(
+          tester,
+          rowKeyPrefix: 'home_activity',
+          title: 'Receiving',
+          amount: '+0.25 ZEC',
+          status: 'In progress',
+        );
+
+        await _openActivity(tester);
+        await _expectAnyActivityRow(
+          tester,
+          rowKeyPrefix: 'activity_screen',
+          title: 'Received',
+          amount: '0.25 ZEC',
+          status: 'Failed',
+          timeout: const Duration(minutes: 2),
+        );
+        _expectNoActivityRow(
+          tester,
+          rowKeyPrefix: 'activity_screen',
+          title: 'Receiving',
+          amount: '+0.25 ZEC',
+          status: 'In progress',
+        );
+      },
+      timeout: const Timeout(Duration(minutes: 12)),
+    );
+  }
 }
 
 Future<void> _importFirstWallet(WidgetTester tester) async {
@@ -265,9 +385,35 @@ Future<String> _fundPreparedUnmined(String address, String amount) async {
   return txid;
 }
 
+Future<_ExpiringFunding> _fundExpiringUnmined(
+  String address,
+  String amount,
+) async {
+  _log(
+    'requesting expiring external unmined funding of $amount ZEC to $address',
+  );
+  final response = await _postDriver('/fund-unmined-expiring', {
+    'address': address,
+    'amount': amount,
+  }, timeout: const Duration(minutes: 2));
+  final txid = response['txid'] as String? ?? '';
+  final expiryHeight = (response['expiryHeight'] as num?)?.toInt() ?? 0;
+  if (txid.isEmpty) fail('E2E driver did not return a txid.');
+  if (expiryHeight <= 0) fail('E2E driver did not return an expiry height.');
+  return _ExpiringFunding(txid: txid, expiryHeight: expiryHeight);
+}
+
 Future<void> _mineRegtestBlocks(int blocks) async {
   _log('requesting external mining of $blocks regtest blocks');
   await _postDriver('/mine', {'blocks': blocks});
+}
+
+Future<void> _mineToExpiry(String txid, int expiryHeight) async {
+  _log('requesting external mining to expiry height $expiryHeight for $txid');
+  await _postDriver('/mine-to-expiry', {
+    'txid': txid,
+    'expiryHeight': expiryHeight,
+  }, timeout: const Duration(minutes: 5));
 }
 
 Future<Map<String, Object?>> _postDriver(
@@ -474,12 +620,113 @@ Future<void> _waitForHistoryTx(
   );
 }
 
+Future<void> _waitForExpiredHistoryTx(
+  WidgetTester tester, {
+  required String accountUuid,
+  required String txidHex,
+  required BigInt displayAmount,
+}) async {
+  final dbPath = await getWalletDbPath();
+  final deadline = DateTime.now().add(const Duration(minutes: 4));
+  Object? lastError;
+  var lastHistorySummary = '<not read>';
+  final acceptedTxids = {txidHex, _reverseTxidHex(txidHex)};
+
+  while (DateTime.now().isBefore(deadline)) {
+    try {
+      final history = await rust_sync.getTransactionHistory(
+        dbPath: dbPath,
+        network: _network,
+        limit: 20,
+        accountUuid: accountUuid,
+      );
+      lastHistorySummary = history
+          .map(
+            (tx) =>
+                '${tx.txidHex}:${tx.txKind}:${tx.displayAmount}:'
+                'mined=${tx.minedHeight}:expired=${tx.expiredUnmined}',
+          )
+          .join(', ');
+      if (history.any(
+        (tx) =>
+            acceptedTxids.contains(tx.txidHex) &&
+            tx.txKind == 'received' &&
+            tx.displayAmount == displayAmount &&
+            tx.minedHeight == BigInt.zero &&
+            tx.expiredUnmined,
+      )) {
+        _log('history matched expired receive tx $txidHex');
+        return;
+      }
+    } catch (e) {
+      lastError = e;
+    }
+
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail(
+    'Timed out waiting for expired history tx $txidHex. '
+    'Observed history: $lastHistorySummary.$error',
+  );
+}
+
 String _reverseTxidHex(String txidHex) {
   final pairs = <String>[];
   for (var i = 0; i + 1 < txidHex.length; i += 2) {
     pairs.add(txidHex.substring(i, i + 2));
   }
   return pairs.reversed.join();
+}
+
+Future<_ShieldedBalanceSnapshot> _shieldedBalance(String accountUuid) async {
+  final dbPath = await getWalletDbPath();
+  final balance = await rust_sync.getBalance(
+    dbPath: dbPath,
+    network: _network,
+    accountUuid: accountUuid,
+  );
+  return _ShieldedBalanceSnapshot(
+    pending: balance.saplingPending + balance.orchardPending,
+    spendable: balance.sapling + balance.orchard,
+  );
+}
+
+Future<void> _waitForShieldedBalance(
+  WidgetTester tester, {
+  required String accountUuid,
+  required BigInt pending,
+  required BigInt spendable,
+  Duration timeout = const Duration(minutes: 2),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  Object? lastError;
+  var lastBalance = '<not read>';
+
+  while (DateTime.now().isBefore(deadline)) {
+    try {
+      final balance = await _shieldedBalance(accountUuid);
+      lastBalance =
+          'pending=${balance.pending}, spendable=${balance.spendable}';
+      if (balance.pending == pending && balance.spendable == spendable) {
+        _log('shielded balance matched: $lastBalance');
+        return;
+      }
+    } catch (e) {
+      lastError = e;
+    }
+
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail(
+    'Timed out waiting for shielded balance pending=$pending '
+    'spendable=$spendable. Last balance: $lastBalance.$error',
+  );
 }
 
 Future<void> _expectActivityRow(
@@ -499,6 +746,36 @@ Future<void> _expectActivityRow(
           texts.contains(status);
     },
     description: '$key activity row to show $title $amount $status',
+    timeout: timeout,
+  );
+  _log('activity row matched: $title $amount $status');
+}
+
+Future<void> _expectAnyActivityRow(
+  WidgetTester tester, {
+  required String rowKeyPrefix,
+  required String title,
+  required String amount,
+  required String status,
+  Duration timeout = const Duration(minutes: 2),
+}) async {
+  await _pumpUntil(
+    tester,
+    () {
+      for (var i = 0; i < 10; i++) {
+        final texts = _textSetIn(
+          tester,
+          find.byKey(ValueKey('${rowKeyPrefix}_row_$i')),
+        );
+        if (texts.contains(title) &&
+            texts.contains(amount) &&
+            texts.contains(status)) {
+          return true;
+        }
+      }
+      return false;
+    },
+    description: '$rowKeyPrefix activity row to show $title $amount $status',
     timeout: timeout,
   );
   _log('activity row matched: $title $amount $status');

--- a/integration_test/regtest_multi_account_send_test.dart
+++ b/integration_test/regtest_multi_account_send_test.dart
@@ -13,6 +13,10 @@ import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
 
+const _network = String.fromEnvironment(
+  'ZCASH_E2E_NETWORK',
+  defaultValue: 'regtest',
+);
 const _lightwalletdUrl = String.fromEnvironment(
   'ZCASH_E2E_LIGHTWALLETD_URL',
   defaultValue: 'http://127.0.0.1:9067',
@@ -66,17 +70,44 @@ void main() {
       _log('copying second account shielded address');
       final secondAddress = await _copyActiveShieldedAddress(tester);
       expect(secondAddress, startsWith('uregtest1'));
+      final secondAccountUuid = await _accountUuidAtOrder(1);
       _log('second account shielded address copied');
 
       await _openWallet(tester);
       await _switchAccount(tester, 0);
       await _waitForBalance(tester, shielded: '1.25 zec');
+      await _waitForMempoolObserver();
 
       await _sendToAddress(tester, secondAddress, '0.25');
-      await _mineRegtestBlocks(10);
 
       await _openWallet(tester);
       await _switchAccount(tester, 1);
+      await _waitForHistoryEntry(
+        tester,
+        accountUuid: secondAccountUuid,
+        txKind: 'receiving',
+        displayAmount: BigInt.from(25_000_000),
+        pending: true,
+      );
+      await _expectActivityRow(
+        tester,
+        const ValueKey('home_activity_row_1'),
+        title: 'Receiving',
+        amount: '+0.25 ZEC',
+        status: 'In progress',
+      );
+      await _openActivity(tester);
+      await _expectActivityRow(
+        tester,
+        const ValueKey('activity_screen_row_1'),
+        title: 'Receiving',
+        amount: '+0.25 ZEC',
+        status: 'In progress',
+      );
+
+      await _mineRegtestBlocks(10);
+
+      await _openWallet(tester);
       await _waitForBalance(
         tester,
         shielded: '0.25 zec',
@@ -89,6 +120,13 @@ void main() {
         amount: '+0.25 ZEC',
         status: 'Completed',
       );
+      _expectNoActivityRow(
+        tester,
+        rowKeyPrefix: 'home_activity',
+        title: 'Receiving',
+        amount: '+0.25 ZEC',
+        status: 'In progress',
+      );
       await _openActivity(tester);
       await _expectActivityRow(
         tester,
@@ -96,6 +134,13 @@ void main() {
         title: 'Received',
         amount: '+0.25 ZEC',
         status: 'Completed',
+      );
+      _expectNoActivityRow(
+        tester,
+        rowKeyPrefix: 'activity_screen',
+        title: 'Receiving',
+        amount: '+0.25 ZEC',
+        status: 'In progress',
       );
       _log('second account received shielded funds');
 
@@ -108,6 +153,13 @@ void main() {
         amount: '-0.25 ZEC',
         status: 'Completed',
       );
+      _expectNoActivityRow(
+        tester,
+        rowKeyPrefix: 'home_activity',
+        title: 'Sent',
+        amount: '-0.25 ZEC',
+        status: 'In progress',
+      );
       await _openActivity(tester);
       await _expectActivityRow(
         tester,
@@ -115,6 +167,13 @@ void main() {
         title: 'Sent',
         amount: '-0.25 ZEC',
         status: 'Completed',
+      );
+      _expectNoActivityRow(
+        tester,
+        rowKeyPrefix: 'activity_screen',
+        title: 'Sent',
+        amount: '-0.25 ZEC',
+        status: 'In progress',
       );
       _log('first account sent activity matched');
     },
@@ -316,6 +375,79 @@ Future<void> _waitForHome(WidgetTester tester) async {
   );
 }
 
+Future<void> _waitForMempoolObserver() async {
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  while (DateTime.now().isBefore(deadline)) {
+    if (rust_sync.isMempoolObserverRunning()) return;
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+  fail('Timed out waiting for mempool observer to run.');
+}
+
+Future<String> _accountUuidAtOrder(int order) async {
+  final dbPath = await getWalletDbPath();
+  final accounts = await rust_wallet.listAccounts(
+    dbPath: dbPath,
+    network: _network,
+  );
+  if (order >= accounts.length) {
+    fail('Expected account order $order, got ${accounts.length} accounts.');
+  }
+  return accounts[order].uuid;
+}
+
+Future<void> _waitForHistoryEntry(
+  WidgetTester tester, {
+  required String accountUuid,
+  required String txKind,
+  required BigInt displayAmount,
+  required bool pending,
+}) async {
+  final dbPath = await getWalletDbPath();
+  final deadline = DateTime.now().add(const Duration(minutes: 2));
+  Object? lastError;
+  var lastHistorySummary = '<not read>';
+
+  while (DateTime.now().isBefore(deadline)) {
+    try {
+      final history = await rust_sync.getTransactionHistory(
+        dbPath: dbPath,
+        network: _network,
+        limit: 20,
+        accountUuid: accountUuid,
+      );
+      lastHistorySummary = history
+          .map(
+            (tx) =>
+                '${tx.txidHex}:${tx.txKind}:${tx.displayAmount}:'
+                'mined=${tx.minedHeight}:expired=${tx.expiredUnmined}',
+          )
+          .join(', ');
+      if (history.any(
+        (tx) =>
+            tx.txKind == txKind &&
+            tx.displayAmount == displayAmount &&
+            (tx.minedHeight == BigInt.zero) == pending &&
+            !tx.expiredUnmined,
+      )) {
+        _log('history matched $txKind tx amount=$displayAmount');
+        return;
+      }
+    } catch (e) {
+      lastError = e;
+    }
+
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail(
+    'Timed out waiting for history $txKind amount=$displayAmount '
+    'pending=$pending. Observed history: $lastHistorySummary.$error',
+  );
+}
+
 Future<void> _waitForBalance(
   WidgetTester tester, {
   String? shielded,
@@ -369,6 +501,25 @@ Future<void> _expectActivityRow(
     timeout: const Duration(minutes: 2),
   );
   _log('activity row matched: $title $amount $status');
+}
+
+void _expectNoActivityRow(
+  WidgetTester tester, {
+  required String rowKeyPrefix,
+  required String title,
+  required String amount,
+  required String status,
+}) {
+  for (var i = 0; i < 10; i++) {
+    final key = ValueKey('${rowKeyPrefix}_row_$i');
+    final texts = _textSetIn(tester, find.byKey(key));
+    if (texts.contains(title) &&
+        texts.contains(amount) &&
+        texts.contains(status)) {
+      fail('Unexpected stale activity row $key: $title $amount $status');
+    }
+  }
+  _log('no stale activity row matched: $title $amount $status');
 }
 
 Future<void> _cleanupE2eWalletState() async {

--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -112,10 +112,12 @@ ActivityRowData buildTransactionActivityRow({
   final kind = transaction.txKind;
   final amount = transaction.displayAmount;
   final isReceived = kind == 'received';
+  final isReceiving = kind == 'receiving';
   final isSent = kind == 'sent';
   final isShielded = kind == 'shielded';
+  final isInbound = isReceived || isReceiving;
   final signedAmount = isSent ? -amount : amount;
-  final subtitle = isReceived || isSent
+  final subtitle = isInbound || isSent
       ? _poolLabel(transaction.displayPool)
       : null;
 
@@ -142,7 +144,7 @@ ActivityRowData buildTransactionActivityRow({
     amountIconColor: isFailed ? colors.icon.regular : null,
     amountColor: isFailed
         ? colors.text.accent
-        : isReceived
+        : isInbound
         ? colors.text.brandCrimson
         : colors.text.accent,
     statusText: isFailed
@@ -201,6 +203,7 @@ String formatActivityTimestamp(DateTime? timestamp) {
 
 String _txTitle(String kind) {
   return switch (kind) {
+    'receiving' => 'Receiving',
     'received' => 'Received',
     'sent' => 'Sent',
     'shielded' => 'Shielded',
@@ -210,6 +213,7 @@ String _txTitle(String kind) {
 
 String _txIcon(String kind) {
   return switch (kind) {
+    'receiving' => AppIcons.arrowDownCircle,
     'received' => AppIcons.arrowDownCircle,
     'sent' => AppIcons.plane,
     'shielded' => AppIcons.shieldKeyholeOutline,

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -161,7 +161,8 @@ class _ActivityTransactionStatusScreenState
     final normalized = txidHex.toLowerCase();
     if (txKind != null) {
       for (final tx in transactions) {
-        if (tx.txidHex.toLowerCase() == normalized && tx.txKind == txKind) {
+        if (tx.txidHex.toLowerCase() == normalized &&
+            _txKindMatches(txKind, tx.txKind)) {
           return tx;
         }
       }
@@ -181,7 +182,8 @@ class _ActivityTransactionStatusScreenState
         widget.args.txKind;
     if (txKind != null) {
       for (final tx in sync?.recentTransactions ?? const []) {
-        if (tx.txidHex.toLowerCase() == txid && tx.txKind == txKind) {
+        if (tx.txidHex.toLowerCase() == txid &&
+            _txKindMatches(txKind, tx.txKind)) {
           return [
             tx.txidHex,
             tx.minedHeight,
@@ -205,6 +207,12 @@ class _ActivityTransactionStatusScreenState
       }
     }
     return '';
+  }
+
+  bool _txKindMatches(String expected, String actual) {
+    if (expected == actual) return true;
+    return (expected == 'receiving' && actual == 'received') ||
+        (expected == 'received' && actual == 'receiving');
   }
 
   Future<void> _copyTransactionHash() async {
@@ -315,7 +323,7 @@ class _ActivityTransactionStatusScreenState
     if (detail.txidHex.toLowerCase() != tx.txidHex.toLowerCase()) {
       return null;
     }
-    if (detail.txKind != tx.txKind) return null;
+    if (!_txKindMatches(detail.txKind, tx.txKind)) return null;
     return detail;
   }
 
@@ -386,7 +394,7 @@ class _ActivityTransactionStatusScreenState
         compactAddress: compactAddress,
       );
     }
-    if (tx?.txKind == 'received' &&
+    if ((tx?.txKind == 'received' || tx?.txKind == 'receiving') &&
         primaryAddress != null &&
         primaryAddress.isNotEmpty) {
       return _addressBlock(

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -1528,43 +1528,56 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       return;
     }
 
+    // Commit against the latest state so a slow balance/history refresh
+    // cannot roll sync progress or completion metadata back to the snapshot
+    // captured before the awaits above.
+    final current = state.value;
+    final currentScoped = _previousScopedState(current, accountUuid);
+    final accountFallback = currentScoped ?? scopedPrev;
+
     state = AsyncData(
       SyncState(
         accountUuid: accountUuid,
         hasBalanceData:
-            didFetchBalance || (scopedPrev?.hasBalanceData ?? false),
+            didFetchBalance || (accountFallback?.hasBalanceData ?? false),
         hasRecentTransactionsData:
             didFetchRecentTxs ||
-            (scopedPrev?.hasRecentTransactionsData ?? false),
-        isSyncing: prev?.isSyncing ?? false,
-        isBackgroundMode: _bgDelegate.isActive,
-        percentage: prev?.percentage ?? 0.0,
-        displayPercentage: prev?.displayPercentage ?? prev?.percentage ?? 0.0,
-        scannedHeight: prev?.scannedHeight ?? 0,
-        chainTipHeight: prev?.chainTipHeight ?? 0,
-        transparentBalance: transparent ?? scopedPrev?.transparentBalance,
-        saplingBalance: sapling ?? scopedPrev?.saplingBalance,
-        orchardBalance: orchard ?? scopedPrev?.orchardBalance,
+            (accountFallback?.hasRecentTransactionsData ?? false),
+        isSyncing: current?.isSyncing ?? false,
+        isBackgroundMode: current?.isBackgroundMode ?? _bgDelegate.isActive,
+        percentage: current?.percentage ?? 0.0,
+        displayPercentage:
+            current?.displayPercentage ?? current?.percentage ?? 0.0,
+        scannedHeight: current?.scannedHeight ?? 0,
+        chainTipHeight: current?.chainTipHeight ?? 0,
+        transparentBalance: transparent ?? accountFallback?.transparentBalance,
+        saplingBalance: sapling ?? accountFallback?.saplingBalance,
+        orchardBalance: orchard ?? accountFallback?.orchardBalance,
         transparentPendingBalance:
-            transparentPending ?? scopedPrev?.transparentPendingBalance,
+            transparentPending ?? accountFallback?.transparentPendingBalance,
         saplingPendingBalance:
-            saplingPending ?? scopedPrev?.saplingPendingBalance,
+            saplingPending ?? accountFallback?.saplingPendingBalance,
         orchardPendingBalance:
-            orchardPending ?? scopedPrev?.orchardPendingBalance,
+            orchardPending ?? accountFallback?.orchardPendingBalance,
         canShieldTransparentBalance:
             canShieldTransparentBalance ??
-            scopedPrev?.canShieldTransparentBalance ??
+            accountFallback?.canShieldTransparentBalance ??
             false,
         shieldTransparentFee:
-            shieldTransparentFee ?? scopedPrev?.shieldTransparentFee,
+            shieldTransparentFee ?? accountFallback?.shieldTransparentFee,
         shieldTransparentAmount:
-            shieldTransparentAmount ?? scopedPrev?.shieldTransparentAmount,
-        spendableBalance: spendable ?? scopedPrev?.spendableBalance,
-        totalBalance: total ?? scopedPrev?.totalBalance,
-        recentTransactions: recentTxs,
-        lastSyncStartedAt: prev?.lastSyncStartedAt,
-        lastSyncCompletedAt: prev?.lastSyncCompletedAt,
-        lastSyncFailedAt: prev?.lastSyncFailedAt,
+            shieldTransparentAmount ?? accountFallback?.shieldTransparentAmount,
+        spendableBalance: spendable ?? accountFallback?.spendableBalance,
+        totalBalance: total ?? accountFallback?.totalBalance,
+        failure: current?.failure,
+        error: current?.error,
+        recentTransactions: didFetchRecentTxs
+            ? recentTxs
+            : accountFallback?.recentTransactions ?? const [],
+        lastSyncStartedAt: current?.lastSyncStartedAt,
+        lastSyncCompletedAt: current?.lastSyncCompletedAt,
+        lastSyncFailedAt: current?.lastSyncFailedAt,
+        phase: current?.phase ?? '',
       ),
     );
   }

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -247,6 +247,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   bool _isSyncing = false;
   bool _isInForeground = true;
   int _lastLoggedHeight = 0;
+  SyncProgressEvent? _lastForegroundSyncProgress;
   int _syncGen = 0; // incremented by stopSync to invalidate pending startSync
   String? _cachedDbPath;
   StreamSubscription? _syncSub;
@@ -466,6 +467,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     }
     _isSyncing = true;
     _lastLoggedHeight = 0;
+    _lastForegroundSyncProgress = null;
     _stopDisplayProgressTimer();
     final gen = ++_syncGen;
     final prev = state.value;
@@ -520,8 +522,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
             mode: 1,
           );
           _syncSub = stream.listen(
-            (event) => _onSyncProgress(
-              SyncProgressEvent(
+            (event) {
+              final progress = SyncProgressEvent(
                 scannedHeight: event.scannedHeight.toInt(),
                 chainTipHeight: event.chainTipHeight.toInt(),
                 percentage: event.percentage,
@@ -531,8 +533,10 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
                 isComplete: event.isComplete,
                 hasNewTx: event.hasNewTx,
                 phase: event.phase,
-              ),
-            ),
+              );
+              _lastForegroundSyncProgress = progress;
+              unawaited(_onSyncProgress(progress));
+            },
             onDone: () {
               log('Sync: stream ended');
               _syncSub = null;
@@ -548,12 +552,20 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               // already ran, these are no-ops.
               if (_isSyncing) {
                 final current = state.value;
-                final endedAtTip =
+                final lastProgress = _lastForegroundSyncProgress;
+                final endedAtTipFromState =
                     current != null &&
                     current.percentage >= 1.0 &&
                     current.chainTipHeight > 0 &&
-                    current.scannedHeight >= current.chainTipHeight &&
-                    rust_sync.getSyncMode() == 1;
+                    current.scannedHeight >= current.chainTipHeight;
+                final endedAtTipFromProgress =
+                    lastProgress != null &&
+                    lastProgress.percentage >= 1.0 &&
+                    lastProgress.chainTipHeight > 0 &&
+                    lastProgress.scannedHeight >= lastProgress.chainTipHeight;
+                final endedAtTip =
+                    rust_sync.getSyncMode() == 1 &&
+                    (endedAtTipFromState || endedAtTipFromProgress);
                 _isSyncing = false;
                 _stopDisplayProgressTimer();
                 if (endedAtTip) {

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -572,6 +572,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
                   log(
                     'Sync: stream ended at tip without isComplete, treating as complete',
                   );
+                  _finalizeEndedAtTipSyncState(lastProgress);
                   _bgDelegate.onSyncDone();
                   _startPolling();
                 } else {
@@ -978,6 +979,33 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   void _stopPolling() {
     _pollTimer?.cancel();
     _pollTimer = null;
+  }
+
+  void _finalizeEndedAtTipSyncState(SyncProgressEvent? lastProgress) {
+    final prev = state.value;
+    final completedAt = DateTime.now();
+    final chainTipHeight = math.max(
+      prev?.chainTipHeight ?? 0,
+      lastProgress?.chainTipHeight ?? 0,
+    );
+    final scannedHeight = chainTipHeight > 0
+        ? chainTipHeight
+        : math.max(prev?.scannedHeight ?? 0, lastProgress?.scannedHeight ?? 0);
+    final base = prev ?? SyncState(accountUuid: _getActiveAccountUuid());
+
+    state = AsyncData(
+      base.copyWith(
+        isSyncing: false,
+        isBackgroundMode: _bgDelegate.isActive,
+        percentage: 1.0,
+        displayPercentage: 1.0,
+        scannedHeight: scannedHeight,
+        chainTipHeight: chainTipHeight,
+        lastSyncStartedAt: prev?.lastSyncStartedAt ?? completedAt,
+        lastSyncCompletedAt: completedAt,
+        phase: '',
+      ),
+    );
   }
 
   Future<void> _checkAndSync() async {

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -807,6 +807,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _syncSub?.cancel();
     _syncSub = null;
     _stopMempoolObserver();
+    _mempoolRefreshInFlight = false;
+    _mempoolRefreshQueued = false;
     state = AsyncData(SyncState());
 
     // Sign-out should cancel the current Rust run immediately.

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -1024,16 +1024,14 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   /// backoff, so the Dart side only needs to:
   ///
   ///   1. Subscribe to the emitted stream.
-  ///   2. On each `matched=true` event, trigger the same balance
-  ///      refresh path sync uses for `hasNewTx` events. (When an
-  ///      outbound send first lands in lightwalletd's mempool the
-  ///      wallet hasn't seen the tx mined yet, but the relayed
-  ///      bytes are enough for us to flip the UI from "broadcast
-  ///      pending" to "propagating" sooner than the next block
-  ///      scan would.)
-  ///   3. Silently ignore `matched=false` events — they're other
-  ///      people's transactions, used only for future mempool-side
-  ///      inbound discovery (not in scope for v1).
+  ///   2. On each `matched=true` event for the active account, trigger
+  ///      the same balance refresh path sync uses for `hasNewTx`
+  ///      events. Already-known outbound txs refresh as before; new
+  ///      inbound shielded txs are first stored by Rust as unmined
+  ///      wallet transactions.
+  ///   3. Skip refresh for inactive-account events. The wallet-wide
+  ///      observer has already stored the tx, so switching accounts can
+  ///      surface it through the normal account-scoped history read.
   ///
   /// Reuses [_mempoolSub] as the single subscription handle. The
   /// `startMempoolObserver` FRB call is guarded on the Rust side
@@ -1056,6 +1054,14 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _mempoolSub = stream.listen(
       (event) {
         if (!event.matched) return;
+        final activeAccountUuid = _getActiveAccountUuid();
+        if (event.accountUuids.isNotEmpty &&
+            !event.accountUuids.contains(activeAccountUuid)) {
+          log(
+            'Mempool: matched ${event.txidHex} for inactive account, skipping active refresh',
+          );
+          return;
+        }
         log('Mempool: matched ${event.txidHex}, refreshing balance');
         // Fire-and-forget: _refreshBalance rebuilds state and
         // logs its own errors. We don't await because the

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -547,10 +547,25 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               // calls. Clean up unconditionally here; if isComplete
               // already ran, these are no-ops.
               if (_isSyncing) {
-                log('Sync: stream ended without isComplete, cleaning up');
+                final current = state.value;
+                final endedAtTip =
+                    current != null &&
+                    current.percentage >= 1.0 &&
+                    current.chainTipHeight > 0 &&
+                    current.scannedHeight >= current.chainTipHeight &&
+                    rust_sync.getSyncMode() == 1;
                 _isSyncing = false;
                 _stopDisplayProgressTimer();
-                _stopMempoolObserver();
+                if (endedAtTip) {
+                  log(
+                    'Sync: stream ended at tip without isComplete, treating as complete',
+                  );
+                  _bgDelegate.onSyncDone();
+                  _startPolling();
+                } else {
+                  log('Sync: stream ended without isComplete, cleaning up');
+                  _stopMempoolObserver();
+                }
               }
             },
             onError: (e) {

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -264,6 +264,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
   // what actually stops it, and `_mempoolSub` is just the Dart
   // side of the corresponding stream.
   StreamSubscription? _mempoolSub;
+  bool _mempoolRefreshInFlight = false;
+  bool _mempoolRefreshQueued = false;
 
   @override
   Future<SyncState> build() async {
@@ -1063,11 +1065,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
           return;
         }
         log('Mempool: matched ${event.txidHex}, refreshing balance');
-        // Fire-and-forget: _refreshBalance rebuilds state and
-        // logs its own errors. We don't await because the
-        // mempool stream callback should stay non-blocking so
-        // the next incoming tx isn't delayed.
-        _refreshBalance();
+        _scheduleMempoolRefresh();
       },
       onDone: () {
         log('Mempool: stream ended');
@@ -1081,6 +1079,32 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         _mempoolSub = null;
       },
     );
+  }
+
+  void _scheduleMempoolRefresh() {
+    if (_mempoolRefreshInFlight) {
+      _mempoolRefreshQueued = true;
+      return;
+    }
+
+    _mempoolRefreshInFlight = true;
+    unawaited(_runMempoolRefreshLoop());
+  }
+
+  Future<void> _runMempoolRefreshLoop() async {
+    try {
+      do {
+        _mempoolRefreshQueued = false;
+        try {
+          await _refreshBalance();
+        } catch (e, st) {
+          log('Mempool: refresh failed: $e\n$st');
+        }
+      } while (_mempoolRefreshQueued && !_requiresUnlock);
+    } finally {
+      _mempoolRefreshInFlight = false;
+      _mempoolRefreshQueued = false;
+    }
   }
 
   /// Cancel the running mempool observer (if any) and tear down

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -1059,6 +1059,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       (event) {
         if (!event.matched) return;
         final activeAccountUuid = _getActiveAccountUuid();
+        // Empty account scope means Rust knows the tx is wallet-relevant,
+        // but cannot narrow it to an account yet; preserve the legacy
+        // active-account refresh behavior in that case.
         if (event.accountUuids.isNotEmpty &&
             !event.accountUuids.contains(activeAccountUuid)) {
           log(

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -60,9 +60,9 @@ bool isSyncRunning() => RustLib.instance.api.crateApiSyncIsSyncRunning();
 /// Start the background mempool observer.
 ///
 /// Blocks until [`stop_mempool_observer`] is called or the
-/// observer returns on an unrecoverable setup error. Every
-/// incoming mempool tx that can be parsed is pushed to `sink` as
-/// an [`ApiMempoolTxEvent`].
+/// observer returns on an unrecoverable setup error. Only parsed
+/// wallet-relevant mempool txs are pushed to `sink` as
+/// [`ApiMempoolTxEvent`]s; unrelated txs are filtered inside Rust.
 ///
 /// The FRB layer runs this on the Rust isolate thread pool, so
 /// Dart can `await` the call while the observer keeps polling
@@ -488,15 +488,18 @@ class AddressValidationResult {
           addressType == other.addressType;
 }
 
-/// Event emitted by the mempool observer when a transaction
-/// appears on lightwalletd's mempool stream. Mirrored one-to-one
-/// from `sync_engine::mempool::MempoolTxEvent` for FRB codegen.
+/// Event emitted by the mempool observer when a wallet-relevant
+/// transaction appears on lightwalletd's mempool stream. Mirrored
+/// one-to-one from `sync_engine::mempool::MempoolTxEvent` for FRB
+/// codegen.
 class ApiMempoolTxEvent {
   /// Lower-case hex of the tx id.
   final String txidHex;
 
-  /// Account UUIDs that this event is known to affect. Empty
-  /// keeps the legacy behavior of refreshing the active account.
+  /// Account UUIDs that this event is known to affect. Empty means the
+  /// tx is wallet-relevant but not account-scoped enough for Rust to
+  /// name the account, so Dart keeps the legacy behavior of refreshing
+  /// the active account.
   final List<String> accountUuids;
 
   /// `true` when the tx is wallet-relevant: either the wallet DB

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -499,10 +499,11 @@ class ApiMempoolTxEvent {
   /// keeps the legacy behavior of refreshing the active account.
   final List<String> accountUuids;
 
-  /// `true` when the wallet DB already has this txid in its
-  /// `transactions` table with `mined_height IS NULL`. Dart
-  /// uses this flag to decide whether to refresh balance +
-  /// history immediately.
+  /// `true` when the tx is wallet-relevant: either the wallet DB
+  /// already has this txid as unmined, or the observer decrypted
+  /// and stored a new inbound transaction from the mempool. Dart
+  /// uses this flag to decide whether to refresh balance + history
+  /// immediately.
   final bool matched;
 
   const ApiMempoolTxEvent({

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -495,16 +495,25 @@ class ApiMempoolTxEvent {
   /// Lower-case hex of the tx id.
   final String txidHex;
 
+  /// Account UUIDs that this event is known to affect. Empty
+  /// keeps the legacy behavior of refreshing the active account.
+  final List<String> accountUuids;
+
   /// `true` when the wallet DB already has this txid in its
   /// `transactions` table with `mined_height IS NULL`. Dart
   /// uses this flag to decide whether to refresh balance +
   /// history immediately.
   final bool matched;
 
-  const ApiMempoolTxEvent({required this.txidHex, required this.matched});
+  const ApiMempoolTxEvent({
+    required this.txidHex,
+    required this.accountUuids,
+    required this.matched,
+  });
 
   @override
-  int get hashCode => txidHex.hashCode ^ matched.hashCode;
+  int get hashCode =>
+      txidHex.hashCode ^ accountUuids.hashCode ^ matched.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -512,6 +521,7 @@ class ApiMempoolTxEvent {
       other is ApiMempoolTxEvent &&
           runtimeType == other.runtimeType &&
           txidHex == other.txidHex &&
+          accountUuids == other.accountUuids &&
           matched == other.matched;
 }
 

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -2861,11 +2861,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ApiMempoolTxEvent dco_decode_api_mempool_tx_event(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
     return ApiMempoolTxEvent(
       txidHex: dco_decode_String(arr[0]),
-      matched: dco_decode_bool(arr[1]),
+      accountUuids: dco_decode_list_String(arr[1]),
+      matched: dco_decode_bool(arr[2]),
     );
   }
 
@@ -3411,8 +3412,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_txidHex = sse_decode_String(deserializer);
+    var var_accountUuids = sse_decode_list_String(deserializer);
     var var_matched = sse_decode_bool(deserializer);
-    return ApiMempoolTxEvent(txidHex: var_txidHex, matched: var_matched);
+    return ApiMempoolTxEvent(
+      txidHex: var_txidHex,
+      accountUuids: var_accountUuids,
+      matched: var_matched,
+    );
   }
 
   @protected
@@ -4098,6 +4104,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.txidHex, serializer);
+    sse_encode_list_String(self.accountUuids, serializer);
     sse_encode_bool(self.matched, serializer);
   }
 

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -153,14 +153,17 @@ pub(crate) static SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 
 // ======================== Mempool Observer ========================
 
-/// Event emitted by the mempool observer when a transaction
-/// appears on lightwalletd's mempool stream. Mirrored one-to-one
-/// from `sync_engine::mempool::MempoolTxEvent` for FRB codegen.
+/// Event emitted by the mempool observer when a wallet-relevant
+/// transaction appears on lightwalletd's mempool stream. Mirrored
+/// one-to-one from `sync_engine::mempool::MempoolTxEvent` for FRB
+/// codegen.
 pub struct ApiMempoolTxEvent {
     /// Lower-case hex of the tx id.
     pub txid_hex: String,
-    /// Account UUIDs that this event is known to affect. Empty
-    /// keeps the legacy behavior of refreshing the active account.
+    /// Account UUIDs that this event is known to affect. Empty means the
+    /// tx is wallet-relevant but not account-scoped enough for Rust to
+    /// name the account, so Dart keeps the legacy behavior of refreshing
+    /// the active account.
     pub account_uuids: Vec<String>,
     /// `true` when the tx is wallet-relevant: either the wallet DB
     /// already has this txid as unmined, or the observer decrypted
@@ -213,9 +216,9 @@ pub(crate) static MEMPOOL_OBSERVER_STATE: std::sync::LazyLock<
 /// Start the background mempool observer.
 ///
 /// Blocks until [`stop_mempool_observer`] is called or the
-/// observer returns on an unrecoverable setup error. Every
-/// incoming mempool tx that can be parsed is pushed to `sink` as
-/// an [`ApiMempoolTxEvent`].
+/// observer returns on an unrecoverable setup error. Only parsed
+/// wallet-relevant mempool txs are pushed to `sink` as
+/// [`ApiMempoolTxEvent`]s; unrelated txs are filtered inside Rust.
 ///
 /// The FRB layer runs this on the Rust isolate thread pool, so
 /// Dart can `await` the call while the observer keeps polling

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -159,6 +159,9 @@ pub(crate) static SYNC_RUNNING: AtomicBool = AtomicBool::new(false);
 pub struct ApiMempoolTxEvent {
     /// Lower-case hex of the tx id.
     pub txid_hex: String,
+    /// Account UUIDs that this event is known to affect. Empty
+    /// keeps the legacy behavior of refreshing the active account.
+    pub account_uuids: Vec<String>,
     /// `true` when the wallet DB already has this txid in its
     /// `transactions` table with `mined_height IS NULL`. Dart
     /// uses this flag to decide whether to refresh balance +
@@ -258,6 +261,7 @@ pub fn start_mempool_observer(
                     if sink
                         .add(ApiMempoolTxEvent {
                             txid_hex: event.txid_hex,
+                            account_uuids: event.account_uuids,
                             matched: event.matched,
                         })
                         .is_err()

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -162,10 +162,11 @@ pub struct ApiMempoolTxEvent {
     /// Account UUIDs that this event is known to affect. Empty
     /// keeps the legacy behavior of refreshing the active account.
     pub account_uuids: Vec<String>,
-    /// `true` when the wallet DB already has this txid in its
-    /// `transactions` table with `mined_height IS NULL`. Dart
-    /// uses this flag to decide whether to refresh balance +
-    /// history immediately.
+    /// `true` when the tx is wallet-relevant: either the wallet DB
+    /// already has this txid as unmined, or the observer decrypted
+    /// and stored a new inbound transaction from the mempool. Dart
+    /// uses this flag to decide whether to refresh balance + history
+    /// immediately.
     pub matched: bool,
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -2575,9 +2575,11 @@ impl SseDecode for crate::api::sync::ApiMempoolTxEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_txidHex = <String>::sse_decode(deserializer);
+        let mut var_accountUuids = <Vec<String>>::sse_decode(deserializer);
         let mut var_matched = <bool>::sse_decode(deserializer);
         return crate::api::sync::ApiMempoolTxEvent {
             txid_hex: var_txidHex,
+            account_uuids: var_accountUuids,
             matched: var_matched,
         };
     }
@@ -3429,6 +3431,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::sync::ApiMempoolTxEvent {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.txid_hex.into_into_dart().into_dart(),
+            self.account_uuids.into_into_dart().into_dart(),
             self.matched.into_into_dart().into_dart(),
         ]
         .into_dart()
@@ -4013,6 +4016,7 @@ impl SseEncode for crate::api::sync::ApiMempoolTxEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.txid_hex, serializer);
+        <Vec<String>>::sse_encode(self.account_uuids, serializer);
         <bool>::sse_encode(self.matched, serializer);
     }
 }

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -2453,6 +2453,58 @@ mod tests {
     }
 
     #[test]
+    fn history_prioritizes_active_unmined_sent_rows() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let confirmed = fake_txid(0xE3);
+        let pending = fake_txid(0xE4);
+
+        insert_history_tx(
+            &db,
+            account,
+            &confirmed,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            1_000_000,
+            0,
+            1_000_000,
+            false,
+            Some("2026-04-28T16:32:00Z"),
+        );
+        insert_output(&db, &confirmed, 3, None, Some(account), 1_000_000, false);
+
+        insert_history_tx(
+            &db,
+            account,
+            &pending,
+            None,
+            0,
+            Some(1_000_100),
+            -1_010_000,
+            1_010_000,
+            0,
+            false,
+            None,
+        );
+        insert_output(&db, &pending, 3, Some(account), None, 1_000_000, false);
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            Some(1),
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].txid_hex, hex::encode(pending));
+        assert_eq!(got[0].tx_kind, "sent");
+        assert_eq!(got[0].mined_height, 0);
+        assert_eq!(got[0].display_amount, 1_000_000);
+    }
+
+    #[test]
     fn history_accepts_unmined_tx_with_null_tx_index() {
         let db = fresh_history_db();
         let account = test_account_uuid();

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -910,6 +910,23 @@ fn classify_history_tx(base: &TxBase, summary: &ActivitySummary) -> Vec<Classifi
     }
 
     if rows.is_empty() {
+        if base.mined_height.is_none() && base.account_balance_delta < 0 {
+            let sent_amount = base
+                .account_balance_delta
+                .unsigned_abs()
+                .saturating_sub(base.fee);
+            if sent_amount > 0 {
+                rows.push(build_classified_tx(
+                    base,
+                    "sent",
+                    sent_amount,
+                    "unknown",
+                    false,
+                    1,
+                ));
+                return rows;
+            }
+        }
         if base.total_spent > 0 && base.total_received > 0 {
             return rows;
         }
@@ -1428,6 +1445,15 @@ mod tests {
         conn.execute(
             "UPDATE v_transactions SET tx_index = NULL WHERE txid = ?1",
             rusqlite::params![txid],
+        )
+        .unwrap();
+    }
+
+    fn set_history_fee(db: &NamedTempFile, txid: &[u8], fee_paid: i64) {
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        conn.execute(
+            "UPDATE v_transactions SET fee_paid = ?2 WHERE txid = ?1",
+            rusqlite::params![txid, fee_paid],
         )
         .unwrap();
     }
@@ -2345,6 +2371,43 @@ mod tests {
         assert_eq!(got.len(), 1);
         assert_eq!(got[0].txid_hex, hex::encode(txid));
         assert_eq!(got[0].tx_kind, "sent");
+    }
+
+    #[test]
+    fn history_shows_unmined_sent_when_output_metadata_missing() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let txid = fake_txid(0xD2);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            None,
+            0,
+            Some(1_000_100),
+            -10_010_000,
+            10_010_000,
+            9_000_000,
+            false,
+            Some("2026-04-28T13:04:00Z"),
+        );
+        set_history_fee(&db, &txid, 10_000);
+        insert_output(&db, &txid, 3, Some(account), Some(account), 9_000_000, true);
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].txid_hex, hex::encode(txid));
+        assert_eq!(got[0].tx_kind, "sent");
+        assert_eq!(got[0].display_amount, 10_000_000);
+        assert_eq!(got[0].mined_height, 0);
     }
 
     #[test]

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -314,6 +314,7 @@ struct ActivitySummary {
 
 struct ClassifiedTx {
     info: TransactionInfo,
+    sort_pending_rank: u8,
     sort_timestamp: u64,
     sort_mined_height: u64,
     tx_index: i64,
@@ -370,8 +371,9 @@ pub fn get_transaction_history(
     });
 
     visible.sort_by(|a, b| {
-        b.sort_timestamp
-            .cmp(&a.sort_timestamp)
+        b.sort_pending_rank
+            .cmp(&a.sort_pending_rank)
+            .then_with(|| b.sort_timestamp.cmp(&a.sort_timestamp))
             .then_with(|| b.sort_mined_height.cmp(&a.sort_mined_height))
             .then_with(|| b.tx_index.cmp(&a.tx_index))
             .then_with(|| b.info.txid_hex.cmp(&a.info.txid_hex))
@@ -791,7 +793,7 @@ fn detail_includes_output(
         "sent" => {
             !base.is_shielding && from_own && (!to_own || is_user_visible_self_output(output))
         }
-        "received" => {
+        "received" | "receiving" => {
             !base.is_shielding && to_own && (!from_own || is_user_visible_self_output(output))
         }
         _ => false,
@@ -901,7 +903,7 @@ fn classify_history_tx(base: &TxBase, summary: &ActivitySummary) -> Vec<Classifi
     if summary.received.amount > 0 {
         rows.push(build_classified_tx(
             base,
-            "received",
+            receiving_tx_kind(base),
             summary.received.amount,
             summary.received.display_pool(),
             summary.received.has_transparent,
@@ -933,7 +935,7 @@ fn classify_history_tx(base: &TxBase, summary: &ActivitySummary) -> Vec<Classifi
         if base.account_balance_delta > 0 {
             rows.push(build_classified_tx(
                 base,
-                "received",
+                receiving_tx_kind(base),
                 base.account_balance_delta as u64,
                 "unknown",
                 false,
@@ -945,6 +947,14 @@ fn classify_history_tx(base: &TxBase, summary: &ActivitySummary) -> Vec<Classifi
     }
 
     rows
+}
+
+fn receiving_tx_kind(base: &TxBase) -> &'static str {
+    if base.mined_height.is_none() && !base.expired_unmined {
+        "receiving"
+    } else {
+        "received"
+    }
 }
 
 fn build_classified_tx(
@@ -970,6 +980,7 @@ fn build_classified_tx(
             display_pool: display_pool.to_string(),
             created_time: base.created_time,
         },
+        sort_pending_rank: u8::from(base.mined_height.is_none() && !base.expired_unmined),
         sort_timestamp,
         sort_mined_height: base.mined_height.unwrap_or(0) as u64,
         tx_index: base.tx_index,
@@ -2102,6 +2113,57 @@ mod tests {
     }
 
     #[test]
+    fn detail_receiving_row_uses_received_outputs() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let txid = fake_txid(0xD6);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            None,
+            1,
+            Some(1_000_100),
+            2_000_000,
+            0,
+            2_000_000,
+            false,
+            None,
+        );
+        insert_output_with_address_and_memo(
+            &db,
+            &txid,
+            3,
+            None,
+            Some(account),
+            2_000_000,
+            false,
+            Some("u-my-pending-receiver"),
+            Some(0),
+            Some(b"pending incoming memo"),
+        );
+
+        let got = get_transaction_detail(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            &account.to_string(),
+            &hex::encode(txid),
+            "receiving",
+        )
+        .unwrap();
+
+        assert_eq!(got.tx_kind, "receiving");
+        assert_eq!(got.primary_address, None);
+        assert_eq!(got.memo.as_deref(), Some("pending incoming memo"));
+        assert_eq!(got.outputs.len(), 1);
+        assert_eq!(
+            got.outputs[0].address.as_deref(),
+            Some("u-my-pending-receiver")
+        );
+    }
+
+    #[test]
     fn detail_separates_same_account_self_send_by_kind() {
         let db = fresh_history_db();
         let account = test_account_uuid();
@@ -2336,6 +2398,58 @@ mod tests {
         assert_eq!(limited.len(), 1);
         assert_eq!(limited[0].txid_hex, hex::encode(newer_self_send));
         assert_eq!(limited[0].tx_kind, "sent");
+    }
+
+    #[test]
+    fn history_prioritizes_unmined_receiving_rows() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let confirmed = fake_txid(0xE1);
+        let pending = fake_txid(0xE2);
+
+        insert_history_tx(
+            &db,
+            account,
+            &confirmed,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            1_000_000,
+            0,
+            1_000_000,
+            false,
+            Some("2026-04-28T16:32:00Z"),
+        );
+        insert_output(&db, &confirmed, 3, None, Some(account), 1_000_000, false);
+
+        insert_history_tx(
+            &db,
+            account,
+            &pending,
+            None,
+            0,
+            Some(1_000_100),
+            2_000_000,
+            0,
+            2_000_000,
+            false,
+            None,
+        );
+        insert_output(&db, &pending, 3, None, Some(account), 2_000_000, false);
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            Some(1),
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].txid_hex, hex::encode(pending));
+        assert_eq!(got[0].tx_kind, "receiving");
+        assert_eq!(got[0].mined_height, 0);
+        assert_eq!(got[0].display_amount, 2_000_000);
     }
 
     #[test]

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -912,7 +912,7 @@ fn classify_history_tx(base: &TxBase, summary: &ActivitySummary) -> Vec<Classifi
     }
 
     if rows.is_empty() {
-        if base.mined_height.is_none() && base.account_balance_delta < 0 {
+        if base.mined_height.is_none() && base.account_balance_delta < 0 && base.total_spent > 0 {
             let sent_amount = base
                 .account_balance_delta
                 .unsigned_abs()

--- a/rust/src/wallet/sync_engine/mempool.rs
+++ b/rust/src/wallet/sync_engine/mempool.rs
@@ -55,8 +55,8 @@ use crate::wallet::network::WalletNetwork;
 use super::lwd::start_mempool_stream;
 use super::open_lwd_channel;
 
-/// Event emitted by [`run_mempool_observer`] for every transaction
-/// arriving on the mempool stream that we can parse.
+/// Event emitted by [`run_mempool_observer`] for every wallet-relevant
+/// transaction arriving on the mempool stream that we can parse.
 ///
 /// `matched` is `true` when the txid is wallet-relevant: either it
 /// was already present in the wallet DB as unmined, or the observer
@@ -540,9 +540,10 @@ async fn watch_for_cancel(cancel: &Arc<AtomicBool>) {
 ///
 /// Unmatched transactions (other people's txs) are silently
 /// dropped on the Rust side without crossing the FRB bridge.
-/// Unknown txs may still pay the cost of trial decryption, but they
-/// never take the wallet DB write lock unless a shielded output
-/// decrypts for one of our accounts.
+/// Unknown txs may still pay the cost of shielded trial decryption,
+/// but they never take the wallet DB write lock unless a Sapling or
+/// Orchard output decrypts for one of our accounts. Transparent
+/// inbound transactions are still discovered by the normal sync path.
 ///
 /// All failures are logged and swallowed — one un-parseable tx
 /// must not break the observer loop.
@@ -590,6 +591,10 @@ fn handle_mempool_tx<F>(
 
     if known.matched || !known.account_uuids.is_empty() {
         stats.record_known_pending_hit();
+        // `matched=true` with no account UUIDs is possible while the
+        // transaction table has an unmined row but the account-scoped view
+        // has not projected it yet. Dart treats empty account scope as the
+        // legacy "refresh active account" fallback.
         emit_wallet_relevant_tx(
             txid_hex,
             txid_bytes,

--- a/rust/src/wallet/sync_engine/mempool.rs
+++ b/rust/src/wallet/sync_engine/mempool.rs
@@ -53,11 +53,11 @@ use std::time::{Duration, Instant};
 
 use zcash_client_backend::{data_api::WalletRead, proto::service::RawTransaction};
 use zcash_primitives::transaction::Transaction;
-use zcash_protocol::consensus::BranchId;
+use zcash_protocol::consensus::{BlockHeight, BranchId};
 
 use crate::wallet::network::WalletNetwork;
 
-use super::lwd::start_mempool_stream;
+use super::lwd::{get_latest_block, start_mempool_stream};
 use super::open_lwd_channel;
 
 /// Event emitted by [`run_mempool_observer`] for every wallet-relevant
@@ -454,6 +454,43 @@ where
             }
         };
 
+        // Fetch the current network tip before subscribing. Mempool
+        // decryption treats unmined transactions as being at
+        // chain_tip + 1 for ZIP-212 enforcement, and the store path in
+        // librustzcash independently reads the wallet DB chain height.
+        // Updating the DB here keeps both trial-decrypt and store-decrypt
+        // on the same network tip even while foreground sync is still
+        // catching up from an older birthday.
+        let tip_result = tokio::select! {
+            biased;
+            _ = watch_for_cancel(&cancel) => {
+                log::info!("mempool: observer cancelled during tip refresh");
+                return Ok(());
+            }
+            r = get_latest_block(&mut client) => r,
+        };
+        let tip = match tip_result {
+            Ok(tip) => tip,
+            Err(e) => {
+                log::warn!("mempool: get_latest_block before stream failed: {e}");
+                consecutive_errors += 1;
+                sleep_respecting_cancel(backoff_for(consecutive_errors), &cancel).await;
+                continue;
+            }
+        };
+        let chain_tip_height = match update_mempool_chain_tip(&db_path, network, tip.height) {
+            Ok(height) => height,
+            Err(e) => {
+                log::warn!(
+                    "mempool: update_chain_tip({}) before stream failed: {e}",
+                    tip.height
+                );
+                consecutive_errors += 1;
+                sleep_respecting_cancel(backoff_for(consecutive_errors), &cancel).await;
+                continue;
+            }
+        };
+
         // Start the mempool stream — also cancel-aware.
         let stream_result = tokio::select! {
             biased;
@@ -517,6 +554,7 @@ where
                             handle_mempool_tx(
                                 &db_path,
                                 network,
+                                chain_tip_height,
                                 &mut seen_cache,
                                 &mut unmatched_cache,
                                 &mut stats,
@@ -613,6 +651,17 @@ async fn watch_for_cancel(cancel: &Arc<AtomicBool>) {
     }
 }
 
+fn update_mempool_chain_tip(
+    db_path: &str,
+    network: WalletNetwork,
+    height: u64,
+) -> Result<BlockHeight, String> {
+    let height_u32 =
+        u32::try_from(height).map_err(|_| format!("chain tip height {height} exceeds u32"))?;
+    crate::wallet::sync::update_chain_tip(db_path, network, u64::from(height_u32))?;
+    Ok(BlockHeight::from_u32(height_u32))
+}
+
 /// Parse `raw_tx`, compute the txid, skip duplicate wallet-relevant
 /// observations and very recent unmatched observations, and emit a
 /// [`MempoolTxEvent`] only for wallet-relevant txs.
@@ -629,6 +678,7 @@ async fn watch_for_cancel(cancel: &Arc<AtomicBool>) {
 fn handle_mempool_tx<F>(
     db_path: &str,
     network: WalletNetwork,
+    chain_tip_height: BlockHeight,
     seen_cache: &mut TxidSeenCache,
     unmatched_cache: &mut TxidTtlCache,
     stats: &mut MempoolObserverStats,
@@ -672,17 +722,18 @@ fn handle_mempool_tx<F>(
     if known.matched || !known.account_uuids.is_empty() {
         stats.record_known_pending_hit();
         let decrypt_started_at = Instant::now();
-        let decrypted_account_uuids = match trial_decrypt_account_uuids(db_path, network, &tx) {
-            Ok(accounts) => {
-                stats.record_trial_decrypt(decrypt_started_at.elapsed(), !accounts.is_empty());
-                accounts
-            }
-            Err(e) => {
-                stats.record_trial_decrypt_fail(decrypt_started_at.elapsed());
-                log::debug!("mempool: trial decrypt for known {txid_hex} failed: {e}");
-                Vec::new()
-            }
-        };
+        let decrypted_account_uuids =
+            match trial_decrypt_account_uuids(db_path, network, chain_tip_height, &tx) {
+                Ok(accounts) => {
+                    stats.record_trial_decrypt(decrypt_started_at.elapsed(), !accounts.is_empty());
+                    accounts
+                }
+                Err(e) => {
+                    stats.record_trial_decrypt_fail(decrypt_started_at.elapsed());
+                    log::debug!("mempool: trial decrypt for known {txid_hex} failed: {e}");
+                    Vec::new()
+                }
+            };
         let (account_uuids, has_new_account) =
             merge_account_uuids(&known.account_uuids, &decrypted_account_uuids);
 
@@ -735,7 +786,7 @@ fn handle_mempool_tx<F>(
     }
 
     let decrypt_started_at = Instant::now();
-    let account_uuids = match trial_decrypt_account_uuids(db_path, network, &tx) {
+    let account_uuids = match trial_decrypt_account_uuids(db_path, network, chain_tip_height, &tx) {
         Ok(accounts) => {
             stats.record_trial_decrypt(decrypt_started_at.elapsed(), !accounts.is_empty());
             accounts
@@ -853,6 +904,7 @@ fn lookup_known_pending_tx(db_path: &str, txid_bytes: &[u8]) -> Result<KnownPend
 fn trial_decrypt_account_uuids(
     db_path: &str,
     network: WalletNetwork,
+    chain_tip_height: BlockHeight,
     tx: &Transaction,
 ) -> Result<Vec<String>, String> {
     let db = crate::wallet::sync::open_wallet_db_for_read(db_path, network)
@@ -863,8 +915,7 @@ fn trial_decrypt_account_uuids(
     let decrypted = zcash_client_backend::decrypt_transaction(
         &network,
         None,
-        db.chain_height()
-            .map_err(|e| format!("chain height: {e}"))?,
+        Some(chain_tip_height),
         tx,
         &ufvks,
     );

--- a/rust/src/wallet/sync_engine/mempool.rs
+++ b/rust/src/wallet/sync_engine/mempool.rs
@@ -3,11 +3,10 @@
 //! The block-scan loop in `sync_engine::mod` catches wallet-related
 //! transactions at the granularity of a block batch — fast enough
 //! for most flows, but always *after* the tx has been mined. This
-//! observer closes that gap for outbound sends: as soon as
-//! lightwalletd relays the wallet's own transaction back through
-//! its mempool stream, we emit a `MempoolTxEvent { matched: true }`
-//! and the Dart side refreshes balance + history without waiting
-//! for the next block.
+//! observer closes that gap for wallet-relevant mempool traffic:
+//! already-known outbound transactions are confirmed as propagated,
+//! and new inbound shielded transactions are trial-decrypted and
+//! stored as unmined wallet transactions before the next block.
 //!
 //! Design choices:
 //!
@@ -26,15 +25,13 @@
 //!     fresh channel via [`super::open_lwd_channel`], which also
 //!     means we inherit the same TLS transport the scan loop uses.
 //!
-//!   * **Read-only DB access.** V1 of the observer does *not* call
-//!     `decrypt_and_store_transaction`. It parses the raw bytes
-//!     just far enough to get the txid, then checks whether that
-//!     txid already exists in the wallet's `transactions` table
-//!     with `mined_height IS NULL`. That is enough to power the
-//!     "outbound tx just hit mempool" UX without racing against
-//!     the sync loop's writes. A future v2 can re-add decryption
-//!     for earlier discovery of *inbound* txs at the cost of
-//!     handling SQLite write contention more carefully.
+//!   * **Write only after a wallet hit.** The hot path parses the
+//!     txid, skips txs already seen in this observer session, and
+//!     checks for existing unmined wallet rows. Unknown txs go
+//!     through read-only trial decryption first; only txs that
+//!     decrypt for one of our UFVKs call `decrypt_and_store_transaction`.
+//!     That keeps SQLite write contention proportional to wallet
+//!     relevance instead of global mempool volume.
 //!
 //!   * **Reconnect semantics match the SDK.** lightwalletd closes
 //!     the stream every time a new block is mined — normal EOF,
@@ -44,11 +41,12 @@
 //!     successful connect. Cancel is checked inside the sleep so
 //!     we don't block `stop_mempool_observer()` for 30s.
 
+use std::collections::{BTreeSet, HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use zcash_client_backend::proto::service::RawTransaction;
+use zcash_client_backend::{data_api::WalletRead, proto::service::RawTransaction};
 use zcash_primitives::transaction::Transaction;
 use zcash_protocol::consensus::BranchId;
 
@@ -60,18 +58,233 @@ use super::open_lwd_channel;
 /// Event emitted by [`run_mempool_observer`] for every transaction
 /// arriving on the mempool stream that we can parse.
 ///
-/// `matched` is `true` when the txid is already known to the wallet
-/// DB with `mined_height IS NULL` — i.e. an outbound send that the
-/// network just relayed back to us, or any previously-recorded
-/// pending tx that's still in the mempool. Dart consumers use
-/// that flag to decide whether to trigger a balance refresh.
+/// `matched` is `true` when the txid is wallet-relevant: either it
+/// was already present in the wallet DB as unmined, or the observer
+/// decrypted and stored a new inbound shielded transaction.
 #[derive(Clone, Debug)]
 pub struct MempoolTxEvent {
     /// Lower-case hex of the txid (stable across consumers).
     pub txid_hex: String,
+    /// Account UUIDs that this tx currently maps to in the wallet.
+    /// Empty means the event is wallet-relevant but not account-scoped
+    /// enough for the Rust side to tell Dart which active account to
+    /// refresh. Dart keeps the pre-existing "refresh active account"
+    /// behavior in that case.
+    pub account_uuids: Vec<String>,
     /// Whether the txid corresponds to a row in the wallet's
     /// `transactions` table with `mined_height IS NULL`.
     pub matched: bool,
+}
+
+struct TxidSeenCache {
+    max_len: usize,
+    order: VecDeque<Vec<u8>>,
+    entries: HashSet<Vec<u8>>,
+}
+
+impl TxidSeenCache {
+    fn new(max_len: usize) -> Self {
+        Self {
+            max_len,
+            order: VecDeque::new(),
+            entries: HashSet::new(),
+        }
+    }
+
+    fn contains(&self, txid_bytes: &[u8]) -> bool {
+        self.entries.contains(txid_bytes)
+    }
+
+    fn insert(&mut self, txid_bytes: Vec<u8>) {
+        if self.max_len == 0 || !self.entries.insert(txid_bytes.clone()) {
+            return;
+        }
+
+        self.order.push_back(txid_bytes);
+        while self.order.len() > self.max_len {
+            if let Some(oldest) = self.order.pop_front() {
+                self.entries.remove(&oldest);
+            }
+        }
+    }
+}
+
+const STATS_LOG_INTERVAL: Duration = Duration::from_secs(30);
+
+#[derive(Debug)]
+struct MempoolObserverStats {
+    window_started_at: Instant,
+    tx_count: u64,
+    tx_bytes: u64,
+    seen_skip: u64,
+    parse_fail: u64,
+    pending_lookup_fail: u64,
+    known_pending_hit: u64,
+    trial_decrypt_count: u64,
+    trial_decrypt_hit: u64,
+    trial_decrypt_fail: u64,
+    trial_decrypt_total: Duration,
+    trial_decrypt_max: Duration,
+    store_ok: u64,
+    store_fail: u64,
+    store_total: Duration,
+    store_max: Duration,
+    stream_connects: u64,
+    stream_eofs: u64,
+    stream_errors: u64,
+}
+
+#[derive(Debug, Default)]
+struct KnownPendingTx {
+    matched: bool,
+    account_uuids: Vec<String>,
+}
+
+impl MempoolObserverStats {
+    fn new(now: Instant) -> Self {
+        Self {
+            window_started_at: now,
+            tx_count: 0,
+            tx_bytes: 0,
+            seen_skip: 0,
+            parse_fail: 0,
+            pending_lookup_fail: 0,
+            known_pending_hit: 0,
+            trial_decrypt_count: 0,
+            trial_decrypt_hit: 0,
+            trial_decrypt_fail: 0,
+            trial_decrypt_total: Duration::ZERO,
+            trial_decrypt_max: Duration::ZERO,
+            store_ok: 0,
+            store_fail: 0,
+            store_total: Duration::ZERO,
+            store_max: Duration::ZERO,
+            stream_connects: 0,
+            stream_eofs: 0,
+            stream_errors: 0,
+        }
+    }
+
+    fn record_tx(&mut self, bytes: usize) {
+        self.tx_count += 1;
+        self.tx_bytes = self.tx_bytes.saturating_add(bytes as u64);
+    }
+
+    fn record_seen_skip(&mut self) {
+        self.seen_skip += 1;
+    }
+
+    fn record_parse_fail(&mut self) {
+        self.parse_fail += 1;
+    }
+
+    fn record_pending_lookup_fail(&mut self) {
+        self.pending_lookup_fail += 1;
+    }
+
+    fn record_known_pending_hit(&mut self) {
+        self.known_pending_hit += 1;
+    }
+
+    fn record_trial_decrypt(&mut self, duration: Duration, hit: bool) {
+        self.trial_decrypt_count += 1;
+        if hit {
+            self.trial_decrypt_hit += 1;
+        }
+        self.trial_decrypt_total += duration;
+        self.trial_decrypt_max = self.trial_decrypt_max.max(duration);
+    }
+
+    fn record_trial_decrypt_fail(&mut self, duration: Duration) {
+        self.trial_decrypt_fail += 1;
+        self.record_trial_decrypt(duration, false);
+    }
+
+    fn record_store(&mut self, duration: Duration, ok: bool) {
+        if ok {
+            self.store_ok += 1;
+        } else {
+            self.store_fail += 1;
+        }
+        self.store_total += duration;
+        self.store_max = self.store_max.max(duration);
+    }
+
+    fn record_stream_connect(&mut self) {
+        self.stream_connects += 1;
+    }
+
+    fn record_stream_eof(&mut self) {
+        self.stream_eofs += 1;
+    }
+
+    fn record_stream_error(&mut self) {
+        self.stream_errors += 1;
+    }
+
+    fn take_summary_if_due(&mut self, now: Instant) -> Option<String> {
+        let elapsed = now.duration_since(self.window_started_at);
+        if elapsed < STATS_LOG_INTERVAL {
+            return None;
+        }
+
+        let line = self.summary_line(elapsed);
+        *self = Self::new(now);
+        line
+    }
+
+    fn summary_line(&self, elapsed: Duration) -> Option<String> {
+        if !self.has_activity() {
+            return None;
+        }
+
+        let store_count = self.store_ok + self.store_fail;
+        Some(format!(
+            "mempool: stats {}s tx={} bytes={} seen_skip={} known_hit={} \
+             decrypt={} decrypt_hit={} decrypt_fail={} decrypt_avg={:.1}ms \
+             decrypt_max={:.1}ms store_ok={} store_fail={} store_avg={:.1}ms \
+             store_max={:.1}ms parse_fail={} pending_lookup_fail={} \
+             stream_connect={} stream_eof={} stream_error={}",
+            elapsed.as_secs(),
+            self.tx_count,
+            self.tx_bytes,
+            self.seen_skip,
+            self.known_pending_hit,
+            self.trial_decrypt_count,
+            self.trial_decrypt_hit,
+            self.trial_decrypt_fail,
+            average_ms(self.trial_decrypt_total, self.trial_decrypt_count),
+            duration_ms(self.trial_decrypt_max),
+            self.store_ok,
+            self.store_fail,
+            average_ms(self.store_total, store_count),
+            duration_ms(self.store_max),
+            self.parse_fail,
+            self.pending_lookup_fail,
+            self.stream_connects,
+            self.stream_eofs,
+            self.stream_errors,
+        ))
+    }
+
+    fn has_activity(&self) -> bool {
+        self.tx_count > 0
+            || self.stream_connects > 0
+            || self.stream_eofs > 0
+            || self.stream_errors > 0
+    }
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+fn average_ms(total: Duration, count: u64) -> f64 {
+    if count == 0 {
+        0.0
+    } else {
+        duration_ms(total) / count as f64
+    }
 }
 
 /// Run the mempool observer until `cancel` is set.
@@ -96,7 +309,7 @@ pub struct MempoolTxEvent {
 /// `StreamSink` which is effectively a non-blocking push.
 pub(crate) async fn run_mempool_observer<F>(
     db_path: String,
-    _network: WalletNetwork,
+    network: WalletNetwork,
     lightwalletd_url: String,
     cancel: Arc<AtomicBool>,
     emit: F,
@@ -108,6 +321,8 @@ where
     const LATER_BACKOFF: Duration = Duration::from_secs(30);
 
     let mut consecutive_errors: u32 = 0;
+    let mut seen_cache = TxidSeenCache::new(2048);
+    let mut stats = MempoolObserverStats::new(Instant::now());
 
     /// Pick the backoff delay based on how many consecutive errors
     /// we've accumulated. First failure: 1s. Subsequent: 30s.
@@ -177,6 +392,8 @@ where
         };
 
         log::info!("mempool: observer connected");
+        stats.record_stream_connect();
+        log_stats_if_due(&mut stats);
         consecutive_errors = 0;
 
         // Consume the stream until EOF, error, or cancel.
@@ -215,7 +432,15 @@ where
                 msg = stream.message() => {
                     match msg {
                         Ok(Some(raw_tx)) => {
-                            handle_mempool_tx(&db_path, &raw_tx, &emit);
+                            handle_mempool_tx(
+                                &db_path,
+                                network,
+                                &mut seen_cache,
+                                &mut stats,
+                                &raw_tx,
+                                &emit,
+                            );
+                            log_stats_if_due(&mut stats);
                         }
                         Ok(None) => {
                             // Clean EOF. lightwalletd documents this
@@ -226,11 +451,13 @@ where
                             log::debug!(
                                 "mempool: stream closed by server (new block?)"
                             );
+                            stats.record_stream_eof();
                             break StreamExit::CleanEof;
                         }
                         Err(e) => {
                             log::warn!("mempool: stream error: {e}");
                             consecutive_errors += 1;
+                            stats.record_stream_error();
                             break StreamExit::Error;
                         }
                     }
@@ -271,6 +498,7 @@ where
             }
             StreamExit::Error => backoff_for(consecutive_errors),
         };
+        log_stats_if_due(&mut stats);
         sleep_respecting_cancel(reconnect_delay, &cancel).await;
     }
 }
@@ -302,24 +530,29 @@ async fn watch_for_cancel(cancel: &Arc<AtomicBool>) {
     }
 }
 
-/// Parse `raw_tx`, compute the txid, check whether the wallet DB
-/// knows about it as an unmined entry, and — only if it matches —
-/// emit a [`MempoolTxEvent`] to the Dart side.
+/// Parse `raw_tx`, compute the txid, skip duplicate observations,
+/// and emit a [`MempoolTxEvent`] only for wallet-relevant txs.
 ///
 /// Unmatched transactions (other people's txs) are silently
 /// dropped on the Rust side without crossing the FRB bridge.
-/// This keeps the observer's CPU / battery cost proportional to
-/// the wallet's own pending-tx count rather than to global
-/// mempool volume, and avoids starving the matched-event delivery
-/// path behind a flood of `matched=false` noise (Codex 5th-round
-/// finding 2).
+/// Unknown txs may still pay the cost of trial decryption, but they
+/// never take the wallet DB write lock unless a shielded output
+/// decrypts for one of our accounts.
 ///
 /// All failures are logged and swallowed — one un-parseable tx
 /// must not break the observer loop.
-fn handle_mempool_tx<F>(db_path: &str, raw_tx: &RawTransaction, emit: &F)
-where
+fn handle_mempool_tx<F>(
+    db_path: &str,
+    network: WalletNetwork,
+    seen_cache: &mut TxidSeenCache,
+    stats: &mut MempoolObserverStats,
+    raw_tx: &RawTransaction,
+    emit: &F,
+) where
     F: Fn(MempoolTxEvent),
 {
+    stats.record_tx(raw_tx.data.len());
+
     // Parse far enough to get the txid. `BranchId::Sapling` matches
     // what the sync loop's enhance path uses; any new-network-era
     // txs that fail parse here would also fail there and surface
@@ -327,6 +560,7 @@ where
     let tx = match Transaction::read(&raw_tx.data[..], BranchId::Sapling) {
         Ok(t) => t,
         Err(e) => {
+            stats.record_parse_fail();
             log::debug!("mempool: Transaction::read failed: {e}");
             return;
         }
@@ -335,47 +569,177 @@ where
     let txid_hex = format!("{txid}");
     let txid_bytes = txid.as_ref().to_vec();
 
-    let matched = match is_known_pending_txid(db_path, &txid_bytes) {
-        Ok(b) => b,
+    if seen_cache.contains(&txid_bytes) {
+        stats.record_seen_skip();
+        return;
+    }
+
+    let known = match lookup_known_pending_tx(db_path, &txid_bytes) {
+        Ok(known) => known,
         Err(e) => {
+            stats.record_pending_lookup_fail();
             log::debug!("mempool: DB lookup for {txid_hex} failed: {e}");
             return;
         }
     };
 
-    // Only emit wallet-relevant hits. Unmatched txs stay entirely
-    // on the Rust side — no FRB hop, no Dart callback, no
-    // StreamSink pressure. The Dart listener's
-    // `if (!event.matched) return` guard is kept as a defensive
-    // belt, but should never fire now that filtering happens here.
-    if !matched {
+    if known.matched || !known.account_uuids.is_empty() {
+        stats.record_known_pending_hit();
+        emit_wallet_relevant_tx(
+            txid_hex,
+            txid_bytes,
+            known.account_uuids,
+            seen_cache,
+            emit,
+            "matched tx",
+        );
         return;
     }
 
-    log::info!("mempool: matched tx {txid_hex}");
-    emit(MempoolTxEvent { txid_hex, matched });
+    let decrypt_started_at = Instant::now();
+    let account_uuids = match trial_decrypt_account_uuids(db_path, network, &tx) {
+        Ok(accounts) => {
+            stats.record_trial_decrypt(decrypt_started_at.elapsed(), !accounts.is_empty());
+            accounts
+        }
+        Err(e) => {
+            stats.record_trial_decrypt_fail(decrypt_started_at.elapsed());
+            log::debug!("mempool: trial decrypt for {txid_hex} failed: {e}");
+            return;
+        }
+    };
+
+    if account_uuids.is_empty() {
+        seen_cache.insert(txid_bytes);
+        return;
+    }
+
+    let store_started_at = Instant::now();
+    match crate::wallet::sync::decrypt_and_store_transaction(db_path, network, &raw_tx.data, None) {
+        Ok(()) => {
+            stats.record_store(store_started_at.elapsed(), true);
+            emit_wallet_relevant_tx(
+                txid_hex,
+                txid_bytes,
+                account_uuids,
+                seen_cache,
+                emit,
+                "stored inbound tx",
+            );
+        }
+        Err(e) => {
+            stats.record_store(store_started_at.elapsed(), false);
+            log::warn!("mempool: failed to store inbound tx {txid_hex}: {e}");
+        }
+    }
 }
 
-/// Read-only check: does the wallet know about this txid as an
-/// unmined transaction? One SELECT against `transactions`, no
-/// joins, no write lock — safe to run concurrently with the sync
-/// loop's writes.
-fn is_known_pending_txid(db_path: &str, txid_bytes: &[u8]) -> Result<bool, String> {
+fn log_stats_if_due(stats: &mut MempoolObserverStats) {
+    if let Some(line) = stats.take_summary_if_due(Instant::now()) {
+        log::info!("{line}");
+    }
+}
+
+fn emit_wallet_relevant_tx<F>(
+    txid_hex: String,
+    txid_bytes: Vec<u8>,
+    account_uuids: Vec<String>,
+    seen_cache: &mut TxidSeenCache,
+    emit: &F,
+    log_label: &str,
+) where
+    F: Fn(MempoolTxEvent),
+{
+    seen_cache.insert(txid_bytes);
+    log::info!("mempool: {log_label} {txid_hex}");
+    emit(MempoolTxEvent {
+        txid_hex: txid_hex.clone(),
+        account_uuids: account_uuids.clone(),
+        matched: true,
+    });
+}
+
+/// Read-only lookup: does the wallet know about this txid as an
+/// unmined transaction, and which accounts currently map to it?
+/// Uses one SQLite connection for both checks and never takes the
+/// wallet write lock, so it is safe while the scan loop is writing.
+fn lookup_known_pending_tx(db_path: &str, txid_bytes: &[u8]) -> Result<KnownPendingTx, String> {
     use rusqlite::OptionalExtension;
 
     let conn = crate::wallet::sync::open_readonly_conn_fail_fast(db_path)
         .map_err(|e| format!("open DB: {e}"))?;
 
-    let found: Option<i64> = conn
+    let matched = conn
         .query_row(
             "SELECT 1 FROM transactions WHERE txid = ?1 AND mined_height IS NULL LIMIT 1",
             [txid_bytes],
-            |row| row.get(0),
+            |row| row.get::<_, i64>(0),
         )
         .optional()
-        .map_err(|e| format!("query: {e}"))?;
+        .map_err(|e| format!("transactions query: {e}"))?
+        .is_some();
 
-    Ok(found.is_some())
+    let mut stmt = conn
+        .prepare(
+            "SELECT DISTINCT account_uuid \
+             FROM v_transactions \
+             WHERE txid = ?1 AND mined_height IS NULL",
+        )
+        .map_err(|e| format!("account prepare: {e}"))?;
+
+    let rows = stmt
+        .query_map([txid_bytes], |row| {
+            let bytes: Vec<u8> = row.get(0)?;
+            let uuid = uuid::Uuid::from_slice(&bytes).map_err(|e| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    bytes.len(),
+                    rusqlite::types::Type::Blob,
+                    Box::new(e),
+                )
+            })?;
+            Ok(uuid.to_string())
+        })
+        .map_err(|e| format!("account query: {e}"))?;
+
+    let mut account_uuids = rows
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("account row: {e}"))?;
+    account_uuids.sort();
+
+    Ok(KnownPendingTx {
+        matched,
+        account_uuids,
+    })
+}
+
+fn trial_decrypt_account_uuids(
+    db_path: &str,
+    network: WalletNetwork,
+    tx: &Transaction,
+) -> Result<Vec<String>, String> {
+    let db = crate::wallet::sync::open_wallet_db_for_read(db_path, network)
+        .map_err(|e| format!("open wallet DB: {e}"))?;
+    let ufvks = db
+        .get_unified_full_viewing_keys()
+        .map_err(|e| format!("get UFVKs: {e}"))?;
+    let decrypted = zcash_client_backend::decrypt_transaction(
+        &network,
+        None,
+        db.chain_height()
+            .map_err(|e| format!("chain height: {e}"))?,
+        tx,
+        &ufvks,
+    );
+
+    let mut accounts = BTreeSet::new();
+    for output in decrypted.sapling_outputs() {
+        accounts.insert(output.account().expose_uuid().to_string());
+    }
+    for output in decrypted.orchard_outputs() {
+        accounts.insert(output.account().expose_uuid().to_string());
+    }
+
+    Ok(accounts.into_iter().collect())
 }
 
 /// Cancel-aware sleep. Breaks into 100ms slices so a pending
@@ -400,11 +764,11 @@ mod tests {
     //! live lightwalletd — that's integration-test territory. What
     //! we *can* test in isolation is:
     //!
-    //!   * `is_known_pending_txid`, the read-only predicate that
-    //!     decides whether each parsed mempool tx sets
-    //!     `matched = true`. Its SQL has to stay in sync with the
-    //!     `transactions` table shape and the "unmined" definition
-    //!     (`mined_height IS NULL`).
+    //!   * `lookup_known_pending_tx`, the read-only lookup that
+    //!     decides whether each parsed mempool tx is already known
+    //!     and which account UUIDs it maps to. Its SQL has to stay
+    //!     in sync with the `transactions` / `v_transactions` table
+    //!     shapes and the "unmined" definition (`mined_height IS NULL`).
     //!
     //!   * `sleep_respecting_cancel`, which must (a) return early
     //!     when `cancel` flips and (b) at minimum sleep through the
@@ -417,7 +781,7 @@ mod tests {
     /// Create a throwaway SQLite database with a stand-in
     /// `transactions` table. `zcash_client_sqlite` stores far more
     /// columns here than we query, so we only materialize the ones
-    /// `is_known_pending_txid` actually reads.
+    /// `lookup_known_pending_tx` actually reads.
     fn fresh_db() -> NamedTempFile {
         let file = NamedTempFile::new().unwrap();
         let conn = rusqlite::Connection::open(file.path()).unwrap();
@@ -425,6 +789,12 @@ mod tests {
             "CREATE TABLE transactions (
                  txid BLOB NOT NULL,
                  mined_height INTEGER
+             );
+             CREATE TABLE v_transactions (
+                 account_uuid BLOB NOT NULL,
+                 txid BLOB NOT NULL,
+                 mined_height INTEGER,
+                 block_time INTEGER
              );",
         )
         .unwrap();
@@ -440,17 +810,35 @@ mod tests {
         .unwrap();
     }
 
-    #[test]
-    fn is_known_pending_txid_finds_unmined_tx() {
-        let db = fresh_db();
-        let txid = [0x01u8; 32];
-        insert_tx(&db, &txid, None);
-        let found = is_known_pending_txid(db.path().to_str().unwrap(), &txid).unwrap();
-        assert!(found, "unmined tx in DB must register as known pending");
+    fn insert_v_transaction(
+        db: &NamedTempFile,
+        txid: &[u8],
+        account_uuid: uuid::Uuid,
+        mined_height: Option<i64>,
+    ) {
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        conn.execute(
+            "INSERT INTO v_transactions (account_uuid, txid, mined_height)
+             VALUES (?1, ?2, ?3)",
+            rusqlite::params![account_uuid.as_bytes().as_slice(), txid, mined_height],
+        )
+        .unwrap();
     }
 
     #[test]
-    fn is_known_pending_txid_ignores_mined_tx() {
+    fn lookup_known_pending_tx_finds_unmined_tx() {
+        let db = fresh_db();
+        let txid = [0x01u8; 32];
+        insert_tx(&db, &txid, None);
+        let found = lookup_known_pending_tx(db.path().to_str().unwrap(), &txid).unwrap();
+        assert!(
+            found.matched,
+            "unmined tx in DB must register as known pending"
+        );
+    }
+
+    #[test]
+    fn lookup_known_pending_tx_ignores_mined_tx() {
         // The whole point of the "unmined" filter: if sync already
         // settled this tx into a block, we don't care that it's
         // bouncing around the mempool (shouldn't be anyway, but
@@ -458,29 +846,149 @@ mod tests {
         let db = fresh_db();
         let txid = [0x02u8; 32];
         insert_tx(&db, &txid, Some(2_500_000));
-        let found = is_known_pending_txid(db.path().to_str().unwrap(), &txid).unwrap();
-        assert!(!found, "mined tx must NOT count as known pending");
+        let found = lookup_known_pending_tx(db.path().to_str().unwrap(), &txid).unwrap();
+        assert!(!found.matched, "mined tx must NOT count as known pending");
     }
 
     #[test]
-    fn is_known_pending_txid_handles_unknown_tx() {
+    fn lookup_known_pending_tx_handles_unknown_tx() {
         let db = fresh_db();
         let known_txid = [0x03u8; 32];
         let unknown_txid = [0x04u8; 32];
         insert_tx(&db, &known_txid, None);
-        let found = is_known_pending_txid(db.path().to_str().unwrap(), &unknown_txid).unwrap();
-        assert!(!found, "txid not in DB must return false");
+        let found = lookup_known_pending_tx(db.path().to_str().unwrap(), &unknown_txid).unwrap();
+        assert!(!found.matched, "txid not in DB must return false");
     }
 
     #[test]
-    fn is_known_pending_txid_handles_empty_db() {
+    fn lookup_known_pending_tx_handles_empty_db() {
         // Baseline: cold wallet with no txs at all still returns Ok(false),
         // not an error. The observer's fall-through branch relies on
         // this — a missing-row condition is "not matched", not a bug.
         let db = fresh_db();
         let txid = [0x05u8; 32];
-        let found = is_known_pending_txid(db.path().to_str().unwrap(), &txid).unwrap();
-        assert!(!found);
+        let found = lookup_known_pending_tx(db.path().to_str().unwrap(), &txid).unwrap();
+        assert!(!found.matched);
+    }
+
+    #[test]
+    fn seen_cache_evicts_oldest_txid() {
+        let mut cache = TxidSeenCache::new(2);
+        let first = vec![0x01; 32];
+        let second = vec![0x02; 32];
+        let third = vec![0x03; 32];
+
+        cache.insert(first.clone());
+        cache.insert(second.clone());
+        assert!(cache.contains(&first));
+        assert!(cache.contains(&second));
+
+        cache.insert(third.clone());
+        assert!(!cache.contains(&first));
+        assert!(cache.contains(&second));
+        assert!(cache.contains(&third));
+    }
+
+    #[test]
+    fn lookup_known_pending_tx_returns_distinct_accounts() {
+        let db = fresh_db();
+        let txid = [0x06u8; 32];
+        let first_uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let second_uuid = uuid::Uuid::parse_str("67e55044-10b1-426f-9247-bb680e5fe0c8").unwrap();
+        insert_v_transaction(&db, &txid, first_uuid, None);
+        insert_v_transaction(&db, &txid, first_uuid, None);
+        insert_v_transaction(&db, &txid, second_uuid, None);
+        insert_v_transaction(
+            &db,
+            &[0x07u8; 32],
+            uuid::Uuid::parse_str("2c2f2a4b-9c64-41f8-9801-fd06553fd4f6").unwrap(),
+            None,
+        );
+
+        let known = lookup_known_pending_tx(db.path().to_str().unwrap(), &txid).unwrap();
+        assert_eq!(
+            known.account_uuids,
+            vec![first_uuid.to_string(), second_uuid.to_string()]
+        );
+    }
+
+    #[test]
+    fn lookup_known_pending_tx_ignores_mined_account_rows() {
+        let db = fresh_db();
+        let txid = [0x08u8; 32];
+        let uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        insert_v_transaction(&db, &txid, uuid, Some(2_500_000));
+
+        let known = lookup_known_pending_tx(db.path().to_str().unwrap(), &txid).unwrap();
+        assert!(known.account_uuids.is_empty());
+    }
+
+    #[test]
+    fn lookup_known_pending_tx_returns_match_and_accounts() {
+        let db = fresh_db();
+        let txid = [0x09u8; 32];
+        let first_uuid = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let second_uuid = uuid::Uuid::parse_str("67e55044-10b1-426f-9247-bb680e5fe0c8").unwrap();
+        insert_tx(&db, &txid, None);
+        insert_v_transaction(&db, &txid, second_uuid, None);
+        insert_v_transaction(&db, &txid, first_uuid, None);
+        insert_v_transaction(&db, &txid, first_uuid, None);
+
+        let known = lookup_known_pending_tx(db.path().to_str().unwrap(), &txid).unwrap();
+
+        assert!(known.matched);
+        assert_eq!(
+            known.account_uuids,
+            vec![first_uuid.to_string(), second_uuid.to_string()]
+        );
+    }
+
+    #[test]
+    fn stats_summary_reports_volume_and_latency() {
+        let start = Instant::now();
+        let mut stats = MempoolObserverStats::new(start);
+        stats.record_tx(100);
+        stats.record_tx(50);
+        stats.record_seen_skip();
+        stats.record_known_pending_hit();
+        stats.record_trial_decrypt(Duration::from_millis(10), false);
+        stats.record_trial_decrypt(Duration::from_millis(30), true);
+        stats.record_store(Duration::from_millis(40), true);
+        stats.record_store(Duration::from_millis(80), false);
+
+        let line = stats.summary_line(Duration::from_secs(30)).unwrap();
+        assert!(line.contains("tx=2"));
+        assert!(line.contains("bytes=150"));
+        assert!(line.contains("seen_skip=1"));
+        assert!(line.contains("known_hit=1"));
+        assert!(line.contains("decrypt=2"));
+        assert!(line.contains("decrypt_hit=1"));
+        assert!(line.contains("decrypt_avg=20.0ms"));
+        assert!(line.contains("decrypt_max=30.0ms"));
+        assert!(line.contains("store_ok=1"));
+        assert!(line.contains("store_fail=1"));
+        assert!(line.contains("store_avg=60.0ms"));
+        assert!(line.contains("store_max=80.0ms"));
+    }
+
+    #[test]
+    fn stats_take_summary_resets_after_interval() {
+        let start = Instant::now();
+        let mut stats = MempoolObserverStats::new(start);
+        stats.record_tx(10);
+
+        assert!(stats
+            .take_summary_if_due(start + Duration::from_secs(29))
+            .is_none());
+        assert!(stats
+            .take_summary_if_due(start + Duration::from_secs(30))
+            .is_some());
+        assert!(
+            stats
+                .take_summary_if_due(start + Duration::from_secs(60))
+                .is_none(),
+            "no activity after reset should not log empty windows"
+        );
     }
 
     #[tokio::test]

--- a/rust/src/wallet/sync_engine/mempool.rs
+++ b/rust/src/wallet/sync_engine/mempool.rs
@@ -71,8 +71,9 @@ pub struct MempoolTxEvent {
     /// refresh. Dart keeps the pre-existing "refresh active account"
     /// behavior in that case.
     pub account_uuids: Vec<String>,
-    /// Whether the txid corresponds to a row in the wallet's
-    /// `transactions` table with `mined_height IS NULL`.
+    /// Whether the tx was wallet-relevant enough to emit. The observer
+    /// currently emits only matched events; the field stays in the API
+    /// as a defensive guard for consumers.
     pub matched: bool,
 }
 
@@ -136,6 +137,10 @@ struct MempoolObserverStats {
 
 #[derive(Debug, Default)]
 struct KnownPendingTx {
+    /// True when `transactions` already has this txid as unmined.
+    /// `account_uuids` can still be empty if `v_transactions` has not
+    /// projected account rows yet; the caller intentionally falls back
+    /// to an active-account refresh in that transient case.
     matched: bool,
     account_uuids: Vec<String>,
 }

--- a/rust/src/wallet/sync_engine/mempool.rs
+++ b/rust/src/wallet/sync_engine/mempool.rs
@@ -28,10 +28,12 @@
 //!   * **Write only after a wallet hit.** The hot path parses the
 //!     txid, skips txs already seen in this observer session, and
 //!     checks for existing unmined wallet rows. Unknown txs go
-//!     through read-only trial decryption first; only txs that
-//!     decrypt for one of our UFVKs call `decrypt_and_store_transaction`.
-//!     That keeps SQLite write contention proportional to wallet
-//!     relevance instead of global mempool volume.
+//!     through read-only trial decryption first; already-known txs
+//!     are also trial-decrypted once so wallet-internal sends can
+//!     discover recipient accounts in the same DB. Only txs that add
+//!     wallet relevance call `decrypt_and_store_transaction`. That
+//!     keeps SQLite write contention proportional to wallet relevance
+//!     instead of global mempool volume.
 //!
 //!   * **Reconnect semantics match the SDK.** lightwalletd closes
 //!     the stream every time a new block is mined — normal EOF,
@@ -591,6 +593,48 @@ fn handle_mempool_tx<F>(
 
     if known.matched || !known.account_uuids.is_empty() {
         stats.record_known_pending_hit();
+        let decrypt_started_at = Instant::now();
+        let decrypted_account_uuids = match trial_decrypt_account_uuids(db_path, network, &tx) {
+            Ok(accounts) => {
+                stats.record_trial_decrypt(decrypt_started_at.elapsed(), !accounts.is_empty());
+                accounts
+            }
+            Err(e) => {
+                stats.record_trial_decrypt_fail(decrypt_started_at.elapsed());
+                log::debug!("mempool: trial decrypt for known {txid_hex} failed: {e}");
+                Vec::new()
+            }
+        };
+        let (account_uuids, has_new_account) =
+            merge_account_uuids(&known.account_uuids, &decrypted_account_uuids);
+
+        if has_new_account {
+            let store_started_at = Instant::now();
+            match crate::wallet::sync::decrypt_and_store_transaction(
+                db_path,
+                network,
+                &raw_tx.data,
+                None,
+            ) {
+                Ok(()) => {
+                    stats.record_store(store_started_at.elapsed(), true);
+                    emit_wallet_relevant_tx(
+                        txid_hex,
+                        txid_bytes,
+                        account_uuids,
+                        seen_cache,
+                        emit,
+                        "stored known tx",
+                    );
+                    return;
+                }
+                Err(e) => {
+                    stats.record_store(store_started_at.elapsed(), false);
+                    log::warn!("mempool: failed to store known tx {txid_hex}: {e}");
+                }
+            }
+        }
+
         // `matched=true` with no account UUIDs is possible while the
         // transaction table has an unmined row but the account-scoped view
         // has not projected it yet. Dart treats empty account scope as the
@@ -750,6 +794,21 @@ fn trial_decrypt_account_uuids(
     }
 
     Ok(accounts.into_iter().collect())
+}
+
+fn merge_account_uuids(known: &[String], decrypted: &[String]) -> (Vec<String>, bool) {
+    let known_set = known.iter().cloned().collect::<BTreeSet<_>>();
+    let mut merged = known_set.clone();
+    let mut has_new_account = false;
+
+    for account_uuid in decrypted {
+        if !known_set.contains(account_uuid) {
+            has_new_account = true;
+        }
+        merged.insert(account_uuid.clone());
+    }
+
+    (merged.into_iter().collect(), has_new_account)
 }
 
 /// Cancel-aware sleep. Breaks into 100ms slices so a pending
@@ -950,6 +1009,53 @@ mod tests {
         assert_eq!(
             known.account_uuids,
             vec![first_uuid.to_string(), second_uuid.to_string()]
+        );
+    }
+
+    #[test]
+    fn merge_account_uuids_detects_new_decrypted_accounts() {
+        let known = vec![
+            "67e55044-10b1-426f-9247-bb680e5fe0c8".to_string(),
+            "550e8400-e29b-41d4-a716-446655440000".to_string(),
+        ];
+        let decrypted = vec![
+            "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            "2c2f2a4b-9c64-41f8-9801-fd06553fd4f6".to_string(),
+        ];
+
+        let (merged, has_new_account) = merge_account_uuids(&known, &decrypted);
+
+        assert!(has_new_account);
+        assert_eq!(
+            merged,
+            vec![
+                "2c2f2a4b-9c64-41f8-9801-fd06553fd4f6".to_string(),
+                "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                "67e55044-10b1-426f-9247-bb680e5fe0c8".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_account_uuids_avoids_store_when_decrypted_accounts_are_known() {
+        let known = vec![
+            "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            "67e55044-10b1-426f-9247-bb680e5fe0c8".to_string(),
+        ];
+        let decrypted = vec![
+            "67e55044-10b1-426f-9247-bb680e5fe0c8".to_string(),
+            "550e8400-e29b-41d4-a716-446655440000".to_string(),
+        ];
+
+        let (merged, has_new_account) = merge_account_uuids(&known, &decrypted);
+
+        assert!(!has_new_account);
+        assert_eq!(
+            merged,
+            vec![
+                "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                "67e55044-10b1-426f-9247-bb680e5fe0c8".to_string(),
+            ]
         );
     }
 

--- a/rust/src/wallet/sync_engine/mempool.rs
+++ b/rust/src/wallet/sync_engine/mempool.rs
@@ -26,14 +26,17 @@
 //!     means we inherit the same TLS transport the scan loop uses.
 //!
 //!   * **Write only after a wallet hit.** The hot path parses the
-//!     txid, skips txs already seen in this observer session, and
-//!     checks for existing unmined wallet rows. Unknown txs go
-//!     through read-only trial decryption first; already-known txs
-//!     are also trial-decrypted once so wallet-internal sends can
-//!     discover recipient accounts in the same DB. Only txs that add
-//!     wallet relevance call `decrypt_and_store_transaction`. That
-//!     keeps SQLite write contention proportional to wallet relevance
-//!     instead of global mempool volume.
+//!     txid, skips wallet-relevant txs already emitted in this
+//!     observer session, and checks for existing unmined wallet rows.
+//!     Unknown txs go through read-only trial decryption first; a
+//!     negative match is cached only briefly so a tx first observed
+//!     before local wallet persistence can be re-evaluated soon after.
+//!     Already-known txs are also trial-decrypted once so
+//!     wallet-internal sends can discover recipient accounts in the
+//!     same DB. Only txs that add wallet relevance call
+//!     `decrypt_and_store_transaction`. That keeps SQLite write
+//!     contention proportional to wallet relevance instead of global
+//!     mempool volume.
 //!
 //!   * **Reconnect semantics match the SDK.** lightwalletd closes
 //!     the stream every time a new block is mined — normal EOF,
@@ -43,7 +46,7 @@
 //!     successful connect. Cancel is checked inside the sleep so
 //!     we don't block `stop_mempool_observer()` for 30s.
 
-use std::collections::{BTreeSet, HashSet, VecDeque};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -112,7 +115,78 @@ impl TxidSeenCache {
     }
 }
 
+struct TxidTtlCache {
+    max_len: usize,
+    ttl: Duration,
+    order: VecDeque<Vec<u8>>,
+    entries: HashMap<Vec<u8>, Instant>,
+}
+
+impl TxidTtlCache {
+    fn new(max_len: usize, ttl: Duration) -> Self {
+        Self {
+            max_len,
+            ttl,
+            order: VecDeque::new(),
+            entries: HashMap::new(),
+        }
+    }
+
+    fn contains_unexpired(&mut self, txid_bytes: &[u8], now: Instant) -> bool {
+        self.prune_expired(now);
+
+        match self.entries.get(txid_bytes).copied() {
+            Some(expires_at) if expires_at > now => true,
+            Some(_) => {
+                self.entries.remove(txid_bytes);
+                false
+            }
+            None => false,
+        }
+    }
+
+    fn insert(&mut self, txid_bytes: Vec<u8>, now: Instant) {
+        if self.max_len == 0 {
+            return;
+        }
+
+        self.prune_expired(now);
+        let expires_at = now + self.ttl;
+        if self
+            .entries
+            .insert(txid_bytes.clone(), expires_at)
+            .is_none()
+        {
+            self.order.push_back(txid_bytes);
+        }
+
+        while self.order.len() > self.max_len {
+            if let Some(oldest) = self.order.pop_front() {
+                self.entries.remove(&oldest);
+            }
+        }
+    }
+
+    fn prune_expired(&mut self, now: Instant) {
+        while let Some(txid_bytes) = self.order.front() {
+            let expired = self
+                .entries
+                .get(txid_bytes)
+                .map(|expires_at| *expires_at <= now)
+                .unwrap_or(true);
+            if !expired {
+                break;
+            }
+
+            if let Some(oldest) = self.order.pop_front() {
+                self.entries.remove(&oldest);
+            }
+        }
+    }
+}
+
 const STATS_LOG_INTERVAL: Duration = Duration::from_secs(30);
+const UNMATCHED_TXID_TTL: Duration = Duration::from_secs(10);
 
 #[derive(Debug)]
 struct MempoolObserverStats {
@@ -329,6 +403,7 @@ where
 
     let mut consecutive_errors: u32 = 0;
     let mut seen_cache = TxidSeenCache::new(2048);
+    let mut unmatched_cache = TxidTtlCache::new(2048, UNMATCHED_TXID_TTL);
     let mut stats = MempoolObserverStats::new(Instant::now());
 
     /// Pick the backoff delay based on how many consecutive errors
@@ -443,6 +518,7 @@ where
                                 &db_path,
                                 network,
                                 &mut seen_cache,
+                                &mut unmatched_cache,
                                 &mut stats,
                                 &raw_tx,
                                 &emit,
@@ -537,8 +613,9 @@ async fn watch_for_cancel(cancel: &Arc<AtomicBool>) {
     }
 }
 
-/// Parse `raw_tx`, compute the txid, skip duplicate observations,
-/// and emit a [`MempoolTxEvent`] only for wallet-relevant txs.
+/// Parse `raw_tx`, compute the txid, skip duplicate wallet-relevant
+/// observations and very recent unmatched observations, and emit a
+/// [`MempoolTxEvent`] only for wallet-relevant txs.
 ///
 /// Unmatched transactions (other people's txs) are silently
 /// dropped on the Rust side without crossing the FRB bridge.
@@ -553,6 +630,7 @@ fn handle_mempool_tx<F>(
     db_path: &str,
     network: WalletNetwork,
     seen_cache: &mut TxidSeenCache,
+    unmatched_cache: &mut TxidTtlCache,
     stats: &mut MempoolObserverStats,
     raw_tx: &RawTransaction,
     emit: &F,
@@ -650,6 +728,12 @@ fn handle_mempool_tx<F>(
         return;
     }
 
+    let now = Instant::now();
+    if unmatched_cache.contains_unexpired(&txid_bytes, now) {
+        stats.record_seen_skip();
+        return;
+    }
+
     let decrypt_started_at = Instant::now();
     let account_uuids = match trial_decrypt_account_uuids(db_path, network, &tx) {
         Ok(accounts) => {
@@ -664,7 +748,7 @@ fn handle_mempool_tx<F>(
     };
 
     if account_uuids.is_empty() {
-        seen_cache.insert(txid_bytes);
+        unmatched_cache.insert(txid_bytes, Instant::now());
         return;
     }
 
@@ -839,6 +923,9 @@ mod tests {
     //!     in sync with the `transactions` / `v_transactions` table
     //!     shapes and the "unmined" definition (`mined_height IS NULL`).
     //!
+    //!   * The txid caches that bound duplicate work without making
+    //!     unmatched txs permanent false negatives.
+    //!
     //!   * `sleep_respecting_cancel`, which must (a) return early
     //!     when `cancel` flips and (b) at minimum sleep through the
     //!     requested duration when `cancel` stays false. Both
@@ -956,6 +1043,38 @@ mod tests {
         assert!(!cache.contains(&first));
         assert!(cache.contains(&second));
         assert!(cache.contains(&third));
+    }
+
+    #[test]
+    fn ttl_cache_skips_only_until_expiry() {
+        let mut cache = TxidTtlCache::new(2, Duration::from_secs(10));
+        let now = Instant::now();
+        let txid = vec![0x0a; 32];
+
+        assert!(!cache.contains_unexpired(&txid, now));
+        cache.insert(txid.clone(), now);
+        assert!(cache.contains_unexpired(&txid, now + Duration::from_secs(9)));
+        assert!(!cache.contains_unexpired(&txid, now + Duration::from_secs(10)));
+        assert!(!cache.contains_unexpired(&txid, now + Duration::from_secs(11)));
+    }
+
+    #[test]
+    fn ttl_cache_evicts_oldest_txid() {
+        let mut cache = TxidTtlCache::new(2, Duration::from_secs(10));
+        let now = Instant::now();
+        let first = vec![0x01; 32];
+        let second = vec![0x02; 32];
+        let third = vec![0x03; 32];
+
+        cache.insert(first.clone(), now);
+        cache.insert(second.clone(), now);
+        assert!(cache.contains_unexpired(&first, now));
+        assert!(cache.contains_unexpired(&second, now));
+
+        cache.insert(third.clone(), now);
+        assert!(!cache.contains_unexpired(&first, now));
+        assert!(cache.contains_unexpired(&second, now));
+        assert!(cache.contains_unexpired(&third, now));
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -113,6 +113,36 @@ fn batch_size_for_range(base_batch_size: u32, start: BlockHeight, range_end: Blo
     }
 }
 
+fn effective_base_batch_size(default_batch_size: u32) -> u32 {
+    #[cfg(debug_assertions)]
+    {
+        if let Ok(raw) = std::env::var("ZCASH_E2E_SYNC_BATCH_SIZE") {
+            if let Ok(parsed) = raw.parse::<u32>() {
+                if parsed > 0 {
+                    return parsed.min(default_batch_size);
+                }
+            }
+        }
+    }
+
+    default_batch_size
+}
+
+#[cfg(debug_assertions)]
+async fn maybe_sleep_for_e2e_sync_batch_delay() {
+    let Ok(raw) = std::env::var("ZCASH_E2E_SYNC_BATCH_DELAY_MS") else {
+        return;
+    };
+    let Ok(parsed) = raw.parse::<u64>() else {
+        return;
+    };
+    if parsed == 0 {
+        return;
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(parsed.min(5_000))).await;
+}
+
 fn target_percentage_after_blocks(initial_total: u64, remaining: u64, blocks: u64) -> f64 {
     if initial_total == 0 {
         1.0
@@ -312,11 +342,12 @@ async fn run_sync_impl(
     desired_mode: &AtomicU8,
     progress_fn: &(impl Fn(SyncProgressEvent) + Send + Sync),
 ) -> Result<(), SyncError> {
-    let base_batch_size = if running_mode == 2 {
+    let default_batch_size = if running_mode == 2 {
         BATCH_SIZE_BACKGROUND
     } else {
         BATCH_SIZE_FOREGROUND
     };
+    let base_batch_size = effective_base_batch_size(default_batch_size);
     log::info!(
         "[{}] sync: starting (mode={}, base_batch={})",
         elapsed(),
@@ -1018,6 +1049,8 @@ async fn run_sync_impl(
             initial_total - remaining
         );
         progress_fn(progress);
+        #[cfg(debug_assertions)]
+        maybe_sleep_for_e2e_sync_batch_delay().await;
 
         // Prefetch: if the current range still has blocks beyond
         // `end`, kick off a background download of the next batch

--- a/scripts/e2e/flutter-macos-regtest-full.sh
+++ b/scripts/e2e/flutter-macos-regtest-full.sh
@@ -27,14 +27,17 @@ require_cmd python3
 cd "$ROOT_DIR"
 
 # Keep this ordered from the narrowest smoke test to broader user flows.
-run_test "1/3 import funded wallet and sync balances" \
+run_test "1/4 import funded wallet and sync balances" \
   "scripts/e2e/flutter-macos-regtest-import-sync.sh"
 
-run_test "2/3 import two accounts and send shielded funds" \
+run_test "2/4 import two accounts and send shielded funds" \
   "scripts/e2e/flutter-macos-regtest-multi-account-send.sh"
 
-run_test "3/3 show mempool receives in activity history" \
+run_test "3/4 show mempool receives in activity history" \
   "scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh"
+
+run_test "4/4 show mempool receives while sync is running" \
+  "scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh"
 
 echo
 echo "all macOS regtest E2E tests passed"

--- a/scripts/e2e/flutter-macos-regtest-full.sh
+++ b/scripts/e2e/flutter-macos-regtest-full.sh
@@ -27,11 +27,14 @@ require_cmd python3
 cd "$ROOT_DIR"
 
 # Keep this ordered from the narrowest smoke test to broader user flows.
-run_test "1/2 import funded wallet and sync balances" \
+run_test "1/3 import funded wallet and sync balances" \
   "scripts/e2e/flutter-macos-regtest-import-sync.sh"
 
-run_test "2/2 import two accounts and send shielded funds" \
+run_test "2/3 import two accounts and send shielded funds" \
   "scripts/e2e/flutter-macos-regtest-multi-account-send.sh"
+
+run_test "3/3 show mempool receives in activity history" \
+  "scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh"
 
 echo
 echo "all macOS regtest E2E tests passed"

--- a/scripts/e2e/flutter-macos-regtest-full.sh
+++ b/scripts/e2e/flutter-macos-regtest-full.sh
@@ -27,17 +27,20 @@ require_cmd python3
 cd "$ROOT_DIR"
 
 # Keep this ordered from the narrowest smoke test to broader user flows.
-run_test "1/4 import funded wallet and sync balances" \
+run_test "1/5 import funded wallet and sync balances" \
   "scripts/e2e/flutter-macos-regtest-import-sync.sh"
 
-run_test "2/4 import two accounts and send shielded funds" \
+run_test "2/5 import two accounts and send shielded funds" \
   "scripts/e2e/flutter-macos-regtest-multi-account-send.sh"
 
-run_test "3/4 show mempool receives in activity history" \
+run_test "3/5 show mempool receives in activity history" \
   "scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh"
 
-run_test "4/4 show mempool receives while sync is running" \
+run_test "4/5 show mempool receives while sync is running" \
   "scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh"
+
+run_test "5/5 expire unmined mempool receives" \
+  "scripts/e2e/flutter-macos-regtest-mempool-expiry.sh"
 
 echo
 echo "all macOS regtest E2E tests passed"

--- a/scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh
+++ b/scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh
@@ -76,11 +76,10 @@ ZCASH_E2E_SYNC_BATCH_DELAY_MS="$SYNC_BATCH_DELAY_MS" \
 fvm flutter test \
   integration_test/regtest_mempool_receive_history_test.dart \
   -d "$FLUTTER_DEVICE" \
-  --dart-define=ZCASH_E2E_NETWORK=regtest \
+  --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
   --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$LIGHTWALLETD_URL" \
   --dart-define=ZCASH_E2E_DRIVER_URL="$DRIVER_URL" \
-  --dart-define=ZCASH_E2E_MEMPOOL_TEST_MODE=during-sync \
-  --dart-define=ZCASH_USE_E2E_STORAGE=true
+  --dart-define=ZCASH_E2E_MEMPOOL_TEST_MODE=during-sync
 status="$?"
 set -e
 

--- a/scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh
+++ b/scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIGHTWALLETD_URL="${E2E_LIGHTWALLETD_URL:-http://127.0.0.1:9067}"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+DRIVER_PORT="${E2E_DRIVER_PORT:-39068}"
+DRIVER_URL="http://127.0.0.1:${DRIVER_PORT}"
+DRIVER_LOG="$ROOT_DIR/.regtest/mempool-during-sync-driver.log"
+EXTRA_BLOCKS="${E2E_DURING_SYNC_EXTRA_BLOCKS:-650}"
+SYNC_BATCH_SIZE="${E2E_SYNC_BATCH_SIZE:-50}"
+SYNC_BATCH_DELAY_MS="${E2E_SYNC_BATCH_DELAY_MS:-750}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd fvm
+require_cmd python3
+
+cd "$ROOT_DIR"
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+echo "pre-mining $EXTRA_BLOCKS blocks so foreground sync stays active"
+scripts/regtest/mine.sh "$EXTRA_BLOCKS" >/dev/null
+
+echo "preparing shielded faucet for fast unmined external funding"
+PREPARED_FAUCET_ZADDR="$(scripts/regtest/prepare-unmined-faucet.sh 0.35)"
+
+mkdir -p "$ROOT_DIR/.regtest"
+: > "$DRIVER_LOG"
+
+python3 -u scripts/e2e/mempool-receive-history-driver.py \
+  --repo-root "$ROOT_DIR" \
+  --port "$DRIVER_PORT" \
+  --prepared-faucet-zaddr "$PREPARED_FAUCET_ZADDR" \
+  >"$DRIVER_LOG" 2>&1 &
+driver_pid="$!"
+
+cleanup() {
+  kill "$driver_pid" >/dev/null 2>&1 || true
+  wait "$driver_pid" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+python3 - "$DRIVER_URL" <<'PY'
+import sys
+import time
+import urllib.request
+
+url = sys.argv[1] + "/health"
+for _ in range(50):
+    try:
+        with urllib.request.urlopen(url, timeout=1) as response:
+            if response.status == 200:
+                raise SystemExit(0)
+    except Exception:
+        time.sleep(0.1)
+
+raise SystemExit("Timed out waiting for mempool during-sync driver")
+PY
+
+echo "running Flutter macOS mempool during-sync integration test"
+set +e
+ZCASH_E2E_SYNC_BATCH_SIZE="$SYNC_BATCH_SIZE" \
+ZCASH_E2E_SYNC_BATCH_DELAY_MS="$SYNC_BATCH_DELAY_MS" \
+fvm flutter test \
+  integration_test/regtest_mempool_receive_history_test.dart \
+  -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_E2E_NETWORK=regtest \
+  --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$LIGHTWALLETD_URL" \
+  --dart-define=ZCASH_E2E_DRIVER_URL="$DRIVER_URL" \
+  --dart-define=ZCASH_E2E_MEMPOOL_TEST_MODE=during-sync \
+  --dart-define=ZCASH_USE_E2E_STORAGE=true
+status="$?"
+set -e
+
+if [[ "$status" -ne 0 ]]; then
+  echo "mempool during-sync driver log:" >&2
+  sed -n '1,220p' "$DRIVER_LOG" >&2 || true
+fi
+
+exit "$status"

--- a/scripts/e2e/flutter-macos-regtest-mempool-expiry.sh
+++ b/scripts/e2e/flutter-macos-regtest-mempool-expiry.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIGHTWALLETD_URL="${E2E_LIGHTWALLETD_URL:-http://127.0.0.1:9067}"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+DRIVER_PORT="${E2E_DRIVER_PORT:-39069}"
+DRIVER_URL="http://127.0.0.1:${DRIVER_PORT}"
+DRIVER_LOG="$ROOT_DIR/.regtest/mempool-expiry-driver.log"
+BASE_COMPOSE="$ROOT_DIR/docker-compose.zcash-regtest.yml"
+EXPIRY_COMPOSE="$ROOT_DIR/docker-compose.zcash-regtest-expiry.yml"
+driver_pid=""
+expiry_stack_started=0
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd fvm
+require_cmd python3
+
+cd "$ROOT_DIR"
+
+cleanup() {
+  if [[ -n "$driver_pid" ]]; then
+    kill "$driver_pid" >/dev/null 2>&1 || true
+    wait "$driver_pid" >/dev/null 2>&1 || true
+  fi
+
+  if [[ "$expiry_stack_started" == "1" && "${RESTORE_REGTEST_CONFIG:-1}" == "1" ]]; then
+    echo "restoring regtest stack with default mining config"
+    docker compose -f "$BASE_COMPOSE" up -d --force-recreate zcashd lightwalletd >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+echo "preparing shielded faucet for expiring unmined external funding"
+PREPARED_FAUCET_ZADDR="$(scripts/regtest/prepare-unmined-faucet.sh 0.35)"
+
+echo "restarting regtest stack with expiry mining config"
+docker compose -f "$BASE_COMPOSE" -f "$EXPIRY_COMPOSE" up -d --force-recreate zcashd lightwalletd
+expiry_stack_started=1
+source scripts/regtest/lib.sh
+wait_for_zcashd
+wait_for_lightwalletd
+wait_for_lightwalletd_tip "$(zcash_cli getblockcount)"
+
+mkdir -p "$ROOT_DIR/.regtest"
+: > "$DRIVER_LOG"
+
+python3 -u scripts/e2e/mempool-receive-history-driver.py \
+  --repo-root "$ROOT_DIR" \
+  --port "$DRIVER_PORT" \
+  --prepared-faucet-zaddr "$PREPARED_FAUCET_ZADDR" \
+  >"$DRIVER_LOG" 2>&1 &
+driver_pid="$!"
+
+python3 - "$DRIVER_URL" <<'PY'
+import sys
+import time
+import urllib.request
+
+url = sys.argv[1] + "/health"
+for _ in range(50):
+    try:
+        with urllib.request.urlopen(url, timeout=1) as response:
+            if response.status == 200:
+                raise SystemExit(0)
+    except Exception:
+        time.sleep(0.1)
+
+raise SystemExit("Timed out waiting for mempool expiry driver")
+PY
+
+echo "running Flutter macOS mempool expiry integration test"
+set +e
+fvm flutter test \
+  integration_test/regtest_mempool_receive_history_test.dart \
+  -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
+  --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$LIGHTWALLETD_URL" \
+  --dart-define=ZCASH_E2E_DRIVER_URL="$DRIVER_URL" \
+  --dart-define=ZCASH_E2E_MEMPOOL_TEST_MODE=expiry
+status="$?"
+set -e
+
+if [[ "$status" -ne 0 ]]; then
+  echo "mempool expiry driver log:" >&2
+  sed -n '1,260p' "$DRIVER_LOG" >&2 || true
+fi
+
+exit "$status"

--- a/scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh
+++ b/scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+LIGHTWALLETD_URL="${E2E_LIGHTWALLETD_URL:-http://127.0.0.1:9067}"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+DRIVER_PORT="${E2E_DRIVER_PORT:-39067}"
+DRIVER_URL="http://127.0.0.1:${DRIVER_PORT}"
+DRIVER_LOG="$ROOT_DIR/.regtest/mempool-receive-history-driver.log"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd fvm
+require_cmd python3
+
+cd "$ROOT_DIR"
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+mkdir -p "$ROOT_DIR/.regtest"
+: > "$DRIVER_LOG"
+
+python3 -u scripts/e2e/mempool-receive-history-driver.py \
+  --repo-root "$ROOT_DIR" \
+  --port "$DRIVER_PORT" \
+  >"$DRIVER_LOG" 2>&1 &
+driver_pid="$!"
+
+cleanup() {
+  kill "$driver_pid" >/dev/null 2>&1 || true
+  wait "$driver_pid" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+python3 - "$DRIVER_URL" <<'PY'
+import sys
+import time
+import urllib.request
+
+url = sys.argv[1] + "/health"
+for _ in range(50):
+    try:
+        with urllib.request.urlopen(url, timeout=1) as response:
+            if response.status == 200:
+                raise SystemExit(0)
+    except Exception:
+        time.sleep(0.1)
+
+raise SystemExit("Timed out waiting for mempool receive-history driver")
+PY
+
+echo "running Flutter macOS mempool receive-history integration test"
+set +e
+fvm flutter test \
+  integration_test/regtest_mempool_receive_history_test.dart \
+  -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_E2E_NETWORK=regtest \
+  --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$LIGHTWALLETD_URL" \
+  --dart-define=ZCASH_E2E_DRIVER_URL="$DRIVER_URL" \
+  --dart-define=ZCASH_USE_E2E_STORAGE=true
+status="$?"
+set -e
+
+if [[ "$status" -ne 0 ]]; then
+  echo "mempool receive-history driver log:" >&2
+  sed -n '1,220p' "$DRIVER_LOG" >&2 || true
+fi
+
+exit "$status"

--- a/scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh
+++ b/scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh
@@ -64,10 +64,9 @@ set +e
 fvm flutter test \
   integration_test/regtest_mempool_receive_history_test.dart \
   -d "$FLUTTER_DEVICE" \
-  --dart-define=ZCASH_E2E_NETWORK=regtest \
+  --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
   --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$LIGHTWALLETD_URL" \
-  --dart-define=ZCASH_E2E_DRIVER_URL="$DRIVER_URL" \
-  --dart-define=ZCASH_USE_E2E_STORAGE=true
+  --dart-define=ZCASH_E2E_DRIVER_URL="$DRIVER_URL"
 status="$?"
 set -e
 

--- a/scripts/e2e/mempool-receive-history-driver.py
+++ b/scripts/e2e/mempool-receive-history-driver.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import List
+
+
+def run_command(repo_root: Path, args: List[str], timeout: int) -> str:
+    result = subprocess.run(
+        args,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"{' '.join(args)} failed with {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+    return result.stdout.strip()
+
+
+class DriverHandler(BaseHTTPRequestHandler):
+    repo_root: Path
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            self.respond(200, {"ok": True})
+            return
+        self.respond(404, {"error": "not found"})
+
+    def do_POST(self) -> None:
+        try:
+            payload = self.read_json()
+            if self.path == "/fund-unmined":
+                address = str(payload["address"])
+                amount = str(payload.get("amount", "0.25"))
+                output = run_command(
+                    self.repo_root,
+                    ["scripts/regtest/fund-wallet-unmined.sh", address, amount],
+                    timeout=300,
+                )
+                txid = output.splitlines()[-1].strip() if output else ""
+                if not txid:
+                    raise RuntimeError("fund-wallet-unmined.sh returned no txid")
+                self.respond(200, {"txid": txid})
+                return
+
+            if self.path == "/mine":
+                blocks = int(payload.get("blocks", 1))
+                run_command(
+                    self.repo_root,
+                    ["scripts/regtest/mine.sh", str(blocks)],
+                    timeout=180,
+                )
+                self.respond(200, {"ok": True})
+                return
+
+            self.respond(404, {"error": "not found"})
+        except Exception as exc:
+            self.respond(500, {"error": str(exc)})
+
+    def read_json(self) -> dict:
+        length = int(self.headers.get("content-length", "0"))
+        raw = self.rfile.read(length) if length else b"{}"
+        return json.loads(raw.decode("utf-8"))
+
+    def respond(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        print(f"[mempool-driver] {self.address_string()} - {format % args}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", required=True)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    args = parser.parse_args()
+
+    handler = DriverHandler
+    handler.repo_root = Path(args.repo_root).resolve()
+    server = ThreadingHTTPServer((args.host, args.port), handler)
+    print(f"[mempool-driver] listening on http://{args.host}:{args.port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/e2e/mempool-receive-history-driver.py
+++ b/scripts/e2e/mempool-receive-history-driver.py
@@ -83,6 +83,54 @@ class DriverHandler(BaseHTTPRequestHandler):
                 self.respond(200, {"txid": txid})
                 return
 
+            if self.path == "/fund-unmined-expiring":
+                if not self.prepared_faucet_zaddr:
+                    raise RuntimeError("No prepared faucet zaddr was configured")
+                address = str(payload["address"])
+                amount = str(payload.get("amount", "0.25"))
+                output = run_command(
+                    self.repo_root,
+                    ["scripts/regtest/fund-wallet-unmined.sh", address, amount],
+                    timeout=120,
+                    env={
+                        "REGTEST_UNMINED_FAUCET_ZADDR": self.prepared_faucet_zaddr,
+                    },
+                )
+                txid = output.splitlines()[-1].strip() if output else ""
+                if not txid:
+                    raise RuntimeError("fund-wallet-unmined.sh returned no txid")
+                expiry_height_raw = run_command(
+                    self.repo_root,
+                    ["scripts/regtest/tx-expiry-height.sh", txid],
+                    timeout=60,
+                )
+                self.respond(
+                    200,
+                    {
+                        "txid": txid,
+                        "expiryHeight": int(expiry_height_raw.splitlines()[-1]),
+                    },
+                )
+                return
+
+            if self.path == "/mine-to-expiry":
+                txid = str(payload["txid"])
+                expiry_height = int(payload["expiryHeight"])
+                extra_blocks = int(payload.get("extraBlocks", 0))
+                output = run_command(
+                    self.repo_root,
+                    [
+                        "scripts/regtest/mine-to-expiry.sh",
+                        txid,
+                        str(expiry_height),
+                        str(extra_blocks),
+                    ],
+                    timeout=300,
+                )
+                target_height = output.splitlines()[-1].strip() if output else ""
+                self.respond(200, {"targetHeight": int(target_height)})
+                return
+
             if self.path == "/mine":
                 blocks = int(payload.get("blocks", 1))
                 run_command(

--- a/scripts/e2e/mempool-receive-history-driver.py
+++ b/scripts/e2e/mempool-receive-history-driver.py
@@ -1,13 +1,24 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import os
 import subprocess
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import List
+from typing import Dict, List, Optional
 
 
-def run_command(repo_root: Path, args: List[str], timeout: int) -> str:
+def run_command(
+    repo_root: Path,
+    args: List[str],
+    timeout: int,
+    env: Optional[Dict[str, str]] = None,
+) -> str:
+    command_env = None
+    if env is not None:
+        command_env = os.environ.copy()
+        command_env.update(env)
+
     result = subprocess.run(
         args,
         cwd=repo_root,
@@ -15,6 +26,7 @@ def run_command(repo_root: Path, args: List[str], timeout: int) -> str:
         capture_output=True,
         timeout=timeout,
         check=False,
+        env=command_env,
     )
     if result.returncode != 0:
         raise RuntimeError(
@@ -27,6 +39,7 @@ def run_command(repo_root: Path, args: List[str], timeout: int) -> str:
 
 class DriverHandler(BaseHTTPRequestHandler):
     repo_root: Path
+    prepared_faucet_zaddr: str
 
     def do_GET(self) -> None:
         if self.path == "/health":
@@ -44,6 +57,25 @@ class DriverHandler(BaseHTTPRequestHandler):
                     self.repo_root,
                     ["scripts/regtest/fund-wallet-unmined.sh", address, amount],
                     timeout=300,
+                )
+                txid = output.splitlines()[-1].strip() if output else ""
+                if not txid:
+                    raise RuntimeError("fund-wallet-unmined.sh returned no txid")
+                self.respond(200, {"txid": txid})
+                return
+
+            if self.path == "/fund-unmined-prepared":
+                if not self.prepared_faucet_zaddr:
+                    raise RuntimeError("No prepared faucet zaddr was configured")
+                address = str(payload["address"])
+                amount = str(payload.get("amount", "0.25"))
+                output = run_command(
+                    self.repo_root,
+                    ["scripts/regtest/fund-wallet-unmined.sh", address, amount],
+                    timeout=120,
+                    env={
+                        "REGTEST_UNMINED_FAUCET_ZADDR": self.prepared_faucet_zaddr,
+                    },
                 )
                 txid = output.splitlines()[-1].strip() if output else ""
                 if not txid:
@@ -87,10 +119,12 @@ def main() -> None:
     parser.add_argument("--repo-root", required=True)
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--prepared-faucet-zaddr", default="")
     args = parser.parse_args()
 
     handler = DriverHandler
     handler.repo_root = Path(args.repo_root).resolve()
+    handler.prepared_faucet_zaddr = args.prepared_faucet_zaddr
     server = ThreadingHTTPServer((args.host, args.port), handler)
     print(f"[mempool-driver] listening on http://{args.host}:{args.port}")
     server.serve_forever()

--- a/scripts/regtest/fund-wallet-unmined.sh
+++ b/scripts/regtest/fund-wallet-unmined.sh
@@ -11,48 +11,19 @@ wait_for_wallet_spend_ready
 wait_for_lightwalletd
 ensure_faucet_state
 
-wait_for_zaddr_balance() {
-  local address="$1"
-  local amount="$2"
+faucet_zaddr="${REGTEST_UNMINED_FAUCET_ZADDR:-}"
+if [[ -z "$faucet_zaddr" ]]; then
+  sender_address="$(faucet_transparent_sender)"
+  faucet_zaddr="$(zcash_cli z_getnewaddress sapling)"
 
-  for _ in $(seq 1 60); do
-    local utxos
-    utxos="$(zcash_cli z_listunspent 1 9999999 false "[\"$address\"]")"
-    if python3 - "$utxos" "$amount" <<'PY'
-from decimal import Decimal
-import json
-import sys
+  shield_opid="$(extract_opid "$(zcash_cli z_shieldcoinbase "$sender_address" "$faucet_zaddr" 0.0001 1)")"
+  wait_for_operation "$shield_opid" >/dev/null
 
-utxos = json.loads(sys.argv[1])
-balance = Decimal("0")
-for utxo in utxos:
-    if "amountZat" in utxo:
-        balance += Decimal(int(utxo["amountZat"])) / Decimal(100_000_000)
-    else:
-        balance += Decimal(str(utxo.get("amount", "0")))
-amount = Decimal(sys.argv[2])
-raise SystemExit(0 if balance >= amount else 1)
-PY
-    then
-      return 0
-    fi
-    sleep 1
-  done
-
-  echo "Timed out waiting for shielded faucet balance at $address" >&2
-  return 1
-}
-
-sender_address="$(faucet_transparent_sender)"
-faucet_zaddr="$(zcash_cli z_getnewaddress sapling)"
-
-shield_opid="$(extract_opid "$(zcash_cli z_shieldcoinbase "$sender_address" "$faucet_zaddr" 0.0001 1)")"
-wait_for_operation "$shield_opid" >/dev/null
-
-# Confirm only the faucet shielding transaction. The final z_sendmany below is
-# intentionally left unmined so wallet mempool observers can discover it.
-zcash_cli generate 20 >/dev/null
-wait_for_lightwalletd_tip "$(zcash_cli getblockcount)"
+  # Confirm only the faucet shielding transaction. The final z_sendmany below is
+  # intentionally left unmined so wallet mempool observers can discover it.
+  zcash_cli generate 20 >/dev/null
+  wait_for_lightwalletd_tip "$(zcash_cli getblockcount)"
+fi
 wait_for_zaddr_balance "$faucet_zaddr" "$requested_amount"
 
 recipients="$(python3 - "$destination" "$requested_amount" <<'PY'

--- a/scripts/regtest/fund-wallet-unmined.sh
+++ b/scripts/regtest/fund-wallet-unmined.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+destination="${1:?usage: fund-wallet-unmined.sh <destination-address> [zec-amount]}"
+requested_amount="${2:-0.25}"
+
+wait_for_zcashd
+wait_for_wallet_spend_ready
+wait_for_lightwalletd
+ensure_faucet_state
+
+wait_for_zaddr_balance() {
+  local address="$1"
+  local amount="$2"
+
+  for _ in $(seq 1 60); do
+    local utxos
+    utxos="$(zcash_cli z_listunspent 1 9999999 false "[\"$address\"]")"
+    if python3 - "$utxos" "$amount" <<'PY'
+from decimal import Decimal
+import json
+import sys
+
+utxos = json.loads(sys.argv[1])
+balance = Decimal("0")
+for utxo in utxos:
+    if "amountZat" in utxo:
+        balance += Decimal(int(utxo["amountZat"])) / Decimal(100_000_000)
+    else:
+        balance += Decimal(str(utxo.get("amount", "0")))
+amount = Decimal(sys.argv[2])
+raise SystemExit(0 if balance >= amount else 1)
+PY
+    then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Timed out waiting for shielded faucet balance at $address" >&2
+  return 1
+}
+
+sender_address="$(faucet_transparent_sender)"
+faucet_zaddr="$(zcash_cli z_getnewaddress sapling)"
+
+shield_opid="$(extract_opid "$(zcash_cli z_shieldcoinbase "$sender_address" "$faucet_zaddr" 0.0001 1)")"
+wait_for_operation "$shield_opid" >/dev/null
+
+# Confirm only the faucet shielding transaction. The final z_sendmany below is
+# intentionally left unmined so wallet mempool observers can discover it.
+zcash_cli generate 20 >/dev/null
+wait_for_lightwalletd_tip "$(zcash_cli getblockcount)"
+wait_for_zaddr_balance "$faucet_zaddr" "$requested_amount"
+
+recipients="$(python3 - "$destination" "$requested_amount" <<'PY'
+import json
+import sys
+
+print(json.dumps([{"address": sys.argv[1], "amount": float(sys.argv[2])}]))
+PY
+)"
+
+privacy_policy="AllowRevealedAmounts"
+if [[ "$destination" == t* ]]; then
+  privacy_policy="AllowRevealedRecipients"
+fi
+
+opid="$(extract_opid "$(zcash_cli z_sendmany "$faucet_zaddr" "$recipients" 1 0.0001 "$privacy_policy")")"
+txid="$(wait_for_operation "$opid")"
+
+for _ in $(seq 1 30); do
+  mempool_json="$(zcash_cli getrawmempool)"
+  if python3 - "$txid" "$mempool_json" <<'PY'
+import json
+import sys
+
+txid = sys.argv[1]
+mempool = json.loads(sys.argv[2])
+raise SystemExit(0 if txid in mempool else 1)
+PY
+  then
+    echo "$txid"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Timed out waiting for $txid to appear in zcashd mempool" >&2
+exit 1

--- a/scripts/regtest/lib.sh
+++ b/scripts/regtest/lib.sh
@@ -176,6 +176,38 @@ PY
   return 1
 }
 
+wait_for_zaddr_balance() {
+  local address="$1"
+  local amount="$2"
+
+  for _ in $(seq 1 60); do
+    local utxos
+    utxos="$(zcash_cli z_listunspent 1 9999999 false "[\"$address\"]")"
+    if python3 - "$utxos" "$amount" <<'PY'
+from decimal import Decimal
+import json
+import sys
+
+utxos = json.loads(sys.argv[1])
+balance = Decimal("0")
+for utxo in utxos:
+    if "amountZat" in utxo:
+        balance += Decimal(int(utxo["amountZat"])) / Decimal(100_000_000)
+    else:
+        balance += Decimal(str(utxo.get("amount", "0")))
+amount = Decimal(sys.argv[2])
+raise SystemExit(0 if balance >= amount else 1)
+PY
+    then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Timed out waiting for shielded faucet balance at $address" >&2
+  return 1
+}
+
 extract_opid() {
   python3 - "$1" <<'PY'
 import json

--- a/scripts/regtest/mine-to-expiry.sh
+++ b/scripts/regtest/mine-to-expiry.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+txid="${1:?usage: mine-to-expiry.sh <txid> <expiry-height> [extra-blocks]}"
+expiry_height="${2:?usage: mine-to-expiry.sh <txid> <expiry-height> [extra-blocks]}"
+extra_blocks="${3:-0}"
+target_height=$((expiry_height + extra_blocks))
+
+wait_for_zcashd
+wait_for_lightwalletd
+
+is_mined() {
+  local raw_json
+  if ! raw_json="$(zcash_cli getrawtransaction "$txid" 1 2>/dev/null)"; then
+    return 1
+  fi
+
+  python3 - "$raw_json" <<'PY'
+import json
+import sys
+
+data = json.loads(sys.argv[1])
+confirmations = int(data.get("confirmations") or 0)
+height = int(data.get("height") or 0)
+blockhash = data.get("blockhash")
+raise SystemExit(0 if confirmations > 0 or height > 0 or blockhash else 1)
+PY
+}
+
+while [[ "$(zcash_cli getblockcount)" -lt "$target_height" ]]; do
+  zcash_cli generate 1 >/dev/null
+  if is_mined; then
+    echo "Transaction $txid was mined before expiry height $expiry_height" >&2
+    exit 1
+  fi
+done
+
+wait_for_lightwalletd_tip "$target_height"
+echo "$target_height"

--- a/scripts/regtest/prepare-unmined-faucet.sh
+++ b/scripts/regtest/prepare-unmined-faucet.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+requested_amount="${1:-0.35}"
+
+wait_for_zcashd
+wait_for_wallet_spend_ready
+wait_for_lightwalletd
+ensure_faucet_state
+
+sender_address="$(faucet_transparent_sender)"
+faucet_zaddr="$(zcash_cli z_getnewaddress sapling)"
+
+shield_opid="$(extract_opid "$(zcash_cli z_shieldcoinbase "$sender_address" "$faucet_zaddr" 0.0001 1)")"
+wait_for_operation "$shield_opid" >/dev/null
+
+zcash_cli generate 20 >/dev/null
+wait_for_lightwalletd_tip "$(zcash_cli getblockcount)"
+wait_for_zaddr_balance "$faucet_zaddr" "$requested_amount"
+
+echo "$faucet_zaddr"

--- a/scripts/regtest/tx-expiry-height.sh
+++ b/scripts/regtest/tx-expiry-height.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+txid="${1:?usage: tx-expiry-height.sh <txid>}"
+
+wait_for_zcashd
+
+raw_json="$(zcash_cli getrawtransaction "$txid" 1)"
+
+python3 - "$raw_json" <<'PY'
+import json
+import sys
+
+data = json.loads(sys.argv[1])
+
+for key, value in data.items():
+    normalized = key.replace("_", "").lower()
+    if normalized == "expiryheight":
+        print(int(value))
+        raise SystemExit(0)
+
+raise SystemExit(f"expiry height not found in getrawtransaction output: {data}")
+PY

--- a/scripts/regtest/zcash-expiry.conf
+++ b/scripts/regtest/zcash-expiry.conf
@@ -1,0 +1,33 @@
+regtest=1
+i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1
+server=1
+listen=0
+discover=0
+dnsseed=0
+txindex=1
+experimentalfeatures=1
+lightwalletd=1
+insightexplorer=1
+# Allow shielded transactions into the mempool but keep unpaid-action
+# transactions out of generated blocks. This lets expiry E2E tests advance
+# the chain tip without mining the observed mempool transaction.
+txunpaidactionlimit=50
+blockunpaidactionlimit=0
+rpcuser=zcash
+rpcpassword=zcash
+rpcconnect=zcashd
+rpcbind=0.0.0.0
+rpcallowip=0.0.0.0/0
+rpcport=18232
+allowdeprecated=z_getnewaddress
+
+# Activate all relevant network upgrades at height 1 so wallet
+# consensus parameters and zcashd regtest stay aligned.
+nuparams=5ba81b19:1
+nuparams=76b809bb:1
+nuparams=2bb40e60:1
+nuparams=f5b9230b:1
+nuparams=e9ff75a6:1
+nuparams=c2d6d0b4:1
+nuparams=c8e71055:1
+nuparams=4dec4df0:1

--- a/test/activity_table_row_test.dart
+++ b/test/activity_table_row_test.dart
@@ -99,6 +99,44 @@ void main() {
     expect(find.text('-1.00 ZEC'), findsOneWidget);
   });
 
+  testWidgets('pending inbound activity rows render as receiving', (
+    tester,
+  ) async {
+    late final List<ActivityRowData> rows;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: Builder(
+            builder: (context) {
+              rows = buildActivityRows(
+                context: context,
+                sync: SyncState(totalBalance: BigInt.zero),
+                transactions: [
+                  _tx(
+                    txidHex: 'receiving',
+                    kind: 'receiving',
+                    amount: BigInt.from(123450000),
+                    minedHeight: BigInt.zero,
+                  ),
+                ],
+              );
+              return ActivityTable(rows: rows);
+            },
+          ),
+        ),
+      ),
+    );
+
+    expect(rows[1].title, 'Receiving');
+    expect(rows[1].amountText, '+1.23 ZEC');
+    expect(rows[1].statusText, 'In progress');
+    expect(rows[1].leadingIconName, AppIcons.arrowDownCircle);
+    expect(find.text('Receiving'), findsOneWidget);
+    expect(find.text('In progress'), findsOneWidget);
+  });
+
   testWidgets('activity rows hide asset amounts with a fixed mask', (
     tester,
   ) async {
@@ -207,11 +245,13 @@ rust_sync.TransactionInfo _tx({
   required String txidHex,
   required String kind,
   required BigInt amount,
+  BigInt? minedHeight,
+  bool expiredUnmined = false,
 }) {
   return rust_sync.TransactionInfo(
     txidHex: txidHex,
-    minedHeight: BigInt.one,
-    expiredUnmined: false,
+    minedHeight: minedHeight ?? BigInt.one,
+    expiredUnmined: expiredUnmined,
     accountBalanceDelta: 0,
     fee: BigInt.zero,
     blockTime: BigInt.from(1800000000),


### PR DESCRIPTION
## Summary

- Add a Rust mempool observer path that detects wallet-relevant mempool transactions from lightwalletd.
- Decrypt and store inbound wallet matches as unmined transactions so they can appear before the next block scan confirms them.
- Expose matched account UUIDs through FRB and refresh the active account history only when the mempool match is relevant to that account.
- Coalesce mempool-triggered refreshes so bursts of matched events do not fan out into repeated balance/history reloads.
- Show pending inbound activity as `Receiving`, keep active unmined rows at the top of history/Home activity, and let the detail screen follow the later `receiving -> received` transition.
- Keep outbound pending/resubmit behavior scoped to wallet-created sends, with a history fallback for outbound unmined txs that are missing output metadata.

## What Changed

### Rust

- Added a mempool observer that runs alongside sync, tracks a bounded seen cache, skips already-known pending txs, and decrypts candidate mempool transactions against wallet accounts.
- Stored inbound mempool matches through the normal wallet transaction storage path as unmined transactions instead of adding a debug-only observation table.
- Added mempool event account scope so the UI can distinguish active-account matches from matches for other wallet accounts.
- Updated transaction history classification so active unmined inbound txs are `receiving`; mined or expired inbound txs continue through the existing `received` path.
- Prioritized active unmined rows before confirmed activity so pending receives are visible in Activity and in Home Recent Activity.
- Treated `receiving` details like received details so memos and outputs remain available from the transaction status screen.

### Dart / UI

- Added mempool match metadata to the generated sync API surface.
- Updated `SyncProvider` to queue, coalesce, and account-gate mempool refreshes.
- Updated activity row mapping so `receiving` renders as an inbound in-progress row with a plus amount and down-arrow icon.
- Updated transaction detail matching so a row opened as `receiving` can refresh into the same tx after it becomes `received`.

## Decisions and Tradeoffs

- Surface inbound receives from mempool instead of waiting for mined-block scanning. This gives immediate Activity/Home feedback while still letting normal sync confirmation reconcile the row after mining.
- Keep mempool observation ephemeral. We removed the proposed `mempool_tx_observations` debug table and kept diagnostics in logs/stats rather than adding persistent schema for temporary observation data.
- Use account-scoped refreshes. `account_uuids` exists so a mempool event only refreshes the active account when that account was actually matched, which avoids broad multi-account UI churn.
- Coalesce refresh work instead of refreshing inline for every event. This keeps the observer responsive and avoids reload storms during mempool bursts.
- Represent pending inbound as a separate UI state (`Receiving`) rather than overloading `Received`. Once the tx is mined, the existing `Received` state is restored.
- Do not add an extra block rescan path for mempool matches. The PR relies on decrypt-and-store for mempool visibility and the existing sync/enhancement path for final confirmation.

## Validation

- `cd rust && cargo test wallet::sync_engine::mempool::tests`
- `cd rust && cargo test wallet::sync::transactions::tests`
- `cd rust && cargo test`
- `fvm flutter test test/activity_row_mapper_test.dart test/activity_table_row_test.dart`
- `fvm flutter analyze lib/src/features/activity/activity_row_mapper.dart lib/src/features/activity/screens/activity_transaction_status_screen.dart test/activity_table_row_test.dart`
- `fvm dart analyze lib/src/providers/sync_provider.dart lib/src/rust/api/sync.dart lib/src/rust/frb_generated.dart`
- `git diff --check`

## Notes

- `macos/Podfile.lock` remains outside this PR scope.
- Docker-backed regtest cases remain ignored unless the local zcashd/lightwalletd regtest services are running.