### PR TITLE
[codex] Improve duplicate import error messages

### DIFF
--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -13,6 +13,7 @@ import '../../../providers/app_security_provider.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/wallet_mutation_guard.dart';
+import '../shared/onboarding_error_messages.dart';
 import '../shared/onboarding_flow_args.dart';
 import 'import_birthday_estimator.dart';
 import 'import_birthday_calendar_overlay.dart';
@@ -263,7 +264,7 @@ class _ImportWalletBirthdayScreenState
       if (!mounted) return;
       setState(() {
         _submitPhase = _ImportWalletSubmitPhase.idle;
-        _submitError = e.toString();
+        _submitError = onboardingSubmitErrorMessage(e);
       });
       return;
     }

--- a/lib/src/features/onboarding/shared/onboarding_error_messages.dart
+++ b/lib/src/features/onboarding/shared/onboarding_error_messages.dart
@@ -1,14 +1,33 @@
 import '../../../providers/account_provider.dart';
 
+const kDuplicateSecretPassphraseImportErrorMessage =
+    'This account is already in your wallet.';
+const kDuplicateKeystoneAccountImportErrorMessage =
+    'This Keystone account is already in your wallet.';
+const kDuplicateAccountImportErrorMessage =
+    'This account is already in your wallet.';
+
 String onboardingSubmitErrorMessage(Object error) {
   if (error is WalletCreationCurrentBlockHeightException) {
     return kWalletCreationCurrentBlockHeightErrorMessage;
   }
 
   const exceptionPrefix = 'Exception: ';
-  final message = error.toString();
+  var message = error.toString();
   if (message.startsWith(exceptionPrefix)) {
-    return message.substring(exceptionPrefix.length);
+    message = message.substring(exceptionPrefix.length);
+  }
+  final anyhowMatch = RegExp(r'^AnyhowException\((.*)\)$').firstMatch(message);
+  if (anyhowMatch != null) {
+    message = anyhowMatch.group(1)!;
+  }
+  if (_isAccountCollisionMessage(message)) {
+    return kDuplicateAccountImportErrorMessage;
   }
   return message;
+}
+
+bool _isAccountCollisionMessage(String message) {
+  return message.contains('account corresponding to the data provided') &&
+      message.contains('already exists in the wallet');
 }

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -7,7 +7,7 @@ use zcash_client_backend::data_api::{
     chain::ChainState, Account as _, AccountBirthday, AccountPurpose, AccountSource, WalletRead,
     WalletWrite, Zip32Derivation,
 };
-use zcash_client_sqlite::{wallet::init::init_wallet_db, AccountUuid};
+use zcash_client_sqlite::{error::SqliteClientError, wallet::init::init_wallet_db, AccountUuid};
 use zcash_keys::{
     encoding::encode_transparent_address,
     keys::{ReceiverRequirement, UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
@@ -24,6 +24,21 @@ use crate::wallet::{
     },
     network::WalletNetwork,
 };
+
+const DUPLICATE_SOFTWARE_ACCOUNT_MESSAGE: &str =
+    "This account is already in your wallet.";
+const DUPLICATE_KEYSTONE_ACCOUNT_MESSAGE: &str = "This Keystone account is already in your wallet.";
+
+fn map_account_import_error(
+    error: SqliteClientError,
+    duplicate_message: &str,
+    fallback_prefix: &str,
+) -> String {
+    match error {
+        SqliteClientError::AccountCollision(_) => duplicate_message.to_string(),
+        other => format!("{fallback_prefix}: {other}"),
+    }
+}
 
 fn open_wallet_db_for_init(
     db_path: &str,
@@ -146,7 +161,13 @@ pub fn add_account(
         let mut db = open_wallet_db_for_mutation(db_path, network)?;
         let account = db
             .import_account_ufvk(name, &ufvk, &birthday, purpose, None)
-            .map_err(|e| format!("Failed to import account: {e}"))?;
+            .map_err(|e| {
+                map_account_import_error(
+                    e,
+                    DUPLICATE_SOFTWARE_ACCOUNT_MESSAGE,
+                    "Failed to import account",
+                )
+            })?;
         Ok::<_, String>(account.id())
     })?;
     let (ua, _di) = ufvk
@@ -201,7 +222,13 @@ pub fn import_hardware_account(
 
         let account = db
             .import_account_ufvk(name, &ufvk, &birthday, purpose, None)
-            .map_err(|e| format!("Failed to import hardware account: {e}"))?;
+            .map_err(|e| {
+                map_account_import_error(
+                    e,
+                    DUPLICATE_KEYSTONE_ACCOUNT_MESSAGE,
+                    "Failed to import hardware account",
+                )
+            })?;
         Ok::<_, String>(account.id())
     })?;
     // Hardware wallets (Keystone) have Orchard + transparent but no Sapling,
@@ -672,6 +699,69 @@ mod tests {
                 .unwrap()
                 .unified_address
         );
+    }
+
+    #[test]
+    fn test_add_account_duplicate_seed_returns_user_message() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let phrase = generate_mnemonic();
+        let seed = mnemonic_to_seed(&phrase).unwrap();
+
+        init_db_and_create_account(db_path_str, WalletNetwork::Main, &seed, None, "first").unwrap();
+
+        let error = add_account(db_path_str, WalletNetwork::Main, "duplicate", &seed, None)
+            .expect_err("duplicate seed import should fail");
+
+        assert_eq!(error, DUPLICATE_SOFTWARE_ACCOUNT_MESSAGE);
+    }
+
+    #[test]
+    fn test_import_hardware_duplicate_ufvk_returns_user_message() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let phrase = generate_mnemonic();
+        let seed = mnemonic_to_seed(&phrase).unwrap();
+        let account_index = zip32::AccountId::ZERO;
+        let usk = UnifiedSpendingKey::from_seed(
+            &WalletNetwork::Main,
+            seed.expose_secret(),
+            account_index,
+        )
+        .unwrap();
+        let ufvk = usk.to_unified_full_viewing_key();
+        let ufvk_string = ufvk.encode(&WalletNetwork::Main);
+        let seed_fingerprint = SeedFingerprint::from_seed(seed.expose_secret())
+            .unwrap()
+            .to_bytes();
+
+        import_hardware_account(
+            db_path_str,
+            WalletNetwork::Main,
+            "Keystone",
+            &ufvk_string,
+            &seed_fingerprint,
+            u32::from(account_index),
+            None,
+        )
+        .unwrap();
+
+        let error = import_hardware_account(
+            db_path_str,
+            WalletNetwork::Main,
+            "Keystone",
+            &ufvk_string,
+            &seed_fingerprint,
+            u32::from(account_index),
+            None,
+        )
+        .expect_err("duplicate Keystone UFVK import should fail");
+
+        assert_eq!(error, DUPLICATE_KEYSTONE_ACCOUNT_MESSAGE);
     }
 
     #[test]

--- a/test/onboarding_error_messages_test.dart
+++ b/test/onboarding_error_messages_test.dart
@@ -15,4 +15,43 @@ void main() {
   test('strips default Exception prefix from onboarding submit errors', () {
     expect(onboardingSubmitErrorMessage(Exception('bad input')), 'bad input');
   });
+
+  test('strips rust wrapper from duplicate Secret Passphrase import error', () {
+    expect(
+      onboardingSubmitErrorMessage(
+        _FakeAnyhowException(kDuplicateSecretPassphraseImportErrorMessage),
+      ),
+      kDuplicateSecretPassphraseImportErrorMessage,
+    );
+  });
+
+  test('strips flutter rust bridge anyhow wrapper from submit errors', () {
+    expect(
+      onboardingSubmitErrorMessage(
+        _FakeAnyhowException(kDuplicateKeystoneAccountImportErrorMessage),
+      ),
+      kDuplicateKeystoneAccountImportErrorMessage,
+    );
+  });
+
+  test('maps raw account collision errors to generic duplicate account copy', () {
+    expect(
+      onboardingSubmitErrorMessage(
+        const _FakeAnyhowException(
+          'Failed to import account: An account corresponding to the data '
+          'provided already exists in the wallet with UUID 00000000-0000-0000-0000-000000000000.',
+        ),
+      ),
+      kDuplicateAccountImportErrorMessage,
+    );
+  });
+}
+
+class _FakeAnyhowException implements Exception {
+  const _FakeAnyhowException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'AnyhowException($message)';
 }


### PR DESCRIPTION
## Summary
- Map duplicate software account imports to account-centered copy instead of mentioning the Secret Passphrase.
- Keep Keystone duplicate imports specific to Keystone accounts.
- Normalize wrapped onboarding errors so raw account-collision messages become user-friendly duplicate-account copy.

## Validation
- `fvm flutter test test/onboarding_error_messages_test.dart`
- `cd rust && cargo test duplicate --lib`