### PR TITLE
Update accounts page interactions

### DIFF
--- a/assets/icons/keystone.svg
+++ b/assets/icons/keystone.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19.6492 20H10.5106L16.3592 7.63619H20.7459L19.6492 20Z" fill="#E1E1E1"/>
+<path d="M7.58673 16.3628H3.20001L4.29669 4H13.4354L7.58673 16.3628Z" fill="#E1E1E1"/>
+</svg>

--- a/lib/src/core/widgets/app_icon.dart
+++ b/lib/src/core/widgets/app_icon.dart
@@ -49,6 +49,7 @@ abstract final class AppIcons {
   static const history = 'history';
   static const importWallet = 'import_wallet';
   static const key = 'key';
+  static const keystone = 'keystone';
   static const link = 'link';
   static const loader = 'loader';
   static const lock = 'lock';
@@ -83,10 +84,10 @@ abstract final class AppIcons {
 
 /// Renders a Figma-exported icon from `assets/icons/<name>.svg`.
 ///
-/// Each SVG ships with a `viewBox="0 0 24 24"` — the exact dimensions
-/// of the Figma icon frame — so the art's position inside the frame is
-/// preserved when Flutter scales the SVG to any [size]. Colour is
-/// swapped at paint time via `ColorFilter.mode(color, BlendMode.srcIn)`:
+/// SVGs preserve their Figma icon frame in the viewBox, so the art's
+/// position inside the frame is preserved when Flutter scales the SVG to any
+/// [size]. Colour is swapped at paint time via
+/// `ColorFilter.mode(color, BlendMode.srcIn)`:
 /// the SVG keeps its own alpha shape, every non-transparent pixel gets
 /// re-colored to [color]. Works for the single-fill monochrome icons
 /// the design system currently ships; multi-fill / gradient icons

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -329,8 +329,9 @@ class _AccountsPane extends StatelessWidget {
                   AppButton(
                     key: const ValueKey('accounts_add_account_button'),
                     onPressed: () => context.go('/add-account'),
+                    variant: AppButtonVariant.secondary,
                     minWidth: 256,
-                    trailing: const AppIcon(AppIcons.chevronForward),
+                    leading: const AppIcon(AppIcons.addNew),
                     child: const Text('Add Account'),
                   ),
                 ],
@@ -390,7 +391,9 @@ class _AccountsListState extends State<_AccountsList> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            if (widget.activeAccount != null)
+            if (widget.activeAccount != null) ...[
+              const _AccountsSectionLabel(label: 'Current'),
+              const SizedBox(height: AppSpacing.xs),
               _AccountRow(
                 key: ValueKey(
                   'accounts_active_row_${widget.activeAccount!.uuid}',
@@ -406,8 +409,12 @@ class _AccountsListState extends State<_AccountsList> {
                   seedAnchorCount,
                 ),
               ),
+            ],
             if (widget.otherAccounts.isNotEmpty) ...[
+              if (widget.activeAccount != null)
+                const SizedBox(height: AppSpacing.md),
               const _AccountsSectionLabel(label: 'Other'),
+              const SizedBox(height: AppSpacing.xs),
               Expanded(
                 child: LayoutBuilder(
                   builder: (context, constraints) {
@@ -566,25 +573,31 @@ class _AccountRow extends StatefulWidget {
 
 class _AccountRowState extends State<_AccountRow> {
   bool _isHovered = false;
-  bool _isMenuOpen = false;
+
+  void _setHovered(bool isHovered) {
+    if (_isHovered == isHovered) return;
+    setState(() {
+      _isHovered = isHovered;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
-    final colors = context.colors;
     final enabled = widget.onTap != null;
-    final isHighlighted = _isHovered || _isMenuOpen;
+    final isHighlighted = enabled && _isHovered;
 
     return MouseRegion(
       cursor: enabled ? SystemMouseCursors.click : MouseCursor.defer,
-      onEnter: (_) => _setHovered(true),
-      onExit: (_) => _setHovered(false),
+      onEnter: enabled ? (_) => _setHovered(true) : null,
+      onExit: enabled ? (_) => _setHovered(false) : null,
       child: AnimatedContainer(
+        key: ValueKey('accounts_row_background_${widget.account.uuid}'),
         duration: const Duration(milliseconds: 120),
         curve: Curves.easeOut,
         height: _accountRowHeight,
         padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
         decoration: BoxDecoration(
-          color: isHighlighted ? colors.background.base : null,
+          color: isHighlighted ? context.colors.background.base : null,
           borderRadius: BorderRadius.circular(AppRadii.xSmall),
         ),
         child: Row(
@@ -593,29 +606,25 @@ class _AccountRowState extends State<_AccountRow> {
               child: GestureDetector(
                 behavior: HitTestBehavior.opaque,
                 onTap: widget.onTap,
-                child: Row(
-                  children: [
-                    AppProfilePicture(
-                      profilePictureId: widget.account.profilePictureId,
-                      size: AppProfilePictureSize.large,
-                    ),
-                    const SizedBox(width: AppSpacing.xs),
-                    Expanded(
-                      child: Text(
-                        widget.account.name,
-                        overflow: TextOverflow.ellipsis,
-                        style: AppTypography.labelLarge.copyWith(
-                          color: colors.text.accent,
-                        ),
+                child: SizedBox(
+                  height: _accountRowHeight,
+                  child: Row(
+                    children: [
+                      AppProfilePicture(
+                        profilePictureId: widget.account.profilePictureId,
+                        size: AppProfilePictureSize.large,
                       ),
-                    ),
-                  ],
+                      const SizedBox(width: AppSpacing.xs),
+                      Expanded(
+                        child: _AccountRowContent(account: widget.account),
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ),
             _AccountRowMenuButton(
               key: ValueKey('accounts_row_menu_button_${widget.account.uuid}'),
-              onOpenChanged: _setMenuOpen,
               onEditName: () => widget.onEditName(widget.account),
               onChangePicture: () => widget.onChangePicture(widget.account),
               onRemove: () => widget.onRemove(widget.account),
@@ -626,25 +635,63 @@ class _AccountRowState extends State<_AccountRow> {
       ),
     );
   }
+}
 
-  void _setHovered(bool value) {
-    if (_isHovered == value) return;
-    setState(() {
-      _isHovered = value;
-    });
-  }
+class _AccountRowContent extends StatelessWidget {
+  const _AccountRowContent({required this.account});
 
-  void _setMenuOpen(bool value) {
-    if (_isMenuOpen == value) return;
-    setState(() {
-      _isMenuOpen = value;
-    });
+  final AccountInfo account;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    if (!account.isHardware) {
+      return Text(
+        account.name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: AppTypography.labelLarge.copyWith(color: colors.text.accent),
+      );
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          account.name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTypography.labelLarge.copyWith(color: colors.text.accent),
+        ),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AppIcon(
+              AppIcons.keystone,
+              size: AppIconSize.medium,
+              color: colors.icon.accent,
+            ),
+            const SizedBox(width: AppSpacing.xxs),
+            Flexible(
+              child: Text(
+                'Keystone',
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.labelMedium.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
   }
 }
 
 class _AccountRowMenuButton extends StatefulWidget {
   const _AccountRowMenuButton({
-    required this.onOpenChanged,
     required this.onEditName,
     required this.onChangePicture,
     required this.onRemove,
@@ -652,7 +699,6 @@ class _AccountRowMenuButton extends StatefulWidget {
     super.key,
   });
 
-  final ValueChanged<bool> onOpenChanged;
   final VoidCallback onEditName;
   final VoidCallback onChangePicture;
   final VoidCallback onRemove;
@@ -665,10 +711,11 @@ class _AccountRowMenuButton extends StatefulWidget {
 class _AccountRowMenuButtonState extends State<_AccountRowMenuButton> {
   final LayerLink _layerLink = LayerLink();
   OverlayEntry? _menuEntry;
+  bool _isHovered = false;
 
   @override
   void dispose() {
-    _hideMenu(notify: false, rebuild: false);
+    _hideMenu(rebuild: false);
     super.dispose();
   }
 
@@ -711,16 +758,14 @@ class _AccountRowMenuButtonState extends State<_AccountRowMenuButton> {
       },
     );
     overlay.insert(_menuEntry!);
-    widget.onOpenChanged(true);
     setState(() {});
   }
 
-  void _hideMenu({bool notify = true, bool rebuild = true}) {
+  void _hideMenu({bool rebuild = true}) {
     final entry = _menuEntry;
     if (entry == null) return;
     _menuEntry = null;
     entry.remove();
-    if (notify) widget.onOpenChanged(false);
     if (rebuild && mounted) setState(() {});
   }
 
@@ -741,19 +786,30 @@ class _AccountRowMenuButtonState extends State<_AccountRowMenuButton> {
 
   @override
   Widget build(BuildContext context) {
+    final isHighlighted = _isHovered || _menuEntry != null;
+
     return CompositedTransformTarget(
       link: _layerLink,
       child: MouseRegion(
         cursor: SystemMouseCursors.click,
+        onEnter: (_) => _setHovered(true),
+        onExit: (_) => _setHovered(false),
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: _toggleMenu,
           child: Semantics(
             button: true,
             label: 'Account actions',
-            child: SizedBox(
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 120),
+              curve: Curves.easeOut,
               width: 20,
               height: 20,
+              padding: const EdgeInsets.all(2),
+              decoration: BoxDecoration(
+                color: isHighlighted ? context.colors.background.base : null,
+                borderRadius: BorderRadius.circular(AppRadii.xSmall),
+              ),
               child: Center(
                 child: Transform.rotate(
                   angle: -math.pi / 2,
@@ -769,6 +825,13 @@ class _AccountRowMenuButtonState extends State<_AccountRowMenuButton> {
         ),
       ),
     );
+  }
+
+  void _setHovered(bool value) {
+    if (_isHovered == value) return;
+    setState(() {
+      _isHovered = value;
+    });
   }
 }
 

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -270,8 +270,9 @@ final _accountsState = AccountState(
     for (var index = 2; index <= 20; index += 1)
       AccountInfo(
         uuid: 'preview-account-$index',
-        name: 'Account $index',
+        name: index == 2 ? 'Keystone Vault' : 'Account $index',
         order: index - 1,
+        isHardware: index == 2,
         profilePictureId: index.isEven ? 'samurai' : 'knight',
       ),
   ],

--- a/test/features/accounts/accounts_screen_test.dart
+++ b/test/features/accounts/accounts_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
 import 'package:zcash_wallet/src/core/layout/app_main_sidebar.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_pane_modal_overlay.dart';
 import 'package:zcash_wallet/src/features/accounts/screens/accounts_screen.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
@@ -45,7 +46,13 @@ void main() {
       find.byKey(const ValueKey('accounts_other_row_account-3')),
       findsOneWidget,
     );
+    expect(find.text('Current'), findsOneWidget);
     expect(find.text('Other'), findsOneWidget);
+    expect(find.text('Keystone'), findsOneWidget);
+    final keystoneIcon = tester
+        .widgetList<AppIcon>(find.byType(AppIcon))
+        .singleWhere((icon) => icon.name == AppIcons.keystone);
+    expect(keystoneIcon.color, AppThemeData.light.colors.icon.accent);
 
     await tester.tap(find.text('Add Account'));
     await tester.pumpAndSettle();
@@ -84,6 +91,7 @@ void main() {
         find.byKey(const ValueKey('accounts_active_row_account-1')),
         findsOneWidget,
       );
+      expect(find.text('Current'), findsOneWidget);
       expect(find.text('Other'), findsNothing);
       expect(find.text('Add Account'), findsOneWidget);
     },
@@ -220,7 +228,9 @@ void main() {
     );
     await tester.pump();
 
-    final row = find.byKey(const ValueKey('accounts_other_row_account-2'));
+    final menuButton = find.byKey(
+      const ValueKey('accounts_row_menu_button_account-2'),
+    );
     await tester.tap(
       find.byKey(const ValueKey('accounts_row_menu_button_account-2')),
     );
@@ -238,7 +248,7 @@ void main() {
       findsOneWidget,
     );
     expect(
-      _accountRowBackgroundColor(tester, row),
+      _accountMenuButtonBackgroundColor(tester, menuButton),
       AppThemeData.light.colors.background.base,
     );
     expect(syncNotifier.refreshCount, 0);
@@ -251,7 +261,7 @@ void main() {
     expect(find.text('Remove Account'), findsNothing);
   });
 
-  testWidgets('account rows show hover treatment', (tester) async {
+  testWidgets('account row hover is limited to other accounts', (tester) async {
     await tester.binding.setSurfaceSize(const Size(1512, 982));
     addTearDown(() async {
       await tester.binding.setSurfaceSize(null);
@@ -261,7 +271,19 @@ void main() {
     await tester.pump();
 
     final row = find.byKey(const ValueKey('accounts_other_row_account-2'));
-    expect(_accountRowBackgroundColor(tester, row), isNull);
+    final activeRow = find.byKey(
+      const ValueKey('accounts_active_row_account-1'),
+    );
+    final menuButton = find.byKey(
+      const ValueKey('accounts_row_menu_button_account-2'),
+    );
+    final activeMenuButton = find.byKey(
+      const ValueKey('accounts_row_menu_button_account-1'),
+    );
+    expect(_accountRowBackgroundColor(tester, 'account-2'), isNull);
+    expect(_accountRowBackgroundColor(tester, 'account-1'), isNull);
+    expect(_accountMenuButtonBackgroundColor(tester, menuButton), isNull);
+    expect(_accountMenuButtonBackgroundColor(tester, activeMenuButton), isNull);
 
     final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
     addTearDown(mouse.removePointer);
@@ -270,7 +292,35 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      _accountRowBackgroundColor(tester, row),
+      _accountRowBackgroundColor(tester, 'account-2'),
+      AppThemeData.light.colors.background.base,
+    );
+    expect(_accountMenuButtonBackgroundColor(tester, menuButton), isNull);
+
+    await mouse.moveTo(tester.getCenter(menuButton));
+    await tester.pumpAndSettle();
+
+    expect(
+      _accountRowBackgroundColor(tester, 'account-2'),
+      AppThemeData.light.colors.background.base,
+    );
+    expect(
+      _accountMenuButtonBackgroundColor(tester, menuButton),
+      AppThemeData.light.colors.background.base,
+    );
+
+    await mouse.moveTo(tester.getCenter(activeRow));
+    await tester.pumpAndSettle();
+
+    expect(_accountRowBackgroundColor(tester, 'account-1'), isNull);
+    expect(_accountMenuButtonBackgroundColor(tester, activeMenuButton), isNull);
+
+    await mouse.moveTo(tester.getCenter(activeMenuButton));
+    await tester.pumpAndSettle();
+
+    expect(_accountRowBackgroundColor(tester, 'account-1'), isNull);
+    expect(
+      _accountMenuButtonBackgroundColor(tester, activeMenuButton),
       AppThemeData.light.colors.background.base,
     );
   });
@@ -807,6 +857,7 @@ final _bootstrap = AppBootstrapState(
         uuid: 'account-2',
         name: 'Shielded Savings',
         order: 1,
+        isHardware: true,
         profilePictureId: kDefaultProfilePictureId,
       ),
       AccountInfo(uuid: 'account-3', name: 'Travel Funds', order: 2),
@@ -955,11 +1006,18 @@ class _FakeSyncNotifier extends SyncNotifier {
   }
 }
 
-Color? _accountRowBackgroundColor(WidgetTester tester, Finder row) {
+Color? _accountMenuButtonBackgroundColor(WidgetTester tester, Finder button) {
   final containerFinder = find.descendant(
-    of: row,
+    of: button,
     matching: find.byType(AnimatedContainer),
   );
   final container = tester.widget<AnimatedContainer>(containerFinder.first);
+  return (container.decoration as BoxDecoration?)?.color;
+}
+
+Color? _accountRowBackgroundColor(WidgetTester tester, String accountUuid) {
+  final container = tester.widget<AnimatedContainer>(
+    find.byKey(ValueKey('accounts_row_background_$accountUuid')),
+  );
   return (container.decoration as BoxDecoration?)?.color;
 }


### PR DESCRIPTION
## Summary

- Added a `Current` section for the active account and kept the remaining accounts under `Other`.
- Updated account row spacing to match the revised Accounts design.
- Restored row hover treatment for `Other` accounts while keeping the active account row non-hoverable.
- Kept the active account context menu hover/open treatment on the `...` button only.
- Updated the `Add Account` button to the secondary pill style with the leading add icon.
- Added Keystone hardware-account subtext in account rows, including a Figma-exported Keystone icon asset.
- Updated the Widgetbook Accounts fixture so the preview includes a Keystone account.
- Expanded Accounts widget tests for the section labels, Keystone label, menu hover/open state, and active-vs-other row hover behavior.

## Validation

- `fvm dart format lib/src/features/accounts/screens/accounts_screen.dart lib/src/core/widgets/app_icon.dart test/features/accounts/accounts_screen_test.dart`
- `fvm flutter test test/features/accounts/accounts_screen_test.dart`
- `fvm flutter analyze lib/src/features/accounts/screens/accounts_screen.dart lib/src/core/widgets/app_icon.dart lib/widgetbook/screen_use_cases.dart test/features/accounts/accounts_screen_test.dart`
- `git diff --cached --check`