### PR TITLE
Auto-lock wallet after 10 minutes in background

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -8,6 +8,7 @@ import 'package:desktop_window_bootstrap/desktop_window_bootstrap.dart';
 import 'src/app_bootstrap.dart';
 import 'src/core/layout/app_layout.dart';
 import 'src/core/motion/onboarding_motion.dart';
+import 'src/core/security/wallet_lock_controller.dart';
 import 'src/core/theme/app_theme_host.dart';
 import 'src/core/theme/legacy_material_theme.dart';
 import 'src/core/widgets/network_fallback_toast.dart';
@@ -591,21 +592,23 @@ class ZcashWalletApp extends ConsumerWidget {
           // (buttons, TextFields) win the gesture arena first, keeping
           // focused buttons focused when re-clicked.
           child: _RpcEndpointFailoverToastListener(
-            child: DesktopWindowTitlebarSafeArea(
-              child: GestureDetector(
-                onTap: () {
-                  // Leaf-only: skip when the primary focus is a
-                  // `FocusScopeNode` rather than a concrete `FocusNode`.
-                  // Unfocusing the scope itself strips the scope's
-                  // "most-recently-focused child" memory, which leaves the
-                  // next Tab with no deterministic starting point.
-                  final primary = FocusManager.instance.primaryFocus;
-                  if (primary != null && primary is! FocusScopeNode) {
-                    primary.unfocus();
-                  }
-                },
-                behavior: HitTestBehavior.translucent,
-                child: child!,
+            child: AutoLockObserver(
+              child: DesktopWindowTitlebarSafeArea(
+                child: GestureDetector(
+                  onTap: () {
+                    // Leaf-only: skip when the primary focus is a
+                    // `FocusScopeNode` rather than a concrete `FocusNode`.
+                    // Unfocusing the scope itself strips the scope's
+                    // "most-recently-focused child" memory, which leaves the
+                    // next Tab with no deterministic starting point.
+                    final primary = FocusManager.instance.primaryFocus;
+                    if (primary != null && primary is! FocusScopeNode) {
+                      primary.unfocus();
+                    }
+                  },
+                  behavior: HitTestBehavior.translucent,
+                  child: child!,
+                ),
               ),
             ),
           ),

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -6,6 +6,7 @@ import '../../providers/account_provider.dart';
 import '../../providers/app_security_provider.dart';
 import '../../providers/sync_provider.dart';
 import '../profile_pictures.dart';
+import '../security/wallet_lock_controller.dart';
 import '../theme/app_theme.dart';
 import '../widgets/app_icon.dart';
 import '../widgets/app_profile_picture.dart';
@@ -44,12 +45,16 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
     });
 
     try {
-      securityNotifier.lock();
-      accountNotifier.clearSensitiveStateForLock();
+      final lockFuture = lockWalletSession(
+        securityNotifier: securityNotifier,
+        accountNotifier: accountNotifier,
+        syncNotifier: syncNotifier,
+        awaitSync: true,
+      );
       if (mounted) {
         context.go('/unlock');
       }
-      await syncNotifier.clearSensitiveStateForLock();
+      await lockFuture;
     } finally {
       if (mounted) {
         setState(() {

--- a/lib/src/core/security/wallet_lock_controller.dart
+++ b/lib/src/core/security/wallet_lock_controller.dart
@@ -7,6 +7,7 @@ import '../../../main.dart' show log;
 import '../../providers/account_provider.dart';
 import '../../providers/app_security_provider.dart';
 import '../../providers/sync_provider.dart';
+import '../../providers/wallet_provider.dart';
 
 const Duration kAutoLockBackgroundTimeout = Duration(minutes: 10);
 
@@ -61,9 +62,15 @@ class _AutoLockObserverState extends ConsumerState<AutoLockObserver> {
     super.dispose();
   }
 
-  void _onHide() {
+  bool _isLockable() {
     final security = ref.read(appSecurityProvider);
-    if (!security.isUnlocked) return;
+    if (!security.isUnlocked) return false;
+    final wallet = ref.read(walletProvider).value;
+    return wallet?.hasWallet ?? false;
+  }
+
+  void _onHide() {
+    if (!_isLockable()) return;
     _monoHiddenAt = _clock.elapsed;
     _wallHiddenAt = DateTime.now();
   }
@@ -74,8 +81,7 @@ class _AutoLockObserverState extends ConsumerState<AutoLockObserver> {
     _monoHiddenAt = null;
     _wallHiddenAt = null;
     if (monoHiddenAt == null || wallHiddenAt == null) return;
-    final security = ref.read(appSecurityProvider);
-    if (!security.isUnlocked) return;
+    if (!_isLockable()) return;
     final monoElapsed = _clock.elapsed - monoHiddenAt;
     final wallElapsed = DateTime.now().difference(wallHiddenAt);
     if (!shouldAutoLock(elapsed: monoElapsed) &&

--- a/lib/src/core/security/wallet_lock_controller.dart
+++ b/lib/src/core/security/wallet_lock_controller.dart
@@ -11,12 +11,10 @@ import '../../providers/sync_provider.dart';
 const Duration kAutoLockBackgroundTimeout = Duration(minutes: 10);
 
 bool shouldAutoLock({
-  required Duration? hiddenAt,
-  required Duration now,
+  required Duration elapsed,
   Duration threshold = kAutoLockBackgroundTimeout,
 }) {
-  if (hiddenAt == null) return false;
-  return (now - hiddenAt) >= threshold;
+  return elapsed >= threshold;
 }
 
 Future<void> lockWalletSession({
@@ -47,7 +45,8 @@ class AutoLockObserver extends ConsumerStatefulWidget {
 class _AutoLockObserverState extends ConsumerState<AutoLockObserver> {
   AppLifecycleListener? _listener;
   final Stopwatch _clock = Stopwatch()..start();
-  Duration? _hiddenAt;
+  Duration? _monoHiddenAt;
+  DateTime? _wallHiddenAt;
 
   @override
   void initState() {
@@ -59,25 +58,34 @@ class _AutoLockObserverState extends ConsumerState<AutoLockObserver> {
   void dispose() {
     _listener?.dispose();
     _listener = null;
-    _clock.stop();
     super.dispose();
   }
 
   void _onHide() {
     final security = ref.read(appSecurityProvider);
     if (!security.isUnlocked) return;
-    _hiddenAt = _clock.elapsed;
+    _monoHiddenAt = _clock.elapsed;
+    _wallHiddenAt = DateTime.now();
   }
 
   void _onShow() {
-    final hiddenAt = _hiddenAt;
-    _hiddenAt = null;
-    if (hiddenAt == null) return;
+    final monoHiddenAt = _monoHiddenAt;
+    final wallHiddenAt = _wallHiddenAt;
+    _monoHiddenAt = null;
+    _wallHiddenAt = null;
+    if (monoHiddenAt == null || wallHiddenAt == null) return;
     final security = ref.read(appSecurityProvider);
     if (!security.isUnlocked) return;
-    final now = _clock.elapsed;
-    if (!shouldAutoLock(hiddenAt: hiddenAt, now: now)) return;
-    log('AutoLock: hidden for ${now - hiddenAt}, locking wallet session');
+    final monoElapsed = _clock.elapsed - monoHiddenAt;
+    final wallElapsed = DateTime.now().difference(wallHiddenAt);
+    if (!shouldAutoLock(elapsed: monoElapsed) &&
+        !shouldAutoLock(elapsed: wallElapsed)) {
+      return;
+    }
+    log(
+      'AutoLock: monoElapsed=$monoElapsed wallElapsed=$wallElapsed, '
+      'locking wallet session',
+    );
     lockWalletSession(
       securityNotifier: ref.read(appSecurityProvider.notifier),
       accountNotifier: ref.read(accountProvider.notifier),

--- a/lib/src/core/security/wallet_lock_controller.dart
+++ b/lib/src/core/security/wallet_lock_controller.dart
@@ -11,12 +11,12 @@ import '../../providers/sync_provider.dart';
 const Duration kAutoLockBackgroundTimeout = Duration(minutes: 10);
 
 bool shouldAutoLock({
-  required DateTime? hiddenAt,
-  required DateTime now,
+  required Duration? hiddenAt,
+  required Duration now,
   Duration threshold = kAutoLockBackgroundTimeout,
 }) {
   if (hiddenAt == null) return false;
-  return now.difference(hiddenAt) >= threshold;
+  return (now - hiddenAt) >= threshold;
 }
 
 Future<void> lockWalletSession({
@@ -46,7 +46,8 @@ class AutoLockObserver extends ConsumerStatefulWidget {
 
 class _AutoLockObserverState extends ConsumerState<AutoLockObserver> {
   AppLifecycleListener? _listener;
-  DateTime? _hiddenAt;
+  final Stopwatch _clock = Stopwatch()..start();
+  Duration? _hiddenAt;
 
   @override
   void initState() {
@@ -58,13 +59,14 @@ class _AutoLockObserverState extends ConsumerState<AutoLockObserver> {
   void dispose() {
     _listener?.dispose();
     _listener = null;
+    _clock.stop();
     super.dispose();
   }
 
   void _onHide() {
     final security = ref.read(appSecurityProvider);
     if (!security.isUnlocked) return;
-    _hiddenAt = DateTime.now();
+    _hiddenAt = _clock.elapsed;
   }
 
   void _onShow() {
@@ -73,12 +75,9 @@ class _AutoLockObserverState extends ConsumerState<AutoLockObserver> {
     if (hiddenAt == null) return;
     final security = ref.read(appSecurityProvider);
     if (!security.isUnlocked) return;
-    final now = DateTime.now();
+    final now = _clock.elapsed;
     if (!shouldAutoLock(hiddenAt: hiddenAt, now: now)) return;
-    log(
-      'AutoLock: hidden for ${now.difference(hiddenAt)}, '
-      'locking wallet session',
-    );
+    log('AutoLock: hidden for ${now - hiddenAt}, locking wallet session');
     lockWalletSession(
       securityNotifier: ref.read(appSecurityProvider.notifier),
       accountNotifier: ref.read(accountProvider.notifier),

--- a/lib/src/core/security/wallet_lock_controller.dart
+++ b/lib/src/core/security/wallet_lock_controller.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../main.dart' show log;
+import '../../providers/account_provider.dart';
+import '../../providers/app_security_provider.dart';
+import '../../providers/sync_provider.dart';
+
+const Duration kAutoLockBackgroundTimeout = Duration(minutes: 10);
+
+bool shouldAutoLock({
+  required DateTime? hiddenAt,
+  required DateTime now,
+  Duration threshold = kAutoLockBackgroundTimeout,
+}) {
+  if (hiddenAt == null) return false;
+  return now.difference(hiddenAt) >= threshold;
+}
+
+Future<void> lockWalletSession({
+  required AppSecurityNotifier securityNotifier,
+  required AccountNotifier accountNotifier,
+  required SyncNotifier syncNotifier,
+  bool awaitSync = false,
+}) async {
+  securityNotifier.lock();
+  accountNotifier.clearSensitiveStateForLock();
+  final syncFuture = syncNotifier.clearSensitiveStateForLock();
+  if (awaitSync) {
+    await syncFuture;
+  } else {
+    unawaited(syncFuture);
+  }
+}
+
+class AutoLockObserver extends ConsumerStatefulWidget {
+  const AutoLockObserver({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  ConsumerState<AutoLockObserver> createState() => _AutoLockObserverState();
+}
+
+class _AutoLockObserverState extends ConsumerState<AutoLockObserver> {
+  AppLifecycleListener? _listener;
+  DateTime? _hiddenAt;
+
+  @override
+  void initState() {
+    super.initState();
+    _listener = AppLifecycleListener(onHide: _onHide, onShow: _onShow);
+  }
+
+  @override
+  void dispose() {
+    _listener?.dispose();
+    _listener = null;
+    super.dispose();
+  }
+
+  void _onHide() {
+    final security = ref.read(appSecurityProvider);
+    if (!security.isUnlocked) return;
+    _hiddenAt = DateTime.now();
+  }
+
+  void _onShow() {
+    final hiddenAt = _hiddenAt;
+    _hiddenAt = null;
+    if (hiddenAt == null) return;
+    final security = ref.read(appSecurityProvider);
+    if (!security.isUnlocked) return;
+    final now = DateTime.now();
+    if (!shouldAutoLock(hiddenAt: hiddenAt, now: now)) return;
+    log(
+      'AutoLock: hidden for ${now.difference(hiddenAt)}, '
+      'locking wallet session',
+    );
+    lockWalletSession(
+      securityNotifier: ref.read(appSecurityProvider.notifier),
+      accountNotifier: ref.read(accountProvider.notifier),
+      syncNotifier: ref.read(syncProvider.notifier),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -152,10 +152,12 @@ class AppSecureStore {
     await _storage.delete(key: key);
   }
 
-  Future<void> deleteAll() async {
-    await _storage.deleteAll();
-    _cachedSecretKey = null;
-    _sessionPassword = null;
+  Future<void> deleteAll() {
+    return _secretMutationLock.run(() async {
+      await _storage.deleteAll();
+      _cachedSecretKey = null;
+      _sessionPassword = null;
+    });
   }
 
   Future<String?> readPlain(String key) {
@@ -316,11 +318,13 @@ class AppSecureStore {
     clearSessionPassword();
   }
 
-  Future<void> clearPasswordConfiguration() async {
-    await delete(_passwordVerifierSaltKey);
-    await delete(_passwordVerifierKey);
-    await delete(_passwordRotationInProgressKey);
-    clearSessionPassword();
+  Future<void> clearPasswordConfiguration() {
+    return _secretMutationLock.run(() async {
+      await _storage.delete(key: _passwordVerifierSaltKey);
+      await _storage.delete(key: _passwordVerifierKey);
+      await _storage.delete(key: _passwordRotationInProgressKey);
+      clearSessionPassword();
+    });
   }
 
   /// Checks the wallet password without opening or refreshing the encrypted

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -3,7 +3,13 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:cryptography/cryptography.dart';
-import 'package:flutter/foundation.dart' show debugPrint, visibleForTesting;
+import 'package:flutter/foundation.dart'
+    show
+        TargetPlatform,
+        debugPrint,
+        defaultTargetPlatform,
+        kIsWeb,
+        visibleForTesting;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../config/network_config.dart';
@@ -20,6 +26,8 @@ const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';
 const _passwordRotationInProgressKey = 'zcash_rotation_in_progress';
 const _passwordRotationRollbackFailedKind = 'rollbackFailed';
 const _accountMnemonicKeyPrefix = 'zcash_account_mnemonic_';
+const _accountMnemonicMigrationCompleteKey =
+    'zcash_mnemonic_storage_migrated_v1';
 
 class PasswordRotationRecoveryFailedException implements Exception {
   const PasswordRotationRecoveryFailedException();
@@ -30,12 +38,18 @@ class PasswordRotationRecoveryFailedException implements Exception {
 }
 
 class AppSecureStore {
-  AppSecureStore._({FlutterSecureStorage? storage})
-    : _storage = storage ?? _defaultStorage();
+  AppSecureStore._({
+    FlutterSecureStorage? storage,
+    FlutterSecureStorage? mnemonicStorage,
+  }) : _storage = storage ?? _defaultStorage(),
+       _mnemonicStorage = mnemonicStorage ?? _defaultMnemonicStorage();
 
   @visibleForTesting
-  AppSecureStore.testing({required FlutterSecureStorage storage})
-    : _storage = storage;
+  AppSecureStore.testing({
+    required FlutterSecureStorage storage,
+    FlutterSecureStorage? mnemonicStorage,
+  }) : _storage = storage,
+       _mnemonicStorage = mnemonicStorage ?? storage;
 
   static final AppSecureStore instance = AppSecureStore._();
 
@@ -57,6 +71,27 @@ class AppSecureStore {
     );
   }
 
+  static FlutterSecureStorage _defaultMnemonicStorage() {
+    final service = secureStoreServiceForNetwork(kZcashDefaultNetworkName);
+    final macOsService = _mnemonicSecureStoreServiceForNetwork(
+      kZcashDefaultNetworkName,
+    );
+    return FlutterSecureStorage(
+      iOptions: IOSOptions(
+        accountName: service,
+        accessibility: KeychainAccessibility.first_unlock,
+      ),
+      aOptions: kZcashDefaultNetworkName == 'main'
+          ? AndroidOptions.defaultOptions
+          : AndroidOptions(sharedPreferencesName: service),
+      mOptions: MacOsOptions(
+        accountName: macOsService,
+        accessibility: KeychainAccessibility.unlocked,
+        usesDataProtectionKeychain: true,
+      ),
+    );
+  }
+
   static final Cipher _cipher = AesGcm.with256bits();
   static final Pbkdf2 _kdf = Pbkdf2(
     macAlgorithm: Hmac.sha256(),
@@ -65,6 +100,7 @@ class AppSecureStore {
   );
 
   final FlutterSecureStorage _storage;
+  final FlutterSecureStorage _mnemonicStorage;
   final _secretMutationLock = _AsyncLock();
   SecretKey? _cachedSecretKey;
   String? _sessionPassword;
@@ -92,31 +128,29 @@ class AppSecureStore {
     bool requireUnlockedSession = false,
   }) {
     return _secretMutationLock.run(() async {
-      if (requireUnlockedSession && !hasSessionPassword) {
-        return null;
-      }
-      if (!hasSessionPassword) {
-        throw StateError('Secret storage requires an unlocked session.');
-      }
-
+      if (_shouldSkipLockedSecretRead(requireUnlockedSession)) return null;
       final raw = await _storage.read(key: key);
-      if (raw == null || raw.isEmpty) return null;
-
-      final payload = _EncryptedPayload.tryParse(raw);
-      if (payload == null) {
-        return null;
-      }
-
-      final secretKey = await _getSecretKey();
-      final clearText = await _cipher.decrypt(
-        SecretBox(
-          payload.cipherText,
-          nonce: payload.nonce,
-          mac: Mac(payload.mac),
-        ),
-        secretKey: secretKey,
+      return _decryptStoredSecretString(
+        raw,
+        key: key,
+        requireUnlockedSession: requireUnlockedSession,
       );
-      return utf8.decode(clearText);
+    });
+  }
+
+  Future<String?> readAccountMnemonic(
+    String accountUuid, {
+    bool requireUnlockedSession = false,
+  }) {
+    return _secretMutationLock.run(() async {
+      if (_shouldSkipLockedSecretRead(requireUnlockedSession)) return null;
+      final key = _accountMnemonicKey(accountUuid);
+      final raw = await _mnemonicStorage.read(key: key);
+      return _decryptStoredSecretString(
+        raw,
+        key: key,
+        requireUnlockedSession: requireUnlockedSession,
+      );
     });
   }
 
@@ -126,35 +160,44 @@ class AppSecureStore {
 
   Future<void> writeSecretString(String key, String value) {
     return _secretMutationLock.run(() async {
-      final secretKey = await _getSecretKey();
-      final nonce = _randomBytes(12);
-      final secretBox = await _cipher.encrypt(
-        utf8.encode(value),
-        secretKey: secretKey,
-        nonce: nonce,
-      );
-      await _storage.write(
-        key: key,
-        value: _EncryptedPayload(
-          nonce: secretBox.nonce,
-          cipherText: secretBox.cipherText,
-          mac: secretBox.mac.bytes,
-        ).serialize(),
+      await _storage.write(key: key, value: await _encryptSecretString(value));
+    });
+  }
+
+  Future<void> writeAccountMnemonic(String accountUuid, String mnemonic) {
+    return _secretMutationLock.run(() async {
+      await _mnemonicStorage.write(
+        key: _accountMnemonicKey(accountUuid),
+        value: await _encryptSecretString(mnemonic),
       );
     });
   }
 
   Future<void> delete(String key) async {
     if (key.startsWith(_accountMnemonicKeyPrefix)) {
-      await _secretMutationLock.run(() => _storage.delete(key: key));
+      await _secretMutationLock.run(() async {
+        await _mnemonicStorage.delete(key: key);
+        await _deleteLegacyAccountMnemonicBestEffort(key);
+      });
       return;
     }
     await _storage.delete(key: key);
   }
 
+  Future<void> deleteAccountMnemonic(String accountUuid) {
+    final key = _accountMnemonicKey(accountUuid);
+    return _secretMutationLock.run(() async {
+      await _mnemonicStorage.delete(key: key);
+      await _deleteLegacyAccountMnemonicBestEffort(key);
+    });
+  }
+
   Future<void> deleteAll() {
     return _secretMutationLock.run(() async {
       await _storage.deleteAll();
+      if (!identical(_mnemonicStorage, _storage)) {
+        await _mnemonicStorage.deleteAll();
+      }
       _cachedSecretKey = null;
       _sessionPassword = null;
     });
@@ -230,7 +273,13 @@ class AppSecureStore {
       );
       final newSecretKey = await _deriveSecretKeyForPassword(newPassword);
       try {
-        final storedValues = await _storage.readAll();
+        final migration = await _migrateAccountMnemonicsAfterUnlockLocked();
+        if (!migration.legacyCleanupComplete) {
+          throw StateError(
+            'Failed to migrate account mnemonics before password rotation.',
+          );
+        }
+        final storedValues = await _mnemonicStorage.readAll();
         final rotatedSecrets = <_PasswordRotationEntry>[];
         final rollbackSecrets = <_PasswordRotationRollbackEntry>[];
 
@@ -354,8 +403,29 @@ class AppSecureStore {
     final isMatch = await verifyPasswordOnly(password);
     if (isMatch) {
       setSessionPassword(password);
+      try {
+        final migratedForRead = await migrateAccountMnemonicsAfterUnlock();
+        if (!migratedForRead) {
+          clearSessionPassword();
+          return false;
+        }
+      } catch (error, stackTrace) {
+        clearSessionPassword();
+        debugPrint(
+          'AppSecureStore: failed to migrate account mnemonics after unlock: '
+          '$error\n$stackTrace',
+        );
+        return false;
+      }
     }
     return isMatch;
+  }
+
+  Future<bool> migrateAccountMnemonicsAfterUnlock() {
+    return _secretMutationLock.run(() async {
+      final migration = await _migrateAccountMnemonicsAfterUnlockLocked();
+      return migration.mnemonicsAvailable;
+    });
   }
 
   void setSessionPassword(String password) {
@@ -366,6 +436,120 @@ class AppSecureStore {
   void clearSessionPassword() {
     _sessionPassword = null;
     _cachedSecretKey = null;
+  }
+
+  bool _shouldSkipLockedSecretRead(bool requireUnlockedSession) {
+    return requireUnlockedSession && !hasSessionPassword;
+  }
+
+  Future<String?> _decryptStoredSecretString(
+    String? raw, {
+    required String key,
+    required bool requireUnlockedSession,
+  }) async {
+    if (requireUnlockedSession && !hasSessionPassword) {
+      return null;
+    }
+    if (!hasSessionPassword) {
+      throw StateError('Secret storage requires an unlocked session.');
+    }
+    if (raw == null || raw.isEmpty) return null;
+
+    final payload = _EncryptedPayload.tryParse(raw);
+    if (payload == null) {
+      return null;
+    }
+
+    final secretKey = await _getSecretKey();
+    return _decryptPayloadForKey(key, payload, secretKey);
+  }
+
+  Future<String> _encryptSecretString(String value) async {
+    final secretKey = await _getSecretKey();
+    final nonce = _randomBytes(12);
+    final secretBox = await _cipher.encrypt(
+      utf8.encode(value),
+      secretKey: secretKey,
+      nonce: nonce,
+    );
+    return _EncryptedPayload(
+      nonce: secretBox.nonce,
+      cipherText: secretBox.cipherText,
+      mac: secretBox.mac.bytes,
+    ).serialize();
+  }
+
+  Future<_AccountMnemonicMigrationResult>
+  _migrateAccountMnemonicsAfterUnlockLocked() async {
+    if (!_usesSeparateMacOsMnemonicStorage ||
+        identical(_mnemonicStorage, _storage)) {
+      return _AccountMnemonicMigrationResult.complete;
+    }
+    if (await readPlain(_accountMnemonicMigrationCompleteKey) == 'true') {
+      return _AccountMnemonicMigrationResult.complete;
+    }
+
+    final legacyValues = await _storage.readAll();
+    var mnemonicsAvailable = true;
+    var legacyCleanupComplete = true;
+    for (final entry in legacyValues.entries) {
+      if (!_isAccountMnemonicKey(entry.key)) continue;
+
+      try {
+        final existing = await _mnemonicStorage.read(key: entry.key);
+        if (existing == null) {
+          await _mnemonicStorage.write(key: entry.key, value: entry.value);
+        }
+      } catch (error, stackTrace) {
+        mnemonicsAvailable = false;
+        legacyCleanupComplete = false;
+        debugPrint(
+          'AppSecureStore: failed to copy account mnemonic "${entry.key}": '
+          '$error\n$stackTrace',
+        );
+        continue;
+      }
+
+      try {
+        await _storage.delete(key: entry.key);
+      } catch (error, stackTrace) {
+        legacyCleanupComplete = false;
+        debugPrint(
+          'AppSecureStore: failed to delete legacy account mnemonic '
+          '"${entry.key}": '
+          '$error\n$stackTrace',
+        );
+      }
+    }
+    if (legacyCleanupComplete) {
+      try {
+        await writePlain(_accountMnemonicMigrationCompleteKey, 'true');
+      } catch (error, stackTrace) {
+        debugPrint(
+          'AppSecureStore: failed to mark account mnemonic migration complete: '
+          '$error\n$stackTrace',
+        );
+      }
+    }
+    return _AccountMnemonicMigrationResult(
+      mnemonicsAvailable: mnemonicsAvailable,
+      legacyCleanupComplete: legacyCleanupComplete,
+    );
+  }
+
+  Future<void> _deleteLegacyAccountMnemonicBestEffort(String key) async {
+    if (!_usesSeparateMacOsMnemonicStorage ||
+        identical(_mnemonicStorage, _storage)) {
+      return;
+    }
+    try {
+      await _storage.delete(key: key);
+    } catch (error, stackTrace) {
+      debugPrint(
+        'AppSecureStore: failed to delete legacy account mnemonic "$key": '
+        '$error\n$stackTrace',
+      );
+    }
   }
 
   Future<SecretKey> _getSecretKey() async {
@@ -457,7 +641,7 @@ class AppSecureStore {
     _PasswordRotationRecord rotation,
   ) async {
     for (final entry in rotation.entries) {
-      await writePlain(entry.key, entry.rotatedValue);
+      await _mnemonicStorage.write(key: entry.key, value: entry.rotatedValue);
     }
     await writePlain(_passwordVerifierSaltKey, rotation.newVerifierSalt);
     await writePlain(_passwordVerifierKey, rotation.newVerifier);
@@ -469,7 +653,10 @@ class AppSecureStore {
   ) async {
     try {
       for (final entry in rollback.entries) {
-        await writePlain(entry.key, entry.originalValue);
+        await _mnemonicStorage.write(
+          key: entry.key,
+          value: entry.originalValue,
+        );
       }
       if (rollback.oldVerifierSalt == null) {
         await delete(_passwordVerifierSaltKey);
@@ -540,6 +727,34 @@ class AppSecureStore {
     }
     return buffer.toString();
   }
+}
+
+bool get _usesSeparateMacOsMnemonicStorage =>
+    !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS;
+
+bool _isAccountMnemonicKey(String key) =>
+    key.startsWith(_accountMnemonicKeyPrefix);
+
+String _accountMnemonicKey(String accountUuid) =>
+    '$_accountMnemonicKeyPrefix$accountUuid';
+
+String _mnemonicSecureStoreServiceForNetwork(String networkName) {
+  return '${secureStoreServiceForNetwork(networkName)}.mnemonic';
+}
+
+class _AccountMnemonicMigrationResult {
+  const _AccountMnemonicMigrationResult({
+    required this.mnemonicsAvailable,
+    required this.legacyCleanupComplete,
+  });
+
+  static const complete = _AccountMnemonicMigrationResult(
+    mnemonicsAvailable: true,
+    legacyCleanupComplete: true,
+  );
+
+  final bool mnemonicsAvailable;
+  final bool legacyCleanupComplete;
 }
 
 class _AsyncLock {

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -93,10 +93,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       }
 
       // Store mnemonic per-account
-      await _storage.writeSecretString(
-        'zcash_account_mnemonic_$accountUuid',
-        mnemonic,
-      );
+      await _storage.writeAccountMnemonic(accountUuid, mnemonic);
 
       // Update account list
       final newAccount = AccountInfo(
@@ -172,10 +169,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         unifiedAddress = result.unifiedAddress;
       }
 
-      await _storage.writeSecretString(
-        'zcash_account_mnemonic_$accountUuid',
-        mnemonic,
-      );
+      await _storage.writeAccountMnemonic(accountUuid, mnemonic);
 
       final newAccount = AccountInfo(
         uuid: accountUuid,
@@ -247,10 +241,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         unifiedAddress = result.unifiedAddress;
       }
 
-      await _storage.writeSecretString(
-        'zcash_account_mnemonic_$accountUuid',
-        mnemonic,
-      );
+      await _storage.writeAccountMnemonic(accountUuid, mnemonic);
 
       final newAccount = AccountInfo(
         uuid: accountUuid,
@@ -374,7 +365,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       '${rustDeleteWatch.elapsedMilliseconds}ms uuid=$uuid',
     );
     try {
-      await _storage.delete('zcash_account_mnemonic_$uuid');
+      await _storage.deleteAccountMnemonic(uuid);
     } catch (e, st) {
       log('removeAccount: failed to delete mnemonic for $uuid: $e\n$st');
     }
@@ -542,18 +533,12 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   Future<String?> getActiveMnemonic() async {
     final uuid = state.value?.activeAccountUuid;
     if (uuid == null) return null;
-    return _storage.readSecretStringWithOptions(
-      'zcash_account_mnemonic_$uuid',
-      requireUnlockedSession: true,
-    );
+    return _storage.readAccountMnemonic(uuid, requireUnlockedSession: true);
   }
 
   /// Get the mnemonic for a specific account.
   Future<String?> getMnemonicForAccount(String uuid) async {
-    return _storage.readSecretStringWithOptions(
-      'zcash_account_mnemonic_$uuid',
-      requireUnlockedSession: true,
-    );
+    return _storage.readAccountMnemonic(uuid, requireUnlockedSession: true);
   }
 
   // ======================== Helpers ========================

--- a/test/core/security/wallet_lock_controller_test.dart
+++ b/test/core/security/wallet_lock_controller_test.dart
@@ -5,35 +5,32 @@ void main() {
   group('shouldAutoLock', () {
     test('returns false when no hidden timestamp is recorded', () {
       expect(
-        shouldAutoLock(
-          hiddenAt: null,
-          now: DateTime(2026, 1, 1, 12, 0, 0),
-        ),
+        shouldAutoLock(hiddenAt: null, now: const Duration(hours: 1)),
         isFalse,
       );
     });
 
     test('returns false when hidden duration is shorter than threshold', () {
-      final hiddenAt = DateTime(2026, 1, 1, 12, 0, 0);
-      final now = hiddenAt.add(kAutoLockBackgroundTimeout - const Duration(seconds: 1));
+      const hiddenAt = Duration(minutes: 5);
+      final now = hiddenAt + kAutoLockBackgroundTimeout - const Duration(seconds: 1);
       expect(shouldAutoLock(hiddenAt: hiddenAt, now: now), isFalse);
     });
 
     test('returns true at exactly the threshold boundary', () {
-      final hiddenAt = DateTime(2026, 1, 1, 12, 0, 0);
-      final now = hiddenAt.add(kAutoLockBackgroundTimeout);
+      const hiddenAt = Duration(minutes: 5);
+      final now = hiddenAt + kAutoLockBackgroundTimeout;
       expect(shouldAutoLock(hiddenAt: hiddenAt, now: now), isTrue);
     });
 
     test('returns true when hidden duration exceeds threshold', () {
-      final hiddenAt = DateTime(2026, 1, 1, 12, 0, 0);
-      final now = hiddenAt.add(kAutoLockBackgroundTimeout * 3);
+      const hiddenAt = Duration(minutes: 5);
+      final now = hiddenAt + kAutoLockBackgroundTimeout * 3;
       expect(shouldAutoLock(hiddenAt: hiddenAt, now: now), isTrue);
     });
 
     test('respects a custom threshold override', () {
-      final hiddenAt = DateTime(2026, 1, 1, 12, 0, 0);
-      final now = hiddenAt.add(const Duration(seconds: 30));
+      const hiddenAt = Duration(minutes: 5);
+      final now = hiddenAt + const Duration(seconds: 30);
       expect(
         shouldAutoLock(
           hiddenAt: hiddenAt,
@@ -54,6 +51,12 @@ void main() {
 
     test('default threshold is 10 minutes', () {
       expect(kAutoLockBackgroundTimeout, const Duration(minutes: 10));
+    });
+
+    test('does not lock when monotonic time appears to go backward', () {
+      const hiddenAt = Duration(minutes: 30);
+      const now = Duration(minutes: 5);
+      expect(shouldAutoLock(hiddenAt: hiddenAt, now: now), isFalse);
     });
   });
 }

--- a/test/core/security/wallet_lock_controller_test.dart
+++ b/test/core/security/wallet_lock_controller_test.dart
@@ -3,46 +3,41 @@ import 'package:zcash_wallet/src/core/security/wallet_lock_controller.dart';
 
 void main() {
   group('shouldAutoLock', () {
-    test('returns false when no hidden timestamp is recorded', () {
+    test('returns false for zero elapsed', () {
+      expect(shouldAutoLock(elapsed: Duration.zero), isFalse);
+    });
+
+    test('returns false when elapsed is shorter than threshold', () {
       expect(
-        shouldAutoLock(hiddenAt: null, now: const Duration(hours: 1)),
+        shouldAutoLock(
+          elapsed: kAutoLockBackgroundTimeout - const Duration(seconds: 1),
+        ),
         isFalse,
       );
     });
 
-    test('returns false when hidden duration is shorter than threshold', () {
-      const hiddenAt = Duration(minutes: 5);
-      final now = hiddenAt + kAutoLockBackgroundTimeout - const Duration(seconds: 1);
-      expect(shouldAutoLock(hiddenAt: hiddenAt, now: now), isFalse);
-    });
-
     test('returns true at exactly the threshold boundary', () {
-      const hiddenAt = Duration(minutes: 5);
-      final now = hiddenAt + kAutoLockBackgroundTimeout;
-      expect(shouldAutoLock(hiddenAt: hiddenAt, now: now), isTrue);
+      expect(shouldAutoLock(elapsed: kAutoLockBackgroundTimeout), isTrue);
     });
 
-    test('returns true when hidden duration exceeds threshold', () {
-      const hiddenAt = Duration(minutes: 5);
-      final now = hiddenAt + kAutoLockBackgroundTimeout * 3;
-      expect(shouldAutoLock(hiddenAt: hiddenAt, now: now), isTrue);
+    test('returns true when elapsed exceeds threshold', () {
+      expect(
+        shouldAutoLock(elapsed: kAutoLockBackgroundTimeout * 3),
+        isTrue,
+      );
     });
 
     test('respects a custom threshold override', () {
-      const hiddenAt = Duration(minutes: 5);
-      final now = hiddenAt + const Duration(seconds: 30);
       expect(
         shouldAutoLock(
-          hiddenAt: hiddenAt,
-          now: now,
+          elapsed: const Duration(seconds: 30),
           threshold: const Duration(seconds: 15),
         ),
         isTrue,
       );
       expect(
         shouldAutoLock(
-          hiddenAt: hiddenAt,
-          now: now,
+          elapsed: const Duration(seconds: 30),
           threshold: const Duration(minutes: 1),
         ),
         isFalse,
@@ -53,10 +48,11 @@ void main() {
       expect(kAutoLockBackgroundTimeout, const Duration(minutes: 10));
     });
 
-    test('does not lock when monotonic time appears to go backward', () {
-      const hiddenAt = Duration(minutes: 30);
-      const now = Duration(minutes: 5);
-      expect(shouldAutoLock(hiddenAt: hiddenAt, now: now), isFalse);
+    test('returns false when elapsed is negative (backward-time guard)', () {
+      expect(
+        shouldAutoLock(elapsed: const Duration(seconds: -1)),
+        isFalse,
+      );
     });
   });
 }

--- a/test/core/security/wallet_lock_controller_test.dart
+++ b/test/core/security/wallet_lock_controller_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/security/wallet_lock_controller.dart';
+
+void main() {
+  group('shouldAutoLock', () {
+    test('returns false when no hidden timestamp is recorded', () {
+      expect(
+        shouldAutoLock(
+          hiddenAt: null,
+          now: DateTime(2026, 1, 1, 12, 0, 0),
+        ),
+        isFalse,
+      );
+    });
+
+    test('returns false when hidden duration is shorter than threshold', () {
+      final hiddenAt = DateTime(2026, 1, 1, 12, 0, 0);
+      final now = hiddenAt.add(kAutoLockBackgroundTimeout - const Duration(seconds: 1));
+      expect(shouldAutoLock(hiddenAt: hiddenAt, now: now), isFalse);
+    });
+
+    test('returns true at exactly the threshold boundary', () {
+      final hiddenAt = DateTime(2026, 1, 1, 12, 0, 0);
+      final now = hiddenAt.add(kAutoLockBackgroundTimeout);
+      expect(shouldAutoLock(hiddenAt: hiddenAt, now: now), isTrue);
+    });
+
+    test('returns true when hidden duration exceeds threshold', () {
+      final hiddenAt = DateTime(2026, 1, 1, 12, 0, 0);
+      final now = hiddenAt.add(kAutoLockBackgroundTimeout * 3);
+      expect(shouldAutoLock(hiddenAt: hiddenAt, now: now), isTrue);
+    });
+
+    test('respects a custom threshold override', () {
+      final hiddenAt = DateTime(2026, 1, 1, 12, 0, 0);
+      final now = hiddenAt.add(const Duration(seconds: 30));
+      expect(
+        shouldAutoLock(
+          hiddenAt: hiddenAt,
+          now: now,
+          threshold: const Duration(seconds: 15),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldAutoLock(
+          hiddenAt: hiddenAt,
+          now: now,
+          threshold: const Duration(minutes: 1),
+        ),
+        isFalse,
+      );
+    });
+
+    test('default threshold is 10 minutes', () {
+      expect(kAutoLockBackgroundTimeout, const Duration(minutes: 10));
+    });
+  });
+}

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -361,6 +361,58 @@ void main() {
       expect(await store.readPlain(_mnemonicKey), isNull);
     },
   );
+
+  test('deleteAll waits for concurrent mnemonic writes', () async {
+    const lateMnemonicKey = 'zcash_account_mnemonic_delete-all-account';
+    const lateMnemonic = 'legal winner thank year wave sausage worth useful';
+    final blockingStorage = _BlockingWriteStorage(blockKey: lateMnemonicKey);
+    store = AppSecureStore.testing(storage: blockingStorage);
+    await store.configurePassword(_oldPassword);
+
+    blockingStorage.blockNextWrite = true;
+    final lateWrite = store.writeSecretString(lateMnemonicKey, lateMnemonic);
+    await blockingStorage.writeStarted.future;
+
+    var deleteAllCompleted = false;
+    final deleteAll = store.deleteAll().then((_) {
+      deleteAllCompleted = true;
+    });
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(deleteAllCompleted, isFalse);
+
+    blockingStorage.release();
+    await lateWrite;
+    await deleteAll;
+
+    expect(await store.readPlain(lateMnemonicKey), isNull);
+    expect(store.hasSessionPassword, isFalse);
+  });
+
+  test('clearPasswordConfiguration waits for concurrent mnemonic writes', () async {
+    const lateMnemonicKey = 'zcash_account_mnemonic_clear-password-account';
+    const lateMnemonic = 'legal winner thank year wave sausage worth useful';
+    final blockingStorage = _BlockingWriteStorage(blockKey: lateMnemonicKey);
+    store = AppSecureStore.testing(storage: blockingStorage);
+    await store.configurePassword(_oldPassword);
+
+    blockingStorage.blockNextWrite = true;
+    final lateWrite = store.writeSecretString(lateMnemonicKey, lateMnemonic);
+    await blockingStorage.writeStarted.future;
+
+    var clearCompleted = false;
+    final clear = store.clearPasswordConfiguration().then((_) {
+      clearCompleted = true;
+    });
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(clearCompleted, isFalse);
+
+    blockingStorage.release();
+    await lateWrite;
+    await clear;
+
+    expect(await store.readPlain(lateMnemonicKey), isNotNull);
+    expect(store.hasSessionPassword, isFalse);
+  });
 }
 
 class _FailingWriteStorage extends FlutterSecureStorage {

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/security/password_policy.dart';
@@ -9,6 +10,7 @@ import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 const _oldPassword = 'Oldpass1!';
 const _newPassword = 'Newpass1!';
 const _wrongPassword = 'Wrongpass1!';
+const _accountUuid = 'test-account';
 const _mnemonicKey = 'zcash_account_mnemonic_test-account';
 const _externalEncryptedKey = 'external_encrypted_key';
 const _mnemonic = 'abandon abandon abandon abandon abandon abandon';
@@ -16,25 +18,29 @@ const _mnemonic = 'abandon abandon abandon abandon abandon abandon';
 const _passwordVerifierKey = 'zcash_password_verifier';
 const _passwordVerifierSaltKey = 'zcash_password_verifier_salt';
 const _rotationInProgressKey = 'zcash_rotation_in_progress';
+const _migrationCompleteKey = 'zcash_mnemonic_storage_migrated_v1';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late AppSecureStore store;
+  TargetPlatform? previousTargetPlatform;
 
   setUp(() async {
+    previousTargetPlatform = debugDefaultTargetPlatformOverride;
     FlutterSecureStorage.setMockInitialValues({});
-    store = AppSecureStore.instance;
+    store = AppSecureStore.testing(storage: const FlutterSecureStorage());
     await store.deleteAll();
   });
 
   tearDown(() async {
     await store.deleteAll();
+    debugDefaultTargetPlatformOverride = previousTargetPlatform;
   });
 
   test('changePassword rotates mnemonic payloads and verifier', () async {
     await store.configurePassword(_oldPassword);
-    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
 
     final didChange = await store.changePassword(
       currentPassword: _oldPassword,
@@ -46,7 +52,7 @@ void main() {
     store.clearSessionPassword();
     expect(await store.verifyPasswordOnly(_oldPassword), isFalse);
     expect(await store.verifyPassword(_newPassword), isTrue);
-    expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+    expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
   });
 
   test('changePassword journal stores only roll-forward data', () async {
@@ -55,7 +61,7 @@ void main() {
     );
     store = AppSecureStore.testing(storage: blockingStorage);
     await store.configurePassword(_oldPassword);
-    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
     final originalPayload = await store.readPlain(_mnemonicKey);
     final oldVerifier = await store.readPlain(_passwordVerifierKey);
 
@@ -112,7 +118,7 @@ void main() {
       store.clearSessionPassword();
       expect(await store.verifyPasswordOnly(_oldPassword), isFalse);
       expect(await store.verifyPassword(_newPassword), isTrue);
-      expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+      expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
     },
   );
 
@@ -132,7 +138,7 @@ void main() {
       expect(await store.readPlain(_rotationInProgressKey), isNull);
       expect(await store.readPlain(_mnemonicKey), originalPayload);
       expect(await store.verifyPassword(_oldPassword), isTrue);
-      expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+      expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
     },
   );
 
@@ -156,7 +162,7 @@ void main() {
 
   test('changePassword only rotates app-managed mnemonic payloads', () async {
     await store.configurePassword(_oldPassword);
-    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
     await store.writeSecretString(_externalEncryptedKey, 'external secret');
     final externalPayload = await store.readPlain(_externalEncryptedKey);
 
@@ -167,7 +173,7 @@ void main() {
 
     expect(didChange, isTrue);
     expect(await store.readPlain(_externalEncryptedKey), externalPayload);
-    expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+    expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
   });
 
   test('changePassword rejects unreadable mnemonic payloads', () async {
@@ -192,7 +198,7 @@ void main() {
     final failingStorage = _FailingWriteStorage(failKey: _passwordVerifierKey);
     store = AppSecureStore.testing(storage: failingStorage);
     await store.configurePassword(_oldPassword);
-    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
     final originalPayload = await store.readPlain(_mnemonicKey);
 
     failingStorage.failNextMatchingWrite = true;
@@ -215,7 +221,7 @@ void main() {
     expect(await store.readPlain(_mnemonicKey), originalPayload);
     expect(await store.verifyPasswordOnly(_newPassword), isFalse);
     expect(await store.verifyPassword(_oldPassword), isTrue);
-    expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+    expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
   });
 
   test(
@@ -257,20 +263,21 @@ void main() {
       expect(await store.readPlain(_rotationInProgressKey), isNull);
       expect(await store.verifyPasswordOnly(_oldPassword), isFalse);
       expect(await store.verifyPassword(_newPassword), isTrue);
-      expect(await store.readSecretStringWithOptions(_mnemonicKey), _mnemonic);
+      expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
     },
   );
 
   test('changePassword waits for concurrent mnemonic writes', () async {
+    const lateAccountUuid = 'late-account';
     const lateMnemonicKey = 'zcash_account_mnemonic_late-account';
     const lateMnemonic = 'legal winner thank year wave sausage worth useful';
     final blockingStorage = _BlockingWriteStorage(blockKey: lateMnemonicKey);
     store = AppSecureStore.testing(storage: blockingStorage);
     await store.configurePassword(_oldPassword);
-    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
 
     blockingStorage.blockNextWrite = true;
-    final lateWrite = store.writeSecretString(lateMnemonicKey, lateMnemonic);
+    final lateWrite = store.writeAccountMnemonic(lateAccountUuid, lateMnemonic);
     await blockingStorage.writeStarted.future;
 
     final rotation = store.changePassword(
@@ -293,10 +300,7 @@ void main() {
 
     store.clearSessionPassword();
     expect(await store.verifyPassword(_newPassword), isTrue);
-    expect(
-      await store.readSecretStringWithOptions(lateMnemonicKey),
-      lateMnemonic,
-    );
+    expect(await store.readAccountMnemonic(lateAccountUuid), lateMnemonic);
   });
 
   test(
@@ -342,7 +346,7 @@ void main() {
       );
       store = AppSecureStore.testing(storage: blockingStorage);
       await store.configurePassword(_oldPassword);
-      await store.writeSecretString(_mnemonicKey, _mnemonic);
+      await store.writeAccountMnemonic(_accountUuid, _mnemonic);
 
       blockingStorage.blockNextWrite = true;
       final rotation = store.changePassword(
@@ -351,14 +355,176 @@ void main() {
       );
       await blockingStorage.writeStarted.future;
 
-      final delete = store.delete(_mnemonicKey);
+      final delete = store.deleteAccountMnemonic(_accountUuid);
       blockingStorage.release();
       await rotation;
       await delete;
 
       store.clearSessionPassword();
       expect(await store.verifyPassword(_newPassword), isTrue);
-      expect(await store.readPlain(_mnemonicKey), isNull);
+      expect(await store.readAccountMnemonic(_accountUuid), isNull);
+    },
+  );
+
+  test('account mnemonic writes use mnemonic storage only', () async {
+    final regularStorage = _MapStorage('regular');
+    final mnemonicStorage = _MapStorage('mnemonic');
+    store = AppSecureStore.testing(
+      storage: regularStorage,
+      mnemonicStorage: mnemonicStorage,
+    );
+
+    await store.configurePassword(_oldPassword);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
+
+    expect(regularStorage.valueFor(_mnemonicKey), isNull);
+    expect(mnemonicStorage.valueFor(_mnemonicKey), isNotNull);
+    expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
+  });
+
+  test(
+    'locked mnemonic read skips keychain when session is required',
+    () async {
+      final operations = <String>[];
+      final regularStorage = _MapStorage('regular', operations: operations);
+      final mnemonicStorage = _MapStorage('mnemonic', operations: operations);
+      store = AppSecureStore.testing(
+        storage: regularStorage,
+        mnemonicStorage: mnemonicStorage,
+      );
+
+      await store.configurePassword(_oldPassword);
+      await store.writeAccountMnemonic(_accountUuid, _mnemonic);
+      store.clearSessionPassword();
+      operations.clear();
+
+      expect(
+        await store.readAccountMnemonic(
+          _accountUuid,
+          requireUnlockedSession: true,
+        ),
+        isNull,
+      );
+      expect(operations, isEmpty);
+    },
+  );
+
+  test(
+    'macOS unlock migrates legacy mnemonic payloads write then delete',
+    () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final operations = <String>[];
+      final regularStorage = _MapStorage('regular', operations: operations);
+      final mnemonicStorage = _MapStorage('mnemonic', operations: operations);
+      store = AppSecureStore.testing(
+        storage: regularStorage,
+        mnemonicStorage: mnemonicStorage,
+      );
+
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(_mnemonicKey, _mnemonic);
+      store.clearSessionPassword();
+      operations.clear();
+
+      expect(await store.verifyPassword(_oldPassword), isTrue);
+
+      expect(regularStorage.valueFor(_mnemonicKey), isNull);
+      expect(mnemonicStorage.valueFor(_mnemonicKey), isNotNull);
+      expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
+      expect(
+        operations,
+        containsAllInOrder([
+          'mnemonic.write $_mnemonicKey',
+          'regular.delete $_mnemonicKey',
+        ]),
+      );
+    },
+  );
+
+  test('macOS mnemonic migration flag skips repeated legacy scans', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final operations = <String>[];
+    final regularStorage = _MapStorage('regular', operations: operations);
+    final mnemonicStorage = _MapStorage('mnemonic', operations: operations);
+    store = AppSecureStore.testing(
+      storage: regularStorage,
+      mnemonicStorage: mnemonicStorage,
+    );
+
+    await store.configurePassword(_oldPassword);
+    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    store.clearSessionPassword();
+
+    expect(await store.verifyPassword(_oldPassword), isTrue);
+    expect(regularStorage.valueFor(_migrationCompleteKey), 'true');
+    expect(operations, contains('regular.readAll'));
+
+    operations.clear();
+    store.clearSessionPassword();
+
+    expect(await store.verifyPassword(_oldPassword), isTrue);
+    expect(operations, isNot(contains('regular.readAll')));
+  });
+
+  test('macOS unlock fails if mnemonic copy migration fails', () async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+    final regularStorage = _MapStorage('regular');
+    final mnemonicStorage = _FailingMapStorage('mnemonic');
+    store = AppSecureStore.testing(
+      storage: regularStorage,
+      mnemonicStorage: mnemonicStorage,
+    );
+
+    await store.configurePassword(_oldPassword);
+    await store.writeSecretString(_mnemonicKey, _mnemonic);
+    store.clearSessionPassword();
+    mnemonicStorage.failNextWriteFor(_mnemonicKey);
+
+    expect(await store.verifyPassword(_oldPassword), isFalse);
+    expect(store.hasSessionPassword, isFalse);
+    expect(regularStorage.valueFor(_mnemonicKey), isNotNull);
+    expect(mnemonicStorage.valueFor(_mnemonicKey), isNull);
+    expect(regularStorage.valueFor(_migrationCompleteKey), isNull);
+  });
+
+  test(
+    'macOS unlock allows legacy cleanup retry after delete failure',
+    () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final regularStorage = _FailingMapStorage('regular');
+      final mnemonicStorage = _MapStorage('mnemonic');
+      store = AppSecureStore.testing(
+        storage: regularStorage,
+        mnemonicStorage: mnemonicStorage,
+      );
+
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(_mnemonicKey, _mnemonic);
+      store.clearSessionPassword();
+      regularStorage.failNextDeleteFor(_mnemonicKey);
+
+      expect(await store.verifyPassword(_oldPassword), isTrue);
+      expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
+      expect(regularStorage.valueFor(_mnemonicKey), isNotNull);
+      expect(regularStorage.valueFor(_migrationCompleteKey), isNull);
+    },
+  );
+
+  test(
+    'macOS mnemonic reads do not fallback before unlock migration',
+    () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final regularStorage = _MapStorage('regular');
+      final mnemonicStorage = _MapStorage('mnemonic');
+      store = AppSecureStore.testing(
+        storage: regularStorage,
+        mnemonicStorage: mnemonicStorage,
+      );
+
+      await store.configurePassword(_oldPassword);
+      await store.writeSecretString(_mnemonicKey, _mnemonic);
+
+      expect(await store.readAccountMnemonic(_accountUuid), isNull);
     },
   );
 
@@ -388,31 +554,34 @@ void main() {
     expect(store.hasSessionPassword, isFalse);
   });
 
-  test('clearPasswordConfiguration waits for concurrent mnemonic writes', () async {
-    const lateMnemonicKey = 'zcash_account_mnemonic_clear-password-account';
-    const lateMnemonic = 'legal winner thank year wave sausage worth useful';
-    final blockingStorage = _BlockingWriteStorage(blockKey: lateMnemonicKey);
-    store = AppSecureStore.testing(storage: blockingStorage);
-    await store.configurePassword(_oldPassword);
+  test(
+    'clearPasswordConfiguration waits for concurrent mnemonic writes',
+    () async {
+      const lateMnemonicKey = 'zcash_account_mnemonic_clear-password-account';
+      const lateMnemonic = 'legal winner thank year wave sausage worth useful';
+      final blockingStorage = _BlockingWriteStorage(blockKey: lateMnemonicKey);
+      store = AppSecureStore.testing(storage: blockingStorage);
+      await store.configurePassword(_oldPassword);
 
-    blockingStorage.blockNextWrite = true;
-    final lateWrite = store.writeSecretString(lateMnemonicKey, lateMnemonic);
-    await blockingStorage.writeStarted.future;
+      blockingStorage.blockNextWrite = true;
+      final lateWrite = store.writeSecretString(lateMnemonicKey, lateMnemonic);
+      await blockingStorage.writeStarted.future;
 
-    var clearCompleted = false;
-    final clear = store.clearPasswordConfiguration().then((_) {
-      clearCompleted = true;
-    });
-    await Future<void>.delayed(const Duration(milliseconds: 20));
-    expect(clearCompleted, isFalse);
+      var clearCompleted = false;
+      final clear = store.clearPasswordConfiguration().then((_) {
+        clearCompleted = true;
+      });
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(clearCompleted, isFalse);
 
-    blockingStorage.release();
-    await lateWrite;
-    await clear;
+      blockingStorage.release();
+      await lateWrite;
+      await clear;
 
-    expect(await store.readPlain(lateMnemonicKey), isNotNull);
-    expect(store.hasSessionPassword, isFalse);
-  });
+      expect(await store.readPlain(lateMnemonicKey), isNotNull);
+      expect(store.hasSessionPassword, isFalse);
+    },
+  );
 }
 
 class _FailingWriteStorage extends FlutterSecureStorage {
@@ -439,6 +608,155 @@ class _FailingWriteStorage extends FlutterSecureStorage {
     return super.write(
       key: key,
       value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
+}
+
+class _MapStorage extends FlutterSecureStorage {
+  _MapStorage(this.name, {List<String>? operations})
+    : operations = operations ?? <String>[];
+
+  final String name;
+  final List<String> operations;
+  final _values = <String, String>{};
+
+  String? valueFor(String key) => _values[key];
+
+  @override
+  Future<String?> read({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    operations.add('$name.read $key');
+    return _values[key];
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    operations.add('$name.write $key');
+    if (value == null) {
+      _values.remove(key);
+      return;
+    }
+    _values[key] = value;
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    operations.add('$name.delete $key');
+    _values.remove(key);
+  }
+
+  @override
+  Future<Map<String, String>> readAll({
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    operations.add('$name.readAll');
+    return Map<String, String>.from(_values);
+  }
+
+  @override
+  Future<void> deleteAll({
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    operations.add('$name.deleteAll');
+    _values.clear();
+  }
+}
+
+class _FailingMapStorage extends _MapStorage {
+  _FailingMapStorage(super.name);
+
+  final _failNextWrite = <String>{};
+  final _failNextDelete = <String>{};
+
+  void failNextWriteFor(String key) {
+    _failNextWrite.add(key);
+  }
+
+  void failNextDeleteFor(String key) {
+    _failNextDelete.add(key);
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String? value,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) {
+    if (_failNextWrite.remove(key)) {
+      throw StateError('forced map write failure for $key');
+    }
+    return super.write(
+      key: key,
+      value: value,
+      iOptions: iOptions,
+      aOptions: aOptions,
+      lOptions: lOptions,
+      webOptions: webOptions,
+      mOptions: mOptions,
+      wOptions: wOptions,
+    );
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) {
+    if (_failNextDelete.remove(key)) {
+      throw StateError('forced map delete failure for $key');
+    }
+    return super.delete(
+      key: key,
       iOptions: iOptions,
       aOptions: aOptions,
       lOptions: lOptions,


### PR DESCRIPTION
## Summary

Adds an auto-lock layer so the wallet locks itself after the UI has been
hidden for 10 minutes, then re-prompts for the password on next activation.
Previously the wallet stayed unlocked indefinitely while the app was in
the background, relying only on manual Sign Out or cold-start memory
wipes for protection.

- New `AutoLockObserver` widget mounts a single `AppLifecycleListener`
  inside `MaterialApp.builder` so the timer survives route transitions.
- Shared `lockWalletSession` helper centralises the lock sequence
  (`securityNotifier.lock()` + both `clearSensitiveStateForLock` calls),
  used by both the sidebar Sign Out and the new observer so the two
  paths cannot drift.
- `onHide`/`onShow` chosen over `onPause`/`onResume` so brief iOS
  `inactive` transitions (Control Center pull-down, incoming-call
  banner) do not start the clock.
- Elapsed time is measured against **both** a monotonic `Stopwatch`
  and `DateTime.now()`; the wallet locks if either source exceeds the
  threshold. The monotonic clock defeats wall-clock manipulation
  attacks (manual system-time change or NTP step), and the wall clock
  covers iOS/macOS deep-sleep cases where `mach_absolute_time()`
  pauses while the device is suspended.
- Threshold defined as `kAutoLockBackgroundTimeout = Duration(minutes: 10)`