### PR TITLE
Serialize secure store wipes

### DIFF
--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -152,10 +152,12 @@ class AppSecureStore {
     await _storage.delete(key: key);
   }
 
-  Future<void> deleteAll() async {
-    await _storage.deleteAll();
-    _cachedSecretKey = null;
-    _sessionPassword = null;
+  Future<void> deleteAll() {
+    return _secretMutationLock.run(() async {
+      await _storage.deleteAll();
+      _cachedSecretKey = null;
+      _sessionPassword = null;
+    });
   }
 
   Future<String?> readPlain(String key) {
@@ -316,11 +318,13 @@ class AppSecureStore {
     clearSessionPassword();
   }
 
-  Future<void> clearPasswordConfiguration() async {
-    await delete(_passwordVerifierSaltKey);
-    await delete(_passwordVerifierKey);
-    await delete(_passwordRotationInProgressKey);
-    clearSessionPassword();
+  Future<void> clearPasswordConfiguration() {
+    return _secretMutationLock.run(() async {
+      await _storage.delete(key: _passwordVerifierSaltKey);
+      await _storage.delete(key: _passwordVerifierKey);
+      await _storage.delete(key: _passwordRotationInProgressKey);
+      clearSessionPassword();
+    });
   }
 
   /// Checks the wallet password without opening or refreshing the encrypted

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -361,6 +361,58 @@ void main() {
       expect(await store.readPlain(_mnemonicKey), isNull);
     },
   );
+
+  test('deleteAll waits for concurrent mnemonic writes', () async {
+    const lateMnemonicKey = 'zcash_account_mnemonic_delete-all-account';
+    const lateMnemonic = 'legal winner thank year wave sausage worth useful';
+    final blockingStorage = _BlockingWriteStorage(blockKey: lateMnemonicKey);
+    store = AppSecureStore.testing(storage: blockingStorage);
+    await store.configurePassword(_oldPassword);
+
+    blockingStorage.blockNextWrite = true;
+    final lateWrite = store.writeSecretString(lateMnemonicKey, lateMnemonic);
+    await blockingStorage.writeStarted.future;
+
+    var deleteAllCompleted = false;
+    final deleteAll = store.deleteAll().then((_) {
+      deleteAllCompleted = true;
+    });
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(deleteAllCompleted, isFalse);
+
+    blockingStorage.release();
+    await lateWrite;
+    await deleteAll;
+
+    expect(await store.readPlain(lateMnemonicKey), isNull);
+    expect(store.hasSessionPassword, isFalse);
+  });
+
+  test('clearPasswordConfiguration waits for concurrent mnemonic writes', () async {
+    const lateMnemonicKey = 'zcash_account_mnemonic_clear-password-account';
+    const lateMnemonic = 'legal winner thank year wave sausage worth useful';
+    final blockingStorage = _BlockingWriteStorage(blockKey: lateMnemonicKey);
+    store = AppSecureStore.testing(storage: blockingStorage);
+    await store.configurePassword(_oldPassword);
+
+    blockingStorage.blockNextWrite = true;
+    final lateWrite = store.writeSecretString(lateMnemonicKey, lateMnemonic);
+    await blockingStorage.writeStarted.future;
+
+    var clearCompleted = false;
+    final clear = store.clearPasswordConfiguration().then((_) {
+      clearCompleted = true;
+    });
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(clearCompleted, isFalse);
+
+    blockingStorage.release();
+    await lateWrite;
+    await clear;
+
+    expect(await store.readPlain(lateMnemonicKey), isNotNull);
+    expect(store.hasSessionPassword, isFalse);
+  });
 }
 
 class _FailingWriteStorage extends FlutterSecureStorage {


### PR DESCRIPTION
## Summary
- serialize full secure-store wipe and password-configuration cleanup with the secret mutation lock
- add regression coverage for blocked mnemonic writes racing with deleteAll and password cleanup

Closes #83

## Verification
- fvm flutter test test/core/storage/app_secure_store_test.dart
- fvm flutter analyze lib test/core/storage/app_secure_store_test.dart