### PR TITLE
[codex] Secure mnemonic bytes in send flows

### DIFF
--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:cryptography/cryptography.dart';
 import 'package:flutter/foundation.dart'
@@ -147,6 +148,22 @@ class AppSecureStore {
       final key = _accountMnemonicKey(accountUuid);
       final raw = await _mnemonicStorage.read(key: key);
       return _decryptStoredSecretString(
+        raw,
+        key: key,
+        requireUnlockedSession: requireUnlockedSession,
+      );
+    });
+  }
+
+  Future<Uint8List?> readAccountMnemonicBytes(
+    String accountUuid, {
+    bool requireUnlockedSession = false,
+  }) {
+    return _secretMutationLock.run(() async {
+      if (_shouldSkipLockedSecretRead(requireUnlockedSession)) return null;
+      final key = _accountMnemonicKey(accountUuid);
+      final raw = await _mnemonicStorage.read(key: key);
+      return _decryptStoredSecretBytes(
         raw,
         key: key,
         requireUnlockedSession: requireUnlockedSession,
@@ -464,19 +481,46 @@ class AppSecureStore {
     return _decryptPayloadForKey(key, payload, secretKey);
   }
 
+  Future<Uint8List?> _decryptStoredSecretBytes(
+    String? raw, {
+    required String key,
+    required bool requireUnlockedSession,
+  }) async {
+    if (requireUnlockedSession && !hasSessionPassword) {
+      return null;
+    }
+    if (!hasSessionPassword) {
+      throw StateError('Secret storage requires an unlocked session.');
+    }
+    if (raw == null || raw.isEmpty) return null;
+
+    final payload = _EncryptedPayload.tryParse(raw);
+    if (payload == null) {
+      return null;
+    }
+
+    final secretKey = await _getSecretKey();
+    return _decryptPayloadBytesForKey(key, payload, secretKey);
+  }
+
   Future<String> _encryptSecretString(String value) async {
     final secretKey = await _getSecretKey();
     final nonce = _randomBytes(12);
-    final secretBox = await _cipher.encrypt(
-      utf8.encode(value),
-      secretKey: secretKey,
-      nonce: nonce,
-    );
-    return _EncryptedPayload(
-      nonce: secretBox.nonce,
-      cipherText: secretBox.cipherText,
-      mac: secretBox.mac.bytes,
-    ).serialize();
+    final clearText = utf8.encode(value);
+    try {
+      final secretBox = await _cipher.encrypt(
+        clearText,
+        secretKey: secretKey,
+        nonce: nonce,
+      );
+      return _EncryptedPayload(
+        nonce: secretBox.nonce,
+        cipherText: secretBox.cipherText,
+        mac: secretBox.mac.bytes,
+      ).serialize();
+    } finally {
+      _zeroizeList(clearText);
+    }
   }
 
   Future<_AccountMnemonicMigrationResult>
@@ -587,7 +631,33 @@ class AppSecureStore {
       ),
       secretKey: secretKey,
     );
-    return utf8.decode(clearText);
+    try {
+      return utf8.decode(clearText);
+    } finally {
+      _zeroizeList(clearText);
+    }
+  }
+
+  Future<Uint8List> _decryptPayloadBytes(
+    _EncryptedPayload payload,
+    SecretKey secretKey,
+  ) async {
+    final clearText = await _cipher.decrypt(
+      SecretBox(
+        payload.cipherText,
+        nonce: payload.nonce,
+        mac: Mac(payload.mac),
+      ),
+      secretKey: secretKey,
+    );
+    if (clearText is Uint8List) {
+      return clearText;
+    }
+    try {
+      return Uint8List.fromList(clearText);
+    } finally {
+      _zeroizeList(clearText);
+    }
   }
 
   Future<String> _decryptPayloadForKey(
@@ -605,21 +675,41 @@ class AppSecureStore {
     }
   }
 
+  Future<Uint8List> _decryptPayloadBytesForKey(
+    String key,
+    _EncryptedPayload payload,
+    SecretKey secretKey,
+  ) async {
+    try {
+      return await _decryptPayloadBytes(payload, secretKey);
+    } catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        StateError('Failed to decrypt secure-storage value for "$key": $error'),
+        stackTrace,
+      );
+    }
+  }
+
   Future<String> _encryptStringWithKey(
     String value,
     SecretKey secretKey,
   ) async {
     final nonce = _randomBytes(12);
-    final secretBox = await _cipher.encrypt(
-      utf8.encode(value),
-      secretKey: secretKey,
-      nonce: nonce,
-    );
-    return _EncryptedPayload(
-      nonce: secretBox.nonce,
-      cipherText: secretBox.cipherText,
-      mac: secretBox.mac.bytes,
-    ).serialize();
+    final clearText = utf8.encode(value);
+    try {
+      final secretBox = await _cipher.encrypt(
+        clearText,
+        secretKey: secretKey,
+        nonce: nonce,
+      );
+      return _EncryptedPayload(
+        nonce: secretBox.nonce,
+        cipherText: secretBox.cipherText,
+        mac: secretBox.mac.bytes,
+      ).serialize();
+    } finally {
+      _zeroizeList(clearText);
+    }
   }
 
   Future<String> _derivePasswordVerifier(
@@ -634,6 +724,15 @@ class AppSecureStore {
       return base64Encode(await key.extractBytes());
     } finally {
       key.destroy();
+    }
+  }
+
+  void _zeroizeList(List<int> value) {
+    try {
+      value.fillRange(0, value.length, 0);
+    } catch (_) {
+      // Best effort only: some cryptography implementations may return
+      // fixed or unmodifiable list views.
     }
   }
 

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -116,6 +116,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         );
       }
 
+      final dbPath = await getWalletDbPath();
+      final endpoint = ref.read(rpcEndpointFailoverProvider).current;
+      attemptedEndpoint = endpoint;
+
       final mnemonicBytes = await accountNotifier.getMnemonicBytesForAccount(
         accountUuid,
       );
@@ -123,12 +127,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         throw Exception('Mnemonic not found for the active account.');
       }
 
-      final dbPath = await getWalletDbPath();
-      final endpoint = ref.read(rpcEndpointFailoverProvider).current;
-      attemptedEndpoint = endpoint;
       late final rust_sync.ShieldTransparentResult result;
+      late final Future<rust_sync.ShieldTransparentResult> resultFuture;
       try {
-        result = await rust_sync.shieldTransparentBalance(
+        resultFuture = rust_sync.shieldTransparentBalance(
           dbPath: dbPath,
           lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
           network: endpoint.networkName,
@@ -138,6 +140,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       } finally {
         mnemonicBytes.fillRange(0, mnemonicBytes.length, 0);
       }
+      result = await resultFuture;
       log(
         'HomeScreen: shielded transparent balance txids=${result.txids} '
         'fee=${result.feeZatoshi} shielded=${result.shieldedZatoshi}',

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -24,7 +24,6 @@ import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
-import '../../../rust/api/wallet.dart' as rust_wallet;
 import '../../activity/activity_row_mapper.dart';
 import '../../activity/models/activity_row_data.dart';
 import '../../activity/screens/activity_transaction_status_screen.dart';
@@ -117,22 +116,28 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         );
       }
 
-      final mnemonic = await accountNotifier.getMnemonicForAccount(accountUuid);
-      if (mnemonic == null) {
+      final mnemonicBytes = await accountNotifier.getMnemonicBytesForAccount(
+        accountUuid,
+      );
+      if (mnemonicBytes == null || mnemonicBytes.isEmpty) {
         throw Exception('Mnemonic not found for the active account.');
       }
 
-      final seedBytes = await rust_wallet.deriveSeed(mnemonic: mnemonic);
       final dbPath = await getWalletDbPath();
       final endpoint = ref.read(rpcEndpointFailoverProvider).current;
       attemptedEndpoint = endpoint;
-      final result = await rust_sync.shieldTransparentBalance(
-        dbPath: dbPath,
-        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-        network: endpoint.networkName,
-        accountUuid: accountUuid,
-        seed: seedBytes,
-      );
+      late final rust_sync.ShieldTransparentResult result;
+      try {
+        result = await rust_sync.shieldTransparentBalance(
+          dbPath: dbPath,
+          lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+          network: endpoint.networkName,
+          accountUuid: accountUuid,
+          mnemonicBytes: mnemonicBytes,
+        );
+      } finally {
+        mnemonicBytes.fillRange(0, mnemonicBytes.length, 0);
+      }
       log(
         'HomeScreen: shielded transparent balance txids=${result.txids} '
         'fee=${result.feeZatoshi} shielded=${result.shieldedZatoshi}',

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -387,8 +387,9 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
         }
 
         late final rust_sync.ExecuteProposalResult result;
+        late final Future<rust_sync.ExecuteProposalResult> resultFuture;
         try {
-          result = await rust_sync.executeProposal(
+          resultFuture = rust_sync.executeProposal(
             dbPath: dbPath,
             lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
             proposalId: widget.args.proposalId,
@@ -404,6 +405,7 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
         } finally {
           mnemonicBytes.fillRange(0, mnemonicBytes.length, 0);
         }
+        result = await resultFuture;
         _proposalConsumed = true;
         txids = result.txids;
         broadcastComplete = result.status == 'broadcasted';

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -20,7 +20,6 @@ import '../../../providers/account_provider.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
-import '../../../rust/api/wallet.dart' as rust_wallet;
 import '../../keystone/widgets/keystone_transaction_progress_panel.dart';
 import '../services/sapling_params.dart';
 import '../widgets/sapling_params_prompt.dart';
@@ -375,10 +374,10 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
             : _pcztBroadcastStatusMessage(result);
         broadcastMessageForFallback = result.message;
       } else {
-        final mnemonic = await accountNotifier.getMnemonicForAccount(
+        final mnemonicBytes = await accountNotifier.getMnemonicBytesForAccount(
           widget.args.proposalAccountUuid,
         );
-        if (mnemonic == null) {
+        if (mnemonicBytes == null || mnemonicBytes.isEmpty) {
           if (await _abortIfUnmounted()) return;
           setState(() {
             _phase = _SendStatusPhase.failed;
@@ -387,20 +386,24 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
           return;
         }
 
-        final seedBytes = await rust_wallet.deriveSeed(mnemonic: mnemonic);
-        final result = await rust_sync.executeProposal(
-          dbPath: dbPath,
-          lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-          proposalId: widget.args.proposalId,
-          sendFlowId: widget.args.sendFlowId,
-          seed: seedBytes,
-          spendParamsPath: widget.args.needsSaplingParams
-              ? saplingParams.spendPath
-              : null,
-          outputParamsPath: widget.args.needsSaplingParams
-              ? saplingParams.outputPath
-              : null,
-        );
+        late final rust_sync.ExecuteProposalResult result;
+        try {
+          result = await rust_sync.executeProposal(
+            dbPath: dbPath,
+            lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+            proposalId: widget.args.proposalId,
+            sendFlowId: widget.args.sendFlowId,
+            mnemonicBytes: mnemonicBytes,
+            spendParamsPath: widget.args.needsSaplingParams
+                ? saplingParams.spendPath
+                : null,
+            outputParamsPath: widget.args.needsSaplingParams
+                ? saplingParams.outputPath
+                : null,
+          );
+        } finally {
+          mnemonicBytes.fillRange(0, mnemonicBytes.length, 0);
+        }
         _proposalConsumed = true;
         txids = result.txids;
         broadcastComplete = result.status == 'broadcasted';

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -539,6 +540,13 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   /// Get the mnemonic for a specific account.
   Future<String?> getMnemonicForAccount(String uuid) async {
     return _storage.readAccountMnemonic(uuid, requireUnlockedSession: true);
+  }
+
+  Future<Uint8List?> getMnemonicBytesForAccount(String uuid) async {
+    return _storage.readAccountMnemonicBytes(
+      uuid,
+      requireUnlockedSession: true,
+    );
   }
 
   // ======================== Helpers ========================

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -258,7 +258,7 @@ Future<ExecuteProposalResult> executeProposal({
   required String lightwalletdUrl,
   required BigInt proposalId,
   required String sendFlowId,
-  required List<int> seed,
+  required List<int> mnemonicBytes,
   String? spendParamsPath,
   String? outputParamsPath,
 }) => RustLib.instance.api.crateApiSyncExecuteProposal(
@@ -266,7 +266,7 @@ Future<ExecuteProposalResult> executeProposal({
   lightwalletdUrl: lightwalletdUrl,
   proposalId: proposalId,
   sendFlowId: sendFlowId,
-  seed: seed,
+  mnemonicBytes: mnemonicBytes,
   spendParamsPath: spendParamsPath,
   outputParamsPath: outputParamsPath,
 );
@@ -301,13 +301,13 @@ Future<ShieldTransparentResult> shieldTransparentBalance({
   required String lightwalletdUrl,
   required String network,
   required String accountUuid,
-  required List<int> seed,
+  required List<int> mnemonicBytes,
 }) => RustLib.instance.api.crateApiSyncShieldTransparentBalance(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
   network: network,
   accountUuid: accountUuid,
-  seed: seed,
+  mnemonicBytes: mnemonicBytes,
 );
 
 Future<String> getNextAvailableAddress({

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -130,11 +130,6 @@ bool walletExists({required String dbPath}) =>
 bool validateMnemonic({required String mnemonic}) =>
     RustLib.instance.api.crateApiWalletValidateMnemonic(mnemonic: mnemonic);
 
-/// Derive seed bytes from a mnemonic phrase.
-/// Returns 64 raw bytes. The caller should treat these as sensitive.
-Future<Uint8List> deriveSeed({required String mnemonic}) =>
-    RustLib.instance.api.crateApiWalletDeriveSeed(mnemonic: mnemonic);
-
 /// Get the transparent address for a specific account (or first account if uuid is None).
 Future<String> getTransparentAddress({
   required String dbPath,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -70,7 +70,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -292915742;
+  int get rustContentHash => 9336009;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -149,8 +149,6 @@ abstract class RustLibApi extends BaseApi {
     required String accountUuid,
   });
 
-  Future<Uint8List> crateApiWalletDeriveSeed({required String mnemonic});
-
   Future<void> crateApiSyncDiscardProposal({
     required BigInt proposalId,
     required String sendFlowId,
@@ -185,7 +183,7 @@ abstract class RustLibApi extends BaseApi {
     required String lightwalletdUrl,
     required BigInt proposalId,
     required String sendFlowId,
-    required List<int> seed,
+    required List<int> mnemonicBytes,
     String? spendParamsPath,
     String? outputParamsPath,
   });
@@ -386,7 +384,7 @@ abstract class RustLibApi extends BaseApi {
     required String lightwalletdUrl,
     required String network,
     required String accountUuid,
-    required List<int> seed,
+    required List<int> mnemonicBytes,
   });
 
   Stream<ApiSyncProgressEvent> crateApiSyncStartFullSync({
@@ -892,34 +890,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<Uint8List> crateApiWalletDeriveSeed({required String mnemonic}) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(mnemonic, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 14,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_String,
-        ),
-        constMeta: kCrateApiWalletDeriveSeedConstMeta,
-        argValues: [mnemonic],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiWalletDeriveSeedConstMeta =>
-      const TaskConstMeta(debugName: "derive_seed", argNames: ["mnemonic"]);
-
-  @override
   Future<void> crateApiSyncDiscardProposal({
     required BigInt proposalId,
     required String sendFlowId,
@@ -933,7 +903,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 14,
             port: port_,
           );
         },
@@ -966,7 +936,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 15,
             port: port_,
           );
         },
@@ -1001,7 +971,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 16,
             port: port_,
           );
         },
@@ -1044,7 +1014,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 17,
             port: port_,
           );
         },
@@ -1098,7 +1068,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 18,
             port: port_,
           );
         },
@@ -1125,7 +1095,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String lightwalletdUrl,
     required BigInt proposalId,
     required String sendFlowId,
-    required List<int> seed,
+    required List<int> mnemonicBytes,
     String? spendParamsPath,
     String? outputParamsPath,
   }) {
@@ -1137,13 +1107,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(lightwalletdUrl, serializer);
           sse_encode_u_64(proposalId, serializer);
           sse_encode_String(sendFlowId, serializer);
-          sse_encode_list_prim_u_8_loose(seed, serializer);
+          sse_encode_list_prim_u_8_loose(mnemonicBytes, serializer);
           sse_encode_opt_String(spendParamsPath, serializer);
           sse_encode_opt_String(outputParamsPath, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 19,
             port: port_,
           );
         },
@@ -1157,7 +1127,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           lightwalletdUrl,
           proposalId,
           sendFlowId,
-          seed,
+          mnemonicBytes,
           spendParamsPath,
           outputParamsPath,
         ],
@@ -1174,7 +1144,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "lightwalletdUrl",
           "proposalId",
           "sendFlowId",
-          "seed",
+          "mnemonicBytes",
           "spendParamsPath",
           "outputParamsPath",
         ],
@@ -1204,7 +1174,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 20,
             port: port_,
           );
         },
@@ -1247,7 +1217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 22)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 21)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1279,7 +1249,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 22,
             port: port_,
           );
         },
@@ -1313,7 +1283,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 23,
             port: port_,
           );
         },
@@ -1340,7 +1310,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cachePath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 24)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1372,7 +1342,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 25,
             port: port_,
           );
         },
@@ -1405,7 +1375,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 27,
+            funcId: 26,
             port: port_,
           );
         },
@@ -1438,7 +1408,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 27,
             port: port_,
           );
         },
@@ -1475,7 +1445,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 28,
             port: port_,
           );
         },
@@ -1510,7 +1480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1547,7 +1517,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1574,7 +1544,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 31)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -1604,7 +1574,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 32,
             port: port_,
           );
         },
@@ -1638,7 +1608,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1676,7 +1646,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(txidHex, serializer);
           sse_encode_String(txKind, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 35)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_transaction_detail,
@@ -1713,7 +1683,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1750,7 +1720,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1787,7 +1757,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1815,7 +1785,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -1855,7 +1825,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 39,
             port: port_,
           );
         },
@@ -1912,7 +1882,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1947,7 +1917,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1971,7 +1941,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 42)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -1996,7 +1966,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2018,7 +1988,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 45)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2048,7 +2018,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 45,
             port: port_,
           );
         },
@@ -2074,7 +2044,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 46)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -2114,7 +2084,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 47,
             port: port_,
           );
         },
@@ -2172,7 +2142,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 48,
             port: port_,
           );
         },
@@ -2219,7 +2189,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 49,
             port: port_,
           );
         },
@@ -2246,7 +2216,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2278,7 +2248,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 51,
             port: port_,
           );
         },
@@ -2316,7 +2286,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 52,
             port: port_,
           );
         },
@@ -2369,7 +2339,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 53,
             port: port_,
           );
         },
@@ -2420,7 +2390,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2454,7 +2424,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 55,
             port: port_,
           );
         },
@@ -2481,7 +2451,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String lightwalletdUrl,
     required String network,
     required String accountUuid,
-    required List<int> seed,
+    required List<int> mnemonicBytes,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -2491,11 +2461,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(lightwalletdUrl, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
-          sse_encode_list_prim_u_8_loose(seed, serializer);
+          sse_encode_list_prim_u_8_loose(mnemonicBytes, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 56,
             port: port_,
           );
         },
@@ -2504,7 +2474,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncShieldTransparentBalanceConstMeta,
-        argValues: [dbPath, lightwalletdUrl, network, accountUuid, seed],
+        argValues: [
+          dbPath,
+          lightwalletdUrl,
+          network,
+          accountUuid,
+          mnemonicBytes,
+        ],
         apiImpl: this,
       ),
     );
@@ -2518,7 +2494,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "lightwalletdUrl",
           "network",
           "accountUuid",
-          "seed",
+          "mnemonicBytes",
         ],
       );
 
@@ -2543,7 +2519,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 58,
+              funcId: 57,
               port: port_,
             );
           },
@@ -2584,7 +2560,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 59,
+              funcId: 58,
               port: port_,
             );
           },
@@ -2613,7 +2589,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -2643,7 +2619,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 60,
             port: port_,
           );
         },
@@ -2680,7 +2656,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2712,7 +2688,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 62,
             port: port_,
           );
         },
@@ -2737,7 +2713,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(mnemonic, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2763,7 +2739,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(dbPath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -2793,7 +2769,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 65,
             port: port_,
           );
         },

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2493,6 +2493,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
+ "zeroize",
  "zip32",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,6 +46,7 @@ nonempty = "0.10"
 
 # Security
 secrecy = "0.8"
+zeroize = "1"
 
 # Random number generation
 rand = "0.8"

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 
 use flutter_rust_bridge::frb;
+use zeroize::Zeroizing;
 
 use crate::frb_generated::StreamSink;
 use crate::wallet::{keys, sync as wallet_sync, sync_engine};
@@ -703,18 +704,22 @@ pub fn execute_proposal(
     lightwalletd_url: String,
     proposal_id: u64,
     send_flow_id: String,
-    seed: Vec<u8>,
+    mnemonic_bytes: Vec<u8>,
     spend_params_path: Option<String>,
     output_params_path: Option<String>,
 ) -> Result<ExecuteProposalResult, String> {
     catch(|| {
+        let mnemonic_bytes = Zeroizing::new(mnemonic_bytes);
+        let seed = keys::mnemonic_bytes_to_seed(mnemonic_bytes.as_slice())?;
+        drop(mnemonic_bytes);
+
         let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
         let r = rt.block_on(wallet_sync::execute_proposal(
             &db_path,
             &lightwalletd_url,
             proposal_id,
             &send_flow_id,
-            &seed,
+            seed,
             spend_params_path.as_deref(),
             output_params_path.as_deref(),
         ))?;
@@ -772,17 +777,21 @@ pub fn shield_transparent_balance(
     lightwalletd_url: String,
     network: String,
     account_uuid: String,
-    seed: Vec<u8>,
+    mnemonic_bytes: Vec<u8>,
 ) -> Result<ShieldTransparentResult, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
+        let mnemonic_bytes = Zeroizing::new(mnemonic_bytes);
+        let seed = keys::mnemonic_bytes_to_seed(mnemonic_bytes.as_slice())?;
+        drop(mnemonic_bytes);
+
         let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
         let r = rt.block_on(wallet_sync::shield_transparent_balance(
             &db_path,
             &lightwalletd_url,
             network,
             &account_uuid,
-            &seed,
+            seed,
         ))?;
         Ok(ShieldTransparentResult {
             txids: r.txids,

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -1,7 +1,5 @@
 use std::panic;
 
-use secrecy::ExposeSecret;
-
 use crate::wallet::keys;
 
 /// Result of wallet creation, containing the mnemonic, unified address, and account UUID.
@@ -252,15 +250,6 @@ pub fn wallet_exists(db_path: String) -> bool {
 #[flutter_rust_bridge::frb(sync)]
 pub fn validate_mnemonic(mnemonic: String) -> bool {
     keys::mnemonic_to_seed(&mnemonic).is_ok()
-}
-
-/// Derive seed bytes from a mnemonic phrase.
-/// Returns 64 raw bytes. The caller should treat these as sensitive.
-pub fn derive_seed(mnemonic: String) -> Result<Vec<u8>, String> {
-    catch(|| {
-        let seed = keys::mnemonic_to_seed(&mnemonic)?;
-        Ok(seed.expose_secret().to_vec())
-    })
 }
 
 /// Get the transparent address for a specific account (or first account if uuid is None).

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -292915742;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 9336009;
 
 // Section: executor
 
@@ -526,39 +526,6 @@ fn wire__crate__api__wallet__delete_account_impl(
         },
     )
 }
-fn wire__crate__api__wallet__derive_seed_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "derive_seed",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_mnemonic = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| {
-                transform_result_sse::<_, String>((move || {
-                    let output_ok = crate::api::wallet::derive_seed(api_mnemonic)?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
 fn wire__crate__api__sync__discard_proposal_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -779,7 +746,7 @@ fn wire__crate__api__sync__execute_proposal_impl(
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
             let api_proposal_id = <u64>::sse_decode(&mut deserializer);
             let api_send_flow_id = <String>::sse_decode(&mut deserializer);
-            let api_seed = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_mnemonic_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
             let api_spend_params_path = <Option<String>>::sse_decode(&mut deserializer);
             let api_output_params_path = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
@@ -790,7 +757,7 @@ fn wire__crate__api__sync__execute_proposal_impl(
                         api_lightwalletd_url,
                         api_proposal_id,
                         api_send_flow_id,
-                        api_seed,
+                        api_mnemonic_bytes,
                         api_spend_params_path,
                         api_output_params_path,
                     )?;
@@ -2153,7 +2120,7 @@ fn wire__crate__api__sync__shield_transparent_balance_impl(
             let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
-            let api_seed = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_mnemonic_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -2162,7 +2129,7 @@ fn wire__crate__api__sync__shield_transparent_balance_impl(
                         api_lightwalletd_url,
                         api_network,
                         api_account_uuid,
-                        api_seed,
+                        api_mnemonic_bytes,
                     )?;
                     Ok(output_ok)
                 })())
@@ -3243,109 +3210,108 @@ fn pde_ffi_dispatcher_primary_impl(
             data_len,
         ),
         13 => wire__crate__api__wallet__delete_account_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__wallet__derive_seed_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
-        17 => {
+        14 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
+        15 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
+        16 => {
             wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len)
         }
-        18 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
-        19 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
-        20 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-        21 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(
+        17 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
+        19 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+        20 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        23 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__sync__get_export_birthday_height_impl(
+        22 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
+        25 => wire__crate__api__sync__get_export_birthday_height_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        27 => wire__crate__api__wallet__get_latest_block_height_impl(
+        26 => wire__crate__api__wallet__get_latest_block_height_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        28 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(
+        27 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        29 => wire__crate__api__sync__get_next_available_address_impl(
+        28 => wire__crate__api__sync__get_next_available_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        30 => {
+        29 => {
             wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len)
         }
-        31 => wire__crate__api__sync__get_shield_transparent_status_impl(
+        30 => wire__crate__api__sync__get_shield_transparent_status_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        33 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-        34 => wire__crate__api__sync__get_transaction_data_requests_impl(
+        32 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__sync__get_transaction_data_requests_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        36 => {
+        35 => {
             wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len)
         }
-        37 => wire__crate__api__wallet__get_transparent_address_impl(
+        36 => wire__crate__api__wallet__get_transparent_address_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__wallet__import_hardware_account_impl(
+        37 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__wallet__import_hardware_account_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        41 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-        49 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-        50 => {
+        40 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+        45 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+        49 => {
             wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len)
         }
-        52 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-        53 => {
+        51 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+        52 => {
             wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len)
         }
-        54 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-        56 => {
+        53 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+        55 => {
             wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len)
         }
-        57 => wire__crate__api__sync__shield_transparent_balance_impl(
+        56 => wire__crate__api__sync__shield_transparent_balance_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        58 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-        59 => {
+        57 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+        58 => {
             wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len)
         }
-        61 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-        66 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3359,20 +3325,20 @@ fn pde_ffi_dispatcher_sync_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         3 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        32 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        35 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        64 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        24 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
+        38 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        63 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -14,6 +14,7 @@ use zcash_keys::{
 };
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::{BlockHeight, NetworkConstants, NetworkUpgrade, Parameters};
+use zeroize::Zeroizing;
 use zip32::fingerprint::SeedFingerprint;
 
 use crate::wallet::{
@@ -79,7 +80,8 @@ pub fn mnemonic_word_list() -> Vec<String> {
 pub fn mnemonic_to_seed(phrase: &str) -> Result<SecretVec<u8>, String> {
     let mnemonic =
         Mnemonic::<English>::from_phrase(phrase).map_err(|e| format!("Invalid mnemonic: {e}"))?;
-    Ok(SecretVec::new(mnemonic.to_seed("").to_vec()))
+    let seed = Zeroizing::new(mnemonic.to_seed(""));
+    Ok(SecretVec::new(seed.to_vec()))
 }
 
 /// Convert UTF-8 mnemonic bytes to a 64-byte seed wrapped in SecretVec.

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -25,8 +25,7 @@ use crate::wallet::{
     network::WalletNetwork,
 };
 
-const DUPLICATE_SOFTWARE_ACCOUNT_MESSAGE: &str =
-    "This account is already in your wallet.";
+const DUPLICATE_SOFTWARE_ACCOUNT_MESSAGE: &str = "This account is already in your wallet.";
 const DUPLICATE_KEYSTONE_ACCOUNT_MESSAGE: &str = "This Keystone account is already in your wallet.";
 
 fn map_account_import_error(
@@ -81,6 +80,13 @@ pub fn mnemonic_to_seed(phrase: &str) -> Result<SecretVec<u8>, String> {
     let mnemonic =
         Mnemonic::<English>::from_phrase(phrase).map_err(|e| format!("Invalid mnemonic: {e}"))?;
     Ok(SecretVec::new(mnemonic.to_seed("").to_vec()))
+}
+
+/// Convert UTF-8 mnemonic bytes to a 64-byte seed wrapped in SecretVec.
+/// The caller remains responsible for zeroizing the input bytes.
+pub fn mnemonic_bytes_to_seed(phrase: &[u8]) -> Result<SecretVec<u8>, String> {
+    let phrase = std::str::from_utf8(phrase).map_err(|_| "Mnemonic must be valid UTF-8")?;
+    mnemonic_to_seed(phrase)
 }
 
 /// Parse network string to wallet network enum.

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -14,7 +14,7 @@
 //!      amount field.
 //!
 //!   3. [`execute_proposal`] — consume the stored proposal, derive
-//!      the USK from the supplied seed (scoped + dropped before
+//!      the USK from the supplied seed (scoped + zeroized before
 //!      network I/O), build + sign the transaction(s), and broadcast
 //!      them via `send_transaction` gRPC. Once transaction creation
 //!      succeeds, broadcast failures are returned as a structured
@@ -413,7 +413,7 @@ pub(crate) async fn shield_transparent_balance(
     lightwalletd_url: &str,
     network: WalletNetwork,
     account_uuid: &str,
-    seed_bytes: &[u8],
+    seed: SecretVec<u8>,
 ) -> Result<ShieldTransparentResult, String> {
     let shielding_threshold = shielding_threshold()?;
 
@@ -432,7 +432,6 @@ pub(crate) async fn shield_transparent_balance(
             let fee_zatoshi = proposal_fee_zatoshi(&proposal);
             let shielded_zatoshi = proposal_shielded_zatoshi(&proposal);
 
-            let seed = SecretVec::new(seed_bytes.to_vec());
             let zip32_index = account
                 .source()
                 .key_derivation()
@@ -457,6 +456,7 @@ pub(crate) async fn shield_transparent_balance(
             Ok::<_, String>((txids, fee_zatoshi, shielded_zatoshi))
         },
     )?;
+    drop(seed);
 
     let txids: Vec<TxId> = txids.iter().cloned().collect();
     let txids = broadcast_created_transactions(db_path, lightwalletd_url, &txids, "shield")
@@ -481,7 +481,7 @@ pub async fn execute_proposal(
     lightwalletd_url: &str,
     proposal_id: u64,
     send_flow_id: &str,
-    seed_bytes: &[u8],
+    seed: SecretVec<u8>,
     spend_params_path: Option<&str>,
     output_params_path: Option<&str>,
 ) -> Result<ExecuteProposalResult, String> {
@@ -500,7 +500,6 @@ pub async fn execute_proposal(
             .get_account(account_id)
             .map_err(|e| format!("{e}"))?
             .ok_or("Account not found")?;
-        let seed = SecretVec::new(seed_bytes.to_vec());
         let zip32_index = account
             .source()
             .key_derivation()
@@ -541,6 +540,7 @@ pub async fn execute_proposal(
         // seed + usk dropped here, before broadcast
         Ok::<_, String>(txids)
     })?;
+    drop(seed);
 
     let txids: Vec<TxId> = txids.iter().cloned().collect();
     Ok(

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -419,7 +419,7 @@ pub(crate) async fn shield_transparent_balance(
 
     let (txids, fee_zatoshi, shielded_zatoshi) = with_wallet_db_write_lock(
         "send.shield_transparent_balance.create_transactions",
-        || {
+        move || {
             let mut db = open_wallet_db(db_path, network)?;
             let account_id = parse_account_uuid(account_uuid)?;
             let account = db
@@ -439,6 +439,7 @@ pub(crate) async fn shield_transparent_balance(
                 .account_index();
             let usk = UnifiedSpendingKey::from_seed(&network, seed.expose_secret(), zip32_index)
                 .map_err(|e| format!("USK derivation failed: {e:?}"))?;
+            drop(seed);
 
             let spend_prover = NoOpSpendProver;
             let output_prover = NoOpOutputProver;
@@ -456,7 +457,6 @@ pub(crate) async fn shield_transparent_balance(
             Ok::<_, String>((txids, fee_zatoshi, shielded_zatoshi))
         },
     )?;
-    drop(seed);
 
     let txids: Vec<TxId> = txids.iter().cloned().collect();
     let txids = broadcast_created_transactions(db_path, lightwalletd_url, &txids, "shield")
@@ -492,55 +492,57 @@ pub async fn execute_proposal(
     )?;
     let network = stored.network;
 
-    // Scope DB writes and seed/USK so they are dropped before network I/O (broadcast).
-    let txids = with_wallet_db_write_lock("send.execute_proposal.create_transactions", || {
-        let mut db = open_wallet_db(db_path, network)?;
-        let account_id = stored.account_id;
-        let account = db
-            .get_account(account_id)
-            .map_err(|e| format!("{e}"))?
-            .ok_or("Account not found")?;
-        let zip32_index = account
-            .source()
-            .key_derivation()
-            .ok_or("No key derivation")?
-            .account_index();
-        let usk = UnifiedSpendingKey::from_seed(&network, seed.expose_secret(), zip32_index)
-            .map_err(|e| format!("USK derivation failed: {e:?}"))?;
+    // Scope DB writes and signing material so they are dropped before network I/O (broadcast).
+    let txids =
+        with_wallet_db_write_lock("send.execute_proposal.create_transactions", move || {
+            let mut db = open_wallet_db(db_path, network)?;
+            let account_id = stored.account_id;
+            let account = db
+                .get_account(account_id)
+                .map_err(|e| format!("{e}"))?
+                .ok_or("Account not found")?;
+            let zip32_index = account
+                .source()
+                .key_derivation()
+                .ok_or("No key derivation")?
+                .account_index();
+            let usk = UnifiedSpendingKey::from_seed(&network, seed.expose_secret(), zip32_index)
+                .map_err(|e| format!("USK derivation failed: {e:?}"))?;
+            drop(seed);
 
-        let txids = match (spend_params_path, output_params_path) {
-            (Some(sp), Some(op)) if !sp.is_empty() && !op.is_empty() => {
-                let prover = LocalTxProver::new(std::path::Path::new(sp), std::path::Path::new(op));
-                create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
-                    &mut db,
-                    &network,
-                    &prover,
-                    &prover,
-                    &wallet::SpendingKeys::from_unified_spending_key(usk),
-                    OvkPolicy::Sender,
-                    &stored.proposal,
-                )
-                .map_err(|e| format!("Create TX failed: {e}"))?
-            }
-            _ => {
-                let spend_prover = NoOpSpendProver;
-                let output_prover = NoOpOutputProver;
-                create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
-                    &mut db,
-                    &network,
-                    &spend_prover,
-                    &output_prover,
-                    &wallet::SpendingKeys::from_unified_spending_key(usk),
-                    OvkPolicy::Sender,
-                    &stored.proposal,
-                )
-                .map_err(|e| format!("Create TX failed: {e}"))?
-            }
-        };
-        // seed + usk dropped here, before broadcast
-        Ok::<_, String>(txids)
-    })?;
-    drop(seed);
+            let txids = match (spend_params_path, output_params_path) {
+                (Some(sp), Some(op)) if !sp.is_empty() && !op.is_empty() => {
+                    let prover =
+                        LocalTxProver::new(std::path::Path::new(sp), std::path::Path::new(op));
+                    create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+                        &mut db,
+                        &network,
+                        &prover,
+                        &prover,
+                        &wallet::SpendingKeys::from_unified_spending_key(usk),
+                        OvkPolicy::Sender,
+                        &stored.proposal,
+                    )
+                    .map_err(|e| format!("Create TX failed: {e}"))?
+                }
+                _ => {
+                    let spend_prover = NoOpSpendProver;
+                    let output_prover = NoOpOutputProver;
+                    create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+                        &mut db,
+                        &network,
+                        &spend_prover,
+                        &output_prover,
+                        &wallet::SpendingKeys::from_unified_spending_key(usk),
+                        OvkPolicy::Sender,
+                        &stored.proposal,
+                    )
+                    .map_err(|e| format!("Create TX failed: {e}"))?
+                }
+            };
+            // USK and derived spending keys dropped here, before broadcast.
+            Ok::<_, String>(txids)
+        })?;
 
     let txids: Vec<TxId> = txids.iter().cloned().collect();
     Ok(

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -196,13 +196,12 @@ pub fn execute_send(
         None
     };
 
-    let seed = wallet_api::derive_seed(sender_mnemonic.into()).expect("derive_seed");
     sync_api::execute_proposal(
         path_str(db_path),
         LIGHTWALLETD_URL.into(),
         proposal.proposal_id,
         send_flow_id.into(),
-        seed,
+        sender_mnemonic.as_bytes().to_vec(),
         sapling_params.as_ref().map(|p| p.spend_path.clone()),
         sapling_params.as_ref().map(|p| p.output_path.clone()),
     )

--- a/test/core/storage/app_secure_store_test.dart
+++ b/test/core/storage/app_secure_store_test.dart
@@ -55,6 +55,19 @@ void main() {
     expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
   });
 
+  test('readAccountMnemonicBytes returns mutable mnemonic bytes', () async {
+    await store.configurePassword(_oldPassword);
+    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
+
+    final bytes = await store.readAccountMnemonicBytes(_accountUuid);
+
+    expect(bytes, isNotNull);
+    expect(utf8.decode(bytes!), _mnemonic);
+    bytes.fillRange(0, bytes.length, 0);
+    expect(bytes.every((byte) => byte == 0), isTrue);
+    expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
+  });
+
   test('changePassword journal stores only roll-forward data', () async {
     final blockingStorage = _BlockingDeleteStorage(
       blockKey: _rotationInProgressKey,
@@ -436,33 +449,36 @@ void main() {
     },
   );
 
-  test('fresh macOS mnemonic survives lock unlock without legacy copy', () async {
-    debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
-    final operations = <String>[];
-    final regularStorage = _MapStorage('regular', operations: operations);
-    final mnemonicStorage = _MapStorage('mnemonic', operations: operations);
-    store = AppSecureStore.testing(
-      storage: regularStorage,
-      mnemonicStorage: mnemonicStorage,
-    );
+  test(
+    'fresh macOS mnemonic survives lock unlock without legacy copy',
+    () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      final operations = <String>[];
+      final regularStorage = _MapStorage('regular', operations: operations);
+      final mnemonicStorage = _MapStorage('mnemonic', operations: operations);
+      store = AppSecureStore.testing(
+        storage: regularStorage,
+        mnemonicStorage: mnemonicStorage,
+      );
 
-    await store.configurePassword(_oldPassword);
-    await store.writeAccountMnemonic(_accountUuid, _mnemonic);
-    expect(regularStorage.valueFor(_mnemonicKey), isNull);
-    expect(mnemonicStorage.valueFor(_mnemonicKey), isNotNull);
+      await store.configurePassword(_oldPassword);
+      await store.writeAccountMnemonic(_accountUuid, _mnemonic);
+      expect(regularStorage.valueFor(_mnemonicKey), isNull);
+      expect(mnemonicStorage.valueFor(_mnemonicKey), isNotNull);
 
-    store.clearSessionPassword();
-    operations.clear();
+      store.clearSessionPassword();
+      operations.clear();
 
-    expect(await store.verifyPassword(_oldPassword), isTrue);
-    expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
-    expect(regularStorage.valueFor(_mnemonicKey), isNull);
-    expect(mnemonicStorage.valueFor(_mnemonicKey), isNotNull);
-    expect(regularStorage.valueFor(_migrationCompleteKey), 'true');
-    expect(operations, contains('regular.readAll'));
-    expect(operations, isNot(contains('mnemonic.write $_mnemonicKey')));
-    expect(operations, isNot(contains('regular.delete $_mnemonicKey')));
-  });
+      expect(await store.verifyPassword(_oldPassword), isTrue);
+      expect(await store.readAccountMnemonic(_accountUuid), _mnemonic);
+      expect(regularStorage.valueFor(_mnemonicKey), isNull);
+      expect(mnemonicStorage.valueFor(_mnemonicKey), isNotNull);
+      expect(regularStorage.valueFor(_migrationCompleteKey), 'true');
+      expect(operations, contains('regular.readAll'));
+      expect(operations, isNot(contains('mnemonic.write $_mnemonicKey')));
+      expect(operations, isNot(contains('regular.delete $_mnemonicKey')));
+    },
+  );
 
   test(
     'macOS unlock migrates legacy mnemonic payloads write then delete',


### PR DESCRIPTION
## Summary
- Move software send and transparent shielding away from Dart-side seed derivation.
- Pass mnemonic material to Rust as bytes for the runtime send/shield paths, then zeroize the Dart buffers immediately after FRB serialization.
- Derive the seed inside Rust, zeroize mnemonic/seed temporaries, and keep the raw seed lifetime shorter before broadcast.

## Related PR
This covers the core goal of #92 (`Keep seed derivation inside Rust`) and goes further by avoiding Dart `String` mnemonic transport in the send/shield runtime paths where possible.

## Validation
- `flutter_rust_bridge_codegen generate` (rerun after the latest commit; generated files stayed unchanged)
- `fvm flutter analyze lib test`
- `fvm flutter test test/core/storage/app_secure_store_test.dart`
- `cd rust && cargo test`
- `git diff --check`
