### PR TITLE
fix: relax account name length

### DIFF
--- a/lib/src/core/account_name_policy.dart
+++ b/lib/src/core/account_name_policy.dart
@@ -1,0 +1,26 @@
+import 'package:characters/characters.dart';
+
+const kAccountNameMinCharacters = 1;
+const kAccountNameMaxCharacters = 20;
+const kAccountNameLengthMessage = 'Use up to 20 characters.';
+
+String normalizeAccountName(String name) => name.trim();
+
+int accountNameCharacterLength(String name) =>
+    normalizeAccountName(name).characters.length;
+
+bool isAccountNameLengthValid(String name) {
+  final length = accountNameCharacterLength(name);
+  return length >= kAccountNameMinCharacters &&
+      length <= kAccountNameMaxCharacters;
+}
+
+void validateAccountName(String name) {
+  if (!isAccountNameLengthValid(name)) {
+    throw ArgumentError.value(
+      name,
+      'name',
+      'Use 1-20 user-perceived characters.',
+    );
+  }
+}

--- a/lib/src/features/accounts/widgets/account_name_modal.dart
+++ b/lib/src/features/accounts/widgets/account_name_modal.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../../core/theme/app_theme.dart';
@@ -27,7 +26,7 @@ class AccountNameModal extends StatefulWidget {
 class _AccountNameModalState extends State<AccountNameModal> {
   static const _fieldHeight = 86.0;
   static const _buttonWidth = 280.0;
-  static const _minNameLength = 5;
+  static const _minNameLength = 1;
   static const _maxNameLength = 20;
 
   final _controller = TextEditingController();
@@ -47,8 +46,8 @@ class _AccountNameModalState extends State<AccountNameModal> {
 
   String? get _messageText {
     if (_submitError != null) return _submitError;
-    if (_controller.text.isEmpty || _isLengthValid) return null;
-    return 'Use 5-20 characters.';
+    if (_trimmedName.length <= _maxNameLength) return null;
+    return 'Use up to 20 characters.';
   }
 
   @override
@@ -102,20 +101,16 @@ class _AccountNameModalState extends State<AccountNameModal> {
             height: _fieldHeight,
             child: AppTextField(
               label: 'New Account Name',
-              hintText: '5-20 Characters',
+              hintText: '1-20 Characters',
               controller: _controller,
               autofocus: true,
               enabled: !_isSubmitting,
               trailingSlotWidth: 40,
               inputHorizontalPadding: AppSpacing.s,
-              inputFormatters: [
-                LengthLimitingTextInputFormatter(_maxNameLength),
-              ],
               messageText: _messageText,
-              tone:
-                  _messageText == null
-                      ? AppTextFieldTone.neutral
-                      : AppTextFieldTone.destructive,
+              tone: _messageText == null
+                  ? AppTextFieldTone.neutral
+                  : AppTextFieldTone.destructive,
               onChanged: (_) => _handleChanged(),
               onSubmitted: (_) => _submit(),
             ),
@@ -160,7 +155,11 @@ class _AccountNameModalCard extends StatelessWidget {
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
-        children: [header, const SizedBox(height: AppSpacing.md), child],
+        children: [
+          header,
+          const SizedBox(height: AppSpacing.md),
+          child,
+        ],
       ),
     );
   }

--- a/lib/src/features/accounts/widgets/account_name_modal.dart
+++ b/lib/src/features/accounts/widgets/account_name_modal.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 
+import '../../../core/account_name_policy.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_profile_picture.dart';
@@ -26,8 +27,6 @@ class AccountNameModal extends StatefulWidget {
 class _AccountNameModalState extends State<AccountNameModal> {
   static const _fieldHeight = 86.0;
   static const _buttonWidth = 280.0;
-  static const _minNameLength = 1;
-  static const _maxNameLength = 20;
 
   final _controller = TextEditingController();
   bool _isSubmitting = false;
@@ -35,9 +34,7 @@ class _AccountNameModalState extends State<AccountNameModal> {
 
   String get _trimmedName => _controller.text.trim();
 
-  bool get _isLengthValid =>
-      _trimmedName.length >= _minNameLength &&
-      _trimmedName.length <= _maxNameLength;
+  bool get _isLengthValid => isAccountNameLengthValid(_trimmedName);
 
   bool get _canUpdate =>
       !_isSubmitting &&
@@ -46,8 +43,10 @@ class _AccountNameModalState extends State<AccountNameModal> {
 
   String? get _messageText {
     if (_submitError != null) return _submitError;
-    if (_trimmedName.length <= _maxNameLength) return null;
-    return 'Use up to 20 characters.';
+    if (accountNameCharacterLength(_trimmedName) <= kAccountNameMaxCharacters) {
+      return null;
+    }
+    return kAccountNameLengthMessage;
   }
 
   @override
@@ -101,7 +100,8 @@ class _AccountNameModalState extends State<AccountNameModal> {
             height: _fieldHeight,
             child: AppTextField(
               label: 'New Account Name',
-              hintText: '1-20 Characters',
+              hintText:
+                  '$kAccountNameMinCharacters-$kAccountNameMaxCharacters Characters',
               controller: _controller,
               autofocus: true,
               enabled: !_isSubmitting,

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../main.dart' show log;
 import '../app_bootstrap.dart';
+import '../core/account_name_policy.dart';
 import '../core/config/network_config.dart';
 import '../core/profile_pictures.dart';
 import '../core/storage/app_secure_store.dart';
@@ -296,13 +297,15 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
 
   /// Rename an account.
   Future<void> renameAccount(String uuid, String newName) async {
+    validateAccountName(newName);
+    final normalizedName = normalizeAccountName(newName);
     final prev = state.value ?? const AccountState();
     final updated = prev.accounts
-        .map((a) => a.uuid == uuid ? a.copyWith(name: newName) : a)
+        .map((a) => a.uuid == uuid ? a.copyWith(name: normalizedName) : a)
         .toList();
     await _saveAccounts(updated);
     state = AsyncData(prev.copyWith(accounts: updated));
-    log('renameAccount: $uuid → $newName');
+    log('renameAccount: $uuid → $normalizedName');
   }
 
   /// Update an account profile picture.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -106,7 +106,7 @@ packages:
     source: hosted
     version: "8.12.5"
   characters:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: characters
       sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   flutter:
     sdk: flutter
 
+  characters: ^1.4.1
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8

--- a/test/core/account_name_policy_test.dart
+++ b/test/core/account_name_policy_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/account_name_policy.dart';
+
+void main() {
+  test('counts user-perceived characters for account names', () {
+    final twentyEmoji = List.filled(20, '😀').join();
+    final twentyOneEmoji = List.filled(21, '😀').join();
+
+    expect(accountNameCharacterLength(twentyEmoji), 20);
+    expect(isAccountNameLengthValid(twentyEmoji), isTrue);
+    expect(isAccountNameLengthValid(twentyOneEmoji), isFalse);
+  });
+
+  test('trims account names before validating length', () {
+    expect(normalizeAccountName('  Account  '), 'Account');
+    expect(isAccountNameLengthValid('   '), isFalse);
+  });
+
+  test('throws for invalid account names', () {
+    expect(() => validateAccountName(''), throwsArgumentError);
+    expect(
+      () => validateAccountName('123456789012345678901'),
+      throwsArgumentError,
+    );
+  });
+}

--- a/test/features/accounts/account_name_modal_test.dart
+++ b/test/features/accounts/account_name_modal_test.dart
@@ -29,6 +29,31 @@ void main() {
     expect(updatedName, 'J');
   });
 
+  testWidgets('allows submitting twenty user-perceived characters', (
+    tester,
+  ) async {
+    var updatedName = '';
+    final name = List.filled(20, '😀').join();
+
+    await tester.pumpWidget(
+      _AccountNameModalHarness(
+        onUpdate: (name) async {
+          updatedName = name;
+        },
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), name);
+    await tester.pump();
+
+    expect(find.text('Use up to 20 characters.'), findsNothing);
+
+    await tester.tap(find.text('Update'));
+    await tester.pump();
+
+    expect(updatedName, name);
+  });
+
   testWidgets('does not show the length warning for an empty name', (
     tester,
   ) async {
@@ -51,6 +76,32 @@ void main() {
     await tester.pump();
 
     expect(find.text('Use up to 20 characters.'), findsOneWidget);
+  });
+
+  testWidgets('does not submit empty or overlong names', (tester) async {
+    var updateCount = 0;
+
+    await tester.pumpWidget(
+      _AccountNameModalHarness(
+        onUpdate: (_) async {
+          updateCount += 1;
+        },
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), '   ');
+    await tester.pump();
+    await tester.tap(find.text('Update'));
+    await tester.pump();
+
+    expect(updateCount, 0);
+
+    await tester.enterText(find.byType(TextField), '123456789012345678901');
+    await tester.pump();
+    await tester.tap(find.text('Update'));
+    await tester.pump();
+
+    expect(updateCount, 0);
   });
 }
 

--- a/test/features/accounts/account_name_modal_test.dart
+++ b/test/features/accounts/account_name_modal_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show FontLoader, rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/accounts/widgets/account_name_modal.dart';
+
+void main() {
+  setUpAll(_loadAppFonts);
+
+  testWidgets('allows submitting a one-character account name', (tester) async {
+    var updatedName = '';
+
+    await tester.pumpWidget(
+      _AccountNameModalHarness(
+        onUpdate: (name) async {
+          updatedName = name;
+        },
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'J');
+    await tester.pump();
+
+    expect(find.text('Use up to 20 characters.'), findsNothing);
+
+    await tester.tap(find.text('Update'));
+    await tester.pump();
+
+    expect(updatedName, 'J');
+  });
+
+  testWidgets('does not show the length warning for an empty name', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const _AccountNameModalHarness());
+
+    expect(find.text('Use up to 20 characters.'), findsNothing);
+  });
+
+  testWidgets('only shows the length warning when the name exceeds 20 chars', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const _AccountNameModalHarness());
+
+    await tester.enterText(find.byType(TextField), '12345678901234567890');
+    await tester.pump();
+
+    expect(find.text('Use up to 20 characters.'), findsNothing);
+
+    await tester.enterText(find.byType(TextField), '123456789012345678901');
+    await tester.pump();
+
+    expect(find.text('Use up to 20 characters.'), findsOneWidget);
+  });
+}
+
+Future<void> _loadAppFonts() async {
+  final geist = FontLoader('Geist')
+    ..addFont(rootBundle.load('assets/fonts/Geist-Regular.ttf'))
+    ..addFont(rootBundle.load('assets/fonts/Geist-Medium.ttf'));
+
+  await geist.load();
+}
+
+class _AccountNameModalHarness extends StatelessWidget {
+  const _AccountNameModalHarness({this.onUpdate});
+
+  final Future<void> Function(String name)? onUpdate;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(platform: TargetPlatform.macOS),
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: Scaffold(
+          body: Center(
+            child: AccountNameModal(
+              accountName: 'Account 2',
+              profilePictureId: 'knight',
+              onCancel: () {},
+              onUpdate: onUpdate ?? (_) async {},
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Allow one-character account names while keeping the 20-character maximum.
- Remove the hard input formatter so users can see the length validation message when they exceed the limit.
- Add focused widget coverage for one-character names, empty names, and names longer than 20 characters.

## Root Cause
The account name modal still enforced the old 5-character minimum through its validation copy and input behavior. The updated flow needs to allow shorter names while still preventing empty or overlong submissions.

## Validation
- `fvm flutter test test/features/accounts/account_name_modal_test.dart`
- `fvm flutter analyze lib/src/features/accounts/widgets/account_name_modal.dart test/features/accounts/account_name_modal_test.dart`
- `git diff --check --cached`