### PR TITLE
[codex] Preserve onboarding mnemonic during create flow

### DIFF
--- a/lib/src/features/onboarding/create/intro_zcash_screen.dart
+++ b/lib/src/features/onboarding/create/intro_zcash_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../core/theme/app_theme.dart';
@@ -12,8 +13,25 @@ import 'onboarding_split_view.dart';
 /// split-view shell (sidebar, illustration, acrylic gap) lives in
 /// `onboarding_split_view.dart` so subsequent onboarding steps can reuse
 /// the same left rail while only the right pane cross-fades.
-class IntroZcashScreen extends StatelessWidget {
+class IntroZcashScreen extends ConsumerStatefulWidget {
   const IntroZcashScreen({super.key});
+
+  @override
+  ConsumerState<IntroZcashScreen> createState() => _IntroZcashScreenState();
+}
+
+class _IntroZcashScreenState extends ConsumerState<IntroZcashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref.read(createOnboardingMnemonicProvider.notifier).clear();
+      ref
+          .read(onboardingSecretPassphraseRevealedProvider.notifier)
+          .setRevealed(false);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/features/onboarding/create/onboarding_split_view.dart
+++ b/lib/src/features/onboarding/create/onboarding_split_view.dart
@@ -20,6 +20,24 @@ final onboardingSecretPassphraseRevealedProvider =
       OnboardingSecretPassphraseRevealedNotifier.new,
     );
 
+class CreateOnboardingMnemonicNotifier extends Notifier<String?> {
+  @override
+  String? build() => null;
+
+  void setMnemonic(String mnemonic) {
+    state = mnemonic;
+  }
+
+  void clear() {
+    state = null;
+  }
+}
+
+final createOnboardingMnemonicProvider =
+    NotifierProvider<CreateOnboardingMnemonicNotifier, String?>(
+      CreateOnboardingMnemonicNotifier.new,
+    );
+
 enum OnboardingStep {
   intro,
   addressTypes,

--- a/lib/src/features/onboarding/create/secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/create/secret_passphrase_screen.dart
@@ -57,17 +57,40 @@ class _SecretPassphraseScreenState
     super.initState();
     final args = widget.args;
     if (args == null) {
-      _scheduleSidebarRevealed(false);
-      _prepareMnemonic();
+      final existingMnemonic = ref.read(createOnboardingMnemonicProvider);
+      if (existingMnemonic == null) {
+        _scheduleSidebarRevealed(false);
+        _prepareMnemonic();
+      } else {
+        _useMnemonic(
+          existingMnemonic,
+          revealed: ref.read(onboardingSecretPassphraseRevealedProvider),
+        );
+      }
     } else {
-      _mnemonic = args.mnemonic;
-      _isPreparing = false;
-      _revealed = true;
-      _scheduleSidebarRevealed(true);
+      _useMnemonic(args.mnemonic, revealed: true);
     }
   }
 
+  void _useMnemonic(String mnemonic, {required bool revealed}) {
+    _mnemonic = mnemonic;
+    _isPreparing = false;
+    _revealed = revealed;
+    if (ref.read(createOnboardingMnemonicProvider) != mnemonic) {
+      _scheduleCreateMnemonic(mnemonic);
+    }
+    _scheduleSidebarRevealed(revealed);
+  }
+
+  void _scheduleCreateMnemonic(String mnemonic) {
+    Future<void>(() {
+      if (!mounted) return;
+      ref.read(createOnboardingMnemonicProvider.notifier).setMnemonic(mnemonic);
+    });
+  }
+
   void _scheduleSidebarRevealed(bool value) {
+    if (ref.read(onboardingSecretPassphraseRevealedProvider) == value) return;
     Future<void>(() {
       if (!mounted) return;
       ref
@@ -78,7 +101,9 @@ class _SecretPassphraseScreenState
 
   void _prepareMnemonic() {
     try {
-      _mnemonic = rust_wallet.generateMnemonic();
+      final mnemonic = rust_wallet.generateMnemonic();
+      _mnemonic = mnemonic;
+      _scheduleCreateMnemonic(mnemonic);
       _isPreparing = false;
     } catch (e, st) {
       log('SecretPassphraseScreen._prepareMnemonic: ERROR: $e\n$st');
@@ -143,6 +168,12 @@ class _SecretPassphraseScreenState
         _submitError = onboardingSubmitErrorMessage(e);
       });
       return;
+    }
+    if (mounted) {
+      ref.read(createOnboardingMnemonicProvider.notifier).clear();
+      ref
+          .read(onboardingSecretPassphraseRevealedProvider.notifier)
+          .setRevealed(false);
     }
     router.go('/home');
   }

--- a/test/features/onboarding/create_onboarding_mnemonic_test.dart
+++ b/test/features/onboarding/create_onboarding_mnemonic_test.dart
@@ -1,0 +1,83 @@
+import 'dart:ui' show Size;
+
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart' show Widget;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/onboarding/create/intro_zcash_screen.dart';
+import 'package:zcash_wallet/src/features/onboarding/create/onboarding_split_view.dart';
+import 'package:zcash_wallet/src/features/onboarding/create/secret_passphrase_screen.dart';
+
+void main() {
+  testWidgets('reuses pending create mnemonic when returning to passphrase', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final container = _providerContainer();
+    addTearDown(container.dispose);
+    container
+        .read(createOnboardingMnemonicProvider.notifier)
+        .setMnemonic(_mnemonic);
+    container
+        .read(onboardingSecretPassphraseRevealedProvider.notifier)
+        .setRevealed(true);
+
+    await tester.pumpWidget(
+      _harness(container, const SecretPassphraseScreen()),
+    );
+    await tester.pump();
+
+    expect(find.text('alpha'), findsOneWidget);
+    expect(find.text('xray'), findsOneWidget);
+    expect(container.read(createOnboardingMnemonicProvider), _mnemonic);
+  });
+
+  testWidgets('intro clears pending create mnemonic', (tester) async {
+    await _setDesktopViewport(tester);
+    final container = _providerContainer();
+    addTearDown(container.dispose);
+    container
+        .read(createOnboardingMnemonicProvider.notifier)
+        .setMnemonic(_mnemonic);
+    container
+        .read(onboardingSecretPassphraseRevealedProvider.notifier)
+        .setRevealed(true);
+
+    await tester.pumpWidget(_harness(container, const IntroZcashScreen()));
+    await tester.pump();
+
+    expect(container.read(createOnboardingMnemonicProvider), isNull);
+    expect(container.read(onboardingSecretPassphraseRevealedProvider), isFalse);
+  });
+}
+
+Future<void> _setDesktopViewport(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(1280, 900));
+  addTearDown(() async {
+    await tester.binding.setSurfaceSize(null);
+  });
+}
+
+ProviderContainer _providerContainer() {
+  return ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+    ],
+  );
+}
+
+Widget _harness(ProviderContainer container, Widget child) {
+  return UncontrolledProviderScope(
+    container: container,
+    child: MaterialApp(
+      home: AppTheme(data: AppThemeData.light, child: child),
+    ),
+  );
+}
+
+const _mnemonic =
+    'alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima '
+    'mike november oscar papa quebec romeo sierra tango uniform victor whiskey '
+    'xray';


### PR DESCRIPTION
## Summary
- Preserve the generated create-onboarding mnemonic in ephemeral Riverpod state while the user moves between create-flow steps.
- Clear the pending mnemonic when the flow returns to the intro boundary or after wallet creation succeeds.
- Add widget coverage for reusing the pending mnemonic and clearing it on intro.

## Why
The secret-passphrase screen generated the recovery phrase inside widget state, so navigating back and then forward could generate a different phrase from the one the user had already recorded. The create flow now keeps one pending phrase until the user intentionally returns to the start of the flow.

## Validation
- `fvm flutter test test/features/onboarding/create_onboarding_mnemonic_test.dart`
- `fvm flutter analyze lib/src/features/onboarding/create test/features/onboarding/create_onboarding_mnemonic_test.dart`
- `fvm flutter test test/features/onboarding`