### PR TITLE
[codex] Add birthday fallback confirmation

### DIFF
--- a/lib/src/features/onboarding/import/import_birthday_unknown_height_modal.dart
+++ b/lib/src/features/onboarding/import/import_birthday_unknown_height_modal.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/widgets.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_pane_modal_overlay.dart';
+
+class ImportBirthdayUnknownHeightModal extends StatelessWidget {
+  const ImportBirthdayUnknownHeightModal({
+    required this.onConfirm,
+    required this.onCancel,
+    super.key,
+  });
+
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return AppPaneModalOverlay(
+      onDismiss: onCancel,
+      child: Container(
+        width: 312,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: AppSpacing.md,
+        ),
+        decoration: BoxDecoration(
+          color: colors.background.ground,
+          borderRadius: BorderRadius.circular(AppRadii.large),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: colors.background.neutralSubtleOpacity,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Center(
+                    child: AppIcon(
+                      AppIcons.warning,
+                      size: AppIconSize.medium,
+                      color: colors.icon.regular,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.xs),
+                Expanded(
+                  child: Text(
+                    'Import from the earliest height?',
+                    style: AppTypography.bodyLarge.copyWith(
+                      color: colors.text.accent,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    'If you continue without a wallet birthday, Vizor will '
+                    'scan from the earliest supported shielded height. This '
+                    'is safe, but the first sync can take a very long time.',
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    'Choosing even an approximate date will be much faster.',
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.secondary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            AppButton(
+              key: const ValueKey('unknown_birthday_confirm_button'),
+              onPressed: onConfirm,
+              minWidth: 280,
+              child: const Text('Continue Anyway'),
+            ),
+            const SizedBox(height: AppSpacing.s),
+            AppButton(
+              key: const ValueKey('unknown_birthday_cancel_button'),
+              onPressed: onCancel,
+              variant: AppButtonVariant.ghost,
+              minWidth: 280,
+              child: const Text('Go Back'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -17,6 +17,7 @@ import '../shared/onboarding_error_messages.dart';
 import '../shared/onboarding_flow_args.dart';
 import 'import_birthday_estimator.dart';
 import 'import_birthday_calendar_overlay.dart';
+import 'import_birthday_unknown_height_modal.dart';
 import 'import_split_view.dart';
 
 enum ImportBirthdayTab { date, blockHeight }
@@ -50,6 +51,7 @@ class _ImportWalletBirthdayScreenState
   int? _birthdayHeight;
   bool _isEstimating = false;
   bool _isCalendarOpen = false;
+  bool _isUnknownBirthdayConfirmOpen = false;
   _ImportWalletSubmitPhase _submitPhase = _ImportWalletSubmitPhase.idle;
   String? _metadataError;
   String? _submitError;
@@ -198,6 +200,30 @@ class _ImportWalletBirthdayScreenState
     setState(() {
       _isCalendarOpen = false;
     });
+  }
+
+  void _showUnknownBirthdayConfirmation() {
+    if (_isSubmitting) return;
+    setState(() {
+      _isCalendarOpen = false;
+      _isUnknownBirthdayConfirmOpen = true;
+      _submitError = null;
+    });
+  }
+
+  void _dismissUnknownBirthdayConfirmation() {
+    if (!_isUnknownBirthdayConfirmOpen) return;
+    setState(() {
+      _isUnknownBirthdayConfirmOpen = false;
+    });
+  }
+
+  Future<void> _confirmUnknownBirthday() async {
+    if (_isSubmitting) return;
+    setState(() {
+      _isUnknownBirthdayConfirmOpen = false;
+    });
+    await _submit(birthdayHeightOverride: _minimumBirthdayHeight);
   }
 
   Future<void> _handleCalendarDateSelected(DateTime selected) async {
@@ -354,7 +380,12 @@ class _ImportWalletBirthdayScreenState
     };
 
     return ImportOnboardingTrailingPane(
-      overlay: _isCalendarOpen
+      overlay: _isUnknownBirthdayConfirmOpen
+          ? ImportBirthdayUnknownHeightModal(
+              onConfirm: _confirmUnknownBirthday,
+              onCancel: _dismissUnknownBirthdayConfirmation,
+            )
+          : _isCalendarOpen
           ? ImportBirthdayCalendarOverlay(
               initialMonth: _calendarInitialDate ?? calendarLastDate,
               selectedDate: _selectedDate,
@@ -475,9 +506,7 @@ class _ImportWalletBirthdayScreenState
                         key: const ValueKey('import_birthday_skip_button'),
                         onPressed: _isSubmitting
                             ? null
-                            : () => _submit(
-                                birthdayHeightOverride: _minimumBirthdayHeight,
-                              ),
+                            : _showUnknownBirthdayConfirmation,
                         variant: AppButtonVariant.ghost,
                         minWidth: _buttonWidth,
                         trailing: const AppIcon(AppIcons.skip),

--- a/lib/src/features/onboarding/keystone/keystone_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/keystone/keystone_wallet_birthday_screen.dart
@@ -14,6 +14,7 @@ import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/wallet_mutation_guard.dart';
 import '../import/import_birthday_calendar_overlay.dart';
 import '../import/import_birthday_estimator.dart';
+import '../import/import_birthday_unknown_height_modal.dart';
 import '../shared/onboarding_error_messages.dart';
 import '../shared/onboarding_flow_args.dart';
 import 'keystone_onboarding_flow.dart';
@@ -47,6 +48,7 @@ class _KeystoneWalletBirthdayScreenState
   int? _birthdayHeight;
   bool _isEstimating = false;
   bool _isCalendarOpen = false;
+  bool _isUnknownBirthdayConfirmOpen = false;
   _KeystoneBirthdaySubmitPhase _submitPhase = _KeystoneBirthdaySubmitPhase.idle;
   String? _metadataError;
   String? _submitError;
@@ -182,6 +184,30 @@ class _KeystoneWalletBirthdayScreenState
     setState(() {
       _isCalendarOpen = false;
     });
+  }
+
+  void _showUnknownBirthdayConfirmation() {
+    if (_isSubmitting) return;
+    setState(() {
+      _isCalendarOpen = false;
+      _isUnknownBirthdayConfirmOpen = true;
+      _submitError = null;
+    });
+  }
+
+  void _dismissUnknownBirthdayConfirmation() {
+    if (!_isUnknownBirthdayConfirmOpen) return;
+    setState(() {
+      _isUnknownBirthdayConfirmOpen = false;
+    });
+  }
+
+  Future<void> _confirmUnknownBirthday() async {
+    if (_isSubmitting) return;
+    setState(() {
+      _isUnknownBirthdayConfirmOpen = false;
+    });
+    await _submit(birthdayHeightOverride: _minimumBirthdayHeight);
   }
 
   Future<void> _handleCalendarDateSelected(DateTime selected) async {
@@ -351,7 +377,12 @@ class _KeystoneWalletBirthdayScreenState
     };
 
     return KeystoneOnboardingTrailingPane(
-      overlay: _isCalendarOpen
+      overlay: _isUnknownBirthdayConfirmOpen
+          ? ImportBirthdayUnknownHeightModal(
+              onConfirm: _confirmUnknownBirthday,
+              onCancel: _dismissUnknownBirthdayConfirmation,
+            )
+          : _isCalendarOpen
           ? ImportBirthdayCalendarOverlay(
               initialMonth: _calendarInitialDate ?? calendarLastDate,
               selectedDate: _selectedDate,
@@ -469,9 +500,7 @@ class _KeystoneWalletBirthdayScreenState
                         key: const ValueKey('keystone_birthday_skip_button'),
                         onPressed: _isSubmitting
                             ? null
-                            : () => _submit(
-                                birthdayHeightOverride: _minimumBirthdayHeight,
-                              ),
+                            : _showUnknownBirthdayConfirmation,
                         variant: AppButtonVariant.ghost,
                         minWidth: _buttonWidth,
                         trailing: const AppIcon(AppIcons.skip),


### PR DESCRIPTION
## Summary

Adds a confirmation modal when a user chooses `I can’t remember` on the wallet birthday screen. The modal explains that importing without a wallet birthday scans from the earliest supported shielded height and can make the first sync take a long time.

This is wired into both mnemonic import and Keystone import flows. The existing fallback to the network minimum birthday height only runs after the user explicitly confirms.

## Validation

- `fvm dart format lib/src/features/onboarding/import/import_birthday_unknown_height_modal.dart lib/src/features/onboarding/import/import_wallet_birthday_screen.dart lib/src/features/onboarding/keystone/keystone_wallet_birthday_screen.dart`
- `fvm flutter analyze`