### PR TITLE
[codex] Refine Keystone connect and scan guidance

### DIFF
--- a/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
+++ b/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
@@ -647,7 +647,14 @@ class _TroubleScanningTip extends StatelessWidget {
 
     return Padding(
       padding: const EdgeInsets.only(bottom: AppSpacing.xxs),
-      child: Text(text, style: style),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('•', style: style),
+          const SizedBox(width: AppSpacing.xxs),
+          Expanded(child: Text(text, style: style)),
+        ],
+      ),
     );
   }
 }

--- a/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
+++ b/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
@@ -71,6 +71,8 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
     return MobileScannerController(
       cameraId: cameraId,
       facing: defaultQrScannerFacing,
+      formats: QrScanner.formats,
+      detectionSpeed: QrScanner.detectionSpeed,
     );
   }
 
@@ -943,7 +945,7 @@ class _ScanOverlay extends StatelessWidget {
 class _ScanOverlayPainter extends CustomPainter {
   const _ScanOverlayPainter();
 
-  static const _cutoutSize = 210.0;
+  static const _cutoutSize = 250.0;
   static const _cutoutRadius = 32.0;
   static const _strokeWidth = 5.0;
   static const _cornerArmLength = 12.0;

--- a/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
+++ b/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
@@ -134,13 +134,21 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
   void _toggleCameraPicker() {
     if (_cameras.length < 2 || widget.decoding) return;
     setState(() {
+      _troubleScanningOpen = false;
       _cameraPickerOpen = !_cameraPickerOpen;
     });
   }
 
   void _toggleTroubleScanning() {
     setState(() {
+      _cameraPickerOpen = false;
       _troubleScanningOpen = !_troubleScanningOpen;
+    });
+  }
+
+  void _dismissTroubleScanning() {
+    setState(() {
+      _troubleScanningOpen = false;
     });
   }
 
@@ -260,196 +268,215 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
               borderRadius: BorderRadius.circular(_outerRadius),
             ),
             clipBehavior: Clip.antiAlias,
-            child: Column(
+            child: Stack(
               children: [
-                SizedBox(
-                  width: _cameraWidth,
-                  height: _cameraHeight,
-                  child: Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(_cameraRadius),
-                        clipBehavior: Clip.antiAliasWithSaveLayer,
-                        child: DecoratedBox(
-                          decoration: BoxDecoration(
-                            color: colors.background.base,
-                          ),
-                          child: ValueListenableBuilder<MobileScannerState>(
-                            valueListenable: _controller,
-                            builder: (context, scannerState, _) {
-                              final accessStatus = _cameraAccessStatus(
-                                scannerState,
-                              );
-                              final canScan =
-                                  accessStatus == _CameraAccessStatus.active;
+                Column(
+                  children: [
+                    SizedBox(
+                      width: _cameraWidth,
+                      height: _cameraHeight,
+                      child: Stack(
+                        fit: StackFit.expand,
+                        children: [
+                          ClipRRect(
+                            borderRadius: BorderRadius.circular(_cameraRadius),
+                            clipBehavior: Clip.antiAliasWithSaveLayer,
+                            child: DecoratedBox(
+                              decoration: BoxDecoration(
+                                color: colors.background.base,
+                              ),
+                              child: ValueListenableBuilder<MobileScannerState>(
+                                valueListenable: _controller,
+                                builder: (context, scannerState, _) {
+                                  final accessStatus = _cameraAccessStatus(
+                                    scannerState,
+                                  );
+                                  final canScan =
+                                      accessStatus ==
+                                      _CameraAccessStatus.active;
 
-                              return Stack(
-                                fit: StackFit.expand,
-                                clipBehavior: Clip.none,
-                                children: [
-                                  if (QrScanner.isAvailable)
-                                    AnimatedUrScannerView(
-                                      controller: _controller,
-                                      expectedUrType: widget.expectedUrType,
-                                      scanSessionResetToken:
-                                          _scanSessionResetToken,
-                                      onProgress: _handleScanProgress,
-                                      onDecodeError: widget.onDecodeError,
-                                      onComplete: _handleScanComplete,
-                                    )
-                                  else
-                                    Center(
-                                      child: Padding(
-                                        padding: const EdgeInsets.all(
-                                          AppSpacing.md,
-                                        ),
-                                        child: Text(
-                                          widget.unavailableMessage,
-                                          style: AppTypography.bodyMediumStrong
-                                              .copyWith(
-                                                color: colors.text.accent,
-                                              ),
-                                          textAlign: TextAlign.center,
-                                        ),
-                                      ),
-                                    ),
-                                  if (canScan) const _ScanOverlay(),
-                                  if (canScan &&
-                                      _scanProgress > 0 &&
-                                      _scanProgress < 100 &&
-                                      !widget.decoding)
-                                    Positioned(
-                                      left: 0,
-                                      right: 0,
-                                      bottom: 20,
-                                      child: Center(
-                                        child: _QrScanProgressBar(
-                                          progress: _scanProgress / 100,
-                                        ),
-                                      ),
-                                    ),
-                                  if (canScan && widget.decoding)
-                                    Positioned(
-                                      left: -2,
-                                      top: -2,
-                                      right: -2,
-                                      bottom: -2,
-                                      child: KeystoneTransactionProgressOverlay(
-                                        label: widget.decodingLabel,
-                                        borderRadius: BorderRadius.circular(
-                                          _cameraRadius,
-                                        ),
-                                      ),
-                                    ),
-                                  if (canScan && _cameraPickerOpen)
-                                    AppPaneModalOverlay(
-                                      onDismiss: _toggleCameraPicker,
-                                      borderRadius: BorderRadius.circular(
-                                        _cameraRadius,
-                                      ),
-                                      child: _CameraPickerModal(
-                                        cameras: _cameras,
-                                        selectedCameraId:
-                                            _selectedCameraId ??
-                                            _controller.value.camera?.id,
-                                        onSelect: _selectCamera,
-                                        onCancel: _toggleCameraPicker,
-                                      ),
-                                    ),
-                                  if (accessStatus ==
-                                      _CameraAccessStatus.requesting)
-                                    const _CameraPermissionPrompt(
-                                      icon: AppIcons.camera,
-                                      title: 'Enable the Camera access',
-                                      description:
-                                          'A Camera is required to connect Keystone.\n'
-                                          'You can revert this in settings anytime later.',
-                                      iconStyle:
-                                          _CameraPermissionIconStyle.inverse,
-                                    ),
-                                  if (accessStatus ==
-                                      _CameraAccessStatus.denied)
-                                    _CameraPermissionPrompt(
-                                      icon: AppIcons.cameraDenied,
-                                      title: "You've denied the Camera access",
-                                      description:
-                                          'Request again, or enable manually\n'
-                                          'in the System settings.',
-                                      iconStyle:
-                                          _CameraPermissionIconStyle.raised,
-                                      action: AppButton(
-                                        onPressed: () => unawaited(
-                                          _retryCameraStart(
-                                            openSettingsOnDenied: true,
+                                  return Stack(
+                                    fit: StackFit.expand,
+                                    clipBehavior: Clip.none,
+                                    children: [
+                                      if (QrScanner.isAvailable)
+                                        AnimatedUrScannerView(
+                                          controller: _controller,
+                                          expectedUrType: widget.expectedUrType,
+                                          scanSessionResetToken:
+                                              _scanSessionResetToken,
+                                          onProgress: _handleScanProgress,
+                                          onDecodeError: widget.onDecodeError,
+                                          onComplete: _handleScanComplete,
+                                        )
+                                      else
+                                        Center(
+                                          child: Padding(
+                                            padding: const EdgeInsets.all(
+                                              AppSpacing.md,
+                                            ),
+                                            child: Text(
+                                              widget.unavailableMessage,
+                                              style: AppTypography
+                                                  .bodyMediumStrong
+                                                  .copyWith(
+                                                    color: colors.text.accent,
+                                                  ),
+                                              textAlign: TextAlign.center,
+                                            ),
                                           ),
                                         ),
-                                        variant: AppButtonVariant.secondary,
-                                        size: AppButtonSize.medium,
-                                        minWidth: 96,
-                                        leading: const AppIcon(AppIcons.renew),
-                                        child: const Text('Request again'),
-                                      ),
-                                    ),
-                                ],
-                              );
-                            },
-                          ),
-                        ),
-                      ),
-                      Positioned.fill(
-                        child: IgnorePointer(
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(
-                              borderRadius: BorderRadius.circular(
-                                _cameraRadius,
-                              ),
-                              border: Border.all(
-                                color: colors.border.subtleOpacity,
-                                width: 2,
+                                      if (canScan) const _ScanOverlay(),
+                                      if (canScan &&
+                                          _scanProgress > 0 &&
+                                          _scanProgress < 100 &&
+                                          !widget.decoding)
+                                        Positioned(
+                                          left: 0,
+                                          right: 0,
+                                          bottom: 20,
+                                          child: Center(
+                                            child: _QrScanProgressBar(
+                                              progress: _scanProgress / 100,
+                                            ),
+                                          ),
+                                        ),
+                                      if (canScan && widget.decoding)
+                                        Positioned(
+                                          left: -2,
+                                          top: -2,
+                                          right: -2,
+                                          bottom: -2,
+                                          child:
+                                              KeystoneTransactionProgressOverlay(
+                                                label: widget.decodingLabel,
+                                                borderRadius:
+                                                    BorderRadius.circular(
+                                                      _cameraRadius,
+                                                    ),
+                                              ),
+                                        ),
+                                      if (canScan && _cameraPickerOpen)
+                                        AppPaneModalOverlay(
+                                          onDismiss: _toggleCameraPicker,
+                                          borderRadius: BorderRadius.circular(
+                                            _cameraRadius,
+                                          ),
+                                          child: _CameraPickerModal(
+                                            cameras: _cameras,
+                                            selectedCameraId:
+                                                _selectedCameraId ??
+                                                _controller.value.camera?.id,
+                                            onSelect: _selectCamera,
+                                            onCancel: _toggleCameraPicker,
+                                          ),
+                                        ),
+                                      if (accessStatus ==
+                                          _CameraAccessStatus.requesting)
+                                        const _CameraPermissionPrompt(
+                                          icon: AppIcons.camera,
+                                          title: 'Enable the Camera access',
+                                          description:
+                                              'A Camera is required to connect Keystone.\n'
+                                              'You can revert this in settings anytime later.',
+                                          iconStyle: _CameraPermissionIconStyle
+                                              .inverse,
+                                        ),
+                                      if (accessStatus ==
+                                          _CameraAccessStatus.denied)
+                                        _CameraPermissionPrompt(
+                                          icon: AppIcons.cameraDenied,
+                                          title:
+                                              "You've denied the Camera access",
+                                          description:
+                                              'Request again, or enable manually\n'
+                                              'in the System settings.',
+                                          iconStyle:
+                                              _CameraPermissionIconStyle.raised,
+                                          action: AppButton(
+                                            onPressed: () => unawaited(
+                                              _retryCameraStart(
+                                                openSettingsOnDenied: true,
+                                              ),
+                                            ),
+                                            variant: AppButtonVariant.secondary,
+                                            size: AppButtonSize.medium,
+                                            minWidth: 96,
+                                            leading: const AppIcon(
+                                              AppIcons.renew,
+                                            ),
+                                            child: const Text('Request again'),
+                                          ),
+                                        ),
+                                    ],
+                                  );
+                                },
                               ),
                             ),
                           ),
+                          Positioned.fill(
+                            child: IgnorePointer(
+                              child: DecoratedBox(
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(
+                                    _cameraRadius,
+                                  ),
+                                  border: Border.all(
+                                    color: colors.border.subtleOpacity,
+                                    width: 2,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                    _TroubleScanningDisclosure(
+                      expanded: _troubleScanningOpen,
+                      onToggle: _toggleTroubleScanning,
+                    ),
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(minHeight: 56),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: AppSpacing.s,
+                          vertical: AppSpacing.sm,
+                        ),
+                        child: ValueListenableBuilder<MobileScannerState>(
+                          valueListenable: _controller,
+                          builder: (context, scannerState, _) {
+                            final accessStatus = _cameraAccessStatus(
+                              scannerState,
+                            );
+                            if (accessStatus != _CameraAccessStatus.active) {
+                              return const SizedBox.shrink();
+                            }
+                            final canChooseCamera =
+                                _cameras.length > 1 &&
+                                !widget.decoding &&
+                                scannerState.isInitialized;
+                            return _CameraControlRow(
+                              label: _cameraLabel(scannerState),
+                              canChooseCamera: canChooseCamera,
+                              disabled: widget.decoding,
+                              onTap: _toggleCameraPicker,
+                            );
+                          },
                         ),
                       ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: AppSpacing.sm),
-                const _ScanHelperText(),
-                const SizedBox(height: AppSpacing.xxs),
-                _TroubleScanningDisclosure(
-                  expanded: _troubleScanningOpen,
-                  onToggle: _toggleTroubleScanning,
-                ),
-                ConstrainedBox(
-                  constraints: const BoxConstraints(minHeight: 56),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: AppSpacing.s,
-                      vertical: AppSpacing.sm,
                     ),
-                    child: ValueListenableBuilder<MobileScannerState>(
-                      valueListenable: _controller,
-                      builder: (context, scannerState, _) {
-                        final accessStatus = _cameraAccessStatus(scannerState);
-                        if (accessStatus != _CameraAccessStatus.active) {
-                          return const SizedBox.shrink();
-                        }
-                        final canChooseCamera =
-                            _cameras.length > 1 &&
-                            !widget.decoding &&
-                            scannerState.isInitialized;
-                        return _CameraControlRow(
-                          label: _cameraLabel(scannerState),
-                          canChooseCamera: canChooseCamera,
-                          disabled: widget.decoding,
-                          onTap: _toggleCameraPicker,
-                        );
-                      },
+                  ],
+                ),
+                if (_troubleScanningOpen)
+                  AppPaneModalOverlay(
+                    onDismiss: _dismissTroubleScanning,
+                    borderRadius: BorderRadius.circular(_outerRadius),
+                    child: _TroubleScanningPopover(
+                      onDismiss: _dismissTroubleScanning,
                     ),
                   ),
-                ),
               ],
             ),
           ),
@@ -473,23 +500,6 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
             ),
           ],
         ],
-      ),
-    );
-  }
-}
-
-class _ScanHelperText extends StatelessWidget {
-  const _ScanHelperText();
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s),
-      child: Text(
-        'Hold the QR code steady in front of your camera.',
-        style: AppTypography.bodyMedium.copyWith(color: colors.text.secondary),
-        textAlign: TextAlign.center,
       ),
     );
   }
@@ -562,21 +572,61 @@ class _TroubleScanningDisclosure extends StatelessWidget {
               ),
             ),
           ),
-          if (expanded) ...[
-            const SizedBox(height: AppSpacing.xxs),
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: AppSpacing.xs,
-                vertical: AppSpacing.xxs,
+        ],
+      ),
+    );
+  }
+}
+
+class _TroubleScanningPopover extends StatelessWidget {
+  const _TroubleScanningPopover({required this.onDismiss});
+
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Container(
+      width: 360,
+      padding: const EdgeInsets.all(AppSpacing.sm),
+      decoration: BoxDecoration(
+        color: colors.background.ground,
+        borderRadius: BorderRadius.circular(AppRadii.large),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Trouble scanning?',
+                  style: AppTypography.bodyMediumStrong.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
               ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  for (final tip in _tips) _TroubleScanningTip(text: tip),
-                ],
+              MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: onDismiss,
+                  child: Padding(
+                    padding: const EdgeInsets.all(AppSpacing.xxs),
+                    child: AppIcon(
+                      AppIcons.cross,
+                      size: AppIconSize.medium,
+                      color: colors.icon.muted,
+                    ),
+                  ),
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          for (final tip in _TroubleScanningDisclosure._tips)
+            _TroubleScanningTip(text: tip),
         ],
       ),
     );

--- a/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
+++ b/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
@@ -55,6 +55,7 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
   String? _selectedCameraId;
   bool _loadingCameras = false;
   bool _cameraPickerOpen = false;
+  bool _troubleScanningOpen = false;
   int _scanProgress = 0;
   int _scanSessionResetToken = 0;
 
@@ -134,6 +135,12 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
     if (_cameras.length < 2 || widget.decoding) return;
     setState(() {
       _cameraPickerOpen = !_cameraPickerOpen;
+    });
+  }
+
+  void _toggleTroubleScanning() {
+    setState(() {
+      _troubleScanningOpen = !_troubleScanningOpen;
     });
   }
 
@@ -408,6 +415,13 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
                     ],
                   ),
                 ),
+                const SizedBox(height: AppSpacing.sm),
+                const _ScanHelperText(),
+                const SizedBox(height: AppSpacing.xxs),
+                _TroubleScanningDisclosure(
+                  expanded: _troubleScanningOpen,
+                  onToggle: _toggleTroubleScanning,
+                ),
                 ConstrainedBox(
                   constraints: const BoxConstraints(minHeight: 56),
                   child: Padding(
@@ -460,6 +474,130 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
           ],
         ],
       ),
+    );
+  }
+}
+
+class _ScanHelperText extends StatelessWidget {
+  const _ScanHelperText();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s),
+      child: Text(
+        'Hold the QR code steady in front of your camera.',
+        style: AppTypography.bodyMedium.copyWith(color: colors.text.secondary),
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}
+
+class _TroubleScanningDisclosure extends StatelessWidget {
+  const _TroubleScanningDisclosure({
+    required this.expanded,
+    required this.onToggle,
+  });
+
+  static const _tips = [
+    'Tap the QR code on your Keystone to show it full screen. This is the '
+        'easiest fix.',
+    'Move your Keystone a few inches further from the camera so it can focus.',
+    "Make sure the room is well-lit and the QR code isn't reflecting glare.",
+    'On a Mac, you can use Continuity Camera to scan with your iPhone instead.',
+  ];
+
+  final bool expanded;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final labelColor = colors.button.ghost.label;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Align(
+            alignment: Alignment.center,
+            child: Semantics(
+              button: true,
+              toggled: expanded,
+              child: MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: onToggle,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.xxs,
+                      vertical: AppSpacing.xxs,
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          'Trouble scanning?',
+                          style: AppTypography.labelLarge.copyWith(
+                            color: labelColor,
+                          ),
+                        ),
+                        const SizedBox(width: AppSpacing.xxs),
+                        Transform.rotate(
+                          angle: expanded ? math.pi : 0,
+                          child: AppIcon(
+                            AppIcons.expand,
+                            size: AppIconSize.medium,
+                            color: labelColor,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          if (expanded) ...[
+            const SizedBox(height: AppSpacing.xxs),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.xs,
+                vertical: AppSpacing.xxs,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (final tip in _tips) _TroubleScanningTip(text: tip),
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _TroubleScanningTip extends StatelessWidget {
+  const _TroubleScanningTip({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final style = AppTypography.bodyMedium.copyWith(
+      color: colors.text.secondary,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.xxs),
+      child: Text(text, style: style),
     );
   }
 }

--- a/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
+++ b/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
@@ -55,7 +55,7 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
   String? _selectedCameraId;
   bool _loadingCameras = false;
   bool _cameraPickerOpen = false;
-  bool _troubleScanningOpen = false;
+  bool _troubleScanningPopoverOpen = false;
   int _scanProgress = 0;
   int _scanSessionResetToken = 0;
 
@@ -134,7 +134,7 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
   void _toggleCameraPicker() {
     if (_cameras.length < 2 || widget.decoding) return;
     setState(() {
-      _troubleScanningOpen = false;
+      _troubleScanningPopoverOpen = false;
       _cameraPickerOpen = !_cameraPickerOpen;
     });
   }
@@ -142,13 +142,13 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
   void _toggleTroubleScanning() {
     setState(() {
       _cameraPickerOpen = false;
-      _troubleScanningOpen = !_troubleScanningOpen;
+      _troubleScanningPopoverOpen = !_troubleScanningPopoverOpen;
     });
   }
 
   void _dismissTroubleScanning() {
     setState(() {
-      _troubleScanningOpen = false;
+      _troubleScanningPopoverOpen = false;
     });
   }
 
@@ -434,7 +434,6 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
                     ),
                     const SizedBox(height: AppSpacing.xs),
                     _TroubleScanningDisclosure(
-                      expanded: _troubleScanningOpen,
                       onToggle: _toggleTroubleScanning,
                     ),
                     ConstrainedBox(
@@ -469,7 +468,7 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
                     ),
                   ],
                 ),
-                if (_troubleScanningOpen)
+                if (_troubleScanningPopoverOpen)
                   AppPaneModalOverlay(
                     onDismiss: _dismissTroubleScanning,
                     borderRadius: BorderRadius.circular(_cameraRadius),
@@ -505,21 +504,17 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
   }
 }
 
+const _troubleScanningTips = [
+  'Tap the QR code on your Keystone to show it full screen. This is the '
+      'easiest fix.',
+  'Move your Keystone a few inches further from the camera so it can focus.',
+  "Make sure the room is well-lit and the QR code isn't reflecting glare.",
+  'On a Mac, you can use Continuity Camera to scan with your iPhone instead.',
+];
+
 class _TroubleScanningDisclosure extends StatelessWidget {
-  const _TroubleScanningDisclosure({
-    required this.expanded,
-    required this.onToggle,
-  });
+  const _TroubleScanningDisclosure({required this.onToggle});
 
-  static const _tips = [
-    'Tap the QR code on your Keystone to show it full screen. This is the '
-        'easiest fix.',
-    'Move your Keystone a few inches further from the camera so it can focus.',
-    "Make sure the room is well-lit and the QR code isn't reflecting glare.",
-    'On a Mac, you can use Continuity Camera to scan with your iPhone instead.',
-  ];
-
-  final bool expanded;
   final VoidCallback onToggle;
 
   @override
@@ -536,7 +531,6 @@ class _TroubleScanningDisclosure extends StatelessWidget {
             alignment: Alignment.center,
             child: Semantics(
               button: true,
-              toggled: expanded,
               child: MouseRegion(
                 cursor: SystemMouseCursors.click,
                 child: GestureDetector(
@@ -557,13 +551,10 @@ class _TroubleScanningDisclosure extends StatelessWidget {
                           ),
                         ),
                         const SizedBox(width: AppSpacing.xxs),
-                        Transform.rotate(
-                          angle: expanded ? math.pi : 0,
-                          child: AppIcon(
-                            AppIcons.expand,
-                            size: AppIconSize.medium,
-                            color: labelColor,
-                          ),
+                        AppIcon(
+                          AppIcons.expand,
+                          size: AppIconSize.medium,
+                          color: labelColor,
                         ),
                       ],
                     ),
@@ -625,7 +616,7 @@ class _TroubleScanningPopover extends StatelessWidget {
             ],
           ),
           const SizedBox(height: AppSpacing.sm),
-          for (final tip in _TroubleScanningDisclosure._tips)
+          for (final tip in _troubleScanningTips)
             _TroubleScanningTip(text: tip),
         ],
       ),

--- a/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
+++ b/lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart
@@ -472,7 +472,7 @@ class _KeystoneQrScannerCardState extends State<KeystoneQrScannerCard>
                 if (_troubleScanningOpen)
                   AppPaneModalOverlay(
                     onDismiss: _dismissTroubleScanning,
-                    borderRadius: BorderRadius.circular(_outerRadius),
+                    borderRadius: BorderRadius.circular(_cameraRadius),
                     child: _TroubleScanningPopover(
                       onDismiss: _dismissTroubleScanning,
                     ),

--- a/lib/src/features/onboarding/keystone/keystone_how_to_connect_screen.dart
+++ b/lib/src/features/onboarding/keystone/keystone_how_to_connect_screen.dart
@@ -331,10 +331,9 @@ class _ConnectionSteps extends StatelessWidget {
 
   static const _steps = [
     'Unlock your Keystone.',
-    'Tap the ⋯ menu (top right), then choose Connect Software Wallet.',
-    "Vizor isn't listed, so select Zodl. It uses the same connection method.",
-    'Your Keystone will show a moving QR code. Vizor will scan it through '
-        'your webcam, so allow camera access when prompted.',
+    'Tap the ⋯ menu, then Connect Software Wallet.',
+    "Vizor isn't listed. Select Zodl, it uses the same method.",
+    'Allow camera access when prompted. Vizor scans the QR through your webcam.',
   ];
 
   static const _markerWidth = 15.0;

--- a/lib/src/features/onboarding/keystone/keystone_how_to_connect_screen.dart
+++ b/lib/src/features/onboarding/keystone/keystone_how_to_connect_screen.dart
@@ -278,7 +278,7 @@ class _KeystoneCardContent extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(
-            _isPrep ? 'Check Keystone firmware' : 'Prepare to connect',
+            _isPrep ? 'Check your firmware' : 'Prepare to connect',
             style: AppTypography.bodyLarge.copyWith(
               color: colors.text.accent,
               fontWeight: FontWeight.w500,
@@ -304,8 +304,8 @@ class _FirmwareCardBody extends StatelessWidget {
         SizedBox(
           width: 256,
           child: Text(
-            'Check if your Keystone device has the latest version of the '
-            'Cypherpunk firmware, update or install if needed.',
+            'Vizor only works with Keystone devices running the Cypherpunk '
+            'firmware. Update or install it before continuing.',
             style: AppTypography.bodyMedium.copyWith(
               color: colors.text.primary,
             ),
@@ -319,7 +319,7 @@ class _FirmwareCardBody extends StatelessWidget {
           minWidth: 96,
           iconGap: 0,
           leading: const AppIcon(AppIcons.link),
-          child: const Text('Keystone Firmware'),
+          child: const Text('Get Cypherpunk firmware'),
         ),
       ],
     );
@@ -331,9 +331,10 @@ class _ConnectionSteps extends StatelessWidget {
 
   static const _steps = [
     'Unlock your Keystone.',
-    'Tap the ... Menu, then go to Sync',
-    'Open the Zcash QR Code in order to connect.',
-    'Grant camera access in your laptop settings and proceed with QR code import to Vizor.',
+    'Tap the ⋯ menu (top right), then choose Connect Software Wallet.',
+    "Vizor isn't listed, so select Zodl. It uses the same connection method.",
+    'Your Keystone will show a moving QR code. Vizor will scan it through '
+        'your webcam, so allow camera access when prompted.',
   ];
 
   static const _markerWidth = 15.0;

--- a/lib/src/features/onboarding/keystone/keystone_scan_qr_screen.dart
+++ b/lib/src/features/onboarding/keystone/keystone_scan_qr_screen.dart
@@ -91,7 +91,7 @@ class _KeystoneScanQrScreenState extends ConsumerState<KeystoneScanQrScreen> {
                     ),
                     const SizedBox(height: AppSpacing.sm),
                     Text(
-                      'Keep your Keystone steady while we scan',
+                      'Hold the QR code steady in front of your camera',
                       style: AppTypography.bodyMediumStrong.copyWith(
                         color: colors.text.accent,
                       ),

--- a/lib/src/features/onboarding/keystone/keystone_scan_qr_screen.dart
+++ b/lib/src/features/onboarding/keystone/keystone_scan_qr_screen.dart
@@ -91,7 +91,7 @@ class _KeystoneScanQrScreenState extends ConsumerState<KeystoneScanQrScreen> {
                     ),
                     const SizedBox(height: AppSpacing.sm),
                     Text(
-                      'Prepare your Keystone wallet',
+                      'Keep your Keystone steady while we scan',
                       style: AppTypography.bodyMediumStrong.copyWith(
                         color: colors.text.accent,
                       ),

--- a/lib/src/features/send/screens/keystone_send_scan_screen.dart
+++ b/lib/src/features/send/screens/keystone_send_scan_screen.dart
@@ -110,7 +110,7 @@ class _KeystoneSendScanScreenState
                       ),
                       const SizedBox(height: AppSpacing.sm),
                       Text(
-                        'Prepare your Keystone wallet',
+                        'Keep your Keystone steady while we scan',
                         style: AppTypography.bodyMediumStrong.copyWith(
                           color: colors.text.accent,
                         ),

--- a/lib/src/features/send/screens/keystone_send_scan_screen.dart
+++ b/lib/src/features/send/screens/keystone_send_scan_screen.dart
@@ -110,7 +110,7 @@ class _KeystoneSendScanScreenState
                       ),
                       const SizedBox(height: AppSpacing.sm),
                       Text(
-                        'Keep your Keystone steady while we scan',
+                        'Hold the QR code steady in front of your camera',
                         style: AppTypography.bodyMediumStrong.copyWith(
                           color: colors.text.accent,
                         ),

--- a/lib/src/services/qr_scanner.dart
+++ b/lib/src/services/qr_scanner.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
@@ -21,8 +22,29 @@ CameraFacing get defaultQrScannerFacing => _defaultFacing;
 class QrScanner {
   QrScanner._();
 
+  static const formats = <BarcodeFormat>[BarcodeFormat.qrCode];
+  static const detectionSpeed = DetectionSpeed.noDuplicates;
+  static const scanWindowUpdateThreshold = 8.0;
+
   static bool get isAvailable =>
       Platform.isIOS || Platform.isAndroid || Platform.isMacOS;
+
+  static Rect? scanWindowFor(Size layoutSize) {
+    if (!layoutSize.width.isFinite ||
+        !layoutSize.height.isFinite ||
+        layoutSize.width <= 0 ||
+        layoutSize.height <= 0) {
+      return null;
+    }
+
+    final shortestSide = math.min(layoutSize.width, layoutSize.height);
+    final side = math.min(shortestSide * 0.9, 280.0);
+    return Rect.fromCenter(
+      center: layoutSize.center(Offset.zero),
+      width: side,
+      height: side,
+    );
+  }
 }
 
 class ScanResult {
@@ -78,7 +100,11 @@ class _AnimatedUrScannerViewState extends State<AnimatedUrScannerView> {
     _ownsController = controller == null;
     _controller =
         controller ??
-        MobileScannerController(facing: widget.facing ?? _defaultFacing);
+        MobileScannerController(
+          facing: widget.facing ?? _defaultFacing,
+          formats: QrScanner.formats,
+          detectionSpeed: QrScanner.detectionSpeed,
+        );
   }
 
   void _resetScanSession() {
@@ -165,6 +191,15 @@ class _AnimatedUrScannerViewState extends State<AnimatedUrScannerView> {
 
   @override
   Widget build(BuildContext context) {
-    return MobileScanner(controller: _controller, onDetect: _onDetect);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return MobileScanner(
+          controller: _controller,
+          onDetect: _onDetect,
+          scanWindow: QrScanner.scanWindowFor(constraints.biggest),
+          scanWindowUpdateThreshold: QrScanner.scanWindowUpdateThreshold,
+        );
+      },
+    );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -596,8 +596,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: f31f8351106e62ebdf9b2fd9575f14e3ab5f1ebe
-      resolved-ref: f31f8351106e62ebdf9b2fd9575f14e3ab5f1ebe
+      ref: "92141705ce5dc5afdb239fb5af5d512b1a0a726e"
+      resolved-ref: "92141705ce5dc5afdb239fb5af5d512b1a0a726e"
       url: "https://github.com/chainapsis/mobile_scanner.git"
     source: git
     version: "7.2.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   mobile_scanner:
     git:
       url: https://github.com/chainapsis/mobile_scanner.git
-      ref: f31f8351106e62ebdf9b2fd9575f14e3ab5f1ebe
+      ref: 92141705ce5dc5afdb239fb5af5d512b1a0a726e
   desktop_window_bootstrap:
     git:
       url: https://github.com/chainapsis/desktop_window_bootstrap.git


### PR DESCRIPTION
## Summary

- Update the Connect Keystone preparation copy for Cypherpunk firmware and the Zodl-compatible connection flow.
- Update Keystone QR scan subtitles to tell users to hold the QR code steady in front of the camera.
- Add a non-resizing "Trouble scanning?" popover with practical camera/Keystone scanning tips.

## Why

The previous onboarding copy pointed users toward an older/generic Keystone flow and the first help implementation expanded inline, which is risky in the fixed-size macOS window because it can push controls out of view. This keeps the core scanner layout stable while making recovery guidance easier to find.

## Validation

- `fvm flutter analyze lib/src/features/onboarding/keystone/keystone_how_to_connect_screen.dart lib/src/features/onboarding/keystone/keystone_scan_qr_screen.dart lib/src/features/send/screens/keystone_send_scan_screen.dart lib/src/features/keystone/widgets/keystone_qr_scanner_card.dart`
- `fvm flutter build macos --debug`
