### PR TITLE
[codex] Harden macOS mnemonic secure storage

### DIFF
--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -271,8 +271,8 @@ class AppSecureStore {
       );
       final newSecretKey = await _deriveSecretKeyForPassword(newPassword);
       try {
-        final migrated = await _migrateAccountMnemonicsAfterUnlockLocked();
-        if (!migrated) {
+        final migration = await _migrateAccountMnemonicsAfterUnlockLocked();
+        if (!migration.legacyCleanupComplete) {
           throw StateError(
             'Failed to migrate account mnemonics before password rotation.',
           );
@@ -402,19 +402,28 @@ class AppSecureStore {
     if (isMatch) {
       setSessionPassword(password);
       try {
-        await migrateAccountMnemonicsAfterUnlock();
+        final migratedForRead = await migrateAccountMnemonicsAfterUnlock();
+        if (!migratedForRead) {
+          clearSessionPassword();
+          return false;
+        }
       } catch (error, stackTrace) {
+        clearSessionPassword();
         debugPrint(
           'AppSecureStore: failed to migrate account mnemonics after unlock: '
           '$error\n$stackTrace',
         );
+        return false;
       }
     }
     return isMatch;
   }
 
   Future<bool> migrateAccountMnemonicsAfterUnlock() {
-    return _secretMutationLock.run(_migrateAccountMnemonicsAfterUnlockLocked);
+    return _secretMutationLock.run(() async {
+      final migration = await _migrateAccountMnemonicsAfterUnlockLocked();
+      return migration.mnemonicsAvailable;
+    });
   }
 
   void setSessionPassword(String password) {
@@ -464,17 +473,19 @@ class AppSecureStore {
     ).serialize();
   }
 
-  Future<bool> _migrateAccountMnemonicsAfterUnlockLocked() async {
+  Future<_AccountMnemonicMigrationResult>
+  _migrateAccountMnemonicsAfterUnlockLocked() async {
     if (!_usesSeparateMacOsMnemonicStorage ||
         identical(_mnemonicStorage, _storage)) {
-      return true;
+      return _AccountMnemonicMigrationResult.complete;
     }
     if (await readPlain(_accountMnemonicMigrationCompleteKey) == 'true') {
-      return true;
+      return _AccountMnemonicMigrationResult.complete;
     }
 
     final legacyValues = await _storage.readAll();
-    var succeeded = true;
+    var mnemonicsAvailable = true;
+    var legacyCleanupComplete = true;
     for (final entry in legacyValues.entries) {
       if (!_isAccountMnemonicKey(entry.key)) continue;
 
@@ -483,16 +494,28 @@ class AppSecureStore {
         if (existing == null) {
           await _mnemonicStorage.write(key: entry.key, value: entry.value);
         }
+      } catch (error, stackTrace) {
+        mnemonicsAvailable = false;
+        legacyCleanupComplete = false;
+        debugPrint(
+          'AppSecureStore: failed to copy account mnemonic "${entry.key}": '
+          '$error\n$stackTrace',
+        );
+        continue;
+      }
+
+      try {
         await _storage.delete(key: entry.key);
       } catch (error, stackTrace) {
-        succeeded = false;
+        legacyCleanupComplete = false;
         debugPrint(
-          'AppSecureStore: failed to migrate account mnemonic "${entry.key}": '
+          'AppSecureStore: failed to delete legacy account mnemonic '
+          '"${entry.key}": '
           '$error\n$stackTrace',
         );
       }
     }
-    if (succeeded) {
+    if (legacyCleanupComplete) {
       try {
         await writePlain(_accountMnemonicMigrationCompleteKey, 'true');
       } catch (error, stackTrace) {
@@ -502,7 +525,10 @@ class AppSecureStore {
         );
       }
     }
-    return succeeded;
+    return _AccountMnemonicMigrationResult(
+      mnemonicsAvailable: mnemonicsAvailable,
+      legacyCleanupComplete: legacyCleanupComplete,
+    );
   }
 
   Future<void> _deleteLegacyAccountMnemonicBestEffort(String key) async {
@@ -708,6 +734,21 @@ String _accountMnemonicKey(String accountUuid) =>
 
 String _mnemonicSecureStoreServiceForNetwork(String networkName) {
   return '${secureStoreServiceForNetwork(networkName)}.mnemonic';
+}
+
+class _AccountMnemonicMigrationResult {
+  const _AccountMnemonicMigrationResult({
+    required this.mnemonicsAvailable,
+    required this.legacyCleanupComplete,
+  });
+
+  static const complete = _AccountMnemonicMigrationResult(
+    mnemonicsAvailable: true,
+    legacyCleanupComplete: true,
+  );
+
+  final bool mnemonicsAvailable;
+  final bool legacyCleanupComplete;
 }
 
 class _AsyncLock {

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -128,6 +128,7 @@ class AppSecureStore {
     bool requireUnlockedSession = false,
   }) {
     return _secretMutationLock.run(() async {
+      if (_shouldSkipLockedSecretRead(requireUnlockedSession)) return null;
       final raw = await _storage.read(key: key);
       return _decryptStoredSecretString(
         raw,
@@ -142,6 +143,7 @@ class AppSecureStore {
     bool requireUnlockedSession = false,
   }) {
     return _secretMutationLock.run(() async {
+      if (_shouldSkipLockedSecretRead(requireUnlockedSession)) return null;
       final key = _accountMnemonicKey(accountUuid);
       final raw = await _mnemonicStorage.read(key: key);
       return _decryptStoredSecretString(
@@ -434,6 +436,10 @@ class AppSecureStore {
   void clearSessionPassword() {
     _sessionPassword = null;
     _cachedSecretKey = null;
+  }
+
+  bool _shouldSkipLockedSecretRead(bool requireUnlockedSession) {
+    return requireUnlockedSession && !hasSessionPassword;
   }
 
   Future<String?> _decryptStoredSecretString(

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -3,7 +3,13 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:cryptography/cryptography.dart';
-import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
+import 'package:flutter/foundation.dart'
+    show
+        TargetPlatform,
+        debugPrint,
+        defaultTargetPlatform,
+        kIsWeb,
+        visibleForTesting;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../config/network_config.dart';
@@ -30,12 +36,18 @@ class PasswordRotationRecoveryFailedException implements Exception {
 }
 
 class AppSecureStore {
-  AppSecureStore._({FlutterSecureStorage? storage})
-    : _storage = storage ?? _defaultStorage();
+  AppSecureStore._({
+    FlutterSecureStorage? storage,
+    FlutterSecureStorage? mnemonicStorage,
+  }) : _storage = storage ?? _defaultStorage(),
+       _mnemonicStorage = mnemonicStorage ?? _defaultMnemonicStorage();
 
   @visibleForTesting
-  AppSecureStore.testing({required FlutterSecureStorage storage})
-    : _storage = storage;
+  AppSecureStore.testing({
+    required FlutterSecureStorage storage,
+    FlutterSecureStorage? mnemonicStorage,
+  }) : _storage = storage,
+       _mnemonicStorage = mnemonicStorage ?? storage;
 
   static final AppSecureStore instance = AppSecureStore._();
 
@@ -57,6 +69,27 @@ class AppSecureStore {
     );
   }
 
+  static FlutterSecureStorage _defaultMnemonicStorage() {
+    final service = secureStoreServiceForNetwork(kZcashDefaultNetworkName);
+    final macOsService = _mnemonicSecureStoreServiceForNetwork(
+      kZcashDefaultNetworkName,
+    );
+    return FlutterSecureStorage(
+      iOptions: IOSOptions(
+        accountName: service,
+        accessibility: KeychainAccessibility.first_unlock,
+      ),
+      aOptions: kZcashDefaultNetworkName == 'main'
+          ? AndroidOptions.defaultOptions
+          : AndroidOptions(sharedPreferencesName: service),
+      mOptions: MacOsOptions(
+        accountName: macOsService,
+        accessibility: KeychainAccessibility.unlocked,
+        usesDataProtectionKeychain: true,
+      ),
+    );
+  }
+
   static final Cipher _cipher = AesGcm.with256bits();
   static final Pbkdf2 _kdf = Pbkdf2(
     macAlgorithm: Hmac.sha256(),
@@ -65,6 +98,7 @@ class AppSecureStore {
   );
 
   final FlutterSecureStorage _storage;
+  final FlutterSecureStorage _mnemonicStorage;
   final _secretMutationLock = _AsyncLock();
   SecretKey? _cachedSecretKey;
   String? _sessionPassword;
@@ -92,31 +126,27 @@ class AppSecureStore {
     bool requireUnlockedSession = false,
   }) {
     return _secretMutationLock.run(() async {
-      if (requireUnlockedSession && !hasSessionPassword) {
-        return null;
-      }
-      if (!hasSessionPassword) {
-        throw StateError('Secret storage requires an unlocked session.');
-      }
-
       final raw = await _storage.read(key: key);
-      if (raw == null || raw.isEmpty) return null;
-
-      final payload = _EncryptedPayload.tryParse(raw);
-      if (payload == null) {
-        return null;
-      }
-
-      final secretKey = await _getSecretKey();
-      final clearText = await _cipher.decrypt(
-        SecretBox(
-          payload.cipherText,
-          nonce: payload.nonce,
-          mac: Mac(payload.mac),
-        ),
-        secretKey: secretKey,
+      return _decryptStoredSecretString(
+        raw,
+        key: key,
+        requireUnlockedSession: requireUnlockedSession,
       );
-      return utf8.decode(clearText);
+    });
+  }
+
+  Future<String?> readAccountMnemonic(
+    String accountUuid, {
+    bool requireUnlockedSession = false,
+  }) {
+    return _secretMutationLock.run(() async {
+      final key = _accountMnemonicKey(accountUuid);
+      final raw = await _mnemonicStorage.read(key: key);
+      return _decryptStoredSecretString(
+        raw,
+        key: key,
+        requireUnlockedSession: requireUnlockedSession,
+      );
     });
   }
 
@@ -126,35 +156,44 @@ class AppSecureStore {
 
   Future<void> writeSecretString(String key, String value) {
     return _secretMutationLock.run(() async {
-      final secretKey = await _getSecretKey();
-      final nonce = _randomBytes(12);
-      final secretBox = await _cipher.encrypt(
-        utf8.encode(value),
-        secretKey: secretKey,
-        nonce: nonce,
-      );
-      await _storage.write(
-        key: key,
-        value: _EncryptedPayload(
-          nonce: secretBox.nonce,
-          cipherText: secretBox.cipherText,
-          mac: secretBox.mac.bytes,
-        ).serialize(),
+      await _storage.write(key: key, value: await _encryptSecretString(value));
+    });
+  }
+
+  Future<void> writeAccountMnemonic(String accountUuid, String mnemonic) {
+    return _secretMutationLock.run(() async {
+      await _mnemonicStorage.write(
+        key: _accountMnemonicKey(accountUuid),
+        value: await _encryptSecretString(mnemonic),
       );
     });
   }
 
   Future<void> delete(String key) async {
     if (key.startsWith(_accountMnemonicKeyPrefix)) {
-      await _secretMutationLock.run(() => _storage.delete(key: key));
+      await _secretMutationLock.run(() async {
+        await _mnemonicStorage.delete(key: key);
+        await _deleteLegacyAccountMnemonicBestEffort(key);
+      });
       return;
     }
     await _storage.delete(key: key);
   }
 
+  Future<void> deleteAccountMnemonic(String accountUuid) {
+    final key = _accountMnemonicKey(accountUuid);
+    return _secretMutationLock.run(() async {
+      await _mnemonicStorage.delete(key: key);
+      await _deleteLegacyAccountMnemonicBestEffort(key);
+    });
+  }
+
   Future<void> deleteAll() {
     return _secretMutationLock.run(() async {
       await _storage.deleteAll();
+      if (!identical(_mnemonicStorage, _storage)) {
+        await _mnemonicStorage.deleteAll();
+      }
       _cachedSecretKey = null;
       _sessionPassword = null;
     });
@@ -230,7 +269,13 @@ class AppSecureStore {
       );
       final newSecretKey = await _deriveSecretKeyForPassword(newPassword);
       try {
-        final storedValues = await _storage.readAll();
+        final migrated = await _migrateAccountMnemonicsAfterUnlockLocked();
+        if (!migrated) {
+          throw StateError(
+            'Failed to migrate account mnemonics before password rotation.',
+          );
+        }
+        final storedValues = await _mnemonicStorage.readAll();
         final rotatedSecrets = <_PasswordRotationEntry>[];
         final rollbackSecrets = <_PasswordRotationRollbackEntry>[];
 
@@ -354,8 +399,20 @@ class AppSecureStore {
     final isMatch = await verifyPasswordOnly(password);
     if (isMatch) {
       setSessionPassword(password);
+      try {
+        await migrateAccountMnemonicsAfterUnlock();
+      } catch (error, stackTrace) {
+        debugPrint(
+          'AppSecureStore: failed to migrate account mnemonics after unlock: '
+          '$error\n$stackTrace',
+        );
+      }
     }
     return isMatch;
+  }
+
+  Future<bool> migrateAccountMnemonicsAfterUnlock() {
+    return _secretMutationLock.run(_migrateAccountMnemonicsAfterUnlockLocked);
   }
 
   void setSessionPassword(String password) {
@@ -366,6 +423,86 @@ class AppSecureStore {
   void clearSessionPassword() {
     _sessionPassword = null;
     _cachedSecretKey = null;
+  }
+
+  Future<String?> _decryptStoredSecretString(
+    String? raw, {
+    required String key,
+    required bool requireUnlockedSession,
+  }) async {
+    if (requireUnlockedSession && !hasSessionPassword) {
+      return null;
+    }
+    if (!hasSessionPassword) {
+      throw StateError('Secret storage requires an unlocked session.');
+    }
+    if (raw == null || raw.isEmpty) return null;
+
+    final payload = _EncryptedPayload.tryParse(raw);
+    if (payload == null) {
+      return null;
+    }
+
+    final secretKey = await _getSecretKey();
+    return _decryptPayloadForKey(key, payload, secretKey);
+  }
+
+  Future<String> _encryptSecretString(String value) async {
+    final secretKey = await _getSecretKey();
+    final nonce = _randomBytes(12);
+    final secretBox = await _cipher.encrypt(
+      utf8.encode(value),
+      secretKey: secretKey,
+      nonce: nonce,
+    );
+    return _EncryptedPayload(
+      nonce: secretBox.nonce,
+      cipherText: secretBox.cipherText,
+      mac: secretBox.mac.bytes,
+    ).serialize();
+  }
+
+  Future<bool> _migrateAccountMnemonicsAfterUnlockLocked() async {
+    if (!_usesSeparateMacOsMnemonicStorage ||
+        identical(_mnemonicStorage, _storage)) {
+      return true;
+    }
+
+    final legacyValues = await _storage.readAll();
+    var succeeded = true;
+    for (final entry in legacyValues.entries) {
+      if (!_isAccountMnemonicKey(entry.key)) continue;
+
+      try {
+        final existing = await _mnemonicStorage.read(key: entry.key);
+        if (existing == null) {
+          await _mnemonicStorage.write(key: entry.key, value: entry.value);
+        }
+        await _storage.delete(key: entry.key);
+      } catch (error, stackTrace) {
+        succeeded = false;
+        debugPrint(
+          'AppSecureStore: failed to migrate account mnemonic "${entry.key}": '
+          '$error\n$stackTrace',
+        );
+      }
+    }
+    return succeeded;
+  }
+
+  Future<void> _deleteLegacyAccountMnemonicBestEffort(String key) async {
+    if (!_usesSeparateMacOsMnemonicStorage ||
+        identical(_mnemonicStorage, _storage)) {
+      return;
+    }
+    try {
+      await _storage.delete(key: key);
+    } catch (error, stackTrace) {
+      debugPrint(
+        'AppSecureStore: failed to delete legacy account mnemonic "$key": '
+        '$error\n$stackTrace',
+      );
+    }
   }
 
   Future<SecretKey> _getSecretKey() async {
@@ -457,7 +594,7 @@ class AppSecureStore {
     _PasswordRotationRecord rotation,
   ) async {
     for (final entry in rotation.entries) {
-      await writePlain(entry.key, entry.rotatedValue);
+      await _mnemonicStorage.write(key: entry.key, value: entry.rotatedValue);
     }
     await writePlain(_passwordVerifierSaltKey, rotation.newVerifierSalt);
     await writePlain(_passwordVerifierKey, rotation.newVerifier);
@@ -469,7 +606,10 @@ class AppSecureStore {
   ) async {
     try {
       for (final entry in rollback.entries) {
-        await writePlain(entry.key, entry.originalValue);
+        await _mnemonicStorage.write(
+          key: entry.key,
+          value: entry.originalValue,
+        );
       }
       if (rollback.oldVerifierSalt == null) {
         await delete(_passwordVerifierSaltKey);
@@ -540,6 +680,19 @@ class AppSecureStore {
     }
     return buffer.toString();
   }
+}
+
+bool get _usesSeparateMacOsMnemonicStorage =>
+    !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS;
+
+bool _isAccountMnemonicKey(String key) =>
+    key.startsWith(_accountMnemonicKeyPrefix);
+
+String _accountMnemonicKey(String accountUuid) =>
+    '$_accountMnemonicKeyPrefix$accountUuid';
+
+String _mnemonicSecureStoreServiceForNetwork(String networkName) {
+  return '${secureStoreServiceForNetwork(networkName)}.mnemonic';
 }
 
 class _AsyncLock {

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -26,6 +26,8 @@ const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';
 const _passwordRotationInProgressKey = 'zcash_rotation_in_progress';
 const _passwordRotationRollbackFailedKind = 'rollbackFailed';
 const _accountMnemonicKeyPrefix = 'zcash_account_mnemonic_';
+const _accountMnemonicMigrationCompleteKey =
+    'zcash_mnemonic_storage_migrated_v1';
 
 class PasswordRotationRecoveryFailedException implements Exception {
   const PasswordRotationRecoveryFailedException();
@@ -467,6 +469,9 @@ class AppSecureStore {
         identical(_mnemonicStorage, _storage)) {
       return true;
     }
+    if (await readPlain(_accountMnemonicMigrationCompleteKey) == 'true') {
+      return true;
+    }
 
     final legacyValues = await _storage.readAll();
     var succeeded = true;
@@ -483,6 +488,16 @@ class AppSecureStore {
         succeeded = false;
         debugPrint(
           'AppSecureStore: failed to migrate account mnemonic "${entry.key}": '
+          '$error\n$stackTrace',
+        );
+      }
+    }
+    if (succeeded) {
+      try {
+        await writePlain(_accountMnemonicMigrationCompleteKey, 'true');
+      } catch (error, stackTrace) {
+        debugPrint(
+          'AppSecureStore: failed to mark account mnemonic migration complete: '
           '$error\n$stackTrace',
         );
       }

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -93,10 +93,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       }
 
       // Store mnemonic per-account
-      await _storage.writeSecretString(
-        'zcash_account_mnemonic_$accountUuid',
-        mnemonic,
-      );
+      await _storage.writeAccountMnemonic(accountUuid, mnemonic);
 
       // Update account list
       final newAccount = AccountInfo(
@@ -172,10 +169,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         unifiedAddress = result.unifiedAddress;
       }
 
-      await _storage.writeSecretString(
-        'zcash_account_mnemonic_$accountUuid',
-        mnemonic,
-      );
+      await _storage.writeAccountMnemonic(accountUuid, mnemonic);
 
       final newAccount = AccountInfo(
         uuid: accountUuid,
@@ -247,10 +241,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         unifiedAddress = result.unifiedAddress;
       }
 
-      await _storage.writeSecretString(
-        'zcash_account_mnemonic_$accountUuid',
-        mnemonic,
-      );
+      await _storage.writeAccountMnemonic(accountUuid, mnemonic);
 
       final newAccount = AccountInfo(
         uuid: accountUuid,
@@ -374,7 +365,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       '${rustDeleteWatch.elapsedMilliseconds}ms uuid=$uuid',
     );
     try {
-      await _storage.delete('zcash_account_mnemonic_$uuid');
+      await _storage.deleteAccountMnemonic(uuid);
     } catch (e, st) {
       log('removeAccount: failed to delete mnemonic for $uuid: $e\n$st');
     }
@@ -542,18 +533,12 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   Future<String?> getActiveMnemonic() async {
     final uuid = state.value?.activeAccountUuid;
     if (uuid == null) return null;
-    return _storage.readSecretStringWithOptions(
-      'zcash_account_mnemonic_$uuid',
-      requireUnlockedSession: true,
-    );
+    return _storage.readAccountMnemonic(uuid, requireUnlockedSession: true);
   }
 
   /// Get the mnemonic for a specific account.
   Future<String?> getMnemonicForAccount(String uuid) async {
-    return _storage.readSecretStringWithOptions(
-      'zcash_account_mnemonic_$uuid',
-      requireUnlockedSession: true,
-    );
+    return _storage.readAccountMnemonic(uuid, requireUnlockedSession: true);
   }
 
   // ======================== Helpers ========================

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -439,6 +439,50 @@ void main() {
     expect(operations, isNot(contains('regular.readAll')));
   });
 
+  test('macOS unlock fails if mnemonic copy migration fails', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final regularStorage = _MapStorage('regular');
+    final mnemonicStorage = _FailingMapStorage('mnemonic');
+    store = AppSecureStore.testing(
+      storage: regularStorage,
+      mnemonicStorage: mnemonicStorage,
+    );
+
+    await store.configurePassword(_oldPassword);
+    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    store.clearSessionPassword();
+    mnemonicStorage.failNextWriteFor(_mnemonicKey);
+
+    expect(await store.verifyPassword(_oldPassword), isFalse);
+    expect(store.hasSessionPassword, isFalse);
+    expect(regularStorage.valueFor(_mnemonicKey), isNotNull);
+    expect(mnemonicStorage.valueFor(_mnemonicKey), isNull);
+    expect(regularStorage.valueFor(_migrationCompleteKey), isNull);
+  });
+
+  test(
+    'macOS unlock allows legacy cleanup retry after delete failure',
+    () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final regularStorage = _FailingMapStorage('regular');
+      final mnemonicStorage = _MapStorage('mnemonic');
+      store = AppSecureStore.testing(
+        storage: regularStorage,
+        mnemonicStorage: mnemonicStorage,
+      );
+
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(_mnemonicKey, _mnemonic);
+      store.clearSessionPassword();
+      regularStorage.failNextDeleteFor(_mnemonicKey);
+
+      expect(await store.verifyPassword(_oldPassword), isTrue);
+      expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
+      expect(regularStorage.valueFor(_mnemonicKey), isNotNull);
+      expect(regularStorage.valueFor(_migrationCompleteKey), isNull);
+    },
+  );
+
   test(
     'macOS mnemonic reads do not fallback before unlock migration',
     () async {
@@ -483,31 +527,34 @@ void main() {
     expect(store.hasSessionPassword, isFalse);
   });
 
-  test('clearPasswordConfiguration waits for concurrent mnemonic writes', () async {
-    const lateMnemonicKey = 'zcash_account_mnemonic_clear-password-account';
-    const lateMnemonic = 'legal winner thank year wave sausage worth useful';
-    final blockingStorage = _BlockingWriteStorage(blockKey: lateMnemonicKey);
-    store = AppSecureStore.testing(storage: blockingStorage);
-    await store.configurePassword(_oldPassword);
+  test(
+    'clearPasswordConfiguration waits for concurrent mnemonic writes',
+    () async {
+      const lateMnemonicKey = 'zcash_account_mnemonic_clear-password-account';
+      const lateMnemonic = 'legal winner thank year wave sausage worth useful';
+      final blockingStorage = _BlockingWriteStorage(blockKey: lateMnemonicKey);
+      store = AppSecureStore.testing(storage: blockingStorage);
+      await store.configurePassword(_oldPassword);
 
-    blockingStorage.blockNextWrite = true;
-    final lateWrite = store.writeSecretString(lateMnemonicKey, lateMnemonic);
-    await blockingStorage.writeStarted.future;
+      blockingStorage.blockNextWrite = true;
+      final lateWrite = store.writeSecretString(lateMnemonicKey, lateMnemonic);
+      await blockingStorage.writeStarted.future;
 
-    var clearCompleted = false;
-    final clear = store.clearPasswordConfiguration().then((_) {
-      clearCompleted = true;
-    });
-    await Future<void>.delayed(const Duration(milliseconds: 20));
-    expect(clearCompleted, isFalse);
+      var clearCompleted = false;
+      final clear = store.clearPasswordConfiguration().then((_) {
+        clearCompleted = true;
+      });
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(clearCompleted, isFalse);
 
-    blockingStorage.release();
-    await lateWrite;
-    await clear;
+      blockingStorage.release();
+      await lateWrite;
+      await clear;
 
-    expect(await store.readPlain(lateMnemonicKey), isNotNull);
-    expect(store.hasSessionPassword, isFalse);
-  });
+      expect(await store.readPlain(lateMnemonicKey), isNotNull);
+      expect(store.hasSessionPassword, isFalse);
+    },
+  );
 }
 
 class _FailingWriteStorage extends FlutterSecureStorage {
@@ -625,6 +672,71 @@ class _MapStorage extends FlutterSecureStorage {
   }) async {
     operations.add('$name.deleteAll');
     _values.clear();
+  }
+}
+
+class _FailingMapStorage extends _MapStorage {
+  _FailingMapStorage(super.name);
+
+  final _failNextWrite = <String>{};
+  final _failNextDelete = <String>{};
+
+  void failNextWriteFor(String key) {
+    _failNextWrite.add(key);
+  }
+
+  void failNextDeleteFor(String key) {
+    _failNextDelete.add(key);
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) {
+    if (_failNextWrite.remove(key)) {
+      throw StateError('forced map write failure for $key');
+    }
+    return super.write(
+      key: key,
+      value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) {
+    if (_failNextDelete.remove(key)) {
+      throw StateError('forced map delete failure for $key');
+    }
+    return super.delete(
+      key: key,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
   }
 }
 

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -383,6 +383,33 @@ void main() {
   });
 
   test(
+    'locked mnemonic read skips keychain when session is required',
+    () async {
+      final operations = <String>[];
+      final regularStorage = _MapStorage('regular', operations: operations);
+      final mnemonicStorage = _MapStorage('mnemonic', operations: operations);
+      store = AppSecureStore.testing(
+        storage: regularStorage,
+        mnemonicStorage: mnemonicStorage,
+      );
+
+      await store.configurePassword(_oldPassword);
+      await store.writeAccountMnemonic(_accountUuid, _mnemonic);
+      store.clearSessionPassword();
+      operations.clear();
+
+      expect(
+        await store.readAccountMnemonic(
+          _accountUuid,
+          requireUnlockedSession: true,
+        ),
+        isNull,
+      );
+      expect(operations, isEmpty);
+    },
+  );
+
+  test(
     'macOS unlock migrates legacy mnemonic payloads write then delete',
     () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -18,6 +18,7 @@ const _mnemonic = 'abandon abandon abandon abandon abandon abandon';
 const _passwordVerifierKey = 'zcash_password_verifier';
 const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';
 const _rotationInProgressKey = 'zcash_rotation_in_progress';
+const _migrationCompleteKey = 'zcash_mnemonic_storage_migrated_v1';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -412,6 +413,31 @@ void main() {
       );
     },
   );
+
+  test('macOS mnemonic migration flag skips repeated legacy scans', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final operations = <String>[];
+    final regularStorage = _MapStorage('regular', operations: operations);
+    final mnemonicStorage = _MapStorage('mnemonic', operations: operations);
+    store = AppSecureStore.testing(
+      storage: regularStorage,
+      mnemonicStorage: mnemonicStorage,
+    );
+
+    await store.configurePassword(_oldPassword);
+    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    store.clearSessionPassword();
+
+    expect(await store.verifyPassword(_oldPassword), isTrue);
+    expect(regularStorage.valueFor(_migrationCompleteKey), 'true');
+    expect(operations, contains('regular.readAll'));
+
+    operations.clear();
+    store.clearSessionPassword();
+
+    expect(await store.verifyPassword(_oldPassword), isTrue);
+    expect(operations, isNot(contains('regular.readAll')));
+  });
 
   test(
     'macOS mnemonic reads do not fallback before unlock migration',

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/security/password_policy.dart';
@@ -9,6 +10,7 @@ import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 const _oldPassword = 'Oldpass1!';
 const _newPassword = 'Newpass1!';
 const _wrongPassword = 'Wrongpass1!';
+const _accountUuid = 'test-account';
 const _mnemonicKey = 'zcash_account_mnemonic_test-account';
 const _externalEncryptedKey = 'external_encrypted_key';
 const _mnemonic = 'abandon abandon abandon abandon abandon abandon';
@@ -21,20 +23,23 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late AppSecureStore store;
+  TargetPlatform? previousTargetPlatform;
 
   setUp(() async {
+    previousTargetPlatform = debugDefaultTargetPlatformOverride;
     FlutterSecureStorage.setMockInitialValues({});
-    store = AppSecureStore.instance;
+    store = AppSecureStore.testing(storage: const FlutterSecureStorage());
     await store.deleteAll();
   });
 
   tearDown(() async {
     await store.deleteAll();
+    debugDefaultTargetPlatformOverride = previousTargetPlatform;
   });
 
   test('changePassword rotates mnemonic payloads and verifier', () async {
     await store.configurePassword(_oldPassword);
-    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
 
     final didChange = await store.changePassword(
       currentPassword: _oldPassword,
@@ -46,7 +51,7 @@ void main() {
     store.clearSessionPassword();
     expect(await store.verifyPasswordOnly(_oldPassword), isFalse);
     expect(await store.verifyPassword(_newPassword), isTrue);
-    expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+    expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
   });
 
   test('changePassword journal stores only roll-forward data', () async {
@@ -55,7 +60,7 @@ void main() {
     );
     store = AppSecureStore.testing(storage: blockingStorage);
     await store.configurePassword(_oldPassword);
-    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
     final originalPayload = await store.readPlain(_mnemonicKey);
     final oldVerifier = await store.readPlain(_passwordVerifierKey);
 
@@ -112,7 +117,7 @@ void main() {
       store.clearSessionPassword();
       expect(await store.verifyPasswordOnly(_oldPassword), isFalse);
       expect(await store.verifyPassword(_newPassword), isTrue);
-      expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+      expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
     },
   );
 
@@ -132,7 +137,7 @@ void main() {
       expect(await store.readPlain(_rotationInProgressKey), isNull);
       expect(await store.readPlain(_mnemonicKey), originalPayload);
       expect(await store.verifyPassword(_oldPassword), isTrue);
-      expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+      expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
     },
   );
 
@@ -156,7 +161,7 @@ void main() {
 
   test('changePassword only rotates app-managed mnemonic payloads', () async {
     await store.configurePassword(_oldPassword);
-    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
     await store.writeSecretString(_externalEncryptedKey, 'external secret');
     final externalPayload = await store.readPlain(_externalEncryptedKey);
 
@@ -167,7 +172,7 @@ void main() {
 
     expect(didChange, isTrue);
     expect(await store.readPlain(_externalEncryptedKey), externalPayload);
-    expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+    expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
   });
 
   test('changePassword rejects unreadable mnemonic payloads', () async {
@@ -192,7 +197,7 @@ void main() {
     final failingStorage = _FailingWriteStorage(failKey: _passwordVerifierKey);
     store = AppSecureStore.testing(storage: failingStorage);
     await store.configurePassword(_oldPassword);
-    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
     final originalPayload = await store.readPlain(_mnemonicKey);
 
     failingStorage.failNextMatchingWrite = true;
@@ -215,7 +220,7 @@ void main() {
     expect(await store.readPlain(_mnemonicKey), originalPayload);
     expect(await store.verifyPasswordOnly(_newPassword), isFalse);
     expect(await store.verifyPassword(_oldPassword), isTrue);
-    expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+    expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
   });
 
   test(
@@ -257,20 +262,21 @@ void main() {
       expect(await store.readPlain(_rotationInProgressKey), isNull);
       expect(await store.verifyPasswordOnly(_oldPassword), isFalse);
       expect(await store.verifyPassword(_newPassword), isTrue);
-      expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+      expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
     },
   );
 
   test('changePassword waits for concurrent mnemonic writes', () async {
+    const lateAccountUuid = 'late-account';
     const lateMnemonicKey = 'zcash_account_mnemonic_late-account';
     const lateMnemonic = 'legal winner thank year wave sausage worth useful';
     final blockingStorage = _BlockingWriteStorage(blockKey: lateMnemonicKey);
     store = AppSecureStore.testing(storage: blockingStorage);
     await store.configurePassword(_oldPassword);
-    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
 
     blockingStorage.blockNextWrite = true;
-    final lateWrite = store.writeSecretString(lateMnemonicKey, lateMnemonic);
+    final lateWrite = store.writeAccountMnemonic(lateAccountUuid, lateMnemonic);
     await blockingStorage.writeStarted.future;
 
     final rotation = store.changePassword(
@@ -293,10 +299,7 @@ void main() {
 
     store.clearSessionPassword();
     expect(await store.verifyPassword(_newPassword), isTrue);
-    expect(
-      await store.readSecretStringWithOptions(lateMnemonicKey),
-      lateMnemonic,
-    );
+    expect(await store.readAccountMnemonic(lateAccountUuid), lateMnemonic);
   });
 
   test(
@@ -342,7 +345,7 @@ void main() {
       );
       store = AppSecureStore.testing(storage: blockingStorage);
       await store.configurePassword(_oldPassword);
-      await store.writeSecretString(_mnemonicKey, _mnemonic);
+      await store.writeAccountMnemonic(_accountUuid, _mnemonic);
 
       blockingStorage.blockNextWrite = true;
       final rotation = store.changePassword(
@@ -351,14 +354,80 @@ void main() {
       );
       await blockingStorage.writeStarted.future;
 
-      final delete = store.delete(_mnemonicKey);
+      final delete = store.deleteAccountMnemonic(_accountUuid);
       blockingStorage.release();
       await rotation;
       await delete;
 
       store.clearSessionPassword();
       expect(await store.verifyPassword(_newPassword), isTrue);
-      expect(await store.readPlain(_mnemonicKey), isNull);
+      expect(await store.readAccountMnemonic(_accountUuid), isNull);
+    },
+  );
+
+  test('account mnemonic writes use mnemonic storage only', () async {
+    final regularStorage = _MapStorage('regular');
+    final mnemonicStorage = _MapStorage('mnemonic');
+    store = AppSecureStore.testing(
+      storage: regularStorage,
+      mnemonicStorage: mnemonicStorage,
+    );
+
+    await store.configurePassword(_oldPassword);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
+
+    expect(regularStorage.valueFor(_mnemonicKey), isNull);
+    expect(mnemonicStorage.valueFor(_mnemonicKey), isNotNull);
+    expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
+  });
+
+  test(
+    'macOS unlock migrates legacy mnemonic payloads write then delete',
+    () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final operations = <String>[];
+      final regularStorage = _MapStorage('regular', operations: operations);
+      final mnemonicStorage = _MapStorage('mnemonic', operations: operations);
+      store = AppSecureStore.testing(
+        storage: regularStorage,
+        mnemonicStorage: mnemonicStorage,
+      );
+
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(_mnemonicKey, _mnemonic);
+      store.clearSessionPassword();
+      operations.clear();
+
+      expect(await store.verifyPassword(_oldPassword), isTrue);
+
+      expect(regularStorage.valueFor(_mnemonicKey), isNull);
+      expect(mnemonicStorage.valueFor(_mnemonicKey), isNotNull);
+      expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
+      expect(
+        operations,
+        containsAllInOrder([
+          'mnemonic.write $_mnemonicKey',
+          'regular.delete $_mnemonicKey',
+        ]),
+      );
+    },
+  );
+
+  test(
+    'macOS mnemonic reads do not fallback before unlock migration',
+    () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final regularStorage = _MapStorage('regular');
+      final mnemonicStorage = _MapStorage('mnemonic');
+      store = AppSecureStore.testing(
+        storage: regularStorage,
+        mnemonicStorage: mnemonicStorage,
+      );
+
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(_mnemonicKey, _mnemonic);
+
+      expect(await store.readAccountMnemonic(_accountUuid), isNull);
     },
   );
 
@@ -446,6 +515,90 @@ class _FailingWriteStorage extends FlutterSecureStorage {
       mOptions: mOptions,
       wOptions: wOptions,
     );
+  }
+}
+
+class _MapStorage extends FlutterSecureStorage {
+  _MapStorage(this.name, {List<String>? operations})
+    : operations = operations ?? <String>[];
+
+  final String name;
+  final List<String> operations;
+  final _values = <String, String>{};
+
+  String? valueFor(String key) => _values[key];
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    operations.add('$name.read $key');
+    return _values[key];
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    operations.add('$name.write $key');
+    if (value == null) {
+      _values.remove(key);
+      return;
+    }
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    operations.add('$name.delete $key');
+    _values.remove(key);
+  }
+
+  @override
+  Future<Map<String, String>> readAll({
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    operations.add('$name.readAll');
+    return Map<String, String>.from(_values);
+  }
+
+  @override
+  Future<void> deleteAll({
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    operations.add('$name.deleteAll');
+    _values.clear();
   }
 }
 


### PR DESCRIPTION
## Summary
- Split account mnemonic storage from the general secure store.
- Use a dedicated macOS Keychain service for mnemonic payloads with `KeychainAccessibility.unlocked` and Data Protection Keychain enabled.
- Migrate legacy macOS mnemonic entries on unlock by writing to the new mnemonic storage before deleting the legacy key.
- Route account mnemonic reads, writes, and deletes through explicit storage APIs.

## Validation
- `fvm flutter analyze`
- `fvm flutter test test/core/storage/app_secure_store_test.dart`
- `fvm flutter test test/core/storage/app_secure_store_test.dart test/providers/account_provider_test.dart`