### PR TITLE
[codex] Fix import birthday calendar delay

### DIFF
--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -48,7 +48,6 @@ class _ImportWalletBirthdayScreenState
   ImportBirthdayTab _activeTab = ImportBirthdayTab.date;
   DateTime? _selectedDate;
   int? _birthdayHeight;
-  bool _isLoadingMetadata = true;
   bool _isEstimating = false;
   bool _isCalendarOpen = false;
   _ImportWalletSubmitPhase _submitPhase = _ImportWalletSubmitPhase.idle;
@@ -91,7 +90,6 @@ class _ImportWalletBirthdayScreenState
 
   Future<void> _loadMetadata() async {
     setState(() {
-      _isLoadingMetadata = true;
       _metadataError = null;
     });
 
@@ -106,7 +104,6 @@ class _ImportWalletBirthdayScreenState
       if (!mounted) return;
       setState(() {
         _metadata = metadata;
-        _isLoadingMetadata = false;
       });
 
       if (_selectedDate != null && _birthdayHeight == null) {
@@ -116,7 +113,6 @@ class _ImportWalletBirthdayScreenState
       log('ImportWalletBirthdayScreen._loadMetadata: ERROR: $e\n$st');
       if (!mounted) return;
       setState(() {
-        _isLoadingMetadata = false;
         _metadataError = 'Could not load wallet birthday metadata.';
       });
     }
@@ -182,12 +178,12 @@ class _ImportWalletBirthdayScreenState
   }
 
   Future<void> _pickDate() async {
-    final metadata = _metadata;
-    if (metadata == null) return;
+    final firstDate = _calendarFirstDate;
+    final lastDate = _calendarLastDate;
     final initialDate = _clampDate(
-      _selectedDate ?? metadata.tipDate,
-      metadata.saplingActivationDate,
-      metadata.tipDate,
+      _selectedDate ?? lastDate,
+      firstDate,
+      lastDate,
     );
 
     setState(() {
@@ -209,6 +205,27 @@ class _ImportWalletBirthdayScreenState
       _isCalendarOpen = false;
     });
     await _estimateSelectedDate(selected);
+  }
+
+  DateTime get _calendarFirstDate {
+    final metadataDate = _metadata?.saplingActivationDate;
+    if (metadataDate != null) return metadataDate;
+
+    final networkName = ref.read(rpcEndpointProvider).networkName;
+    if (networkName == 'regtest') {
+      return _dateOnly(DateTime.now().subtract(const Duration(days: 6)));
+    }
+
+    // UI-only fallback so the picker can open while endpoint metadata loads.
+    // The eventual height estimate still clamps pre-Sapling dates correctly.
+    return DateTime(2016, 10, 28);
+  }
+
+  DateTime get _calendarLastDate {
+    final firstDate = _calendarFirstDate;
+    final lastDate = _dateOnly(_metadata?.tipDate ?? DateTime.now());
+    if (lastDate.isBefore(firstDate)) return firstDate;
+    return lastDate;
   }
 
   Future<void> _submit({int? birthdayHeightOverride}) async {
@@ -325,6 +342,8 @@ class _ImportWalletBirthdayScreenState
   @override
   Widget build(BuildContext context) {
     final activeTab = _activeTab;
+    final calendarFirstDate = _calendarFirstDate;
+    final calendarLastDate = _calendarLastDate;
     final buttonLabel = switch (_submitPhase) {
       _ImportWalletSubmitPhase.stoppingSync => 'Stop syncing...',
       _ImportWalletSubmitPhase.importing => 'Importing...',
@@ -335,12 +354,12 @@ class _ImportWalletBirthdayScreenState
     };
 
     return ImportOnboardingTrailingPane(
-      overlay: _isCalendarOpen && _metadata != null
+      overlay: _isCalendarOpen
           ? ImportBirthdayCalendarOverlay(
-              initialMonth: _calendarInitialDate ?? _metadata!.tipDate,
+              initialMonth: _calendarInitialDate ?? calendarLastDate,
               selectedDate: _selectedDate,
-              firstDate: _metadata!.saplingActivationDate,
-              lastDate: _metadata!.tipDate,
+              firstDate: calendarFirstDate,
+              lastDate: calendarLastDate,
               onDismiss: _dismissCalendar,
               onDateSelected: _handleCalendarDateSelected,
             )
@@ -404,9 +423,7 @@ class _ImportWalletBirthdayScreenState
                                     valueText: _selectedDate == null
                                         ? null
                                         : _formatDate(_selectedDate!),
-                                    enabled:
-                                        !_isLoadingMetadata &&
-                                        _metadata != null,
+                                    enabled: !_isSubmitting,
                                     onTap: _pickDate,
                                   )
                                 else
@@ -750,6 +767,10 @@ DateTime _clampDate(DateTime value, DateTime min, DateTime max) {
   if (date.isBefore(minDate)) return minDate;
   if (date.isAfter(maxDate)) return maxDate;
   return date;
+}
+
+DateTime _dateOnly(DateTime value) {
+  return DateTime(value.year, value.month, value.day);
 }
 
 String _formatDate(DateTime date) {

--- a/lib/src/features/onboarding/keystone/keystone_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/keystone/keystone_wallet_birthday_screen.dart
@@ -45,7 +45,6 @@ class _KeystoneWalletBirthdayScreenState
   KeystoneBirthdayTab _activeTab = KeystoneBirthdayTab.date;
   DateTime? _selectedDate;
   int? _birthdayHeight;
-  bool _isLoadingMetadata = true;
   bool _isEstimating = false;
   bool _isCalendarOpen = false;
   _KeystoneBirthdaySubmitPhase _submitPhase = _KeystoneBirthdaySubmitPhase.idle;
@@ -82,7 +81,6 @@ class _KeystoneWalletBirthdayScreenState
 
   Future<void> _loadMetadata() async {
     setState(() {
-      _isLoadingMetadata = true;
       _metadataError = null;
     });
 
@@ -94,7 +92,6 @@ class _KeystoneWalletBirthdayScreenState
       if (!mounted) return;
       setState(() {
         _metadata = metadata;
-        _isLoadingMetadata = false;
       });
 
       if (_selectedDate != null && _birthdayHeight == null) {
@@ -104,7 +101,6 @@ class _KeystoneWalletBirthdayScreenState
       log('KeystoneWalletBirthdayScreen._loadMetadata: ERROR: $e\n$st');
       if (!mounted) return;
       setState(() {
-        _isLoadingMetadata = false;
         _metadataError = 'Could not load wallet birthday metadata.';
       });
     }
@@ -166,12 +162,12 @@ class _KeystoneWalletBirthdayScreenState
   }
 
   Future<void> _pickDate() async {
-    final metadata = _metadata;
-    if (metadata == null) return;
+    final firstDate = _calendarFirstDate;
+    final lastDate = _calendarLastDate;
     final initialDate = _clampDate(
-      _selectedDate ?? metadata.tipDate,
-      metadata.saplingActivationDate,
-      metadata.tipDate,
+      _selectedDate ?? lastDate,
+      firstDate,
+      lastDate,
     );
 
     setState(() {
@@ -193,6 +189,27 @@ class _KeystoneWalletBirthdayScreenState
       _isCalendarOpen = false;
     });
     await _estimateSelectedDate(selected);
+  }
+
+  DateTime get _calendarFirstDate {
+    final metadataDate = _metadata?.saplingActivationDate;
+    if (metadataDate != null) return metadataDate;
+
+    final networkName = ref.read(rpcEndpointProvider).networkName;
+    if (networkName == 'regtest') {
+      return _dateOnly(DateTime.now().subtract(const Duration(days: 6)));
+    }
+
+    // UI-only fallback so the picker can open while endpoint metadata loads.
+    // The eventual height estimate still clamps pre-Sapling dates correctly.
+    return DateTime(2016, 10, 28);
+  }
+
+  DateTime get _calendarLastDate {
+    final firstDate = _calendarFirstDate;
+    final lastDate = _dateOnly(_metadata?.tipDate ?? DateTime.now());
+    if (lastDate.isBefore(firstDate)) return firstDate;
+    return lastDate;
   }
 
   Future<void> _submit({int? birthdayHeightOverride}) async {
@@ -322,6 +339,8 @@ class _KeystoneWalletBirthdayScreenState
   @override
   Widget build(BuildContext context) {
     final activeTab = _activeTab;
+    final calendarFirstDate = _calendarFirstDate;
+    final calendarLastDate = _calendarLastDate;
     final buttonLabel = switch (_submitPhase) {
       _KeystoneBirthdaySubmitPhase.stoppingSync => 'Stop syncing...',
       _KeystoneBirthdaySubmitPhase.importing => 'Importing...',
@@ -332,12 +351,12 @@ class _KeystoneWalletBirthdayScreenState
     };
 
     return KeystoneOnboardingTrailingPane(
-      overlay: _isCalendarOpen && _metadata != null
+      overlay: _isCalendarOpen
           ? ImportBirthdayCalendarOverlay(
-              initialMonth: _calendarInitialDate ?? _metadata!.tipDate,
+              initialMonth: _calendarInitialDate ?? calendarLastDate,
               selectedDate: _selectedDate,
-              firstDate: _metadata!.saplingActivationDate,
-              lastDate: _metadata!.tipDate,
+              firstDate: calendarFirstDate,
+              lastDate: calendarLastDate,
               onDismiss: _dismissCalendar,
               onDateSelected: _handleCalendarDateSelected,
             )
@@ -398,9 +417,7 @@ class _KeystoneWalletBirthdayScreenState
                                     valueText: _selectedDate == null
                                         ? null
                                         : _formatDate(_selectedDate!),
-                                    enabled:
-                                        !_isLoadingMetadata &&
-                                        _metadata != null,
+                                    enabled: !_isSubmitting,
                                     onTap: _pickDate,
                                   )
                                 else
@@ -689,6 +706,10 @@ DateTime _clampDate(DateTime value, DateTime min, DateTime max) {
   if (date.isBefore(minDate)) return minDate;
   if (date.isAfter(maxDate)) return maxDate;
   return date;
+}
+
+DateTime _dateOnly(DateTime value) {
+  return DateTime(value.year, value.month, value.day);
 }
 
 String _formatDate(DateTime date) {

--- a/test/features/onboarding/import_wallet_birthday_screen_test.dart
+++ b/test/features/onboarding/import_wallet_birthday_screen_test.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/onboarding/import/import_birthday_calendar_overlay.dart';
 import 'package:zcash_wallet/src/features/onboarding/import/import_birthday_estimator.dart';
 import 'package:zcash_wallet/src/features/onboarding/import/import_wallet_birthday_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args.dart';
@@ -32,6 +35,35 @@ void main() {
 
     expect(_cursorForText(tester, 'mm/dd/yyyy'), SystemMouseCursors.click);
   });
+
+  testWidgets('birthday date field opens before endpoint metadata finishes', (
+    tester,
+  ) async {
+    final metadataCompleter = Completer<ImportBirthdayMetadata>();
+    addTearDown(() {
+      if (!metadataCompleter.isCompleted) {
+        metadataCompleter.complete(_metadataFixture());
+      }
+    });
+
+    await _setDesktopSurface(tester);
+    await tester.pumpWidget(
+      _birthdayHarness(
+        failoverBuilder: () => _PendingMetadataRpcEndpointFailoverNotifier(
+          metadataCompleter.future,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.text('mm/dd/yyyy'));
+    await tester.pump();
+
+    expect(find.byType(ImportBirthdayCalendarOverlay), findsOneWidget);
+
+    metadataCompleter.complete(_metadataFixture());
+    await tester.pump();
+  });
 }
 
 Future<void> _setDesktopSurface(WidgetTester tester) async {
@@ -41,12 +73,14 @@ Future<void> _setDesktopSurface(WidgetTester tester) async {
   });
 }
 
-Widget _birthdayHarness() {
+Widget _birthdayHarness({
+  RpcEndpointFailoverNotifier Function()? failoverBuilder,
+}) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
       rpcEndpointFailoverProvider.overrideWith(
-        _FakeRpcEndpointFailoverNotifier.new,
+        failoverBuilder ?? _FakeRpcEndpointFailoverNotifier.new,
       ),
     ],
     child: MaterialApp(
@@ -72,6 +106,15 @@ MouseCursor _cursorForText(WidgetTester tester, String text) {
   return tester.widget<MouseRegion>(mouseRegion).cursor;
 }
 
+ImportBirthdayMetadata _metadataFixture() {
+  return ImportBirthdayMetadata(
+    saplingActivationHeight: 419200,
+    saplingActivationDate: DateTime(2016, 10, 28),
+    tipHeight: 3336000,
+    tipDate: DateTime(2026, 5, 11),
+  );
+}
+
 class _FakeRpcEndpointFailoverNotifier extends RpcEndpointFailoverNotifier {
   @override
   RpcEndpointFailoverState build() {
@@ -92,13 +135,38 @@ class _FakeRpcEndpointFailoverNotifier extends RpcEndpointFailoverNotifier {
         shouldFallbackFromLightwalletdError,
   }) async {
     if (operation == 'import birthday metadata') {
-      return ImportBirthdayMetadata(
-            saplingActivationHeight: 419200,
-            saplingActivationDate: DateTime(2016, 10, 28),
-            tipHeight: 3336000,
-            tipDate: DateTime(2026, 5, 11),
-          )
-          as T;
+      return _metadataFixture() as T;
+    }
+    return action(state.current);
+  }
+}
+
+class _PendingMetadataRpcEndpointFailoverNotifier
+    extends RpcEndpointFailoverNotifier {
+  _PendingMetadataRpcEndpointFailoverNotifier(this.metadata);
+
+  final Future<ImportBirthdayMetadata> metadata;
+
+  @override
+  RpcEndpointFailoverState build() {
+    final endpoint = defaultRpcEndpointConfig('main');
+    return RpcEndpointFailoverState(
+      primary: endpoint,
+      current: endpoint,
+      fallbackCandidates: const [],
+    );
+  }
+
+  @override
+  Future<T> runWithEndpointFallback<T>({
+    required String operation,
+    required Future<T> Function(RpcEndpointConfig endpoint) action,
+    bool allowFallback = true,
+    bool Function(Object error) shouldFallback =
+        shouldFallbackFromLightwalletdError,
+  }) async {
+    if (operation == 'import birthday metadata') {
+      return await metadata as T;
     }
     return action(state.current);
   }


### PR DESCRIPTION
## Summary

- Opens the import wallet birthday calendar immediately instead of waiting for endpoint birthday metadata.
- Keeps birthday height estimation behind the existing endpoint-backed flow before enabling Continue.
- Applies the same behavior to the Keystone birthday picker and adds a regression test for pending metadata.

## Root Cause

The date field was disabled until `ImportBirthdayEstimator.loadMetadata()` completed. That call runs through endpoint failover and can block on slow or unavailable endpoints, so the calendar UI appeared frozen for 10-15 seconds before opening.

## Impact

Users can now open the calendar immediately while endpoint metadata loads in the background. The selected date still needs a successful endpoint-backed height estimate before import can continue, so import correctness remains guarded.

## Validation

- `fvm flutter test test/features/onboarding/import_wallet_birthday_screen_test.dart`
- `fvm flutter analyze lib/src/features/onboarding/import/import_wallet_birthday_screen.dart lib/src/features/onboarding/keystone/keystone_wallet_birthday_screen.dart test/features/onboarding/import_wallet_birthday_screen_test.dart`
