### PR TITLE
[codex] Update Zcash endpoints

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -41,9 +41,11 @@ import UIKit
           let args = call.arguments as? [String: Any]
           let lightwalletdUrl = args?["lightwalletdUrl"] as? String
           let network = args?["network"] as? String
+          let presetId = args?["presetId"] as? String
           let success = BackgroundSyncManager.shared.startBackgroundSync(
             lightwalletdUrl: lightwalletdUrl,
-            network: network
+            network: network,
+            presetId: presetId
           )
           result(success)
         } else {
@@ -60,17 +62,23 @@ import UIKit
         let args = call.arguments as? [String: Any]
         let lightwalletdUrl = args?["lightwalletdUrl"] as? String
         let network = args?["network"] as? String
+        let presetId = args?["presetId"] as? String
         RpcEndpointConfigStore.save(
           lightwalletdUrl: lightwalletdUrl,
-          network: network
+          network: network,
+          presetId: presetId
         )
         result(true)
       case "startTxTracking":
         if #available(iOS 26.0, *) {
           let args = call.arguments as? [String: Any]
           let lightwalletdUrl = args?["lightwalletdUrl"] as? String
+          let network = args?["network"] as? String
+          let presetId = args?["presetId"] as? String
           let success = TxTrackManager.shared.startTxTracking(
-            lightwalletdUrl: lightwalletdUrl
+            lightwalletdUrl: lightwalletdUrl,
+            network: network,
+            presetId: presetId
           )
           result(success)
         } else {

--- a/ios/Runner/BackgroundSyncManager.swift
+++ b/ios/Runner/BackgroundSyncManager.swift
@@ -175,10 +175,15 @@ class BackgroundSyncManager {
         try resolveWalletDbPath()
     }
 
-    func startBackgroundSync(lightwalletdUrl: String? = nil, network: String? = nil) -> Bool {
+    func startBackgroundSync(
+        lightwalletdUrl: String? = nil,
+        network: String? = nil,
+        presetId: String? = nil
+    ) -> Bool {
         RpcEndpointConfigStore.save(
             lightwalletdUrl: lightwalletdUrl,
-            network: network
+            network: network,
+            presetId: presetId
         )
         print("[BGSync] startBackgroundSync: submitting BGContinuedProcessingTaskRequest")
         let request = BGContinuedProcessingTaskRequest(

--- a/ios/Runner/RpcEndpointConfigStore.swift
+++ b/ios/Runner/RpcEndpointConfigStore.swift
@@ -6,7 +6,7 @@ enum RpcEndpointConfigStore {
     // with rpc_endpoint_config.dart.
     private static let lightwalletdUrlKey = "zcash_rpc_endpoint_url_ios_mirror"
     private static let networkKey = "zcash_rpc_endpoint_network_ios_mirror"
-    private static let defaultLightwalletdUrl = "https://zec.rocks:443"
+    private static let defaultLightwalletdUrl = "https://us.zec.stardust.rest:443"
     private static let defaultNetwork = "main"
 
     static var lightwalletdUrl: String {

--- a/ios/Runner/RpcEndpointConfigStore.swift
+++ b/ios/Runner/RpcEndpointConfigStore.swift
@@ -6,10 +6,15 @@ enum RpcEndpointConfigStore {
     // with rpc_endpoint_config.dart.
     private static let lightwalletdUrlKey = "zcash_rpc_endpoint_url_ios_mirror"
     private static let networkKey = "zcash_rpc_endpoint_network_ios_mirror"
+    private static let presetIdKey = "zcash_rpc_endpoint_preset_ios_mirror"
     private static let defaultLightwalletdUrl = "https://us.zec.stardust.rest:443"
     private static let defaultNetwork = "main"
+    private static let defaultPresetId = "default-mainnet"
 
     static var lightwalletdUrl: String {
+        if UserDefaults.standard.string(forKey: presetIdKey) == defaultPresetId {
+            return defaultLightwalletdUrl
+        }
         UserDefaults.standard.string(forKey: lightwalletdUrlKey) ?? defaultLightwalletdUrl
     }
 
@@ -17,7 +22,17 @@ enum RpcEndpointConfigStore {
         UserDefaults.standard.string(forKey: networkKey) ?? defaultNetwork
     }
 
-    static func save(lightwalletdUrl: String?, network: String? = nil) {
+    static func save(lightwalletdUrl: String?, network: String? = nil, presetId: String? = nil) {
+        if let presetId, !presetId.isEmpty {
+            UserDefaults.standard.set(presetId, forKey: presetIdKey)
+            if presetId == defaultPresetId {
+                UserDefaults.standard.removeObject(forKey: lightwalletdUrlKey)
+                if let network, !network.isEmpty {
+                    UserDefaults.standard.set(network, forKey: networkKey)
+                }
+                return
+            }
+        }
         if let lightwalletdUrl, !lightwalletdUrl.isEmpty {
             UserDefaults.standard.set(lightwalletdUrl, forKey: lightwalletdUrlKey)
         }

--- a/ios/Runner/RpcEndpointConfigStore.swift
+++ b/ios/Runner/RpcEndpointConfigStore.swift
@@ -15,7 +15,7 @@ enum RpcEndpointConfigStore {
         if UserDefaults.standard.string(forKey: presetIdKey) == defaultPresetId {
             return defaultLightwalletdUrl
         }
-        UserDefaults.standard.string(forKey: lightwalletdUrlKey) ?? defaultLightwalletdUrl
+        return UserDefaults.standard.string(forKey: lightwalletdUrlKey) ?? defaultLightwalletdUrl
     }
 
     static var network: String {

--- a/ios/Runner/TxTrackManager.swift
+++ b/ios/Runner/TxTrackManager.swift
@@ -32,8 +32,16 @@ class TxTrackManager {
         print("[TxTrack] registered")
     }
 
-    func startTxTracking(lightwalletdUrl: String? = nil) -> Bool {
-        RpcEndpointConfigStore.save(lightwalletdUrl: lightwalletdUrl)
+    func startTxTracking(
+        lightwalletdUrl: String? = nil,
+        network: String? = nil,
+        presetId: String? = nil
+    ) -> Bool {
+        RpcEndpointConfigStore.save(
+            lightwalletdUrl: lightwalletdUrl,
+            network: network,
+            presetId: presetId
+        )
         print("[TxTrack] submitting task request")
         let request = BGContinuedProcessingTaskRequest(
             identifier: Self.taskIdentifier,

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -323,19 +323,10 @@ Future<RpcEndpointConfig> _readRpcEndpointConfig(
   try {
     final storedUrl = await storage.readString(kRpcEndpointUrlKey);
     final storedPreset = await storage.readString(kRpcEndpointPresetKey);
-    if (storedUrl == null || storedUrl.trim().isEmpty) {
-      return defaultRpcEndpointConfig(network);
-    }
-
-    return RpcEndpointConfig(
+    return resolveStoredRpcEndpointConfig(
       networkName: zcashNetworkFromName(network).name,
-      lightwalletdUrl: normalizeRpcEndpointUrl(
-        storedUrl,
-        allowDefaultPort: true,
-      ),
-      presetId: storedPreset == null || storedPreset.trim().isEmpty
-          ? findRpcEndpointPresetByUrl(storedUrl, networkName: network)?.id
-          : storedPreset,
+      storedUrl: storedUrl,
+      storedPresetId: storedPreset,
     );
   } catch (e) {
     log('bootstrap: failed to read RPC endpoint: $e');

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -307,6 +307,7 @@ Future<void> _seedNativeRpcEndpointMirror(RpcEndpointConfig endpoint) async {
         .invokeMethod<bool>('updateEndpoint', {
           'lightwalletdUrl': endpoint.normalizedLightwalletdUrl,
           'network': endpoint.networkName,
+          'presetId': endpoint.effectivePresetId,
         });
     if (success != true) {
       log('bootstrap: iOS RPC endpoint mirror seed returned $success');

--- a/lib/src/core/config/network_config.dart
+++ b/lib/src/core/config/network_config.dart
@@ -40,7 +40,7 @@ enum ZcashNetwork {
   };
 
   String get lightwalletdHost => switch (this) {
-    mainnet => 'zec.rocks',
+    mainnet => 'us.zec.stardust.rest',
     testnet => 'lightwalletd.testnet.electriccoin.co',
     regtest => '127.0.0.1',
   };

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -184,6 +184,40 @@ RpcEndpointConfig defaultRpcEndpointConfig(String networkName) {
   );
 }
 
+RpcEndpointConfig resolveStoredRpcEndpointConfig({
+  required String networkName,
+  required String? storedUrl,
+  required String? storedPresetId,
+}) {
+  final network = zcashNetworkFromName(networkName);
+  final presetId = storedPresetId?.trim();
+  if (presetId != null &&
+      presetId.isNotEmpty &&
+      presetId != kCustomRpcEndpointPresetId) {
+    final preset = findRpcEndpointPresetById(network.name, presetId);
+    if (preset != null) {
+      return RpcEndpointConfig(
+        networkName: network.name,
+        lightwalletdUrl: preset.url,
+        presetId: preset.id,
+      );
+    }
+  }
+
+  final url = storedUrl?.trim();
+  if (url == null || url.isEmpty) {
+    return defaultRpcEndpointConfig(network.name);
+  }
+
+  return RpcEndpointConfig(
+    networkName: network.name,
+    lightwalletdUrl: normalizeRpcEndpointUrl(url, allowDefaultPort: true),
+    presetId: presetId == kCustomRpcEndpointPresetId
+        ? kCustomRpcEndpointPresetId
+        : findRpcEndpointPresetByUrl(url, networkName: network.name)?.id,
+  );
+}
+
 RpcEndpointPreset? findRpcEndpointPresetById(
   String networkName,
   String presetId,

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -63,21 +63,15 @@ class RpcEndpointPreset {
   String get hostPort => rpcEndpointHostPort(url);
 }
 
-// Additional regional lightwalletd presets while keeping this app's existing
-// zec.rocks default unchanged.
+// Public lightwalletd presets. Keep the mainnet default aligned with Zodl's
+// default endpoint while preserving zec.rocks as a selectable fallback.
 final kMainnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
   RpcEndpointPreset(
     id: kDefaultRpcEndpointPresetId,
     region: 'Default',
-    label: 'Zec Rocks',
+    label: 'Stardust US',
     url: ZcashNetwork.mainnet.lightwalletdUrl,
     isDefault: true,
-  ),
-  const RpcEndpointPreset(
-    id: 'us-zec-stardust',
-    region: 'Americas',
-    label: 'Stardust US',
-    url: 'https://us.zec.stardust.rest:443',
   ),
   const RpcEndpointPreset(
     id: 'eu-zec-stardust',
@@ -96,6 +90,12 @@ final kMainnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
     region: 'Asia Pacific',
     label: 'Stardust Japan',
     url: 'https://jp.zec.stardust.rest:443',
+  ),
+  const RpcEndpointPreset(
+    id: 'zec-rocks',
+    region: 'Global',
+    label: 'Zec Rocks',
+    url: 'https://zec.rocks:443',
   ),
   const RpcEndpointPreset(
     id: 'na-zec-rocks',
@@ -120,6 +120,24 @@ final kMainnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
     region: 'Asia Pacific',
     label: 'Zec Rocks Asia Pacific',
     url: 'https://ap.zec.rocks:443',
+  ),
+  const RpcEndpointPreset(
+    id: 'z3-deepikaw',
+    region: 'Community',
+    label: 'Deepikaw Z3',
+    url: 'https://z3.deepikaw.xyz:443',
+  ),
+  const RpcEndpointPreset(
+    id: 'zprivacy',
+    region: 'Community',
+    label: 'ZPrivacy',
+    url: 'https://zprivacy.online:443',
+  ),
+  const RpcEndpointPreset(
+    id: 'zcash-explorer',
+    region: 'Community',
+    label: 'Zcash Explorer',
+    url: 'https://lwd.zcashexplorer.app:9067',
   ),
 ]);
 
@@ -220,13 +238,13 @@ String normalizeRpcEndpointUrl(
   final hasExplicitPort = _hasExplicitPort(candidate);
   if (!hasExplicitPort && !allowDefaultPort) {
     throw const FormatException(
-      'Include a valid port, for example zec.rocks:443.',
+      'Include a valid port, for example us.zec.stardust.rest:443.',
     );
   }
   final port = hasExplicitPort ? uri.port : _defaultPortForScheme(uri.scheme);
   if (port <= 0 || port > 65535) {
     throw const FormatException(
-      'Include a valid port, for example zec.rocks:443.',
+      'Include a valid port, for example us.zec.stardust.rest:443.',
     );
   }
 

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -410,6 +410,8 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
           if (available) {
             await channel.invokeMethod('startTxTracking', {
               'lightwalletdUrl': endpoint.normalizedLightwalletdUrl,
+              'network': endpoint.networkName,
+              'presetId': endpoint.effectivePresetId,
             });
           }
         } catch (e) {

--- a/lib/src/providers/rpc_endpoint_provider.dart
+++ b/lib/src/providers/rpc_endpoint_provider.dart
@@ -37,8 +37,17 @@ class RpcEndpointNotifier extends Notifier<RpcEndpointConfig> {
   }
 
   Future<void> _persist(RpcEndpointConfig next) async {
-    await _store.writePlain(kRpcEndpointUrlKey, next.normalizedLightwalletdUrl);
-    await _store.writePlain(kRpcEndpointPresetKey, next.effectivePresetId);
+    final effectivePresetId = next.effectivePresetId;
+    if (effectivePresetId == kDefaultRpcEndpointPresetId) {
+      await _store.delete(kRpcEndpointUrlKey);
+      await _store.writePlain(kRpcEndpointPresetKey, effectivePresetId);
+    } else {
+      await _store.writePlain(
+        kRpcEndpointUrlKey,
+        next.normalizedLightwalletdUrl,
+      );
+      await _store.writePlain(kRpcEndpointPresetKey, effectivePresetId);
+    }
     try {
       await bg_sync.updateBackgroundSyncEndpoint(endpoint: next);
     } catch (e) {

--- a/lib/src/services/background_sync_service.dart
+++ b/lib/src/services/background_sync_service.dart
@@ -61,6 +61,7 @@ Future<void> startBackgroundSync({RpcEndpointConfig? endpoint}) async {
             : {
                 'lightwalletdUrl': endpoint.normalizedLightwalletdUrl,
                 'network': endpoint.networkName,
+                'presetId': endpoint.effectivePresetId,
               },
       );
       log('BackgroundSync: iOS BGTask submitted: $success');
@@ -78,6 +79,7 @@ Future<void> updateBackgroundSyncEndpoint({
   final success = await _iosChannel.invokeMethod<bool>('updateEndpoint', {
     'lightwalletdUrl': endpoint.normalizedLightwalletdUrl,
     'network': endpoint.networkName,
+    'presetId': endpoint.effectivePresetId,
   });
   if (success != true) {
     throw StateError('iOS endpoint mirror update failed.');

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -162,6 +162,39 @@ void main() {
       );
       expect(defaultEndpoint.presetId, kDefaultRpcEndpointPresetId);
     });
+
+    test('resolves stored default preset to the current default URL', () {
+      final config = resolveStoredRpcEndpointConfig(
+        networkName: 'main',
+        storedUrl: 'https://zec.rocks:443',
+        storedPresetId: kDefaultRpcEndpointPresetId,
+      );
+
+      expect(config.lightwalletdUrl, 'https://us.zec.stardust.rest:443');
+      expect(config.presetId, kDefaultRpcEndpointPresetId);
+    });
+
+    test('resolves stored non-default presets by preset id', () {
+      final config = resolveStoredRpcEndpointConfig(
+        networkName: 'main',
+        storedUrl: 'https://us.zec.stardust.rest:443',
+        storedPresetId: 'zec-rocks',
+      );
+
+      expect(config.lightwalletdUrl, 'https://zec.rocks:443');
+      expect(config.presetId, 'zec-rocks');
+    });
+
+    test('keeps stored custom endpoint URLs literal', () {
+      final config = resolveStoredRpcEndpointConfig(
+        networkName: 'main',
+        storedUrl: 'https://example.com:443',
+        storedPresetId: kCustomRpcEndpointPresetId,
+      );
+
+      expect(config.lightwalletdUrl, 'https://example.com:443');
+      expect(config.presetId, kCustomRpcEndpointPresetId);
+    });
   });
 
   group('RpcEndpointConfig', () {

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -80,16 +80,19 @@ void main() {
         'https://sa.zec.rocks:443',
         'https://eu.zec.rocks:443',
         'https://ap.zec.rocks:443',
+        'https://z3.deepikaw.xyz:443',
+        'https://zprivacy.online:443',
+        'https://lwd.zcashexplorer.app:9067',
       });
     });
 
-    test('mainnet presets are grouped by geography, not provider', () {
+    test('mainnet presets expose expected regions for endpoint selection', () {
       expect(
         findRpcEndpointPresetByUrl(
           'us.zec.stardust.rest:443',
           networkName: 'main',
         )?.region,
-        'Americas',
+        'Default',
       );
       expect(
         findRpcEndpointPresetByUrl(
@@ -109,11 +112,20 @@ void main() {
 
     test('matches normalized URLs within the requested network', () {
       final preset = findRpcEndpointPresetByUrl(
-        'zec.rocks',
+        'us.zec.stardust.rest',
         networkName: 'main',
       );
 
       expect(preset?.id, kDefaultRpcEndpointPresetId);
+    });
+
+    test('keeps the previous zec.rocks default as a selectable fallback', () {
+      final preset = findRpcEndpointPresetByUrl(
+        'zec.rocks',
+        networkName: 'main',
+      );
+
+      expect(preset?.id, 'zec-rocks');
     });
 
     test('does not cross-match testnet URLs when mainnet is requested', () {
@@ -138,6 +150,17 @@ void main() {
         )?.id,
         'default-regtest',
       );
+    });
+
+    test('uses Stardust US as the mainnet default endpoint', () {
+      final defaultEndpoint = defaultRpcEndpointConfig('main');
+
+      expect(defaultEndpoint.networkName, 'main');
+      expect(
+        defaultEndpoint.lightwalletdUrl,
+        'https://us.zec.stardust.rest:443',
+      );
+      expect(defaultEndpoint.presetId, kDefaultRpcEndpointPresetId);
     });
   });
 


### PR DESCRIPTION
## Summary

- Change the mainnet default lightwalletd endpoint to `https://us.zec.stardust.rest:443`.
- Keep `zec.rocks` and compatible Stardust / community endpoints available as selectable presets.
- Resolve stored preset IDs dynamically so users on the default endpoint follow future app default changes.
- Mirror the default preset sentinel into iOS native `UserDefaults` so background sync and TX tracking do not pin the old default URL.

## Validation

- `fvm flutter test test/core/config/rpc_endpoint_config_test.dart`
- `fvm flutter test test/providers/rpc_endpoint_latency_provider_test.dart`
- `fvm flutter analyze`
- `/Users/junghwanyun/.rbenv/shims/bundle exec pod install`
- `xcodebuild -workspace ios/Runner.xcworkspace -scheme Runner -sdk iphonesimulator -configuration Debug CODE_SIGNING_ALLOWED=NO build`