### PR TITLE
Refine activity receipt amount display

### DIFF
--- a/lib/src/core/formatting/zec_amount.dart
+++ b/lib/src/core/formatting/zec_amount.dart
@@ -114,6 +114,14 @@ class ZecAmount {
 
   ZecAmountPretty get activity => activityPretty();
 
+  ZecAmountPretty activityDetailPretty({String? denomination}) => pretty(
+    minFractionDigits: 2,
+    denomStyle: ZecDenomStyle.upper,
+    denomination: denomination,
+  );
+
+  ZecAmountPretty get activityDetail => activityDetailPretty();
+
   ZecAmountPretty signedActivityPretty({String? denomination}) =>
       _activity(signed: true, denomination: denomination);
 

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -263,7 +263,7 @@ class _ActivityTransactionStatusScreenState
     }
     if (tx.displayAmount == BigInt.zero) return '--';
     return hideAmountIfPrivacyMode(
-      ZecAmount.fromZatoshi(tx.displayAmount).activity.toString(),
+      ZecAmount.fromZatoshi(tx.displayAmount).activityDetail.toString(),
       privacyModeEnabled: privacyModeEnabled,
     );
   }

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -529,10 +529,7 @@ class _SendReviewReceiptCard extends StatelessWidget {
             top: 0,
             width: 352,
             height: receiptHeight + 80.0,
-            child: Image.asset(
-              receiptMaskAsset,
-              fit: BoxFit.fill,
-            ),
+            child: Image.asset(receiptMaskAsset, fit: BoxFit.fill),
           ),
           Positioned(
             top: 23,
@@ -554,13 +551,19 @@ class _SendReviewReceiptCard extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: AppSpacing.xs),
-                Text(
-                  amountText,
-                  maxLines: 1,
-                  softWrap: false,
-                  overflow: TextOverflow.visible,
-                  style: AppTypography.displayLarge.copyWith(
-                    color: colors.text.accent,
+                SizedBox(
+                  width: double.infinity,
+                  child: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      amountText,
+                      maxLines: 1,
+                      softWrap: false,
+                      style: AppTypography.displayLarge.copyWith(
+                        color: colors.text.accent,
+                      ),
+                    ),
                   ),
                 ),
               ],

--- a/lib/src/features/send/widgets/transaction_receipt_view.dart
+++ b/lib/src/features/send/widgets/transaction_receipt_view.dart
@@ -112,7 +112,7 @@ class TransactionReceiptView extends StatelessWidget {
               const SizedBox(width: AppSpacing.sm),
               Expanded(
                 child: _TransactionReceiptBlock(
-                  title: 'Fee',
+                  title: 'Tx Fee',
                   child: Text(
                     feeText,
                     style: AppTypography.bodyMedium.copyWith(
@@ -475,9 +475,20 @@ class _TransactionReceiptHeadline extends StatelessWidget {
           ),
         ),
         const SizedBox(height: AppSpacing.xs),
-        Text(
-          amountText,
-          style: AppTypography.displayLarge.copyWith(color: colors.text.accent),
+        SizedBox(
+          width: double.infinity,
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.centerLeft,
+            child: Text(
+              amountText,
+              maxLines: 1,
+              softWrap: false,
+              style: AppTypography.displayLarge.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+          ),
         ),
         if (useFailedReceiptLayout) ...[
           const SizedBox(height: AppSpacing.xs),

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -63,6 +63,32 @@ void main() {
     expect(sendButton.trailing, isNull);
   });
 
+  testWidgets('scales down long receipt amount text', (tester) async {
+    const amountText = '123456789.12345678 zec';
+
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _sendReviewHarness(
+        _reviewArgs(
+          addressType: 'unified',
+          amountZatoshi: BigInt.from(12345678912345678),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(
+      find.ancestor(
+        of: find.text(amountText),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is FittedBox && widget.fit == BoxFit.scaleDown,
+        ),
+      ),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('dark preview uses dark semantic colors', (tester) async {
     await _setDesktopViewport(tester);
     await tester.pumpWidget(
@@ -259,6 +285,7 @@ SendReviewArgs _reviewArgs({
   required String addressType,
   String? memo,
   String address = _longAddress,
+  BigInt? amountZatoshi,
 }) {
   return SendReviewArgs(
     proposalId: BigInt.one,
@@ -266,7 +293,7 @@ SendReviewArgs _reviewArgs({
     proposalAccountUuid: 'test-account',
     address: address,
     addressType: addressType,
-    amountZatoshi: BigInt.from(1512000000),
+    amountZatoshi: amountZatoshi ?? BigInt.from(1512000000),
     feeZatoshi: BigInt.from(12000),
     needsSaplingParams: false,
     memo: memo,

--- a/test/transaction_receipt_view_test.dart
+++ b/test/transaction_receipt_view_test.dart
@@ -48,6 +48,38 @@ void main() {
     expect(tester.getTopLeft(button).dy, moreOrLessEquals(456, epsilon: 0.1));
   });
 
+  testWidgets('labels tx fee and scales down long amount text', (tester) async {
+    const longAmount = '123456789.12345678 ZEC';
+
+    await tester.pumpWidget(
+      _receiptHarness(
+        const TransactionReceiptView(
+          phase: TransactionReceiptPhase.succeeded,
+          amountText: longAmount,
+          primaryBlock: TransactionReceiptBlockData(
+            title: 'To',
+            child: Text('u1testaddress'),
+          ),
+          dateText: 'April 20, 2026 13:50',
+          feeText: '0.00012 ZEC',
+          onTransactionHashPressed: _noop,
+        ),
+      ),
+    );
+
+    expect(find.text('Tx Fee'), findsOneWidget);
+    expect(
+      find.ancestor(
+        of: find.text(longAmount),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is FittedBox && widget.fit == BoxFit.scaleDown,
+        ),
+      ),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('message block toggles between collapsed and expanded text', (
     tester,
   ) async {

--- a/test/zec_amount_test.dart
+++ b/test/zec_amount_test.dart
@@ -92,6 +92,21 @@ void main() {
       );
     });
 
+    test('formats activity details with full precision', () {
+      expect(
+        ZecAmount.fromZatoshi(BigInt.from(123450000)).activityDetail.toString(),
+        '1.2345 $kZcashDefaultCurrencyTicker',
+      );
+      expect(
+        ZecAmount.fromZatoshi(BigInt.one).activityDetail.toString(),
+        '0.00000001 $kZcashDefaultCurrencyTicker',
+      );
+      expect(
+        ZecAmount.fromZatoshi(BigInt.from(100000000)).activityDetail.toString(),
+        '1.00 $kZcashDefaultCurrencyTicker',
+      );
+    });
+
     test('can render testnet amounts with TAZ denomination', () {
       final ticker = ZcashNetwork.testnet.currencyTicker;
 


### PR DESCRIPTION
## Summary

- Show full ZEC precision on the Activity details amount while keeping Activity list rows at their existing two-decimal summary precision.
- Add an `activityDetail` ZEC amount preset so the details-screen precision policy is explicit and test-covered.
- Prevent long receipt amount strings from overflowing by scaling them down in the shared receipt view and the send review receipt.
- Rename the shared receipt fee label from `Fee` to `Tx Fee`.
- Keep zero-amount Activity details behavior unchanged (`--`).

## Validation

- `fvm flutter test test/transaction_receipt_view_test.dart test/features/send/send_review_screen_test.dart test/zec_amount_test.dart`
- `fvm flutter analyze lib/src/core/formatting/zec_amount.dart lib/src/features/activity/screens/activity_transaction_status_screen.dart lib/src/features/send/widgets/transaction_receipt_view.dart lib/src/features/send/screens/send_review_screen.dart test/zec_amount_test.dart test/transaction_receipt_view_test.dart test/features/send/send_review_screen_test.dart`