### PR TITLE
[codex] Extend import birthday date buffer

### DIFF
--- a/lib/src/features/onboarding/import/import_birthday_estimator.dart
+++ b/lib/src/features/onboarding/import/import_birthday_estimator.dart
@@ -86,7 +86,7 @@ class ImportBirthdayEstimator {
         selectedDate.day,
       );
       final searchDate = normalizedSelectedDate.subtract(
-        const Duration(days: 3),
+        const Duration(days: 15),
       );
       final targetEpoch = searchDate.toUtc().millisecondsSinceEpoch ~/ 1000;
 


### PR DESCRIPTION
## Summary
- Change the import birthday date estimator buffer from 3 days to 15 days before the selected date.

## Impact
- Wallet imports from a selected birthday date scan a wider safety window, reducing the chance of missing earlier activity near the chosen date at the cost of additional sync work.

## Validation
- `fvm flutter test test/features/onboarding/import_birthday_estimator_test.dart`