### PR TITLE
[codex] Add endpoint fallback handling

### DIFF
--- a/integration_test/regtest_custom_endpoint_no_fallback_test.dart
+++ b/integration_test/regtest_custom_endpoint_no_fallback_test.dart
@@ -17,6 +17,11 @@ const _mnemonic =
 const _password = 'Vizor123!';
 const _fallbackToast =
     'Selected endpoint is unstable. Switched to fallback endpoint.';
+const _networkFailure =
+    "Network connection lost. We'll keep trying automatically.";
+const _endpointFailure =
+    'Cannot reach the configured Zcash endpoint. Check your endpoint settings.';
+const _genericFailure = 'Sync failed. Retry sync to continue.';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -26,16 +31,16 @@ void main() {
   });
 
   testWidgets(
-    'falls back from an unavailable primary endpoint during sync',
+    'does not fallback from an unavailable custom endpoint',
     (tester) async {
       addTearDown(() async {
         await _cleanupE2eWalletState();
       });
 
       await _cleanupE2eWalletState();
-      await _configureUnavailablePresetPrimary();
+      await _configureUnavailableCustomPrimary();
 
-      _log('pumping app with intentionally unavailable primary endpoint');
+      _log('pumping app with intentionally unavailable custom endpoint');
       await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
 
       _log('opening import flow');
@@ -67,35 +72,26 @@ void main() {
 
       await _pumpUntil(
         tester,
-        () => tester.any(find.text(_fallbackToast)),
-        description: 'fallback endpoint toast',
+        () =>
+            tester.any(find.text(_networkFailure)) ||
+            tester.any(find.text(_endpointFailure)) ||
+            tester.any(find.text(_genericFailure)),
+        description: 'sync failure notice without fallback',
         timeout: const Duration(seconds: 60),
       );
-      _log('fallback toast appeared');
 
-      await _pumpUntil(
-        tester,
-        () => _keyedTextEquals(
-          tester,
-          const ValueKey('home_shielded_balance_text'),
-          '1.25 zec',
-        ),
-        description: 'shielded balance to sync through fallback',
-        timeout: const Duration(minutes: 4),
-      );
-      _log('shielded balance synced through fallback');
+      await tester.pump(const Duration(seconds: 2));
+      expect(tester.any(find.text(_fallbackToast)), isFalse);
+      _log('custom endpoint failed without fallback toast');
     },
-    timeout: const Timeout(Duration(minutes: 6)),
+    timeout: const Timeout(Duration(minutes: 3)),
   );
 }
 
-Future<void> _configureUnavailablePresetPrimary() async {
+Future<void> _configureUnavailableCustomPrimary() async {
   final storage = AppSecureStore.instance;
   await storage.writePlain(kRpcEndpointUrlKey, 'http://127.0.0.1:19067');
-  await storage.writePlain(
-    kRpcEndpointPresetKey,
-    kRegtestUnavailableRpcEndpointPresetId,
-  );
+  await storage.writePlain(kRpcEndpointPresetKey, kCustomRpcEndpointPresetId);
 }
 
 Future<void> _cleanupE2eWalletState() async {
@@ -172,13 +168,6 @@ Future<void> _enterText(WidgetTester tester, Key key, String text) async {
   _log('entered text into $key');
 }
 
-bool _keyedTextEquals(WidgetTester tester, Key key, String expected) {
-  final finder = find.byKey(key);
-  if (!tester.any(finder)) return false;
-  final widget = tester.widget<Text>(finder);
-  return widget.data == expected;
-}
-
 Future<void> _pumpUntil(
   WidgetTester tester,
   bool Function() condition, {
@@ -207,5 +196,5 @@ Future<void> _pumpUntil(
 }
 
 void _log(String message) {
-  debugPrint('[fallback-e2e] $message');
+  debugPrint('[custom-no-fallback-e2e] $message');
 }

--- a/integration_test/regtest_fallback_endpoint_test.dart
+++ b/integration_test/regtest_fallback_endpoint_test.dart
@@ -1,0 +1,201 @@
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+const _mnemonic =
+    'winter shiver fetch refuse absurd mail pistol eight market lounge manual '
+    'roast miracle ethics found child scare curve congress renew salute pig '
+    'better used';
+const _password = 'Vizor123!';
+const _fallbackToast =
+    'Selected endpoint is unstable. Switched to fallback endpoint.';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeZcashWalletRuntime();
+  });
+
+  testWidgets(
+    'falls back from an unavailable primary endpoint during sync',
+    (tester) async {
+      addTearDown(() async {
+        await _cleanupE2eWalletState();
+      });
+
+      await _cleanupE2eWalletState();
+
+      _log('pumping app with intentionally unavailable primary endpoint');
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+
+      _log('opening import flow');
+      await _tapButton(tester, const ValueKey('welcome_import_wallet_button'));
+
+      _log('entering mnemonic');
+      await _enterText(
+        tester,
+        const ValueKey('import_mnemonic_first_word_field'),
+        _mnemonic,
+      );
+      await _tapButton(tester, const ValueKey('import_secret_submit_button'));
+
+      _log('skipping birthday');
+      await _tapButton(tester, const ValueKey('import_birthday_skip_button'));
+
+      _log('setting password');
+      await _enterText(
+        tester,
+        const ValueKey('set_password_password_field'),
+        _password,
+      );
+      await _enterText(
+        tester,
+        const ValueKey('set_password_confirm_field'),
+        _password,
+      );
+      await _tapButton(tester, const ValueKey('set_password_submit_button'));
+
+      await _pumpUntil(
+        tester,
+        () => tester.any(find.text(_fallbackToast)),
+        description: 'fallback endpoint toast',
+        timeout: const Duration(seconds: 60),
+      );
+      _log('fallback toast appeared');
+
+      await _pumpUntil(
+        tester,
+        () => _keyedTextEquals(
+          tester,
+          const ValueKey('home_shielded_balance_text'),
+          '1.25 zec',
+        ),
+        description: 'shielded balance to sync through fallback',
+        timeout: const Duration(minutes: 4),
+      );
+      _log('shielded balance synced through fallback');
+    },
+    timeout: const Timeout(Duration(minutes: 6)),
+  );
+}
+
+Future<void> _cleanupE2eWalletState() async {
+  if (kZcashDefaultNetworkName != ZcashNetwork.regtest.name) {
+    throw StateError(
+      'Refusing to clean wallet state without ZCASH_DEFAULT_NETWORK=regtest.',
+    );
+  }
+
+  final storage = AppSecureStore.instance;
+  final dbName = await getWalletDbName();
+
+  _log('cleaning regtest wallet state');
+  await _stopRustWorkForCleanup();
+
+  await storage.deleteAll();
+
+  final supportDir = await getWalletSupportDirectory();
+  if (!supportDir.existsSync()) return;
+
+  for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
+    final file = File('${supportDir.path}${Platform.pathSeparator}$name');
+    if (file.existsSync()) file.deleteSync();
+  }
+}
+
+Future<void> _stopRustWorkForCleanup() async {
+  rust_sync.setSyncMode(mode: 0);
+  rust_sync.cancelFullSync();
+  rust_sync.stopMempoolObserver();
+
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  while ((rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) &&
+      DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  if (rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) {
+    _log(
+      'timed out waiting for Rust work to stop; continuing E2E storage cleanup',
+    );
+  }
+}
+
+Future<void> _tapButton(WidgetTester tester, Key key) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () =>
+        tester.any(finder) &&
+        tester.widget<AppButton>(finder).onPressed != null,
+    description: '$key button to be enabled',
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _enterText(WidgetTester tester, Key key, String text) async {
+  final editable = find.descendant(
+    of: find.byKey(key),
+    matching: find.byType(EditableText),
+  );
+  await _pumpUntil(
+    tester,
+    () => tester.any(editable),
+    description: '$key editable text field',
+  );
+  await tester.tap(editable);
+  await tester.enterText(editable, text);
+  await tester.pump(const Duration(milliseconds: 100));
+  _log('entered text into $key');
+}
+
+bool _keyedTextEquals(WidgetTester tester, Key key, String expected) {
+  final finder = find.byKey(key);
+  if (!tester.any(finder)) return false;
+  final widget = tester.widget<Text>(finder);
+  return widget.data == expected;
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  required String description,
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final end = DateTime.now().add(timeout);
+  Object? lastError;
+  var polls = 0;
+  while (DateTime.now().isBefore(end)) {
+    try {
+      if (condition()) return;
+    } catch (e) {
+      lastError = e;
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    polls++;
+    if (polls % 25 == 0) {
+      _log('still waiting for $description');
+    }
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail('Timed out waiting for $description.$error');
+}
+
+void _log(String message) {
+  debugPrint('[fallback-e2e] $message');
+}

--- a/integration_test/regtest_multi_account_send_test.dart
+++ b/integration_test/regtest_multi_account_send_test.dart
@@ -10,6 +10,7 @@ import 'package:zcash_wallet/src/core/config/network_config.dart';
 import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
 
@@ -27,6 +28,7 @@ const _zcashdRpcUrl = String.fromEnvironment(
 );
 const _zcashdRpcUser = 'zcash';
 const _zcashdRpcPassword = 'zcash';
+const _accountsKey = 'zcash_accounts';
 const _firstMnemonic =
     'winter shiver fetch refuse absurd mail pistol eight market lounge manual '
     'roast miracle ethics found child scare curve congress renew salute pig '
@@ -387,11 +389,25 @@ Future<void> _waitForMempoolObserver() async {
 }
 
 Future<String> _accountUuidAtOrder(int order) async {
-  final dbPath = await getWalletDbPath();
-  final accounts = await rust_wallet.listAccounts(
-    dbPath: dbPath,
-    network: _network,
-  );
+  final rawAccounts = await AppSecureStore.instance.readString(_accountsKey);
+  if (rawAccounts == null || rawAccounts.trim().isEmpty) {
+    fail('Expected stored accounts before reading account order $order.');
+  }
+
+  final decoded = jsonDecode(rawAccounts);
+  if (decoded is! List) {
+    fail('Expected stored accounts to be a JSON list.');
+  }
+
+  final accounts = <AccountInfo>[];
+  for (final entry in decoded) {
+    if (entry is! Map) {
+      fail('Expected stored account entry to be a JSON object.');
+    }
+    accounts.add(AccountInfo.fromJson(Map<String, dynamic>.from(entry)));
+  }
+  accounts.sort((a, b) => a.order.compareTo(b.order));
+
   if (order >= accounts.length) {
     fail('Expected account order $order, got ${accounts.length} accounts.');
   }

--- a/integration_test/regtest_slow_height_fallback_test.dart
+++ b/integration_test/regtest_slow_height_fallback_test.dart
@@ -1,0 +1,597 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:fixnum/fixnum.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:grpc/grpc.dart' as grpc;
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/generated/compact_formats.pb.dart' as compact;
+import 'package:zcash_wallet/src/generated/service.pb.dart' as service;
+import 'package:zcash_wallet/src/generated/service.pbgrpc.dart' as service_grpc;
+import 'package:zcash_wallet/src/providers/rpc_endpoint_failover_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
+
+const _mnemonic =
+    'winter shiver fetch refuse absurd mail pistol eight market lounge manual '
+    'roast miracle ethics found child scare curve congress renew salute pig '
+    'better used';
+const _password = 'Vizor123!';
+const _primaryProxyUrl = 'http://127.0.0.1:19068';
+const _realLightwalletdUrl = 'http://127.0.0.1:9067';
+const _driverUrl = String.fromEnvironment('ZCASH_E2E_DRIVER_URL');
+const _unifiedAddress = String.fromEnvironment('ZCASH_E2E_UNIFIED_ADDRESS');
+const _faucetZaddr = String.fromEnvironment('ZCASH_E2E_FAUCET_ZADDR');
+const _fallbackToast =
+    'Selected endpoint is unstable. Switched to fallback endpoint.';
+const _primaryToast = 'Selected endpoint recovered. Switched back.';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeZcashWalletRuntime();
+  });
+
+  testWidgets(
+    'falls back on slow height, returns to primary, then falls back when down',
+    (tester) async {
+      if (_unifiedAddress.isEmpty || _faucetZaddr.isEmpty) {
+        fail(
+          'ZCASH_E2E_UNIFIED_ADDRESS and ZCASH_E2E_FAUCET_ZADDR are required.',
+        );
+      }
+      if (_driverUrl.isEmpty) {
+        fail('ZCASH_E2E_DRIVER_URL is required.');
+      }
+
+      addTearDown(() async {
+        await _cleanupE2eWalletState();
+      });
+
+      await _cleanupE2eWalletState();
+      final proxy = _RegtestLightwalletdProxy();
+      await proxy.start();
+      addTearDown(proxy.stop);
+      await _configureSlowPresetPrimary();
+
+      _log('pumping app with slow regtest primary proxy');
+      await tester.pumpWidget(
+        await buildBootstrappedZcashWalletApp(
+          overrides: [
+            rpcEndpointFailoverSettingsProvider.overrideWithValue(
+              const RpcEndpointFailoverSettings(
+                primaryProbeInterval: Duration(seconds: 3),
+                slowHeightWindow: Duration(seconds: 3),
+                minHeightIncreaseInSlowWindow: 2,
+                slowFallbackLeadBlocks: 2,
+              ),
+            ),
+          ],
+        ),
+      );
+
+      await _importWallet(tester);
+      await _waitForBalance(tester, {'1.25 zec'}, 'initial primary sync');
+
+      final baselineHeight = await rust_wallet.getLatestBlockHeight(
+        lightwalletdUrl: _realLightwalletdUrl,
+      );
+      proxy.setSlowHeight(baselineHeight.toInt() + 1);
+      await _pumpFor(tester, const Duration(seconds: 4));
+
+      _log('funding while primary reports slow height');
+      await _fundWallet('0.50');
+      await _pumpUntil(
+        tester,
+        () => tester.any(find.text(_fallbackToast)),
+        description: 'slow-height fallback toast',
+        timeout: const Duration(minutes: 2),
+      );
+      await _waitForBalance(tester, {'1.75 zec'}, 'sync through fallback');
+
+      _log('recovering primary proxy');
+      proxy.setHealthy();
+      await _pumpUntil(
+        tester,
+        () => tester.any(find.text(_primaryToast)),
+        description: 'primary recovery toast',
+        timeout: const Duration(minutes: 2),
+      );
+      await _pumpFor(tester, const Duration(seconds: 5));
+
+      _log('funding after primary recovery');
+      await _fundWallet('0.25');
+      await _waitForBalance(tester, {
+        '2 zec',
+        '2.00 zec',
+      }, 'sync through recovered primary');
+
+      _log('making primary proxy unavailable');
+      proxy.setDown();
+      await _fundWallet('0.25');
+      await _pumpUntil(
+        tester,
+        () => tester.any(find.text(_fallbackToast)),
+        description: 'fallback toast after primary down',
+        timeout: const Duration(minutes: 2),
+      );
+      await _waitForBalance(tester, {
+        '2.25 zec',
+      }, 'sync through fallback after primary down');
+    },
+    timeout: const Timeout(Duration(minutes: 12)),
+  );
+}
+
+Future<void> _importWallet(WidgetTester tester) async {
+  _log('opening import flow');
+  await _tapButton(tester, const ValueKey('welcome_import_wallet_button'));
+
+  _log('entering mnemonic');
+  await _enterText(
+    tester,
+    const ValueKey('import_mnemonic_first_word_field'),
+    _mnemonic,
+  );
+  await _tapButton(tester, const ValueKey('import_secret_submit_button'));
+
+  _log('skipping birthday');
+  await _tapButton(tester, const ValueKey('import_birthday_skip_button'));
+
+  _log('setting password');
+  await _enterText(
+    tester,
+    const ValueKey('set_password_password_field'),
+    _password,
+  );
+  await _enterText(
+    tester,
+    const ValueKey('set_password_confirm_field'),
+    _password,
+  );
+  await _tapButton(tester, const ValueKey('set_password_submit_button'));
+}
+
+Future<void> _configureSlowPresetPrimary() async {
+  final storage = AppSecureStore.instance;
+  await storage.writePlain(kRpcEndpointUrlKey, _primaryProxyUrl);
+  await storage.writePlain(
+    kRpcEndpointPresetKey,
+    kRegtestSlowRpcEndpointPresetId,
+  );
+}
+
+Future<void> _fundWallet(String amountZec) async {
+  _log('funding $_unifiedAddress with $amountZec ZEC');
+  await _postDriver('/fund-unmined-prepared', {
+    'address': _unifiedAddress,
+    'amount': amountZec,
+  });
+  await _postDriver('/mine', {'blocks': 3});
+}
+
+Future<Map<String, dynamic>> _postDriver(
+  String path,
+  Map<String, Object> payload,
+) async {
+  final client = HttpClient();
+  try {
+    final bodyBytes = utf8.encode(jsonEncode(payload));
+    final request = await client.postUrl(Uri.parse('$_driverUrl$path'));
+    request.headers.contentType = ContentType.json;
+    request.contentLength = bodyBytes.length;
+    request.add(bodyBytes);
+    final response = await request.close();
+    final body = await utf8.decodeStream(response);
+    final decoded = jsonDecode(body) as Map<String, dynamic>;
+    if (response.statusCode != HttpStatus.ok) {
+      fail(
+        'E2E driver $path failed with status ${response.statusCode}: '
+        '${decoded['error'] ?? body}',
+      );
+    }
+    return decoded;
+  } finally {
+    client.close(force: true);
+  }
+}
+
+Future<void> _cleanupE2eWalletState() async {
+  if (kZcashDefaultNetworkName != ZcashNetwork.regtest.name) {
+    throw StateError(
+      'Refusing to clean wallet state without ZCASH_DEFAULT_NETWORK=regtest.',
+    );
+  }
+
+  final storage = AppSecureStore.instance;
+  final dbName = await getWalletDbName();
+
+  _log('cleaning regtest wallet state');
+  await _stopRustWorkForCleanup();
+
+  await storage.deleteAll();
+
+  final supportDir = await getWalletSupportDirectory();
+  if (!supportDir.existsSync()) return;
+
+  for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
+    final file = File('${supportDir.path}${Platform.pathSeparator}$name');
+    if (file.existsSync()) file.deleteSync();
+  }
+}
+
+Future<void> _stopRustWorkForCleanup() async {
+  rust_sync.setSyncMode(mode: 0);
+  rust_sync.cancelFullSync();
+  rust_sync.stopMempoolObserver();
+
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  while ((rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) &&
+      DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  if (rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) {
+    _log(
+      'timed out waiting for Rust work to stop; continuing E2E storage cleanup',
+    );
+  }
+}
+
+Future<void> _tapButton(WidgetTester tester, Key key) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () =>
+        tester.any(finder) &&
+        tester.widget<AppButton>(finder).onPressed != null,
+    description: '$key button to be enabled',
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _enterText(WidgetTester tester, Key key, String text) async {
+  final editable = find.descendant(
+    of: find.byKey(key),
+    matching: find.byType(EditableText),
+  );
+  await _pumpUntil(
+    tester,
+    () => tester.any(editable),
+    description: '$key editable text field',
+  );
+  await tester.tap(editable);
+  await tester.enterText(editable, text);
+  await tester.pump(const Duration(milliseconds: 100));
+  _log('entered text into $key');
+}
+
+Future<void> _waitForBalance(
+  WidgetTester tester,
+  Set<String> expected,
+  String description,
+) {
+  return _pumpUntil(
+    tester,
+    () => _keyedTextIn(
+      tester,
+      const ValueKey('home_shielded_balance_text'),
+      expected,
+    ),
+    description: description,
+    timeout: const Duration(minutes: 4),
+  );
+}
+
+bool _keyedTextIn(WidgetTester tester, Key key, Set<String> expected) {
+  final finder = find.byKey(key);
+  if (!tester.any(finder)) return false;
+  final widget = tester.widget<Text>(finder);
+  return expected.contains(widget.data);
+}
+
+Future<void> _pumpFor(WidgetTester tester, Duration duration) async {
+  final end = DateTime.now().add(duration);
+  while (DateTime.now().isBefore(end)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  required String description,
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final end = DateTime.now().add(timeout);
+  Object? lastError;
+  var polls = 0;
+  while (DateTime.now().isBefore(end)) {
+    try {
+      if (condition()) return;
+    } catch (e) {
+      lastError = e;
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    polls++;
+    if (polls % 25 == 0) {
+      _log('still waiting for $description');
+    }
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail('Timed out waiting for $description.$error');
+}
+
+void _log(String message) {
+  debugPrint('[slow-height-fallback-e2e] $message');
+}
+
+enum _ProxyMode { healthy, slowHeight, down }
+
+class _RegtestLightwalletdProxy
+    extends service_grpc.CompactTxStreamerServiceBase {
+  _RegtestLightwalletdProxy()
+    : _channel = grpc.ClientChannel(
+        '127.0.0.1',
+        port: 9067,
+        options: const grpc.ChannelOptions(
+          credentials: grpc.ChannelCredentials.insecure(),
+        ),
+      ) {
+    _client = service_grpc.CompactTxStreamerClient(_channel);
+  }
+
+  final grpc.ClientChannel _channel;
+  late final service_grpc.CompactTxStreamerClient _client;
+  grpc.Server? _server;
+  _ProxyMode _mode = _ProxyMode.healthy;
+  int? _slowHeight;
+
+  Future<void> start() async {
+    _server = grpc.Server.create(services: [this]);
+    await _server!.serve(address: InternetAddress.loopbackIPv4, port: 19068);
+    _log('primary proxy listening on $_primaryProxyUrl');
+  }
+
+  Future<void> stop() async {
+    await _server?.shutdown();
+    await _channel.shutdown();
+  }
+
+  void setHealthy() {
+    _mode = _ProxyMode.healthy;
+    _slowHeight = null;
+    _log('primary proxy mode=healthy');
+  }
+
+  void setSlowHeight(int height) {
+    _mode = _ProxyMode.slowHeight;
+    _slowHeight = height;
+    _log('primary proxy mode=slowHeight height=$height');
+  }
+
+  void setDown() {
+    _mode = _ProxyMode.down;
+    _log('primary proxy mode=down');
+  }
+
+  void _throwIfDown() {
+    if (_mode == _ProxyMode.down) {
+      throw grpc.GrpcError.unavailable('regtest primary proxy is down');
+    }
+  }
+
+  service.BlockID _withModeHeight(service.BlockID block) {
+    final slowHeight = _slowHeight;
+    if (_mode != _ProxyMode.slowHeight || slowHeight == null) return block;
+    if (block.height.toInt() <= slowHeight) return block;
+    final copy = block.deepCopy();
+    copy.height = Int64(slowHeight);
+    return copy;
+  }
+
+  service.LightdInfo _withModeInfoHeight(service.LightdInfo info) {
+    final slowHeight = _slowHeight;
+    if (_mode != _ProxyMode.slowHeight || slowHeight == null) return info;
+    final copy = info.deepCopy();
+    final height = Int64(slowHeight);
+    if (copy.blockHeight > height) copy.blockHeight = height;
+    if (copy.estimatedHeight > height) copy.estimatedHeight = height;
+    return copy;
+  }
+
+  @override
+  Future<service.BlockID> getLatestBlock(
+    grpc.ServiceCall call,
+    service.ChainSpec request,
+  ) async {
+    _throwIfDown();
+    return _withModeHeight(await _client.getLatestBlock(request));
+  }
+
+  @override
+  Future<compact.CompactBlock> getBlock(
+    grpc.ServiceCall call,
+    service.BlockID request,
+  ) {
+    _throwIfDown();
+    return _client.getBlock(request);
+  }
+
+  @override
+  Future<compact.CompactBlock> getBlockNullifiers(
+    grpc.ServiceCall call,
+    service.BlockID request,
+  ) {
+    _throwIfDown();
+    return _client.getBlockNullifiers(request);
+  }
+
+  @override
+  Stream<compact.CompactBlock> getBlockRange(
+    grpc.ServiceCall call,
+    service.BlockRange request,
+  ) {
+    _throwIfDown();
+    return _client.getBlockRange(request);
+  }
+
+  @override
+  Stream<compact.CompactBlock> getBlockRangeNullifiers(
+    grpc.ServiceCall call,
+    service.BlockRange request,
+  ) {
+    _throwIfDown();
+    return _client.getBlockRangeNullifiers(request);
+  }
+
+  @override
+  Future<service.RawTransaction> getTransaction(
+    grpc.ServiceCall call,
+    service.TxFilter request,
+  ) {
+    _throwIfDown();
+    return _client.getTransaction(request);
+  }
+
+  @override
+  Future<service.SendResponse> sendTransaction(
+    grpc.ServiceCall call,
+    service.RawTransaction request,
+  ) {
+    _throwIfDown();
+    return _client.sendTransaction(request);
+  }
+
+  @override
+  Stream<service.RawTransaction> getTaddressTxids(
+    grpc.ServiceCall call,
+    service.TransparentAddressBlockFilter request,
+  ) {
+    _throwIfDown();
+    return _client.getTaddressTxids(request);
+  }
+
+  @override
+  Stream<service.RawTransaction> getTaddressTransactions(
+    grpc.ServiceCall call,
+    service.TransparentAddressBlockFilter request,
+  ) {
+    _throwIfDown();
+    return _client.getTaddressTransactions(request);
+  }
+
+  @override
+  Future<service.Balance> getTaddressBalance(
+    grpc.ServiceCall call,
+    service.AddressList request,
+  ) {
+    _throwIfDown();
+    return _client.getTaddressBalance(request);
+  }
+
+  @override
+  Future<service.Balance> getTaddressBalanceStream(
+    grpc.ServiceCall call,
+    Stream<service.Address> request,
+  ) {
+    _throwIfDown();
+    return _client.getTaddressBalanceStream(request);
+  }
+
+  @override
+  Stream<compact.CompactTx> getMempoolTx(
+    grpc.ServiceCall call,
+    service.GetMempoolTxRequest request,
+  ) {
+    _throwIfDown();
+    return _client.getMempoolTx(request);
+  }
+
+  @override
+  Stream<service.RawTransaction> getMempoolStream(
+    grpc.ServiceCall call,
+    service.Empty request,
+  ) {
+    _throwIfDown();
+    return _client.getMempoolStream(request);
+  }
+
+  @override
+  Future<service.TreeState> getTreeState(
+    grpc.ServiceCall call,
+    service.BlockID request,
+  ) {
+    _throwIfDown();
+    return _client.getTreeState(request);
+  }
+
+  @override
+  Future<service.TreeState> getLatestTreeState(
+    grpc.ServiceCall call,
+    service.Empty request,
+  ) {
+    _throwIfDown();
+    return _client.getLatestTreeState(request);
+  }
+
+  @override
+  Stream<service.SubtreeRoot> getSubtreeRoots(
+    grpc.ServiceCall call,
+    service.GetSubtreeRootsArg request,
+  ) {
+    _throwIfDown();
+    return _client.getSubtreeRoots(request);
+  }
+
+  @override
+  Future<service.GetAddressUtxosReplyList> getAddressUtxos(
+    grpc.ServiceCall call,
+    service.GetAddressUtxosArg request,
+  ) {
+    _throwIfDown();
+    return _client.getAddressUtxos(request);
+  }
+
+  @override
+  Stream<service.GetAddressUtxosReply> getAddressUtxosStream(
+    grpc.ServiceCall call,
+    service.GetAddressUtxosArg request,
+  ) {
+    _throwIfDown();
+    return _client.getAddressUtxosStream(request);
+  }
+
+  @override
+  Future<service.LightdInfo> getLightdInfo(
+    grpc.ServiceCall call,
+    service.Empty request,
+  ) async {
+    _throwIfDown();
+    return _withModeInfoHeight(await _client.getLightdInfo(request));
+  }
+
+  @override
+  Future<service.PingResponse> ping(
+    grpc.ServiceCall call,
+    service.Duration request,
+  ) {
+    _throwIfDown();
+    return _client.ping(request);
+  }
+}

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,7 @@ import 'src/core/layout/app_layout.dart';
 import 'src/core/motion/onboarding_motion.dart';
 import 'src/core/theme/app_theme_host.dart';
 import 'src/core/theme/legacy_material_theme.dart';
+import 'src/core/widgets/app_toast.dart';
 import 'src/features/activity/screens/activity_screen.dart';
 import 'src/features/activity/screens/activity_transaction_status_screen.dart';
 import 'src/features/home/screens/home_screen.dart';
@@ -36,6 +37,7 @@ import 'src/features/settings/screens/settings_endpoint_screen.dart';
 import 'src/features/settings/screens/settings_seed_phrase_screen.dart';
 import 'src/providers/theme_mode_provider.dart';
 import 'src/providers/app_security_provider.dart';
+import 'src/providers/rpc_endpoint_failover_provider.dart';
 import 'src/providers/router_refresh_provider.dart';
 import 'src/providers/wallet_provider.dart';
 import 'src/rust/frb_generated.dart';
@@ -462,25 +464,54 @@ class ZcashWalletApp extends ConsumerWidget {
           // events over empty regions while descendant GestureDetectors
           // (buttons, TextFields) win the gesture arena first, keeping
           // focused buttons focused when re-clicked.
-          child: DesktopWindowTitlebarSafeArea(
-            child: GestureDetector(
-              onTap: () {
-                // Leaf-only: skip when the primary focus is a
-                // `FocusScopeNode` rather than a concrete `FocusNode`.
-                // Unfocusing the scope itself strips the scope's
-                // "most-recently-focused child" memory, which leaves the
-                // next Tab with no deterministic starting point.
-                final primary = FocusManager.instance.primaryFocus;
-                if (primary != null && primary is! FocusScopeNode) {
-                  primary.unfocus();
-                }
-              },
-              behavior: HitTestBehavior.translucent,
-              child: child!,
+          child: AppToastHost(
+            child: _RpcEndpointFailoverToastListener(
+              child: DesktopWindowTitlebarSafeArea(
+                child: GestureDetector(
+                  onTap: () {
+                    // Leaf-only: skip when the primary focus is a
+                    // `FocusScopeNode` rather than a concrete `FocusNode`.
+                    // Unfocusing the scope itself strips the scope's
+                    // "most-recently-focused child" memory, which leaves the
+                    // next Tab with no deterministic starting point.
+                    final primary = FocusManager.instance.primaryFocus;
+                    if (primary != null && primary is! FocusScopeNode) {
+                      primary.unfocus();
+                    }
+                  },
+                  behavior: HitTestBehavior.translucent,
+                  child: child!,
+                ),
+              ),
             ),
           ),
         );
       },
     );
+  }
+}
+
+class _RpcEndpointFailoverToastListener extends ConsumerWidget {
+  const _RpcEndpointFailoverToastListener({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<RpcEndpointFailoverEvent?>(
+      rpcEndpointFailoverProvider.select((state) => state.lastEvent),
+      (previous, next) {
+        if (next == null || next.sequence == previous?.sequence) return;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!context.mounted) return;
+          showAppToast(
+            context,
+            next.message,
+            duration: const Duration(seconds: 4),
+          );
+        });
+      },
+    );
+    return child;
   }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -10,6 +10,7 @@ import 'src/core/motion/onboarding_motion.dart';
 import 'src/core/theme/app_theme_host.dart';
 import 'src/core/theme/legacy_material_theme.dart';
 import 'src/core/widgets/app_toast.dart';
+import 'src/core/widgets/network_fallback_toast.dart';
 import 'src/features/activity/screens/activity_screen.dart';
 import 'src/features/activity/screens/activity_transaction_status_screen.dart';
 import 'src/features/home/screens/home_screen.dart';
@@ -464,23 +465,25 @@ class ZcashWalletApp extends ConsumerWidget {
           // events over empty regions while descendant GestureDetectors
           // (buttons, TextFields) win the gesture arena first, keeping
           // focused buttons focused when re-clicked.
-          child: AppToastHost(
-            child: _RpcEndpointFailoverToastListener(
-              child: DesktopWindowTitlebarSafeArea(
-                child: GestureDetector(
-                  onTap: () {
-                    // Leaf-only: skip when the primary focus is a
-                    // `FocusScopeNode` rather than a concrete `FocusNode`.
-                    // Unfocusing the scope itself strips the scope's
-                    // "most-recently-focused child" memory, which leaves the
-                    // next Tab with no deterministic starting point.
-                    final primary = FocusManager.instance.primaryFocus;
-                    if (primary != null && primary is! FocusScopeNode) {
-                      primary.unfocus();
-                    }
-                  },
-                  behavior: HitTestBehavior.translucent,
-                  child: child!,
+          child: NetworkFallbackToastHost(
+            child: AppToastHost(
+              child: _RpcEndpointFailoverToastListener(
+                child: DesktopWindowTitlebarSafeArea(
+                  child: GestureDetector(
+                    onTap: () {
+                      // Leaf-only: skip when the primary focus is a
+                      // `FocusScopeNode` rather than a concrete `FocusNode`.
+                      // Unfocusing the scope itself strips the scope's
+                      // "most-recently-focused child" memory, which leaves the
+                      // next Tab with no deterministic starting point.
+                      final primary = FocusManager.instance.primaryFocus;
+                      if (primary != null && primary is! FocusScopeNode) {
+                        primary.unfocus();
+                      }
+                    },
+                    behavior: HitTestBehavior.translucent,
+                    child: child!,
+                  ),
                 ),
               ),
             ),
@@ -504,7 +507,7 @@ class _RpcEndpointFailoverToastListener extends ConsumerWidget {
         if (next == null || next.sequence == previous?.sequence) return;
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (!context.mounted) return;
-          showAppToast(
+          showNetworkFallbackToast(
             context,
             next.message,
             duration: const Duration(seconds: 4),

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:go_router/go_router.dart';
 import 'package:desktop_window_bootstrap/desktop_window_bootstrap.dart';
@@ -62,14 +63,22 @@ Future<void> initializeZcashWalletRuntime() async {
   }
 }
 
-Future<Widget> buildBootstrappedZcashWalletApp() async {
+Future<Widget> buildBootstrappedZcashWalletApp({
+  List<Override> overrides = const [],
+}) async {
   final bootstrap = await loadAppBootstrap();
-  return buildZcashWalletApp(bootstrap: bootstrap);
+  return buildZcashWalletApp(bootstrap: bootstrap, overrides: overrides);
 }
 
-Widget buildZcashWalletApp({required AppBootstrapState bootstrap}) {
+Widget buildZcashWalletApp({
+  required AppBootstrapState bootstrap,
+  List<Override> overrides = const [],
+}) {
   return ProviderScope(
-    overrides: [appBootstrapProvider.overrideWithValue(bootstrap)],
+    overrides: [
+      appBootstrapProvider.overrideWithValue(bootstrap),
+      ...overrides,
+    ],
     child: const ZcashWalletApp(),
   );
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,7 +9,6 @@ import 'src/core/layout/app_layout.dart';
 import 'src/core/motion/onboarding_motion.dart';
 import 'src/core/theme/app_theme_host.dart';
 import 'src/core/theme/legacy_material_theme.dart';
-import 'src/core/widgets/app_toast.dart';
 import 'src/core/widgets/network_fallback_toast.dart';
 import 'src/features/activity/screens/activity_screen.dart';
 import 'src/features/activity/screens/activity_transaction_status_screen.dart';
@@ -465,26 +464,22 @@ class ZcashWalletApp extends ConsumerWidget {
           // events over empty regions while descendant GestureDetectors
           // (buttons, TextFields) win the gesture arena first, keeping
           // focused buttons focused when re-clicked.
-          child: NetworkFallbackToastHost(
-            child: AppToastHost(
-              child: _RpcEndpointFailoverToastListener(
-                child: DesktopWindowTitlebarSafeArea(
-                  child: GestureDetector(
-                    onTap: () {
-                      // Leaf-only: skip when the primary focus is a
-                      // `FocusScopeNode` rather than a concrete `FocusNode`.
-                      // Unfocusing the scope itself strips the scope's
-                      // "most-recently-focused child" memory, which leaves the
-                      // next Tab with no deterministic starting point.
-                      final primary = FocusManager.instance.primaryFocus;
-                      if (primary != null && primary is! FocusScopeNode) {
-                        primary.unfocus();
-                      }
-                    },
-                    behavior: HitTestBehavior.translucent,
-                    child: child!,
-                  ),
-                ),
+          child: _RpcEndpointFailoverToastListener(
+            child: DesktopWindowTitlebarSafeArea(
+              child: GestureDetector(
+                onTap: () {
+                  // Leaf-only: skip when the primary focus is a
+                  // `FocusScopeNode` rather than a concrete `FocusNode`.
+                  // Unfocusing the scope itself strips the scope's
+                  // "most-recently-focused child" memory, which leaves the
+                  // next Tab with no deterministic starting point.
+                  final primary = FocusManager.instance.primaryFocus;
+                  if (primary != null && primary is! FocusScopeNode) {
+                    primary.unfocus();
+                  }
+                },
+                behavior: HitTestBehavior.translucent,
+                child: child!,
               ),
             ),
           ),
@@ -501,20 +496,26 @@ class _RpcEndpointFailoverToastListener extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen<RpcEndpointFailoverEvent?>(
-      rpcEndpointFailoverProvider.select((state) => state.lastEvent),
-      (previous, next) {
-        if (next == null || next.sequence == previous?.sequence) return;
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!context.mounted) return;
-          showNetworkFallbackToast(
-            context,
-            next.message,
-            duration: const Duration(seconds: 4),
+    return NetworkFallbackToastHost(
+      child: Builder(
+        builder: (toastContext) {
+          ref.listen<RpcEndpointFailoverEvent?>(
+            rpcEndpointFailoverProvider.select((state) => state.lastEvent),
+            (previous, next) {
+              if (next == null || next.sequence == previous?.sequence) return;
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                if (!toastContext.mounted) return;
+                showNetworkFallbackToast(
+                  toastContext,
+                  next.message,
+                  duration: const Duration(seconds: 4),
+                );
+              });
+            },
           );
-        });
-      },
+          return child;
+        },
+      ),
     );
-    return child;
   }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -489,33 +489,40 @@ class ZcashWalletApp extends ConsumerWidget {
   }
 }
 
-class _RpcEndpointFailoverToastListener extends ConsumerWidget {
+class _RpcEndpointFailoverToastListener extends StatelessWidget {
   const _RpcEndpointFailoverToastListener({required this.child});
 
   final Widget child;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     return NetworkFallbackToastHost(
-      child: Builder(
-        builder: (toastContext) {
-          ref.listen<RpcEndpointFailoverEvent?>(
-            rpcEndpointFailoverProvider.select((state) => state.lastEvent),
-            (previous, next) {
-              if (next == null || next.sequence == previous?.sequence) return;
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                if (!toastContext.mounted) return;
-                showNetworkFallbackToast(
-                  toastContext,
-                  next.message,
-                  duration: const Duration(seconds: 4),
-                );
-              });
-            },
-          );
-          return child;
-        },
-      ),
+      child: _RpcEndpointFailoverToastBridge(child: child),
     );
+  }
+}
+
+class _RpcEndpointFailoverToastBridge extends ConsumerWidget {
+  const _RpcEndpointFailoverToastBridge({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<RpcEndpointFailoverEvent?>(
+      rpcEndpointFailoverProvider.select((state) => state.lastEvent),
+      (previous, next) {
+        if (next == null || next.sequence == previous?.sequence) return;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!context.mounted) return;
+          showNetworkFallbackToast(
+            context,
+            next.message,
+            duration: const Duration(seconds: 4),
+          );
+        });
+      },
+    );
+    return child;
   }
 }

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -293,7 +293,7 @@ AccountInfo mergeBootstrappedAccountInfo({
   return AccountInfo(
     uuid: rustAccount.uuid,
     name: storedAccount?.name ?? rustAccount.name,
-    order: order,
+    order: storedAccount?.order ?? order,
     isHardware: storedAccount?.isHardware ?? false,
     profilePictureId:
         storedAccount?.profilePictureId ?? kDefaultProfilePictureId,

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -5,6 +5,7 @@ export 'network_config.dart';
 
 const kDefaultRpcEndpointPresetId = 'default-mainnet';
 const kCustomRpcEndpointPresetId = 'custom';
+const kMainnetFallbackRpcEndpointPresetId = 'zec-rocks';
 
 class RpcEndpointConfig {
   const RpcEndpointConfig({
@@ -187,6 +188,49 @@ RpcEndpointConfig defaultRpcEndpointConfig(String networkName) {
     networkName: network.name,
     lightwalletdUrl: preset.url,
     presetId: preset.id,
+  );
+}
+
+RpcEndpointConfig? fallbackRpcEndpointConfigFor(RpcEndpointConfig primary) {
+  final primaryNormalized = primary.normalizedLightwalletdUrl;
+  final candidates = rpcEndpointPresetsForNetwork(primary.networkName)
+      .where(
+        (preset) =>
+            normalizeRpcEndpointUrl(preset.url, allowDefaultPort: true) !=
+            primaryNormalized,
+      )
+      .toList(growable: false);
+  if (candidates.isEmpty) return null;
+
+  final preferredPresetIds = switch (primary.network) {
+    ZcashNetwork.mainnet => [
+      if (primary.effectivePresetId == kDefaultRpcEndpointPresetId)
+        kMainnetFallbackRpcEndpointPresetId
+      else
+        kDefaultRpcEndpointPresetId,
+      kMainnetFallbackRpcEndpointPresetId,
+    ],
+    ZcashNetwork.testnet => ['default-testnet'],
+    ZcashNetwork.regtest => ['default-regtest'],
+  };
+
+  for (final presetId in preferredPresetIds) {
+    for (final candidate in candidates) {
+      if (candidate.id == presetId) {
+        return RpcEndpointConfig(
+          networkName: primary.networkName,
+          lightwalletdUrl: candidate.url,
+          presetId: candidate.id,
+        );
+      }
+    }
+  }
+
+  final fallback = candidates.first;
+  return RpcEndpointConfig(
+    networkName: primary.networkName,
+    lightwalletdUrl: fallback.url,
+    presetId: fallback.id,
   );
 }
 

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -5,30 +5,7 @@ export 'network_config.dart';
 
 const kDefaultRpcEndpointPresetId = 'default-mainnet';
 const kCustomRpcEndpointPresetId = 'custom';
-const kMainnetFallbackRpcEndpointPresetId = 'zec-rocks';
 const kRegtestUnavailableRpcEndpointPresetId = 'unavailable-regtest';
-
-const kMainnetRpcEndpointFallbackPresetOrder = [
-  kDefaultRpcEndpointPresetId,
-  kMainnetFallbackRpcEndpointPresetId,
-  'na-zec-rocks',
-  'sa-zec-rocks',
-  'eu-zec-rocks',
-  'ap-zec-rocks',
-  'eu-zec-stardust',
-  'eu2-zec-stardust',
-  'jp-zec-stardust',
-  'z3-deepikaw',
-  'zprivacy',
-  'zcash-explorer',
-];
-
-const kTestnetRpcEndpointFallbackPresetOrder = ['default-testnet'];
-
-const kRegtestRpcEndpointFallbackPresetOrder = [
-  'default-regtest',
-  kRegtestUnavailableRpcEndpointPresetId,
-];
 
 class RpcEndpointConfig {
   const RpcEndpointConfig({
@@ -224,15 +201,6 @@ bool isCustomRpcEndpointConfig(RpcEndpointConfig config) {
   return config.presetId == kCustomRpcEndpointPresetId;
 }
 
-List<String> rpcEndpointFallbackPresetOrderForNetwork(String networkName) {
-  final network = zcashNetworkFromName(networkName);
-  return switch (network) {
-    ZcashNetwork.mainnet => kMainnetRpcEndpointFallbackPresetOrder,
-    ZcashNetwork.testnet => kTestnetRpcEndpointFallbackPresetOrder,
-    ZcashNetwork.regtest => kRegtestRpcEndpointFallbackPresetOrder,
-  };
-}
-
 List<RpcEndpointConfig> fallbackRpcEndpointCandidatesFor(
   RpcEndpointConfig primary,
 ) {
@@ -243,12 +211,7 @@ List<RpcEndpointConfig> fallbackRpcEndpointCandidatesFor(
   final seenUrls = <String>{};
   final candidates = <RpcEndpointConfig>[];
 
-  for (final presetId in rpcEndpointFallbackPresetOrderForNetwork(
-    primary.networkName,
-  )) {
-    final preset = findRpcEndpointPresetById(primary.networkName, presetId);
-    if (preset == null) continue;
-
+  for (final preset in rpcEndpointPresetsForNetwork(primary.networkName)) {
     final normalized = normalizeRpcEndpointUrl(
       preset.url,
       allowDefaultPort: true,

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -26,12 +26,7 @@ class RpcEndpointConfig {
   String get hostPort => rpcEndpointHostPort(lightwalletdUrl);
 
   String get effectivePresetId =>
-      findRpcEndpointPresetByUrl(
-        normalizedLightwalletdUrl,
-        networkName: networkName,
-      )?.id ??
-      presetId ??
-      kCustomRpcEndpointPresetId;
+      explicitRpcEndpointPresetFor(this)?.id ?? kCustomRpcEndpointPresetId;
 
   RpcEndpointConfig copyWith({
     String? networkName,
@@ -201,6 +196,17 @@ bool isCustomRpcEndpointConfig(RpcEndpointConfig config) {
   return config.presetId == kCustomRpcEndpointPresetId;
 }
 
+RpcEndpointPreset? explicitRpcEndpointPresetFor(RpcEndpointConfig config) {
+  final presetId = config.presetId?.trim();
+  if (presetId == null ||
+      presetId.isEmpty ||
+      presetId == kCustomRpcEndpointPresetId) {
+    return null;
+  }
+
+  return findRpcEndpointPresetById(config.networkName, presetId);
+}
+
 List<RpcEndpointConfig> fallbackRpcEndpointCandidatesFor(
   RpcEndpointConfig primary,
 ) {
@@ -239,18 +245,7 @@ RpcEndpointConfig? fallbackRpcEndpointConfigFor(RpcEndpointConfig primary) {
 }
 
 RpcEndpointPreset? _selectedFallbackPrimaryPreset(RpcEndpointConfig primary) {
-  if (isCustomRpcEndpointConfig(primary)) return null;
-
-  final presetId = primary.presetId?.trim();
-  if (presetId != null && presetId.isNotEmpty) {
-    final preset = findRpcEndpointPresetById(primary.networkName, presetId);
-    if (preset != null) return preset;
-  }
-
-  return findRpcEndpointPresetByUrl(
-    primary.normalizedLightwalletdUrl,
-    networkName: primary.networkName,
-  );
+  return explicitRpcEndpointPresetFor(primary);
 }
 
 RpcEndpointConfig resolveStoredRpcEndpointConfig({
@@ -281,9 +276,7 @@ RpcEndpointConfig resolveStoredRpcEndpointConfig({
   return RpcEndpointConfig(
     networkName: network.name,
     lightwalletdUrl: normalizeRpcEndpointUrl(url, allowDefaultPort: true),
-    presetId: presetId == kCustomRpcEndpointPresetId
-        ? kCustomRpcEndpointPresetId
-        : findRpcEndpointPresetByUrl(url, networkName: network.name)?.id,
+    presetId: kCustomRpcEndpointPresetId,
   );
 }
 

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -6,6 +6,29 @@ export 'network_config.dart';
 const kDefaultRpcEndpointPresetId = 'default-mainnet';
 const kCustomRpcEndpointPresetId = 'custom';
 const kMainnetFallbackRpcEndpointPresetId = 'zec-rocks';
+const kRegtestUnavailableRpcEndpointPresetId = 'unavailable-regtest';
+
+const kMainnetRpcEndpointFallbackPresetOrder = [
+  kDefaultRpcEndpointPresetId,
+  kMainnetFallbackRpcEndpointPresetId,
+  'na-zec-rocks',
+  'sa-zec-rocks',
+  'eu-zec-rocks',
+  'ap-zec-rocks',
+  'eu-zec-stardust',
+  'eu2-zec-stardust',
+  'jp-zec-stardust',
+  'z3-deepikaw',
+  'zprivacy',
+  'zcash-explorer',
+];
+
+const kTestnetRpcEndpointFallbackPresetOrder = ['default-testnet'];
+
+const kRegtestRpcEndpointFallbackPresetOrder = [
+  'default-regtest',
+  kRegtestUnavailableRpcEndpointPresetId,
+];
 
 class RpcEndpointConfig {
   const RpcEndpointConfig({
@@ -166,6 +189,12 @@ final kRegtestRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
     url: ZcashNetwork.regtest.lightwalletdUrl,
     isDefault: true,
   ),
+  const RpcEndpointPreset(
+    id: kRegtestUnavailableRpcEndpointPresetId,
+    region: 'Regtest',
+    label: 'Unavailable Regtest',
+    url: 'http://127.0.0.1:19067',
+  ),
 ]);
 
 List<RpcEndpointPreset> rpcEndpointPresetsForNetwork(String networkName) {
@@ -191,46 +220,73 @@ RpcEndpointConfig defaultRpcEndpointConfig(String networkName) {
   );
 }
 
-RpcEndpointConfig? fallbackRpcEndpointConfigFor(RpcEndpointConfig primary) {
-  final primaryNormalized = primary.normalizedLightwalletdUrl;
-  final candidates = rpcEndpointPresetsForNetwork(primary.networkName)
-      .where(
-        (preset) =>
-            normalizeRpcEndpointUrl(preset.url, allowDefaultPort: true) !=
-            primaryNormalized,
-      )
-      .toList(growable: false);
-  if (candidates.isEmpty) return null;
+bool isCustomRpcEndpointConfig(RpcEndpointConfig config) {
+  return config.presetId == kCustomRpcEndpointPresetId;
+}
 
-  final preferredPresetIds = switch (primary.network) {
-    ZcashNetwork.mainnet => [
-      if (primary.effectivePresetId == kDefaultRpcEndpointPresetId)
-        kMainnetFallbackRpcEndpointPresetId
-      else
-        kDefaultRpcEndpointPresetId,
-      kMainnetFallbackRpcEndpointPresetId,
-    ],
-    ZcashNetwork.testnet => ['default-testnet'],
-    ZcashNetwork.regtest => ['default-regtest'],
+List<String> rpcEndpointFallbackPresetOrderForNetwork(String networkName) {
+  final network = zcashNetworkFromName(networkName);
+  return switch (network) {
+    ZcashNetwork.mainnet => kMainnetRpcEndpointFallbackPresetOrder,
+    ZcashNetwork.testnet => kTestnetRpcEndpointFallbackPresetOrder,
+    ZcashNetwork.regtest => kRegtestRpcEndpointFallbackPresetOrder,
   };
+}
 
-  for (final presetId in preferredPresetIds) {
-    for (final candidate in candidates) {
-      if (candidate.id == presetId) {
-        return RpcEndpointConfig(
-          networkName: primary.networkName,
-          lightwalletdUrl: candidate.url,
-          presetId: candidate.id,
-        );
-      }
+List<RpcEndpointConfig> fallbackRpcEndpointCandidatesFor(
+  RpcEndpointConfig primary,
+) {
+  final primaryPreset = _selectedFallbackPrimaryPreset(primary);
+  if (primaryPreset == null) return const [];
+
+  final primaryNormalized = primary.normalizedLightwalletdUrl;
+  final seenUrls = <String>{};
+  final candidates = <RpcEndpointConfig>[];
+
+  for (final presetId in rpcEndpointFallbackPresetOrderForNetwork(
+    primary.networkName,
+  )) {
+    final preset = findRpcEndpointPresetById(primary.networkName, presetId);
+    if (preset == null) continue;
+
+    final normalized = normalizeRpcEndpointUrl(
+      preset.url,
+      allowDefaultPort: true,
+    );
+    if (preset.id == primaryPreset.id || normalized == primaryNormalized) {
+      continue;
     }
+    if (!seenUrls.add(normalized)) continue;
+
+    candidates.add(
+      RpcEndpointConfig(
+        networkName: primary.networkName,
+        lightwalletdUrl: preset.url,
+        presetId: preset.id,
+      ),
+    );
   }
 
-  final fallback = candidates.first;
-  return RpcEndpointConfig(
+  return List.unmodifiable(candidates);
+}
+
+RpcEndpointConfig? fallbackRpcEndpointConfigFor(RpcEndpointConfig primary) {
+  final candidates = fallbackRpcEndpointCandidatesFor(primary);
+  return candidates.isEmpty ? null : candidates.first;
+}
+
+RpcEndpointPreset? _selectedFallbackPrimaryPreset(RpcEndpointConfig primary) {
+  if (isCustomRpcEndpointConfig(primary)) return null;
+
+  final presetId = primary.presetId?.trim();
+  if (presetId != null && presetId.isNotEmpty) {
+    final preset = findRpcEndpointPresetById(primary.networkName, presetId);
+    if (preset != null) return preset;
+  }
+
+  return findRpcEndpointPresetByUrl(
+    primary.normalizedLightwalletdUrl,
     networkName: primary.networkName,
-    lightwalletdUrl: fallback.url,
-    presetId: fallback.id,
   );
 }
 

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -5,6 +5,7 @@ export 'network_config.dart';
 
 const kDefaultRpcEndpointPresetId = 'default-mainnet';
 const kCustomRpcEndpointPresetId = 'custom';
+const kRegtestSlowRpcEndpointPresetId = 'slow-regtest';
 const kRegtestUnavailableRpcEndpointPresetId = 'unavailable-regtest';
 
 class RpcEndpointConfig {
@@ -160,6 +161,12 @@ final kRegtestRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
     label: 'Local Regtest',
     url: ZcashNetwork.regtest.lightwalletdUrl,
     isDefault: true,
+  ),
+  const RpcEndpointPreset(
+    id: kRegtestSlowRpcEndpointPresetId,
+    region: 'Regtest',
+    label: 'Slow Regtest',
+    url: 'http://127.0.0.1:19068',
   ),
   const RpcEndpointPreset(
     id: kRegtestUnavailableRpcEndpointPresetId,

--- a/lib/src/core/widgets/app_toast.dart
+++ b/lib/src/core/widgets/app_toast.dart
@@ -64,6 +64,8 @@ class AppToast extends StatelessWidget {
 class AppToastHost extends StatefulWidget {
   const AppToastHost({required this.child, super.key});
 
+  static const animationDuration = Duration(milliseconds: 220);
+
   final Widget child;
 
   @override
@@ -111,15 +113,30 @@ class _AppToastHostState extends State<AppToastHost> {
         fit: StackFit.expand,
         children: [
           widget.child,
-          if (message != null)
-            Positioned(
-              top: AppSpacing.base,
-              left: 0,
-              right: 0,
-              child: IgnorePointer(
-                child: Center(child: AppToast(message: message)),
+          Positioned(
+            top: AppSpacing.base,
+            left: 0,
+            right: 0,
+            child: IgnorePointer(
+              child: Center(
+                child: AnimatedSwitcher(
+                  duration: AppToastHost.animationDuration,
+                  switchInCurve: Curves.easeOutCubic,
+                  switchOutCurve: Curves.easeInCubic,
+                  transitionBuilder: (child, animation) {
+                    final position = Tween<Offset>(
+                      begin: const Offset(0, -1),
+                      end: Offset.zero,
+                    ).animate(animation);
+                    return SlideTransition(position: position, child: child);
+                  },
+                  child: message == null
+                      ? const SizedBox.shrink(key: ValueKey('empty-toast'))
+                      : AppToast(key: ValueKey(message), message: message),
+                ),
               ),
             ),
+          ),
         ],
       ),
     );

--- a/lib/src/core/widgets/app_toast.dart
+++ b/lib/src/core/widgets/app_toast.dart
@@ -20,36 +20,41 @@ class AppToast extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: colors.background.inverse,
-        borderRadius: BorderRadius.circular(AppRadii.small),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSpacing.s,
-          vertical: AppSpacing.xs,
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 560),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: colors.background.inverse,
+          borderRadius: BorderRadius.circular(AppRadii.small),
         ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            AppIcon(
-              iconName,
-              size: AppIconSize.medium,
-              color: colors.icon.inverse,
-            ),
-            const SizedBox(width: AppSpacing.xxs),
-            Text(
-              message,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.center,
-              style: AppTypography.labelLarge.copyWith(
-                color: colors.text.inverse,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.s,
+            vertical: AppSpacing.xs,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              AppIcon(
+                iconName,
+                size: AppIconSize.medium,
+                color: colors.icon.inverse,
               ),
-            ),
-          ],
+              const SizedBox(width: AppSpacing.xxs),
+              Flexible(
+                child: Text(
+                  message,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                  style: AppTypography.labelLarge.copyWith(
+                    color: colors.text.inverse,
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/core/widgets/app_toast.dart
+++ b/lib/src/core/widgets/app_toast.dart
@@ -20,60 +20,36 @@ class AppToast extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final isDark = AppTheme.of(context) == AppThemeData.dark;
-    return DefaultTextStyle.merge(
-      style: const TextStyle(decoration: TextDecoration.none),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 560),
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: colors.background.ground,
-            borderRadius: BorderRadius.circular(AppRadii.small),
-            border: isDark ? Border.all(color: colors.border.subtle) : null,
-            boxShadow: isDark
-                ? null
-                : const [
-                    BoxShadow(
-                      color: Color(0xFFE1E1E1),
-                      offset: Offset(0, 2),
-                      blurRadius: 2,
-                    ),
-                    BoxShadow(
-                      color: Color(0xFFE1E1E1),
-                      offset: Offset(0, 10),
-                      blurRadius: 15,
-                    ),
-                  ],
-          ),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSpacing.s,
-              vertical: AppSpacing.xs,
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colors.background.inverse,
+        borderRadius: BorderRadius.circular(AppRadii.small),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.s,
+          vertical: AppSpacing.xs,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            AppIcon(
+              iconName,
+              size: AppIconSize.medium,
+              color: colors.icon.inverse,
             ),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                AppIcon(
-                  iconName,
-                  size: AppIconSize.medium,
-                  color: colors.icon.accent,
-                ),
-                const SizedBox(width: AppSpacing.xxs),
-                Flexible(
-                  child: Text(
-                    message,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    textAlign: TextAlign.center,
-                    style: AppTypography.labelLarge.copyWith(
-                      color: colors.text.accent,
-                    ),
-                  ),
-                ),
-              ],
+            const SizedBox(width: AppSpacing.xxs),
+            Text(
+              message,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.inverse,
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );
@@ -82,8 +58,6 @@ class AppToast extends StatelessWidget {
 
 class AppToastHost extends StatefulWidget {
   const AppToastHost({required this.child, super.key});
-
-  static const animationDuration = Duration(milliseconds: 220);
 
   final Widget child;
 
@@ -132,30 +106,15 @@ class _AppToastHostState extends State<AppToastHost> {
         fit: StackFit.expand,
         children: [
           widget.child,
-          Positioned(
-            top: AppSpacing.base,
-            left: 0,
-            right: 0,
-            child: IgnorePointer(
-              child: Center(
-                child: AnimatedSwitcher(
-                  duration: AppToastHost.animationDuration,
-                  switchInCurve: Curves.easeOutCubic,
-                  switchOutCurve: Curves.easeInCubic,
-                  transitionBuilder: (child, animation) {
-                    final position = Tween<Offset>(
-                      begin: const Offset(0, -1),
-                      end: Offset.zero,
-                    ).animate(animation);
-                    return SlideTransition(position: position, child: child);
-                  },
-                  child: message == null
-                      ? const SizedBox.shrink(key: ValueKey('empty-toast'))
-                      : AppToast(key: ValueKey(message), message: message),
-                ),
+          if (message != null)
+            Positioned(
+              top: AppSpacing.base,
+              left: 0,
+              right: 0,
+              child: IgnorePointer(
+                child: Center(child: AppToast(message: message)),
               ),
             ),
-          ),
         ],
       ),
     );

--- a/lib/src/core/widgets/app_toast.dart
+++ b/lib/src/core/widgets/app_toast.dart
@@ -21,55 +21,58 @@ class AppToast extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final isDark = AppTheme.of(context) == AppThemeData.dark;
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxWidth: 560),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: colors.background.ground,
-          borderRadius: BorderRadius.circular(AppRadii.small),
-          border: isDark ? Border.all(color: colors.border.subtle) : null,
-          boxShadow: isDark
-              ? null
-              : const [
-                  BoxShadow(
-                    color: Color(0xFFE1E1E1),
-                    offset: Offset(0, 2),
-                    blurRadius: 2,
-                  ),
-                  BoxShadow(
-                    color: Color(0xFFE1E1E1),
-                    offset: Offset(0, 10),
-                    blurRadius: 15,
-                  ),
-                ],
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSpacing.s,
-            vertical: AppSpacing.xs,
+    return DefaultTextStyle.merge(
+      style: const TextStyle(decoration: TextDecoration.none),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 560),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: colors.background.ground,
+            borderRadius: BorderRadius.circular(AppRadii.small),
+            border: isDark ? Border.all(color: colors.border.subtle) : null,
+            boxShadow: isDark
+                ? null
+                : const [
+                    BoxShadow(
+                      color: Color(0xFFE1E1E1),
+                      offset: Offset(0, 2),
+                      blurRadius: 2,
+                    ),
+                    BoxShadow(
+                      color: Color(0xFFE1E1E1),
+                      offset: Offset(0, 10),
+                      blurRadius: 15,
+                    ),
+                  ],
           ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              AppIcon(
-                iconName,
-                size: AppIconSize.medium,
-                color: colors.icon.accent,
-              ),
-              const SizedBox(width: AppSpacing.xxs),
-              Flexible(
-                child: Text(
-                  message,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.center,
-                  style: AppTypography.labelLarge.copyWith(
-                    color: colors.text.accent,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.s,
+              vertical: AppSpacing.xs,
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                AppIcon(
+                  iconName,
+                  size: AppIconSize.medium,
+                  color: colors.icon.accent,
+                ),
+                const SizedBox(width: AppSpacing.xxs),
+                Flexible(
+                  child: Text(
+                    message,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: colors.text.accent,
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/core/widgets/app_toast.dart
+++ b/lib/src/core/widgets/app_toast.dart
@@ -20,12 +20,28 @@ class AppToast extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final isDark = AppTheme.of(context) == AppThemeData.dark;
     return ConstrainedBox(
       constraints: const BoxConstraints(maxWidth: 560),
       child: DecoratedBox(
         decoration: BoxDecoration(
-          color: colors.background.inverse,
+          color: colors.background.ground,
           borderRadius: BorderRadius.circular(AppRadii.small),
+          border: isDark ? Border.all(color: colors.border.subtle) : null,
+          boxShadow: isDark
+              ? null
+              : const [
+                  BoxShadow(
+                    color: Color(0xFFE1E1E1),
+                    offset: Offset(0, 2),
+                    blurRadius: 2,
+                  ),
+                  BoxShadow(
+                    color: Color(0xFFE1E1E1),
+                    offset: Offset(0, 10),
+                    blurRadius: 15,
+                  ),
+                ],
         ),
         child: Padding(
           padding: const EdgeInsets.symmetric(
@@ -39,7 +55,7 @@ class AppToast extends StatelessWidget {
               AppIcon(
                 iconName,
                 size: AppIconSize.medium,
-                color: colors.icon.inverse,
+                color: colors.icon.accent,
               ),
               const SizedBox(width: AppSpacing.xxs),
               Flexible(
@@ -49,7 +65,7 @@ class AppToast extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                   textAlign: TextAlign.center,
                   style: AppTypography.labelLarge.copyWith(
-                    color: colors.text.inverse,
+                    color: colors.text.accent,
                   ),
                 ),
               ),

--- a/lib/src/core/widgets/network_fallback_toast.dart
+++ b/lib/src/core/widgets/network_fallback_toast.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import '../theme/app_theme.dart';
+
+class NetworkFallbackToast extends StatelessWidget {
+  const NetworkFallbackToast({required this.message, super.key});
+
+  static const defaultDuration = Duration(seconds: 4);
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final isDark = AppTheme.of(context) == AppThemeData.dark;
+
+    return DefaultTextStyle.merge(
+      style: const TextStyle(decoration: TextDecoration.none),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 560),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: colors.background.ground,
+            borderRadius: BorderRadius.circular(AppRadii.small),
+            border: isDark ? Border.all(color: colors.border.subtle) : null,
+            boxShadow: isDark
+                ? null
+                : const [
+                    BoxShadow(
+                      color: Color(0xFFE1E1E1),
+                      offset: Offset(0, 2),
+                      blurRadius: 2,
+                    ),
+                    BoxShadow(
+                      color: Color(0xFFE1E1E1),
+                      offset: Offset(0, 10),
+                      blurRadius: 15,
+                    ),
+                  ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.s,
+              vertical: AppSpacing.xs,
+            ),
+            child: Text(
+              message,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class NetworkFallbackToastHost extends StatefulWidget {
+  const NetworkFallbackToastHost({required this.child, super.key});
+
+  static const animationDuration = Duration(milliseconds: 220);
+
+  final Widget child;
+
+  @override
+  State<NetworkFallbackToastHost> createState() =>
+      _NetworkFallbackToastHostState();
+}
+
+class _NetworkFallbackToastHostState extends State<NetworkFallbackToastHost> {
+  static final List<_NetworkFallbackToastHostState> _activeStates = [];
+
+  String? _message;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _activeStates.add(this);
+  }
+
+  void show(
+    String message, {
+    Duration duration = NetworkFallbackToast.defaultDuration,
+  }) {
+    _timer?.cancel();
+    setState(() {
+      _message = message;
+    });
+    _timer = Timer(duration, () {
+      if (!mounted) return;
+      setState(() {
+        _message = null;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _activeStates.remove(this);
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final message = _message;
+    return _NetworkFallbackToastScope(
+      state: this,
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          widget.child,
+          Positioned(
+            top: AppSpacing.base,
+            left: 0,
+            right: 0,
+            child: IgnorePointer(
+              child: Center(
+                child: AnimatedSwitcher(
+                  duration: NetworkFallbackToastHost.animationDuration,
+                  switchInCurve: Curves.easeOutCubic,
+                  switchOutCurve: Curves.easeInCubic,
+                  transitionBuilder: (child, animation) {
+                    final position = Tween<Offset>(
+                      begin: const Offset(0, -1),
+                      end: Offset.zero,
+                    ).animate(animation);
+                    return SlideTransition(position: position, child: child);
+                  },
+                  child: message == null
+                      ? const SizedBox.shrink(
+                          key: ValueKey('empty-network-fallback-toast'),
+                        )
+                      : NetworkFallbackToast(
+                          key: ValueKey(message),
+                          message: message,
+                        ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+void showNetworkFallbackToast(
+  BuildContext context,
+  String message, {
+  Duration duration = NetworkFallbackToast.defaultDuration,
+}) {
+  final element = context
+      .getElementForInheritedWidgetOfExactType<_NetworkFallbackToastScope>();
+  final scope = element?.widget as _NetworkFallbackToastScope?;
+  final state =
+      scope?.state ??
+      (_NetworkFallbackToastHostState._activeStates.isEmpty
+          ? null
+          : _NetworkFallbackToastHostState._activeStates.last);
+  assert(
+    state != null,
+    'showNetworkFallbackToast called without a NetworkFallbackToastHost '
+    'ancestor.',
+  );
+  state?.show(message, duration: duration);
+}
+
+class _NetworkFallbackToastScope extends InheritedWidget {
+  const _NetworkFallbackToastScope({required this.state, required super.child});
+
+  final _NetworkFallbackToastHostState state;
+
+  @override
+  bool updateShouldNotify(_NetworkFallbackToastScope oldWidget) =>
+      state != oldWidget.state;
+}

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -8,7 +8,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../app_bootstrap.dart';
-import '../../../core/config/network_config.dart';
+import '../../../core/config/rpc_endpoint_config.dart';
 import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/layout/app_desktop_shell.dart';
@@ -86,6 +86,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       _shieldBalanceErrorDetail = null;
     });
 
+    RpcEndpointConfig? attemptedEndpoint;
     try {
       final wallet = ref.read(walletProvider).value;
       final accountUuid = wallet?.activeAccountUuid;
@@ -110,6 +111,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       final seedBytes = await rust_wallet.deriveSeed(mnemonic: mnemonic);
       final dbPath = await getWalletDbPath();
       final endpoint = ref.read(rpcEndpointFailoverProvider).current;
+      attemptedEndpoint = endpoint;
       final result = await rust_sync.shieldTransparentBalance(
         dbPath: dbPath,
         lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
@@ -131,7 +133,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       log('HomeScreen: shield transparent balance failed: $e\n$st');
       final switched = await ref
           .read(rpcEndpointFailoverProvider.notifier)
-          .switchToFallbackFor(e, operation: 'shield transparent balance');
+          .switchToFallbackFor(
+            e,
+            endpoint: attemptedEndpoint,
+            operation: 'shield transparent balance',
+          );
       if (switched) {
         unawaited(ref.read(syncProvider.notifier).restartSync());
       }

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -20,7 +20,7 @@ import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/privacy_mode_provider.dart';
-import '../../../providers/rpc_endpoint_provider.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
@@ -109,7 +109,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
       final seedBytes = await rust_wallet.deriveSeed(mnemonic: mnemonic);
       final dbPath = await getWalletDbPath();
-      final endpoint = ref.read(rpcEndpointProvider);
+      final endpoint = ref.read(rpcEndpointFailoverProvider).current;
       final result = await rust_sync.shieldTransparentBalance(
         dbPath: dbPath,
         lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
@@ -129,6 +129,12 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       }
     } catch (e, st) {
       log('HomeScreen: shield transparent balance failed: $e\n$st');
+      final switched = await ref
+          .read(rpcEndpointFailoverProvider.notifier)
+          .switchToFallbackFor(e, operation: 'shield transparent balance');
+      if (switched) {
+        unawaited(ref.read(syncProvider.notifier).restartSync());
+      }
       if (!mounted) return;
       setState(() {
         _shieldBalanceError = _friendlyShieldBalanceError(e);
@@ -507,7 +513,7 @@ class _HomePaneState extends ConsumerState<_HomePane> {
 
     try {
       final dbPath = await getWalletDbPath();
-      final endpoint = ref.read(rpcEndpointProvider);
+      final endpoint = ref.read(rpcEndpointFailoverProvider).current;
       if (!mounted ||
           accountUuid != ref.read(accountProvider).value?.activeAccountUuid) {
         return null;

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -10,6 +10,7 @@ import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/wallet_mutation_guard.dart';
 import '../shared/onboarding_flow_args.dart';
@@ -94,10 +95,13 @@ class _ImportWalletBirthdayScreenState
     });
 
     try {
-      final endpoint = ref.read(rpcEndpointProvider);
-      final metadata = await ImportBirthdayEstimator.loadMetadata(
-        endpoint: endpoint,
-      );
+      final metadata = await ref
+          .read(rpcEndpointFailoverProvider.notifier)
+          .runWithEndpointFallback(
+            operation: 'import birthday metadata',
+            action: (endpoint) =>
+                ImportBirthdayEstimator.loadMetadata(endpoint: endpoint),
+          );
       if (!mounted) return;
       setState(() {
         _metadata = metadata;
@@ -127,11 +131,15 @@ class _ImportWalletBirthdayScreenState
     });
 
     try {
-      final endpoint = ref.read(rpcEndpointProvider);
-      final estimatedHeight =
-          await ImportBirthdayEstimator.estimateBirthdayHeight(
-            endpoint: endpoint,
-            selectedDate: date,
+      final estimatedHeight = await ref
+          .read(rpcEndpointFailoverProvider.notifier)
+          .runWithEndpointFallback(
+            operation: 'import birthday estimate',
+            action: (endpoint) =>
+                ImportBirthdayEstimator.estimateBirthdayHeight(
+                  endpoint: endpoint,
+                  selectedDate: date,
+                ),
           );
       if (!mounted || seq != _estimateSeq) return;
       setState(() {

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -18,7 +18,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_toast.dart';
 import '../../../providers/account_provider.dart';
-import '../../../providers/rpc_endpoint_provider.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../../rust/api/wallet.dart' as rust_wallet;
@@ -292,7 +292,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
   Future<void> _openTransactionExplorer() async {
     final txid = _txid;
     if (txid == null) return;
-    final endpoint = ref.read(rpcEndpointProvider);
+    final endpoint = ref.read(rpcEndpointFailoverProvider).current;
     final launched = await launchZcashExplorerTransaction(
       networkName: endpoint.networkName,
       txidHex: txid,
@@ -330,7 +330,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     try {
       final supportDir = await getWalletSupportDirectory();
       final dbPath = await getWalletDbPath();
-      final endpoint = ref.read(rpcEndpointProvider);
+      final endpoint = ref.read(rpcEndpointFailoverProvider).current;
       final paramsDir =
           '${supportDir.path}${Platform.pathSeparator}sapling_params';
       final spendPath =
@@ -399,6 +399,14 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
       );
       _proposalConsumed = true;
       final broadcastComplete = result.status == 'broadcasted';
+      if (!broadcastComplete && result.message != null) {
+        final switched = await ref
+            .read(rpcEndpointFailoverProvider.notifier)
+            .switchToFallbackFor(result.message!, operation: 'send broadcast');
+        if (switched) {
+          unawaited(ref.read(syncProvider.notifier).restartSync());
+        }
+      }
 
       try {
         await ref.read(syncProvider.notifier).refreshAfterSend();

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -402,7 +402,11 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
       if (!broadcastComplete && result.message != null) {
         final switched = await ref
             .read(rpcEndpointFailoverProvider.notifier)
-            .switchToFallbackFor(result.message!, operation: 'send broadcast');
+            .switchToFallbackFor(
+              result.message!,
+              endpoint: endpoint,
+              operation: 'send broadcast',
+            );
         if (switched) {
           unawaited(ref.read(syncProvider.notifier).restartSync());
         }

--- a/lib/src/features/settings/screens/settings_endpoint_screen.dart
+++ b/lib/src/features/settings/screens/settings_endpoint_screen.dart
@@ -45,10 +45,7 @@ class _SettingsEndpointScreenState
           .read(rpcEndpointLatencyProvider.notifier)
           .refresh(endpoint.networkName);
     });
-    final currentPreset = findRpcEndpointPresetByUrl(
-      endpoint.normalizedLightwalletdUrl,
-      networkName: endpoint.networkName,
-    );
+    final currentPreset = explicitRpcEndpointPresetFor(endpoint);
     _selectedPresetId = currentPreset?.id;
     if (currentPreset == null) {
       _activeTab = _EndpointTab.custom;
@@ -99,11 +96,12 @@ class _SettingsEndpointScreenState
 
   bool _customEndpointChanged(RpcEndpointConfig current) {
     try {
-      return normalizeRpcEndpointUrl(
-            _customController.text,
-            allowDefaultPort: true,
-          ) !=
-          current.normalizedLightwalletdUrl;
+      final normalized = normalizeRpcEndpointUrl(
+        _customController.text,
+        allowDefaultPort: true,
+      );
+      return normalized != current.normalizedLightwalletdUrl ||
+          current.effectivePresetId != kCustomRpcEndpointPresetId;
     } on FormatException {
       return false;
     }
@@ -148,10 +146,7 @@ class _SettingsEndpointScreenState
       final next = ref.read(rpcEndpointProvider);
       ref.read(rpcEndpointLatencyProvider.notifier).refresh(next.networkName);
       setState(() {
-        _selectedPresetId = findRpcEndpointPresetByUrl(
-          next.normalizedLightwalletdUrl,
-          networkName: next.networkName,
-        )?.id;
+        _selectedPresetId = explicitRpcEndpointPresetFor(next)?.id;
         if (_selectedPresetId == null) {
           _customController.text = rpcEndpointInputText(next.lightwalletdUrl);
         }

--- a/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
@@ -20,6 +20,7 @@ import '../../../core/widgets/password_text_field.dart';
 import '../../../core/widgets/app_text_field.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 
@@ -294,11 +295,15 @@ class _SettingsSeedPhraseScreenState
   }
 
   Future<int> _loadBirthdayBlockTime(int height) async {
-    final endpoint = ref.read(rpcEndpointProvider);
-    final blockTime = await rust_sync.getBlockTime(
-      lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-      height: BigInt.from(height),
-    );
+    final blockTime = await ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .runWithEndpointFallback(
+          operation: 'birthday block time',
+          action: (endpoint) => rust_sync.getBlockTime(
+            lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+            height: BigInt.from(height),
+          ),
+        );
     return blockTime.toInt();
   }
 

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -13,6 +13,7 @@ import '../core/storage/wallet_paths.dart';
 import '../rust/api/wallet.dart' as rust_wallet;
 import 'account_models.dart';
 import 'app_security_provider.dart';
+import 'rpc_endpoint_failover_provider.dart';
 import 'rpc_endpoint_provider.dart';
 
 export 'account_models.dart';
@@ -53,9 +54,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       final endpoint = ref.read(rpcEndpointProvider);
       final network = endpoint.networkName;
 
-      final birthday = await _fetchCreationBirthdayHeight(
-        endpoint.normalizedLightwalletdUrl,
-      );
+      final birthday = await _fetchCreationBirthdayHeight();
       log('createAccount: birthday=$birthday');
 
       final accounts = state.value?.accounts ?? [];
@@ -138,9 +137,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       final endpoint = ref.read(rpcEndpointProvider);
       final network = endpoint.networkName;
 
-      final birthday = await _fetchCreationBirthdayHeight(
-        endpoint.normalizedLightwalletdUrl,
-      );
+      final birthday = await _fetchCreationBirthdayHeight();
       log('createAccountFromMnemonic: birthday=$birthday');
 
       final accounts = state.value?.accounts ?? [];
@@ -504,11 +501,11 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     return getWalletDbPath();
   }
 
-  Future<BigInt> _fetchCreationBirthdayHeight(String lightwalletdUrl) async {
+  Future<BigInt> _fetchCreationBirthdayHeight() async {
     try {
-      return await rust_wallet.getLatestBlockHeight(
-        lightwalletdUrl: lightwalletdUrl,
-      );
+      return await ref
+          .read(rpcEndpointFailoverProvider.notifier)
+          .getLatestBlockHeight();
     } catch (e, st) {
       Error.throwWithStackTrace(
         WalletCreationCurrentBlockHeightException(e),

--- a/lib/src/providers/rpc_endpoint_failover_provider.dart
+++ b/lib/src/providers/rpc_endpoint_failover_provider.dart
@@ -47,7 +47,7 @@ class RpcEndpointFailoverState {
   const RpcEndpointFailoverState({
     required this.primary,
     required this.current,
-    required this.fallback,
+    required this.fallbackCandidates,
     this.primaryFailureCount = 0,
     this.lastFailure,
     this.switchedAt,
@@ -57,12 +57,15 @@ class RpcEndpointFailoverState {
 
   final RpcEndpointConfig primary;
   final RpcEndpointConfig current;
-  final RpcEndpointConfig? fallback;
+  final List<RpcEndpointConfig> fallbackCandidates;
   final int primaryFailureCount;
   final String? lastFailure;
   final DateTime? switchedAt;
   final DateTime? lastPrimaryProbeAt;
   final RpcEndpointFailoverEvent? lastEvent;
+
+  RpcEndpointConfig? get fallback =>
+      fallbackCandidates.isEmpty ? null : fallbackCandidates.first;
 
   bool get isUsingFallback =>
       current.normalizedLightwalletdUrl != primary.normalizedLightwalletdUrl;
@@ -70,7 +73,7 @@ class RpcEndpointFailoverState {
   RpcEndpointFailoverState copyWith({
     RpcEndpointConfig? primary,
     RpcEndpointConfig? current,
-    RpcEndpointConfig? fallback,
+    List<RpcEndpointConfig>? fallbackCandidates,
     int? primaryFailureCount,
     String? lastFailure,
     bool clearLastFailure = false,
@@ -82,7 +85,7 @@ class RpcEndpointFailoverState {
     return RpcEndpointFailoverState(
       primary: primary ?? this.primary,
       current: current ?? this.current,
-      fallback: fallback ?? this.fallback,
+      fallbackCandidates: fallbackCandidates ?? this.fallbackCandidates,
       primaryFailureCount: primaryFailureCount ?? this.primaryFailureCount,
       lastFailure: clearLastFailure ? null : lastFailure ?? this.lastFailure,
       switchedAt: clearSwitchedAt ? null : switchedAt ?? this.switchedAt,
@@ -173,7 +176,7 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
     return RpcEndpointFailoverState(
       primary: primary,
       current: primary,
-      fallback: fallbackRpcEndpointConfigFor(primary),
+      fallbackCandidates: fallbackRpcEndpointCandidatesFor(primary),
     );
   }
 
@@ -250,8 +253,8 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       return false;
     }
 
-    final fallback = state.fallback;
-    if (fallback == null) {
+    final fallbackCandidates = state.fallbackCandidates;
+    if (fallbackCandidates.isEmpty) {
       log(
         'RpcEndpointFailover: no fallback endpoint for '
         '${state.primary.hostPort} after $operation failure: $error',
@@ -263,12 +266,26 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       return false;
     }
 
-    try {
-      await _checkHealth(fallback);
-    } catch (fallbackError) {
+    RpcEndpointConfig? fallback;
+    Object? lastFallbackError;
+    for (final candidate in fallbackCandidates) {
+      try {
+        await _checkHealth(candidate);
+        fallback = candidate;
+        break;
+      } catch (fallbackError) {
+        lastFallbackError = fallbackError;
+        log(
+          'RpcEndpointFailover: fallback ${candidate.hostPort} failed health '
+          'check after $operation failure: $fallbackError',
+        );
+      }
+    }
+
+    if (fallback == null) {
       log(
-        'RpcEndpointFailover: fallback ${fallback.hostPort} failed health '
-        'check after $operation failure: $fallbackError',
+        'RpcEndpointFailover: all fallback endpoints failed health checks '
+        'after $operation failure: $lastFallbackError',
       );
       state = state.copyWith(
         primaryFailureCount: nextFailureCount,

--- a/lib/src/providers/rpc_endpoint_failover_provider.dart
+++ b/lib/src/providers/rpc_endpoint_failover_provider.dart
@@ -236,16 +236,19 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
         shouldFallbackFromLightwalletdError,
   }) async {
     final attempted = endpoint ?? state.current;
-    if (state.isUsingFallback ||
-        attempted.normalizedLightwalletdUrl !=
-            state.primary.normalizedLightwalletdUrl ||
-        !shouldFallback(error)) {
+    final attemptedUrl = attempted.normalizedLightwalletdUrl;
+    final currentUrl = state.current.normalizedLightwalletdUrl;
+    final primaryUrl = state.primary.normalizedLightwalletdUrl;
+    if (attemptedUrl != currentUrl || !shouldFallback(error)) {
       return false;
     }
 
-    final nextFailureCount = state.primaryFailureCount + 1;
+    final failedPrimary = attemptedUrl == primaryUrl;
+    final nextFailureCount = failedPrimary
+        ? state.primaryFailureCount + 1
+        : state.primaryFailureCount;
     final settings = ref.read(rpcEndpointFailoverSettingsProvider);
-    if (nextFailureCount < settings.primaryFailureThreshold) {
+    if (failedPrimary && nextFailureCount < settings.primaryFailureThreshold) {
       state = state.copyWith(
         primaryFailureCount: nextFailureCount,
         lastFailure: error.toString(),
@@ -253,11 +256,15 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       return false;
     }
 
-    final fallbackCandidates = state.fallbackCandidates;
+    final fallbackCandidates = state.fallbackCandidates
+        .where(
+          (candidate) => candidate.normalizedLightwalletdUrl != attemptedUrl,
+        )
+        .toList(growable: false);
     if (fallbackCandidates.isEmpty) {
       log(
         'RpcEndpointFailover: no fallback endpoint for '
-        '${state.primary.hostPort} after $operation failure: $error',
+        '${attempted.hostPort} after $operation failure: $error',
       );
       state = state.copyWith(
         primaryFailureCount: nextFailureCount,
@@ -302,7 +309,7 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       endpoint: fallback,
     );
     log(
-      'RpcEndpointFailover: switched ${state.primary.hostPort} -> '
+      'RpcEndpointFailover: switched ${attempted.hostPort} -> '
       '${fallback.hostPort} after $operation failure: $error',
     );
     state = state.copyWith(
@@ -310,7 +317,7 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       primaryFailureCount: nextFailureCount,
       lastFailure: error.toString(),
       switchedAt: now,
-      lastPrimaryProbeAt: now,
+      lastPrimaryProbeAt: failedPrimary ? now : state.lastPrimaryProbeAt,
       lastEvent: event,
     );
     return true;

--- a/lib/src/providers/rpc_endpoint_failover_provider.dart
+++ b/lib/src/providers/rpc_endpoint_failover_provider.dart
@@ -138,6 +138,20 @@ class _FallbackHealth {
   final RpcEndpointHealth health;
 }
 
+class _FailoverContext {
+  const _FailoverContext({
+    required this.generation,
+    required this.primary,
+    required this.current,
+    required this.fallbackCandidates,
+  });
+
+  final int generation;
+  final RpcEndpointConfig primary;
+  final RpcEndpointConfig current;
+  final List<RpcEndpointConfig> fallbackCandidates;
+}
+
 Future<RpcEndpointHealth> checkRpcEndpointHealth({
   required RpcEndpointConfig endpoint,
   required RpcEndpointChainNameGetter getChainName,
@@ -212,9 +226,11 @@ final rpcEndpointFailoverLatestBlockHeightGetterProvider =
 
 class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
   int _eventSequence = 0;
+  int _configGeneration = 0;
 
   @override
   RpcEndpointFailoverState build() {
+    _configGeneration += 1;
     final primary = ref.watch(rpcEndpointProvider);
     return RpcEndpointFailoverState(
       primary: primary,
@@ -313,14 +329,14 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
         shouldFallbackFromLightwalletdError,
   }) async {
     final attempted = endpoint ?? state.current;
-    final attemptedUrl = attempted.normalizedLightwalletdUrl;
-    final currentUrl = state.current.normalizedLightwalletdUrl;
-    final primaryUrl = state.primary.normalizedLightwalletdUrl;
-    if (attemptedUrl != currentUrl || !shouldFallback(error)) {
+    final context = _captureContext();
+    if (!_sameEndpointIdentity(attempted, context.current) ||
+        !shouldFallback(error)) {
       return false;
     }
 
-    final failedPrimary = attemptedUrl == primaryUrl;
+    final attemptedUrl = attempted.normalizedLightwalletdUrl;
+    final failedPrimary = _sameEndpointIdentity(attempted, context.primary);
     final nextFailureCount = failedPrimary
         ? state.primaryFailureCount + 1
         : state.primaryFailureCount;
@@ -333,7 +349,7 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       return false;
     }
 
-    final fallbackCandidates = state.fallbackCandidates
+    final fallbackCandidates = context.fallbackCandidates
         .where(
           (candidate) => candidate.normalizedLightwalletdUrl != attemptedUrl,
         )
@@ -369,6 +385,7 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
     }
 
     if (fallback == null) {
+      if (!_isCurrentContext(context)) return false;
       log(
         'RpcEndpointFailover: all fallback endpoints failed health checks '
         'after $operation failure: $lastFallbackError',
@@ -376,6 +393,14 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       state = state.copyWith(
         primaryFailureCount: nextFailureCount,
         lastFailure: error.toString(),
+      );
+      return false;
+    }
+
+    if (!_isCurrentContext(context)) {
+      log(
+        'RpcEndpointFailover: ignored stale fallback result for '
+        '${attempted.hostPort} after endpoint settings changed',
       );
       return false;
     }
@@ -410,6 +435,9 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
   Future<bool> maybeProbePrimary({bool force = false}) async {
     if (!state.isUsingFallback) return false;
 
+    final context = _captureContext();
+    final primary = context.primary;
+    final currentEndpoint = context.current;
     final now = ref.read(rpcEndpointFailoverClockProvider)();
     final settings = ref.read(rpcEndpointFailoverSettingsProvider);
     final lastProbe = state.lastPrimaryProbeAt;
@@ -422,24 +450,36 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
     state = state.copyWith(lastPrimaryProbeAt: now);
     late final RpcEndpointHealth primaryHealth;
     try {
-      primaryHealth = await _checkHealth(state.primary);
+      primaryHealth = await _checkHealth(primary);
     } catch (e) {
+      log('RpcEndpointFailover: primary ${primary.hostPort} probe failed: $e');
+      return false;
+    }
+    if (!_isCurrentContext(context)) {
       log(
-        'RpcEndpointFailover: primary ${state.primary.hostPort} probe failed: $e',
+        'RpcEndpointFailover: ignored stale primary probe for '
+        '${primary.hostPort} after endpoint settings changed',
       );
       return false;
     }
 
-    final currentEndpoint = state.current;
     var currentHeight = state.lastObservedHeight;
     try {
       final currentHealth = await _checkHealth(currentEndpoint);
+      if (!_isCurrentContext(context)) {
+        log(
+          'RpcEndpointFailover: ignored stale fallback probe for '
+          '${currentEndpoint.hostPort} after endpoint settings changed',
+        );
+        return false;
+      }
       currentHeight = _maxHeight(currentHeight, currentHealth.height);
       state = state.copyWith(
         lastObservedHeight: currentHeight,
         lastObservedAt: now,
       );
     } catch (e) {
+      if (!_isCurrentContext(context)) return false;
       log(
         'RpcEndpointFailover: current fallback ${currentEndpoint.hostPort} '
         'probe failed while checking primary recovery: $e',
@@ -454,24 +494,25 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
     if (currentHeight != null &&
         primaryHealth.height + tolerance < currentHeight) {
       log(
-        'RpcEndpointFailover: primary ${state.primary.hostPort} probe lagging '
+        'RpcEndpointFailover: primary ${primary.hostPort} probe lagging '
         'at height ${primaryHealth.height}; current height is $currentHeight',
       );
       return false;
     }
+    if (!_isCurrentContext(context)) return false;
 
     final event = RpcEndpointFailoverEvent(
       sequence: ++_eventSequence,
       kind: RpcEndpointFailoverEventKind.switchedToPrimary,
       message: 'Selected endpoint recovered. Switched back.',
-      endpoint: state.primary,
+      endpoint: primary,
     );
     log(
-      'RpcEndpointFailover: primary ${state.primary.hostPort} recovered; '
-      'leaving fallback ${state.current.hostPort}',
+      'RpcEndpointFailover: primary ${primary.hostPort} recovered; '
+      'leaving fallback ${currentEndpoint.hostPort}',
     );
     state = state.copyWith(
-      current: state.primary,
+      current: primary,
       primaryFailureCount: 0,
       clearLastFailure: true,
       clearSwitchedAt: true,
@@ -492,6 +533,7 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
   }) async {
     if (!_isCurrentEndpoint(endpoint)) return null;
 
+    final context = _captureContext();
     final now = ref.read(rpcEndpointFailoverClockProvider)();
     final windowStartedAt = state.heightWindowStartedAt;
     final windowStartHeight = state.heightWindowStartHeight;
@@ -517,10 +559,12 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
 
     final fallback = await _findFallbackAheadOf(
       endpoint,
+      candidates: context.fallbackCandidates,
       currentHeight: height,
       operation: operation,
     );
     if (fallback == null) {
+      if (!_isCurrentContext(context)) return null;
       log(
         'RpcEndpointFailover: ${endpoint.hostPort} height increased by '
         '$heightIncrease blocks in ${settings.slowHeightWindow.inSeconds}s, '
@@ -530,8 +574,15 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       return null;
     }
 
-    final primaryUrl = state.primary.normalizedLightwalletdUrl;
-    final failedPrimary = endpoint.normalizedLightwalletdUrl == primaryUrl;
+    if (!_isCurrentContext(context)) {
+      log(
+        'RpcEndpointFailover: ignored stale slow-height fallback for '
+        '${endpoint.hostPort} after endpoint settings changed',
+      );
+      return null;
+    }
+
+    final failedPrimary = _sameEndpointIdentity(endpoint, context.primary);
     final event = RpcEndpointFailoverEvent(
       sequence: ++_eventSequence,
       kind: RpcEndpointFailoverEventKind.switchedToFallback,
@@ -562,6 +613,7 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
 
   Future<_FallbackHealth?> _findFallbackAheadOf(
     RpcEndpointConfig attempted, {
+    required List<RpcEndpointConfig> candidates,
     required BigInt currentHeight,
     required String operation,
   }) async {
@@ -569,7 +621,7 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
     final requiredHeight =
         currentHeight + BigInt.from(settings.slowFallbackLeadBlocks);
     final attemptedUrl = attempted.normalizedLightwalletdUrl;
-    for (final candidate in state.fallbackCandidates) {
+    for (final candidate in candidates) {
       if (candidate.normalizedLightwalletdUrl == attemptedUrl) continue;
       try {
         final health = await _checkHealth(candidate);
@@ -607,8 +659,28 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
   }
 
   bool _isCurrentEndpoint(RpcEndpointConfig endpoint) {
-    return endpoint.normalizedLightwalletdUrl ==
-        state.current.normalizedLightwalletdUrl;
+    return _sameEndpointIdentity(endpoint, state.current);
+  }
+
+  _FailoverContext _captureContext() {
+    return _FailoverContext(
+      generation: _configGeneration,
+      primary: state.primary,
+      current: state.current,
+      fallbackCandidates: state.fallbackCandidates,
+    );
+  }
+
+  bool _isCurrentContext(_FailoverContext context) {
+    return _configGeneration == context.generation &&
+        _sameEndpointIdentity(state.primary, context.primary) &&
+        _sameEndpointIdentity(state.current, context.current);
+  }
+
+  bool _sameEndpointIdentity(RpcEndpointConfig a, RpcEndpointConfig b) {
+    return a.networkName == b.networkName &&
+        a.effectivePresetId == b.effectivePresetId &&
+        a.normalizedLightwalletdUrl == b.normalizedLightwalletdUrl;
   }
 
   BigInt _maxHeight(BigInt? a, BigInt b) {

--- a/lib/src/providers/rpc_endpoint_failover_provider.dart
+++ b/lib/src/providers/rpc_endpoint_failover_provider.dart
@@ -430,7 +430,22 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       return false;
     }
 
-    final currentHeight = state.lastObservedHeight;
+    final currentEndpoint = state.current;
+    var currentHeight = state.lastObservedHeight;
+    try {
+      final currentHealth = await _checkHealth(currentEndpoint);
+      currentHeight = _maxHeight(currentHeight, currentHealth.height);
+      state = state.copyWith(
+        lastObservedHeight: currentHeight,
+        lastObservedAt: now,
+      );
+    } catch (e) {
+      log(
+        'RpcEndpointFailover: current fallback ${currentEndpoint.hostPort} '
+        'probe failed while checking primary recovery: $e',
+      );
+    }
+
     final tolerance = BigInt.from(
       ref
           .read(rpcEndpointFailoverSettingsProvider)
@@ -594,6 +609,11 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
   bool _isCurrentEndpoint(RpcEndpointConfig endpoint) {
     return endpoint.normalizedLightwalletdUrl ==
         state.current.normalizedLightwalletdUrl;
+  }
+
+  BigInt _maxHeight(BigInt? a, BigInt b) {
+    if (a == null || b > a) return b;
+    return a;
   }
 
   Future<RpcEndpointHealth> _checkHealth(RpcEndpointConfig endpoint) {

--- a/lib/src/providers/rpc_endpoint_failover_provider.dart
+++ b/lib/src/providers/rpc_endpoint_failover_provider.dart
@@ -30,10 +30,18 @@ class RpcEndpointFailoverSettings {
   const RpcEndpointFailoverSettings({
     this.primaryProbeInterval = const Duration(seconds: 60),
     this.primaryFailureThreshold = 1,
+    this.slowHeightWindow = const Duration(minutes: 5),
+    this.minHeightIncreaseInSlowWindow = 2,
+    this.slowFallbackLeadBlocks = 2,
+    this.primaryReturnLagToleranceBlocks = 1,
   });
 
   final Duration primaryProbeInterval;
   final int primaryFailureThreshold;
+  final Duration slowHeightWindow;
+  final int minHeightIncreaseInSlowWindow;
+  final int slowFallbackLeadBlocks;
+  final int primaryReturnLagToleranceBlocks;
 }
 
 class RpcEndpointHealth {
@@ -53,6 +61,10 @@ class RpcEndpointFailoverState {
     this.switchedAt,
     this.lastPrimaryProbeAt,
     this.lastEvent,
+    this.heightWindowStartedAt,
+    this.heightWindowStartHeight,
+    this.lastObservedHeight,
+    this.lastObservedAt,
   });
 
   final RpcEndpointConfig primary;
@@ -63,6 +75,10 @@ class RpcEndpointFailoverState {
   final DateTime? switchedAt;
   final DateTime? lastPrimaryProbeAt;
   final RpcEndpointFailoverEvent? lastEvent;
+  final DateTime? heightWindowStartedAt;
+  final BigInt? heightWindowStartHeight;
+  final BigInt? lastObservedHeight;
+  final DateTime? lastObservedAt;
 
   RpcEndpointConfig? get fallback =>
       fallbackCandidates.isEmpty ? null : fallbackCandidates.first;
@@ -81,6 +97,14 @@ class RpcEndpointFailoverState {
     bool clearSwitchedAt = false,
     DateTime? lastPrimaryProbeAt,
     RpcEndpointFailoverEvent? lastEvent,
+    DateTime? heightWindowStartedAt,
+    bool clearHeightWindowStartedAt = false,
+    BigInt? heightWindowStartHeight,
+    bool clearHeightWindowStartHeight = false,
+    BigInt? lastObservedHeight,
+    bool clearLastObservedHeight = false,
+    DateTime? lastObservedAt,
+    bool clearLastObservedAt = false,
   }) {
     return RpcEndpointFailoverState(
       primary: primary ?? this.primary,
@@ -91,8 +115,27 @@ class RpcEndpointFailoverState {
       switchedAt: clearSwitchedAt ? null : switchedAt ?? this.switchedAt,
       lastPrimaryProbeAt: lastPrimaryProbeAt ?? this.lastPrimaryProbeAt,
       lastEvent: lastEvent ?? this.lastEvent,
+      heightWindowStartedAt: clearHeightWindowStartedAt
+          ? null
+          : heightWindowStartedAt ?? this.heightWindowStartedAt,
+      heightWindowStartHeight: clearHeightWindowStartHeight
+          ? null
+          : heightWindowStartHeight ?? this.heightWindowStartHeight,
+      lastObservedHeight: clearLastObservedHeight
+          ? null
+          : lastObservedHeight ?? this.lastObservedHeight,
+      lastObservedAt: clearLastObservedAt
+          ? null
+          : lastObservedAt ?? this.lastObservedAt,
     );
   }
+}
+
+class _FallbackHealth {
+  const _FallbackHealth({required this.endpoint, required this.health});
+
+  final RpcEndpointConfig endpoint;
+  final RpcEndpointHealth health;
 }
 
 Future<RpcEndpointHealth> checkRpcEndpointHealth({
@@ -182,13 +225,47 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
 
   RpcEndpointConfig get currentEndpoint => state.current;
 
-  Future<BigInt> getLatestBlockHeight() {
-    return runWithEndpointFallback(
-      operation: 'latest block height',
-      action: (endpoint) => ref
-          .read(rpcEndpointFailoverLatestBlockHeightGetterProvider)
-          .call(endpoint.normalizedLightwalletdUrl),
+  Future<BigInt> getLatestBlockHeight() async {
+    const operation = 'latest block height';
+    await maybeProbePrimary();
+    final endpoint = state.current;
+    final getLatestBlockHeight = ref.read(
+      rpcEndpointFailoverLatestBlockHeightGetterProvider,
     );
+
+    try {
+      final height = await getLatestBlockHeight(
+        endpoint.normalizedLightwalletdUrl,
+      );
+      _recordEndpointSuccess(endpoint);
+      final slowFallback = await _maybeSwitchFromSlowHeight(
+        endpoint,
+        height,
+        operation: operation,
+      );
+      return slowFallback?.height ?? height;
+    } catch (e, st) {
+      final switched = await switchToFallbackFor(
+        e,
+        endpoint: endpoint,
+        operation: operation,
+      );
+      if (!switched) {
+        Error.throwWithStackTrace(e, st);
+      }
+
+      final fallbackEndpoint = state.current;
+      try {
+        final fallbackHeight = await getLatestBlockHeight(
+          fallbackEndpoint.normalizedLightwalletdUrl,
+        );
+        _recordEndpointSuccess(fallbackEndpoint);
+        _resetHeightWindow(fallbackEndpoint, fallbackHeight);
+        return fallbackHeight;
+      } catch (fallbackError, fallbackStack) {
+        Error.throwWithStackTrace(fallbackError, fallbackStack);
+      }
+    }
   }
 
   Future<T> runWithEndpointFallback<T>({
@@ -274,11 +351,13 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
     }
 
     RpcEndpointConfig? fallback;
+    RpcEndpointHealth? fallbackHealth;
     Object? lastFallbackError;
     for (final candidate in fallbackCandidates) {
       try {
-        await _checkHealth(candidate);
+        final health = await _checkHealth(candidate);
         fallback = candidate;
+        fallbackHealth = health;
         break;
       } catch (fallbackError) {
         lastFallbackError = fallbackError;
@@ -301,6 +380,7 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       return false;
     }
 
+    final selectedFallbackHealth = fallbackHealth!;
     final now = ref.read(rpcEndpointFailoverClockProvider)();
     final event = RpcEndpointFailoverEvent(
       sequence: ++_eventSequence,
@@ -319,6 +399,10 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       switchedAt: now,
       lastPrimaryProbeAt: failedPrimary ? now : state.lastPrimaryProbeAt,
       lastEvent: event,
+      heightWindowStartedAt: now,
+      heightWindowStartHeight: selectedFallbackHealth.height,
+      lastObservedHeight: selectedFallbackHealth.height,
+      lastObservedAt: now,
     );
     return true;
   }
@@ -336,11 +420,27 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
     }
 
     state = state.copyWith(lastPrimaryProbeAt: now);
+    late final RpcEndpointHealth primaryHealth;
     try {
-      await _checkHealth(state.primary);
+      primaryHealth = await _checkHealth(state.primary);
     } catch (e) {
       log(
         'RpcEndpointFailover: primary ${state.primary.hostPort} probe failed: $e',
+      );
+      return false;
+    }
+
+    final currentHeight = state.lastObservedHeight;
+    final tolerance = BigInt.from(
+      ref
+          .read(rpcEndpointFailoverSettingsProvider)
+          .primaryReturnLagToleranceBlocks,
+    );
+    if (currentHeight != null &&
+        primaryHealth.height + tolerance < currentHeight) {
+      log(
+        'RpcEndpointFailover: primary ${state.primary.hostPort} probe lagging '
+        'at height ${primaryHealth.height}; current height is $currentHeight',
       );
       return false;
     }
@@ -362,8 +462,138 @@ class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
       clearSwitchedAt: true,
       lastPrimaryProbeAt: now,
       lastEvent: event,
+      heightWindowStartedAt: now,
+      heightWindowStartHeight: primaryHealth.height,
+      lastObservedHeight: primaryHealth.height,
+      lastObservedAt: now,
     );
     return true;
+  }
+
+  Future<RpcEndpointHealth?> _maybeSwitchFromSlowHeight(
+    RpcEndpointConfig endpoint,
+    BigInt height, {
+    required String operation,
+  }) async {
+    if (!_isCurrentEndpoint(endpoint)) return null;
+
+    final now = ref.read(rpcEndpointFailoverClockProvider)();
+    final windowStartedAt = state.heightWindowStartedAt;
+    final windowStartHeight = state.heightWindowStartHeight;
+    if (windowStartedAt == null ||
+        windowStartHeight == null ||
+        height < windowStartHeight) {
+      _resetHeightWindow(endpoint, height, now: now);
+      return null;
+    }
+
+    state = state.copyWith(lastObservedHeight: height, lastObservedAt: now);
+
+    final settings = ref.read(rpcEndpointFailoverSettingsProvider);
+    if (now.difference(windowStartedAt) < settings.slowHeightWindow) {
+      return null;
+    }
+
+    final heightIncrease = height - windowStartHeight;
+    if (heightIncrease >= BigInt.from(settings.minHeightIncreaseInSlowWindow)) {
+      _resetHeightWindow(endpoint, height, now: now);
+      return null;
+    }
+
+    final fallback = await _findFallbackAheadOf(
+      endpoint,
+      currentHeight: height,
+      operation: operation,
+    );
+    if (fallback == null) {
+      log(
+        'RpcEndpointFailover: ${endpoint.hostPort} height increased by '
+        '$heightIncrease blocks in ${settings.slowHeightWindow.inSeconds}s, '
+        'but no fallback endpoint is ahead enough; keeping current endpoint',
+      );
+      _resetHeightWindow(endpoint, height, now: now);
+      return null;
+    }
+
+    final primaryUrl = state.primary.normalizedLightwalletdUrl;
+    final failedPrimary = endpoint.normalizedLightwalletdUrl == primaryUrl;
+    final event = RpcEndpointFailoverEvent(
+      sequence: ++_eventSequence,
+      kind: RpcEndpointFailoverEventKind.switchedToFallback,
+      message: 'Selected endpoint is unstable. Switched to fallback endpoint.',
+      endpoint: fallback.endpoint,
+    );
+    log(
+      'RpcEndpointFailover: switched ${endpoint.hostPort} -> '
+      '${fallback.endpoint.hostPort} because height only increased '
+      'by $heightIncrease blocks in ${settings.slowHeightWindow.inSeconds}s '
+      'during $operation and fallback is at height ${fallback.health.height}',
+    );
+    state = state.copyWith(
+      current: fallback.endpoint,
+      lastFailure:
+          'Endpoint height increased by $heightIncrease blocks in '
+          '${settings.slowHeightWindow.inSeconds}s.',
+      switchedAt: now,
+      lastPrimaryProbeAt: failedPrimary ? now : state.lastPrimaryProbeAt,
+      lastEvent: event,
+      heightWindowStartedAt: now,
+      heightWindowStartHeight: fallback.health.height,
+      lastObservedHeight: fallback.health.height,
+      lastObservedAt: now,
+    );
+    return fallback.health;
+  }
+
+  Future<_FallbackHealth?> _findFallbackAheadOf(
+    RpcEndpointConfig attempted, {
+    required BigInt currentHeight,
+    required String operation,
+  }) async {
+    final settings = ref.read(rpcEndpointFailoverSettingsProvider);
+    final requiredHeight =
+        currentHeight + BigInt.from(settings.slowFallbackLeadBlocks);
+    final attemptedUrl = attempted.normalizedLightwalletdUrl;
+    for (final candidate in state.fallbackCandidates) {
+      if (candidate.normalizedLightwalletdUrl == attemptedUrl) continue;
+      try {
+        final health = await _checkHealth(candidate);
+        if (health.height >= requiredHeight) {
+          return _FallbackHealth(endpoint: candidate, health: health);
+        }
+        log(
+          'RpcEndpointFailover: fallback ${candidate.hostPort} is not ahead '
+          'enough for slow $operation; height=${health.height}, '
+          'required>=$requiredHeight',
+        );
+      } catch (fallbackError) {
+        log(
+          'RpcEndpointFailover: fallback ${candidate.hostPort} failed health '
+          'check during slow $operation fallback: $fallbackError',
+        );
+      }
+    }
+    return null;
+  }
+
+  void _resetHeightWindow(
+    RpcEndpointConfig endpoint,
+    BigInt height, {
+    DateTime? now,
+  }) {
+    if (!_isCurrentEndpoint(endpoint)) return;
+    final observedAt = now ?? ref.read(rpcEndpointFailoverClockProvider)();
+    state = state.copyWith(
+      heightWindowStartedAt: observedAt,
+      heightWindowStartHeight: height,
+      lastObservedHeight: height,
+      lastObservedAt: observedAt,
+    );
+  }
+
+  bool _isCurrentEndpoint(RpcEndpointConfig endpoint) {
+    return endpoint.normalizedLightwalletdUrl ==
+        state.current.normalizedLightwalletdUrl;
   }
 
   Future<RpcEndpointHealth> _checkHealth(RpcEndpointConfig endpoint) {

--- a/lib/src/providers/rpc_endpoint_failover_provider.dart
+++ b/lib/src/providers/rpc_endpoint_failover_provider.dart
@@ -1,0 +1,367 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../main.dart' show log;
+import '../core/config/rpc_endpoint_config.dart';
+import '../rust/api/wallet.dart' as rust_wallet;
+import 'rpc_endpoint_provider.dart';
+
+typedef RpcEndpointChainNameGetter =
+    Future<String> Function(String lightwalletdUrl);
+typedef RpcEndpointLatestBlockHeightGetter =
+    Future<BigInt> Function(String lightwalletdUrl);
+
+enum RpcEndpointFailoverEventKind { switchedToFallback, switchedToPrimary }
+
+class RpcEndpointFailoverEvent {
+  const RpcEndpointFailoverEvent({
+    required this.sequence,
+    required this.kind,
+    required this.message,
+    required this.endpoint,
+  });
+
+  final int sequence;
+  final RpcEndpointFailoverEventKind kind;
+  final String message;
+  final RpcEndpointConfig endpoint;
+}
+
+class RpcEndpointFailoverSettings {
+  const RpcEndpointFailoverSettings({
+    this.primaryProbeInterval = const Duration(seconds: 60),
+    this.primaryFailureThreshold = 1,
+  });
+
+  final Duration primaryProbeInterval;
+  final int primaryFailureThreshold;
+}
+
+class RpcEndpointHealth {
+  const RpcEndpointHealth({required this.chainName, required this.height});
+
+  final String chainName;
+  final BigInt height;
+}
+
+class RpcEndpointFailoverState {
+  const RpcEndpointFailoverState({
+    required this.primary,
+    required this.current,
+    required this.fallback,
+    this.primaryFailureCount = 0,
+    this.lastFailure,
+    this.switchedAt,
+    this.lastPrimaryProbeAt,
+    this.lastEvent,
+  });
+
+  final RpcEndpointConfig primary;
+  final RpcEndpointConfig current;
+  final RpcEndpointConfig? fallback;
+  final int primaryFailureCount;
+  final String? lastFailure;
+  final DateTime? switchedAt;
+  final DateTime? lastPrimaryProbeAt;
+  final RpcEndpointFailoverEvent? lastEvent;
+
+  bool get isUsingFallback =>
+      current.normalizedLightwalletdUrl != primary.normalizedLightwalletdUrl;
+
+  RpcEndpointFailoverState copyWith({
+    RpcEndpointConfig? primary,
+    RpcEndpointConfig? current,
+    RpcEndpointConfig? fallback,
+    int? primaryFailureCount,
+    String? lastFailure,
+    bool clearLastFailure = false,
+    DateTime? switchedAt,
+    bool clearSwitchedAt = false,
+    DateTime? lastPrimaryProbeAt,
+    RpcEndpointFailoverEvent? lastEvent,
+  }) {
+    return RpcEndpointFailoverState(
+      primary: primary ?? this.primary,
+      current: current ?? this.current,
+      fallback: fallback ?? this.fallback,
+      primaryFailureCount: primaryFailureCount ?? this.primaryFailureCount,
+      lastFailure: clearLastFailure ? null : lastFailure ?? this.lastFailure,
+      switchedAt: clearSwitchedAt ? null : switchedAt ?? this.switchedAt,
+      lastPrimaryProbeAt: lastPrimaryProbeAt ?? this.lastPrimaryProbeAt,
+      lastEvent: lastEvent ?? this.lastEvent,
+    );
+  }
+}
+
+Future<RpcEndpointHealth> checkRpcEndpointHealth({
+  required RpcEndpointConfig endpoint,
+  required RpcEndpointChainNameGetter getChainName,
+  required RpcEndpointLatestBlockHeightGetter getLatestBlockHeight,
+}) async {
+  final chainName = await getChainName(endpoint.normalizedLightwalletdUrl);
+  if (chainName != endpoint.networkName) {
+    throw FormatException(
+      'Endpoint is for $chainName, but this wallet uses ${endpoint.networkName}.',
+    );
+  }
+  final height = await getLatestBlockHeight(endpoint.normalizedLightwalletdUrl);
+  return RpcEndpointHealth(chainName: chainName, height: height);
+}
+
+bool shouldFallbackFromLightwalletdError(Object error) {
+  final message = error.toString().toLowerCase();
+  if (message.contains('wrong network') ||
+      message.contains('endpoint is for') ||
+      message.contains('database is locked') ||
+      message.contains('proposal not found') ||
+      message.contains('send flow mismatch') ||
+      message.contains('insufficient') ||
+      message.contains('invalid amount') ||
+      message.contains('invalid address')) {
+    return false;
+  }
+
+  return message.contains('network:') ||
+      message.contains('deadlineexceeded') ||
+      message.contains('deadline exceeded') ||
+      message.contains('unavailable') ||
+      message.contains('timed out') ||
+      message.contains('timeout') ||
+      message.contains('grpc connect failed') ||
+      message.contains('connect failed') ||
+      message.contains('connection refused') ||
+      message.contains('connection reset') ||
+      message.contains('connection closed') ||
+      message.contains('dns') ||
+      message.contains('failed to lookup address') ||
+      message.contains('tls error') ||
+      message.contains('transport error') ||
+      message.contains('http2') ||
+      message.contains('socket');
+}
+
+final rpcEndpointFailoverSettingsProvider =
+    Provider<RpcEndpointFailoverSettings>(
+      (_) => const RpcEndpointFailoverSettings(),
+    );
+
+final rpcEndpointFailoverClockProvider = Provider<DateTime Function()>(
+  (_) => DateTime.now,
+);
+
+final rpcEndpointFailoverChainNameGetterProvider =
+    Provider<RpcEndpointChainNameGetter>(
+      (_) =>
+          (lightwalletdUrl) => rust_wallet.getLightwalletdChainName(
+            lightwalletdUrl: lightwalletdUrl,
+          ),
+    );
+
+final rpcEndpointFailoverLatestBlockHeightGetterProvider =
+    Provider<RpcEndpointLatestBlockHeightGetter>(
+      (_) =>
+          (lightwalletdUrl) => rust_wallet.getLatestBlockHeight(
+            lightwalletdUrl: lightwalletdUrl,
+          ),
+    );
+
+class RpcEndpointFailoverNotifier extends Notifier<RpcEndpointFailoverState> {
+  int _eventSequence = 0;
+
+  @override
+  RpcEndpointFailoverState build() {
+    final primary = ref.watch(rpcEndpointProvider);
+    return RpcEndpointFailoverState(
+      primary: primary,
+      current: primary,
+      fallback: fallbackRpcEndpointConfigFor(primary),
+    );
+  }
+
+  RpcEndpointConfig get currentEndpoint => state.current;
+
+  Future<BigInt> getLatestBlockHeight() {
+    return runWithEndpointFallback(
+      operation: 'latest block height',
+      action: (endpoint) => ref
+          .read(rpcEndpointFailoverLatestBlockHeightGetterProvider)
+          .call(endpoint.normalizedLightwalletdUrl),
+    );
+  }
+
+  Future<T> runWithEndpointFallback<T>({
+    required String operation,
+    required Future<T> Function(RpcEndpointConfig endpoint) action,
+    bool allowFallback = true,
+    bool Function(Object error) shouldFallback =
+        shouldFallbackFromLightwalletdError,
+  }) async {
+    await maybeProbePrimary();
+    final endpoint = state.current;
+    try {
+      final result = await action(endpoint);
+      _recordEndpointSuccess(endpoint);
+      return result;
+    } catch (e, st) {
+      final switched = allowFallback
+          ? await switchToFallbackFor(
+              e,
+              endpoint: endpoint,
+              operation: operation,
+              shouldFallback: shouldFallback,
+            )
+          : false;
+      if (!switched) {
+        Error.throwWithStackTrace(e, st);
+      }
+
+      final fallbackEndpoint = state.current;
+      try {
+        final result = await action(fallbackEndpoint);
+        _recordEndpointSuccess(fallbackEndpoint);
+        return result;
+      } catch (fallbackError, fallbackStack) {
+        Error.throwWithStackTrace(fallbackError, fallbackStack);
+      }
+    }
+  }
+
+  Future<bool> switchToFallbackFor(
+    Object error, {
+    RpcEndpointConfig? endpoint,
+    required String operation,
+    bool Function(Object error) shouldFallback =
+        shouldFallbackFromLightwalletdError,
+  }) async {
+    final attempted = endpoint ?? state.current;
+    if (state.isUsingFallback ||
+        attempted.normalizedLightwalletdUrl !=
+            state.primary.normalizedLightwalletdUrl ||
+        !shouldFallback(error)) {
+      return false;
+    }
+
+    final nextFailureCount = state.primaryFailureCount + 1;
+    final settings = ref.read(rpcEndpointFailoverSettingsProvider);
+    if (nextFailureCount < settings.primaryFailureThreshold) {
+      state = state.copyWith(
+        primaryFailureCount: nextFailureCount,
+        lastFailure: error.toString(),
+      );
+      return false;
+    }
+
+    final fallback = state.fallback;
+    if (fallback == null) {
+      log(
+        'RpcEndpointFailover: no fallback endpoint for '
+        '${state.primary.hostPort} after $operation failure: $error',
+      );
+      state = state.copyWith(
+        primaryFailureCount: nextFailureCount,
+        lastFailure: error.toString(),
+      );
+      return false;
+    }
+
+    try {
+      await _checkHealth(fallback);
+    } catch (fallbackError) {
+      log(
+        'RpcEndpointFailover: fallback ${fallback.hostPort} failed health '
+        'check after $operation failure: $fallbackError',
+      );
+      state = state.copyWith(
+        primaryFailureCount: nextFailureCount,
+        lastFailure: error.toString(),
+      );
+      return false;
+    }
+
+    final now = ref.read(rpcEndpointFailoverClockProvider)();
+    final event = RpcEndpointFailoverEvent(
+      sequence: ++_eventSequence,
+      kind: RpcEndpointFailoverEventKind.switchedToFallback,
+      message: 'Selected endpoint is unstable. Switched to fallback endpoint.',
+      endpoint: fallback,
+    );
+    log(
+      'RpcEndpointFailover: switched ${state.primary.hostPort} -> '
+      '${fallback.hostPort} after $operation failure: $error',
+    );
+    state = state.copyWith(
+      current: fallback,
+      primaryFailureCount: nextFailureCount,
+      lastFailure: error.toString(),
+      switchedAt: now,
+      lastPrimaryProbeAt: now,
+      lastEvent: event,
+    );
+    return true;
+  }
+
+  Future<bool> maybeProbePrimary({bool force = false}) async {
+    if (!state.isUsingFallback) return false;
+
+    final now = ref.read(rpcEndpointFailoverClockProvider)();
+    final settings = ref.read(rpcEndpointFailoverSettingsProvider);
+    final lastProbe = state.lastPrimaryProbeAt;
+    if (!force &&
+        lastProbe != null &&
+        now.difference(lastProbe) < settings.primaryProbeInterval) {
+      return false;
+    }
+
+    state = state.copyWith(lastPrimaryProbeAt: now);
+    try {
+      await _checkHealth(state.primary);
+    } catch (e) {
+      log(
+        'RpcEndpointFailover: primary ${state.primary.hostPort} probe failed: $e',
+      );
+      return false;
+    }
+
+    final event = RpcEndpointFailoverEvent(
+      sequence: ++_eventSequence,
+      kind: RpcEndpointFailoverEventKind.switchedToPrimary,
+      message: 'Selected endpoint recovered. Switched back.',
+      endpoint: state.primary,
+    );
+    log(
+      'RpcEndpointFailover: primary ${state.primary.hostPort} recovered; '
+      'leaving fallback ${state.current.hostPort}',
+    );
+    state = state.copyWith(
+      current: state.primary,
+      primaryFailureCount: 0,
+      clearLastFailure: true,
+      clearSwitchedAt: true,
+      lastPrimaryProbeAt: now,
+      lastEvent: event,
+    );
+    return true;
+  }
+
+  Future<RpcEndpointHealth> _checkHealth(RpcEndpointConfig endpoint) {
+    return checkRpcEndpointHealth(
+      endpoint: endpoint,
+      getChainName: ref.read(rpcEndpointFailoverChainNameGetterProvider),
+      getLatestBlockHeight: ref.read(
+        rpcEndpointFailoverLatestBlockHeightGetterProvider,
+      ),
+    );
+  }
+
+  void _recordEndpointSuccess(RpcEndpointConfig endpoint) {
+    if (endpoint.normalizedLightwalletdUrl ==
+            state.primary.normalizedLightwalletdUrl &&
+        state.primaryFailureCount != 0) {
+      state = state.copyWith(primaryFailureCount: 0, clearLastFailure: true);
+    }
+  }
+}
+
+final rpcEndpointFailoverProvider =
+    NotifierProvider<RpcEndpointFailoverNotifier, RpcEndpointFailoverState>(
+      RpcEndpointFailoverNotifier.new,
+    );

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -603,7 +603,13 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               // a lightwalletd stream that keeps firing
               // `_refreshBalance()` callbacks with no owning sync.
               _stopMempoolObserver();
-              unawaited(_recoverSyncOnFallbackOrRecordFailure(e, gen));
+              unawaited(
+                _recoverSyncOnFallbackOrRecordFailure(
+                  e,
+                  gen,
+                  endpoint: endpoint,
+                ),
+              );
             },
           );
         })
@@ -625,11 +631,16 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
 
   Future<void> _recoverSyncOnFallbackOrRecordFailure(
     Object error,
-    int gen,
-  ) async {
+    int gen, {
+    RpcEndpointConfig? endpoint,
+  }) async {
     final switched = await ref
         .read(rpcEndpointFailoverProvider.notifier)
-        .switchToFallbackFor(error, operation: 'foreground sync');
+        .switchToFallbackFor(
+          error,
+          endpoint: endpoint,
+          operation: 'foreground sync',
+        );
     if (gen != _syncGen || _requiresUnlock) return;
     if (switched) {
       log('Sync: retrying foreground sync with fallback endpoint');

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -535,6 +535,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
           );
           _syncSub = stream.listen(
             (event) {
+              if (gen != _syncGen) return;
               final progress = SyncProgressEvent(
                 scannedHeight: event.scannedHeight.toInt(),
                 chainTipHeight: event.chainTipHeight.toInt(),
@@ -550,6 +551,10 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               unawaited(_onSyncProgress(progress));
             },
             onDone: () {
+              if (gen != _syncGen) {
+                log('Sync: ignoring stale stream end');
+                return;
+              }
               log('Sync: stream ended');
               _syncSub = null;
               // Normal completion (isComplete=true) is handled inside

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -9,11 +9,10 @@ import '../app_bootstrap.dart';
 import '../core/config/rpc_endpoint_config.dart';
 import '../core/storage/wallet_paths.dart';
 import '../rust/api/sync.dart' as rust_sync;
-import '../rust/api/wallet.dart' as rust_wallet;
 import '../services/background_sync_delegate.dart';
 import 'account_provider.dart';
 import 'app_security_provider.dart';
-import 'rpc_endpoint_provider.dart';
+import 'rpc_endpoint_failover_provider.dart';
 import 'sync_failure.dart';
 
 class SyncState {
@@ -506,8 +505,21 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     );
 
     _getDbPath()
-        .then((dbPath) {
+        .then((dbPath) async {
           if (gen != _syncGen) return; // stopSync was called, abort
+          try {
+            await ref
+                .read(rpcEndpointFailoverProvider.notifier)
+                .getLatestBlockHeight();
+          } catch (e) {
+            if (gen != _syncGen) return;
+            log('Sync: endpoint preflight failed: $e');
+            _isSyncing = false;
+            _stopDisplayProgressTimer();
+            _recordSyncFailure(e);
+            return;
+          }
+
           final endpoint = _endpointConfig;
           log('Sync: starting foreground sync via ${endpoint.hostPort}');
           // Fire up the mempool observer alongside the scan loop.
@@ -591,7 +603,7 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
               // a lightwalletd stream that keeps firing
               // `_refreshBalance()` callbacks with no owning sync.
               _stopMempoolObserver();
-              _recordSyncFailure(e);
+              unawaited(_recoverSyncOnFallbackOrRecordFailure(e, gen));
             },
           );
         })
@@ -607,8 +619,25 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
           // `_stopMempoolObserver()` here; it is idempotent when
           // nothing is running.
           _stopMempoolObserver();
-          _recordSyncFailure(e);
+          unawaited(_recoverSyncOnFallbackOrRecordFailure(e, gen));
         });
+  }
+
+  Future<void> _recoverSyncOnFallbackOrRecordFailure(
+    Object error,
+    int gen,
+  ) async {
+    final switched = await ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .switchToFallbackFor(error, operation: 'foreground sync');
+    if (gen != _syncGen || _requiresUnlock) return;
+    if (switched) {
+      log('Sync: retrying foreground sync with fallback endpoint');
+      startSync();
+      _startPolling();
+      return;
+    }
+    _recordSyncFailure(error);
   }
 
   void _recordSyncFailure(Object error) {
@@ -1023,9 +1052,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     _pollCheckInFlight = true;
     _stopPolling();
     try {
-      final tip = await rust_wallet.getLatestBlockHeight(
-        lightwalletdUrl: _endpointConfig.normalizedLightwalletdUrl,
-      );
+      final tip = await ref
+          .read(rpcEndpointFailoverProvider.notifier)
+          .getLatestBlockHeight();
       final lastSynced = state.value?.chainTipHeight ?? 0;
       final syncComplete = (state.value?.percentage ?? 0) >= 1.0;
       if (gen != _syncGen || epoch != _sensitiveStateEpoch || _requiresUnlock) {
@@ -1649,7 +1678,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     return ref.read(appSecurityProvider).requiresUnlock;
   }
 
-  RpcEndpointConfig get _endpointConfig => ref.read(rpcEndpointProvider);
+  RpcEndpointConfig get _endpointConfig =>
+      ref.read(rpcEndpointFailoverProvider).current;
 }
 
 final syncProvider = AsyncNotifierProvider<SyncNotifier, SyncState>(

--- a/rust/src/wallet/sync_engine/error.rs
+++ b/rust/src/wallet/sync_engine/error.rs
@@ -152,6 +152,52 @@ impl SyncError {
             SyncError::Db(_) | SyncError::Parse(_) => RecoveryStrategy::Fatal,
         }
     }
+
+    /// Whether this error is safe to treat as an endpoint failover
+    /// candidate. Local DB, parser, continuity, and wallet-state errors
+    /// must not cause endpoint switching.
+    #[allow(dead_code)]
+    pub(crate) fn is_endpoint_failover_candidate(&self) -> bool {
+        match self {
+            SyncError::Network(message) => is_endpoint_failover_candidate_message(message),
+            SyncError::Continuity { .. } | SyncError::Db(_) | SyncError::Parse(_) => false,
+            SyncError::Other(message) => is_endpoint_failover_candidate_message(message),
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn is_endpoint_failover_candidate_message(message: &str) -> bool {
+    let lower = message.to_ascii_lowercase();
+    if lower.contains("wrong network")
+        || lower.contains("endpoint is for")
+        || lower.contains("database is locked")
+        || lower.contains("proposal not found")
+        || lower.contains("send flow mismatch")
+        || lower.contains("insufficient")
+        || lower.contains("invalid amount")
+        || lower.contains("invalid address")
+    {
+        return false;
+    }
+
+    lower.contains("network:")
+        || lower.contains("deadlineexceeded")
+        || lower.contains("deadline exceeded")
+        || lower.contains("unavailable")
+        || lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("grpc connect failed")
+        || lower.contains("connect failed")
+        || lower.contains("connection refused")
+        || lower.contains("connection reset")
+        || lower.contains("connection closed")
+        || lower.contains("dns")
+        || lower.contains("failed to lookup address")
+        || lower.contains("tls error")
+        || lower.contains("transport error")
+        || lower.contains("http2")
+        || lower.contains("socket")
 }
 
 impl fmt::Display for SyncError {
@@ -223,6 +269,31 @@ mod tests {
             SyncError::Other("???".into()).recovery_strategy(),
             RecoveryStrategy::RetryWithBackoff,
         );
+    }
+
+    #[test]
+    fn endpoint_failover_candidate_is_limited_to_transport_failures() {
+        assert!(SyncError::Network("gRPC connect failed: connection refused".into())
+            .is_endpoint_failover_candidate());
+        assert!(SyncError::Other("DeadlineExceeded while reading stream".into())
+            .is_endpoint_failover_candidate());
+
+        assert!(!SyncError::Db("database is locked".into()).is_endpoint_failover_candidate());
+        assert!(
+            !SyncError::Continuity {
+                at_height: 123,
+                detail: "PrevHashMismatch".into(),
+            }
+            .is_endpoint_failover_candidate()
+        );
+        assert!(
+            !is_endpoint_failover_candidate_message(
+                "Endpoint is for test, but this wallet uses main."
+            )
+        );
+        assert!(!is_endpoint_failover_candidate_message(
+            "Proposal not found (expired or already executed)"
+        ));
     }
 
     #[test]

--- a/scripts/e2e/flutter-macos-regtest-custom-endpoint-no-fallback.sh
+++ b/scripts/e2e/flutter-macos-regtest-custom-endpoint-no-fallback.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd fvm
+
+cd "$ROOT_DIR"
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+echo "running Flutter macOS custom endpoint no-fallback integration test"
+fvm flutter test \
+  integration_test/regtest_custom_endpoint_no_fallback_test.dart \
+  -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_DEFAULT_NETWORK=regtest

--- a/scripts/e2e/flutter-macos-regtest-fallback-endpoint.sh
+++ b/scripts/e2e/flutter-macos-regtest-fallback-endpoint.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MNEMONIC="winter shiver fetch refuse absurd mail pistol eight market lounge manual roast miracle ethics found child scare curve congress renew salute pig better used"
+SHIELDED_AMOUNT="1.25"
+CONFIRMING_BLOCKS="${E2E_CONFIRMING_BLOCKS:-10}"
+PRIMARY_LIGHTWALLETD_URL="${E2E_PRIMARY_LIGHTWALLETD_URL:-http://127.0.0.1:19067}"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+json_field() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+data = json.loads(sys.argv[1])
+print(data[sys.argv[2]])
+PY
+}
+
+require_cmd cargo
+require_cmd docker
+require_cmd fvm
+require_cmd python3
+
+cd "$ROOT_DIR"
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+addresses_json="$(cd rust && cargo run --quiet --example regtest_wallet_addresses -- "$MNEMONIC")"
+unified_address="$(json_field "$addresses_json" unifiedAddress)"
+
+echo "funding shielded address with ${SHIELDED_AMOUNT} ZEC"
+scripts/regtest/fund-wallet.sh "$unified_address" "$SHIELDED_AMOUNT" "$CONFIRMING_BLOCKS" >/dev/null
+
+echo "running Flutter macOS fallback endpoint integration test"
+fvm flutter test \
+  integration_test/regtest_fallback_endpoint_test.dart \
+  -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
+  --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$PRIMARY_LIGHTWALLETD_URL"

--- a/scripts/e2e/flutter-macos-regtest-fallback-endpoint.sh
+++ b/scripts/e2e/flutter-macos-regtest-fallback-endpoint.sh
@@ -5,7 +5,6 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MNEMONIC="winter shiver fetch refuse absurd mail pistol eight market lounge manual roast miracle ethics found child scare curve congress renew salute pig better used"
 SHIELDED_AMOUNT="1.25"
 CONFIRMING_BLOCKS="${E2E_CONFIRMING_BLOCKS:-10}"
-PRIMARY_LIGHTWALLETD_URL="${E2E_PRIMARY_LIGHTWALLETD_URL:-http://127.0.0.1:19067}"
 FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
 RESET_REGTEST="${RESET_REGTEST:-1}"
 
@@ -48,5 +47,4 @@ echo "running Flutter macOS fallback endpoint integration test"
 fvm flutter test \
   integration_test/regtest_fallback_endpoint_test.dart \
   -d "$FLUTTER_DEVICE" \
-  --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
-  --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$PRIMARY_LIGHTWALLETD_URL"
+  --dart-define=ZCASH_DEFAULT_NETWORK=regtest

--- a/scripts/e2e/flutter-macos-regtest-full.sh
+++ b/scripts/e2e/flutter-macos-regtest-full.sh
@@ -27,22 +27,25 @@ require_cmd python3
 cd "$ROOT_DIR"
 
 # Keep this ordered from the narrowest smoke test to broader user flows.
-run_test "1/6 import funded wallet and sync balances" \
+run_test "1/7 import funded wallet and sync balances" \
   "scripts/e2e/flutter-macos-regtest-import-sync.sh"
 
-run_test "2/6 create wallet and shield transparent funds" \
+run_test "2/7 fallback from unavailable endpoint and sync balances" \
+  "scripts/e2e/flutter-macos-regtest-fallback-endpoint.sh"
+
+run_test "3/7 create wallet and shield transparent funds" \
   "scripts/e2e/flutter-macos-regtest-shield-transparent.sh"
 
-run_test "3/6 import two accounts and send shielded funds" \
+run_test "4/7 import two accounts and send shielded funds" \
   "scripts/e2e/flutter-macos-regtest-multi-account-send.sh"
 
-run_test "4/6 show mempool receives in activity history" \
+run_test "5/7 show mempool receives in activity history" \
   "scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh"
 
-run_test "5/6 show mempool receives while sync is running" \
+run_test "6/7 show mempool receives while sync is running" \
   "scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh"
 
-run_test "6/6 expire unmined mempool receives" \
+run_test "7/7 expire unmined mempool receives" \
   "scripts/e2e/flutter-macos-regtest-mempool-expiry.sh"
 
 echo

--- a/scripts/e2e/flutter-macos-regtest-full.sh
+++ b/scripts/e2e/flutter-macos-regtest-full.sh
@@ -27,25 +27,28 @@ require_cmd python3
 cd "$ROOT_DIR"
 
 # Keep this ordered from the narrowest smoke test to broader user flows.
-run_test "1/7 import funded wallet and sync balances" \
+run_test "1/8 import funded wallet and sync balances" \
   "scripts/e2e/flutter-macos-regtest-import-sync.sh"
 
-run_test "2/7 fallback from unavailable endpoint and sync balances" \
+run_test "2/8 fallback from unavailable endpoint and sync balances" \
   "scripts/e2e/flutter-macos-regtest-fallback-endpoint.sh"
 
-run_test "3/7 create wallet and shield transparent funds" \
+run_test "3/8 keep custom endpoint failures private" \
+  "scripts/e2e/flutter-macos-regtest-custom-endpoint-no-fallback.sh"
+
+run_test "4/8 create wallet and shield transparent funds" \
   "scripts/e2e/flutter-macos-regtest-shield-transparent.sh"
 
-run_test "4/7 import two accounts and send shielded funds" \
+run_test "5/8 import two accounts and send shielded funds" \
   "scripts/e2e/flutter-macos-regtest-multi-account-send.sh"
 
-run_test "5/7 show mempool receives in activity history" \
+run_test "6/8 show mempool receives in activity history" \
   "scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh"
 
-run_test "6/7 show mempool receives while sync is running" \
+run_test "7/8 show mempool receives while sync is running" \
   "scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh"
 
-run_test "7/7 expire unmined mempool receives" \
+run_test "8/8 expire unmined mempool receives" \
   "scripts/e2e/flutter-macos-regtest-mempool-expiry.sh"
 
 echo

--- a/scripts/e2e/flutter-macos-regtest-full.sh
+++ b/scripts/e2e/flutter-macos-regtest-full.sh
@@ -27,28 +27,31 @@ require_cmd python3
 cd "$ROOT_DIR"
 
 # Keep this ordered from the narrowest smoke test to broader user flows.
-run_test "1/8 import funded wallet and sync balances" \
+run_test "1/9 import funded wallet and sync balances" \
   "scripts/e2e/flutter-macos-regtest-import-sync.sh"
 
-run_test "2/8 fallback from unavailable endpoint and sync balances" \
+run_test "2/9 fallback from unavailable endpoint and sync balances" \
   "scripts/e2e/flutter-macos-regtest-fallback-endpoint.sh"
 
-run_test "3/8 keep custom endpoint failures private" \
+run_test "3/9 keep custom endpoint failures private" \
   "scripts/e2e/flutter-macos-regtest-custom-endpoint-no-fallback.sh"
 
-run_test "4/8 create wallet and shield transparent funds" \
+run_test "4/9 fallback from slow-height primary and recover" \
+  "scripts/e2e/flutter-macos-regtest-slow-height-fallback.sh"
+
+run_test "5/9 create wallet and shield transparent funds" \
   "scripts/e2e/flutter-macos-regtest-shield-transparent.sh"
 
-run_test "5/8 import two accounts and send shielded funds" \
+run_test "6/9 import two accounts and send shielded funds" \
   "scripts/e2e/flutter-macos-regtest-multi-account-send.sh"
 
-run_test "6/8 show mempool receives in activity history" \
+run_test "7/9 show mempool receives in activity history" \
   "scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh"
 
-run_test "7/8 show mempool receives while sync is running" \
+run_test "8/9 show mempool receives while sync is running" \
   "scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh"
 
-run_test "8/8 expire unmined mempool receives" \
+run_test "9/9 expire unmined mempool receives" \
   "scripts/e2e/flutter-macos-regtest-mempool-expiry.sh"
 
 echo

--- a/scripts/e2e/flutter-macos-regtest-slow-height-fallback.sh
+++ b/scripts/e2e/flutter-macos-regtest-slow-height-fallback.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MNEMONIC="winter shiver fetch refuse absurd mail pistol eight market lounge manual roast miracle ethics found child scare curve congress renew salute pig better used"
+SHIELDED_AMOUNT="1.25"
+FAUCET_AMOUNT="${E2E_SLOW_FALLBACK_FAUCET_AMOUNT:-3.0}"
+CONFIRMING_BLOCKS="${E2E_CONFIRMING_BLOCKS:-10}"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+DRIVER_PORT="${E2E_SLOW_FALLBACK_DRIVER_PORT:-39068}"
+DRIVER_URL="http://127.0.0.1:${DRIVER_PORT}"
+DRIVER_LOG="$ROOT_DIR/.regtest/slow-height-fallback-driver.log"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+json_field() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+data = json.loads(sys.argv[1])
+print(data[sys.argv[2]])
+PY
+}
+
+require_cmd cargo
+require_cmd docker
+require_cmd fvm
+require_cmd python3
+
+cd "$ROOT_DIR"
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+addresses_json="$(cd rust && cargo run --quiet --example regtest_wallet_addresses -- "$MNEMONIC")"
+unified_address="$(json_field "$addresses_json" unifiedAddress)"
+
+echo "preparing reusable shielded faucet with ${FAUCET_AMOUNT} ZEC"
+faucet_zaddr="$(scripts/regtest/prepare-unmined-faucet.sh "$FAUCET_AMOUNT")"
+
+echo "funding shielded address with ${SHIELDED_AMOUNT} ZEC"
+REGTEST_UNMINED_FAUCET_ZADDR="$faucet_zaddr" \
+  scripts/regtest/fund-wallet-unmined.sh "$unified_address" "$SHIELDED_AMOUNT" >/dev/null
+scripts/regtest/mine.sh "$CONFIRMING_BLOCKS" >/dev/null
+
+mkdir -p "$ROOT_DIR/.regtest"
+: > "$DRIVER_LOG"
+
+python3 -u scripts/e2e/mempool-receive-history-driver.py \
+  --repo-root "$ROOT_DIR" \
+  --port "$DRIVER_PORT" \
+  --prepared-faucet-zaddr "$faucet_zaddr" \
+  >"$DRIVER_LOG" 2>&1 &
+driver_pid="$!"
+
+cleanup() {
+  kill "$driver_pid" >/dev/null 2>&1 || true
+  wait "$driver_pid" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+python3 - "$DRIVER_URL" <<'PY'
+import sys
+import time
+import urllib.request
+
+url = sys.argv[1] + "/health"
+for _ in range(50):
+    try:
+        with urllib.request.urlopen(url, timeout=1) as response:
+            if response.status == 200:
+                raise SystemExit(0)
+    except Exception:
+        time.sleep(0.1)
+
+raise SystemExit("Timed out waiting for slow-height fallback driver")
+PY
+
+echo "running Flutter macOS slow-height fallback integration test"
+set +e
+fvm flutter test \
+  integration_test/regtest_slow_height_fallback_test.dart \
+  -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
+  --dart-define=ZCASH_E2E_DRIVER_URL="$DRIVER_URL" \
+  --dart-define=ZCASH_E2E_UNIFIED_ADDRESS="$unified_address" \
+  --dart-define=ZCASH_E2E_FAUCET_ZADDR="$faucet_zaddr"
+status="$?"
+set -e
+
+if [[ "$status" -ne 0 ]]; then
+  echo "slow-height fallback driver log:" >&2
+  sed -n '1,220p' "$DRIVER_LOG" >&2 || true
+fi
+
+exit "$status"

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -25,7 +25,7 @@ void main() {
 
     expect(merged.uuid, 'account-1');
     expect(merged.name, 'Stored Name');
-    expect(merged.order, 3);
+    expect(merged.order, 9);
     expect(merged.isHardware, isTrue);
     expect(merged.profilePictureId, 'knight-04');
   });

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -232,6 +232,54 @@ void main() {
     );
   });
 
+  group('fallbackRpcEndpointConfigFor', () {
+    test('uses zec.rocks when the mainnet default endpoint is primary', () {
+      final fallback = fallbackRpcEndpointConfigFor(
+        defaultRpcEndpointConfig('main'),
+      );
+
+      expect(fallback?.presetId, kMainnetFallbackRpcEndpointPresetId);
+      expect(fallback?.lightwalletdUrl, 'https://zec.rocks:443');
+    });
+
+    test(
+      'uses the network default when a custom mainnet endpoint is primary',
+      () {
+        final fallback = fallbackRpcEndpointConfigFor(
+          const RpcEndpointConfig(
+            networkName: 'main',
+            lightwalletdUrl: 'https://custom.example:443',
+            presetId: kCustomRpcEndpointPresetId,
+          ),
+        );
+
+        expect(fallback?.presetId, kDefaultRpcEndpointPresetId);
+        expect(fallback?.lightwalletdUrl, 'https://us.zec.stardust.rest:443');
+      },
+    );
+
+    test('uses local regtest default for a custom regtest endpoint', () {
+      final fallback = fallbackRpcEndpointConfigFor(
+        const RpcEndpointConfig(
+          networkName: 'regtest',
+          lightwalletdUrl: 'http://127.0.0.1:19067',
+          presetId: kCustomRpcEndpointPresetId,
+        ),
+      );
+
+      expect(fallback?.presetId, 'default-regtest');
+      expect(fallback?.lightwalletdUrl, 'http://127.0.0.1:9067');
+    });
+
+    test('returns null when no alternate endpoint exists', () {
+      final fallback = fallbackRpcEndpointConfigFor(
+        defaultRpcEndpointConfig('regtest'),
+      );
+
+      expect(fallback, isNull);
+    });
+  });
+
   group('rpcEndpointHostPort', () {
     test('keeps IPv6 brackets so custom endpoint fields can round-trip', () {
       expect(rpcEndpointHostPort('https://[::1]:9067'), '[::1]:9067');

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -232,34 +232,40 @@ void main() {
     );
   });
 
-  group('fallbackRpcEndpointConfigFor', () {
-    test('uses zec.rocks when the mainnet default endpoint is primary', () {
-      final fallback = fallbackRpcEndpointConfigFor(
+  group('fallbackRpcEndpointCandidatesFor', () {
+    test('uses zec.rocks first when the mainnet default is primary', () {
+      final candidates = fallbackRpcEndpointCandidatesFor(
         defaultRpcEndpointConfig('main'),
       );
 
-      expect(fallback?.presetId, kMainnetFallbackRpcEndpointPresetId);
-      expect(fallback?.lightwalletdUrl, 'https://zec.rocks:443');
+      expect(candidates.first.presetId, kMainnetFallbackRpcEndpointPresetId);
+      expect(candidates.first.lightwalletdUrl, 'https://zec.rocks:443');
     });
 
-    test(
-      'uses the network default when a custom mainnet endpoint is primary',
-      () {
-        final fallback = fallbackRpcEndpointConfigFor(
+    test('does not fallback from a custom mainnet endpoint', () {
+      final candidates = fallbackRpcEndpointCandidatesFor(
+        const RpcEndpointConfig(
+          networkName: 'main',
+          lightwalletdUrl: 'https://custom.example:443',
+          presetId: kCustomRpcEndpointPresetId,
+        ),
+      );
+
+      expect(candidates, isEmpty);
+      expect(
+        fallbackRpcEndpointConfigFor(
           const RpcEndpointConfig(
             networkName: 'main',
             lightwalletdUrl: 'https://custom.example:443',
             presetId: kCustomRpcEndpointPresetId,
           ),
-        );
+        ),
+        isNull,
+      );
+    });
 
-        expect(fallback?.presetId, kDefaultRpcEndpointPresetId);
-        expect(fallback?.lightwalletdUrl, 'https://us.zec.stardust.rest:443');
-      },
-    );
-
-    test('uses local regtest default for a custom regtest endpoint', () {
-      final fallback = fallbackRpcEndpointConfigFor(
+    test('does not fallback from a custom regtest endpoint', () {
+      final candidates = fallbackRpcEndpointCandidatesFor(
         const RpcEndpointConfig(
           networkName: 'regtest',
           lightwalletdUrl: 'http://127.0.0.1:19067',
@@ -267,16 +273,53 @@ void main() {
         ),
       );
 
-      expect(fallback?.presetId, 'default-regtest');
-      expect(fallback?.lightwalletdUrl, 'http://127.0.0.1:9067');
+      expect(candidates, isEmpty);
     });
 
-    test('returns null when no alternate endpoint exists', () {
-      final fallback = fallbackRpcEndpointConfigFor(
-        defaultRpcEndpointConfig('regtest'),
+    test('respects custom intent even when the URL matches a preset', () {
+      final candidates = fallbackRpcEndpointCandidatesFor(
+        RpcEndpointConfig(
+          networkName: 'main',
+          lightwalletdUrl: defaultRpcEndpointConfig('main').lightwalletdUrl,
+          presetId: kCustomRpcEndpointPresetId,
+        ),
       );
 
-      expect(fallback, isNull);
+      expect(candidates, isEmpty);
+    });
+
+    test('removes the selected preset and starts from the order beginning', () {
+      final candidates = fallbackRpcEndpointCandidatesFor(
+        const RpcEndpointConfig(
+          networkName: 'main',
+          lightwalletdUrl: 'https://eu.zec.rocks:443',
+          presetId: 'eu-zec-rocks',
+        ),
+      );
+
+      expect(candidates.take(4).map((candidate) => candidate.presetId), [
+        kDefaultRpcEndpointPresetId,
+        kMainnetFallbackRpcEndpointPresetId,
+        'na-zec-rocks',
+        'sa-zec-rocks',
+      ]);
+      expect(
+        candidates.map((candidate) => candidate.presetId),
+        isNot(contains('eu-zec-rocks')),
+      );
+    });
+
+    test('uses local regtest default for the unavailable regtest preset', () {
+      final candidates = fallbackRpcEndpointCandidatesFor(
+        const RpcEndpointConfig(
+          networkName: 'regtest',
+          lightwalletdUrl: 'http://127.0.0.1:19067',
+          presetId: kRegtestUnavailableRpcEndpointPresetId,
+        ),
+      );
+
+      expect(candidates.single.presetId, 'default-regtest');
+      expect(candidates.single.lightwalletdUrl, 'http://127.0.0.1:9067');
     });
   });
 

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -233,13 +233,16 @@ void main() {
   });
 
   group('fallbackRpcEndpointCandidatesFor', () {
-    test('uses zec.rocks first when the mainnet default is primary', () {
+    test('uses preset order when the mainnet default is primary', () {
       final candidates = fallbackRpcEndpointCandidatesFor(
         defaultRpcEndpointConfig('main'),
       );
 
-      expect(candidates.first.presetId, kMainnetFallbackRpcEndpointPresetId);
-      expect(candidates.first.lightwalletdUrl, 'https://zec.rocks:443');
+      expect(candidates.first.presetId, 'eu-zec-stardust');
+      expect(
+        candidates.first.lightwalletdUrl,
+        'https://eu.zec.stardust.rest:443',
+      );
     });
 
     test('does not fallback from a custom mainnet endpoint', () {
@@ -299,9 +302,9 @@ void main() {
 
       expect(candidates.take(4).map((candidate) => candidate.presetId), [
         kDefaultRpcEndpointPresetId,
-        kMainnetFallbackRpcEndpointPresetId,
-        'na-zec-rocks',
-        'sa-zec-rocks',
+        'eu-zec-stardust',
+        'eu2-zec-stardust',
+        'jp-zec-stardust',
       ]);
       expect(
         candidates.map((candidate) => candidate.presetId),

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -214,22 +214,43 @@ void main() {
       expect(config.lightwalletdUrl, 'https://example.com:443');
       expect(config.presetId, kCustomRpcEndpointPresetId);
     });
+
+    test('treats stored preset URLs without preset id as custom', () {
+      final config = resolveStoredRpcEndpointConfig(
+        networkName: 'main',
+        storedUrl: defaultRpcEndpointConfig('main').lightwalletdUrl,
+        storedPresetId: null,
+      );
+
+      expect(
+        config.normalizedLightwalletdUrl,
+        'https://us.zec.stardust.rest:443',
+      );
+      expect(config.presetId, kCustomRpcEndpointPresetId);
+    });
   });
 
   group('RpcEndpointConfig', () {
-    test(
-      'derives the effective preset from the URL before stored preset id',
-      () {
-        final defaultEndpoint = defaultRpcEndpointConfig('main');
-        final config = RpcEndpointConfig(
-          networkName: 'main',
-          lightwalletdUrl: defaultEndpoint.lightwalletdUrl,
-          presetId: kCustomRpcEndpointPresetId,
-        );
+    test('preserves custom intent even when the URL matches a preset', () {
+      final defaultEndpoint = defaultRpcEndpointConfig('main');
+      final config = RpcEndpointConfig(
+        networkName: 'main',
+        lightwalletdUrl: defaultEndpoint.lightwalletdUrl,
+        presetId: kCustomRpcEndpointPresetId,
+      );
 
-        expect(config.effectivePresetId, defaultEndpoint.presetId);
-      },
-    );
+      expect(config.effectivePresetId, kCustomRpcEndpointPresetId);
+    });
+
+    test('uses explicit preset ids as the effective preset', () {
+      final config = const RpcEndpointConfig(
+        networkName: 'main',
+        lightwalletdUrl: 'https://zec.rocks:443',
+        presetId: 'zec-rocks',
+      );
+
+      expect(config.effectivePresetId, 'zec-rocks');
+    });
   });
 
   group('fallbackRpcEndpointCandidatesFor', () {
@@ -290,6 +311,20 @@ void main() {
 
       expect(candidates, isEmpty);
     });
+
+    test(
+      'does not infer fallback intent from a preset URL without preset id',
+      () {
+        final candidates = fallbackRpcEndpointCandidatesFor(
+          RpcEndpointConfig(
+            networkName: 'main',
+            lightwalletdUrl: defaultRpcEndpointConfig('main').lightwalletdUrl,
+          ),
+        );
+
+        expect(candidates, isEmpty);
+      },
+    );
 
     test('removes the selected preset and starts from the order beginning', () {
       final candidates = fallbackRpcEndpointCandidatesFor(

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -356,8 +356,21 @@ void main() {
         ),
       );
 
-      expect(candidates.single.presetId, 'default-regtest');
-      expect(candidates.single.lightwalletdUrl, 'http://127.0.0.1:9067');
+      expect(candidates.first.presetId, 'default-regtest');
+      expect(candidates.first.lightwalletdUrl, 'http://127.0.0.1:9067');
+    });
+
+    test('uses local regtest default for the slow regtest preset', () {
+      final candidates = fallbackRpcEndpointCandidatesFor(
+        const RpcEndpointConfig(
+          networkName: 'regtest',
+          lightwalletdUrl: 'http://127.0.0.1:19068',
+          presetId: kRegtestSlowRpcEndpointPresetId,
+        ),
+      );
+
+      expect(candidates.first.presetId, 'default-regtest');
+      expect(candidates.first.lightwalletdUrl, 'http://127.0.0.1:9067');
     });
   });
 

--- a/test/core/widgets/app_toast_test.dart
+++ b/test/core/widgets/app_toast_test.dart
@@ -75,6 +75,11 @@ void main() {
     expect(find.text('Address Copied'), findsOneWidget);
     final hostTopLeft = tester.getTopLeft(find.byType(AppToastHost));
     final hostSize = tester.getSize(find.byType(AppToastHost));
+    final enteringToastTopLeft = tester.getTopLeft(find.byType(AppToast));
+    expect(enteringToastTopLeft.dy, lessThan(hostTopLeft.dy + AppSpacing.base));
+
+    await tester.pump(AppToastHost.animationDuration);
+
     final toastTopLeft = tester.getTopLeft(find.byType(AppToast));
     final toastSize = tester.getSize(find.byType(AppToast));
     expect(toastTopLeft.dy, hostTopLeft.dy + AppSpacing.base);
@@ -84,7 +89,7 @@ void main() {
     );
 
     await tester.pump(AppToast.defaultDuration);
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(find.text('Address Copied'), findsNothing);
   });

--- a/test/core/widgets/app_toast_test.dart
+++ b/test/core/widgets/app_toast_test.dart
@@ -97,6 +97,27 @@ void main() {
     expect(icon.color, AppThemeData.dark.colors.icon.accent);
   });
 
+  testWidgets('AppToast clears inherited text decoration', (tester) async {
+    await tester.pumpWidget(
+      const _ThemedHarness(
+        theme: AppThemeData.light,
+        child: DefaultTextStyle(
+          style: TextStyle(
+            decoration: TextDecoration.underline,
+            decorationColor: Colors.yellow,
+          ),
+          child: Center(child: AppToast(message: 'Address Copied')),
+        ),
+      ),
+    );
+
+    final textContext = tester.element(find.text('Address Copied'));
+    expect(
+      DefaultTextStyle.of(textContext).style.decoration,
+      TextDecoration.none,
+    );
+  });
+
   testWidgets('showAppToast displays a top-centered transient toast', (
     tester,
   ) async {

--- a/test/core/widgets/app_toast_test.dart
+++ b/test/core/widgets/app_toast_test.dart
@@ -5,7 +5,7 @@ import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_toast.dart';
 
 void main() {
-  testWidgets('AppToast uses inverse neutral tokens in light mode', (
+  testWidgets('AppToast uses seed phrase container styling in light mode', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -26,8 +26,17 @@ void main() {
                 )
                 .decoration
             as BoxDecoration;
-    expect(decoration.color, AppThemeData.light.colors.background.inverse);
+    expect(decoration.color, AppThemeData.light.colors.background.ground);
     expect(decoration.borderRadius, BorderRadius.circular(AppRadii.small));
+    expect(decoration.border, isNull);
+    expect(decoration.boxShadow, const [
+      BoxShadow(color: Color(0xFFE1E1E1), offset: Offset(0, 2), blurRadius: 2),
+      BoxShadow(
+        color: Color(0xFFE1E1E1),
+        offset: Offset(0, 10),
+        blurRadius: 15,
+      ),
+    ]);
 
     final padding = tester.widget<Padding>(
       find.descendant(of: toastFinder, matching: find.byType(Padding)),
@@ -41,7 +50,7 @@ void main() {
     );
 
     final text = tester.widget<Text>(find.text('Address Copied'));
-    expect(text.style?.color, AppThemeData.light.colors.text.inverse);
+    expect(text.style?.color, AppThemeData.light.colors.text.accent);
     expect(text.style?.fontFamily, AppTypography.labelLarge.fontFamily);
     expect(text.style?.fontSize, AppTypography.labelLarge.fontSize);
     expect(text.style?.height, AppTypography.labelLarge.height);
@@ -50,7 +59,42 @@ void main() {
     final icon = tester.widget<AppIcon>(find.byType(AppIcon));
     expect(icon.name, AppIcons.checkCircle);
     expect(icon.size, AppIconSize.medium);
-    expect(icon.color, AppThemeData.light.colors.icon.inverse);
+    expect(icon.color, AppThemeData.light.colors.icon.accent);
+  });
+
+  testWidgets('AppToast uses a subtle border without shadow in dark mode', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const _ThemedHarness(
+        theme: AppThemeData.dark,
+        child: Center(child: AppToast(message: 'Address Copied')),
+      ),
+    );
+
+    final toastFinder = find.byType(AppToast);
+    final decoration =
+        tester
+                .widget<DecoratedBox>(
+                  find.descendant(
+                    of: toastFinder,
+                    matching: find.byType(DecoratedBox),
+                  ),
+                )
+                .decoration
+            as BoxDecoration;
+    final border = decoration.border as Border?;
+
+    expect(decoration.color, AppThemeData.dark.colors.background.ground);
+    expect(decoration.boxShadow, isNull);
+    expect(border?.top.color, AppThemeData.dark.colors.border.subtle);
+    expect(border?.top.width, 1);
+
+    final text = tester.widget<Text>(find.text('Address Copied'));
+    expect(text.style?.color, AppThemeData.dark.colors.text.accent);
+
+    final icon = tester.widget<AppIcon>(find.byType(AppIcon));
+    expect(icon.color, AppThemeData.dark.colors.icon.accent);
   });
 
   testWidgets('showAppToast displays a top-centered transient toast', (

--- a/test/core/widgets/app_toast_test.dart
+++ b/test/core/widgets/app_toast_test.dart
@@ -5,7 +5,7 @@ import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_toast.dart';
 
 void main() {
-  testWidgets('AppToast uses seed phrase container styling in light mode', (
+  testWidgets('AppToast uses inverse neutral tokens in light mode', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -26,17 +26,8 @@ void main() {
                 )
                 .decoration
             as BoxDecoration;
-    expect(decoration.color, AppThemeData.light.colors.background.ground);
+    expect(decoration.color, AppThemeData.light.colors.background.inverse);
     expect(decoration.borderRadius, BorderRadius.circular(AppRadii.small));
-    expect(decoration.border, isNull);
-    expect(decoration.boxShadow, const [
-      BoxShadow(color: Color(0xFFE1E1E1), offset: Offset(0, 2), blurRadius: 2),
-      BoxShadow(
-        color: Color(0xFFE1E1E1),
-        offset: Offset(0, 10),
-        blurRadius: 15,
-      ),
-    ]);
 
     final padding = tester.widget<Padding>(
       find.descendant(of: toastFinder, matching: find.byType(Padding)),
@@ -50,7 +41,7 @@ void main() {
     );
 
     final text = tester.widget<Text>(find.text('Address Copied'));
-    expect(text.style?.color, AppThemeData.light.colors.text.accent);
+    expect(text.style?.color, AppThemeData.light.colors.text.inverse);
     expect(text.style?.fontFamily, AppTypography.labelLarge.fontFamily);
     expect(text.style?.fontSize, AppTypography.labelLarge.fontSize);
     expect(text.style?.height, AppTypography.labelLarge.height);
@@ -59,63 +50,7 @@ void main() {
     final icon = tester.widget<AppIcon>(find.byType(AppIcon));
     expect(icon.name, AppIcons.checkCircle);
     expect(icon.size, AppIconSize.medium);
-    expect(icon.color, AppThemeData.light.colors.icon.accent);
-  });
-
-  testWidgets('AppToast uses a subtle border without shadow in dark mode', (
-    tester,
-  ) async {
-    await tester.pumpWidget(
-      const _ThemedHarness(
-        theme: AppThemeData.dark,
-        child: Center(child: AppToast(message: 'Address Copied')),
-      ),
-    );
-
-    final toastFinder = find.byType(AppToast);
-    final decoration =
-        tester
-                .widget<DecoratedBox>(
-                  find.descendant(
-                    of: toastFinder,
-                    matching: find.byType(DecoratedBox),
-                  ),
-                )
-                .decoration
-            as BoxDecoration;
-    final border = decoration.border as Border?;
-
-    expect(decoration.color, AppThemeData.dark.colors.background.ground);
-    expect(decoration.boxShadow, isNull);
-    expect(border?.top.color, AppThemeData.dark.colors.border.subtle);
-    expect(border?.top.width, 1);
-
-    final text = tester.widget<Text>(find.text('Address Copied'));
-    expect(text.style?.color, AppThemeData.dark.colors.text.accent);
-
-    final icon = tester.widget<AppIcon>(find.byType(AppIcon));
-    expect(icon.color, AppThemeData.dark.colors.icon.accent);
-  });
-
-  testWidgets('AppToast clears inherited text decoration', (tester) async {
-    await tester.pumpWidget(
-      const _ThemedHarness(
-        theme: AppThemeData.light,
-        child: DefaultTextStyle(
-          style: TextStyle(
-            decoration: TextDecoration.underline,
-            decorationColor: Colors.yellow,
-          ),
-          child: Center(child: AppToast(message: 'Address Copied')),
-        ),
-      ),
-    );
-
-    final textContext = tester.element(find.text('Address Copied'));
-    expect(
-      DefaultTextStyle.of(textContext).style.decoration,
-      TextDecoration.none,
-    );
+    expect(icon.color, AppThemeData.light.colors.icon.inverse);
   });
 
   testWidgets('showAppToast displays a top-centered transient toast', (
@@ -140,11 +75,6 @@ void main() {
     expect(find.text('Address Copied'), findsOneWidget);
     final hostTopLeft = tester.getTopLeft(find.byType(AppToastHost));
     final hostSize = tester.getSize(find.byType(AppToastHost));
-    final enteringToastTopLeft = tester.getTopLeft(find.byType(AppToast));
-    expect(enteringToastTopLeft.dy, lessThan(hostTopLeft.dy + AppSpacing.base));
-
-    await tester.pump(AppToastHost.animationDuration);
-
     final toastTopLeft = tester.getTopLeft(find.byType(AppToast));
     final toastSize = tester.getSize(find.byType(AppToast));
     expect(toastTopLeft.dy, hostTopLeft.dy + AppSpacing.base);
@@ -154,7 +84,7 @@ void main() {
     );
 
     await tester.pump(AppToast.defaultDuration);
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(find.text('Address Copied'), findsNothing);
   });

--- a/test/core/widgets/network_fallback_toast_test.dart
+++ b/test/core/widgets/network_fallback_toast_test.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/core/widgets/network_fallback_toast.dart';
+
+void main() {
+  testWidgets(
+    'NetworkFallbackToast uses seed phrase container styling in light mode',
+    (tester) async {
+      await tester.pumpWidget(
+        const _ThemedHarness(
+          theme: AppThemeData.light,
+          child: Center(
+            child: NetworkFallbackToast(
+              message: 'Selected endpoint is unstable.',
+            ),
+          ),
+        ),
+      );
+
+      final toastFinder = find.byType(NetworkFallbackToast);
+      final decoration =
+          tester
+                  .widget<DecoratedBox>(
+                    find.descendant(
+                      of: toastFinder,
+                      matching: find.byType(DecoratedBox),
+                    ),
+                  )
+                  .decoration
+              as BoxDecoration;
+
+      expect(decoration.color, AppThemeData.light.colors.background.ground);
+      expect(decoration.borderRadius, BorderRadius.circular(AppRadii.small));
+      expect(decoration.border, isNull);
+      expect(decoration.boxShadow, const [
+        BoxShadow(
+          color: Color(0xFFE1E1E1),
+          offset: Offset(0, 2),
+          blurRadius: 2,
+        ),
+        BoxShadow(
+          color: Color(0xFFE1E1E1),
+          offset: Offset(0, 10),
+          blurRadius: 15,
+        ),
+      ]);
+
+      final text = tester.widget<Text>(
+        find.text('Selected endpoint is unstable.'),
+      );
+      expect(text.style?.color, AppThemeData.light.colors.text.accent);
+      expect(text.style?.fontFamily, AppTypography.labelLarge.fontFamily);
+      expect(text.style?.fontSize, AppTypography.labelLarge.fontSize);
+      expect(text.style?.height, AppTypography.labelLarge.height);
+      expect(text.style?.letterSpacing, AppTypography.labelLarge.letterSpacing);
+      expect(find.byType(AppIcon), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'NetworkFallbackToast uses a subtle border without shadow in dark mode',
+    (tester) async {
+      await tester.pumpWidget(
+        const _ThemedHarness(
+          theme: AppThemeData.dark,
+          child: Center(
+            child: NetworkFallbackToast(
+              message: 'Selected endpoint is unstable.',
+            ),
+          ),
+        ),
+      );
+
+      final toastFinder = find.byType(NetworkFallbackToast);
+      final decoration =
+          tester
+                  .widget<DecoratedBox>(
+                    find.descendant(
+                      of: toastFinder,
+                      matching: find.byType(DecoratedBox),
+                    ),
+                  )
+                  .decoration
+              as BoxDecoration;
+      final border = decoration.border as Border?;
+
+      expect(decoration.color, AppThemeData.dark.colors.background.ground);
+      expect(decoration.boxShadow, isNull);
+      expect(border?.top.color, AppThemeData.dark.colors.border.subtle);
+      expect(border?.top.width, 1);
+
+      final text = tester.widget<Text>(
+        find.text('Selected endpoint is unstable.'),
+      );
+      expect(text.style?.color, AppThemeData.dark.colors.text.accent);
+    },
+  );
+
+  testWidgets('NetworkFallbackToast clears inherited text decoration', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const _ThemedHarness(
+        theme: AppThemeData.light,
+        child: DefaultTextStyle(
+          style: TextStyle(
+            decoration: TextDecoration.underline,
+            decorationColor: Colors.yellow,
+          ),
+          child: Center(
+            child: NetworkFallbackToast(
+              message: 'Selected endpoint is unstable.',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final textContext = tester.element(
+      find.text('Selected endpoint is unstable.'),
+    );
+    expect(
+      DefaultTextStyle.of(textContext).style.decoration,
+      TextDecoration.none,
+    );
+  });
+
+  testWidgets('showNetworkFallbackToast slides in and expires', (tester) async {
+    await tester.pumpWidget(
+      const _ThemedHarness(
+        theme: AppThemeData.light,
+        child: SizedBox(
+          width: 400,
+          height: 300,
+          child: NetworkFallbackToastHost(
+            child: _ToastTrigger(message: 'Fallback selected'),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Fallback selected'), findsNothing);
+
+    await tester.tap(find.text('Show toast'));
+    await tester.pump();
+
+    expect(find.text('Fallback selected'), findsOneWidget);
+    final hostTopLeft = tester.getTopLeft(
+      find.byType(NetworkFallbackToastHost),
+    );
+    final hostSize = tester.getSize(find.byType(NetworkFallbackToastHost));
+    final enteringToastTopLeft = tester.getTopLeft(
+      find.byType(NetworkFallbackToast),
+    );
+    expect(enteringToastTopLeft.dy, lessThan(hostTopLeft.dy + AppSpacing.base));
+
+    await tester.pump(NetworkFallbackToastHost.animationDuration);
+
+    final toastTopLeft = tester.getTopLeft(find.byType(NetworkFallbackToast));
+    final toastSize = tester.getSize(find.byType(NetworkFallbackToast));
+    expect(toastTopLeft.dy, hostTopLeft.dy + AppSpacing.base);
+    expect(
+      toastTopLeft.dx + toastSize.width / 2,
+      moreOrLessEquals(hostTopLeft.dx + hostSize.width / 2),
+    );
+
+    await tester.pump(NetworkFallbackToast.defaultDuration);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Fallback selected'), findsNothing);
+  });
+}
+
+class _ThemedHarness extends StatelessWidget {
+  const _ThemedHarness({required this.theme, required this.child});
+
+  final AppThemeData theme;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: AppTheme(
+        data: theme,
+        child: Directionality(textDirection: TextDirection.ltr, child: child),
+      ),
+    );
+  }
+}
+
+class _ToastTrigger extends StatelessWidget {
+  const _ToastTrigger({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: () => showNetworkFallbackToast(context, message),
+      child: const Text('Show toast'),
+    );
+  }
+}

--- a/test/providers/rpc_endpoint_failover_provider_test.dart
+++ b/test/providers/rpc_endpoint_failover_provider_test.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart' show ThemeMode;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/rpc_endpoint_failover_provider.dart';
+
+void main() {
+  test('classifies transient endpoint failures only', () {
+    expect(
+      shouldFallbackFromLightwalletdError(
+        'network: get_latest_block: status: DeadlineExceeded',
+      ),
+      isTrue,
+    );
+    expect(
+      shouldFallbackFromLightwalletdError(
+        'gRPC connect failed: connection refused',
+      ),
+      isTrue,
+    );
+    expect(
+      shouldFallbackFromLightwalletdError(
+        'Endpoint is for test, but this wallet uses main.',
+      ),
+      isFalse,
+    );
+    expect(
+      shouldFallbackFromLightwalletdError(
+        'Proposal not found (expired or already executed)',
+      ),
+      isFalse,
+    );
+  });
+
+  test('checkRpcEndpointHealth rejects wrong-network endpoints', () async {
+    await expectLater(
+      checkRpcEndpointHealth(
+        endpoint: defaultRpcEndpointConfig('main'),
+        getChainName: (_) async => 'test',
+        getLatestBlockHeight: (_) async => BigInt.from(10),
+      ),
+      throwsA(isA<FormatException>()),
+    );
+  });
+
+  test('runWithEndpointFallback switches to a healthy fallback', () async {
+    final primary = _customRegtestPrimary();
+    final container = _container(
+      primary: primary,
+      chainNameByUrl: {'http://127.0.0.1:9067': 'regtest'},
+      heightByUrl: {'http://127.0.0.1:9067': BigInt.from(10)},
+    );
+    addTearDown(container.dispose);
+
+    final result = await container
+        .read(rpcEndpointFailoverProvider.notifier)
+        .runWithEndpointFallback(
+          operation: 'test read',
+          action: (endpoint) async {
+            if (endpoint.normalizedLightwalletdUrl ==
+                primary.normalizedLightwalletdUrl) {
+              throw Exception('gRPC connect failed: connection refused');
+            }
+            return endpoint.hostPort;
+          },
+        );
+
+    final state = container.read(rpcEndpointFailoverProvider);
+    expect(result, '127.0.0.1:9067');
+    expect(state.isUsingFallback, isTrue);
+    expect(state.current.normalizedLightwalletdUrl, 'http://127.0.0.1:9067');
+    expect(
+      state.lastEvent?.kind,
+      RpcEndpointFailoverEventKind.switchedToFallback,
+    );
+  });
+
+  test('does not fallback for wallet-state errors', () async {
+    final primary = _customRegtestPrimary();
+    final container = _container(
+      primary: primary,
+      chainNameByUrl: {'http://127.0.0.1:9067': 'regtest'},
+      heightByUrl: {'http://127.0.0.1:9067': BigInt.from(10)},
+    );
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container
+          .read(rpcEndpointFailoverProvider.notifier)
+          .runWithEndpointFallback(
+            operation: 'test read',
+            action: (_) async =>
+                throw Exception('Proposal not found (expired)'),
+          ),
+      throwsA(isA<Exception>()),
+    );
+
+    expect(
+      container.read(rpcEndpointFailoverProvider).isUsingFallback,
+      isFalse,
+    );
+  });
+
+  test('periodic primary probe switches back after recovery', () async {
+    var now = DateTime(2026);
+    final primary = _customRegtestPrimary();
+    final primaryUrl = primary.normalizedLightwalletdUrl;
+    final container = _container(
+      primary: primary,
+      clock: () => now,
+      chainNameByUrl: {
+        'http://127.0.0.1:9067': 'regtest',
+        primaryUrl: 'regtest',
+      },
+      heightByUrl: {
+        'http://127.0.0.1:9067': BigInt.from(10),
+        primaryUrl: BigInt.from(11),
+      },
+      settings: const RpcEndpointFailoverSettings(
+        primaryProbeInterval: Duration(seconds: 5),
+      ),
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(rpcEndpointFailoverProvider.notifier)
+        .switchToFallbackFor(
+          Exception('DeadlineExceeded'),
+          operation: 'test sync',
+        );
+    expect(container.read(rpcEndpointFailoverProvider).isUsingFallback, isTrue);
+    expect(
+      await container
+          .read(rpcEndpointFailoverProvider.notifier)
+          .maybeProbePrimary(),
+      isFalse,
+    );
+
+    now = now.add(const Duration(seconds: 5));
+    final recovered = await container
+        .read(rpcEndpointFailoverProvider.notifier)
+        .maybeProbePrimary();
+
+    final state = container.read(rpcEndpointFailoverProvider);
+    expect(recovered, isTrue);
+    expect(state.isUsingFallback, isFalse);
+    expect(
+      state.lastEvent?.kind,
+      RpcEndpointFailoverEventKind.switchedToPrimary,
+    );
+  });
+}
+
+ProviderContainer _container({
+  required RpcEndpointConfig primary,
+  required Map<String, String> chainNameByUrl,
+  required Map<String, BigInt> heightByUrl,
+  DateTime Function()? clock,
+  RpcEndpointFailoverSettings settings = const RpcEndpointFailoverSettings(),
+}) {
+  return ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap(primary)),
+      rpcEndpointFailoverSettingsProvider.overrideWithValue(settings),
+      if (clock != null)
+        rpcEndpointFailoverClockProvider.overrideWithValue(clock),
+      rpcEndpointFailoverChainNameGetterProvider.overrideWithValue(
+        (url) async =>
+            chainNameByUrl[url] ?? (throw Exception('no chain $url')),
+      ),
+      rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue(
+        (url) async => heightByUrl[url] ?? (throw Exception('no height $url')),
+      ),
+    ],
+  );
+}
+
+RpcEndpointConfig _customRegtestPrimary() {
+  return const RpcEndpointConfig(
+    networkName: 'regtest',
+    lightwalletdUrl: 'http://127.0.0.1:19067',
+    presetId: kCustomRpcEndpointPresetId,
+  );
+}
+
+AppBootstrapState _bootstrap(RpcEndpointConfig endpoint) {
+  return AppBootstrapState(
+    initialLocation: '/welcome',
+    initialAccountState: const AccountState(),
+    initialSyncSnapshot: AppSyncSnapshot.empty,
+    network: endpoint.networkName,
+    rpcEndpointConfig: endpoint,
+    themeMode: ThemeMode.system,
+    privacyModeEnabled: false,
+    isPasswordConfigured: false,
+    isUnlocked: false,
+    passwordRotationRecoveryFailed: false,
+  );
+}

--- a/test/providers/rpc_endpoint_failover_provider_test.dart
+++ b/test/providers/rpc_endpoint_failover_provider_test.dart
@@ -49,8 +49,8 @@ void main() {
     final primary = defaultRpcEndpointConfig('main');
     final container = _container(
       primary: primary,
-      chainNameByUrl: {'https://zec.rocks:443': 'main'},
-      heightByUrl: {'https://zec.rocks:443': BigInt.from(10)},
+      chainNameByUrl: {'https://eu.zec.stardust.rest:443': 'main'},
+      heightByUrl: {'https://eu.zec.stardust.rest:443': BigInt.from(10)},
     );
     addTearDown(container.dispose);
 
@@ -68,9 +68,12 @@ void main() {
         );
 
     final state = container.read(rpcEndpointFailoverProvider);
-    expect(result, 'zec.rocks:443');
+    expect(result, 'eu.zec.stardust.rest:443');
     expect(state.isUsingFallback, isTrue);
-    expect(state.current.normalizedLightwalletdUrl, 'https://zec.rocks:443');
+    expect(
+      state.current.normalizedLightwalletdUrl,
+      'https://eu.zec.stardust.rest:443',
+    );
     expect(
       state.lastEvent?.kind,
       RpcEndpointFailoverEventKind.switchedToFallback,
@@ -107,8 +110,8 @@ void main() {
     final primary = defaultRpcEndpointConfig('main');
     final container = _container(
       primary: primary,
-      chainNameByUrl: {'https://na.zec.rocks:443': 'main'},
-      heightByUrl: {'https://na.zec.rocks:443': BigInt.from(12)},
+      chainNameByUrl: {'https://eu2.zec.stardust.rest:443': 'main'},
+      heightByUrl: {'https://eu2.zec.stardust.rest:443': BigInt.from(12)},
     );
     addTearDown(container.dispose);
 
@@ -126,8 +129,8 @@ void main() {
         );
 
     final state = container.read(rpcEndpointFailoverProvider);
-    expect(result, 'na.zec.rocks:443');
-    expect(state.current.presetId, 'na-zec-rocks');
+    expect(result, 'eu2.zec.stardust.rest:443');
+    expect(state.current.presetId, 'eu2-zec-stardust');
   });
 
   test('does not fallback when all candidates fail health checks', () async {
@@ -160,8 +163,8 @@ void main() {
     final primary = defaultRpcEndpointConfig('main');
     final container = _container(
       primary: primary,
-      chainNameByUrl: {'https://zec.rocks:443': 'main'},
-      heightByUrl: {'https://zec.rocks:443': BigInt.from(10)},
+      chainNameByUrl: {'https://eu.zec.stardust.rest:443': 'main'},
+      heightByUrl: {'https://eu.zec.stardust.rest:443': BigInt.from(10)},
     );
     addTearDown(container.dispose);
 
@@ -189,9 +192,12 @@ void main() {
     final container = _container(
       primary: primary,
       clock: () => now,
-      chainNameByUrl: {'https://zec.rocks:443': 'main', primaryUrl: 'main'},
+      chainNameByUrl: {
+        'https://eu.zec.stardust.rest:443': 'main',
+        primaryUrl: 'main',
+      },
       heightByUrl: {
-        'https://zec.rocks:443': BigInt.from(10),
+        'https://eu.zec.stardust.rest:443': BigInt.from(10),
         primaryUrl: BigInt.from(11),
       },
       settings: const RpcEndpointFailoverSettings(

--- a/test/providers/rpc_endpoint_failover_provider_test.dart
+++ b/test/providers/rpc_endpoint_failover_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart' show ThemeMode;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -5,6 +7,7 @@ import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/rpc_endpoint_failover_provider.dart';
+import 'package:zcash_wallet/src/providers/rpc_endpoint_provider.dart';
 
 void main() {
   test('classifies transient endpoint failures only', () {
@@ -550,6 +553,173 @@ void main() {
       expect(state.isUsingFallback, isFalse);
     },
   );
+
+  test(
+    'ignores stale fallback when endpoint changes to custom during health check',
+    () async {
+      final primary = defaultRpcEndpointConfig('main');
+      final customSameUrl = primary.copyWith(
+        presetId: kCustomRpcEndpointPresetId,
+      );
+      final fallbackProbeStarted = Completer<void>();
+      final releaseFallbackProbe = Completer<void>();
+      final harness = _mutableContainer(
+        primary: primary,
+        getChainName: (url) async {
+          if (url == 'https://eu.zec.stardust.rest:443') {
+            if (!fallbackProbeStarted.isCompleted) {
+              fallbackProbeStarted.complete();
+            }
+            await releaseFallbackProbe.future;
+          }
+          return 'main';
+        },
+        getLatestBlockHeight: (_) async => BigInt.from(10),
+      );
+      addTearDown(harness.container.dispose);
+
+      final switchedFuture = harness.container
+          .read(rpcEndpointFailoverProvider.notifier)
+          .switchToFallbackFor(
+            Exception('DeadlineExceeded'),
+            operation: 'primary sync',
+          );
+
+      await fallbackProbeStarted.future;
+      harness.endpointNotifier.setForTest(customSameUrl);
+      harness.container.read(rpcEndpointFailoverProvider);
+      releaseFallbackProbe.complete();
+
+      expect(await switchedFuture, isFalse);
+      final state = harness.container.read(rpcEndpointFailoverProvider);
+      expect(state.current.effectivePresetId, kCustomRpcEndpointPresetId);
+      expect(
+        state.current.normalizedLightwalletdUrl,
+        primary.normalizedLightwalletdUrl,
+      );
+      expect(state.fallbackCandidates, isEmpty);
+      expect(state.lastEvent, isNull);
+    },
+  );
+
+  test(
+    'ignores stale slow-height fallback after endpoint changes to custom',
+    () async {
+      var now = DateTime(2026);
+      final primary = defaultRpcEndpointConfig('main');
+      final primaryUrl = primary.normalizedLightwalletdUrl;
+      final customSameUrl = primary.copyWith(
+        presetId: kCustomRpcEndpointPresetId,
+      );
+      final fallbackProbeStarted = Completer<void>();
+      final releaseFallbackProbe = Completer<void>();
+      final heightByUrl = <String, BigInt>{
+        primaryUrl: BigInt.from(100),
+        'https://eu.zec.stardust.rest:443': BigInt.from(103),
+      };
+      final harness = _mutableContainer(
+        primary: primary,
+        clock: () => now,
+        getChainName: (url) async {
+          if (url == 'https://eu.zec.stardust.rest:443') {
+            if (!fallbackProbeStarted.isCompleted) {
+              fallbackProbeStarted.complete();
+            }
+            await releaseFallbackProbe.future;
+          }
+          return 'main';
+        },
+        getLatestBlockHeight: (url) async =>
+            heightByUrl[url] ?? (throw Exception('no height $url')),
+      );
+      addTearDown(harness.container.dispose);
+
+      final notifier = harness.container.read(
+        rpcEndpointFailoverProvider.notifier,
+      );
+      expect(await notifier.getLatestBlockHeight(), BigInt.from(100));
+
+      now = now.add(const Duration(minutes: 5));
+      heightByUrl[primaryUrl] = BigInt.from(101);
+      final heightFuture = notifier.getLatestBlockHeight();
+
+      await fallbackProbeStarted.future;
+      harness.endpointNotifier.setForTest(customSameUrl);
+      harness.container.read(rpcEndpointFailoverProvider);
+      releaseFallbackProbe.complete();
+
+      expect(await heightFuture, BigInt.from(101));
+      final state = harness.container.read(rpcEndpointFailoverProvider);
+      expect(state.current.effectivePresetId, kCustomRpcEndpointPresetId);
+      expect(state.fallbackCandidates, isEmpty);
+      expect(state.lastEvent, isNull);
+    },
+  );
+
+  test(
+    'ignores stale primary recovery after endpoint changes to custom',
+    () async {
+      var now = DateTime(2026);
+      var blockPrimaryProbe = false;
+      final primary = defaultRpcEndpointConfig('main');
+      final primaryUrl = primary.normalizedLightwalletdUrl;
+      final customSameUrl = primary.copyWith(
+        presetId: kCustomRpcEndpointPresetId,
+      );
+      final primaryProbeStarted = Completer<void>();
+      final releasePrimaryProbe = Completer<void>();
+      final heightByUrl = <String, BigInt>{
+        primaryUrl: BigInt.from(120),
+        'https://eu.zec.stardust.rest:443': BigInt.from(110),
+      };
+      final harness = _mutableContainer(
+        primary: primary,
+        clock: () => now,
+        settings: const RpcEndpointFailoverSettings(
+          primaryProbeInterval: Duration(seconds: 5),
+        ),
+        getChainName: (url) async {
+          if (blockPrimaryProbe && url == primaryUrl) {
+            if (!primaryProbeStarted.isCompleted) {
+              primaryProbeStarted.complete();
+            }
+            await releasePrimaryProbe.future;
+          }
+          return 'main';
+        },
+        getLatestBlockHeight: (url) async =>
+            heightByUrl[url] ?? (throw Exception('no height $url')),
+      );
+      addTearDown(harness.container.dispose);
+
+      final notifier = harness.container.read(
+        rpcEndpointFailoverProvider.notifier,
+      );
+      await notifier.switchToFallbackFor(
+        Exception('DeadlineExceeded'),
+        operation: 'primary sync',
+      );
+      expect(
+        harness.container.read(rpcEndpointFailoverProvider).isUsingFallback,
+        isTrue,
+      );
+
+      blockPrimaryProbe = true;
+      now = now.add(const Duration(seconds: 5));
+      final probeFuture = notifier.maybeProbePrimary();
+
+      await primaryProbeStarted.future;
+      harness.endpointNotifier.setForTest(customSameUrl);
+      harness.container.read(rpcEndpointFailoverProvider);
+      releasePrimaryProbe.complete();
+
+      expect(await probeFuture, isFalse);
+      final state = harness.container.read(rpcEndpointFailoverProvider);
+      expect(state.current.effectivePresetId, kCustomRpcEndpointPresetId);
+      expect(state.fallbackCandidates, isEmpty);
+      expect(state.lastEvent, isNull);
+    },
+  );
 }
 
 ProviderContainer _container({
@@ -574,6 +744,56 @@ ProviderContainer _container({
       ),
     ],
   );
+}
+
+_MutableEndpointHarness _mutableContainer({
+  required RpcEndpointConfig primary,
+  required RpcEndpointChainNameGetter getChainName,
+  required RpcEndpointLatestBlockHeightGetter getLatestBlockHeight,
+  DateTime Function()? clock,
+  RpcEndpointFailoverSettings settings = const RpcEndpointFailoverSettings(),
+}) {
+  late final _MutableRpcEndpointNotifier endpointNotifier;
+  final container = ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap(primary)),
+      rpcEndpointProvider.overrideWith(() {
+        endpointNotifier = _MutableRpcEndpointNotifier(primary);
+        return endpointNotifier;
+      }),
+      rpcEndpointFailoverSettingsProvider.overrideWithValue(settings),
+      if (clock != null)
+        rpcEndpointFailoverClockProvider.overrideWithValue(clock),
+      rpcEndpointFailoverChainNameGetterProvider.overrideWithValue(
+        getChainName,
+      ),
+      rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue(
+        getLatestBlockHeight,
+      ),
+    ],
+  );
+  container.read(rpcEndpointProvider);
+  return _MutableEndpointHarness(container, endpointNotifier);
+}
+
+class _MutableEndpointHarness {
+  const _MutableEndpointHarness(this.container, this.endpointNotifier);
+
+  final ProviderContainer container;
+  final _MutableRpcEndpointNotifier endpointNotifier;
+}
+
+class _MutableRpcEndpointNotifier extends RpcEndpointNotifier {
+  _MutableRpcEndpointNotifier(this.initial);
+
+  final RpcEndpointConfig initial;
+
+  @override
+  RpcEndpointConfig build() => initial;
+
+  void setForTest(RpcEndpointConfig next) {
+    state = next;
+  }
 }
 
 RpcEndpointConfig _customRegtestPrimary() {

--- a/test/providers/rpc_endpoint_failover_provider_test.dart
+++ b/test/providers/rpc_endpoint_failover_provider_test.dart
@@ -133,6 +133,137 @@ void main() {
     expect(state.current.presetId, 'eu2-zec-stardust');
   });
 
+  test('rotates from a failed fallback to the next healthy preset', () async {
+    final primary = defaultRpcEndpointConfig('main');
+    final container = _container(
+      primary: primary,
+      chainNameByUrl: {
+        'https://eu.zec.stardust.rest:443': 'main',
+        'https://eu2.zec.stardust.rest:443': 'main',
+      },
+      heightByUrl: {
+        'https://eu.zec.stardust.rest:443': BigInt.from(10),
+        'https://eu2.zec.stardust.rest:443': BigInt.from(11),
+      },
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(rpcEndpointFailoverProvider.notifier)
+        .switchToFallbackFor(
+          Exception('DeadlineExceeded'),
+          operation: 'primary sync',
+        );
+    var state = container.read(rpcEndpointFailoverProvider);
+    expect(state.current.presetId, 'eu-zec-stardust');
+
+    final switched = await container
+        .read(rpcEndpointFailoverProvider.notifier)
+        .switchToFallbackFor(
+          Exception('connection reset'),
+          endpoint: state.current,
+          operation: 'fallback sync',
+        );
+
+    state = container.read(rpcEndpointFailoverProvider);
+    expect(switched, isTrue);
+    expect(state.current.presetId, 'eu2-zec-stardust');
+    expect(
+      state.lastEvent?.kind,
+      RpcEndpointFailoverEventKind.switchedToFallback,
+    );
+  });
+
+  test(
+    'runWithEndpointFallback retries after current fallback fails',
+    () async {
+      final primary = defaultRpcEndpointConfig('main');
+      final container = _container(
+        primary: primary,
+        chainNameByUrl: {
+          'https://eu.zec.stardust.rest:443': 'main',
+          'https://eu2.zec.stardust.rest:443': 'main',
+        },
+        heightByUrl: {
+          'https://eu.zec.stardust.rest:443': BigInt.from(10),
+          'https://eu2.zec.stardust.rest:443': BigInt.from(11),
+        },
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(rpcEndpointFailoverProvider.notifier);
+      await notifier.switchToFallbackFor(
+        Exception('DeadlineExceeded'),
+        operation: 'primary sync',
+      );
+      expect(
+        container.read(rpcEndpointFailoverProvider).current.presetId,
+        'eu-zec-stardust',
+      );
+
+      final result = await notifier.runWithEndpointFallback(
+        operation: 'fallback poll',
+        action: (endpoint) async {
+          if (endpoint.presetId == 'eu-zec-stardust') {
+            throw Exception('connection reset');
+          }
+          return endpoint.presetId;
+        },
+      );
+
+      expect(result, 'eu2-zec-stardust');
+      expect(
+        container.read(rpcEndpointFailoverProvider).current.presetId,
+        'eu2-zec-stardust',
+      );
+    },
+  );
+
+  test('does not rotate from fallback back to primary outside probe', () async {
+    final primary = defaultRpcEndpointConfig('main');
+    final primaryUrl = primary.normalizedLightwalletdUrl;
+    final chainNameByUrl = <String, String>{
+      'https://eu.zec.stardust.rest:443': 'main',
+    };
+    final heightByUrl = <String, BigInt>{
+      'https://eu.zec.stardust.rest:443': BigInt.from(10),
+    };
+    final container = _container(
+      primary: primary,
+      chainNameByUrl: chainNameByUrl,
+      heightByUrl: heightByUrl,
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(rpcEndpointFailoverProvider.notifier)
+        .switchToFallbackFor(
+          Exception('DeadlineExceeded'),
+          operation: 'primary sync',
+        );
+    var state = container.read(rpcEndpointFailoverProvider);
+    expect(state.current.presetId, 'eu-zec-stardust');
+
+    chainNameByUrl
+      ..clear()
+      ..[primaryUrl] = 'main';
+    heightByUrl
+      ..clear()
+      ..[primaryUrl] = BigInt.from(12);
+
+    final switched = await container
+        .read(rpcEndpointFailoverProvider.notifier)
+        .switchToFallbackFor(
+          Exception('connection reset'),
+          endpoint: state.current,
+          operation: 'fallback sync',
+        );
+
+    state = container.read(rpcEndpointFailoverProvider);
+    expect(switched, isFalse);
+    expect(state.current.presetId, 'eu-zec-stardust');
+  });
+
   test('does not fallback when all candidates fail health checks', () async {
     final primary = defaultRpcEndpointConfig('main');
     final container = _container(

--- a/test/providers/rpc_endpoint_failover_provider_test.dart
+++ b/test/providers/rpc_endpoint_failover_provider_test.dart
@@ -364,6 +364,149 @@ void main() {
       RpcEndpointFailoverEventKind.switchedToPrimary,
     );
   });
+
+  test('switches when current endpoint height progresses too slowly', () async {
+    var now = DateTime(2026);
+    final primary = defaultRpcEndpointConfig('main');
+    final primaryUrl = primary.normalizedLightwalletdUrl;
+    final heightByUrl = <String, BigInt>{
+      primaryUrl: BigInt.from(100),
+      'https://eu.zec.stardust.rest:443': BigInt.from(103),
+    };
+    final container = _container(
+      primary: primary,
+      clock: () => now,
+      chainNameByUrl: {'https://eu.zec.stardust.rest:443': 'main'},
+      heightByUrl: heightByUrl,
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(rpcEndpointFailoverProvider.notifier);
+    expect(await notifier.getLatestBlockHeight(), BigInt.from(100));
+
+    now = now.add(const Duration(minutes: 5));
+    heightByUrl[primaryUrl] = BigInt.from(101);
+
+    expect(await notifier.getLatestBlockHeight(), BigInt.from(103));
+
+    final state = container.read(rpcEndpointFailoverProvider);
+    expect(state.current.presetId, 'eu-zec-stardust');
+    expect(
+      state.lastEvent?.kind,
+      RpcEndpointFailoverEventKind.switchedToFallback,
+    );
+  });
+
+  test(
+    'keeps current slow endpoint when no candidate is far enough ahead',
+    () async {
+      var now = DateTime(2026);
+      final primary = defaultRpcEndpointConfig('main');
+      final primaryUrl = primary.normalizedLightwalletdUrl;
+      final heightByUrl = <String, BigInt>{
+        primaryUrl: BigInt.from(100),
+        'https://eu.zec.stardust.rest:443': BigInt.from(102),
+      };
+      final container = _container(
+        primary: primary,
+        clock: () => now,
+        chainNameByUrl: {'https://eu.zec.stardust.rest:443': 'main'},
+        heightByUrl: heightByUrl,
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(rpcEndpointFailoverProvider.notifier);
+      expect(await notifier.getLatestBlockHeight(), BigInt.from(100));
+
+      now = now.add(const Duration(minutes: 5));
+      heightByUrl[primaryUrl] = BigInt.from(101);
+
+      expect(await notifier.getLatestBlockHeight(), BigInt.from(101));
+
+      final state = container.read(rpcEndpointFailoverProvider);
+      expect(state.isUsingFallback, isFalse);
+      expect(state.lastEvent, isNull);
+      expect(state.heightWindowStartHeight, BigInt.from(101));
+    },
+  );
+
+  test('skips slow fallback candidates and checks the next preset', () async {
+    var now = DateTime(2026);
+    final primary = defaultRpcEndpointConfig('main');
+    final primaryUrl = primary.normalizedLightwalletdUrl;
+    final heightByUrl = <String, BigInt>{
+      primaryUrl: BigInt.from(100),
+      'https://eu.zec.stardust.rest:443': BigInt.from(102),
+      'https://eu2.zec.stardust.rest:443': BigInt.from(104),
+    };
+    final container = _container(
+      primary: primary,
+      clock: () => now,
+      chainNameByUrl: {
+        'https://eu.zec.stardust.rest:443': 'main',
+        'https://eu2.zec.stardust.rest:443': 'main',
+      },
+      heightByUrl: heightByUrl,
+    );
+    addTearDown(container.dispose);
+
+    final notifier = container.read(rpcEndpointFailoverProvider.notifier);
+    expect(await notifier.getLatestBlockHeight(), BigInt.from(100));
+
+    now = now.add(const Duration(minutes: 5));
+    heightByUrl[primaryUrl] = BigInt.from(101);
+
+    expect(await notifier.getLatestBlockHeight(), BigInt.from(104));
+
+    final state = container.read(rpcEndpointFailoverProvider);
+    expect(state.current.presetId, 'eu2-zec-stardust');
+  });
+
+  test(
+    'primary probe waits when primary is still behind current fallback',
+    () async {
+      var now = DateTime(2026);
+      final primary = defaultRpcEndpointConfig('main');
+      final primaryUrl = primary.normalizedLightwalletdUrl;
+      final heightByUrl = <String, BigInt>{
+        'https://eu.zec.stardust.rest:443': BigInt.from(110),
+        primaryUrl: BigInt.from(108),
+      };
+      final container = _container(
+        primary: primary,
+        clock: () => now,
+        chainNameByUrl: {
+          'https://eu.zec.stardust.rest:443': 'main',
+          primaryUrl: 'main',
+        },
+        heightByUrl: heightByUrl,
+        settings: const RpcEndpointFailoverSettings(
+          primaryProbeInterval: Duration(seconds: 5),
+        ),
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(rpcEndpointFailoverProvider.notifier);
+      await notifier.switchToFallbackFor(
+        Exception('DeadlineExceeded'),
+        operation: 'primary sync',
+      );
+
+      now = now.add(const Duration(seconds: 5));
+      expect(await notifier.maybeProbePrimary(), isFalse);
+      expect(
+        container.read(rpcEndpointFailoverProvider).isUsingFallback,
+        isTrue,
+      );
+
+      heightByUrl[primaryUrl] = BigInt.from(109);
+      expect(await notifier.maybeProbePrimary(force: true), isTrue);
+      expect(
+        container.read(rpcEndpointFailoverProvider).isUsingFallback,
+        isFalse,
+      );
+    },
+  );
 }
 
 ProviderContainer _container({

--- a/test/providers/rpc_endpoint_failover_provider_test.dart
+++ b/test/providers/rpc_endpoint_failover_provider_test.dart
@@ -46,11 +46,11 @@ void main() {
   });
 
   test('runWithEndpointFallback switches to a healthy fallback', () async {
-    final primary = _customRegtestPrimary();
+    final primary = defaultRpcEndpointConfig('main');
     final container = _container(
       primary: primary,
-      chainNameByUrl: {'http://127.0.0.1:9067': 'regtest'},
-      heightByUrl: {'http://127.0.0.1:9067': BigInt.from(10)},
+      chainNameByUrl: {'https://zec.rocks:443': 'main'},
+      heightByUrl: {'https://zec.rocks:443': BigInt.from(10)},
     );
     addTearDown(container.dispose);
 
@@ -68,21 +68,100 @@ void main() {
         );
 
     final state = container.read(rpcEndpointFailoverProvider);
-    expect(result, '127.0.0.1:9067');
+    expect(result, 'zec.rocks:443');
     expect(state.isUsingFallback, isTrue);
-    expect(state.current.normalizedLightwalletdUrl, 'http://127.0.0.1:9067');
+    expect(state.current.normalizedLightwalletdUrl, 'https://zec.rocks:443');
     expect(
       state.lastEvent?.kind,
       RpcEndpointFailoverEventKind.switchedToFallback,
     );
   });
 
-  test('does not fallback for wallet-state errors', () async {
+  test('does not fallback from custom endpoints', () async {
     final primary = _customRegtestPrimary();
     final container = _container(
       primary: primary,
       chainNameByUrl: {'http://127.0.0.1:9067': 'regtest'},
       heightByUrl: {'http://127.0.0.1:9067': BigInt.from(10)},
+    );
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container
+          .read(rpcEndpointFailoverProvider.notifier)
+          .runWithEndpointFallback(
+            operation: 'test read',
+            action: (_) async =>
+                throw Exception('gRPC connect failed: connection refused'),
+          ),
+      throwsA(isA<Exception>()),
+    );
+
+    final state = container.read(rpcEndpointFailoverProvider);
+    expect(state.fallbackCandidates, isEmpty);
+    expect(state.isUsingFallback, isFalse);
+    expect(state.lastEvent, isNull);
+  });
+
+  test('tries fallback candidates in configured order', () async {
+    final primary = defaultRpcEndpointConfig('main');
+    final container = _container(
+      primary: primary,
+      chainNameByUrl: {'https://na.zec.rocks:443': 'main'},
+      heightByUrl: {'https://na.zec.rocks:443': BigInt.from(12)},
+    );
+    addTearDown(container.dispose);
+
+    final result = await container
+        .read(rpcEndpointFailoverProvider.notifier)
+        .runWithEndpointFallback(
+          operation: 'test read',
+          action: (endpoint) async {
+            if (endpoint.normalizedLightwalletdUrl ==
+                primary.normalizedLightwalletdUrl) {
+              throw Exception('gRPC connect failed: connection refused');
+            }
+            return endpoint.hostPort;
+          },
+        );
+
+    final state = container.read(rpcEndpointFailoverProvider);
+    expect(result, 'na.zec.rocks:443');
+    expect(state.current.presetId, 'na-zec-rocks');
+  });
+
+  test('does not fallback when all candidates fail health checks', () async {
+    final primary = defaultRpcEndpointConfig('main');
+    final container = _container(
+      primary: primary,
+      chainNameByUrl: const {},
+      heightByUrl: const {},
+    );
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container
+          .read(rpcEndpointFailoverProvider.notifier)
+          .runWithEndpointFallback(
+            operation: 'test read',
+            action: (_) async =>
+                throw Exception('gRPC connect failed: connection refused'),
+          ),
+      throwsA(isA<Exception>()),
+    );
+
+    expect(
+      container.read(rpcEndpointFailoverProvider).isUsingFallback,
+      isFalse,
+    );
+  });
+
+  test('does not fallback for wallet-state errors', () async {
+    final primary = defaultRpcEndpointConfig('main');
+    final container = _container(
+      primary: primary,
+      chainNameByUrl: {'https://zec.rocks:443': 'main'},
+      heightByUrl: {'https://zec.rocks:443': BigInt.from(10)},
     );
     addTearDown(container.dispose);
 
@@ -105,17 +184,14 @@ void main() {
 
   test('periodic primary probe switches back after recovery', () async {
     var now = DateTime(2026);
-    final primary = _customRegtestPrimary();
+    final primary = defaultRpcEndpointConfig('main');
     final primaryUrl = primary.normalizedLightwalletdUrl;
     final container = _container(
       primary: primary,
       clock: () => now,
-      chainNameByUrl: {
-        'http://127.0.0.1:9067': 'regtest',
-        primaryUrl: 'regtest',
-      },
+      chainNameByUrl: {'https://zec.rocks:443': 'main', primaryUrl: 'main'},
       heightByUrl: {
-        'http://127.0.0.1:9067': BigInt.from(10),
+        'https://zec.rocks:443': BigInt.from(10),
         primaryUrl: BigInt.from(11),
       },
       settings: const RpcEndpointFailoverSettings(

--- a/test/providers/rpc_endpoint_failover_provider_test.dart
+++ b/test/providers/rpc_endpoint_failover_provider_test.dart
@@ -507,6 +507,49 @@ void main() {
       );
     },
   );
+
+  test(
+    'primary probe compares against fresh current fallback height',
+    () async {
+      var now = DateTime(2026);
+      final primary = defaultRpcEndpointConfig('main');
+      final primaryUrl = primary.normalizedLightwalletdUrl;
+      const fallbackUrl = 'https://eu.zec.stardust.rest:443';
+      final heightByUrl = <String, BigInt>{
+        fallbackUrl: BigInt.from(110),
+        primaryUrl: BigInt.from(120),
+      };
+      final container = _container(
+        primary: primary,
+        clock: () => now,
+        chainNameByUrl: {fallbackUrl: 'main', primaryUrl: 'main'},
+        heightByUrl: heightByUrl,
+        settings: const RpcEndpointFailoverSettings(
+          primaryProbeInterval: Duration(seconds: 5),
+        ),
+      );
+      addTearDown(container.dispose);
+
+      final notifier = container.read(rpcEndpointFailoverProvider.notifier);
+      await notifier.switchToFallbackFor(
+        Exception('DeadlineExceeded'),
+        operation: 'primary sync',
+      );
+
+      heightByUrl[fallbackUrl] = BigInt.from(150);
+      now = now.add(const Duration(seconds: 5));
+
+      expect(await notifier.maybeProbePrimary(), isFalse);
+      var state = container.read(rpcEndpointFailoverProvider);
+      expect(state.isUsingFallback, isTrue);
+      expect(state.lastObservedHeight, BigInt.from(150));
+
+      heightByUrl[primaryUrl] = BigInt.from(149);
+      expect(await notifier.maybeProbePrimary(force: true), isTrue);
+      state = container.read(rpcEndpointFailoverProvider);
+      expect(state.isUsingFallback, isFalse);
+    },
+  );
 }
 
 ProviderContainer _container({


### PR DESCRIPTION
## Summary

Adds automatic endpoint fallback for preset lightwalletd endpoints while preserving custom endpoint privacy.

## What changed

- Adds a Dart failover provider that tracks the selected primary endpoint, active endpoint, fallback state, health checks, and toast events.
- Uses fallback-aware endpoint access for wallet creation/import metadata, foreground sync preflight/polling, birthday block-time lookup, shielding, and send broadcast recovery paths.
- Restricts automatic fallback to bundled presets only. Custom endpoints never fall back to another server, even if the URL matches a preset.
- Builds fallback candidates from the existing preset order so preset list changes are reflected automatically.
- Adds global toast notifications for fallback and primary recovery.
- Adds regtest E2E coverage for preset fallback and custom endpoint no-fallback behavior.

## Privacy impact

Users who configure a custom endpoint will not be silently moved to a different endpoint. Automatic fallback only applies when the user selected one of the app's known presets.

## Validation

- `fvm flutter test`
- `fvm flutter analyze lib test integration_test`
- `cd rust && cargo test`
- `scripts/e2e/flutter-macos-regtest-fallback-endpoint.sh`
- `scripts/e2e/flutter-macos-regtest-custom-endpoint-no-fallback.sh`
- `git diff --check`

Rust tests emit existing warnings, but all tests pass.
