### PR TITLE
[codex] Guard receive address loads on account switch

### DIFF
--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -106,6 +106,9 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
     } catch (e) {
       log('Receive: ERROR loading addresses: $e');
       if (!mounted) return;
+      if (ref.read(accountProvider).value?.activeAccountUuid != accountUuid) {
+        return;
+      }
       setState(() {
         _shieldedAddress ??= walletAddress;
         _isLoading = false;
@@ -206,6 +209,9 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
     } catch (e) {
       log('Receive: ERROR renewing shielded address: $e');
       if (!mounted) return;
+      if (ref.read(accountProvider).value?.activeAccountUuid != accountUuid) {
+        return;
+      }
       setState(() {
         _isRenewingShielded = false;
         _errorText = e.toString();
@@ -922,6 +928,12 @@ class _CachedQrBitmapState extends State<_CachedQrBitmap> {
         oldWidget.color != widget.color ||
         oldWidget.embeddedImageAsset != widget.embeddedImageAsset ||
         oldWidget.embeddedImageScale != widget.embeddedImageScale) {
+      final previous = _image;
+      setState(() {
+        _image = null;
+        _error = null;
+      });
+      _disposeImageAfterFrame(previous);
       unawaited(_renderQr());
     }
   }

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,7 +10,7 @@ import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/receive/screens/receive_screen.dart';
-import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/receive_address_provider.dart';
 
 void main() {
@@ -43,9 +45,68 @@ void main() {
 
     expect(find.text('send route'), findsOneWidget);
   });
+
+  testWidgets('ignores stale shielded load failure after account switch', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    late _RacyReceiveAddressService service;
+    final bootstrap = _twoAccountBootstrap;
+    await tester.pumpWidget(
+      _receiveRaceHarness(
+        bootstrap: bootstrap,
+        receiveAddressService: (ref) {
+          service = _RacyReceiveAddressService(ref);
+          return service;
+        },
+        accountNotifier: () => _FakeAccountNotifier(
+          bootstrap.initialAccountState,
+          {'account-1': _accountOneAddress, 'account-2': null},
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(service.hasPending('account-1'), isTrue);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ReceiveScreen)),
+      listen: false,
+    );
+    await container.read(accountProvider.notifier).switchAccount('account-2');
+    await tester.pump();
+
+    expect(service.hasPending('account-2'), isTrue);
+
+    service.fail('account-1', StateError('old account load failed'));
+    await tester.pump();
+
+    expect(_findAddressRichText('u1accountone'), findsNothing);
+    expect(find.textContaining('old account load failed'), findsNothing);
+
+    service.complete('account-2', _accountTwoAddress);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(_findAddressRichText('u1accounttwo'), findsOneWidget);
+  });
 }
 
-Widget _receiveHarness() {
+Finder _findAddressRichText(String fragment) {
+  return find.byWidgetPredicate(
+    (widget) =>
+        widget is RichText && widget.text.toPlainText().contains(fragment),
+  );
+}
+
+Widget _receiveHarness({
+  AppBootstrapState? bootstrap,
+  ReceiveAddressService Function(Ref ref)? receiveAddressService,
+}) {
   final router = GoRouter(
     initialLocation: '/receive',
     routes: [
@@ -56,10 +117,36 @@ Widget _receiveHarness() {
 
   return ProviderScope(
     overrides: [
-      appBootstrapProvider.overrideWithValue(_bootstrap),
+      appBootstrapProvider.overrideWithValue(bootstrap ?? _bootstrap),
       receiveAddressServiceProvider.overrideWith(
-        _FakeReceiveAddressService.new,
+        receiveAddressService ?? _FakeReceiveAddressService.new,
       ),
+    ],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+    ),
+  );
+}
+
+Widget _receiveRaceHarness({
+  required AppBootstrapState bootstrap,
+  required ReceiveAddressService Function(Ref ref) receiveAddressService,
+  required AccountNotifier Function() accountNotifier,
+}) {
+  final router = GoRouter(
+    initialLocation: '/receive',
+    routes: [
+      GoRoute(path: '/receive', builder: (_, _) => const ReceiveScreen()),
+      GoRoute(path: '/send', builder: (_, _) => const Text('send route')),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(bootstrap),
+      receiveAddressServiceProvider.overrideWith(receiveAddressService),
+      accountProvider.overrideWith(accountNotifier),
     ],
     child: MaterialApp.router(
       routerConfig: router,
@@ -85,8 +172,30 @@ final _bootstrap = AppBootstrapState(
   passwordRotationRecoveryFailed: false,
 );
 
+final _twoAccountBootstrap = AppBootstrapState(
+  initialLocation: '/receive',
+  initialAccountState: const AccountState(
+    accounts: [
+      AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0),
+      AccountInfo(uuid: 'account-2', name: 'Account 2', order: 1),
+    ],
+    activeAccountUuid: 'account-1',
+    activeAddress: _accountOneAddress,
+  ),
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.system,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);
+
 const _shieldedAddress =
     'u1testshieldedaddress000000000000000000000000000000000000000000000000000';
+const _accountOneAddress = 'u1accountone-stale';
+const _accountTwoAddress = 'u1accounttwo-current';
 
 class _FakeReceiveAddressService extends ReceiveAddressService {
   _FakeReceiveAddressService(super.ref);
@@ -112,5 +221,64 @@ class _FakeReceiveAddressService extends ReceiveAddressService {
   @override
   Future<String> renewShieldedAddress({required String accountUuid}) async {
     return _shieldedAddress;
+  }
+}
+
+class _RacyReceiveAddressService extends ReceiveAddressService {
+  _RacyReceiveAddressService(super.ref);
+
+  final _pending = <String, Completer<String>>{};
+
+  bool hasPending(String accountUuid) => _pending.containsKey(accountUuid);
+
+  void complete(String accountUuid, String address) {
+    _pending.remove(accountUuid)?.complete(address);
+  }
+
+  void fail(String accountUuid, Object error) {
+    _pending.remove(accountUuid)?.completeError(error);
+  }
+
+  @override
+  Future<String> loadShieldedAddress({
+    required String accountUuid,
+    String? currentShieldedAddress,
+  }) {
+    return _pending.putIfAbsent(accountUuid, Completer<String>.new).future;
+  }
+
+  @override
+  String? getCachedTransparentAddress(String accountUuid) => null;
+
+  @override
+  Future<String> loadTransparentAddress({required String accountUuid}) async {
+    return 't1transparent-$accountUuid';
+  }
+
+  @override
+  Future<String> renewShieldedAddress({required String accountUuid}) {
+    return loadShieldedAddress(accountUuid: accountUuid);
+  }
+}
+
+class _FakeAccountNotifier extends AccountNotifier {
+  _FakeAccountNotifier(this.initialState, this.addresses);
+
+  final AccountState initialState;
+  final Map<String, String?> addresses;
+
+  @override
+  FutureOr<AccountState> build() => initialState;
+
+  @override
+  Future<void> switchAccount(String uuid) async {
+    final prev = state.value ?? initialState;
+    state = AsyncData(
+      AccountState(
+        accounts: prev.accounts,
+        activeAccountUuid: uuid,
+        activeAddress: addresses[uuid],
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Ignore stale shielded receive-address load failures after the active account changes.
- Ignore stale shielded renew failures after the active account changes.
- Clear cached QR bitmaps immediately when QR data/style changes so an old receive address QR is not displayed while the new QR is rendering.

## Why

The receive screen already guarded successful async address loads by active account, but the shielded failure paths could still mutate UI state after an account switch. The cached QR renderer also kept showing the previous bitmap until the asynchronous render for the new address completed.

## Validation

- `fvm flutter test test/features/receive/receive_screen_test.dart`
- `fvm flutter analyze lib/src/features/receive/screens/receive_screen.dart test/features/receive/receive_screen_test.dart`