### PR TITLE
Keep seed derivation inside Rust

### DIFF
--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -24,7 +24,6 @@ import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
-import '../../../rust/api/wallet.dart' as rust_wallet;
 import '../../activity/activity_row_mapper.dart';
 import '../../activity/models/activity_row_data.dart';
 import '../../activity/screens/activity_transaction_status_screen.dart';
@@ -122,7 +121,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         throw Exception('Mnemonic not found for the active account.');
       }
 
-      final seedBytes = await rust_wallet.deriveSeed(mnemonic: mnemonic);
       final dbPath = await getWalletDbPath();
       final endpoint = ref.read(rpcEndpointFailoverProvider).current;
       attemptedEndpoint = endpoint;
@@ -131,7 +129,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
         network: endpoint.networkName,
         accountUuid: accountUuid,
-        seed: seedBytes,
+        mnemonic: mnemonic,
       );
       log(
         'HomeScreen: shielded transparent balance txids=${result.txids} '

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -20,7 +20,6 @@ import '../../../providers/account_provider.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
-import '../../../rust/api/wallet.dart' as rust_wallet;
 import '../../keystone/widgets/keystone_transaction_progress_panel.dart';
 import '../services/sapling_params.dart';
 import '../widgets/sapling_params_prompt.dart';
@@ -387,13 +386,12 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
           return;
         }
 
-        final seedBytes = await rust_wallet.deriveSeed(mnemonic: mnemonic);
         final result = await rust_sync.executeProposal(
           dbPath: dbPath,
           lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
           proposalId: widget.args.proposalId,
           sendFlowId: widget.args.sendFlowId,
-          seed: seedBytes,
+          mnemonic: mnemonic,
           spendParamsPath: widget.args.needsSaplingParams
               ? saplingParams.spendPath
               : null,

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -258,7 +258,7 @@ Future<ExecuteProposalResult> executeProposal({
   required String lightwalletdUrl,
   required BigInt proposalId,
   required String sendFlowId,
-  required List<int> seed,
+  required String mnemonic,
   String? spendParamsPath,
   String? outputParamsPath,
 }) => RustLib.instance.api.crateApiSyncExecuteProposal(
@@ -266,7 +266,7 @@ Future<ExecuteProposalResult> executeProposal({
   lightwalletdUrl: lightwalletdUrl,
   proposalId: proposalId,
   sendFlowId: sendFlowId,
-  seed: seed,
+  mnemonic: mnemonic,
   spendParamsPath: spendParamsPath,
   outputParamsPath: outputParamsPath,
 );
@@ -301,13 +301,13 @@ Future<ShieldTransparentResult> shieldTransparentBalance({
   required String lightwalletdUrl,
   required String network,
   required String accountUuid,
-  required List<int> seed,
+  required String mnemonic,
 }) => RustLib.instance.api.crateApiSyncShieldTransparentBalance(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
   network: network,
   accountUuid: accountUuid,
-  seed: seed,
+  mnemonic: mnemonic,
 );
 
 Future<String> getNextAvailableAddress({

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -130,11 +130,6 @@ bool walletExists({required String dbPath}) =>
 bool validateMnemonic({required String mnemonic}) =>
     RustLib.instance.api.crateApiWalletValidateMnemonic(mnemonic: mnemonic);
 
-/// Derive seed bytes from a mnemonic phrase.
-/// Returns 64 raw bytes. The caller should treat these as sensitive.
-Future<Uint8List> deriveSeed({required String mnemonic}) =>
-    RustLib.instance.api.crateApiWalletDeriveSeed(mnemonic: mnemonic);
-
 /// Get the transparent address for a specific account (or first account if uuid is None).
 Future<String> getTransparentAddress({
   required String dbPath,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -70,7 +70,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -292915742;
+  int get rustContentHash => 9336009;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -149,8 +149,6 @@ abstract class RustLibApi extends BaseApi {
     required String accountUuid,
   });
 
-  Future<Uint8List> crateApiWalletDeriveSeed({required String mnemonic});
-
   Future<void> crateApiSyncDiscardProposal({
     required BigInt proposalId,
     required String sendFlowId,
@@ -185,7 +183,7 @@ abstract class RustLibApi extends BaseApi {
     required String lightwalletdUrl,
     required BigInt proposalId,
     required String sendFlowId,
-    required List<int> seed,
+    required String mnemonic,
     String? spendParamsPath,
     String? outputParamsPath,
   });
@@ -386,7 +384,7 @@ abstract class RustLibApi extends BaseApi {
     required String lightwalletdUrl,
     required String network,
     required String accountUuid,
-    required List<int> seed,
+    required String mnemonic,
   });
 
   Stream<ApiSyncProgressEvent> crateApiSyncStartFullSync({
@@ -892,34 +890,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<Uint8List> crateApiWalletDeriveSeed({required String mnemonic}) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(mnemonic, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 14,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_String,
-        ),
-        constMeta: kCrateApiWalletDeriveSeedConstMeta,
-        argValues: [mnemonic],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiWalletDeriveSeedConstMeta =>
-      const TaskConstMeta(debugName: "derive_seed", argNames: ["mnemonic"]);
-
-  @override
   Future<void> crateApiSyncDiscardProposal({
     required BigInt proposalId,
     required String sendFlowId,
@@ -933,7 +903,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 14,
             port: port_,
           );
         },
@@ -966,7 +936,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 15,
             port: port_,
           );
         },
@@ -1001,7 +971,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 16,
             port: port_,
           );
         },
@@ -1044,7 +1014,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 17,
             port: port_,
           );
         },
@@ -1098,7 +1068,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 18,
             port: port_,
           );
         },
@@ -1125,7 +1095,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String lightwalletdUrl,
     required BigInt proposalId,
     required String sendFlowId,
-    required List<int> seed,
+    required String mnemonic,
     String? spendParamsPath,
     String? outputParamsPath,
   }) {
@@ -1137,13 +1107,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(lightwalletdUrl, serializer);
           sse_encode_u_64(proposalId, serializer);
           sse_encode_String(sendFlowId, serializer);
-          sse_encode_list_prim_u_8_loose(seed, serializer);
+          sse_encode_String(mnemonic, serializer);
           sse_encode_opt_String(spendParamsPath, serializer);
           sse_encode_opt_String(outputParamsPath, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 19,
             port: port_,
           );
         },
@@ -1157,7 +1127,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           lightwalletdUrl,
           proposalId,
           sendFlowId,
-          seed,
+          mnemonic,
           spendParamsPath,
           outputParamsPath,
         ],
@@ -1174,7 +1144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "lightwalletdUrl",
           "proposalId",
           "sendFlowId",
-          "seed",
+          "mnemonic",
           "spendParamsPath",
           "outputParamsPath",
         ],
@@ -1204,7 +1174,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 20,
             port: port_,
           );
         },
@@ -1247,7 +1217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1279,7 +1249,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 22,
             port: port_,
           );
         },
@@ -1313,7 +1283,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 23,
             port: port_,
           );
         },
@@ -1340,7 +1310,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cachePath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1372,7 +1342,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1405,7 +1375,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1438,7 +1408,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1475,7 +1445,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1510,7 +1480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1547,7 +1517,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1574,7 +1544,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -1604,7 +1574,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1638,7 +1608,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1676,7 +1646,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(txidHex, serializer);
           sse_encode_String(txKind, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_transaction_detail,
@@ -1713,7 +1683,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1750,7 +1720,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1787,7 +1757,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1815,7 +1785,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1855,7 +1825,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 39,
             port: port_,
           );
         },
@@ -1912,7 +1882,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1947,7 +1917,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1971,7 +1941,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1996,7 +1966,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2018,7 +1988,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2048,7 +2018,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 45,
             port: port_,
           );
         },
@@ -2074,7 +2044,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -2114,7 +2084,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 47,
             port: port_,
           );
         },
@@ -2172,7 +2142,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 48,
             port: port_,
           );
         },
@@ -2219,7 +2189,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 49,
             port: port_,
           );
         },
@@ -2246,7 +2216,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2278,7 +2248,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 51,
             port: port_,
           );
         },
@@ -2316,7 +2286,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 52,
             port: port_,
           );
         },
@@ -2369,7 +2339,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 53,
             port: port_,
           );
         },
@@ -2420,7 +2390,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2454,7 +2424,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 55,
             port: port_,
           );
         },
@@ -2481,7 +2451,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String lightwalletdUrl,
     required String network,
     required String accountUuid,
-    required List<int> seed,
+    required String mnemonic,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -2491,11 +2461,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(lightwalletdUrl, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
-          sse_encode_list_prim_u_8_loose(seed, serializer);
+          sse_encode_String(mnemonic, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2504,7 +2474,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncShieldTransparentBalanceConstMeta,
-        argValues: [dbPath, lightwalletdUrl, network, accountUuid, seed],
+        argValues: [dbPath, lightwalletdUrl, network, accountUuid, mnemonic],
         apiImpl: this,
       ),
     );
@@ -2518,7 +2488,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "lightwalletdUrl",
           "network",
           "accountUuid",
-          "seed",
+          "mnemonic",
         ],
       );
 
@@ -2543,7 +2513,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 58,
+              funcId: 57,
               port: port_,
             );
           },
@@ -2584,7 +2554,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 59,
+              funcId: 58,
               port: port_,
             );
           },
@@ -2613,7 +2583,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2643,7 +2613,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2680,7 +2650,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2712,7 +2682,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 62,
             port: port_,
           );
         },
@@ -2737,7 +2707,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(mnemonic, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2763,7 +2733,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2793,7 +2763,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 65,
             port: port_,
           );
         },

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 
 use flutter_rust_bridge::frb;
+use secrecy::ExposeSecret;
 
 use crate::frb_generated::StreamSink;
 use crate::wallet::{keys, sync as wallet_sync, sync_engine};
@@ -703,18 +704,19 @@ pub fn execute_proposal(
     lightwalletd_url: String,
     proposal_id: u64,
     send_flow_id: String,
-    seed: Vec<u8>,
+    mnemonic: String,
     spend_params_path: Option<String>,
     output_params_path: Option<String>,
 ) -> Result<ExecuteProposalResult, String> {
     catch(|| {
+        let seed = keys::mnemonic_to_seed(&mnemonic)?;
         let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
         let r = rt.block_on(wallet_sync::execute_proposal(
             &db_path,
             &lightwalletd_url,
             proposal_id,
             &send_flow_id,
-            &seed,
+            seed.expose_secret(),
             spend_params_path.as_deref(),
             output_params_path.as_deref(),
         ))?;
@@ -772,17 +774,18 @@ pub fn shield_transparent_balance(
     lightwalletd_url: String,
     network: String,
     account_uuid: String,
-    seed: Vec<u8>,
+    mnemonic: String,
 ) -> Result<ShieldTransparentResult, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
+        let seed = keys::mnemonic_to_seed(&mnemonic)?;
         let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
         let r = rt.block_on(wallet_sync::shield_transparent_balance(
             &db_path,
             &lightwalletd_url,
             network,
             &account_uuid,
-            &seed,
+            seed.expose_secret(),
         ))?;
         Ok(ShieldTransparentResult {
             txids: r.txids,

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -1,7 +1,5 @@
 use std::panic;
 
-use secrecy::ExposeSecret;
-
 use crate::wallet::keys;
 
 /// Result of wallet creation, containing the mnemonic, unified address, and account UUID.
@@ -252,15 +250,6 @@ pub fn wallet_exists(db_path: String) -> bool {
 #[flutter_rust_bridge::frb(sync)]
 pub fn validate_mnemonic(mnemonic: String) -> bool {
     keys::mnemonic_to_seed(&mnemonic).is_ok()
-}
-
-/// Derive seed bytes from a mnemonic phrase.
-/// Returns 64 raw bytes. The caller should treat these as sensitive.
-pub fn derive_seed(mnemonic: String) -> Result<Vec<u8>, String> {
-    catch(|| {
-        let seed = keys::mnemonic_to_seed(&mnemonic)?;
-        Ok(seed.expose_secret().to_vec())
-    })
 }
 
 /// Get the transparent address for a specific account (or first account if uuid is None).

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -292915742;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 9336009;
 
 // Section: executor
 
@@ -526,39 +526,6 @@ fn wire__crate__api__wallet__delete_account_impl(
         },
     )
 }
-fn wire__crate__api__wallet__derive_seed_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "derive_seed",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_mnemonic = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| {
-                transform_result_sse::<_, String>((move || {
-                    let output_ok = crate::api::wallet::derive_seed(api_mnemonic)?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
 fn wire__crate__api__sync__discard_proposal_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -779,7 +746,7 @@ fn wire__crate__api__sync__execute_proposal_impl(
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
             let api_proposal_id = <u64>::sse_decode(&mut deserializer);
             let api_send_flow_id = <String>::sse_decode(&mut deserializer);
-            let api_seed = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_mnemonic = <String>::sse_decode(&mut deserializer);
             let api_spend_params_path = <Option<String>>::sse_decode(&mut deserializer);
             let api_output_params_path = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
@@ -790,7 +757,7 @@ fn wire__crate__api__sync__execute_proposal_impl(
                         api_lightwalletd_url,
                         api_proposal_id,
                         api_send_flow_id,
-                        api_seed,
+                        api_mnemonic,
                         api_spend_params_path,
                         api_output_params_path,
                     )?;
@@ -2153,7 +2120,7 @@ fn wire__crate__api__sync__shield_transparent_balance_impl(
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
-            let api_seed = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_mnemonic = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -2162,7 +2129,7 @@ fn wire__crate__api__sync__shield_transparent_balance_impl(
                         api_lightwalletd_url,
                         api_network,
                         api_account_uuid,
-                        api_seed,
+                        api_mnemonic,
                     )?;
                     Ok(output_ok)
                 })())
@@ -3243,109 +3210,108 @@ fn pde_ffi_dispatcher_primary_impl(
             data_len,
         ),
         13 => wire__crate__api__wallet__delete_account_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__wallet__derive_seed_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
-        17 => {
+        14 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
+        16 => {
             wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len)
         }
-        18 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(
+        17 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        23 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__sync__get_export_birthday_height_impl(
+        22 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__sync__get_export_birthday_height_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        27 => wire__crate__api__wallet__get_latest_block_height_impl(
+        26 => wire__crate__api__wallet__get_latest_block_height_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        28 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(
+        27 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        29 => wire__crate__api__sync__get_next_available_address_impl(
+        28 => wire__crate__api__sync__get_next_available_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        30 => {
+        29 => {
             wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len)
         }
-        31 => wire__crate__api__sync__get_shield_transparent_status_impl(
+        30 => wire__crate__api__sync__get_shield_transparent_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        33 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__sync__get_transaction_data_requests_impl(
+        32 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__sync__get_transaction_data_requests_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        36 => {
+        35 => {
             wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len)
         }
-        37 => wire__crate__api__wallet__get_transparent_address_impl(
+        36 => wire__crate__api__wallet__get_transparent_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__wallet__import_hardware_account_impl(
+        37 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__wallet__import_hardware_account_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-        49 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-        50 => {
+        40 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+        49 => {
             wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len)
         }
-        52 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-        53 => {
+        51 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+        52 => {
             wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len)
         }
-        54 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-        56 => {
+        53 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+        55 => {
             wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len)
         }
-        57 => wire__crate__api__sync__shield_transparent_balance_impl(
+        56 => wire__crate__api__sync__shield_transparent_balance_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        58 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-        59 => {
+        57 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+        58 => {
             wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len)
         }
-        61 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-        66 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3359,20 +3325,20 @@ fn pde_ffi_dispatcher_sync_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         3 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        64 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        63 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -196,13 +196,12 @@ pub fn execute_send(
         None
     };
 
-    let seed = wallet_api::derive_seed(sender_mnemonic.into()).expect("derive_seed");
     sync_api::execute_proposal(
         path_str(db_path),
         LIGHTWALLETD_URL.into(),
         proposal.proposal_id,
         send_flow_id.into(),
-        seed,
+        sender_mnemonic.into(),
         sapling_params.as_ref().map(|p| p.spend_path.clone()),
         sapling_params.as_ref().map(|p| p.output_path.clone()),
     )

--- a/test/security/no_dart_seed_derivation_test.dart
+++ b/test/security/no_dart_seed_derivation_test.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('production Dart signing flows do not derive raw seed bytes', () {
+    final productionFiles = Directory('lib/src/features')
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((file) => file.path.endsWith('.dart'));
+
+    final offenders = <String>[];
+    for (final file in productionFiles) {
+      final content = file.readAsStringSync();
+      if (content.contains('deriveSeed(')) {
+        offenders.add(file.path);
+      }
+    }
+
+    expect(offenders, isEmpty);
+  });
+}


### PR DESCRIPTION
## Summary

- remove the public `derive_seed` / `deriveSeed` FRB API so Dart no longer requests raw 64-byte seed material
- pass mnemonics into the send and transparent-shielding Rust API entry points, deriving seed bytes inside Rust immediately before signing
- regenerate FRB bindings and add a guard test that fails if production feature code starts calling `deriveSeed(` again

Closes #86.

## Verification

- `fvm flutter test test/security/no_dart_seed_derivation_test.dart`
- `fvm flutter analyze lib/src/features/home/screens/home_screen.dart lib/src/features/send/screens/send_status_screen.dart test/security/no_dart_seed_derivation_test.dart`
- `cargo test` from `rust/`
