### PR TITLE
fix: focus AppTextField shell taps

### DIFF
--- a/lib/src/core/widgets/app_text_field.dart
+++ b/lib/src/core/widgets/app_text_field.dart
@@ -349,6 +349,7 @@ class _AppTextFieldState extends State<AppTextField> {
         : null;
 
     final textField = TextField(
+      key: _textFieldRegionKey,
       controller: _controller,
       focusNode: _focusNode,
       enabled: widget.enabled,
@@ -511,7 +512,6 @@ class _AppTextFieldState extends State<AppTextField> {
                               ),
                             Expanded(
                               child: Padding(
-                                key: _textFieldRegionKey,
                                 padding: const EdgeInsets.fromLTRB(
                                   AppSpacing.s,
                                   AppSpacing.s,
@@ -575,7 +575,6 @@ class _AppTextFieldState extends State<AppTextField> {
                               ),
                             Expanded(
                               child: Padding(
-                                key: _textFieldRegionKey,
                                 padding: EdgeInsets.only(
                                   left:
                                       widget.inputHorizontalPadding ??
@@ -629,7 +628,6 @@ class _AppTextFieldState extends State<AppTextField> {
                                 const SizedBox(width: AppSpacing.xs),
                               Expanded(
                                 child: Padding(
-                                  key: _textFieldRegionKey,
                                   padding: const EdgeInsets.only(bottom: 6),
                                   child: fieldInput,
                                 ),

--- a/test/core/widgets/app_text_field_test.dart
+++ b/test/core/widgets/app_text_field_test.dart
@@ -6,6 +6,43 @@ import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_text_field.dart';
 
 void main() {
+  testWidgets('single-line padded input area focuses on the first tap', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      _ThemedHarness(
+        child: SizedBox(
+          width: 352,
+          child: AppTextField(
+            label: 'Send to',
+            controller: controller,
+            focusNode: focusNode,
+            hintText: 'Zcash address',
+            leading: const AppIcon(AppIcons.users),
+            showClearButton: true,
+          ),
+        ),
+      ),
+    );
+
+    final textFieldRect = tester.getRect(find.byType(TextField));
+
+    // This lands in the styled field padding below the actual EditableText.
+    // It used to be classified as "inside the TextField region", so the shell
+    // skipped its own focus fallback while the TextField itself never saw it.
+    await tester.tapAt(
+      Offset(textFieldRect.center.dx, textFieldRect.bottom + 3),
+    );
+    await tester.pump();
+
+    expect(focusNode.hasFocus, isTrue);
+  });
+
   testWidgets('multiline clear button uses the Figma hit target', (
     tester,
   ) async {

--- a/test/core/widgets/app_text_field_test.dart
+++ b/test/core/widgets/app_text_field_test.dart
@@ -6,16 +6,19 @@ import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_text_field.dart';
 
 void main() {
-  testWidgets('single-line padded input area focuses on the first tap', (
+  testWidgets('single-line padded input area wins over root unfocus', (
     tester,
   ) async {
     final controller = TextEditingController();
     final focusNode = FocusNode();
+    var rootTapCount = 0;
     addTearDown(controller.dispose);
     addTearDown(focusNode.dispose);
 
     await tester.pumpWidget(
       _ThemedHarness(
+        includeRootUnfocus: true,
+        onRootTap: () => rootTapCount += 1,
         child: SizedBox(
           width: 352,
           child: AppTextField(
@@ -41,6 +44,45 @@ void main() {
     await tester.pump();
 
     expect(focusNode.hasFocus, isTrue);
+    expect(rootTapCount, isZero);
+  });
+
+  testWidgets('root unfocus still clears focus outside app text field', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    var rootTapCount = 0;
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      _ThemedHarness(
+        includeRootUnfocus: true,
+        onRootTap: () => rootTapCount += 1,
+        child: SizedBox(
+          width: 352,
+          child: AppTextField(
+            label: 'Send to',
+            controller: controller,
+            focusNode: focusNode,
+            hintText: 'Zcash address',
+            leading: const AppIcon(AppIcons.users),
+            showClearButton: true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+    expect(focusNode.hasFocus, isTrue);
+
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pump();
+
+    expect(rootTapCount, 1);
+    expect(focusNode.hasFocus, isFalse);
   });
 
   testWidgets('multiline clear button uses the Figma hit target', (
@@ -259,17 +301,39 @@ void main() {
 }
 
 class _ThemedHarness extends StatelessWidget {
-  const _ThemedHarness({required this.child});
+  const _ThemedHarness({
+    required this.child,
+    this.includeRootUnfocus = false,
+    this.onRootTap,
+  });
 
   final Widget child;
+  final bool includeRootUnfocus;
+  final VoidCallback? onRootTap;
 
   @override
   Widget build(BuildContext context) {
+    final body = Center(child: child);
+
     return MaterialApp(
       theme: ThemeData(platform: TargetPlatform.macOS),
       home: AppTheme(
         data: AppThemeData.light,
-        child: Scaffold(body: Center(child: child)),
+        child: Scaffold(
+          body: includeRootUnfocus
+              ? GestureDetector(
+                  onTap: () {
+                    onRootTap?.call();
+                    final primary = FocusManager.instance.primaryFocus;
+                    if (primary != null && primary is! FocusScopeNode) {
+                      primary.unfocus();
+                    }
+                  },
+                  behavior: HitTestBehavior.translucent,
+                  child: body,
+                )
+              : body,
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Move the AppTextField hit-region key onto the actual TextField instead of its padding wrapper.
- Add a widget regression test for first-click focus from the styled single-line input padding area.

## Root Cause
The custom input shell treated padded decoration space as if it were handled by the inner TextField. A click in that area caused the shell focus fallback to return early, while the actual TextField never received the tap, so the first click could be lost.

## Validation
- `fvm flutter test test/core/widgets/app_text_field_test.dart`
- `fvm flutter analyze lib/src/core/widgets/app_text_field.dart test/core/widgets/app_text_field_test.dart`
- `git diff --check`