### PR TITLE
[codex] Improve network error handling

### DIFF
--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -44,7 +44,8 @@ ActivityRowData buildSyncActivityRow({
 }) {
   final colors = context.colors;
 
-  if (sync.error != null) {
+  final failure = sync.failure;
+  if (failure != null) {
     return ActivityRowData(
       title: 'Wallet Synced',
       leadingIconName: AppIcons.sync,
@@ -52,9 +53,11 @@ ActivityRowData buildSyncActivityRow({
       leadingIconColor: colors.icon.regular,
       amountText: '--',
       amountColor: colors.text.secondary,
-      statusText: 'Failed',
-      statusIconName: AppIcons.skull,
-      statusColor: colors.text.destructive,
+      statusText: failure.isAutoRetrying ? 'Retrying' : 'Failed',
+      statusIconName: failure.isAutoRetrying ? AppIcons.loader : AppIcons.skull,
+      statusColor: failure.isAutoRetrying
+          ? colors.text.secondary
+          : colors.text.destructive,
       timestampText: formatActivityTimestamp(sync.lastSyncFailedAt),
     );
   }

--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -53,11 +53,9 @@ ActivityRowData buildSyncActivityRow({
       leadingIconColor: colors.icon.regular,
       amountText: '--',
       amountColor: colors.text.secondary,
-      statusText: failure.isAutoRetrying ? 'Retrying' : 'Failed',
-      statusIconName: failure.isAutoRetrying ? AppIcons.loader : AppIcons.skull,
-      statusColor: failure.isAutoRetrying
-          ? colors.text.secondary
-          : colors.text.destructive,
+      statusText: 'Failed',
+      statusIconName: AppIcons.skull,
+      statusColor: colors.text.destructive,
       timestampText: formatActivityTimestamp(sync.lastSyncFailedAt),
     );
   }

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -169,7 +169,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final hasActivitySyncData =
         syncState?.hasDataForAccount(activeAccountUuid) ?? false;
     final isActivityLoading =
-        activeAccountUuid != null && !hasActivitySyncData && sync.error == null;
+        activeAccountUuid != null &&
+        !hasActivitySyncData &&
+        sync.failure == null;
     final privacyModeEnabled = ref.watch(privacyModeProvider);
     final shieldedBalance =
         sync.saplingBalance +
@@ -411,12 +413,15 @@ class _HomePaneState extends ConsumerState<_HomePane> {
         onTap: widget.onDismissShieldBalanceError,
       );
     }
-    if (widget.sync.error != null) {
+    final syncFailure = widget.sync.failure;
+    if (syncFailure != null) {
       return _HomeNoticeData(
         iconName: AppIcons.warning,
-        message: 'Sync error',
-        actionLabel: 'Retry',
-        onTap: widget.onRetrySync,
+        message: syncFailure.userMessage,
+        actionLabel: syncFailure.actionLabel,
+        onTap: syncFailure.showSettingsAction
+            ? () => context.push('/settings/endpoint')
+            : widget.onRetrySync,
       );
     }
     if (widget.sync.isBackgroundMode) {

--- a/lib/src/features/onboarding/create/secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/create/secret_passphrase_screen.dart
@@ -18,6 +18,7 @@ import '../../../providers/wallet_mutation_guard.dart';
 import '../../../rust/api/wallet.dart' as rust_wallet;
 import 'onboarding_split_view.dart';
 import '../shared/onboarding_flow_args.dart';
+import '../shared/onboarding_error_messages.dart';
 
 class SecretPassphraseScreen extends ConsumerStatefulWidget {
   const SecretPassphraseScreen({this.args, super.key});
@@ -132,7 +133,7 @@ class _SecretPassphraseScreenState
       if (!mounted) return;
       setState(() {
         _submitPhase = _CreateWalletSubmitPhase.idle;
-        _submitError = e.toString();
+        _submitError = onboardingSubmitErrorMessage(e);
       });
       return;
     }

--- a/lib/src/features/onboarding/shared/onboarding_error_messages.dart
+++ b/lib/src/features/onboarding/shared/onboarding_error_messages.dart
@@ -1,0 +1,14 @@
+import '../../../providers/account_provider.dart';
+
+String onboardingSubmitErrorMessage(Object error) {
+  if (error is WalletCreationCurrentBlockHeightException) {
+    return kWalletCreationCurrentBlockHeightErrorMessage;
+  }
+
+  const exceptionPrefix = 'Exception: ';
+  final message = error.toString();
+  if (message.startsWith(exceptionPrefix)) {
+    return message.substring(exceptionPrefix.length);
+  }
+  return message;
+}

--- a/lib/src/features/onboarding/shared/set_password_screen.dart
+++ b/lib/src/features/onboarding/shared/set_password_screen.dart
@@ -16,6 +16,7 @@ import '../../../providers/wallet_mutation_guard.dart';
 import '../create/onboarding_split_view.dart';
 import '../import/import_split_view.dart';
 import 'onboarding_flow_args.dart';
+import 'onboarding_error_messages.dart';
 
 class SetPasswordScreen extends ConsumerStatefulWidget {
   const SetPasswordScreen({super.key, required this.args});
@@ -134,7 +135,7 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
       if (!mounted) return;
       setState(() {
         _submitPhase = _SetPasswordSubmitPhase.idle;
-        _submitError = e.toString();
+        _submitError = onboardingSubmitErrorMessage(e);
       });
       return;
     }

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -30,7 +30,7 @@ const _saplingSpendHash = 'a15ab54c2888880e53c823a3063820c728444126';
 const _saplingOutputHash = '0ebc5a1ef3653948e1c46cf7a16071eac4b7e352';
 const _saplingParamBaseUrl = 'https://download.z.cash/downloads/';
 
-enum _SendStatusPhase { sending, succeeded, failed }
+enum _SendStatusPhase { sending, pendingBroadcast, succeeded, failed }
 
 class SendStatusScreen extends ConsumerStatefulWidget {
   const SendStatusScreen({super.key, required this.args});
@@ -46,6 +46,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   bool _proposalConsumed = false;
   bool _discardScheduled = false;
   String? _error;
+  String? _statusMessage;
   String? _txid;
   late final DateTime _startedAt = DateTime.now();
   DateTime? _completedAt;
@@ -120,6 +121,25 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
       return 'Transaction expired before it could be sent.';
     }
     return 'Transaction could not be sent. Please return to your wallet and verify the latest status.';
+  }
+
+  String? _firstTxid(String txids) {
+    for (final part in txids.split(',')) {
+      final trimmed = part.trim();
+      if (trimmed.isNotEmpty) return trimmed;
+    }
+    return null;
+  }
+
+  String _broadcastStatusMessage(rust_sync.ExecuteProposalResult result) {
+    if (result.status == 'partial_broadcast') {
+      return 'Some transactions were broadcast and the rest will retry automatically. Check activity before sending again.';
+    }
+    final rawMessage = result.message?.toLowerCase() ?? '';
+    if (rawMessage.contains('broadcast rejected')) {
+      return 'Transaction was created locally, but the network did not accept the first broadcast. It may retry automatically until it expires. Do not send again unless this transaction expires.';
+    }
+    return 'Transaction was created locally but could not be broadcast. It will retry automatically when the network is available. Do not send again unless this transaction expires.';
   }
 
   String _formatReceiptAmount(BigInt zatoshi) {
@@ -364,7 +384,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
       }
 
       final seedBytes = await rust_wallet.deriveSeed(mnemonic: mnemonic);
-      final txid = await rust_sync.executeProposal(
+      final result = await rust_sync.executeProposal(
         dbPath: dbPath,
         lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
         proposalId: widget.args.proposalId,
@@ -374,6 +394,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
         outputParamsPath: widget.args.needsSaplingParams ? outputPath : null,
       );
       _proposalConsumed = true;
+      final broadcastComplete = result.status == 'broadcasted';
 
       try {
         await ref.read(syncProvider.notifier).refreshAfterSend();
@@ -398,8 +419,13 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
 
       if (await _abortIfUnmounted()) return;
       setState(() {
-        _phase = _SendStatusPhase.succeeded;
-        _txid = txid;
+        _phase = broadcastComplete
+            ? _SendStatusPhase.succeeded
+            : _SendStatusPhase.pendingBroadcast;
+        _txid = _firstTxid(result.txids);
+        _statusMessage = broadcastComplete
+            ? null
+            : _broadcastStatusMessage(result);
         _completedAt = DateTime.now();
       });
     } catch (e) {
@@ -419,6 +445,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
       setState(() {
         _phase = _SendStatusPhase.failed;
         _error = message;
+        _statusMessage = null;
       });
     }
   }
@@ -428,10 +455,12 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     final addressLines = _splitAddress();
     final receiptPhase = switch (_phase) {
       _SendStatusPhase.sending => TransactionReceiptPhase.sending,
+      _SendStatusPhase.pendingBroadcast => TransactionReceiptPhase.pending,
       _SendStatusPhase.succeeded => TransactionReceiptPhase.succeeded,
       _SendStatusPhase.failed => TransactionReceiptPhase.failed,
     };
     final useFailedReceiptLayout = _phase == _SendStatusPhase.failed;
+    final statusMessage = _statusMessage;
 
     return PopScope<void>(
       canPop: false,
@@ -506,12 +535,28 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
                               ),
                               feeText:
                                   '${_formatFee(widget.args.feeZatoshi)} ZEC',
+                              extraBlocks: [
+                                if (statusMessage != null)
+                                  TransactionReceiptBlockData(
+                                    title: 'Status',
+                                    child: Text(
+                                      statusMessage,
+                                      style: AppTypography.bodyMedium.copyWith(
+                                        color: context.colors.text.accent,
+                                      ),
+                                    ),
+                                  ),
+                              ],
                               dateText: _formatDate(_completedAt ?? _startedAt),
                               error: _error,
                               failureFallbackText: 'Send failed',
                               useFailedReceiptLayout: useFailedReceiptLayout,
                               onTransactionHashPressed:
-                                  _phase == _SendStatusPhase.succeeded
+                                  (_phase == _SendStatusPhase.succeeded ||
+                                          _phase ==
+                                              _SendStatusPhase
+                                                  .pendingBroadcast) &&
+                                      _txid != null
                                   ? _openTransactionExplorer
                                   : null,
                               onBackToWallet: _phase == _SendStatusPhase.failed

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -21,6 +21,19 @@ const _accountsKey = 'zcash_accounts';
 const _activeAccountKey = 'zcash_active_account';
 const _networkKey = 'zcash_wallet_network';
 
+const kWalletCreationCurrentBlockHeightErrorMessage =
+    'We need the current Zcash block height to create your wallet. '
+    'Check your network connection and try again.';
+
+class WalletCreationCurrentBlockHeightException implements Exception {
+  const WalletCreationCurrentBlockHeightException(this.cause);
+
+  final Object cause;
+
+  @override
+  String toString() => kWalletCreationCurrentBlockHeightErrorMessage;
+}
+
 class AccountNotifier extends AsyncNotifier<AccountState> {
   static final _storage = AppSecureStore.instance;
 
@@ -40,9 +53,8 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       final endpoint = ref.read(rpcEndpointProvider);
       final network = endpoint.networkName;
 
-      // Fetch chain tip as birthday
-      final birthday = await rust_wallet.getLatestBlockHeight(
-        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+      final birthday = await _fetchCreationBirthdayHeight(
+        endpoint.normalizedLightwalletdUrl,
       );
       log('createAccount: birthday=$birthday');
 
@@ -126,8 +138,8 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       final endpoint = ref.read(rpcEndpointProvider);
       final network = endpoint.networkName;
 
-      final birthday = await rust_wallet.getLatestBlockHeight(
-        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+      final birthday = await _fetchCreationBirthdayHeight(
+        endpoint.normalizedLightwalletdUrl,
       );
       log('createAccountFromMnemonic: birthday=$birthday');
 
@@ -490,6 +502,19 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
 
   Future<String> _getDbPath() async {
     return getWalletDbPath();
+  }
+
+  Future<BigInt> _fetchCreationBirthdayHeight(String lightwalletdUrl) async {
+    try {
+      return await rust_wallet.getLatestBlockHeight(
+        lightwalletdUrl: lightwalletdUrl,
+      );
+    } catch (e, st) {
+      Error.throwWithStackTrace(
+        WalletCreationCurrentBlockHeightException(e),
+        st,
+      );
+    }
   }
 
   Future<String> _getNetwork() async {

--- a/lib/src/providers/sync_failure.dart
+++ b/lib/src/providers/sync_failure.dart
@@ -12,16 +12,12 @@ class SyncFailure {
   final SyncFailureKind kind;
   final String rawMessage;
   final String userMessage;
-  final bool isAutoRetrying;
-  final bool canManualRetry;
   final bool showSettingsAction;
 
   const SyncFailure({
     required this.kind,
     required this.rawMessage,
     required this.userMessage,
-    required this.isAutoRetrying,
-    required this.canManualRetry,
     required this.showSettingsAction,
   });
 
@@ -37,8 +33,6 @@ SyncFailure classifySyncFailure(Object error) {
     kind: kind,
     rawMessage: rawMessage,
     userMessage: _syncFailureUserMessage(kind),
-    isAutoRetrying: _syncFailureAutoRetries(kind),
-    canManualRetry: kind != SyncFailureKind.endpoint,
     showSettingsAction: kind == SyncFailureKind.endpoint,
   );
 }
@@ -135,17 +129,5 @@ String _syncFailureUserMessage(SyncFailureKind kind) {
     SyncFailureKind.parseFatal =>
       'Sync data could not be processed. Retry sync or check your endpoint.',
     SyncFailureKind.unknown => 'Sync failed. Retry sync to continue.',
-  };
-}
-
-bool _syncFailureAutoRetries(SyncFailureKind kind) {
-  return switch (kind) {
-    SyncFailureKind.network ||
-    SyncFailureKind.databaseBusy ||
-    SyncFailureKind.chainRecovery ||
-    SyncFailureKind.unknown => true,
-    SyncFailureKind.endpoint ||
-    SyncFailureKind.databaseFatal ||
-    SyncFailureKind.parseFatal => false,
   };
 }

--- a/lib/src/providers/sync_failure.dart
+++ b/lib/src/providers/sync_failure.dart
@@ -1,0 +1,151 @@
+enum SyncFailureKind {
+  network,
+  endpoint,
+  databaseBusy,
+  databaseFatal,
+  chainRecovery,
+  parseFatal,
+  unknown,
+}
+
+class SyncFailure {
+  final SyncFailureKind kind;
+  final String rawMessage;
+  final String userMessage;
+  final bool isAutoRetrying;
+  final bool canManualRetry;
+  final bool showSettingsAction;
+
+  const SyncFailure({
+    required this.kind,
+    required this.rawMessage,
+    required this.userMessage,
+    required this.isAutoRetrying,
+    required this.canManualRetry,
+    required this.showSettingsAction,
+  });
+
+  String get actionLabel => showSettingsAction ? 'Settings' : 'Retry';
+}
+
+SyncFailure classifySyncFailure(Object error) {
+  final rawMessage = _errorText(error);
+  final lower = rawMessage.toLowerCase();
+  final kind = _classifySyncFailureKind(lower);
+
+  return SyncFailure(
+    kind: kind,
+    rawMessage: rawMessage,
+    userMessage: _syncFailureUserMessage(kind),
+    isAutoRetrying: _syncFailureAutoRetries(kind),
+    canManualRetry: kind != SyncFailureKind.endpoint,
+    showSettingsAction: kind == SyncFailureKind.endpoint,
+  );
+}
+
+String _errorText(Object error) {
+  const exceptionPrefix = 'Exception: ';
+  final message = error.toString();
+  if (message.startsWith(exceptionPrefix)) {
+    return message.substring(exceptionPrefix.length);
+  }
+  return message;
+}
+
+SyncFailureKind _classifySyncFailureKind(String lower) {
+  if (_looksLikeEndpointFailure(lower)) {
+    return SyncFailureKind.endpoint;
+  }
+  if (_looksLikeChainRecoveryFailure(lower)) {
+    return SyncFailureKind.chainRecovery;
+  }
+  if (_looksLikeDatabaseBusy(lower)) {
+    return SyncFailureKind.databaseBusy;
+  }
+  if (lower.startsWith('db:') || lower.contains('sqlite')) {
+    return SyncFailureKind.databaseFatal;
+  }
+  if (lower.startsWith('parse:')) {
+    return SyncFailureKind.parseFatal;
+  }
+  if (_looksLikeNetworkFailure(lower)) {
+    return SyncFailureKind.network;
+  }
+  return SyncFailureKind.unknown;
+}
+
+bool _looksLikeEndpointFailure(String lower) {
+  return lower.contains('invalid url') ||
+      lower.contains('invalid uri') ||
+      lower.contains('enter an endpoint') ||
+      lower.contains('use an https:// endpoint') ||
+      lower.contains('select an endpoint') ||
+      lower.contains('network mismatch') ||
+      lower.contains('wrong network') ||
+      lower.contains('chain name');
+}
+
+bool _looksLikeChainRecoveryFailure(String lower) {
+  return lower.contains('chain continuity broken') ||
+      lower.contains('rewind budget exhausted') ||
+      lower.contains('truncate_to_height') ||
+      lower.contains('blockconflict') ||
+      lower.contains('prevhashmismatch') ||
+      lower.contains('blockheightdiscontinuity');
+}
+
+bool _looksLikeDatabaseBusy(String lower) {
+  return lower.contains('database is locked') ||
+      lower.contains('database locked') ||
+      lower.contains('database busy') ||
+      lower.contains('sqlite lock contention');
+}
+
+bool _looksLikeNetworkFailure(String lower) {
+  return lower.startsWith('network:') ||
+      lower.contains('deadline exceeded') ||
+      lower.contains('timed out') ||
+      lower.contains('timeout') ||
+      lower.contains('unavailable') ||
+      lower.contains('cancelled') ||
+      lower.contains('connection refused') ||
+      lower.contains('connection reset') ||
+      lower.contains('connection closed') ||
+      lower.contains('failed to connect') ||
+      lower.contains('grpc connect failed') ||
+      lower.contains('dns') ||
+      lower.contains('tls error') ||
+      lower.contains('transport error') ||
+      lower.contains('broken pipe') ||
+      lower.contains('no route to host');
+}
+
+String _syncFailureUserMessage(SyncFailureKind kind) {
+  return switch (kind) {
+    SyncFailureKind.network =>
+      "Network connection lost. We'll keep trying automatically.",
+    SyncFailureKind.endpoint =>
+      'Cannot reach the configured Zcash endpoint. Check your endpoint settings.',
+    SyncFailureKind.databaseBusy =>
+      "Wallet data is busy. We'll try syncing again automatically.",
+    SyncFailureKind.databaseFatal =>
+      'Wallet data could not be read. Restart the app and retry sync.',
+    SyncFailureKind.chainRecovery =>
+      "The chain changed while syncing. We'll keep trying to recover.",
+    SyncFailureKind.parseFatal =>
+      'Sync data could not be processed. Retry sync or check your endpoint.',
+    SyncFailureKind.unknown => 'Sync failed. Retry sync to continue.',
+  };
+}
+
+bool _syncFailureAutoRetries(SyncFailureKind kind) {
+  return switch (kind) {
+    SyncFailureKind.network ||
+    SyncFailureKind.databaseBusy ||
+    SyncFailureKind.chainRecovery ||
+    SyncFailureKind.unknown => true,
+    SyncFailureKind.endpoint ||
+    SyncFailureKind.databaseFatal ||
+    SyncFailureKind.parseFatal => false,
+  };
+}

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -14,6 +14,7 @@ import '../services/background_sync_delegate.dart';
 import 'account_provider.dart';
 import 'app_security_provider.dart';
 import 'rpc_endpoint_provider.dart';
+import 'sync_failure.dart';
 
 class SyncState {
   /// Account UUID that owns the balance, shield status, and recent transaction
@@ -51,6 +52,11 @@ class SyncState {
 
   /// Sum of spendable + pending balances across all pools. Use for "total holdings".
   final BigInt totalBalance;
+
+  /// Structured sync failure used by UI to choose copy and recovery action.
+  final SyncFailure? failure;
+
+  /// Raw sync error retained for compatibility with existing failure checks.
   final String? error;
   final List<rust_sync.TransactionInfo> recentTransactions;
   final DateTime? lastSyncStartedAt;
@@ -88,6 +94,7 @@ class SyncState {
     BigInt? shieldTransparentAmount,
     BigInt? spendableBalance,
     BigInt? totalBalance,
+    this.failure,
     this.error,
     this.recentTransactions = const [],
     this.lastSyncStartedAt,
@@ -131,7 +138,10 @@ class SyncState {
     BigInt? shieldTransparentAmount,
     BigInt? spendableBalance,
     BigInt? totalBalance,
+    SyncFailure? failure,
+    bool clearFailure = false,
     String? error,
+    bool clearError = false,
     List<rust_sync.TransactionInfo>? recentTransactions,
     DateTime? lastSyncStartedAt,
     DateTime? lastSyncCompletedAt,
@@ -168,7 +178,8 @@ class SyncState {
           shieldTransparentAmount ?? this.shieldTransparentAmount,
       spendableBalance: spendableBalance ?? this.spendableBalance,
       totalBalance: totalBalance ?? this.totalBalance,
-      error: error ?? this.error,
+      failure: clearFailure ? null : failure ?? this.failure,
+      error: clearError ? null : error ?? this.error,
       recentTransactions: recentTransactions ?? this.recentTransactions,
       lastSyncStartedAt: lastSyncStartedAt ?? this.lastSyncStartedAt,
       lastSyncCompletedAt: lastSyncCompletedAt ?? this.lastSyncCompletedAt,
@@ -201,6 +212,7 @@ class SyncState {
       displayPercentage: displayPercentage,
       scannedHeight: scannedHeight,
       chainTipHeight: chainTipHeight,
+      failure: failure,
       error: error,
       lastSyncStartedAt: lastSyncStartedAt,
       lastSyncCompletedAt: lastSyncCompletedAt,
@@ -549,37 +561,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               // a lightwalletd stream that keeps firing
               // `_refreshBalance()` callbacks with no owning sync.
               _stopMempoolObserver();
-              final prev = state.value;
-              final accountUuid = _getActiveAccountUuid();
-              final scopedPrev = _previousScopedState(prev, accountUuid);
-              state = AsyncData(
-                SyncState(
-                  accountUuid: accountUuid,
-                  hasBalanceData: scopedPrev?.hasBalanceData ?? false,
-                  hasRecentTransactionsData:
-                      scopedPrev?.hasRecentTransactionsData ?? false,
-                  error: e.toString(),
-                  transparentBalance: scopedPrev?.transparentBalance,
-                  saplingBalance: scopedPrev?.saplingBalance,
-                  orchardBalance: scopedPrev?.orchardBalance,
-                  transparentPendingBalance:
-                      scopedPrev?.transparentPendingBalance,
-                  saplingPendingBalance: scopedPrev?.saplingPendingBalance,
-                  orchardPendingBalance: scopedPrev?.orchardPendingBalance,
-                  canShieldTransparentBalance:
-                      scopedPrev?.canShieldTransparentBalance ?? false,
-                  shieldTransparentFee: scopedPrev?.shieldTransparentFee,
-                  shieldTransparentAmount: scopedPrev?.shieldTransparentAmount,
-                  spendableBalance: scopedPrev?.spendableBalance,
-                  totalBalance: scopedPrev?.totalBalance,
-                  recentTransactions:
-                      scopedPrev?.recentTransactions ?? const [],
-                  lastSyncStartedAt: prev?.lastSyncStartedAt,
-                  lastSyncCompletedAt: prev?.lastSyncCompletedAt,
-                  lastSyncFailedAt: DateTime.now(),
-                ),
-              );
-              _startPolling();
+              _recordSyncFailure(e);
             },
           );
         })
@@ -595,36 +577,46 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
           // `_stopMempoolObserver()` here; it is idempotent when
           // nothing is running.
           _stopMempoolObserver();
-          final prev = state.value;
-          final accountUuid = _getActiveAccountUuid();
-          final scopedPrev = _previousScopedState(prev, accountUuid);
-          state = AsyncData(
-            SyncState(
-              accountUuid: accountUuid,
-              hasBalanceData: scopedPrev?.hasBalanceData ?? false,
-              hasRecentTransactionsData:
-                  scopedPrev?.hasRecentTransactionsData ?? false,
-              error: e.toString(),
-              transparentBalance: scopedPrev?.transparentBalance,
-              saplingBalance: scopedPrev?.saplingBalance,
-              orchardBalance: scopedPrev?.orchardBalance,
-              transparentPendingBalance: scopedPrev?.transparentPendingBalance,
-              saplingPendingBalance: scopedPrev?.saplingPendingBalance,
-              orchardPendingBalance: scopedPrev?.orchardPendingBalance,
-              canShieldTransparentBalance:
-                  scopedPrev?.canShieldTransparentBalance ?? false,
-              shieldTransparentFee: scopedPrev?.shieldTransparentFee,
-              shieldTransparentAmount: scopedPrev?.shieldTransparentAmount,
-              spendableBalance: scopedPrev?.spendableBalance,
-              totalBalance: scopedPrev?.totalBalance,
-              recentTransactions: scopedPrev?.recentTransactions ?? const [],
-              lastSyncStartedAt: prev?.lastSyncStartedAt,
-              lastSyncCompletedAt: prev?.lastSyncCompletedAt,
-              lastSyncFailedAt: DateTime.now(),
-            ),
-          );
-          _startPolling();
+          _recordSyncFailure(e);
         });
+  }
+
+  void _recordSyncFailure(Object error) {
+    final failure = classifySyncFailure(error);
+    final prev = state.value;
+    final accountUuid = _getActiveAccountUuid();
+    final scopedPrev = _previousScopedState(prev, accountUuid);
+    state = AsyncData(
+      SyncState(
+        accountUuid: accountUuid,
+        hasBalanceData: scopedPrev?.hasBalanceData ?? false,
+        hasRecentTransactionsData:
+            scopedPrev?.hasRecentTransactionsData ?? false,
+        failure: failure,
+        error: failure.rawMessage,
+        transparentBalance: scopedPrev?.transparentBalance,
+        saplingBalance: scopedPrev?.saplingBalance,
+        orchardBalance: scopedPrev?.orchardBalance,
+        transparentPendingBalance: scopedPrev?.transparentPendingBalance,
+        saplingPendingBalance: scopedPrev?.saplingPendingBalance,
+        orchardPendingBalance: scopedPrev?.orchardPendingBalance,
+        canShieldTransparentBalance:
+            scopedPrev?.canShieldTransparentBalance ?? false,
+        shieldTransparentFee: scopedPrev?.shieldTransparentFee,
+        shieldTransparentAmount: scopedPrev?.shieldTransparentAmount,
+        spendableBalance: scopedPrev?.spendableBalance,
+        totalBalance: scopedPrev?.totalBalance,
+        recentTransactions: scopedPrev?.recentTransactions ?? const [],
+        lastSyncStartedAt: prev?.lastSyncStartedAt,
+        lastSyncCompletedAt: prev?.lastSyncCompletedAt,
+        lastSyncFailedAt: DateTime.now(),
+      ),
+    );
+    if (failure.isAutoRetrying) {
+      _startPolling();
+    } else {
+      _stopPolling();
+    }
   }
 
   /// Recovery path for cases like unlock-after-sign-out where a previous

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -612,11 +612,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         lastSyncFailedAt: DateTime.now(),
       ),
     );
-    if (failure.isAutoRetrying) {
-      _startPolling();
-    } else {
-      _stopPolling();
-    }
+    _startPolling();
   }
 
   /// Recovery path for cases like unlock-after-sign-out where a previous

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -253,7 +253,7 @@ Future<SendMaxEstimateResult> estimateSendMax({
 
 /// Step 2: Execute a previously proposed transfer and broadcast to the network.
 /// spend_params_path and output_params_path are required only if needs_sapling_params was true.
-Future<String> executeProposal({
+Future<ExecuteProposalResult> executeProposal({
   required String dbPath,
   required String lightwalletdUrl,
   required BigInt proposalId,
@@ -606,6 +606,41 @@ class BlockMetaInfo {
           time == other.time &&
           saplingOutputsCount == other.saplingOutputsCount &&
           orchardActionsCount == other.orchardActionsCount;
+}
+
+class ExecuteProposalResult {
+  final String txids;
+  final String status;
+  final int broadcastedCount;
+  final int totalCount;
+  final String? message;
+
+  const ExecuteProposalResult({
+    required this.txids,
+    required this.status,
+    required this.broadcastedCount,
+    required this.totalCount,
+    this.message,
+  });
+
+  @override
+  int get hashCode =>
+      txids.hashCode ^
+      status.hashCode ^
+      broadcastedCount.hashCode ^
+      totalCount.hashCode ^
+      message.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ExecuteProposalResult &&
+          runtimeType == other.runtimeType &&
+          txids == other.txids &&
+          status == other.status &&
+          broadcastedCount == other.broadcastedCount &&
+          totalCount == other.totalCount &&
+          message == other.message;
 }
 
 class ProposalResult {

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -449,7 +449,7 @@ Future<Uint8List> redactPcztForSigner({required List<int> pcztBytes}) =>
 /// `extract_and_store_transaction_from_pczt` after broadcast. Orchard-only
 /// sends can pass `None` for both. Mirrors the `add_proofs_to_pczt`
 /// contract: if you needed to supply params there, you need them here too.
-Future<String> extractAndBroadcastPczt({
+Future<ExtractAndBroadcastPcztResult> extractAndBroadcastPczt({
   required String dbPath,
   required String lightwalletdUrl,
   required String network,
@@ -640,6 +640,30 @@ class ExecuteProposalResult {
           status == other.status &&
           broadcastedCount == other.broadcastedCount &&
           totalCount == other.totalCount &&
+          message == other.message;
+}
+
+class ExtractAndBroadcastPcztResult {
+  final String txid;
+  final String status;
+  final String? message;
+
+  const ExtractAndBroadcastPcztResult({
+    required this.txid,
+    required this.status,
+    this.message,
+  });
+
+  @override
+  int get hashCode => txid.hashCode ^ status.hashCode ^ message.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ExtractAndBroadcastPcztResult &&
+          runtimeType == other.runtimeType &&
+          txid == other.txid &&
+          status == other.status &&
           message == other.message;
 }
 

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -178,7 +178,7 @@ abstract class RustLibApi extends BaseApi {
     String? outputParamsPath,
   });
 
-  Future<String> crateApiSyncExtractAndBroadcastPczt({
+  Future<ExtractAndBroadcastPcztResult> crateApiSyncExtractAndBroadcastPczt({
     required String dbPath,
     required String lightwalletdUrl,
     required String network,
@@ -1101,7 +1101,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<String> crateApiSyncExtractAndBroadcastPczt({
+  Future<ExtractAndBroadcastPcztResult> crateApiSyncExtractAndBroadcastPczt({
     required String dbPath,
     required String lightwalletdUrl,
     required String network,
@@ -1129,7 +1129,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
         },
         codec: SseCodec(
-          decodeSuccessData: sse_decode_String,
+          decodeSuccessData: sse_decode_extract_and_broadcast_pczt_result,
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncExtractAndBroadcastPcztConstMeta,
@@ -2937,6 +2937,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ExtractAndBroadcastPcztResult dco_decode_extract_and_broadcast_pczt_result(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return ExtractAndBroadcastPcztResult(
+      txid: dco_decode_String(arr[0]),
+      status: dco_decode_String(arr[1]),
+      message: dco_decode_opt_String(arr[2]),
+    );
+  }
+
+  @protected
   double dco_decode_f_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as double;
@@ -3477,6 +3492,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       status: var_status,
       broadcastedCount: var_broadcastedCount,
       totalCount: var_totalCount,
+      message: var_message,
+    );
+  }
+
+  @protected
+  ExtractAndBroadcastPcztResult sse_decode_extract_and_broadcast_pczt_result(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_txid = sse_decode_String(deserializer);
+    var var_status = sse_decode_String(deserializer);
+    var var_message = sse_decode_opt_String(deserializer);
+    return ExtractAndBroadcastPcztResult(
+      txid: var_txid,
+      status: var_status,
       message: var_message,
     );
   }
@@ -4129,6 +4159,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.status, serializer);
     sse_encode_u_32(self.broadcastedCount, serializer);
     sse_encode_u_32(self.totalCount, serializer);
+    sse_encode_opt_String(self.message, serializer);
+  }
+
+  @protected
+  void sse_encode_extract_and_broadcast_pczt_result(
+    ExtractAndBroadcastPcztResult self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.txid, serializer);
+    sse_encode_String(self.status, serializer);
     sse_encode_opt_String(self.message, serializer);
   }
 

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -168,7 +168,7 @@ abstract class RustLibApi extends BaseApi {
     String? memo,
   });
 
-  Future<String> crateApiSyncExecuteProposal({
+  Future<ExecuteProposalResult> crateApiSyncExecuteProposal({
     required String dbPath,
     required String lightwalletdUrl,
     required BigInt proposalId,
@@ -1040,7 +1040,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<String> crateApiSyncExecuteProposal({
+  Future<ExecuteProposalResult> crateApiSyncExecuteProposal({
     required String dbPath,
     required String lightwalletdUrl,
     required BigInt proposalId,
@@ -1068,7 +1068,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
         },
         codec: SseCodec(
-          decodeSuccessData: sse_decode_String,
+          decodeSuccessData: sse_decode_execute_proposal_result,
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncExecuteProposalConstMeta,
@@ -2922,6 +2922,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ExecuteProposalResult dco_decode_execute_proposal_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
+    return ExecuteProposalResult(
+      txids: dco_decode_String(arr[0]),
+      status: dco_decode_String(arr[1]),
+      broadcastedCount: dco_decode_u_32(arr[2]),
+      totalCount: dco_decode_u_32(arr[3]),
+      message: dco_decode_opt_String(arr[4]),
+    );
+  }
+
+  @protected
   double dco_decode_f_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw as double;
@@ -3445,6 +3460,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BigInt sse_decode_box_autoadd_u_64(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return (sse_decode_u_64(deserializer));
+  }
+
+  @protected
+  ExecuteProposalResult sse_decode_execute_proposal_result(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_txids = sse_decode_String(deserializer);
+    var var_status = sse_decode_String(deserializer);
+    var var_broadcastedCount = sse_decode_u_32(deserializer);
+    var var_totalCount = sse_decode_u_32(deserializer);
+    var var_message = sse_decode_opt_String(deserializer);
+    return ExecuteProposalResult(
+      txids: var_txids,
+      status: var_status,
+      broadcastedCount: var_broadcastedCount,
+      totalCount: var_totalCount,
+      message: var_message,
+    );
   }
 
   @protected
@@ -4083,6 +4117,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_box_autoadd_u_64(BigInt self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_64(self, serializer);
+  }
+
+  @protected
+  void sse_encode_execute_proposal_result(
+    ExecuteProposalResult self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.txids, serializer);
+    sse_encode_String(self.status, serializer);
+    sse_encode_u_32(self.broadcastedCount, serializer);
+    sse_encode_u_32(self.totalCount, serializer);
+    sse_encode_opt_String(self.message, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -64,6 +64,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt dco_decode_box_autoadd_u_64(dynamic raw);
 
   @protected
+  ExecuteProposalResult dco_decode_execute_proposal_result(dynamic raw);
+
+  @protected
   double dco_decode_f_64(dynamic raw);
 
   @protected
@@ -235,6 +238,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   BigInt sse_decode_box_autoadd_u_64(SseDeserializer deserializer);
+
+  @protected
+  ExecuteProposalResult sse_decode_execute_proposal_result(
+    SseDeserializer deserializer,
+  );
 
   @protected
   double sse_decode_f_64(SseDeserializer deserializer);
@@ -444,6 +452,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_box_autoadd_u_64(BigInt self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_execute_proposal_result(
+    ExecuteProposalResult self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -67,6 +67,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ExecuteProposalResult dco_decode_execute_proposal_result(dynamic raw);
 
   @protected
+  ExtractAndBroadcastPcztResult dco_decode_extract_and_broadcast_pczt_result(
+    dynamic raw,
+  );
+
+  @protected
   double dco_decode_f_64(dynamic raw);
 
   @protected
@@ -241,6 +246,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ExecuteProposalResult sse_decode_execute_proposal_result(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ExtractAndBroadcastPcztResult sse_decode_extract_and_broadcast_pczt_result(
     SseDeserializer deserializer,
   );
 
@@ -456,6 +466,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_execute_proposal_result(
     ExecuteProposalResult self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_extract_and_broadcast_pczt_result(
+    ExtractAndBroadcastPcztResult self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -66,6 +66,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt dco_decode_box_autoadd_u_64(dynamic raw);
 
   @protected
+  ExecuteProposalResult dco_decode_execute_proposal_result(dynamic raw);
+
+  @protected
   double dco_decode_f_64(dynamic raw);
 
   @protected
@@ -237,6 +240,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   BigInt sse_decode_box_autoadd_u_64(SseDeserializer deserializer);
+
+  @protected
+  ExecuteProposalResult sse_decode_execute_proposal_result(
+    SseDeserializer deserializer,
+  );
 
   @protected
   double sse_decode_f_64(SseDeserializer deserializer);
@@ -446,6 +454,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_box_autoadd_u_64(BigInt self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_execute_proposal_result(
+    ExecuteProposalResult self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_f_64(double self, SseSerializer serializer);

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -69,6 +69,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ExecuteProposalResult dco_decode_execute_proposal_result(dynamic raw);
 
   @protected
+  ExtractAndBroadcastPcztResult dco_decode_extract_and_broadcast_pczt_result(
+    dynamic raw,
+  );
+
+  @protected
   double dco_decode_f_64(dynamic raw);
 
   @protected
@@ -243,6 +248,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   ExecuteProposalResult sse_decode_execute_proposal_result(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ExtractAndBroadcastPcztResult sse_decode_extract_and_broadcast_pczt_result(
     SseDeserializer deserializer,
   );
 
@@ -458,6 +468,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_execute_proposal_result(
     ExecuteProposalResult self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_extract_and_broadcast_pczt_result(
+    ExtractAndBroadcastPcztResult self,
     SseSerializer serializer,
   );
 

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -572,6 +572,14 @@ pub struct ProposalResult {
     pub fee_zatoshi: u64,
 }
 
+pub struct ExecuteProposalResult {
+    pub txids: String,
+    pub status: String,
+    pub broadcasted_count: u32,
+    pub total_count: u32,
+    pub message: Option<String>,
+}
+
 pub struct SendMaxEstimateResult {
     pub amount_zatoshi: u64,
     pub fee_zatoshi: u64,
@@ -677,10 +685,10 @@ pub fn execute_proposal(
     seed: Vec<u8>,
     spend_params_path: Option<String>,
     output_params_path: Option<String>,
-) -> Result<String, String> {
+) -> Result<ExecuteProposalResult, String> {
     catch(|| {
         let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
-        rt.block_on(wallet_sync::execute_proposal(
+        let r = rt.block_on(wallet_sync::execute_proposal(
             &db_path,
             &lightwalletd_url,
             proposal_id,
@@ -688,7 +696,14 @@ pub fn execute_proposal(
             &seed,
             spend_params_path.as_deref(),
             output_params_path.as_deref(),
-        ))
+        ))?;
+        Ok(ExecuteProposalResult {
+            txids: r.txids,
+            status: r.status,
+            broadcasted_count: r.broadcasted_count,
+            total_count: r.total_count,
+            message: r.message,
+        })
     })
 }
 

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -580,6 +580,12 @@ pub struct ExecuteProposalResult {
     pub message: Option<String>,
 }
 
+pub struct ExtractAndBroadcastPcztResult {
+    pub txid: String,
+    pub status: String,
+    pub message: Option<String>,
+}
+
 pub struct SendMaxEstimateResult {
     pub amount_zatoshi: u64,
     pub fee_zatoshi: u64,
@@ -1030,9 +1036,9 @@ pub async fn extract_and_broadcast_pczt(
     pczt_with_signatures_bytes: Vec<u8>,
     spend_params_path: Option<String>,
     output_params_path: Option<String>,
-) -> Result<String, String> {
+) -> Result<ExtractAndBroadcastPcztResult, String> {
     let network = keys::parse_network(&network)?;
-    wallet_sync::extract_and_broadcast_pczt(
+    let result = wallet_sync::extract_and_broadcast_pczt(
         &db_path,
         &lightwalletd_url,
         network,
@@ -1041,5 +1047,10 @@ pub async fn extract_and_broadcast_pczt(
         spend_params_path.as_deref(),
         output_params_path.as_deref(),
     )
-    .await
+    .await?;
+    Ok(ExtractAndBroadcastPcztResult {
+        txid: result.txid,
+        status: result.status,
+        message: result.message,
+    })
 }

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -52,16 +52,12 @@ pub fn get_latest_block_height(lightwalletd_url: String) -> Result<u64, String> 
     catch(|| {
         let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
         rt.block_on(async {
-            use zcash_client_backend::proto::service::ChainSpec;
-
             let mut client = crate::wallet::sync_engine::open_lwd_channel(&lightwalletd_url)
                 .await
                 .map_err(|e| e.to_string())?;
-            let tip = client
-                .get_latest_block(ChainSpec::default())
+            let tip = crate::wallet::sync_engine::get_latest_block(&mut client)
                 .await
-                .map_err(|e| format!("get_latest_block: {e}"))?
-                .into_inner();
+                .map_err(|e| e.to_string())?;
 
             Ok(tip.height)
         })

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -2634,6 +2634,24 @@ impl SseDecode for bool {
     }
 }
 
+impl SseDecode for crate::api::sync::ExecuteProposalResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_txids = <String>::sse_decode(deserializer);
+        let mut var_status = <String>::sse_decode(deserializer);
+        let mut var_broadcastedCount = <u32>::sse_decode(deserializer);
+        let mut var_totalCount = <u32>::sse_decode(deserializer);
+        let mut var_message = <Option<String>>::sse_decode(deserializer);
+        return crate::api::sync::ExecuteProposalResult {
+            txids: var_txids,
+            status: var_status,
+            broadcasted_count: var_broadcastedCount,
+            total_count: var_totalCount,
+            message: var_message,
+        };
+    }
+}
+
 impl SseDecode for f64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3466,6 +3484,30 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::BlockMetaInfo>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sync::ExecuteProposalResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.txids.into_into_dart().into_dart(),
+            self.status.into_into_dart().into_dart(),
+            self.broadcasted_count.into_into_dart().into_dart(),
+            self.total_count.into_into_dart().into_dart(),
+            self.message.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sync::ExecuteProposalResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ExecuteProposalResult>
+    for crate::api::sync::ExecuteProposalResult
+{
+    fn into_into_dart(self) -> crate::api::sync::ExecuteProposalResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::wallet::keystone::KeystoneAccountInfo {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -3969,6 +4011,17 @@ impl SseEncode for bool {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         serializer.cursor.write_u8(self as _).unwrap();
+    }
+}
+
+impl SseEncode for crate::api::sync::ExecuteProposalResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.txids, serializer);
+        <String>::sse_encode(self.status, serializer);
+        <u32>::sse_encode(self.broadcasted_count, serializer);
+        <u32>::sse_encode(self.total_count, serializer);
+        <Option<String>>::sse_encode(self.message, serializer);
     }
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -2652,6 +2652,20 @@ impl SseDecode for crate::api::sync::ExecuteProposalResult {
     }
 }
 
+impl SseDecode for crate::api::sync::ExtractAndBroadcastPcztResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_txid = <String>::sse_decode(deserializer);
+        let mut var_status = <String>::sse_decode(deserializer);
+        let mut var_message = <Option<String>>::sse_decode(deserializer);
+        return crate::api::sync::ExtractAndBroadcastPcztResult {
+            txid: var_txid,
+            status: var_status,
+            message: var_message,
+        };
+    }
+}
+
 impl SseDecode for f64 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3508,6 +3522,28 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ExecuteProposalResult>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sync::ExtractAndBroadcastPcztResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.txid.into_into_dart().into_dart(),
+            self.status.into_into_dart().into_dart(),
+            self.message.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sync::ExtractAndBroadcastPcztResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ExtractAndBroadcastPcztResult>
+    for crate::api::sync::ExtractAndBroadcastPcztResult
+{
+    fn into_into_dart(self) -> crate::api::sync::ExtractAndBroadcastPcztResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::wallet::keystone::KeystoneAccountInfo {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -4021,6 +4057,15 @@ impl SseEncode for crate::api::sync::ExecuteProposalResult {
         <String>::sse_encode(self.status, serializer);
         <u32>::sse_encode(self.broadcasted_count, serializer);
         <u32>::sse_encode(self.total_count, serializer);
+        <Option<String>>::sse_encode(self.message, serializer);
+    }
+}
+
+impl SseEncode for crate::api::sync::ExtractAndBroadcastPcztResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.txid, serializer);
+        <String>::sse_encode(self.status, serializer);
         <Option<String>>::sse_encode(self.message, serializer);
     }
 }

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -39,7 +39,7 @@ mod transactions;
 // exactly).
 pub use pczt::{
     add_proofs_to_pczt, create_pczt_from_proposal, discard_proposal, extract_and_broadcast_pczt,
-    redact_pczt_for_signer,
+    redact_pczt_for_signer, ExtractAndBroadcastPcztResult,
 };
 pub(crate) use send::estimate_send_max;
 pub use send::{estimate_fee, execute_proposal, propose_send, ExecuteProposalResult};

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -42,7 +42,7 @@ pub use pczt::{
     redact_pczt_for_signer,
 };
 pub(crate) use send::estimate_send_max;
-pub use send::{estimate_fee, execute_proposal, propose_send};
+pub use send::{estimate_fee, execute_proposal, propose_send, ExecuteProposalResult};
 pub(crate) use send::{get_shield_transparent_status, shield_transparent_balance};
 // Internal-only re-export for `sync_engine::run_sync_impl`'s
 // auto-resubmit pass. Not part of the `wallet::sync` public surface.

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -77,6 +77,33 @@ use crate::wallet::network::WalletNetwork;
 
 use super::{consume_stored_proposal, discard_stored_proposal, open_wallet_db};
 
+pub struct ExtractAndBroadcastPcztResult {
+    pub txid: String,
+    pub status: String,
+    pub message: Option<String>,
+}
+
+impl ExtractAndBroadcastPcztResult {
+    const BROADCASTED: &'static str = "broadcasted";
+    const BROADCAST_UNKNOWN: &'static str = "broadcast_unknown";
+
+    fn broadcasted(txid: String) -> Self {
+        Self {
+            txid,
+            status: Self::BROADCASTED.to_string(),
+            message: None,
+        }
+    }
+
+    fn broadcast_unknown(txid: String, message: String) -> Self {
+        Self {
+            txid,
+            status: Self::BROADCAST_UNKNOWN.to_string(),
+            message: Some(message),
+        }
+    }
+}
+
 /// Create a PCZT from a stored proposal (for hardware wallet signing).
 ///
 /// This is the hardware-wallet analogue of `execute_proposal`, and
@@ -212,8 +239,9 @@ pub fn redact_pczt_for_signer(pczt_bytes: &[u8]) -> Result<Vec<u8>, String> {
 }
 
 /// Combine a PCZT-with-proofs and a PCZT-with-signatures, broadcast
-/// the resulting transaction, and persist it to the wallet DB
-/// **only after** the broadcast is accepted.
+/// the resulting transaction, and persist it to the wallet DB after
+/// the broadcast is accepted, or after a broadcast response deadline
+/// leaves acceptance ambiguous.
 ///
 /// Ordering is critical here. See invariants (1) and (2) in the
 /// module-level docstring.
@@ -225,7 +253,7 @@ pub async fn extract_and_broadcast_pczt(
     pczt_with_signatures_bytes: &[u8],
     spend_params_path: Option<&str>,
     output_params_path: Option<&str>,
-) -> Result<String, String> {
+) -> Result<ExtractAndBroadcastPcztResult, String> {
     use pczt::roles::combiner::Combiner;
     use pczt::roles::tx_extractor::TransactionExtractor;
     use zcash_client_backend::data_api::wallet::{
@@ -289,15 +317,95 @@ pub async fn extract_and_broadcast_pczt(
         buf
     };
 
-    // Step 2: broadcast. On any failure here, the DB is untouched,
-    // so the wallet's view of spendable notes is unchanged.
+    let store_locally = || -> Result<(), String> {
+        with_wallet_db_write_lock("pczt.extract_and_broadcast_pczt.store", || {
+            let mut db = open_wallet_db(db_path, network)?;
+
+            // Primary path: rich PCZT-aware storage (preserves
+            // recipient/memo). Hand Sapling verifying keys in whenever the
+            // combined PCZT has a Sapling bundle, otherwise librustzcash
+            // rejects the extraction with `SaplingRequired` before we can
+            // store anything.
+            let sapling_vk_pair = sapling_vks.as_ref().map(|(s, o)| (s, o));
+            match extract_and_store_transaction_from_pczt::<_, zcash_client_sqlite::ReceivedNoteId>(
+                &mut db,
+                combine_pczts(pczt_with_proofs_bytes, pczt_with_signatures_bytes)?,
+                sapling_vk_pair,
+                Some(&orchard_vk),
+            ) {
+                Ok(_) => return Ok(()),
+                Err(primary_err) => {
+                    log::warn!(
+                        "keystone: PCZT-aware storage failed \
+                         (txid={txid}): {primary_err}. Falling back to chain-style \
+                         decrypt_and_store_transaction; rich recipient metadata \
+                         will not be available in history until the next sync."
+                    );
+
+                    // Fallback path: same code sync uses when it discovers a
+                    // wallet tx on the chain. Marks spent notes correctly
+                    // via nullifier matching and picks up any change note
+                    // back to us from enc_ciphertext decryption. The
+                    // recipient/memo metadata that was only in the PCZT
+                    // proprietary fields is lost, but correctness is
+                    // preserved — the spent notes no longer appear
+                    // spendable.
+                    decrypt_and_store_transaction(&network, &mut db, &tx, None).map_err(
+                        |fallback_err| format!("Primary: {primary_err}. Fallback: {fallback_err}"),
+                    )?;
+                }
+            }
+
+            Ok(())
+        })
+    };
+
+    // Step 2: broadcast. Definite rejection leaves the DB untouched,
+    // but a response deadline is ambiguous: lightwalletd may already
+    // have relayed the transaction, so we store locally and let the
+    // normal pending/resubmit path reconcile it.
     let mut client = crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url)
         .await
         .map_err(|e| e.to_string())?;
 
-    let resp = crate::wallet::sync_engine::send_transaction(&mut client, &tx_bytes)
-        .await
-        .map_err(|e| format!("Broadcast: {e}"))?;
+    let resp = match crate::wallet::sync_engine::send_transaction_with_status(
+        &mut client,
+        &tx_bytes,
+    )
+    .await
+    {
+        Ok(resp) => resp,
+        Err(status) if status.code() == tonic::Code::DeadlineExceeded => {
+            let mut message = format!(
+                "Broadcast response timed out for txid={txid}. The transaction may already \
+                 be on the network. Do not send again until sync or an explorer confirms \
+                 whether this transaction was accepted."
+            );
+            match store_locally() {
+                Ok(()) => {
+                    message.push_str(
+                        " It was stored locally and will retry automatically during sync until \
+                         it is confirmed or expires.",
+                    );
+                }
+                Err(storage_err) => {
+                    log::error!(
+                        "keystone: failed to store tx after ambiguous broadcast timeout \
+                         (txid={txid}): {storage_err}"
+                    );
+                    message.push_str(&format!(
+                        " Local tracking also failed: {storage_err}. Check an explorer before \
+                         retrying this send."
+                    ));
+                }
+            }
+            return Ok(ExtractAndBroadcastPcztResult::broadcast_unknown(
+                txid.to_string(),
+                message,
+            ));
+        }
+        Err(status) => return Err(format!("Broadcast: {status}")),
+    };
 
     // zebra-lightwalletd returns the txid in `error_message` on
     // success, so the only reliable signal is `error_code`.
@@ -311,53 +419,13 @@ pub async fn extract_and_broadcast_pczt(
     // Step 3: broadcast was accepted. Persist locally so the UI
     // sees the tx immediately and the spent notes stop showing up
     // as spendable.
-    with_wallet_db_write_lock("pczt.extract_and_broadcast_pczt.store", || {
-        let mut db = open_wallet_db(db_path, network)?;
+    store_locally().map_err(|storage_err| {
+        format!(
+            "Broadcast succeeded (txid={txid}) but local storage failed. {storage_err}. \
+             The transaction is on the network; check an explorer to confirm, and do not \
+             attempt to send again until the next sync reconciles your balance."
+        )
+    })?;
 
-        // Primary path: rich PCZT-aware storage (preserves
-        // recipient/memo). Hand Sapling verifying keys in whenever the
-        // combined PCZT has a Sapling bundle, otherwise librustzcash
-        // rejects the extraction with `SaplingRequired` before we can
-        // store anything.
-        let sapling_vk_pair = sapling_vks.as_ref().map(|(s, o)| (s, o));
-        match extract_and_store_transaction_from_pczt::<_, zcash_client_sqlite::ReceivedNoteId>(
-            &mut db,
-            combine_pczts(pczt_with_proofs_bytes, pczt_with_signatures_bytes)?,
-            sapling_vk_pair,
-            Some(&orchard_vk),
-        ) {
-            Ok(_) => return Ok(txid.to_string()),
-            Err(primary_err) => {
-                log::warn!(
-                    "keystone: PCZT-aware storage failed after broadcast \
-                     (txid={txid}): {primary_err}. Falling back to chain-style \
-                     decrypt_and_store_transaction; rich recipient metadata \
-                     will not be available in history until the next sync."
-                );
-
-                // Fallback path: same code sync uses when it discovers a
-                // wallet tx on the chain. Marks spent notes correctly
-                // via nullifier matching and picks up any change note
-                // back to us from enc_ciphertext decryption. The
-                // recipient/memo metadata that was only in the PCZT
-                // proprietary fields is lost, but correctness is
-                // preserved — the spent notes no longer appear
-                // spendable.
-                decrypt_and_store_transaction(&network, &mut db, &tx, None).map_err(
-                    |fallback_err| {
-                        format!(
-                            "Broadcast succeeded (txid={txid}) but both local \
-                         storage paths failed. Primary: {primary_err}. \
-                         Fallback: {fallback_err}. The transaction is on \
-                         the network; check an explorer to confirm, and \
-                         do not attempt to send again until the next \
-                         sync reconciles your balance."
-                        )
-                    },
-                )?;
-            }
-        }
-
-        Ok(txid.to_string())
-    })
+    Ok(ExtractAndBroadcastPcztResult::broadcasted(txid.to_string()))
 }

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -295,14 +295,9 @@ pub async fn extract_and_broadcast_pczt(
         .await
         .map_err(|e| e.to_string())?;
 
-    let resp = client
-        .send_transaction(zcash_client_backend::proto::service::RawTransaction {
-            data: tx_bytes,
-            height: 0,
-        })
+    let resp = crate::wallet::sync_engine::send_transaction(&mut client, &tx_bytes)
         .await
-        .map_err(|e| format!("Broadcast: {e}"))?
-        .into_inner();
+        .map_err(|e| format!("Broadcast: {e}"))?;
 
     // zebra-lightwalletd returns the txid in `error_message` on
     // success, so the only reliable signal is `error_code`.

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -748,16 +748,9 @@ async fn broadcast_raw_transaction(
     client: &mut zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient<tonic::transport::Channel>,
     raw_tx: &[u8],
 ) -> Result<(), String> {
-    use zcash_client_backend::proto::service::RawTransaction;
-
-    let resp = client
-        .send_transaction(RawTransaction {
-            data: raw_tx.to_vec(),
-            height: 0,
-        })
+    let resp = crate::wallet::sync_engine::send_transaction(client, raw_tx)
         .await
-        .map_err(|e| format!("SendTransaction gRPC failed: {e}"))?
-        .into_inner();
+        .map_err(|e| format!("SendTransaction gRPC failed: {e}"))?;
 
     if resp.error_code != 0 {
         return Err(format!(

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -16,8 +16,9 @@
 //!   3. [`execute_proposal`] — consume the stored proposal, derive
 //!      the USK from the supplied seed (scoped + dropped before
 //!      network I/O), build + sign the transaction(s), and broadcast
-//!      them via `send_transaction` gRPC. Returns a comma-separated
-//!      txid string on success.
+//!      them via `send_transaction` gRPC. Once transaction creation
+//!      succeeds, broadcast failures are returned as a structured
+//!      pending-broadcast result instead of a fatal send failure.
 //!
 //! The `PROPOSAL_STORE` stays in `sync/mod.rs` because the hardware
 //! PCZT pipeline also consumes from it (see `sync/pczt.rs`) and
@@ -82,6 +83,14 @@ pub(crate) struct ProposalResult {
     pub proposal_id: u64,
     pub needs_sapling_params: bool,
     pub fee_zatoshi: u64,
+}
+
+pub struct ExecuteProposalResult {
+    pub txids: String,
+    pub status: String,
+    pub broadcasted_count: u32,
+    pub total_count: u32,
+    pub message: Option<String>,
 }
 
 pub(crate) struct SendMaxEstimateResult {
@@ -342,7 +351,9 @@ pub(crate) async fn shield_transparent_balance(
     )?;
 
     let txids: Vec<TxId> = txids.iter().cloned().collect();
-    let txids = broadcast_created_transactions(db_path, lightwalletd_url, &txids, "shield").await?;
+    let txids = broadcast_created_transactions(db_path, lightwalletd_url, &txids, "shield")
+        .await
+        .into_legacy_result()?;
     Ok(ShieldTransparentResult {
         txids,
         fee_zatoshi,
@@ -351,7 +362,7 @@ pub(crate) async fn shield_transparent_balance(
 }
 
 /// Execute a previously proposed transfer, then broadcast to the
-/// network. Returns comma-separated txids on success.
+/// network.
 ///
 /// Consume-on-entry: the proposal is removed from `PROPOSAL_STORE`
 /// before any fallible work, mirroring `create_pczt_from_proposal`
@@ -365,7 +376,7 @@ pub async fn execute_proposal(
     seed_bytes: &[u8],
     spend_params_path: Option<&str>,
     output_params_path: Option<&str>,
-) -> Result<String, String> {
+) -> Result<ExecuteProposalResult, String> {
     let stored = consume_stored_proposal(
         proposal_id,
         send_flow_id,
@@ -424,7 +435,11 @@ pub async fn execute_proposal(
     })?;
 
     let txids: Vec<TxId> = txids.iter().cloned().collect();
-    broadcast_created_transactions(db_path, lightwalletd_url, &txids, "send").await
+    Ok(
+        broadcast_created_transactions(db_path, lightwalletd_url, &txids, "send")
+            .await
+            .into_execute_result(),
+    )
 }
 
 fn shielding_threshold() -> Result<Zatoshis, String> {
@@ -586,31 +601,110 @@ fn proposal_shielded_zatoshi(proposal: &Proposal<StandardFeeRule, Infallible>) -
         .sum()
 }
 
+#[derive(Debug)]
+struct CreatedBroadcastResult {
+    txids: String,
+    status: &'static str,
+    broadcasted_count: u32,
+    total_count: u32,
+    message: Option<String>,
+}
+
+impl CreatedBroadcastResult {
+    const BROADCASTED: &'static str = "broadcasted";
+    const PENDING_BROADCAST: &'static str = "pending_broadcast";
+    const PARTIAL_BROADCAST: &'static str = "partial_broadcast";
+
+    fn into_execute_result(self) -> ExecuteProposalResult {
+        ExecuteProposalResult {
+            txids: self.txids,
+            status: self.status.to_string(),
+            broadcasted_count: self.broadcasted_count,
+            total_count: self.total_count,
+            message: self.message,
+        }
+    }
+
+    fn into_legacy_result(self) -> Result<String, String> {
+        if self.status == Self::BROADCASTED {
+            Ok(self.txids)
+        } else {
+            Err(self
+                .message
+                .unwrap_or_else(|| "Broadcast did not complete".to_string()))
+        }
+    }
+}
+
 async fn broadcast_created_transactions(
     db_path: &str,
     lightwalletd_url: &str,
     txids: &[TxId],
     log_label: &str,
-) -> Result<String, String> {
-    // Connect to lightwalletd once for all broadcasts.
-    let mut client = crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url)
-        .await
-        .map_err(|e| e.to_string())?;
-
+) -> CreatedBroadcastResult {
     let txid_strings: Vec<String> = txids.iter().map(|id| format!("{id}")).collect();
+    let txids_joined = txid_strings.join(",");
+    let total_count = txids.len() as u32;
 
-    let read_conn =
-        open_readonly_conn(db_path).map_err(|e| format!("Failed to open DB for broadcast: {e}"))?;
+    // Connect to lightwalletd once for all broadcasts.
+    let mut client = match crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await {
+        Ok(client) => client,
+        Err(e) => {
+            let message =
+                format!("Broadcast could not start after local transaction creation. Error: {e}");
+            log::warn!("{log_label}: {message}");
+            return CreatedBroadcastResult {
+                txids: txids_joined,
+                status: CreatedBroadcastResult::PENDING_BROADCAST,
+                broadcasted_count: 0,
+                total_count,
+                message: Some(message),
+            };
+        }
+    };
+
+    let read_conn = match open_readonly_conn(db_path) {
+        Ok(conn) => conn,
+        Err(e) => {
+            let message =
+                format!("Failed to open DB for broadcast after local transaction creation: {e}");
+            log::warn!("{log_label}: {message}");
+            return CreatedBroadcastResult {
+                txids: txids_joined,
+                status: CreatedBroadcastResult::PENDING_BROADCAST,
+                broadcasted_count: 0,
+                total_count,
+                message: Some(message),
+            };
+        }
+    };
 
     let mut broadcast_ok: Vec<String> = Vec::new();
     for txid in txids.iter() {
-        let raw_tx = read_conn
-            .query_row(
-                "SELECT raw FROM transactions WHERE txid = ?1",
-                rusqlite::params![txid.as_ref()],
-                |row| row.get::<_, Vec<u8>>(0),
-            )
-            .map_err(|e| format!("Failed to get raw tx for {txid}: {e}"))?;
+        let raw_tx = match read_conn.query_row(
+            "SELECT raw FROM transactions WHERE txid = ?1",
+            rusqlite::params![txid.as_ref()],
+            |row| row.get::<_, Vec<u8>>(0),
+        ) {
+            Ok(raw_tx) => raw_tx,
+            Err(e) => {
+                let message = format!(
+                    "Failed to get raw tx for {txid} after local transaction creation: {e}"
+                );
+                log::warn!("{log_label}: {message}");
+                return CreatedBroadcastResult {
+                    txids: txids_joined,
+                    status: if broadcast_ok.is_empty() {
+                        CreatedBroadcastResult::PENDING_BROADCAST
+                    } else {
+                        CreatedBroadcastResult::PARTIAL_BROADCAST
+                    },
+                    broadcasted_count: broadcast_ok.len() as u32,
+                    total_count,
+                    message: Some(message),
+                };
+            }
+        };
 
         match broadcast_raw_transaction(&mut client, &raw_tx).await {
             Ok(()) => {
@@ -618,17 +712,35 @@ async fn broadcast_created_transactions(
                 log::info!("{log_label}: broadcast {txid} ({} bytes)", raw_tx.len());
             }
             Err(e) => {
-                return Err(format!(
+                let message = format!(
                     "Broadcast failed after {}/{} txs sent ({}). Error: {e}",
                     broadcast_ok.len(),
                     txids.len(),
                     broadcast_ok.join(",")
-                ));
+                );
+                log::warn!("{log_label}: {message}");
+                return CreatedBroadcastResult {
+                    txids: txids_joined,
+                    status: if broadcast_ok.is_empty() {
+                        CreatedBroadcastResult::PENDING_BROADCAST
+                    } else {
+                        CreatedBroadcastResult::PARTIAL_BROADCAST
+                    },
+                    broadcasted_count: broadcast_ok.len() as u32,
+                    total_count,
+                    message: Some(message),
+                };
             }
         }
     }
 
-    Ok(txid_strings.join(","))
+    CreatedBroadcastResult {
+        txids: txids_joined,
+        status: CreatedBroadcastResult::BROADCASTED,
+        broadcasted_count: total_count,
+        total_count,
+        message: None,
+    }
 }
 
 /// Broadcast a raw transaction using an existing gRPC client.

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -1097,8 +1097,6 @@ pub fn get_pending_transactions(db_path: &str) -> Result<Vec<PendingTxInfo>, Str
 /// Returns: `0` = still in mempool, `> 0` = mined at that height,
 /// `-1` = error / not found.
 pub async fn check_tx_mined(lightwalletd_url: &str, txid_bytes: &[u8]) -> i64 {
-    use zcash_client_backend::proto::service::TxFilter;
-
     let mut client = match crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await {
         Ok(pair) => pair,
         Err(e) => {
@@ -1107,15 +1105,9 @@ pub async fn check_tx_mined(lightwalletd_url: &str, txid_bytes: &[u8]) -> i64 {
         }
     };
 
-    let filter = TxFilter {
-        block: None,
-        index: 0,
-        hash: txid_bytes.to_vec(),
-    };
-
-    match client.get_transaction(filter).await {
-        Ok(resp) => {
-            let height = resp.into_inner().height;
+    match crate::wallet::sync_engine::get_transaction(&mut client, txid_bytes.to_vec()).await {
+        Ok(raw) => {
+            let height = raw.height;
             // height 0 = mempool, 0xffffffffffffffff = fork, else = mined
             if height == 0 || height == u64::MAX {
                 0 // still pending

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -31,9 +31,7 @@ use zcash_client_backend::{
         wallet::decrypt_and_store_transaction, TransactionDataRequest, TransactionStatus,
         WalletRead, WalletWrite,
     },
-    proto::service::{
-        self, compact_tx_streamer_client::CompactTxStreamerClient, BlockId, BlockRange, TxFilter,
-    },
+    proto::service::compact_tx_streamer_client::CompactTxStreamerClient,
 };
 use zcash_primitives::transaction::Transaction;
 use zcash_protocol::consensus::{BlockHeight, BranchId};
@@ -41,7 +39,7 @@ use zcash_protocol::consensus::{BlockHeight, BranchId};
 use crate::wallet::db::with_wallet_db_write_lock;
 use crate::wallet::network::WalletNetwork;
 
-use super::{SyncError, WalletDatabase};
+use super::{lwd, SyncError, WalletDatabase};
 
 /// Drains `db.transaction_data_requests()` against lightwalletd until
 /// the queue is empty or no request is actionable. Returns
@@ -89,18 +87,8 @@ pub(super) async fn run_enhancement(
                         continue;
                     }
 
-                    let hash = txid.as_ref().to_vec();
-
-                    match client
-                        .get_transaction(TxFilter {
-                            block: None,
-                            index: 0,
-                            hash,
-                        })
-                        .await
-                    {
-                        Ok(response) => {
-                            let raw = response.into_inner();
+                    match lwd::get_transaction(client, txid.as_ref().to_vec()).await {
+                        Ok(raw) => {
                             let mined_height = mined_height_from_raw_height(raw.height)?;
                             if !raw.data.is_empty() {
                                 match Transaction::read(&raw.data[..], BranchId::Sapling) {
@@ -174,34 +162,20 @@ pub(super) async fn run_enhancement(
                     let start = u32::from(req.block_range_start()) as u64;
                     let end = u32::from(end_height) as u64;
 
-                    match client
-                        .get_taddress_txids(service::TransparentAddressBlockFilter {
-                            address: addr_str,
-                            range: Some(BlockRange {
-                                start: Some(BlockId {
-                                    height: start,
-                                    hash: vec![],
-                                }),
-                                end: Some(BlockId {
-                                    height: end.saturating_sub(1),
-                                    hash: vec![],
-                                }),
-                            }),
-                        })
+                    match lwd::get_taddress_txids(client, addr_str, start, end.saturating_sub(1))
                         .await
                     {
-                        Ok(response) => {
-                            let mut stream = response.into_inner();
-                            loop {
-                                match stream.message().await {
-                                    Ok(Some(raw)) => {
-                                        if !raw.data.is_empty() {
-                                            let mined_height =
-                                                mined_height_from_raw_height(raw.height)?;
-                                            match Transaction::read(&raw.data[..], BranchId::Sapling)
-                                            {
-                                                Ok(tx) => {
-                                                    if let Err(e) = with_wallet_db_write_lock(
+                        Ok(mut stream) => loop {
+                            match lwd::next_stream_message(&mut stream, "get_taddress_txids stream")
+                                .await
+                            {
+                                Ok(Some(raw)) => {
+                                    if !raw.data.is_empty() {
+                                        let mined_height =
+                                            mined_height_from_raw_height(raw.height)?;
+                                        match Transaction::read(&raw.data[..], BranchId::Sapling) {
+                                            Ok(tx) => {
+                                                if let Err(e) = with_wallet_db_write_lock(
                                                         "sync_engine.enhance.decrypt_and_store_transaction",
                                                         || {
                                                             decrypt_and_store_transaction(
@@ -216,27 +190,20 @@ pub(super) async fn run_enhancement(
                                                             "sync: decrypt_and_store_transaction (addr) failed: {e}"
                                                         );
                                                     }
-                                                }
-                                                Err(e) => {
-                                                    log::warn!(
-                                                        "sync: Transaction::read (addr) failed: {e}"
-                                                    )
-                                                }
+                                            }
+                                            Err(e) => {
+                                                log::warn!(
+                                                    "sync: Transaction::read (addr) failed: {e}"
+                                                )
                                             }
                                         }
                                     }
-                                    Ok(None) => break,
-                                    Err(e) => {
-                                        return Err(SyncError::net(format!(
-                                            "get_taddress_txids stream failed: {e}"
-                                        )));
-                                    }
                                 }
+                                Ok(None) => break,
+                                Err(e) => return Err(e),
                             }
-                        }
-                        Err(e) => {
-                            return Err(SyncError::net(format!("get_taddress_txids failed: {e}")));
-                        }
+                        },
+                        Err(e) => return Err(e),
                     }
                 }
             }

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -25,7 +25,7 @@
 
 use std::collections::HashSet;
 
-use tonic::transport::Channel;
+use tonic::{transport::Channel, Code, Status};
 use zcash_client_backend::{
     data_api::{
         wallet::decrypt_and_store_transaction, TransactionDataRequest, TransactionStatus,
@@ -46,10 +46,11 @@ use super::{SyncError, WalletDatabase};
 /// Drains `db.transaction_data_requests()` against lightwalletd until
 /// the queue is empty or no request is actionable. Returns
 /// `SyncError::Db` if `db.transaction_data_requests()` itself fails.
-/// Per-request failures (bad transaction bytes, network hiccups,
-/// "txid not recognized" from the server) are logged and, for
-/// `GetStatus` requests, recorded via `set_transaction_status` so
-/// they don't get retried forever.
+/// Per-request failures are split by semantics: an explicit
+/// "txid not recognized" response is recorded via
+/// `set_transaction_status` so it doesn't get retried forever, while
+/// transient network failures bubble up as `SyncError::Network` so the
+/// outer sync retry path can recover without deleting the request.
 pub(super) async fn run_enhancement(
     client: &mut CompactTxStreamerClient<Channel>,
     db: &mut WalletDatabase,
@@ -100,19 +101,18 @@ pub(super) async fn run_enhancement(
                     {
                         Ok(response) => {
                             let raw = response.into_inner();
+                            let mined_height = mined_height_from_raw_height(raw.height)?;
                             if !raw.data.is_empty() {
                                 match Transaction::read(&raw.data[..], BranchId::Sapling) {
                                     Ok(tx) => {
-                                        let height = if raw.height > 0 {
-                                            Some(BlockHeight::from_u32(raw.height as u32))
-                                        } else {
-                                            None
-                                        };
                                         if let Err(e) = with_wallet_db_write_lock(
                                             "sync_engine.enhance.decrypt_and_store_transaction",
                                             || {
                                                 decrypt_and_store_transaction(
-                                                    &network, db, &tx, height,
+                                                    &network,
+                                                    db,
+                                                    &tx,
+                                                    mined_height,
                                                 )
                                             },
                                         ) {
@@ -127,12 +127,7 @@ pub(super) async fn run_enhancement(
                                 }
                             }
                             if matches!(req, TransactionDataRequest::GetStatus(_)) {
-                                let height = raw.height;
-                                let status = if height > 0 {
-                                    TransactionStatus::Mined(BlockHeight::from_u32(height as u32))
-                                } else {
-                                    TransactionStatus::NotInMainChain
-                                };
+                                let status = transaction_status_from_raw_height(raw.height)?;
                                 if let Err(e) = with_wallet_db_write_lock(
                                     "sync_engine.enhance.set_transaction_status",
                                     || db.set_transaction_status(*txid, status),
@@ -141,21 +136,30 @@ pub(super) async fn run_enhancement(
                                 }
                             }
                         }
-                        Err(e) => {
-                            log::warn!("sync: get_transaction failed for {txid_str}: {e}");
-                            failed_txids.insert(txid_str);
-                            if let Err(e) = with_wallet_db_write_lock(
-                                "sync_engine.enhance.set_transaction_status",
-                                || {
-                                    db.set_transaction_status(
-                                        *txid,
-                                        TransactionStatus::TxidNotRecognized,
-                                    )
-                                },
-                            ) {
-                                log::error!("sync: set_transaction_status failed: {e}");
+                        Err(e) => match classify_get_transaction_error(&e) {
+                            GetTransactionErrorAction::MarkTxidNotRecognized => {
+                                log::warn!(
+                                    "sync: get_transaction did not recognize {txid_str}: {e}"
+                                );
+                                failed_txids.insert(txid_str);
+                                if let Err(e) = with_wallet_db_write_lock(
+                                    "sync_engine.enhance.set_transaction_status",
+                                    || {
+                                        db.set_transaction_status(
+                                            *txid,
+                                            TransactionStatus::TxidNotRecognized,
+                                        )
+                                    },
+                                ) {
+                                    log::error!("sync: set_transaction_status failed: {e}");
+                                }
                             }
-                        }
+                            GetTransactionErrorAction::RetryAsNetwork => {
+                                return Err(SyncError::net(format!(
+                                    "get_transaction failed for {txid_str}: {e}"
+                                )));
+                            }
+                        },
                     }
                 }
                 TransactionDataRequest::TransactionsInvolvingAddress(req) => {
@@ -188,37 +192,50 @@ pub(super) async fn run_enhancement(
                     {
                         Ok(response) => {
                             let mut stream = response.into_inner();
-                            while let Ok(Some(raw)) = stream.message().await {
-                                if !raw.data.is_empty() {
-                                    match Transaction::read(&raw.data[..], BranchId::Sapling) {
-                                        Ok(tx) => {
-                                            let height = if raw.height > 0 {
-                                                Some(BlockHeight::from_u32(raw.height as u32))
-                                            } else {
-                                                None
-                                            };
-                                            if let Err(e) = with_wallet_db_write_lock(
-                                                "sync_engine.enhance.decrypt_and_store_transaction",
-                                                || {
-                                                    decrypt_and_store_transaction(
-                                                        &network, db, &tx, height,
+                            loop {
+                                match stream.message().await {
+                                    Ok(Some(raw)) => {
+                                        if !raw.data.is_empty() {
+                                            let mined_height =
+                                                mined_height_from_raw_height(raw.height)?;
+                                            match Transaction::read(&raw.data[..], BranchId::Sapling)
+                                            {
+                                                Ok(tx) => {
+                                                    if let Err(e) = with_wallet_db_write_lock(
+                                                        "sync_engine.enhance.decrypt_and_store_transaction",
+                                                        || {
+                                                            decrypt_and_store_transaction(
+                                                                &network,
+                                                                db,
+                                                                &tx,
+                                                                mined_height,
+                                                            )
+                                                        },
+                                                    ) {
+                                                        log::error!(
+                                                            "sync: decrypt_and_store_transaction (addr) failed: {e}"
+                                                        );
+                                                    }
+                                                }
+                                                Err(e) => {
+                                                    log::warn!(
+                                                        "sync: Transaction::read (addr) failed: {e}"
                                                     )
-                                                },
-                                            ) {
-                                                log::error!(
-                                                    "sync: decrypt_and_store_transaction (addr) failed: {e}"
-                                                );
+                                                }
                                             }
                                         }
-                                        Err(e) => {
-                                            log::warn!("sync: Transaction::read (addr) failed: {e}")
-                                        }
+                                    }
+                                    Ok(None) => break,
+                                    Err(e) => {
+                                        return Err(SyncError::net(format!(
+                                            "get_taddress_txids stream failed: {e}"
+                                        )));
                                     }
                                 }
                             }
                         }
                         Err(e) => {
-                            log::warn!("sync: get_taddress_txids failed: {e}");
+                            return Err(SyncError::net(format!("get_taddress_txids failed: {e}")));
                         }
                     }
                 }
@@ -226,4 +243,96 @@ pub(super) async fn run_enhancement(
         }
     }
     Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GetTransactionErrorAction {
+    MarkTxidNotRecognized,
+    RetryAsNetwork,
+}
+
+fn classify_get_transaction_error(status: &Status) -> GetTransactionErrorAction {
+    match status.code() {
+        Code::NotFound => GetTransactionErrorAction::MarkTxidNotRecognized,
+        _ => GetTransactionErrorAction::RetryAsNetwork,
+    }
+}
+
+fn mined_height_from_raw_height(raw_height: u64) -> Result<Option<BlockHeight>, SyncError> {
+    match raw_height {
+        0 | u64::MAX => Ok(None),
+        h if h <= u32::MAX as u64 => Ok(Some(BlockHeight::from_u32(h as u32))),
+        h => Err(SyncError::parse(format!(
+            "raw transaction height out of range: {h}"
+        ))),
+    }
+}
+
+fn transaction_status_from_raw_height(raw_height: u64) -> Result<TransactionStatus, SyncError> {
+    mined_height_from_raw_height(raw_height).map(|height| match height {
+        Some(height) => TransactionStatus::Mined(height),
+        None => TransactionStatus::NotInMainChain,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_transaction_not_found_marks_txid_not_recognized() {
+        let status = Status::new(Code::NotFound, "txid not recognized");
+
+        assert_eq!(
+            classify_get_transaction_error(&status),
+            GetTransactionErrorAction::MarkTxidNotRecognized,
+        );
+    }
+
+    #[test]
+    fn get_transaction_transient_errors_retry_as_network() {
+        for code in [
+            Code::Unavailable,
+            Code::DeadlineExceeded,
+            Code::Cancelled,
+            Code::Unknown,
+            Code::Internal,
+        ] {
+            let status = Status::new(code, "temporary failure");
+            assert_eq!(
+                classify_get_transaction_error(&status),
+                GetTransactionErrorAction::RetryAsNetwork,
+            );
+        }
+    }
+
+    #[test]
+    fn raw_height_zero_and_fork_sentinel_are_not_main_chain() {
+        assert_eq!(
+            transaction_status_from_raw_height(0).unwrap(),
+            TransactionStatus::NotInMainChain,
+        );
+        assert_eq!(
+            transaction_status_from_raw_height(u64::MAX).unwrap(),
+            TransactionStatus::NotInMainChain,
+        );
+    }
+
+    #[test]
+    fn raw_height_nonzero_non_sentinel_is_mined() {
+        match transaction_status_from_raw_height(1_234_567).unwrap() {
+            TransactionStatus::Mined(height) => {
+                assert_eq!(u32::from(height), 1_234_567);
+            }
+            other => panic!("expected mined status, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn raw_height_out_of_u32_range_is_parse_error() {
+        assert!(matches!(
+            mined_height_from_raw_height(u32::MAX as u64 + 1),
+            Err(SyncError::Parse(_)),
+        ));
+    }
 }

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -14,16 +14,20 @@
 //! failures into `SyncError::net` or `SyncError::parse`, so the outer
 //! loop only ever deals with the typed `SyncError` taxonomy.
 
-use std::time::Duration;
+use std::{future::Future, time::Duration};
 
-use tonic::transport::{Channel, ClientTlsConfig, Endpoint};
+use tonic::{
+    transport::{Channel, ClientTlsConfig, Endpoint},
+    Request, Response, Status,
+};
 use zcash_client_backend::{
     data_api::{
         chain::CommitmentTreeRoot, wallet::ConfirmationsPolicy, WalletCommitmentTrees, WalletRead,
     },
     proto::service::{
-        self, compact_tx_streamer_client::CompactTxStreamerClient, BlockId, BlockRange, Empty,
-        GetSubtreeRootsArg, RawTransaction,
+        self, compact_tx_streamer_client::CompactTxStreamerClient, BlockId, BlockRange, ChainSpec,
+        Empty, GetSubtreeRootsArg, RawTransaction, SendResponse, TransparentAddressBlockFilter,
+        TreeState, TxFilter,
     },
 };
 use zcash_protocol::consensus::BlockHeight;
@@ -34,6 +38,54 @@ use super::block_source::MemoryBlockSource;
 use super::{elapsed, SyncError, WalletDatabase};
 
 const LIGHTWALLETD_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const LIGHTWALLETD_UNARY_RPC_TIMEOUT: Duration = Duration::from_secs(20);
+const LIGHTWALLETD_STREAM_START_TIMEOUT: Duration = Duration::from_secs(20);
+const LIGHTWALLETD_STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn timed_request<T>(message: T, timeout: Duration) -> Request<T> {
+    let mut request = Request::new(message);
+    request.set_timeout(timeout);
+    request
+}
+
+fn timeout_status(label: &str, timeout: Duration) -> Status {
+    Status::deadline_exceeded(format!("{label}: timed out after {}s", timeout.as_secs()))
+}
+
+fn status_to_network_error(label: &str, status: Status) -> SyncError {
+    SyncError::net(format!("{label}: {status}"))
+}
+
+async fn await_tonic_response<T, F>(label: &str, timeout: Duration, future: F) -> Result<T, Status>
+where
+    F: Future<Output = Result<Response<T>, Status>>,
+{
+    match tokio::time::timeout(timeout, future).await {
+        Ok(Ok(response)) => Ok(response.into_inner()),
+        Ok(Err(status)) => Err(status),
+        Err(_) => Err(timeout_status(label, timeout)),
+    }
+}
+
+async fn await_tonic_stream<T, F>(
+    label: &str,
+    timeout: Duration,
+    future: F,
+) -> Result<tonic::Streaming<T>, Status>
+where
+    F: Future<Output = Result<Response<tonic::Streaming<T>>, Status>>,
+{
+    match tokio::time::timeout(timeout, future).await {
+        Ok(Ok(response)) => Ok(response.into_inner()),
+        Ok(Err(status)) => Err(status),
+        Err(_) => Err(timeout_status(label, timeout)),
+    }
+}
+
+// Server-streaming calls intentionally use plain `Request::new` at
+// their call sites. A `grpc-timeout` header would bound the whole
+// stream lifetime; here we only bound stream start and per-message idle
+// waits locally.
 
 /// Opens a tonic gRPC channel to the given lightwalletd URL and
 /// returns a `CompactTxStreamerClient`.
@@ -72,6 +124,131 @@ pub(crate) async fn open_lwd_channel(
     Ok(CompactTxStreamerClient::new(channel))
 }
 
+/// Return the current chain tip with a bounded response wait.
+pub(crate) async fn get_latest_block(
+    client: &mut CompactTxStreamerClient<Channel>,
+) -> Result<BlockId, SyncError> {
+    await_tonic_response(
+        "get_latest_block",
+        LIGHTWALLETD_UNARY_RPC_TIMEOUT,
+        client.get_latest_block(timed_request(
+            ChainSpec::default(),
+            LIGHTWALLETD_UNARY_RPC_TIMEOUT,
+        )),
+    )
+    .await
+    .map_err(|e| status_to_network_error("get_latest_block", e))
+}
+
+/// Return the note commitment tree state for a block with a bounded
+/// response wait.
+pub(super) async fn get_tree_state(
+    client: &mut CompactTxStreamerClient<Channel>,
+    height: u64,
+) -> Result<TreeState, SyncError> {
+    await_tonic_response(
+        "get_tree_state",
+        LIGHTWALLETD_UNARY_RPC_TIMEOUT,
+        client.get_tree_state(timed_request(
+            BlockId {
+                height,
+                hash: vec![],
+            },
+            LIGHTWALLETD_UNARY_RPC_TIMEOUT,
+        )),
+    )
+    .await
+    .map_err(|e| status_to_network_error("get_tree_state", e))
+}
+
+/// Return a raw transaction response. This keeps the original tonic
+/// `Status` so callers that distinguish `NotFound` from transient
+/// network failures can make that decision after the timeout wrapper.
+pub(crate) async fn get_transaction(
+    client: &mut CompactTxStreamerClient<Channel>,
+    hash: Vec<u8>,
+) -> Result<RawTransaction, Status> {
+    await_tonic_response(
+        "get_transaction",
+        LIGHTWALLETD_UNARY_RPC_TIMEOUT,
+        client.get_transaction(timed_request(
+            TxFilter {
+                block: None,
+                index: 0,
+                hash,
+            },
+            LIGHTWALLETD_UNARY_RPC_TIMEOUT,
+        )),
+    )
+    .await
+}
+
+/// Submit a raw transaction with a bounded response wait.
+pub(crate) async fn send_transaction(
+    client: &mut CompactTxStreamerClient<Channel>,
+    data: &[u8],
+) -> Result<SendResponse, SyncError> {
+    await_tonic_response(
+        "send_transaction",
+        LIGHTWALLETD_UNARY_RPC_TIMEOUT,
+        client.send_transaction(timed_request(
+            RawTransaction {
+                data: data.to_vec(),
+                height: 0,
+            },
+            LIGHTWALLETD_UNARY_RPC_TIMEOUT,
+        )),
+    )
+    .await
+    .map_err(|e| status_to_network_error("send_transaction", e))
+}
+
+/// Open the deprecated transparent-address transaction stream with a
+/// bounded wait for response headers. Individual stream messages must
+/// still be read with [`next_stream_message`] to bound an idle stream.
+pub(super) async fn get_taddress_txids(
+    client: &mut CompactTxStreamerClient<Channel>,
+    address: String,
+    start_height: u64,
+    end_height: u64,
+) -> Result<tonic::Streaming<RawTransaction>, SyncError> {
+    await_tonic_stream(
+        "get_taddress_txids",
+        LIGHTWALLETD_STREAM_START_TIMEOUT,
+        client.get_taddress_txids(Request::new(TransparentAddressBlockFilter {
+            address,
+            range: Some(BlockRange {
+                start: Some(BlockId {
+                    height: start_height,
+                    hash: vec![],
+                }),
+                end: Some(BlockId {
+                    height: end_height,
+                    hash: vec![],
+                }),
+            }),
+        })),
+    )
+    .await
+    .map_err(|e| status_to_network_error("get_taddress_txids", e))
+}
+
+/// Read the next server-streaming message with a bounded idle wait.
+/// `Ok(None)` remains the server's normal EOF signal.
+pub(super) async fn next_stream_message<T>(
+    stream: &mut tonic::Streaming<T>,
+    label: &str,
+) -> Result<Option<T>, SyncError> {
+    match tokio::time::timeout(LIGHTWALLETD_STREAM_IDLE_TIMEOUT, stream.message()).await {
+        Ok(Ok(message)) => Ok(message),
+        Ok(Err(status)) => Err(status_to_network_error(label, status)),
+        Err(_) => Err(SyncError::net(format!(
+            "{label}: timed out after {}s waiting for next message",
+            LIGHTWALLETD_STREAM_IDLE_TIMEOUT.as_secs()
+        ))),
+    }
+}
+
 /// Pulls the latest sapling + orchard subtree roots from lightwalletd
 /// and writes them into `db` via `put_*_subtree_roots`. The starting
 /// index for each protocol comes from `db`'s wallet summary, so a
@@ -107,22 +284,20 @@ pub(super) async fn download_subtree_roots(
     );
 
     // Sapling
-    let mut stream = client
-        .get_subtree_roots(GetSubtreeRootsArg {
+    let mut stream = await_tonic_stream(
+        "sapling subtree roots",
+        LIGHTWALLETD_STREAM_START_TIMEOUT,
+        client.get_subtree_roots(Request::new(GetSubtreeRootsArg {
             start_index: sap_start as u32,
             shielded_protocol: service::ShieldedProtocol::Sapling.into(),
             max_entries: 0,
-        })
-        .await
-        .map_err(|e| SyncError::net(format!("sapling subtree roots: {e}")))?
-        .into_inner();
+        })),
+    )
+    .await
+    .map_err(|e| status_to_network_error("sapling subtree roots", e))?;
 
     let mut roots = Vec::new();
-    while let Some(root) = stream
-        .message()
-        .await
-        .map_err(|e| SyncError::net(format!("sapling subtree roots stream: {e}")))?
-    {
+    while let Some(root) = next_stream_message(&mut stream, "sapling subtree roots stream").await? {
         // `SubtreeRoot::root_hash` is `bytes = "vec"` in the proto,
         // not a fixed-length field. A slice expression like
         // `root_hash[..32]` would panic before `try_into()` runs if
@@ -155,22 +330,20 @@ pub(super) async fn download_subtree_roots(
     }
 
     // Orchard
-    let mut stream = client
-        .get_subtree_roots(GetSubtreeRootsArg {
+    let mut stream = await_tonic_stream(
+        "orchard subtree roots",
+        LIGHTWALLETD_STREAM_START_TIMEOUT,
+        client.get_subtree_roots(Request::new(GetSubtreeRootsArg {
             start_index: orch_start as u32,
             shielded_protocol: service::ShieldedProtocol::Orchard.into(),
             max_entries: 0,
-        })
-        .await
-        .map_err(|e| SyncError::net(format!("orchard subtree roots: {e}")))?
-        .into_inner();
+        })),
+    )
+    .await
+    .map_err(|e| status_to_network_error("orchard subtree roots", e))?;
 
     let mut roots = Vec::new();
-    while let Some(root) = stream
-        .message()
-        .await
-        .map_err(|e| SyncError::net(format!("orchard subtree roots stream: {e}")))?
-    {
+    while let Some(root) = next_stream_message(&mut stream, "orchard subtree roots stream").await? {
         let bytes: [u8; 32] = root.root_hash.as_slice().try_into().map_err(|_| {
             SyncError::parse(format!(
                 "orchard subtree root: expected 32 bytes, got {}",
@@ -220,11 +393,13 @@ pub(super) async fn download_subtree_roots(
 pub(crate) async fn start_mempool_stream(
     client: &mut CompactTxStreamerClient<Channel>,
 ) -> Result<tonic::Streaming<RawTransaction>, SyncError> {
-    let response = client
-        .get_mempool_stream(Empty {})
-        .await
-        .map_err(|e| SyncError::net(format!("get_mempool_stream: {e}")))?;
-    Ok(response.into_inner())
+    await_tonic_stream(
+        "get_mempool_stream",
+        LIGHTWALLETD_STREAM_START_TIMEOUT,
+        client.get_mempool_stream(Request::new(Empty {})),
+    )
+    .await
+    .map_err(|e| status_to_network_error("get_mempool_stream", e))
 }
 
 /// Streams compact blocks in `[start, end]` (inclusive) from
@@ -237,8 +412,10 @@ pub(super) async fn download_blocks(
     start: BlockHeight,
     end: BlockHeight,
 ) -> Result<MemoryBlockSource, SyncError> {
-    let mut stream = client
-        .get_block_range(BlockRange {
+    let mut stream = await_tonic_stream(
+        "get_block_range",
+        LIGHTWALLETD_STREAM_START_TIMEOUT,
+        client.get_block_range(Request::new(BlockRange {
             start: Some(BlockId {
                 height: u32::from(start) as u64,
                 hash: vec![],
@@ -247,17 +424,13 @@ pub(super) async fn download_blocks(
                 height: u32::from(end) as u64,
                 hash: vec![],
             }),
-        })
-        .await
-        .map_err(|e| SyncError::net(format!("get_block_range: {e}")))?
-        .into_inner();
+        })),
+    )
+    .await
+    .map_err(|e| status_to_network_error("get_block_range", e))?;
 
     let mut blocks = Vec::new();
-    while let Some(block) = stream
-        .message()
-        .await
-        .map_err(|e| SyncError::net(format!("get_block_range stream: {e}")))?
-    {
+    while let Some(block) = next_stream_message(&mut stream, "get_block_range stream").await? {
         blocks.push(block);
     }
 

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -184,10 +184,10 @@ pub(crate) async fn get_transaction(
 }
 
 /// Submit a raw transaction with a bounded response wait.
-pub(crate) async fn send_transaction(
+pub(crate) async fn send_transaction_with_status(
     client: &mut CompactTxStreamerClient<Channel>,
     data: &[u8],
-) -> Result<SendResponse, SyncError> {
+) -> Result<SendResponse, Status> {
     await_tonic_response(
         "send_transaction",
         LIGHTWALLETD_UNARY_RPC_TIMEOUT,
@@ -200,7 +200,17 @@ pub(crate) async fn send_transaction(
         )),
     )
     .await
-    .map_err(|e| status_to_network_error("send_transaction", e))
+}
+
+/// Submit a raw transaction with a bounded response wait and map tonic
+/// errors into the sync error taxonomy.
+pub(crate) async fn send_transaction(
+    client: &mut CompactTxStreamerClient<Channel>,
+    data: &[u8],
+) -> Result<SendResponse, SyncError> {
+    send_transaction_with_status(client, data)
+        .await
+        .map_err(|e| status_to_network_error("send_transaction", e))
 }
 
 /// Open the deprecated transparent-address transaction stream with a

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -46,7 +46,10 @@ use enhance::run_enhancement;
 pub(crate) use error::SyncError;
 use error::{RecoveryStrategy, MAX_REWINDS_PER_RUN};
 use lwd::{download_blocks, download_subtree_roots, get_tree_state};
-pub(crate) use lwd::{get_latest_block, get_transaction, open_lwd_channel, send_transaction};
+pub(crate) use lwd::{
+    get_latest_block, get_transaction, open_lwd_channel, send_transaction,
+    send_transaction_with_status,
+};
 
 /// Progress event sent to caller (Dart or Swift).
 #[derive(Clone, Debug)]

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -8,7 +8,7 @@ use zcash_client_backend::{
         scanning::ScanPriority,
         WalletRead, WalletWrite,
     },
-    proto::service::{self, BlockId, ChainSpec},
+    proto::service,
 };
 use zcash_client_sqlite::error::SqliteClientError;
 use zcash_primitives::block::BlockHash;
@@ -45,8 +45,8 @@ pub(crate) mod mempool;
 use enhance::run_enhancement;
 pub(crate) use error::SyncError;
 use error::{RecoveryStrategy, MAX_REWINDS_PER_RUN};
-pub(crate) use lwd::open_lwd_channel;
-use lwd::{download_blocks, download_subtree_roots};
+use lwd::{download_blocks, download_subtree_roots, get_tree_state};
+pub(crate) use lwd::{get_latest_block, get_transaction, open_lwd_channel, send_transaction};
 
 /// Progress event sent to caller (Dart or Swift).
 #[derive(Clone, Debug)]
@@ -334,11 +334,7 @@ async fn run_sync_impl(
     // one captured at sync start. The initial `tip` response is
     // also kept around for its other fields but `current_tip_height`
     // is the authoritative value for emitted events.
-    let tip = client
-        .get_latest_block(ChainSpec::default())
-        .await
-        .map_err(|e| SyncError::net(format!("get_latest_block: {e}")))?
-        .into_inner();
+    let tip = get_latest_block(&mut client).await?;
     let mut current_tip_height: u64 = tip.height;
     let tip_height = BlockHeight::from_u32(tip.height as u32);
     log::info!("[{}] sync: chain tip = {}", elapsed(), tip.height);
@@ -506,11 +502,7 @@ async fn run_sync_impl(
         // Errors are logged and skipped — we just keep the old
         // tip and try again next period.
         if last_tip_refresh.elapsed() >= TIP_REFRESH_INTERVAL {
-            match client
-                .get_latest_block(ChainSpec::default())
-                .await
-                .map(|resp| resp.into_inner())
-            {
+            match get_latest_block(&mut client).await {
                 Ok(fresh_tip) => {
                     let fresh_height = BlockHeight::from_u32(fresh_tip.height as u32);
                     if let Err(e) =
@@ -666,14 +658,7 @@ async fn run_sync_impl(
         let from_state = if u32::from(start) <= SAPLING_ACTIVATION_HEIGHT {
             chain::ChainState::empty(start - 1, BlockHash([0u8; 32]))
         } else {
-            let ts = client
-                .get_tree_state(BlockId {
-                    height: u32::from(start - 1) as u64,
-                    hash: vec![],
-                })
-                .await
-                .map_err(|e| SyncError::net(format!("get_tree_state: {e}")))?
-                .into_inner();
+            let ts = get_tree_state(&mut client, u32::from(start - 1) as u64).await?;
             ts.to_chain_state()
                 .map_err(|e| SyncError::parse(format!("parse tree state: {e}")))?
         };
@@ -895,10 +880,9 @@ async fn run_sync_impl(
             );
             return Ok(());
         }
-        match client
-            .get_latest_block(ChainSpec::default())
+        match get_latest_block(&mut client)
             .await
-            .map(|resp| resp.into_inner().height as u32)
+            .map(|tip| tip.height as u32)
         {
             Ok(fresh_tip_height) => {
                 // Promote the fresh tip to the authoritative value

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -207,6 +207,7 @@ pub fn execute_send(
         sapling_params.as_ref().map(|p| p.output_path.clone()),
     )
     .expect("execute_proposal")
+    .txids
 }
 
 pub fn positive_history_count(history: &[sync_api::TransactionInfo]) -> usize {

--- a/test/onboarding_error_messages_test.dart
+++ b/test/onboarding_error_messages_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_error_messages.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+
+void main() {
+  test('shows wallet creation block height error without technical detail', () {
+    const error = WalletCreationCurrentBlockHeightException('network down');
+
+    expect(
+      onboardingSubmitErrorMessage(error),
+      kWalletCreationCurrentBlockHeightErrorMessage,
+    );
+  });
+
+  test('strips default Exception prefix from onboarding submit errors', () {
+    expect(onboardingSubmitErrorMessage(Exception('bad input')), 'bad input');
+  });
+}

--- a/test/sync_failure_test.dart
+++ b/test/sync_failure_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/providers/sync_failure.dart';
+
+void main() {
+  test('classifies transient network failures as auto retrying', () {
+    final failure = classifySyncFailure(
+      'network: get_latest_block: status: DeadlineExceeded',
+    );
+
+    expect(failure.kind, SyncFailureKind.network);
+    expect(failure.isAutoRetrying, isTrue);
+    expect(failure.canManualRetry, isTrue);
+    expect(failure.showSettingsAction, isFalse);
+  });
+
+  test('classifies malformed endpoint failures as settings action', () {
+    final failure = classifySyncFailure('network: invalid URL: bad uri');
+
+    expect(failure.kind, SyncFailureKind.endpoint);
+    expect(failure.isAutoRetrying, isFalse);
+    expect(failure.canManualRetry, isFalse);
+    expect(failure.showSettingsAction, isTrue);
+    expect(failure.actionLabel, 'Settings');
+  });
+
+  test('classifies temporary database lock as auto retrying', () {
+    final failure = classifySyncFailure(
+      'other: scan: SQLite lock contention: database is locked',
+    );
+
+    expect(failure.kind, SyncFailureKind.databaseBusy);
+    expect(failure.isAutoRetrying, isTrue);
+  });
+
+  test('classifies fatal database failures without auto retry', () {
+    final failure = classifySyncFailure('db: open wallet DB: disk full');
+
+    expect(failure.kind, SyncFailureKind.databaseFatal);
+    expect(failure.isAutoRetrying, isFalse);
+    expect(failure.canManualRetry, isTrue);
+  });
+
+  test('classifies parse failures without auto retry', () {
+    final failure = classifySyncFailure('parse: bad tree state');
+
+    expect(failure.kind, SyncFailureKind.parseFatal);
+    expect(failure.isAutoRetrying, isFalse);
+  });
+
+  test('classifies chain recovery failures as auto retrying', () {
+    final failure = classifySyncFailure(
+      'chain continuity broken at height 123: PrevHashMismatch',
+    );
+
+    expect(failure.kind, SyncFailureKind.chainRecovery);
+    expect(failure.isAutoRetrying, isTrue);
+  });
+
+  test('classifies unknown failures as retryable fallback', () {
+    final failure = classifySyncFailure(Exception('unexpected failure'));
+
+    expect(failure.kind, SyncFailureKind.unknown);
+    expect(failure.rawMessage, 'unexpected failure');
+    expect(failure.isAutoRetrying, isTrue);
+    expect(failure.actionLabel, 'Retry');
+  });
+}

--- a/test/sync_failure_test.dart
+++ b/test/sync_failure_test.dart
@@ -2,14 +2,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/providers/sync_failure.dart';
 
 void main() {
-  test('classifies transient network failures as auto retrying', () {
+  test('classifies transient network failures', () {
     final failure = classifySyncFailure(
       'network: get_latest_block: status: DeadlineExceeded',
     );
 
     expect(failure.kind, SyncFailureKind.network);
-    expect(failure.isAutoRetrying, isTrue);
-    expect(failure.canManualRetry, isTrue);
     expect(failure.showSettingsAction, isFalse);
   });
 
@@ -17,51 +15,43 @@ void main() {
     final failure = classifySyncFailure('network: invalid URL: bad uri');
 
     expect(failure.kind, SyncFailureKind.endpoint);
-    expect(failure.isAutoRetrying, isFalse);
-    expect(failure.canManualRetry, isFalse);
     expect(failure.showSettingsAction, isTrue);
     expect(failure.actionLabel, 'Settings');
   });
 
-  test('classifies temporary database lock as auto retrying', () {
+  test('classifies temporary database lock', () {
     final failure = classifySyncFailure(
       'other: scan: SQLite lock contention: database is locked',
     );
 
     expect(failure.kind, SyncFailureKind.databaseBusy);
-    expect(failure.isAutoRetrying, isTrue);
   });
 
-  test('classifies fatal database failures without auto retry', () {
+  test('classifies fatal database failures', () {
     final failure = classifySyncFailure('db: open wallet DB: disk full');
 
     expect(failure.kind, SyncFailureKind.databaseFatal);
-    expect(failure.isAutoRetrying, isFalse);
-    expect(failure.canManualRetry, isTrue);
   });
 
-  test('classifies parse failures without auto retry', () {
+  test('classifies parse failures', () {
     final failure = classifySyncFailure('parse: bad tree state');
 
     expect(failure.kind, SyncFailureKind.parseFatal);
-    expect(failure.isAutoRetrying, isFalse);
   });
 
-  test('classifies chain recovery failures as auto retrying', () {
+  test('classifies chain recovery failures', () {
     final failure = classifySyncFailure(
       'chain continuity broken at height 123: PrevHashMismatch',
     );
 
     expect(failure.kind, SyncFailureKind.chainRecovery);
-    expect(failure.isAutoRetrying, isTrue);
   });
 
-  test('classifies unknown failures as retryable fallback', () {
+  test('classifies unknown failures', () {
     final failure = classifySyncFailure(Exception('unexpected failure'));
 
     expect(failure.kind, SyncFailureKind.unknown);
     expect(failure.rawMessage, 'unexpected failure');
-    expect(failure.isAutoRetrying, isTrue);
     expect(failure.actionLabel, 'Retry');
   });
 }


### PR DESCRIPTION
## Summary

- Add bounded lightwalletd RPC timeouts for sync and broadcast paths so stalled servers fail into retry/error handling.
- Preserve ambiguous send state when broadcast may have reached lightwalletd, including hardware PCZT sends.
- Classify enhancement and sync failures so transient network errors retry while endpoint/fatal failures surface clearer actions.
- Show explicit network guidance when wallet creation cannot fetch the current Zcash height.

## Validation

- `cd rust && cargo test`
- `fvm flutter test test/sync_failure_test.dart`