### PR TITLE
[codex] Update welcome tagline

### DIFF
--- a/lib/src/features/onboarding/welcome.dart
+++ b/lib/src/features/onboarding/welcome.dart
@@ -272,7 +272,7 @@ class _TitleBlock extends StatelessWidget {
         const _VizorLogo(),
         const SizedBox(height: AppSpacing.md),
         Text(
-          'Behind the Vizor.\nYour money stays private.',
+          'Private money. By default.',
           style: AppTypography.displayLarge.copyWith(color: colors.text.accent),
           textAlign: TextAlign.center,
         ),

--- a/test/features/about/about_legal_pages_test.dart
+++ b/test/features/about/about_legal_pages_test.dart
@@ -241,19 +241,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Terms of Use'), findsOneWidget);
-    expect(
-      find.text('Behind the Vizor.\nYour money stays private.'),
-      findsNothing,
-    );
+    expect(find.text('Private money. By default.'), findsNothing);
 
     await tester.pumpWidget(_appHarness(_emptyBootstrap('/privacy')));
     await tester.pumpAndSettle();
 
     expect(find.text('Privacy Policy'), findsOneWidget);
-    expect(
-      find.text('Behind the Vizor.\nYour money stays private.'),
-      findsNothing,
-    );
+    expect(find.text('Private money. By default.'), findsNothing);
   });
 
   testWidgets('welcome footer links open legal pages', (tester) async {


### PR DESCRIPTION
## Summary
- Update the welcome screen tagline to "Private money. By default."
- Refresh the related legal-page test expectation so it checks for the new welcome copy.

## Validation
- fvm flutter test test/features/about/about_legal_pages_test.dart
- fvm flutter analyze