### PR TITLE
[codex] Require password confirmation before account deletion

### DIFF
--- a/lib/src/core/theme/colors/app_button_colors.dart
+++ b/lib/src/core/theme/colors/app_button_colors.dart
@@ -173,6 +173,6 @@ class AppDestructiveButtonColors {
     bgHover: PlumPrimitives.p400Light,
     bgPressed: PlumPrimitives.p400Light,
     border: Primitives.p0Alpha15Light,
-    label: PlumPrimitives.p800Light,
+    label: PlumPrimitives.p50Light,
   );
 }

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -18,6 +18,7 @@ import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
 import '../../../core/widgets/app_profile_picture.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/app_security_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_mutation_guard.dart';
 import '../widgets/account_name_modal.dart';
@@ -208,6 +209,9 @@ class _AccountsScreenState extends ConsumerState<AccountsScreen> {
                     profilePictureId: modalAccount.profilePictureId,
                     isLastAccount: isLastModalAccount,
                     onCancel: _closeModal,
+                    onConfirmPassword: (password) => ref
+                        .read(appSecurityProvider.notifier)
+                        .confirmPassword(password),
                     onRemove: (onProgress) => _removeAccount(
                       modalAccount.uuid,
                       isLastAccount: isLastModalAccount,

--- a/lib/src/features/accounts/widgets/account_remove_modal.dart
+++ b/lib/src/features/accounts/widgets/account_remove_modal.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/widgets.dart';
 
+import '../../../core/security/password_policy.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_profile_picture.dart';
+import '../../../core/widgets/app_text_field.dart';
+import '../../../core/widgets/password_text_field.dart';
 
 enum AccountRemoveProgress { stoppingSync, removingAccount }
 
@@ -16,6 +19,7 @@ class AccountRemoveModal extends StatefulWidget {
     required this.profilePictureId,
     required this.isLastAccount,
     required this.onCancel,
+    required this.onConfirmPassword,
     required this.onRemove,
     super.key,
   });
@@ -24,6 +28,7 @@ class AccountRemoveModal extends StatefulWidget {
   final String profilePictureId;
   final bool isLastAccount;
   final VoidCallback onCancel;
+  final Future<bool> Function(String password) onConfirmPassword;
   final Future<void> Function(AccountRemoveProgressCallback onProgress)
   onRemove;
 
@@ -33,17 +38,77 @@ class AccountRemoveModal extends StatefulWidget {
 
 class _AccountRemoveModalState extends State<AccountRemoveModal> {
   static const _buttonWidth = 280.0;
+  static const _fieldHeight = 68.0;
 
+  final _passwordController = TextEditingController();
   bool _isSubmitting = false;
   _AccountRemoveSubmitPhase? _submitPhase;
+  String? _passwordError;
   String? _submitError;
+
+  bool get _canSubmit =>
+      !_isSubmitting && isWalletPasswordValid(_passwordController.text);
+
+  String? get _passwordMessage {
+    if (_passwordError != null) return _passwordError;
+    return validateWalletPassword(_passwordController.text);
+  }
+
+  @override
+  void dispose() {
+    _passwordController.clear();
+    _passwordController.dispose();
+    super.dispose();
+  }
 
   Future<void> _submit() async {
     if (_isSubmitting) return;
+    final passwordError = validateRequiredWalletPassword(
+      _passwordController.text,
+    );
+    if (passwordError != null) {
+      setState(() {
+        _passwordError = passwordError;
+        _submitError = null;
+      });
+      return;
+    }
+
     setState(() {
       _isSubmitting = true;
-      _submitPhase = _AccountRemoveSubmitPhase.stoppingSync;
+      _submitPhase = _AccountRemoveSubmitPhase.checkingPassword;
+      _passwordError = null;
       _submitError = null;
+    });
+
+    bool isPasswordValid;
+    try {
+      isPasswordValid = await widget.onConfirmPassword(
+        _passwordController.text,
+      );
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _passwordError = "Couldn't check your password. Please try again.";
+        _isSubmitting = false;
+        _submitPhase = null;
+      });
+      return;
+    }
+
+    if (!mounted) return;
+    if (!isPasswordValid) {
+      setState(() {
+        _passwordError = 'Incorrect password. Please try again.';
+        _isSubmitting = false;
+        _submitPhase = null;
+      });
+      return;
+    }
+
+    setState(() {
+      _passwordController.clear();
+      _submitPhase = _AccountRemoveSubmitPhase.stoppingSync;
     });
 
     try {
@@ -65,6 +130,13 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
     }
   }
 
+  void _handlePasswordChanged() {
+    setState(() {
+      _passwordError = null;
+      _submitError = null;
+    });
+  }
+
   void _setProgress(AccountRemoveProgress progress) {
     if (!mounted) return;
     final next = switch (progress) {
@@ -81,6 +153,8 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
 
   @override
   Widget build(BuildContext context) {
+    final passwordMessage = _passwordMessage;
+
     return _AccountRemoveModalCard(
       header: _AccountRemoveModalHeader(
         accountName: widget.accountName,
@@ -97,6 +171,34 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
               color: context.colors.text.accent,
             ),
           ),
+          const SizedBox(height: AppSpacing.sm),
+          SizedBox(
+            height: _fieldHeight,
+            child: PasswordTextField(
+              label: 'Password',
+              hintText: 'Enter Your Password',
+              leadingSlotWidth: 32,
+              trailingSlotWidth: 40,
+              inputHorizontalPadding: AppSpacing.s,
+              controller: _passwordController,
+              autofocus: true,
+              enabled: !_isSubmitting,
+              tone: passwordMessage == null
+                  ? AppTextFieldTone.neutral
+                  : AppTextFieldTone.destructive,
+              onChanged: (_) => _handlePasswordChanged(),
+              onSubmitted: (_) => _submit(),
+            ),
+          ),
+          if (passwordMessage != null) ...[
+            const SizedBox(height: AppSpacing.xxs),
+            Text(
+              passwordMessage,
+              style: AppTypography.labelMedium.copyWith(
+                color: context.colors.text.destructive,
+              ),
+            ),
+          ],
           if (_submitError != null) ...[
             const SizedBox(height: AppSpacing.sm),
             Text(
@@ -109,7 +211,7 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
           ],
           const SizedBox(height: AppSpacing.md),
           AppButton(
-            onPressed: _isSubmitting ? null : _submit,
+            onPressed: _canSubmit ? _submit : null,
             variant: AppButtonVariant.destructive,
             minWidth: _buttonWidth,
             leading: _isSubmitting ? null : const AppIcon(AppIcons.trash),
@@ -145,6 +247,7 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
     }
 
     return switch (_submitPhase) {
+      _AccountRemoveSubmitPhase.checkingPassword => 'Checking password...',
       _AccountRemoveSubmitPhase.stoppingSync => 'Stopping sync...',
       _AccountRemoveSubmitPhase.removingAccount =>
         widget.isLastAccount ? 'Resetting...' : 'Removing account...',
@@ -168,7 +271,11 @@ class _AccountRemoveModalState extends State<AccountRemoveModal> {
   }
 }
 
-enum _AccountRemoveSubmitPhase { stoppingSync, removingAccount }
+enum _AccountRemoveSubmitPhase {
+  checkingPassword,
+  stoppingSync,
+  removingAccount,
+}
 
 class _AccountRemoveModalCard extends StatelessWidget {
   const _AccountRemoveModalCard({required this.header, required this.child});

--- a/test/features/accounts/accounts_screen_test.dart
+++ b/test/features/accounts/accounts_screen_test.dart
@@ -15,7 +15,11 @@ import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_pane_modal_overlay.dart';
 import 'package:zcash_wallet/src/features/accounts/screens/accounts_screen.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+const _validDeletePassword = 'Correct123!';
+const _invalidDeletePassword = 'Wrong123!';
 
 void main() {
   testWidgets('accounts screen renders active account and other accounts', (
@@ -493,9 +497,10 @@ void main() {
       find.textContaining('You will have to re-import your account.'),
       findsOneWidget,
     );
+    expect(find.text('Password'), findsOneWidget);
     expect(find.byType(AppPaneModalOverlay), findsOneWidget);
 
-    await tester.tap(find.text('Remove'));
+    await _submitRemovePassword(tester);
     await tester.pumpAndSettle();
 
     expect(accountNotifier.removedUuid, 'account-2');
@@ -507,6 +512,42 @@ void main() {
     expect(
       find.textContaining('Are you sure you want to remove this account?'),
       findsNothing,
+    );
+  });
+
+  testWidgets('remove account requires the current password before deleting', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final accountNotifier = _FakeAccountNotifier(
+      _bootstrap.initialAccountState,
+    );
+    final syncNotifier = _FakeSyncNotifier();
+    final securityNotifier = _FakeAppSecurityNotifier();
+    await tester.pumpWidget(
+      _accountsHarness(
+        accountNotifier: () => accountNotifier,
+        syncNotifier: () => syncNotifier,
+        securityNotifier: () => securityNotifier,
+      ),
+    );
+    await tester.pump();
+
+    await _openRemoveAccountModal(tester, 'account-2');
+    await _submitRemovePassword(tester, password: _invalidDeletePassword);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Incorrect password. Please try again.'), findsOneWidget);
+    expect(securityNotifier.confirmedPasswords, [_invalidDeletePassword]);
+    expect(accountNotifier.removedUuid, isNull);
+    expect(syncNotifier.refreshCount, 0);
+    expect(
+      find.byKey(const ValueKey('accounts_other_row_account-2')),
+      findsOneWidget,
     );
   });
 
@@ -538,7 +579,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('Remove Account'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Remove'));
+    await _submitRemovePassword(tester);
     await tester.pumpAndSettle();
 
     expect(events, ['pause', 'remove:account-2', 'resume', 'refresh']);
@@ -573,7 +614,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('Remove Account'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Remove'));
+    await _submitRemovePassword(tester);
     await tester.pump();
 
     expect(find.text('Stopping sync...'), findsOneWidget);
@@ -624,7 +665,7 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.text('Remove Account'));
       await tester.pumpAndSettle();
-      await tester.tap(find.text('Remove'));
+      await _submitRemovePassword(tester);
       await tester.pumpAndSettle();
     } finally {
       debugPrint = previousDebugPrint;
@@ -707,7 +748,7 @@ void main() {
     );
     expect(find.textContaining('This cannot be undone.'), findsOneWidget);
 
-    await tester.tap(find.text('Reset Vizor'));
+    await _submitRemovePassword(tester, buttonLabel: 'Reset Vizor');
     await tester.pumpAndSettle();
 
     expect(events, ['pause', 'resetWallet', 'clearCachedWalletDbPath']);
@@ -753,7 +794,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.text('Remove Account'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Reset Vizor'));
+    await _submitRemovePassword(tester, buttonLabel: 'Reset Vizor');
     await tester.pumpAndSettle();
 
     expect(find.text("Couldn't reset Vizor."), findsOneWidget);
@@ -762,9 +803,32 @@ void main() {
   });
 }
 
+Future<void> _openRemoveAccountModal(
+  WidgetTester tester,
+  String accountUuid,
+) async {
+  await tester.tap(
+    find.byKey(ValueKey('accounts_row_menu_button_$accountUuid')),
+  );
+  await tester.pumpAndSettle();
+  await tester.tap(find.text('Remove Account'));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _submitRemovePassword(
+  WidgetTester tester, {
+  String password = _validDeletePassword,
+  String buttonLabel = 'Remove',
+}) async {
+  await tester.enterText(find.byType(EditableText), password);
+  await tester.pump();
+  await tester.tap(find.text(buttonLabel));
+}
+
 Widget _accountsHarness({
   AccountNotifier Function()? accountNotifier,
   SyncNotifier Function()? syncNotifier,
+  AppSecurityNotifier Function()? securityNotifier,
 }) {
   final router = GoRouter(
     initialLocation: '/accounts',
@@ -795,6 +859,9 @@ Widget _accountsHarness({
       appBootstrapProvider.overrideWithValue(_bootstrap),
       if (accountNotifier != null)
         accountProvider.overrideWith(accountNotifier),
+      appSecurityProvider.overrideWith(
+        securityNotifier ?? _FakeAppSecurityNotifier.new,
+      ),
       syncProvider.overrideWith(syncNotifier ?? _FakeSyncNotifier.new),
     ],
     child: MaterialApp.router(
@@ -960,6 +1027,24 @@ class _FakeAccountNotifier extends AccountNotifier {
     }
     resetWalletCalled = true;
     state = const AsyncData(AccountState());
+  }
+}
+
+class _FakeAppSecurityNotifier extends AppSecurityNotifier {
+  _FakeAppSecurityNotifier({this.validPassword = _validDeletePassword});
+
+  final String validPassword;
+  final List<String> confirmedPasswords = [];
+
+  @override
+  AppSecurityState build() {
+    return const AppSecurityState(isPasswordConfigured: true, isUnlocked: true);
+  }
+
+  @override
+  Future<bool> confirmPassword(String password) async {
+    confirmedPasswords.add(password);
+    return password == validPassword;
   }
 }
 


### PR DESCRIPTION
## Summary
- Require users to confirm their wallet password before removing an account or resetting Vizor from the account removal modal.
- Keep the password check in the existing app security verifier path so deletion only starts after re-authentication succeeds.
- Align the light-mode destructive button label color with the Figma destructive button spec.

## Impact
- Account deletion and last-account reset now have an explicit password gate before sync pause and wallet mutation begin.
- Incorrect passwords leave the account list untouched and show an inline error.
- Light-mode destructive buttons now use the same label/icon color as the Figma showroom.

## Validation
- `fvm flutter analyze`
- `fvm flutter test test/features/accounts/accounts_screen_test.dart`