### PR TITLE
Fix Sparkle update menu state

### DIFF
--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -5,27 +5,30 @@ import Sparkle
 #endif
 
 @main
-class AppDelegate: FlutterAppDelegate {
+class AppDelegate: FlutterAppDelegate, NSMenuItemValidation {
   @IBOutlet private weak var checkForUpdatesMenuItem: NSMenuItem!
 
 #if SPARKLE_ENABLED
-  private let updaterController: SPUStandardUpdaterController?
+  private var updaterController: SPUStandardUpdaterController?
+  private var canCheckForUpdatesObservation: NSKeyValueObservation?
+  private var lastCanCheckForUpdates: Bool?
 #endif
 
   override init() {
+    super.init()
+
 #if SPARKLE_ENABLED
     if Self.sparkleConfigurationIsValid() {
       updaterController = SPUStandardUpdaterController(
-        startingUpdater: true,
+        startingUpdater: false,
         updaterDelegate: nil,
         userDriverDelegate: nil
       )
     } else {
       updaterController = nil
+      Self.logInvalidSparkleConfiguration()
     }
 #endif
-
-    super.init()
   }
 
   override func applicationDidFinishLaunching(_ notification: Notification) {
@@ -37,8 +40,11 @@ class AppDelegate: FlutterAppDelegate {
       return
     }
 
-    checkForUpdatesMenuItem.target = updaterController
-    checkForUpdatesMenuItem.action = #selector(SPUStandardUpdaterController.checkForUpdates(_:))
+    checkForUpdatesMenuItem.target = self
+    checkForUpdatesMenuItem.action = #selector(checkForUpdates(_:))
+    observeSparkleCanCheckForUpdates(updaterController: updaterController)
+    updaterController.startUpdater()
+    logSparkleState(reason: "started updater")
 #else
     checkForUpdatesMenuItem.isHidden = true
     checkForUpdatesMenuItem.isEnabled = false
@@ -53,7 +59,89 @@ class AppDelegate: FlutterAppDelegate {
     return true
   }
 
+  @objc private func checkForUpdates(_ sender: Any?) {
 #if SPARKLE_ENABLED
+    guard let updaterController else {
+      NSLog("[Sparkle] Ignoring manual update check because the updater is not configured")
+      return
+    }
+
+    logSparkleState(reason: "manual check requested")
+    updaterController.checkForUpdates(sender)
+#else
+    checkForUpdatesMenuItem?.isEnabled = false
+#endif
+  }
+
+  func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+#if SPARKLE_ENABLED
+    if menuItem.action == #selector(checkForUpdates(_:)) {
+      return updaterController?.updater.canCheckForUpdates ?? false
+    }
+#endif
+
+    return true
+  }
+
+#if SPARKLE_ENABLED
+  private func observeSparkleCanCheckForUpdates(updaterController: SPUStandardUpdaterController) {
+    canCheckForUpdatesObservation = updaterController.updater.observe(
+      \.canCheckForUpdates,
+      options: [.initial, .new]
+    ) { [weak self] updater, _ in
+      DispatchQueue.main.async {
+        self?.updateCheckForUpdatesMenuItem(
+          canCheckForUpdates: updater.canCheckForUpdates,
+          reason: "canCheckForUpdates changed"
+        )
+      }
+    }
+  }
+
+  private func updateCheckForUpdatesMenuItem(canCheckForUpdates: Bool, reason: String) {
+    checkForUpdatesMenuItem?.isEnabled = canCheckForUpdates
+
+    guard lastCanCheckForUpdates != canCheckForUpdates else {
+      return
+    }
+
+    lastCanCheckForUpdates = canCheckForUpdates
+    NSLog(
+      "[Sparkle] Check for Updates menu %@ (%@)",
+      canCheckForUpdates ? "enabled" : "disabled",
+      reason
+    )
+  }
+
+  private func logSparkleState(reason: String) {
+    guard let updaterController else {
+      NSLog("[Sparkle] %@: updater is not configured", reason)
+      return
+    }
+
+    let updater = updaterController.updater
+    NSLog(
+      "[Sparkle] %@: feedURL=%@ canCheckForUpdates=%@ sessionInProgress=%@ automaticallyChecksForUpdates=%@",
+      reason,
+      updater.feedURL?.absoluteString ?? "<nil>",
+      updater.canCheckForUpdates ? "true" : "false",
+      updater.sessionInProgress ? "true" : "false",
+      updater.automaticallyChecksForUpdates ? "true" : "false"
+    )
+  }
+
+  private static func logInvalidSparkleConfiguration() {
+    let bundle = Bundle.main
+    let feedURL = bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String
+    let publicKey = bundle.object(forInfoDictionaryKey: "SUPublicEDKey") as? String
+
+    NSLog(
+      "[Sparkle] Updater disabled because configuration is incomplete: hasSUFeedURL=%@ hasSUPublicEDKey=%@",
+      (feedURL?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false) ? "true" : "false",
+      (publicKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false) ? "true" : "false"
+    )
+  }
+
   private static func sparkleConfigurationIsValid() -> Bool {
     let bundle = Bundle.main
     let feedURL = bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -5,46 +5,38 @@ import Sparkle
 #endif
 
 @main
-class AppDelegate: FlutterAppDelegate, NSMenuItemValidation {
+class AppDelegate: FlutterAppDelegate {
   @IBOutlet private weak var checkForUpdatesMenuItem: NSMenuItem!
 
 #if SPARKLE_ENABLED
-  private var updaterController: SPUStandardUpdaterController?
-  private var canCheckForUpdatesObservation: NSKeyValueObservation?
-  private var lastCanCheckForUpdates: Bool?
+  private let updaterController: SPUStandardUpdaterController?
 #endif
 
   override init() {
-    super.init()
-
 #if SPARKLE_ENABLED
     if Self.sparkleConfigurationIsValid() {
       updaterController = SPUStandardUpdaterController(
-        startingUpdater: false,
+        startingUpdater: true,
         updaterDelegate: nil,
         userDriverDelegate: nil
       )
     } else {
       updaterController = nil
-      Self.logInvalidSparkleConfiguration()
     }
 #endif
+
+    super.init()
   }
 
   override func applicationDidFinishLaunching(_ notification: Notification) {
-    super.applicationDidFinishLaunching(notification)
-
 #if SPARKLE_ENABLED
     guard let updaterController else {
       checkForUpdatesMenuItem.isEnabled = false
       return
     }
 
-    checkForUpdatesMenuItem.target = self
-    checkForUpdatesMenuItem.action = #selector(checkForUpdates(_:))
-    observeSparkleCanCheckForUpdates(updaterController: updaterController)
-    updaterController.startUpdater()
-    logSparkleState(reason: "started updater")
+    checkForUpdatesMenuItem.target = updaterController
+    checkForUpdatesMenuItem.action = #selector(SPUStandardUpdaterController.checkForUpdates(_:))
 #else
     checkForUpdatesMenuItem.isHidden = true
     checkForUpdatesMenuItem.isEnabled = false
@@ -59,89 +51,7 @@ class AppDelegate: FlutterAppDelegate, NSMenuItemValidation {
     return true
   }
 
-  @objc private func checkForUpdates(_ sender: Any?) {
 #if SPARKLE_ENABLED
-    guard let updaterController else {
-      NSLog("[Sparkle] Ignoring manual update check because the updater is not configured")
-      return
-    }
-
-    logSparkleState(reason: "manual check requested")
-    updaterController.checkForUpdates(sender)
-#else
-    checkForUpdatesMenuItem?.isEnabled = false
-#endif
-  }
-
-  func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-#if SPARKLE_ENABLED
-    if menuItem.action == #selector(checkForUpdates(_:)) {
-      return updaterController?.updater.canCheckForUpdates ?? false
-    }
-#endif
-
-    return true
-  }
-
-#if SPARKLE_ENABLED
-  private func observeSparkleCanCheckForUpdates(updaterController: SPUStandardUpdaterController) {
-    canCheckForUpdatesObservation = updaterController.updater.observe(
-      \.canCheckForUpdates,
-      options: [.initial, .new]
-    ) { [weak self] updater, _ in
-      DispatchQueue.main.async {
-        self?.updateCheckForUpdatesMenuItem(
-          canCheckForUpdates: updater.canCheckForUpdates,
-          reason: "canCheckForUpdates changed"
-        )
-      }
-    }
-  }
-
-  private func updateCheckForUpdatesMenuItem(canCheckForUpdates: Bool, reason: String) {
-    checkForUpdatesMenuItem?.isEnabled = canCheckForUpdates
-
-    guard lastCanCheckForUpdates != canCheckForUpdates else {
-      return
-    }
-
-    lastCanCheckForUpdates = canCheckForUpdates
-    NSLog(
-      "[Sparkle] Check for Updates menu %@ (%@)",
-      canCheckForUpdates ? "enabled" : "disabled",
-      reason
-    )
-  }
-
-  private func logSparkleState(reason: String) {
-    guard let updaterController else {
-      NSLog("[Sparkle] %@: updater is not configured", reason)
-      return
-    }
-
-    let updater = updaterController.updater
-    NSLog(
-      "[Sparkle] %@: feedURL=%@ canCheckForUpdates=%@ sessionInProgress=%@ automaticallyChecksForUpdates=%@",
-      reason,
-      updater.feedURL?.absoluteString ?? "<nil>",
-      updater.canCheckForUpdates ? "true" : "false",
-      updater.sessionInProgress ? "true" : "false",
-      updater.automaticallyChecksForUpdates ? "true" : "false"
-    )
-  }
-
-  private static func logInvalidSparkleConfiguration() {
-    let bundle = Bundle.main
-    let feedURL = bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String
-    let publicKey = bundle.object(forInfoDictionaryKey: "SUPublicEDKey") as? String
-
-    NSLog(
-      "[Sparkle] Updater disabled because configuration is incomplete: hasSUFeedURL=%@ hasSUPublicEDKey=%@",
-      (feedURL?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false) ? "true" : "false",
-      (publicKey?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false) ? "true" : "false"
-    )
-  }
-
   private static func sparkleConfigurationIsValid() -> Bool {
     let bundle = Bundle.main
     let feedURL = bundle.object(forInfoDictionaryKey: "SUFeedURL") as? String

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -37,7 +37,7 @@
 	<key>SUFeedURL</key>
 	<string>https://github.com/chainapsis/vizor-wallet/releases/latest/download/appcast.xml</string>
 	<key>SUScheduledCheckInterval</key>
-	<integer>10800</integer>
+	<integer>3600</integer>
 	<key>SUPublicEDKey</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
## Summary
- Remove the invalid macOS `super.applicationDidFinishLaunching` call that prevented Sparkle menu wiring from running.
- Set Sparkle's scheduled update check interval to one hour.

## Root Cause
`FlutterAppDelegate` on macOS does not implement `applicationDidFinishLaunching:` in the current Flutter SDK, so calling `super.applicationDidFinishLaunching(notification)` raises an unrecognized selector exception at launch. The exception stops the Sparkle menu setup, leaving `Check for Updates` disabled.

## Validation
- `plutil -lint macos/Runner/Info.plist`
- `xcodebuild -workspace macos/Runner.xcworkspace -scheme Runner -configuration Debug SWIFT_ACTIVE_COMPILATION_CONDITIONS='DEBUG SPARKLE_ENABLED' CODE_SIGNING_ALLOWED=NO build`
- Local Sparkle preflight with `SUPublicEDKey` injected into the built app: `Check for Updates` appeared enabled in the macOS menu and no `unrecognized selector` log was emitted.
