### PR TITLE
[codex] Use TAZ ticker for testnet builds

### DIFF
--- a/integration_test/regtest_import_sync_test.dart
+++ b/integration_test/regtest_import_sync_test.dart
@@ -15,6 +15,8 @@ const _mnemonic =
     'roast miracle ethics found child scare curve congress renew salute pig '
     'better used';
 const _password = 'Vizor123!';
+final _currencyTicker = kZcashDefaultCurrencyTicker;
+final _currencyTickerLower = _currencyTicker.toLowerCase();
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -80,9 +82,9 @@ void main() {
         () => _keyedTextEquals(
           tester,
           const ValueKey('home_shielded_balance_text'),
-          '1.25 zec',
+          '1.25 $_currencyTickerLower',
         ),
-        description: 'shielded balance to show 1.25 zec',
+        description: 'shielded balance to show 1.25 $_currencyTickerLower',
         timeout: const Duration(minutes: 4),
       );
       _log('shielded balance matched');
@@ -92,9 +94,9 @@ void main() {
         () => _keyedTextEquals(
           tester,
           const ValueKey('home_transparent_balance_text'),
-          'Transparent balance: 0.75 ZEC',
+          'Transparent balance: 0.75 $_currencyTicker',
         ),
-        description: 'transparent balance to show 0.75 ZEC',
+        description: 'transparent balance to show 0.75 $_currencyTicker',
         timeout: const Duration(minutes: 1),
       );
       _log('transparent balance matched');

--- a/integration_test/regtest_mempool_receive_history_test.dart
+++ b/integration_test/regtest_mempool_receive_history_test.dart
@@ -28,6 +28,7 @@ const _firstMnemonic =
     'better used';
 const _password = 'Vizor123!';
 final _receiveAmountZatoshi = BigInt.from(25_000_000);
+final _currencyTicker = kZcashDefaultCurrencyTicker;
 
 class _ExpiringFunding {
   const _ExpiringFunding({required this.txid, required this.expiryHeight});
@@ -88,7 +89,7 @@ void main() {
           tester,
           const ValueKey('home_activity_row_1'),
           title: 'Receiving',
-          amount: '+0.25 ZEC',
+          amount: '+0.25 $_currencyTicker',
           status: 'In progress',
           timeout: const Duration(minutes: 4),
         );
@@ -98,7 +99,7 @@ void main() {
           tester,
           const ValueKey('home_activity_row_1'),
           title: 'Received',
-          amount: '+0.25 ZEC',
+          amount: '+0.25 $_currencyTicker',
           status: 'Completed',
           timeout: const Duration(minutes: 4),
         );
@@ -106,7 +107,7 @@ void main() {
           tester,
           rowKeyPrefix: 'home_activity',
           title: 'Receiving',
-          amount: '+0.25 ZEC',
+          amount: '+0.25 $_currencyTicker',
           status: 'In progress',
         );
         await _openActivity(tester);
@@ -114,7 +115,7 @@ void main() {
           tester,
           const ValueKey('activity_screen_row_1'),
           title: 'Received',
-          amount: '+0.25 ZEC',
+          amount: '+0.25 $_currencyTicker',
           status: 'Completed',
           timeout: const Duration(minutes: 2),
         );
@@ -122,7 +123,7 @@ void main() {
           tester,
           rowKeyPrefix: 'activity_screen',
           title: 'Receiving',
-          amount: '+0.25 ZEC',
+          amount: '+0.25 $_currencyTicker',
           status: 'In progress',
         );
       },
@@ -167,7 +168,7 @@ void main() {
           tester,
           const ValueKey('home_activity_row_1'),
           title: 'Receiving',
-          amount: '+0.25 ZEC',
+          amount: '+0.25 $_currencyTicker',
           status: 'In progress',
           timeout: const Duration(minutes: 4),
         );
@@ -177,7 +178,7 @@ void main() {
           tester,
           const ValueKey('home_activity_row_1'),
           title: 'Receiving',
-          amount: '+0.25 ZEC',
+          amount: '+0.25 $_currencyTicker',
           status: 'In progress',
           timeout: const Duration(minutes: 1),
         );
@@ -187,7 +188,7 @@ void main() {
           tester,
           const ValueKey('home_activity_row_1'),
           title: 'Received',
-          amount: '+0.25 ZEC',
+          amount: '+0.25 $_currencyTicker',
           status: 'Completed',
           timeout: const Duration(minutes: 4),
         );
@@ -195,7 +196,7 @@ void main() {
           tester,
           rowKeyPrefix: 'home_activity',
           title: 'Receiving',
-          amount: '+0.25 ZEC',
+          amount: '+0.25 $_currencyTicker',
           status: 'In progress',
         );
       },
@@ -249,7 +250,7 @@ void main() {
           tester,
           const ValueKey('home_activity_row_1'),
           title: 'Receiving',
-          amount: '+0.25 ZEC',
+          amount: '+0.25 $_currencyTicker',
           status: 'In progress',
           timeout: const Duration(minutes: 4),
         );
@@ -272,7 +273,7 @@ void main() {
           tester,
           rowKeyPrefix: 'home_activity',
           title: 'Received',
-          amount: '0.25 ZEC',
+          amount: '0.25 $_currencyTicker',
           status: 'Failed',
           timeout: const Duration(minutes: 4),
         );
@@ -280,7 +281,7 @@ void main() {
           tester,
           rowKeyPrefix: 'home_activity',
           title: 'Receiving',
-          amount: '+0.25 ZEC',
+          amount: '+0.25 $_currencyTicker',
           status: 'In progress',
         );
 
@@ -289,7 +290,7 @@ void main() {
           tester,
           rowKeyPrefix: 'activity_screen',
           title: 'Received',
-          amount: '0.25 ZEC',
+          amount: '0.25 $_currencyTicker',
           status: 'Failed',
           timeout: const Duration(minutes: 2),
         );
@@ -297,7 +298,7 @@ void main() {
           tester,
           rowKeyPrefix: 'activity_screen',
           title: 'Receiving',
-          amount: '+0.25 ZEC',
+          amount: '+0.25 $_currencyTicker',
           status: 'In progress',
         );
       },
@@ -362,7 +363,9 @@ Future<String> _unifiedAddressForAccount(String accountUuid) async {
 }
 
 Future<String> _fundUnmined(String address, String amount) async {
-  _log('requesting external unmined funding of $amount ZEC to $address');
+  _log(
+    'requesting external unmined funding of $amount $_currencyTicker to $address',
+  );
   final response = await _postDriver('/fund-unmined', {
     'address': address,
     'amount': amount,
@@ -374,7 +377,7 @@ Future<String> _fundUnmined(String address, String amount) async {
 
 Future<String> _fundPreparedUnmined(String address, String amount) async {
   _log(
-    'requesting prepared external unmined funding of $amount ZEC to $address',
+    'requesting prepared external unmined funding of $amount $_currencyTicker to $address',
   );
   final response = await _postDriver('/fund-unmined-prepared', {
     'address': address,
@@ -390,7 +393,7 @@ Future<_ExpiringFunding> _fundExpiringUnmined(
   String amount,
 ) async {
   _log(
-    'requesting expiring external unmined funding of $amount ZEC to $address',
+    'requesting expiring external unmined funding of $amount $_currencyTicker to $address',
   );
   final response = await _postDriver('/fund-unmined-expiring', {
     'address': address,

--- a/integration_test/regtest_multi_account_send_test.dart
+++ b/integration_test/regtest_multi_account_send_test.dart
@@ -36,6 +36,8 @@ const _secondMnemonic =
     'range neck proof gauge east rifle swim tray twin venue fossil will '
     'version';
 const _password = 'Vizor123!';
+final _currencyTicker = kZcashDefaultCurrencyTicker;
+final _currencyTickerLower = _currencyTicker.toLowerCase();
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -59,8 +61,8 @@ void main() {
       await _importFirstWallet(tester);
       await _waitForBalance(
         tester,
-        shielded: '1.25 zec',
-        transparent: 'Transparent balance: 0.75 ZEC',
+        shielded: '1.25 $_currencyTickerLower',
+        transparent: 'Transparent balance: 0.75 $_currencyTicker',
       );
 
       await _openAddAccountFlow(tester);
@@ -75,7 +77,7 @@ void main() {
 
       await _openWallet(tester);
       await _switchAccount(tester, 0);
-      await _waitForBalance(tester, shielded: '1.25 zec');
+      await _waitForBalance(tester, shielded: '1.25 $_currencyTickerLower');
       await _waitForMempoolObserver();
 
       await _sendToAddress(tester, secondAddress, '0.25');
@@ -93,7 +95,7 @@ void main() {
         tester,
         const ValueKey('home_activity_row_1'),
         title: 'Receiving',
-        amount: '+0.25 ZEC',
+        amount: '+0.25 $_currencyTicker',
         status: 'In progress',
       );
       await _openActivity(tester);
@@ -101,7 +103,7 @@ void main() {
         tester,
         const ValueKey('activity_screen_row_1'),
         title: 'Receiving',
-        amount: '+0.25 ZEC',
+        amount: '+0.25 $_currencyTicker',
         status: 'In progress',
       );
 
@@ -110,21 +112,21 @@ void main() {
       await _openWallet(tester);
       await _waitForBalance(
         tester,
-        shielded: '0.25 zec',
+        shielded: '0.25 $_currencyTickerLower',
         timeout: const Duration(minutes: 4),
       );
       await _expectActivityRow(
         tester,
         const ValueKey('home_activity_row_1'),
         title: 'Received',
-        amount: '+0.25 ZEC',
+        amount: '+0.25 $_currencyTicker',
         status: 'Completed',
       );
       _expectNoActivityRow(
         tester,
         rowKeyPrefix: 'home_activity',
         title: 'Receiving',
-        amount: '+0.25 ZEC',
+        amount: '+0.25 $_currencyTicker',
         status: 'In progress',
       );
       await _openActivity(tester);
@@ -132,14 +134,14 @@ void main() {
         tester,
         const ValueKey('activity_screen_row_1'),
         title: 'Received',
-        amount: '+0.25 ZEC',
+        amount: '+0.25 $_currencyTicker',
         status: 'Completed',
       );
       _expectNoActivityRow(
         tester,
         rowKeyPrefix: 'activity_screen',
         title: 'Receiving',
-        amount: '+0.25 ZEC',
+        amount: '+0.25 $_currencyTicker',
         status: 'In progress',
       );
       _log('second account received shielded funds');
@@ -150,14 +152,14 @@ void main() {
         tester,
         const ValueKey('home_activity_row_1'),
         title: 'Sent',
-        amount: '-0.25 ZEC',
+        amount: '-0.25 $_currencyTicker',
         status: 'Completed',
       );
       _expectNoActivityRow(
         tester,
         rowKeyPrefix: 'home_activity',
         title: 'Sent',
-        amount: '-0.25 ZEC',
+        amount: '-0.25 $_currencyTicker',
         status: 'In progress',
       );
       await _openActivity(tester);
@@ -165,14 +167,14 @@ void main() {
         tester,
         const ValueKey('activity_screen_row_1'),
         title: 'Sent',
-        amount: '-0.25 ZEC',
+        amount: '-0.25 $_currencyTicker',
         status: 'Completed',
       );
       _expectNoActivityRow(
         tester,
         rowKeyPrefix: 'activity_screen',
         title: 'Sent',
-        amount: '-0.25 ZEC',
+        amount: '-0.25 $_currencyTicker',
         status: 'In progress',
       );
       _log('first account sent activity matched');
@@ -258,7 +260,7 @@ Future<void> _sendToAddress(
   String address,
   String amount,
 ) async {
-  _log('sending $amount ZEC to second account');
+  _log('sending $amount $_currencyTicker to second account');
   await _tapWidget(tester, const ValueKey('sidebar_send_button'));
   await _enterText(tester, const ValueKey('send_address_field'), address);
   await _enterText(tester, const ValueKey('send_amount_field'), amount);

--- a/lib/src/core/config/network_config.dart
+++ b/lib/src/core/config/network_config.dart
@@ -51,6 +51,12 @@ enum ZcashNetwork {
     regtest => 9067,
   };
 
+  String get currencyTicker => switch (this) {
+    mainnet => 'ZEC',
+    testnet => 'TAZ',
+    regtest => 'TAZ',
+  };
+
   String get lightwalletdUrl => switch (this) {
     regtest => 'http://$lightwalletdHost:$lightwalletdPort',
     _ => 'https://$lightwalletdHost:$lightwalletdPort',
@@ -72,6 +78,10 @@ const kZcashDefaultNetworkRaw = String.fromEnvironment(
 final String kZcashDefaultNetworkName = normalizeZcashNetworkName(
   kZcashDefaultNetworkRaw,
 );
+
+final String kZcashDefaultCurrencyTicker = zcashNetworkFromName(
+  kZcashDefaultNetworkName,
+).currencyTicker;
 
 String normalizeZcashNetworkName(String networkName) {
   return switch (networkName.trim()) {

--- a/lib/src/core/formatting/zec_amount.dart
+++ b/lib/src/core/formatting/zec_amount.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/services.dart';
 
+import '../config/network_config.dart';
+
 final BigInt zatoshiPerZec = BigInt.from(100000000);
 
 String _formatZecAmount(
@@ -50,19 +52,19 @@ BigInt? _parseZecAmount(String input) {
 
 bool _digitsOnly(String value) => RegExp(r'^\d*$').hasMatch(value);
 
-/// Formats a raw zatoshi value as ZEC text without appending a denomination.
+/// Formats a raw zatoshi value as decimal text without appending a denomination.
 String formatZecAmount(BigInt zatoshi, {int minFractionDigits = 0}) {
   return _formatZecAmount(zatoshi, minFractionDigits: minFractionDigits);
 }
 
-/// Parses user-entered ZEC text into raw zatoshi, returning null when invalid.
+/// Parses user-entered Zcash amount text into raw zatoshi.
 BigInt? parseZecAmount(String input) {
   return ZecAmount.tryParse(input)?.zatoshi;
 }
 
 enum ZecDenomStyle { none, lower, upper }
 
-/// Typed wrapper for amounts stored in zatoshi, with UI-oriented ZEC presets.
+/// Typed wrapper for amounts stored in zatoshi, with UI-oriented presets.
 class ZecAmount {
   const ZecAmount.fromZatoshi(this.zatoshi);
 
@@ -78,6 +80,7 @@ class ZecAmount {
     int minFractionDigits = 0,
     int maxFractionDigits = 8,
     ZecDenomStyle denomStyle = ZecDenomStyle.none,
+    String? denomination,
     bool signed = false,
   }) {
     return ZecAmountPretty._(
@@ -85,6 +88,7 @@ class ZecAmount {
       minFractionDigits: minFractionDigits,
       maxFractionDigits: maxFractionDigits,
       denomStyle: denomStyle,
+      denomination: denomination,
       signed: signed,
       trimTrailingZeros: true,
     );
@@ -92,20 +96,37 @@ class ZecAmount {
 
   ZecAmountPretty get balance => pretty(minFractionDigits: 2);
 
-  ZecAmountPretty get receipt =>
-      pretty(minFractionDigits: 2, denomStyle: ZecDenomStyle.lower);
+  ZecAmountPretty receiptPretty({String? denomination}) => pretty(
+    minFractionDigits: 2,
+    denomStyle: ZecDenomStyle.lower,
+    denomination: denomination,
+  );
 
-  ZecAmountPretty get fee => pretty(denomStyle: ZecDenomStyle.upper);
+  ZecAmountPretty get receipt => receiptPretty();
 
-  ZecAmountPretty get activity => _activity(signed: false);
+  ZecAmountPretty feePretty({String? denomination}) =>
+      pretty(denomStyle: ZecDenomStyle.upper, denomination: denomination);
 
-  ZecAmountPretty get signedActivity => _activity(signed: true);
+  ZecAmountPretty get fee => feePretty();
 
-  ZecAmountPretty _activity({required bool signed}) {
+  ZecAmountPretty activityPretty({String? denomination}) =>
+      _activity(signed: false, denomination: denomination);
+
+  ZecAmountPretty get activity => activityPretty();
+
+  ZecAmountPretty signedActivityPretty({String? denomination}) =>
+      _activity(signed: true, denomination: denomination);
+
+  ZecAmountPretty get signedActivity => signedActivityPretty();
+
+  ZecAmountPretty _activity({
+    required bool signed,
+    required String? denomination,
+  }) {
     final abs = zatoshi.abs();
     final whole = abs ~/ zatoshiPerZec;
     final fraction = abs % zatoshiPerZec;
-    // Activity rows show extra precision for non-zero values below 0.01 ZEC.
+    // Activity rows show extra precision for non-zero values below 0.01.
     final showFullFraction =
         whole == BigInt.zero &&
         fraction > BigInt.zero &&
@@ -116,24 +137,27 @@ class ZecAmount {
       minFractionDigits: showFullFraction ? 0 : 2,
       maxFractionDigits: showFullFraction ? 8 : 2,
       denomStyle: ZecDenomStyle.upper,
+      denomination: denomination,
       signed: signed,
       trimTrailingZeros: showFullFraction,
     );
   }
 }
 
-/// Immutable formatted ZEC amount; call [toString] for amount plus denom.
+/// Immutable formatted Zcash amount; call [toString] for amount plus denom.
 class ZecAmountPretty {
   const ZecAmountPretty._(
     this._zatoshi, {
     required int minFractionDigits,
     required int maxFractionDigits,
     required ZecDenomStyle denomStyle,
+    required String? denomination,
     required bool signed,
     required bool trimTrailingZeros,
   }) : _minFractionDigits = minFractionDigits,
        _maxFractionDigits = maxFractionDigits,
        _denomStyle = denomStyle,
+       _denomination = denomination,
        _signed = signed,
        _trimTrailingZeros = trimTrailingZeros;
 
@@ -141,6 +165,7 @@ class ZecAmountPretty {
   final int _minFractionDigits;
   final int _maxFractionDigits;
   final ZecDenomStyle _denomStyle;
+  final String? _denomination;
   final bool _signed;
   final bool _trimTrailingZeros;
 
@@ -156,10 +181,14 @@ class ZecAmountPretty {
   }
 
   String get denomText {
+    final value = _denomination?.trim();
+    final denomination = value == null || value.isEmpty
+        ? kZcashDefaultCurrencyTicker
+        : value;
     return switch (_denomStyle) {
       ZecDenomStyle.none => '',
-      ZecDenomStyle.lower => 'zec',
-      ZecDenomStyle.upper => 'ZEC',
+      ZecDenomStyle.lower => denomination.toLowerCase(),
+      ZecDenomStyle.upper => denomination.toUpperCase(),
     };
   }
 

--- a/lib/src/core/privacy/privacy_mask.dart
+++ b/lib/src/core/privacy/privacy_mask.dart
@@ -1,3 +1,5 @@
+import '../config/network_config.dart';
+
 const kDefaultPrivacyMaskLength = 6;
 
 String fixedPrivacyMask({int length = kDefaultPrivacyMaskLength}) {
@@ -18,12 +20,15 @@ String hideAmountIfPrivacyMode(
   String visibleText, {
   required bool privacyModeEnabled,
   int maskLength = kDefaultPrivacyMaskLength,
-  String denomination = 'ZEC',
+  String? denomination,
 }) {
+  final effectiveDenomination = denomination == null
+      ? kZcashDefaultCurrencyTicker
+      : denomination.trim();
   return hideIfPrivacyMode(
     visibleText,
     privacyModeEnabled: privacyModeEnabled,
     maskLength: maskLength,
-    suffix: denomination.isEmpty ? '' : ' $denomination',
+    suffix: effectiveDenomination.isEmpty ? '' : ' $effectiveDenomination',
   );
 }

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -8,6 +8,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../app_bootstrap.dart';
+import '../../../core/config/network_config.dart';
 import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_desktop_shell.dart';
@@ -595,10 +596,11 @@ class _HomeBalanceCardState extends State<_HomeBalanceCard> {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final currencyTickerLower = kZcashDefaultCurrencyTicker.toLowerCase();
     final displayedShieldedBalance = hideIfPrivacyMode(
-      '${widget.shieldedBalanceText} zec',
+      '${widget.shieldedBalanceText} $currencyTickerLower',
       privacyModeEnabled: widget.privacyModeEnabled,
-      suffix: ' zec',
+      suffix: ' $currencyTickerLower',
     );
     final isDark = AppTheme.of(context) == AppThemeData.dark;
     final targetStripHeight = widget.hasTransparentBalance
@@ -1013,7 +1015,7 @@ class _HomeTransparentBalanceStrip extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final displayedBalance = hideAmountIfPrivacyMode(
-      '$balanceText ZEC',
+      '$balanceText $kZcashDefaultCurrencyTicker',
       privacyModeEnabled: privacyModeEnabled,
     );
     final canHoverShieldBalance = canShieldBalance && !isShieldingBalance;

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -11,6 +11,7 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:pretty_qr_code/pretty_qr_code.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/config/network_config.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
 import '../../../core/layout/app_main_sidebar.dart';
@@ -455,7 +456,7 @@ class _ReceiveMainContent extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(
-                        'Receive ZEC',
+                        'Receive $kZcashDefaultCurrencyTicker',
                         style: AppTypography.displaySmall.copyWith(
                           color: colors.text.accent,
                         ),
@@ -1310,13 +1311,13 @@ class _ReceiveInfoDialog extends StatelessWidget {
                   'Each new address is a diversified address derived from the same key. They all receive to the same wallet.',
             ),
           ]
-        : const [
-            _InfoItemData(
+        : [
+            const _InfoItemData(
               iconName: AppIcons.unlock,
               text:
                   'All tx details - sender, receiver, and amount - are publicly visible on-chain.',
             ),
-            _InfoItemData(
+            const _InfoItemData(
               iconName: AppIcons.dragon,
               text:
                   'Commonly used by exchanges that require transparency or regulatory clarity. Also the default for compatibility across many wallets.',
@@ -1324,7 +1325,7 @@ class _ReceiveInfoDialog extends StatelessWidget {
             _InfoItemData(
               iconName: AppIcons.shieldAsset,
               text:
-                  'After receiving ZEC to your transparent address, Vizor will guide you to shield the balance. Otherwise, you won\'t be able to send it.',
+                  'After receiving $kZcashDefaultCurrencyTicker to your transparent address, Vizor will guide you to shield the balance. Otherwise, you won\'t be able to send it.',
             ),
           ];
 

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -102,7 +102,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
   }
 
   String _formatFee(BigInt zatoshi) {
-    return ZecAmount.fromZatoshi(zatoshi).pretty().amountText;
+    return ZecAmount.fromZatoshi(zatoshi).fee.toString();
   }
 
   List<TextSpan> _addressSpans(BuildContext context) {
@@ -402,7 +402,7 @@ class _SendReviewReceiptCard extends StatelessWidget {
             width: 320,
             height: 21,
             child: Text(
-              'Tx Fee: $feeText ZEC',
+              'Tx Fee: $feeText',
               style: AppTypography.bodyMediumStrong.copyWith(
                 color: colors.text.accent,
               ),

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/config/network_config.dart';
 import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_layout.dart';
@@ -1028,7 +1029,7 @@ class _SendTitle extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Text(
-      'Send ZEC',
+      'Send $kZcashDefaultCurrencyTicker',
       style: AppTypography.displaySmall.copyWith(
         color: context.colors.text.accent,
       ),

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -147,7 +147,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   }
 
   String _formatFee(BigInt zatoshi) {
-    return ZecAmount.fromZatoshi(zatoshi).pretty().amountText;
+    return ZecAmount.fromZatoshi(zatoshi).fee.toString();
   }
 
   String _formatDate(DateTime value) {
@@ -535,8 +535,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
                                     ? () => unawaited(_copyRecipientAddress())
                                     : null,
                               ),
-                              feeText:
-                                  '${_formatFee(widget.args.feeZatoshi)} ZEC',
+                              feeText: _formatFee(widget.args.feeZatoshi),
                               extraBlocks: [
                                 if (statusMessage != null)
                                   TransactionReceiptBlockData(

--- a/lib/src/features/settings/screens/settings_endpoint_screen.dart
+++ b/lib/src/features/settings/screens/settings_endpoint_screen.dart
@@ -759,7 +759,7 @@ class _CustomEndpointForm extends StatelessWidget {
                         text:
                             "The wallet will show the balance from the last "
                             "time it was successfully connected. It won't "
-                            'show any ZEC you recently received.',
+                            'show any $kZcashDefaultCurrencyTicker you recently received.',
                         style: TextStyle(color: colors.text.primary),
                       ),
                     ],

--- a/scripts/e2e/flutter-macos-regtest-import-sync.sh
+++ b/scripts/e2e/flutter-macos-regtest-import-sync.sh
@@ -43,10 +43,10 @@ addresses_json="$(cd rust && cargo run --quiet --example regtest_wallet_addresse
 unified_address="$(json_field "$addresses_json" unifiedAddress)"
 transparent_address="$(json_field "$addresses_json" transparentAddress)"
 
-echo "funding shielded address with ${SHIELDED_AMOUNT} ZEC"
+echo "funding shielded address with ${SHIELDED_AMOUNT} TAZ"
 scripts/regtest/fund-wallet.sh "$unified_address" "$SHIELDED_AMOUNT" "$CONFIRMING_BLOCKS" >/dev/null
 
-echo "funding transparent address with ${TRANSPARENT_AMOUNT} ZEC"
+echo "funding transparent address with ${TRANSPARENT_AMOUNT} TAZ"
 scripts/regtest/fund-wallet.sh "$transparent_address" "$TRANSPARENT_AMOUNT" "$CONFIRMING_BLOCKS" >/dev/null
 
 echo "running Flutter macOS integration test"

--- a/scripts/e2e/flutter-macos-regtest-multi-account-send.sh
+++ b/scripts/e2e/flutter-macos-regtest-multi-account-send.sh
@@ -44,10 +44,10 @@ addresses_json="$(cd rust && cargo run --quiet --example regtest_wallet_addresse
 unified_address="$(json_field "$addresses_json" unifiedAddress)"
 transparent_address="$(json_field "$addresses_json" transparentAddress)"
 
-echo "funding shielded address with ${SHIELDED_AMOUNT} ZEC"
+echo "funding shielded address with ${SHIELDED_AMOUNT} TAZ"
 scripts/regtest/fund-wallet.sh "$unified_address" "$SHIELDED_AMOUNT" "$CONFIRMING_BLOCKS" >/dev/null
 
-echo "funding transparent address with ${TRANSPARENT_AMOUNT} ZEC"
+echo "funding transparent address with ${TRANSPARENT_AMOUNT} TAZ"
 scripts/regtest/fund-wallet.sh "$transparent_address" "$TRANSPARENT_AMOUNT" "$CONFIRMING_BLOCKS" >/dev/null
 
 echo "running Flutter macOS multi-account send integration test"

--- a/test/activity_table_row_test.dart
+++ b/test/activity_table_row_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart' show MaterialApp;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/activity/activity_row_mapper.dart';
@@ -11,6 +12,8 @@ import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 void main() {
+  final ticker = kZcashDefaultCurrencyTicker;
+
   testWidgets('transaction rows are keyboard activatable but sync row is not', (
     tester,
   ) async {
@@ -90,13 +93,13 @@ void main() {
       ),
     );
 
-    expect(rows[0].amountText, '0.0001 ZEC');
-    expect(rows[1].amountText, '+1.23 ZEC');
-    expect(rows[2].amountText, '-1.00 ZEC');
-    expect(rows[3].amountText, '0.0001 ZEC');
-    expect(find.text('0.0001 ZEC'), findsNWidgets(2));
-    expect(find.text('+1.23 ZEC'), findsOneWidget);
-    expect(find.text('-1.00 ZEC'), findsOneWidget);
+    expect(rows[0].amountText, '0.0001 $ticker');
+    expect(rows[1].amountText, '+1.23 $ticker');
+    expect(rows[2].amountText, '-1.00 $ticker');
+    expect(rows[3].amountText, '0.0001 $ticker');
+    expect(find.text('0.0001 $ticker'), findsNWidgets(2));
+    expect(find.text('+1.23 $ticker'), findsOneWidget);
+    expect(find.text('-1.00 $ticker'), findsOneWidget);
   });
 
   testWidgets('pending inbound activity rows render as receiving', (
@@ -130,7 +133,7 @@ void main() {
     );
 
     expect(rows[1].title, 'Receiving');
-    expect(rows[1].amountText, '+1.23 ZEC');
+    expect(rows[1].amountText, '+1.23 $ticker');
     expect(rows[1].statusText, 'In progress');
     expect(rows[1].leadingIconName, AppIcons.arrowDownCircle);
     expect(find.text('Receiving'), findsOneWidget);
@@ -177,13 +180,13 @@ void main() {
       ),
     );
 
-    expect(rows[0].amountText, '*** ZEC');
-    expect(rows[1].amountText, '*** ZEC');
-    expect(rows[2].amountText, '*** ZEC');
-    expect(rows[3].amountText, '*** ZEC');
-    expect(find.text('*** ZEC'), findsNWidgets(4));
-    expect(find.text('+1.23 ZEC'), findsNothing);
-    expect(find.text('-1.00 ZEC'), findsNothing);
+    expect(rows[0].amountText, '*** $ticker');
+    expect(rows[1].amountText, '*** $ticker');
+    expect(rows[2].amountText, '*** $ticker');
+    expect(rows[3].amountText, '*** $ticker');
+    expect(find.text('*** $ticker'), findsNWidgets(4));
+    expect(find.text('+1.23 $ticker'), findsNothing);
+    expect(find.text('-1.00 $ticker'), findsNothing);
   });
 
   testWidgets('shielded activity rows use the shield keyhole outline icon', (
@@ -230,7 +233,7 @@ void main() {
       ),
     );
 
-    for (final value in ['1.00 ZEC', 'Completed', 'Today, 13:11']) {
+    for (final value in ['1.00 $ticker', 'Completed', 'Today, 13:11']) {
       final text = tester.widget<Text>(find.text(value));
       expect(text.style?.fontFamily, AppTypography.labelLarge.fontFamily);
       expect(text.style?.fontWeight, AppTypography.labelLarge.fontWeight);
@@ -274,7 +277,7 @@ ActivityRowData _row({
     leadingBackgroundColor: const Color(0xFFE1E1E1),
     leadingIconColor: const Color(0xFF4D5252),
     subtitle: subtitle,
-    amountText: '1.00 ZEC',
+    amountText: '1.00 $kZcashDefaultCurrencyTicker',
     statusText: 'Completed',
     timestampText: 'Today, 13:11',
     onTap: onTap,

--- a/test/core/config/network_config_test.dart
+++ b/test/core/config/network_config_test.dart
@@ -29,6 +29,21 @@ void main() {
     });
   });
 
+  group('currencyTicker', () {
+    test('uses ZEC for mainnet and TAZ for test networks', () {
+      expect(ZcashNetwork.mainnet.currencyTicker, 'ZEC');
+      expect(ZcashNetwork.testnet.currencyTicker, 'TAZ');
+      expect(ZcashNetwork.regtest.currencyTicker, 'TAZ');
+    });
+
+    test('derives the default ticker from the build-time default network', () {
+      expect(
+        kZcashDefaultCurrencyTicker,
+        zcashNetworkFromName(kZcashDefaultNetworkName).currencyTicker,
+      );
+    });
+  });
+
   group('secureStoreServiceForNetwork', () {
     test('keeps the existing mainnet service name', () {
       expect(

--- a/test/core/privacy/privacy_mask_test.dart
+++ b/test/core/privacy/privacy_mask_test.dart
@@ -1,18 +1,22 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
 import 'package:zcash_wallet/src/core/privacy/privacy_mask.dart';
 
 void main() {
   test('privacy mask does not depend on source text length', () {
     expect(
-      hideAmountIfPrivacyMode('0.01 ZEC', privacyModeEnabled: true),
-      '****** ZEC',
+      hideAmountIfPrivacyMode(
+        '0.01 $kZcashDefaultCurrencyTicker',
+        privacyModeEnabled: true,
+      ),
+      '****** $kZcashDefaultCurrencyTicker',
     );
     expect(
       hideAmountIfPrivacyMode(
-        '123456789.12345678 ZEC',
+        '123456789.12345678 $kZcashDefaultCurrencyTicker',
         privacyModeEnabled: true,
       ),
-      '****** ZEC',
+      '****** $kZcashDefaultCurrencyTicker',
     );
   });
 
@@ -34,10 +38,10 @@ void main() {
   test('privacy helper preserves visible text when disabled', () {
     expect(
       hideAmountIfPrivacyMode(
-        '123456789.12345678 ZEC',
+        '123456789.12345678 $kZcashDefaultCurrencyTicker',
         privacyModeEnabled: false,
       ),
-      '123456789.12345678 ZEC',
+      '123456789.12345678 $kZcashDefaultCurrencyTicker',
     );
   });
 }

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
@@ -10,6 +11,8 @@ import 'package:zcash_wallet/src/features/send/screens/send_review_screen.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
 void main() {
+  final tickerLower = kZcashDefaultCurrencyTicker.toLowerCase();
+
   setUpAll(() {
     RustLib.initMock(api: _RustApiFake());
   });
@@ -32,7 +35,7 @@ void main() {
 
     expect(buttonTop - receiptTop, moreOrLessEquals(420));
 
-    final amountText = tester.widget<Text>(find.text('15.12 zec'));
+    final amountText = tester.widget<Text>(find.text('15.12 $tickerLower'));
     expect(amountText.style?.fontFamily, AppTypography.displayLarge.fontFamily);
     expect(amountText.style?.fontSize, AppTypography.displayLarge.fontSize);
     expect(amountText.style?.height, AppTypography.displayLarge.height);

--- a/test/zec_amount_test.dart
+++ b/test/zec_amount_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
 import 'package:zcash_wallet/src/core/formatting/zec_amount.dart';
 
 void main() {
@@ -39,13 +40,15 @@ void main() {
 
   group('ZecAmountPretty', () {
     test('formats balance and receipt presets with existing precision', () {
+      final defaultTickerLower = kZcashDefaultCurrencyTicker.toLowerCase();
+
       expect(
         ZecAmount.fromZatoshi(BigInt.from(100000000)).balance.amountText,
         '1.00',
       );
       expect(
         ZecAmount.fromZatoshi(BigInt.from(100000000)).receipt.toString(),
-        '1.00 zec',
+        '1.00 $defaultTickerLower',
       );
       expect(
         ZecAmount.fromZatoshi(BigInt.one).balance.amountText,
@@ -56,36 +59,53 @@ void main() {
     test('formats fee preset with upper-case denom', () {
       expect(
         ZecAmount.fromZatoshi(BigInt.from(10000)).fee.toString(),
-        '0.0001 ZEC',
+        '0.0001 $kZcashDefaultCurrencyTicker',
       );
     });
 
     test('preserves existing activity precision rules', () {
       expect(
         ZecAmount.fromZatoshi(BigInt.from(123450000)).activity.toString(),
-        '1.23 ZEC',
+        '1.23 $kZcashDefaultCurrencyTicker',
       );
       expect(
         ZecAmount.fromZatoshi(BigInt.from(10000)).activity.toString(),
-        '0.0001 ZEC',
+        '0.0001 $kZcashDefaultCurrencyTicker',
       );
       expect(
         ZecAmount.fromZatoshi(BigInt.zero).activity.toString(),
-        '0.00 ZEC',
+        '0.00 $kZcashDefaultCurrencyTicker',
       );
       expect(
         ZecAmount.fromZatoshi(-BigInt.from(100000000)).activity.toString(),
-        '1.00 ZEC',
+        '1.00 $kZcashDefaultCurrencyTicker',
       );
       expect(
         ZecAmount.fromZatoshi(
           -BigInt.from(100000000),
         ).signedActivity.toString(),
-        '-1.00 ZEC',
+        '-1.00 $kZcashDefaultCurrencyTicker',
       );
       expect(
         ZecAmount.fromZatoshi(BigInt.zero).signedActivity.toString(),
-        '0.00 ZEC',
+        '0.00 $kZcashDefaultCurrencyTicker',
+      );
+    });
+
+    test('can render testnet amounts with TAZ denomination', () {
+      final ticker = ZcashNetwork.testnet.currencyTicker;
+
+      expect(
+        ZecAmount.fromZatoshi(
+          BigInt.from(100000000),
+        ).receiptPretty(denomination: ticker).toString(),
+        '1.00 taz',
+      );
+      expect(
+        ZecAmount.fromZatoshi(
+          BigInt.from(10000),
+        ).feePretty(denomination: ticker).toString(),
+        '0.0001 TAZ',
       );
     });
   });


### PR DESCRIPTION
## Summary
- Add network-specific currency tickers so testnet and regtest builds display TAZ while mainnet keeps ZEC.
- Route amount formatting and privacy masks through the build-time default ticker when no explicit denomination is provided.
- Update app UI and regtest E2E expectations for TAZ while leaving onboarding explanatory copy on mainnet ZEC language.

## Validation
- `fvm flutter test`
- `fvm flutter analyze`
- `fvm flutter test --dart-define=ZCASH_DEFAULT_NETWORK=test test/zec_amount_test.dart test/core/config/network_config_test.dart test/core/privacy/privacy_mask_test.dart test/features/send/send_review_screen_test.dart`
- `scripts/e2e/flutter-macos-regtest-full.sh`
