### PR TITLE
[codex] Add testnet RPC fallback preset

### DIFF
--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -149,6 +149,12 @@ final kTestnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
     url: 'https://testnet.zec.rocks:443',
     isDefault: true,
   ),
+  const RpcEndpointPreset(
+    id: 'mysideoftheweb-testnet',
+    region: 'Community',
+    label: 'My Side of the Web Testnet',
+    url: 'https://zcash.mysideoftheweb.com:19067',
+  ),
 ]);
 
 final kRegtestRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -110,6 +110,25 @@ void main() {
       );
     });
 
+    test('testnet presets include the default and community fallback', () {
+      final urls = kTestnetRpcEndpointPresets
+          .map((preset) => preset.url)
+          .map((url) => normalizeRpcEndpointUrl(url, allowDefaultPort: true))
+          .toSet();
+
+      expect(urls, {
+        'https://testnet.zec.rocks:443',
+        'https://zcash.mysideoftheweb.com:19067',
+      });
+      expect(
+        findRpcEndpointPresetByUrl(
+          'zcash.mysideoftheweb.com:19067',
+          networkName: 'test',
+        )?.id,
+        'mysideoftheweb-testnet',
+      );
+    });
+
     test('matches normalized URLs within the requested network', () {
       final preset = findRpcEndpointPresetByUrl(
         'us.zec.stardust.rest',


### PR DESCRIPTION
## Summary
- Add the My Side of the Web testnet lightwalletd endpoint as a selectable community fallback preset.
- Cover the testnet preset list and lookup behavior in endpoint config tests.

## Validation
- `fvm flutter test test/core/config/rpc_endpoint_config_test.dart`