### PR TITLE
[codex] Limit password rotation journal to roll-forward data

### DIFF
--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -230,6 +230,7 @@ class AppSecureStore {
       try {
         final storedValues = await _storage.readAll();
         final rotatedSecrets = <_PasswordRotationEntry>[];
+        final rollbackSecrets = <_PasswordRotationRollbackEntry>[];
 
         for (final entry in storedValues.entries) {
           if (!entry.key.startsWith(_accountMnemonicKeyPrefix)) continue;
@@ -251,10 +252,12 @@ class AppSecureStore {
             newSecretKey,
           );
           rotatedSecrets.add(
-            _PasswordRotationEntry(
+            _PasswordRotationEntry(key: entry.key, rotatedValue: rotatedValue),
+          );
+          rollbackSecrets.add(
+            _PasswordRotationRollbackEntry(
               key: entry.key,
               originalValue: entry.value,
-              rotatedValue: rotatedValue,
             ),
           );
         }
@@ -266,18 +269,21 @@ class AppSecureStore {
         );
 
         final rotation = _PasswordRotationRecord(
-          oldVerifierSalt: oldVerifierSalt,
-          oldVerifier: oldVerifier,
           newVerifierSalt: base64Encode(newVerifierSalt),
           newVerifier: newVerifier,
           entries: rotatedSecrets,
+        );
+        final rollbackSnapshot = _PasswordRotationRollbackSnapshot(
+          oldVerifierSalt: oldVerifierSalt,
+          oldVerifier: oldVerifier,
+          entries: rollbackSecrets,
         );
         await writePlain(_passwordRotationInProgressKey, rotation.serialize());
 
         try {
           await _writeRotatedPasswordState(rotation);
         } catch (error, stackTrace) {
-          await _rollbackPasswordRotation(rotation, currentPassword);
+          await _rollbackPasswordRotation(rollbackSnapshot, currentPassword);
           Error.throwWithStackTrace(error, stackTrace);
         }
 
@@ -454,29 +460,22 @@ class AppSecureStore {
   }
 
   Future<void> _rollbackPasswordRotation(
-    _PasswordRotationRecord rotation,
+    _PasswordRotationRollbackSnapshot rollback,
     String currentPassword,
   ) async {
     try {
-      final rollbackRecord = rotation.toRollbackRecord();
-      if (rollbackRecord != null) {
-        await writePlain(
-          _passwordRotationInProgressKey,
-          rollbackRecord.serialize(),
-        );
-      }
-      for (final entry in rotation.entries) {
+      for (final entry in rollback.entries) {
         await writePlain(entry.key, entry.originalValue);
       }
-      if (rotation.oldVerifierSalt == null) {
+      if (rollback.oldVerifierSalt == null) {
         await delete(_passwordVerifierSaltKey);
       } else {
-        await writePlain(_passwordVerifierSaltKey, rotation.oldVerifierSalt!);
+        await writePlain(_passwordVerifierSaltKey, rollback.oldVerifierSalt!);
       }
-      if (rotation.oldVerifier == null) {
+      if (rollback.oldVerifier == null) {
         await delete(_passwordVerifierKey);
       } else {
-        await writePlain(_passwordVerifierKey, rotation.oldVerifier!);
+        await writePlain(_passwordVerifierKey, rollback.oldVerifier!);
       }
       setSessionPassword(currentPassword);
       await _deleteRotationRecordBestEffort();
@@ -554,28 +553,41 @@ class _AsyncLock {
 }
 
 class _PasswordRotationEntry {
-  const _PasswordRotationEntry({
+  const _PasswordRotationEntry({required this.key, required this.rotatedValue});
+
+  final String key;
+  final String rotatedValue;
+}
+
+class _PasswordRotationRollbackEntry {
+  const _PasswordRotationRollbackEntry({
     required this.key,
     required this.originalValue,
-    required this.rotatedValue,
   });
 
   final String key;
   final String originalValue;
-  final String rotatedValue;
 }
 
-class _PasswordRotationRecord {
-  const _PasswordRotationRecord({
+class _PasswordRotationRollbackSnapshot {
+  const _PasswordRotationRollbackSnapshot({
     required this.oldVerifierSalt,
     required this.oldVerifier,
-    required this.newVerifierSalt,
-    required this.newVerifier,
     required this.entries,
   });
 
   final String? oldVerifierSalt;
   final String? oldVerifier;
+  final List<_PasswordRotationRollbackEntry> entries;
+}
+
+class _PasswordRotationRecord {
+  const _PasswordRotationRecord({
+    required this.newVerifierSalt,
+    required this.newVerifier,
+    required this.entries,
+  });
+
   final String newVerifierSalt;
   final String newVerifier;
   final List<_PasswordRotationEntry> entries;
@@ -583,17 +595,11 @@ class _PasswordRotationRecord {
   String serialize() {
     return jsonEncode({
       'v': 1,
-      'oldVerifierSalt': oldVerifierSalt,
-      'oldVerifier': oldVerifier,
       'newVerifierSalt': newVerifierSalt,
       'newVerifier': newVerifier,
       'entries': entries
           .map(
-            (entry) => {
-              'key': entry.key,
-              'originalValue': entry.originalValue,
-              'rotatedValue': entry.rotatedValue,
-            },
+            (entry) => {'key': entry.key, 'rotatedValue': entry.rotatedValue},
           )
           .toList(),
     });
@@ -607,47 +613,24 @@ class _PasswordRotationRecord {
 
       final entriesJson = json['entries'];
       if (entriesJson is! List) return null;
+      final newVerifierSalt = json['newVerifierSalt'];
+      final newVerifier = json['newVerifier'];
+      if (newVerifierSalt is! String || newVerifier is! String) return null;
 
       return _PasswordRotationRecord(
-        oldVerifierSalt: json['oldVerifierSalt'] as String?,
-        oldVerifier: json['oldVerifier'] as String?,
-        newVerifierSalt: json['newVerifierSalt'] as String,
-        newVerifier: json['newVerifier'] as String,
-        entries: entriesJson
-            .map(
-              (entry) => _PasswordRotationEntry(
-                key: (entry as Map<String, dynamic>)['key'] as String,
-                originalValue: entry['originalValue'] as String,
-                rotatedValue: entry['rotatedValue'] as String,
-              ),
-            )
-            .toList(),
+        newVerifierSalt: newVerifierSalt,
+        newVerifier: newVerifier,
+        entries: entriesJson.map((entry) {
+          final entryJson = entry as Map<String, dynamic>;
+          return _PasswordRotationEntry(
+            key: entryJson['key'] as String,
+            rotatedValue: entryJson['rotatedValue'] as String,
+          );
+        }).toList(),
       );
     } catch (_) {
       return null;
     }
-  }
-
-  _PasswordRotationRecord? toRollbackRecord() {
-    final oldSalt = oldVerifierSalt;
-    final oldPasswordVerifier = oldVerifier;
-    if (oldSalt == null || oldPasswordVerifier == null) return null;
-
-    return _PasswordRotationRecord(
-      oldVerifierSalt: newVerifierSalt,
-      oldVerifier: newVerifier,
-      newVerifierSalt: oldSalt,
-      newVerifier: oldPasswordVerifier,
-      entries: entries
-          .map(
-            (entry) => _PasswordRotationEntry(
-              key: entry.key,
-              originalValue: entry.rotatedValue,
-              rotatedValue: entry.originalValue,
-            ),
-          )
-          .toList(),
-    );
   }
 }
 

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -49,6 +49,73 @@ void main() {
     expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
   });
 
+  test('changePassword journal stores only roll-forward data', () async {
+    final blockingStorage = _BlockingDeleteStorage(
+      blockKey: _rotationInProgressKey,
+    );
+    store = AppSecureStore.testing(storage: blockingStorage);
+    await store.configurePassword(_oldPassword);
+    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    final originalPayload = await store.readPlain(_mnemonicKey);
+    final oldVerifier = await store.readPlain(_passwordVerifierKey);
+
+    blockingStorage.blockNextDelete = true;
+    final rotation = store.changePassword(
+      currentPassword: _oldPassword,
+      newPassword: _newPassword,
+    );
+    await blockingStorage.deleteStarted.future;
+
+    final journal = await store.readPlain(_rotationInProgressKey);
+    expect(journal, isNotNull);
+    expect(journal, contains('"v":1'));
+    expect(journal, contains('rotatedValue'));
+    expect(journal, isNot(contains('originalValue')));
+    expect(journal, isNot(contains('oldVerifier')));
+    expect(journal, isNot(contains(originalPayload!)));
+    expect(journal, isNot(contains(oldVerifier!)));
+
+    blockingStorage.release();
+    expect(await rotation, isTrue);
+    expect(await store.readPlain(_rotationInProgressKey), isNull);
+  });
+
+  test(
+    'changePassword keeps old cleanup policy with forward-only journal',
+    () async {
+      final failingStorage = _FailingDeleteStorage(
+        failKey: _rotationInProgressKey,
+      );
+      store = AppSecureStore.testing(storage: failingStorage);
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(_mnemonicKey, _mnemonic);
+      final originalPayload = await store.readPlain(_mnemonicKey);
+      final oldVerifier = await store.readPlain(_passwordVerifierKey);
+
+      failingStorage.failNextMatchingDelete = true;
+
+      final didChange = await store.changePassword(
+        currentPassword: _oldPassword,
+        newPassword: _newPassword,
+      );
+
+      expect(didChange, isTrue);
+
+      final retainedJournal = await store.readPlain(_rotationInProgressKey);
+      expect(retainedJournal, isNotNull);
+      expect(retainedJournal, contains('rotatedValue'));
+      expect(retainedJournal, isNot(contains('originalValue')));
+      expect(retainedJournal, isNot(contains('oldVerifier')));
+      expect(retainedJournal, isNot(contains(originalPayload!)));
+      expect(retainedJournal, isNot(contains(oldVerifier!)));
+
+      store.clearSessionPassword();
+      expect(await store.verifyPasswordOnly(_oldPassword), isFalse);
+      expect(await store.verifyPassword(_newPassword), isTrue);
+      expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+    },
+  );
+
   test(
     'changePassword rejects wrong current password without rotating',
     () async {
@@ -152,7 +219,7 @@ void main() {
   });
 
   test(
-    'recoverInterruptedPasswordRotation rolls forward from sentinel',
+    'recoverInterruptedPasswordRotation rolls forward from journal',
     () async {
       await store.configurePassword(_oldPassword);
       await store.writeSecretString(_mnemonicKey, _mnemonic);
@@ -176,16 +243,10 @@ void main() {
         _rotationInProgressKey,
         jsonEncode({
           'v': 1,
-          'oldVerifierSalt': oldVerifierSalt,
-          'oldVerifier': oldVerifier,
           'newVerifierSalt': newVerifierSalt,
           'newVerifier': newVerifier,
           'entries': [
-            {
-              'key': _mnemonicKey,
-              'originalValue': originalPayload,
-              'rotatedValue': rotatedPayload,
-            },
+            {'key': _mnemonicKey, 'rotatedValue': rotatedPayload},
           ],
         }),
       );
@@ -246,8 +307,8 @@ void main() {
       await store.configurePassword(_oldPassword);
       await store.writeSecretString(_mnemonicKey, _mnemonic);
       failingStorage
-        ..failNextWriteFor(_passwordVerifierKey)
-        ..failWriteNumberFor(_rotationInProgressKey, 2);
+        ..failWriteNumberFor(_passwordVerifierKey, 2)
+        ..failWriteNumberFor(_passwordVerifierKey, 3);
 
       await expectLater(
         () => store.changePassword(
@@ -395,6 +456,81 @@ class _BlockingWriteStorage extends FlutterSecureStorage {
     return super.write(
       key: key,
       value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
+}
+
+class _BlockingDeleteStorage extends FlutterSecureStorage {
+  _BlockingDeleteStorage({required this.blockKey});
+
+  final String blockKey;
+  var blockNextDelete = false;
+  Completer<void> deleteStarted = Completer<void>();
+  final Completer<void> _release = Completer<void>();
+
+  void release() {
+    if (!_release.isCompleted) {
+      _release.complete();
+    }
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    if (blockNextDelete && key == blockKey) {
+      blockNextDelete = false;
+      if (!deleteStarted.isCompleted) {
+        deleteStarted.complete();
+      }
+      await _release.future;
+    }
+    return super.delete(
+      key: key,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
+}
+
+class _FailingDeleteStorage extends FlutterSecureStorage {
+  _FailingDeleteStorage({required this.failKey});
+
+  final String failKey;
+  bool failNextMatchingDelete = false;
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) {
+    if (failNextMatchingDelete && key == failKey) {
+      failNextMatchingDelete = false;
+      throw StateError('forced delete failure');
+    }
+    return super.delete(
+      key: key,
       iOptions: iOptions,
       aOptions: aOptions,
       lOptions: lOptions,


### PR DESCRIPTION
## Summary

- Remove old-password rollback material from the persistent password rotation journal.
- Keep old encrypted mnemonic payloads and old verifier values only in the in-process rollback snapshot.
- Preserve the existing cleanup policy: password changes still succeed when journal deletion is best-effort and later recovery remains roll-forward.

## Why

The previous journal persisted `originalValue` and `oldVerifier`, which could leave old-password-decryptable mnemonic ciphertext in secure storage if journal cleanup failed or the app stopped before deletion. The runtime still needs old values for same-process rollback, but crash recovery only needs roll-forward data.

## Validation

- `fvm flutter test test/core/storage/app_secure_store_test.dart`
- `fvm flutter analyze lib/src/core/storage/app_secure_store.dart test/core/storage/app_secure_store_test.dart`