### PR TITLE
[codex] Exclude Cargokit build tool from analyze

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -9,6 +9,10 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer:
+  exclude:
+    - rust_builder/cargokit/build_tool/**
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`


### PR DESCRIPTION
## Summary

- Exclude the vendored Cargokit build tool package from the root Flutter analyzer scope.
- Keeps `fvm flutter analyze` focused on the app/package code instead of analyzing the build tool with the wrong dependency context.

## Validation

- `fvm flutter analyze`