### PR TITLE
[codex] Refine app copy from text QA

### DIFF
--- a/lib/src/features/about/screens/about_screen.dart
+++ b/lib/src/features/about/screens/about_screen.dart
@@ -32,7 +32,8 @@ const _maxSidebarPaneContentWidth = 752.0;
 const _placeholderParagraph = _UtilityParagraphData(
   heading: 'From the team that brought you Keplr Wallet.',
   body:
-      'Unlike Bitcoin or Ethereum, shielded Zcash transactions hide the sender, recipient, and amount - verified by cryptography, not trust.',
+      'Unlike Bitcoin or Ethereum, shielded Zcash transactions hide the '
+      'sender, recipient, and amount.',
 );
 
 const _aboutParagraphs = [_placeholderParagraph, _placeholderParagraph];

--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -70,7 +70,7 @@ ActivityRowData buildSyncActivityRow({
       subtitle: sync.phase.isEmpty ? null : _capitalize(sync.phase),
       amountText: '$pct%',
       amountColor: colors.text.secondary,
-      statusText: 'In progress',
+      statusText: 'Pending',
       statusIconName: AppIcons.loader,
       statusColor: colors.text.secondary,
       timestampText: formatActivityTimestamp(sync.lastSyncStartedAt),

--- a/lib/src/features/activity/widgets/activity_table.dart
+++ b/lib/src/features/activity/widgets/activity_table.dart
@@ -160,11 +160,11 @@ class _ActivityTableHeader extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
         child: _ActivityColumnLayout(
-          txType: Text('Tx Type', style: mutedStyle),
+          txType: Text('Type', style: mutedStyle),
           amount: Text('Amount', style: mutedStyle),
           status: Text('Status', style: mutedStyle),
           timestamp: Text(
-            'Time Stamp',
+            'Date & time',
             textAlign: TextAlign.end,
             style: mutedStyle,
           ),

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -139,10 +139,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final message = error.toString();
     final lower = message.toLowerCase();
     if (lower.contains('mnemonic')) {
-      return 'Mnemonic not found for the active account.';
+      return "Secret Passphrase isn't available for this account.";
     }
     if (lower.contains('sync')) {
-      return 'Sync the wallet before shielding transparent balance.';
+      return 'Wait for sync to finish, then shield.';
     }
     if (lower.contains('insufficient') ||
         lower.contains('threshold') ||
@@ -151,9 +151,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       return 'Transparent balance is too small to shield after fees.';
     }
     if (lower.contains('broadcast') || lower.contains('sendtransaction')) {
-      return 'Shield transaction could not be broadcast.';
+      return "Couldn't broadcast your shielding transaction. Try again.";
     }
-    return 'Shield balance failed. Please try again.';
+    return "Couldn't shield your balance. Try again.";
   }
 
   @override
@@ -191,7 +191,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             loading: () => const Center(child: CircularProgressIndicator()),
             error: (err, _) => Center(
               child: Text(
-                'Error: $err',
+                'Something went wrong. Try again in a moment.\n\n'
+                'Details: $err',
                 style: AppTypography.bodyMedium.copyWith(
                   color: context.colors.text.warning,
                 ),
@@ -400,7 +401,8 @@ class _HomePaneState extends ConsumerState<_HomePane> {
     if (widget.passwordRotationRecoveryFailed) {
       return _HomeNoticeData(
         iconName: AppIcons.warning,
-        message: "We couldn't verify the previous password change.",
+        message:
+            "We couldn't verify the previous password change. Try again or restart Vizor.",
         actionLabel: 'Settings',
         onTap: () => context.push('/settings'),
       );

--- a/lib/src/features/onboarding/create/address_types_screen.dart
+++ b/lib/src/features/onboarding/create/address_types_screen.dart
@@ -126,9 +126,7 @@ class _TitleBlock extends StatelessWidget {
             TextSpan(
               style: bodyStyle,
               children: [
-                const TextSpan(
-                  text: 'Zcash has two addresses types. \nOne for ',
-                ),
+                const TextSpan(text: 'Zcash has two address types: one for '),
                 TextSpan(
                   text: 'Privacy',
                   style: bodyStyle.copyWith(
@@ -330,8 +328,8 @@ class _AddressCardContent extends StatelessWidget {
             child: isShielded
                 ? _ShieldedDescription(colors: colors)
                 : Text(
-                    "Address starts with t, similar to Bitcoin, your address' "
-                    'balance and transaction history are publicly visible.',
+                    'Address starts with t. Balance and transaction history '
+                    'are publicly visible.',
                     style: AppTypography.bodyMedium.copyWith(
                       color: colors.text.primary,
                     ),

--- a/lib/src/features/onboarding/create/intro_zcash_screen.dart
+++ b/lib/src/features/onboarding/create/intro_zcash_screen.dart
@@ -141,7 +141,7 @@ class _HeroBlock extends StatelessWidget {
         ),
         const SizedBox(height: AppSpacing.sm),
         Text(
-          'Zcash (ZEC) built around financial privacy & self-custody.',
+          'Zcash (ZEC) is built around financial privacy and self-custody.',
           style: subtitleStyle,
           textAlign: TextAlign.center,
         ),
@@ -152,8 +152,7 @@ class _HeroBlock extends StatelessWidget {
             children: [
               Text(
                 'Unlike Bitcoin or Ethereum, shielded Zcash transactions '
-                'hide the sender, recipient, and amount — verified by '
-                'cryptography, not trust.',
+                'hide the sender, recipient, and amount.',
                 style: bodyStyle,
                 textAlign: TextAlign.center,
               ),

--- a/lib/src/features/onboarding/create/secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/create/secret_passphrase_screen.dart
@@ -356,7 +356,7 @@ class _HeroBlock extends StatelessWidget {
         ),
         const SizedBox(height: AppSpacing.sm),
         Text(
-          'The Master Key to your wallet.',
+          'The master key to your wallet.',
           style: AppTypography.bodyMedium.copyWith(color: colors.text.accent),
           textAlign: TextAlign.center,
         ),

--- a/lib/src/features/onboarding/create/things_to_know_screen.dart
+++ b/lib/src/features/onboarding/create/things_to_know_screen.dart
@@ -100,7 +100,7 @@ class _HeroBlock extends StatelessWidget {
         ),
         const SizedBox(height: AppSpacing.sm),
         Text(
-          'Useful tips before you started.',
+          'A few tips before you start.',
           style: AppTypography.bodyMedium.copyWith(color: colors.text.accent),
           textAlign: TextAlign.center,
         ),
@@ -126,10 +126,10 @@ class _InfoColumns extends StatelessWidget {
           const _InfoColumn(
             title: 'Time to sync',
             body:
-                'Your wallet syncs directly with the Zcash network instead '
-                'of relying on a server. This protects your privacy, but '
-                'takes a moment. Your funds are safe while the app catches '
-                'up.',
+                'Your balance may be incomplete until your wallet finishes '
+                'syncing. Syncing directly with the Zcash network protects '
+                'your privacy, but takes time. Your funds are safe in the '
+                'meantime.',
             iconName: AppIcons.time,
           ),
           const SizedBox(width: AppSpacing.lg),
@@ -145,9 +145,9 @@ class _InfoColumns extends StatelessWidget {
           const _InfoColumn(
             title: 'How to keep privacy',
             body:
-                "Some exchanges can't send to shielded addresses. If you're "
-                'withdrawing from an exchange, use your transparent address. '
-                'You can shield your ZEC after it arrives.',
+                "Most exchanges don't let you withdraw to a shielded address. "
+                'Use your transparent address, then shield your ZEC after it '
+                'arrives.',
             iconName: AppIcons.shieldKeyholeOutline,
           ),
         ],

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -188,7 +188,7 @@ class _ImportSecretPassphraseScreenState
   String? get _errorText {
     if (_submitError != null) return _submitError;
     if (_showValidationError && !_isMnemonicValid) {
-      return 'Please enter a valid 24-word secret passphrase.';
+      return 'Enter a valid 24-word Secret Passphrase.';
     }
     return null;
   }

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -286,13 +286,13 @@ class _ImportWalletBirthdayScreenState
     final text = _manualHeightController.text.trim();
     if (text.isEmpty) return null;
     final parsed = int.tryParse(text);
-    if (parsed == null) return 'Doesn’t seem like a legit block height';
+    if (parsed == null) return "That doesn't look like a valid block height.";
     if (parsed < _minimumBirthdayHeight) {
-      return 'Doesn’t seem like a legit block height';
+      return "That doesn't look like a valid block height.";
     }
     final maximumHeight = _metadata?.tipHeight;
     if (maximumHeight != null && parsed > maximumHeight) {
-      return 'Doesn’t seem like a legit block height';
+      return "That doesn't look like a valid block height.";
     }
     if (_metadataError != null) return _metadataError;
     return null;
@@ -371,7 +371,7 @@ class _ImportWalletBirthdayScreenState
                           SizedBox(
                             width: _subtitleWidth,
                             child: Text(
-                              'This will help to import your wallet faster.',
+                              'It helps us import your wallet faster.',
                               style: AppTypography.bodyMedium.copyWith(
                                 color: context.colors.text.accent,
                               ),

--- a/lib/src/features/onboarding/lost_password_screen.dart
+++ b/lib/src/features/onboarding/lost_password_screen.dart
@@ -302,7 +302,7 @@ class _LostPasswordContent extends StatelessWidget {
                           "If you've lost your password, the only way to recover your account is to ",
                     ),
                     TextSpan(
-                      text: 'completely reset Vizor app',
+                      text: 'completely reset the Vizor app',
                       style: strongStyle,
                     ),
                     const TextSpan(

--- a/lib/src/features/onboarding/shared/set_password_screen.dart
+++ b/lib/src/features/onboarding/shared/set_password_screen.dart
@@ -229,7 +229,9 @@ class _SetPasswordContent extends StatelessWidget {
                             SizedBox(
                               width: 270,
                               child: Text(
-                                'Minimum 8 symbols including characters.',
+                                'Minimum 8 characters. Add numbers and '
+                                'symbols, or make it longer, for stronger '
+                                'security.',
                                 style: AppTypography.bodyMedium.copyWith(
                                   color: colors.text.accent,
                                 ),

--- a/lib/src/features/onboarding/unlock_screen.dart
+++ b/lib/src/features/onboarding/unlock_screen.dart
@@ -89,7 +89,7 @@ class _UnlockScreenState extends ConsumerState<UnlockScreen> {
       log('UnlockScreen._submit: invalid password');
       setState(() {
         _isSubmitting = false;
-        _errorText = 'Incorrect password. Please try again.';
+        _errorText = 'Incorrect password. Try again.';
       });
     }
   }

--- a/lib/src/features/onboarding/welcome.dart
+++ b/lib/src/features/onboarding/welcome.dart
@@ -262,7 +262,7 @@ class _TitleBlock extends StatelessWidget {
         const _VizorLogo(),
         const SizedBox(height: AppSpacing.md),
         Text(
-          'Behind the Vizor.\nYour money, hidden.',
+          'Behind the Vizor.\nYour money stays private.',
           style: AppTypography.displayLarge.copyWith(color: colors.text.accent),
           textAlign: TextAlign.center,
         ),

--- a/lib/src/features/onboarding/welcome.dart
+++ b/lib/src/features/onboarding/welcome.dart
@@ -262,7 +262,7 @@ class _TitleBlock extends StatelessWidget {
         const _VizorLogo(),
         const SizedBox(height: AppSpacing.md),
         Text(
-          'Private Money.\nFor the New Internet',
+          'Behind the Vizor.\nYour money, hidden.',
           style: AppTypography.displayLarge.copyWith(color: colors.text.accent),
           textAlign: TextAlign.center,
         ),

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -26,6 +26,9 @@ import '../../../providers/wallet_provider.dart';
 
 enum _ReceiveAddressType { shielded, transparent }
 
+const _renewShieldedAddressErrorMessage =
+    "We couldn't refresh your shielded address. Try again, or use your current one.";
+
 class ReceiveScreen extends ConsumerStatefulWidget {
   const ReceiveScreen({super.key});
 
@@ -214,11 +217,11 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
       }
       setState(() {
         _isRenewingShielded = false;
-        _errorText = e.toString();
+        _errorText = '$_renewShieldedAddressErrorMessage\nDetails: $e';
       });
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Error: $e')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text(_renewShieldedAddressErrorMessage)),
+      );
     }
   }
 
@@ -861,7 +864,8 @@ class _QrSurface extends StatelessWidget {
             )
           : Center(
               child: Text(
-                'No address',
+                "We couldn't load your address. Try again in a moment.",
+                textAlign: TextAlign.center,
                 style: AppTypography.bodySmall.copyWith(
                   color: colors.text.secondary,
                 ),
@@ -1097,7 +1101,7 @@ class _RenewButton extends StatelessWidget {
                         AppIcons.renew,
                         size: 20,
                         color: colors.icon.accent,
-                        semanticLabel: 'Renew shielded address',
+                        semanticLabel: 'Generate new shielded address',
                       ),
               ),
             ),
@@ -1186,7 +1190,7 @@ List<TextSpan> _addressSpans(
   if (address.isEmpty) {
     return [
       TextSpan(
-        text: 'Address unavailable',
+        text: "Address couldn't be loaded. Try again.",
         style: TextStyle(color: context.colors.text.secondary),
       ),
     ];

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -402,7 +402,7 @@ class _SendReviewReceiptCard extends StatelessWidget {
             width: 320,
             height: 21,
             child: Text(
-              'Tx Fee: $feeText ZEC',
+              'Fee: $feeText ZEC',
               style: AppTypography.bodyMediumStrong.copyWith(
                 color: colors.text.accent,
               ),

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -533,22 +533,22 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         lower.contains('connection refused') ||
         lower.contains('dns error') ||
         lower.contains('tls error')) {
-      return 'Network error. Please check your connection and try again.';
+      return 'Network error. Check your connection and try again.';
     }
     // Partial broadcast must be checked before generic "broadcast rejected"
     if (lower.contains('broadcast failed after') &&
         lower.contains('txs sent')) {
-      return 'Some transactions were broadcast but not all. '
-          'Please check your transaction history before retrying.';
+      return 'Some parts of this transaction were sent. Open Activity to see '
+          'what went through before you try again.';
     }
     if (lower.contains('broadcast rejected')) {
-      return 'Transaction was rejected by the network. Please try again.';
+      return 'The network rejected this transaction. Try again.';
     }
     if (lower.contains('proposal not found') ||
         lower.contains('send flow mismatch')) {
-      return 'Transaction expired. Please try again.';
+      return 'Transaction expired before it could be sent. Try again.';
     }
-    return 'Send failed. Please try again.';
+    return 'Send failed. Try again.';
   }
 
   Future<void> _openReview() async {
@@ -737,7 +737,8 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
             loading: () => const Center(child: CircularProgressIndicator()),
             error: (err, _) => Center(
               child: Text(
-                'Error: $err',
+                'Something went wrong. Try again in a moment.\n\n'
+                'Details: $err',
                 style: AppTypography.bodyMedium.copyWith(
                   color: context.colors.text.destructive,
                 ),
@@ -1062,7 +1063,7 @@ class _SendAddMessageCard extends StatelessWidget {
               AppIcon(AppIcons.scroll, size: 16, color: colors.icon.accent),
               const SizedBox(width: AppSpacing.xxs),
               Text(
-                'Add a Message',
+                'Add a message',
                 style: AppTypography.labelMedium.copyWith(
                   color: colors.text.accent,
                 ),

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -107,20 +107,22 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
         lower.contains('connection refused') ||
         lower.contains('dns error') ||
         lower.contains('tls error')) {
-      return 'Network error. Please check your connection and try again.';
+      return 'Network error. Check your connection and try again.';
     }
     if (lower.contains('broadcast failed after') &&
         lower.contains('txs sent')) {
-      return 'Some transactions were broadcast but not all. Please check history before retrying.';
+      return 'Some parts of this transaction were sent. Open Activity to see '
+          'what went through before you try again.';
     }
     if (lower.contains('broadcast rejected')) {
-      return 'Transaction was rejected by the network. Please try again later.';
+      return 'The network rejected this transaction. Try again later.';
     }
     if (lower.contains('proposal not found') ||
         lower.contains('send flow mismatch')) {
       return 'Transaction expired before it could be sent.';
     }
-    return 'Transaction could not be sent. Please return to your wallet and verify the latest status.';
+    return "Transaction couldn't be sent. Go back to your wallet and check "
+        'the latest status.';
   }
 
   String? _firstTxid(String txids) {
@@ -137,7 +139,9 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     }
     final rawMessage = result.message?.toLowerCase() ?? '';
     if (rawMessage.contains('broadcast rejected')) {
-      return 'Transaction was created locally, but the network did not accept the first broadcast. It may retry automatically until it expires. Do not send again unless this transaction expires.';
+      return "Transaction was created locally but didn't reach the network. "
+          'The wallet will keep retrying until it expires. '
+          "Don't send again unless this one expires.";
     }
     return 'Transaction was created locally but could not be broadcast. It will retry automatically when the network is available. Do not send again unless this transaction expires.';
   }

--- a/lib/src/features/send/widgets/sapling_params_prompt.dart
+++ b/lib/src/features/send/widgets/sapling_params_prompt.dart
@@ -90,16 +90,16 @@ class SaplingParamsPrompt extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
                         Text(
-                          'This transaction uses Sapling shielded notes, '
-                          'which require proving parameters (~50MB) to '
-                          'generate zero-knowledge proofs.',
+                          'To create this private transaction, your wallet '
+                          'needs to download about 50MB of cryptographic '
+                          'parameters.',
                           style: AppTypography.bodyMedium.copyWith(
                             color: colors.text.accent,
                           ),
                         ),
                         const SizedBox(height: AppSpacing.xs),
                         Text(
-                          'This is a one-time download.\n'
+                          "This happens once, then it's done.\n"
                           'Network data charges may apply.',
                           style: AppTypography.bodyMedium.copyWith(
                             color: colors.text.secondary,

--- a/lib/src/features/send/widgets/transaction_receipt_view.dart
+++ b/lib/src/features/send/widgets/transaction_receipt_view.dart
@@ -112,7 +112,7 @@ class TransactionReceiptView extends StatelessWidget {
               const SizedBox(width: AppSpacing.sm),
               Expanded(
                 child: _TransactionReceiptBlock(
-                  title: 'Tx Fee',
+                  title: 'Fee',
                   child: Text(
                     feeText,
                     style: AppTypography.bodyMedium.copyWith(

--- a/lib/src/features/settings/screens/settings_change_password_screen.dart
+++ b/lib/src/features/settings/screens/settings_change_password_screen.dart
@@ -322,8 +322,7 @@ class _CurrentPasswordView extends StatelessWidget {
                 SizedBox(
                   width: 270,
                   child: Text(
-                    'Enter your current password\n'
-                    'to update your password.',
+                    'Enter your current password to continue.',
                     textAlign: TextAlign.center,
                     style: AppTypography.bodyMedium.copyWith(
                       color: colors.text.accent,
@@ -422,7 +421,8 @@ class _NewPasswordView extends StatelessWidget {
                   SizedBox(
                     width: 270,
                     child: Text(
-                      'Minimum 8 symbols including characters.',
+                      'Minimum 8 characters. Add numbers and symbols, or make '
+                      'it longer, for stronger security.',
                       textAlign: TextAlign.center,
                       style: AppTypography.bodyMedium.copyWith(
                         color: colors.text.accent,

--- a/lib/src/features/settings/screens/settings_endpoint_screen.dart
+++ b/lib/src/features/settings/screens/settings_endpoint_screen.dart
@@ -753,7 +753,7 @@ class _CustomEndpointForm extends StatelessWidget {
                   TextSpan(
                     text:
                         "If the endpoint is configured wrong, your wallet won't "
-                        'be able to sync with Zcash blockchain.\n',
+                        'be able to sync with the Zcash network.\n',
                     children: [
                       TextSpan(
                         text:

--- a/lib/src/providers/receive_address_provider.dart
+++ b/lib/src/providers/receive_address_provider.dart
@@ -21,7 +21,7 @@ class ReceiveAddressBusyException implements Exception {
 
   @override
   String toString() {
-    return 'Wallet database is busy. Please try again in a moment.';
+    return 'Wallet is busy. Try again in a moment.';
   }
 }
 

--- a/test/activity_table_pagination_test.dart
+++ b/test/activity_table_pagination_test.dart
@@ -132,7 +132,7 @@ void main() {
       expect(arrowFinder, findsNothing);
 
       final mutedColor = AppThemeData.light.colors.text.muted;
-      for (final label in ['Tx Type', 'Amount', 'Status', 'Time Stamp']) {
+      for (final label in ['Type', 'Amount', 'Status', 'Date & time']) {
         final text = tester.widget<Text>(find.text(label));
         expect(text.style?.color, mutedColor);
       }

--- a/test/features/about/about_legal_pages_test.dart
+++ b/test/features/about/about_legal_pages_test.dart
@@ -219,13 +219,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Terms of Use'), findsOneWidget);
-    expect(find.text('Private Money.\nFor the New Internet'), findsNothing);
+    expect(find.text('Behind the Vizor.\nYour money, hidden.'), findsNothing);
 
     await tester.pumpWidget(_appHarness(_emptyBootstrap('/privacy')));
     await tester.pumpAndSettle();
 
     expect(find.text('Privacy Policy'), findsOneWidget);
-    expect(find.text('Private Money.\nFor the New Internet'), findsNothing);
+    expect(find.text('Behind the Vizor.\nYour money, hidden.'), findsNothing);
   });
 
   testWidgets('welcome footer links open legal pages', (tester) async {

--- a/test/features/about/about_legal_pages_test.dart
+++ b/test/features/about/about_legal_pages_test.dart
@@ -219,13 +219,19 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Terms of Use'), findsOneWidget);
-    expect(find.text('Behind the Vizor.\nYour money, hidden.'), findsNothing);
+    expect(
+      find.text('Behind the Vizor.\nYour money stays private.'),
+      findsNothing,
+    );
 
     await tester.pumpWidget(_appHarness(_emptyBootstrap('/privacy')));
     await tester.pumpAndSettle();
 
     expect(find.text('Privacy Policy'), findsOneWidget);
-    expect(find.text('Behind the Vizor.\nYour money, hidden.'), findsNothing);
+    expect(
+      find.text('Behind the Vizor.\nYour money stays private.'),
+      findsNothing,
+    );
   });
 
   testWidgets('welcome footer links open legal pages', (tester) async {


### PR DESCRIPTION
## Summary
- Apply accepted text QA copy edits across onboarding, activity, home, receive, send, and settings surfaces.
- Update the welcome headline to "Behind the Vizor. Your money, hidden."
- Keep raw troubleshooting details visible where friendly error copy replaced debug-style messages.

## Validation
- fvm dart analyze on touched Dart files
- fvm flutter test test/features/about/about_legal_pages_test.dart
- git diff --check

## Note
- Full fvm flutter analyze still reports existing rust_builder/cargokit/build_tool missing-package analyzer errors unrelated to this copy-only diff.