### PR TITLE
[codex] Update About Vizor copy

### DIFF
--- a/lib/src/features/about/screens/about_screen.dart
+++ b/lib/src/features/about/screens/about_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart'
@@ -11,6 +12,7 @@ import 'package:flutter/material.dart'
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../../app_bootstrap.dart';
 import '../../../core/config/app_version_config.dart';
@@ -27,23 +29,46 @@ const _backLinkContentGap = AppSpacing.s;
 const _legalUpdatedLabel = 'Last Update:  ';
 const _paragraphWidth = 352.0;
 const _maxSidebarPaneContentWidth = 752.0;
+const _vizorGithubUrl = 'https://github.com/chainapsis/vizor-wallet/';
+const _vizorWebsiteUrl = 'https://vizor.cash';
 
-const _placeholderParagraph = _UtilityParagraphData(
+const _aboutParagraphs = [
+  _UtilityParagraphData(
+    heading: 'Built by the Keplr team',
+    body:
+        'We built Keplr, the wallet used by millions across Cosmos, Ethereum, '
+        'and Bitcoin. Vizor is our take on what a Zcash wallet should feel '
+        'like.',
+  ),
+  _UtilityParagraphData(
+    heading: 'Designed for shielded Zcash',
+    body:
+        'Vizor is built around shielded transactions, where the sender, '
+        'recipient, and amount stay private. Transparent Zcash works too, but '
+        'private is the default here.',
+  ),
+  _UtilityParagraphData(
+    heading: 'Open source, verifiable, and self-custodial',
+    body:
+        "Vizor is Apache licensed. Your keys stay on your device. We don't "
+        "see your balances or your transactions.",
+  ),
+];
+
+const _legalPlaceholderParagraph = _UtilityParagraphData(
   heading: 'From the team that brought you Keplr Wallet.',
   body:
       'Unlike Bitcoin or Ethereum, shielded Zcash transactions hide the '
       'sender, recipient, and amount.',
 );
 
-const _aboutParagraphs = [_placeholderParagraph, _placeholderParagraph];
-
 const _legalParagraphs = [
-  _placeholderParagraph,
-  _placeholderParagraph,
-  _placeholderParagraph,
-  _placeholderParagraph,
-  _placeholderParagraph,
-  _placeholderParagraph,
+  _legalPlaceholderParagraph,
+  _legalPlaceholderParagraph,
+  _legalPlaceholderParagraph,
+  _legalPlaceholderParagraph,
+  _legalPlaceholderParagraph,
+  _legalPlaceholderParagraph,
 ];
 
 class AboutScreen extends StatelessWidget {
@@ -101,6 +126,7 @@ class _AboutContent extends StatelessWidget {
         AppDecorativeDivider(width: 256),
         SizedBox(height: AppSpacing.md),
         _UtilityParagraphList(paragraphs: _aboutParagraphs),
+        _AboutLinkRow(),
         SizedBox(height: AppSpacing.md),
         VizorWordmark(width: 74, height: 27.925),
       ],
@@ -415,6 +441,93 @@ class _UtilityParagraph extends StatelessWidget {
         ),
       ],
     );
+  }
+}
+
+class _AboutLinkRow extends StatelessWidget {
+  const _AboutLinkRow();
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      width: _paragraphWidth,
+      child: Wrap(
+        spacing: AppSpacing.md,
+        runSpacing: AppSpacing.xs,
+        children: [
+          _AboutTextLink(
+            label: 'GitHub',
+            semanticsLabel: 'Open Vizor GitHub',
+            url: _vizorGithubUrl,
+          ),
+          _AboutTextLink(
+            label: 'Website',
+            semanticsLabel: 'Open Vizor website',
+            url: _vizorWebsiteUrl,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AboutTextLink extends StatefulWidget {
+  const _AboutTextLink({
+    required this.label,
+    required this.semanticsLabel,
+    required this.url,
+  });
+
+  final String label;
+  final String semanticsLabel;
+  final String url;
+
+  @override
+  State<_AboutTextLink> createState() => _AboutTextLinkState();
+}
+
+class _AboutTextLinkState extends State<_AboutTextLink> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final textColor = colors.text.accent;
+    return Semantics(
+      button: true,
+      link: true,
+      label: widget.semanticsLabel,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        onEnter: (_) => setState(() => _hovered = true),
+        onExit: (_) => setState(() => _hovered = false),
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () => unawaited(_launchAboutUrl(widget.url)),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 4),
+            child: Text(
+              widget.label,
+              style: AppTypography.labelLarge.copyWith(
+                color: textColor,
+                decoration: _hovered
+                    ? TextDecoration.underline
+                    : TextDecoration.none,
+                decorationColor: textColor,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+Future<void> _launchAboutUrl(String url) async {
+  try {
+    await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+  } on Exception {
+    // External links are best-effort from this utility page.
   }
 }
 

--- a/test/features/about/about_legal_pages_test.dart
+++ b/test/features/about/about_legal_pages_test.dart
@@ -61,6 +61,14 @@ void main() {
 
     expect(find.text('About Vizor Wallet'), findsOneWidget);
     expect(find.text('Version: 0.0.0 Public Beta'), findsOneWidget);
+    expect(find.text('Built by the Keplr team'), findsOneWidget);
+    expect(find.text('Designed for shielded Zcash'), findsOneWidget);
+    expect(
+      find.text('Open source, verifiable, and self-custodial'),
+      findsOneWidget,
+    );
+    expect(find.text('GitHub'), findsOneWidget);
+    expect(find.text('Website'), findsOneWidget);
   });
 
   testWidgets('About sidebar navigation uses the standard Home back target', (
@@ -136,7 +144,11 @@ void main() {
     await tester.pumpAndSettle();
 
     _expectScrollbarFillsPaneEdge(tester, const Size(1280, 900));
-    _expectUtilityContentCentered(tester, const Size(1280, 900));
+    _expectUtilityContentCentered(
+      tester,
+      const Size(1280, 900),
+      headingText: 'From the team that brought you Keplr Wallet.',
+    );
 
     await tester.pumpWidget(
       _routerHarness(
@@ -152,7 +164,11 @@ void main() {
     await tester.pumpAndSettle();
 
     _expectScrollbarFillsPaneEdge(tester, const Size(1280, 900));
-    _expectUtilityContentCentered(tester, const Size(1280, 900));
+    _expectUtilityContentCentered(
+      tester,
+      const Size(1280, 900),
+      headingText: 'Built by the Keplr team',
+    );
   });
 
   testWidgets('legal back row scrolls with the page content', (tester) async {
@@ -317,15 +333,17 @@ void _expectScrollbarFillsPaneEdge(WidgetTester tester, Size viewport) {
   );
 }
 
-void _expectUtilityContentCentered(WidgetTester tester, Size viewport) {
+void _expectUtilityContentCentered(
+  WidgetTester tester,
+  Size viewport, {
+  required String headingText,
+}) {
   final scrollbarRect = tester.getRect(find.byKey(_utilityPageScrollbarKey));
   final dividerRect = tester.getRect(find.byType(AppDecorativeDivider).last);
   expect(dividerRect.width, moreOrLessEquals(256));
   expect(dividerRect.center.dx, moreOrLessEquals(scrollbarRect.center.dx));
 
-  final headingRect = tester.getRect(
-    find.text('From the team that brought you Keplr Wallet.').first,
-  );
+  final headingRect = tester.getRect(find.text(headingText).first);
   expect(headingRect.left, greaterThan(scrollbarRect.left + 100));
 }
 


### PR DESCRIPTION
## Summary
- Update the About Vizor Wallet copy to the requested Keplr/team, shielded Zcash, and self-custody messaging.
- Add GitHub and Website links to the About page.
- Update About page widget assertions for the new copy.

## Validation
- fvm flutter analyze lib/src/features/about/screens/about_screen.dart test/features/about/about_legal_pages_test.dart
- fvm flutter test test/features/about/about_legal_pages_test.dart --name "About Vizor sidebar item opens the About page|About sidebar navigation uses the standard Home back target|utility scrollbars fill the pane edge"