### PR TITLE
[codex] Hide shielded renew for hardware accounts

### DIFF
--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -1343,7 +1343,7 @@ class _ReceiveInfoDialog extends StatelessWidget {
                         'Tx details - sender, receiver, and amount - are encrypted on-chain & hidden.',
                   ),
                   _InfoItemData(
-                    iconName: AppIcons.qr,
+                    iconName: AppIcons.keystone,
                     text:
                         "Keystone accounts use one fixed shielded address, so Renew isn't available.",
                   ),

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -1345,7 +1345,7 @@ class _ReceiveInfoDialog extends StatelessWidget {
                   _InfoItemData(
                     iconName: AppIcons.qr,
                     text:
-                        "Keystone provides an Orchard-only shielded address, so Vizor can't renew it from this screen.",
+                        "Keystone accounts use one fixed shielded address, so Renew isn't available.",
                   ),
                 ]
         : [

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -267,6 +267,9 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
       }
     });
 
+    final accountState = ref.watch(accountProvider).value;
+    final canRenewShieldedAddress =
+        accountState?.activeAccount?.isHardware != true;
     final address = _selectedAddress;
     final isShielded = _selectedType == _ReceiveAddressType.shielded;
     final isLoadingSelectedAddress = isShielded
@@ -288,8 +291,11 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
               errorText: selectedErrorText,
               isLoading: isLoadingSelectedAddress,
               isRenewingShielded: _isRenewingShielded,
+              canRenewShieldedAddress: canRenewShieldedAddress,
               onTypeChanged: _selectAddressType,
-              onRenewShielded: isShielded ? _renewShieldedAddress : null,
+              onRenewShielded: isShielded && canRenewShieldedAddress
+                  ? _renewShieldedAddress
+                  : null,
               onCopy: _copySelectedAddress,
               onShowHelp: () => _showAddressInfo(_selectedType),
             ),
@@ -298,6 +304,7 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
                 onDismiss: _dismissAddressInfo,
                 child: _ReceiveInfoDialog(
                   type: infoDialogType,
+                  canRenewShieldedAddress: canRenewShieldedAddress,
                   onClose: _dismissAddressInfo,
                 ),
               ),
@@ -315,6 +322,7 @@ class _ReceivePane extends StatelessWidget {
     required this.errorText,
     required this.isLoading,
     required this.isRenewingShielded,
+    required this.canRenewShieldedAddress,
     required this.onTypeChanged,
     required this.onRenewShielded,
     required this.onCopy,
@@ -326,6 +334,7 @@ class _ReceivePane extends StatelessWidget {
   final String? errorText;
   final bool isLoading;
   final bool isRenewingShielded;
+  final bool canRenewShieldedAddress;
   final ValueChanged<_ReceiveAddressType> onTypeChanged;
   final VoidCallback? onRenewShielded;
   final VoidCallback onCopy;
@@ -357,6 +366,7 @@ class _ReceivePane extends StatelessWidget {
                           address: address,
                           isLoading: isLoading,
                           isRenewingShielded: isRenewingShielded,
+                          canRenewShieldedAddress: canRenewShieldedAddress,
                           onTypeChanged: onTypeChanged,
                           onRenewShielded: onRenewShielded,
                           onShowHelp: onShowHelp,
@@ -404,6 +414,7 @@ class _ReceiveMainContent extends StatelessWidget {
     required this.address,
     required this.isLoading,
     required this.isRenewingShielded,
+    required this.canRenewShieldedAddress,
     required this.onTypeChanged,
     required this.onRenewShielded,
     required this.onShowHelp,
@@ -413,6 +424,7 @@ class _ReceiveMainContent extends StatelessWidget {
   final String address;
   final bool isLoading;
   final bool isRenewingShielded;
+  final bool canRenewShieldedAddress;
   final ValueChanged<_ReceiveAddressType> onTypeChanged;
   final VoidCallback? onRenewShielded;
   final VoidCallback onShowHelp;
@@ -494,6 +506,7 @@ class _ReceiveMainContent extends StatelessWidget {
                             address: address,
                             renewing: isRenewingShielded,
                             metrics: metrics,
+                            canRenewShieldedAddress: canRenewShieldedAddress,
                             onRenew: onRenewShielded,
                             onShowHelp: onShowHelp,
                           ),
@@ -762,6 +775,7 @@ class _ReceiveQrBlock extends StatelessWidget {
     required this.address,
     required this.renewing,
     required this.metrics,
+    required this.canRenewShieldedAddress,
     required this.onRenew,
     required this.onShowHelp,
     super.key,
@@ -771,6 +785,7 @@ class _ReceiveQrBlock extends StatelessWidget {
   final String address;
   final bool renewing;
   final _ReceiveQrMetrics metrics;
+  final bool canRenewShieldedAddress;
   final VoidCallback? onRenew;
   final VoidCallback onShowHelp;
 
@@ -800,7 +815,7 @@ class _ReceiveQrBlock extends StatelessWidget {
                     type: type,
                   ),
                 ),
-                if (_isShielded)
+                if (_isShielded && canRenewShieldedAddress)
                   Positioned(
                     top: metrics.renewTop,
                     child: _RenewButton(
@@ -1287,9 +1302,14 @@ class _CopyAddressButton extends StatelessWidget {
 }
 
 class _ReceiveInfoDialog extends StatelessWidget {
-  const _ReceiveInfoDialog({required this.type, required this.onClose});
+  const _ReceiveInfoDialog({
+    required this.type,
+    required this.canRenewShieldedAddress,
+    required this.onClose,
+  });
 
   final _ReceiveAddressType type;
+  final bool canRenewShieldedAddress;
   final VoidCallback onClose;
 
   bool get _isShielded => type == _ReceiveAddressType.shielded;
@@ -1298,23 +1318,36 @@ class _ReceiveInfoDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final items = _isShielded
-        ? const [
-            _InfoItemData(
-              iconName: AppIcons.lock,
-              text:
-                  'Tx details - sender, receiver, and amount - are encrypted on-chain & hidden.',
-            ),
-            _InfoItemData(
-              iconName: AppIcons.renew,
-              text:
-                  'A new Zcash Shielded address is generated only when you click the Renew button.',
-            ),
-            _InfoItemData(
-              iconName: AppIcons.wallet,
-              text:
-                  'Each new address is a diversified address derived from the same key. They all receive to the same wallet.',
-            ),
-          ]
+        ? canRenewShieldedAddress
+              ? const [
+                  _InfoItemData(
+                    iconName: AppIcons.lock,
+                    text:
+                        'Tx details - sender, receiver, and amount - are encrypted on-chain & hidden.',
+                  ),
+                  _InfoItemData(
+                    iconName: AppIcons.renew,
+                    text:
+                        'A new Zcash Shielded address is generated only when you click the Renew button.',
+                  ),
+                  _InfoItemData(
+                    iconName: AppIcons.wallet,
+                    text:
+                        'Each new address is a diversified address derived from the same key. They all receive to the same wallet.',
+                  ),
+                ]
+              : const [
+                  _InfoItemData(
+                    iconName: AppIcons.lock,
+                    text:
+                        'Tx details - sender, receiver, and amount - are encrypted on-chain & hidden.',
+                  ),
+                  _InfoItemData(
+                    iconName: AppIcons.qr,
+                    text:
+                        "Keystone provides an Orchard-only shielded address, so Vizor can't renew it from this screen.",
+                  ),
+                ]
         : [
             const _InfoItemData(
               iconName: AppIcons.unlock,

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -14,6 +14,61 @@ import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/receive_address_provider.dart';
 
 void main() {
+  testWidgets('shows shielded renew button for software accounts', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(_receiveHarness());
+    await tester.pump();
+    await tester.pump();
+
+    expect(_findAppIcon(AppIcons.renew), findsOneWidget);
+  });
+
+  testWidgets('hides shielded renew button for hardware accounts', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(_receiveHarness(bootstrap: _hardwareBootstrap));
+    await tester.pump();
+    await tester.pump();
+
+    expect(_findAppIcon(AppIcons.renew), findsNothing);
+  });
+
+  testWidgets('uses Keystone shielded help copy for hardware accounts', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(_receiveHarness(bootstrap: _hardwareBootstrap));
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(_findAppIcon(AppIcons.help));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('Shielded Address'), findsOneWidget);
+    expect(
+      find.text(
+        "Keystone provides an Orchard-only shielded address, so Vizor can't renew it from this screen.",
+      ),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Renew button'), findsNothing);
+  });
+
   testWidgets('receive info modal does not block sidebar navigation', (
     tester,
   ) async {
@@ -103,6 +158,12 @@ Finder _findAddressRichText(String fragment) {
   );
 }
 
+Finder _findAppIcon(String iconName) {
+  return find.byWidgetPredicate(
+    (widget) => widget is AppIcon && widget.name == iconName,
+  );
+}
+
 Widget _receiveHarness({
   AppBootstrapState? bootstrap,
   ReceiveAddressService Function(Ref ref)? receiveAddressService,
@@ -181,6 +242,30 @@ final _twoAccountBootstrap = AppBootstrapState(
     ],
     activeAccountUuid: 'account-1',
     activeAddress: _accountOneAddress,
+  ),
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.system,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);
+
+final _hardwareBootstrap = AppBootstrapState(
+  initialLocation: '/receive',
+  initialAccountState: const AccountState(
+    accounts: [
+      AccountInfo(
+        uuid: 'account-1',
+        name: 'Keystone Vault',
+        order: 0,
+        isHardware: true,
+      ),
+    ],
+    activeAccountUuid: 'account-1',
+    activeAddress: _shieldedAddress,
   ),
   initialSyncSnapshot: AppSyncSnapshot.empty,
   network: 'main',

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -62,7 +62,7 @@ void main() {
     expect(find.text('Shielded Address'), findsOneWidget);
     expect(
       find.text(
-        "Keystone provides an Orchard-only shielded address, so Vizor can't renew it from this screen.",
+        "Keystone accounts use one fixed shielded address, so Renew isn't available.",
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
## Summary

- Hide the shielded address Renew button for hardware accounts on the Receive screen.
- Show Keystone-specific shielded address help copy with the Keystone icon.
- Add widget coverage for software and hardware Receive screen behavior.

## Validation

- `fvm flutter test test/features/receive/receive_screen_test.dart`
- `fvm flutter analyze lib/src/features/receive/screens/receive_screen.dart test/features/receive/receive_screen_test.dart`

Note: full `fvm flutter analyze` was attempted earlier and is blocked by existing `rust_builder/cargokit/build_tool` dependency resolution issues unrelated to this change.