### PR TITLE
[codex] Clear create onboarding mnemonic after setup

### DIFF
--- a/lib/src/features/onboarding/create/intro_zcash_screen.dart
+++ b/lib/src/features/onboarding/create/intro_zcash_screen.dart
@@ -26,10 +26,7 @@ class _IntroZcashScreenState extends ConsumerState<IntroZcashScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      ref.read(createOnboardingMnemonicProvider.notifier).clear();
-      ref
-          .read(onboardingSecretPassphraseRevealedProvider.notifier)
-          .setRevealed(false);
+      clearCreateOnboardingSecretState(ref.read);
     });
   }
 

--- a/lib/src/features/onboarding/create/onboarding_split_view.dart
+++ b/lib/src/features/onboarding/create/onboarding_split_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show ProviderListenable;
 
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/motion/onboarding_motion.dart';
@@ -37,6 +38,13 @@ final createOnboardingMnemonicProvider =
     NotifierProvider<CreateOnboardingMnemonicNotifier, String?>(
       CreateOnboardingMnemonicNotifier.new,
     );
+
+typedef ProviderReader = T Function<T>(ProviderListenable<T> provider);
+
+void clearCreateOnboardingSecretState(ProviderReader read) {
+  read(createOnboardingMnemonicProvider.notifier).clear();
+  read(onboardingSecretPassphraseRevealedProvider.notifier).setRevealed(false);
+}
 
 enum OnboardingStep {
   intro,

--- a/lib/src/features/onboarding/create/secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/create/secret_passphrase_screen.dart
@@ -170,10 +170,7 @@ class _SecretPassphraseScreenState
       return;
     }
     if (mounted) {
-      ref.read(createOnboardingMnemonicProvider.notifier).clear();
-      ref
-          .read(onboardingSecretPassphraseRevealedProvider.notifier)
-          .setRevealed(false);
+      clearCreateOnboardingSecretState(ref.read);
     }
     router.go('/home');
   }

--- a/lib/src/features/onboarding/shared/set_password_screen.dart
+++ b/lib/src/features/onboarding/shared/set_password_screen.dart
@@ -131,6 +131,9 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
         if (args.flow == SetPasswordFlow.importKeystone) {
           ref.read(keystoneOnboardingProvider.notifier).resetScan();
         }
+        if (args.flow == SetPasswordFlow.create) {
+          clearCreateOnboardingSecretState(ref.read);
+        }
         router.go('/home');
       });
     } catch (e, st) {

--- a/test/features/onboarding/create_onboarding_mnemonic_test.dart
+++ b/test/features/onboarding/create_onboarding_mnemonic_test.dart
@@ -51,6 +51,22 @@ void main() {
     expect(container.read(createOnboardingMnemonicProvider), isNull);
     expect(container.read(onboardingSecretPassphraseRevealedProvider), isFalse);
   });
+
+  test('clearCreateOnboardingSecretState clears mnemonic and reveal flag', () {
+    final container = _providerContainer();
+    addTearDown(container.dispose);
+    container
+        .read(createOnboardingMnemonicProvider.notifier)
+        .setMnemonic(_mnemonic);
+    container
+        .read(onboardingSecretPassphraseRevealedProvider.notifier)
+        .setRevealed(true);
+
+    clearCreateOnboardingSecretState(container.read);
+
+    expect(container.read(createOnboardingMnemonicProvider), isNull);
+    expect(container.read(onboardingSecretPassphraseRevealedProvider), isFalse);
+  });
 }
 
 Future<void> _setDesktopViewport(WidgetTester tester) async {


### PR DESCRIPTION
## Summary

Clears the create-onboarding mnemonic provider and revealed flag after first-wallet password setup completes successfully.

## Why

The create onboarding flow preserved the generated mnemonic while navigating between onboarding screens, but the set-password success path created the wallet and routed to `/home` without clearing that root-scoped state. This could keep a plaintext mnemonic and revealed state alive longer than intended.

## Changes

- Added a shared `clearCreateOnboardingSecretState` helper for the create-onboarding mnemonic and reveal flag.
- Reused the helper in the existing intro and direct-create cleanup paths.
- Called the helper after successful `SetPasswordFlow.create` setup before navigating home.
- Added focused coverage for the shared cleanup helper while preserving pending mnemonic reuse during in-progress onboarding.

## Validation

- `fvm flutter test test/features/onboarding/create_onboarding_mnemonic_test.dart`
- `fvm flutter analyze`