### PR TITLE
[codex] Improve macOS Keystone QR scanning

### DIFF
--- a/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
+++ b/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
@@ -71,6 +71,8 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
     return MobileScannerController(
       cameraId: cameraId,
       facing: defaultQrScannerFacing,
+      formats: QrScanner.formats,
+      detectionSpeed: QrScanner.detectionSpeed,
     );
   }
 
@@ -943,7 +945,7 @@ class _ScanOverlay extends StatelessWidget {
 class _ScanOverlayPainter extends CustomPainter {
   const _ScanOverlayPainter();
 
-  static const _cutoutSize = 210.0;
+  static const _cutoutSize = 250.0;
   static const _cutoutRadius = 32.0;
   static const _strokeWidth = 5.0;
   static const _cornerArmLength = 12.0;

--- a/lib/src/services/qr_scanner.dart
+++ b/lib/src/services/qr_scanner.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
@@ -21,8 +22,29 @@ CameraFacing get defaultQrScannerFacing => _defaultFacing;
 class QrScanner {
   QrScanner._();
 
+  static const formats = <BarcodeFormat>[BarcodeFormat.qrCode];
+  static const detectionSpeed = DetectionSpeed.noDuplicates;
+  static const scanWindowUpdateThreshold = 8.0;
+
   static bool get isAvailable =>
       Platform.isIOS || Platform.isAndroid || Platform.isMacOS;
+
+  static Rect? scanWindowFor(Size layoutSize) {
+    if (!layoutSize.width.isFinite ||
+        !layoutSize.height.isFinite ||
+        layoutSize.width <= 0 ||
+        layoutSize.height <= 0) {
+      return null;
+    }
+
+    final shortestSide = math.min(layoutSize.width, layoutSize.height);
+    final side = math.min(shortestSide * 0.9, 280.0);
+    return Rect.fromCenter(
+      center: layoutSize.center(Offset.zero),
+      width: side,
+      height: side,
+    );
+  }
 }
 
 class ScanResult {
@@ -78,7 +100,11 @@ class _AnimatedUrScannerViewState extends State<AnimatedUrScannerView> {
     _ownsController = controller == null;
     _controller =
         controller ??
-        MobileScannerController(facing: widget.facing ?? _defaultFacing);
+        MobileScannerController(
+          facing: widget.facing ?? _defaultFacing,
+          formats: QrScanner.formats,
+          detectionSpeed: QrScanner.detectionSpeed,
+        );
   }
 
   void _resetScanSession() {
@@ -165,6 +191,15 @@ class _AnimatedUrScannerViewState extends State<AnimatedUrScannerView> {
 
   @override
   Widget build(BuildContext context) {
-    return MobileScanner(controller: _controller, onDetect: _onDetect);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return MobileScanner(
+          controller: _controller,
+          onDetect: _onDetect,
+          scanWindow: QrScanner.scanWindowFor(constraints.biggest),
+          scanWindowUpdateThreshold: QrScanner.scanWindowUpdateThreshold,
+        );
+      },
+    );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -596,8 +596,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: f31f8351106e62ebdf9b2fd9575f14e3ab5f1ebe
-      resolved-ref: f31f8351106e62ebdf9b2fd9575f14e3ab5f1ebe
+      ref: "92141705ce5dc5afdb239fb5af5d512b1a0a726e"
+      resolved-ref: "92141705ce5dc5afdb239fb5af5d512b1a0a726e"
       url: "https://github.com/chainapsis/mobile_scanner.git"
     source: git
     version: "7.2.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   mobile_scanner:
     git:
       url: https://github.com/chainapsis/mobile_scanner.git
-      ref: f31f8351106e62ebdf9b2fd9575f14e3ab5f1ebe
+      ref: 92141705ce5dc5afdb239fb5af5d512b1a0a726e
   desktop_window_bootstrap:
     git:
       url: https://github.com/chainapsis/desktop_window_bootstrap.git


### PR DESCRIPTION
## Summary

- Tune Keystone QR scanning to QR-only detection with duplicate suppression.
- Add a centered scan window and larger visual target for Keystone account/signature scans.
- Point `mobile_scanner` at the macOS preview-flip commit instead of vendoring the package.

## Why

The wallet-side scanner struggled with Keystone animated QR flows, especially signed PCZT scans on macOS. The visible camera preview was also horizontally confusing for users trying to align Keystone with the wallet scanner.

## Details

Both Keystone import/connect (`zcash-accounts`) and signed transaction scan (`zcash-pczt`) use the shared Keystone scanner card, so these tuning changes apply to both wallet scanning flows.

The macOS preview flip lives in `chainapsis/mobile_scanner` commit `92141705ce5dc5afdb239fb5af5d512b1a0a726e`, with the companion scanner PR at https://github.com/chainapsis/mobile_scanner/pull/1. That native change flips only the preview texture; QR detection still runs against the original unflipped camera frames.

## Validation

- `fvm flutter pub get`
- `fvm flutter analyze lib/src/services/qr_scanner.dart lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart`
- `fvm flutter build macos --config-only`
- Unsigned macOS release build via `xcodebuild ... CODE_SIGNING_ALLOWED=NO ... clean build`
