### PR TITLE
[codex] Fix activity recipient display

### DIFF
--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -272,6 +272,7 @@ struct TxOutput {
     to_account_uuid: Option<Vec<u8>>,
     to_address: Option<String>,
     sent_to_address: Option<String>,
+    transparent_receiver_address: Option<String>,
     to_key_scope: Option<i64>,
     value: u64,
     is_change: bool,
@@ -281,6 +282,14 @@ struct TxOutput {
 impl TxOutput {
     fn detail_address(&self, tx_kind: &str) -> Option<String> {
         if tx_kind == "sent" {
+            if self.output_pool == 0 {
+                return self
+                    .transparent_receiver_address
+                    .clone()
+                    .or_else(|| self.sent_to_address.clone())
+                    .or_else(|| self.to_address.clone());
+            }
+
             self.sent_to_address
                 .clone()
                 .or_else(|| self.to_address.clone())
@@ -646,18 +655,8 @@ fn read_history_outputs(
             txo.from_account_uuid,
             txo.to_account_uuid,
             txo.to_address,
-            (
-                SELECT sn.to_address
-                FROM sent_notes sn
-                JOIN transactions st ON st.id_tx = sn.transaction_id
-                JOIN accounts from_acc ON from_acc.id = sn.from_account_id
-                WHERE st.txid = txo.txid
-                  AND from_acc.uuid = ?1
-                  AND sn.output_pool = txo.output_pool
-                  AND sn.output_index = txo.output_index
-                  AND sn.to_address IS NOT NULL
-                LIMIT 1
-            ) AS sent_to_address,
+            NULL AS sent_to_address,
+            NULL AS transparent_receiver_address,
             (
                 SELECT a.key_scope
                 FROM accounts acc
@@ -694,10 +693,11 @@ fn read_history_outputs(
                 to_account_uuid: row.get(4)?,
                 to_address: row.get(5)?,
                 sent_to_address: row.get(6)?,
-                to_key_scope: row.get(7)?,
-                value: row.get::<_, i64>(8)?.unsigned_abs(),
-                is_change: row.get(9)?,
-                memo: row.get(10)?,
+                transparent_receiver_address: row.get(7)?,
+                to_key_scope: row.get(8)?,
+                value: row.get::<_, i64>(9)?.unsigned_abs(),
+                is_change: row.get(10)?,
+                memo: row.get(11)?,
             })
         })
         .map_err(|e| format!("Query error: {e}"))?;
@@ -738,6 +738,19 @@ fn read_outputs_for_tx(
                 LIMIT 1
             ) AS sent_to_address,
             (
+                SELECT a.cached_transparent_receiver_address
+                FROM accounts acc
+                JOIN addresses a ON a.account_id = acc.id
+                WHERE acc.uuid = txo.to_account_uuid
+                  AND txo.output_pool = 0
+                  AND (
+                      a.address = txo.to_address
+                      OR a.cached_transparent_receiver_address = txo.to_address
+                  )
+                  AND a.cached_transparent_receiver_address IS NOT NULL
+                LIMIT 1
+            ) AS transparent_receiver_address,
+            (
                 SELECT a.key_scope
                 FROM accounts acc
                 JOIN addresses a ON a.account_id = acc.id
@@ -771,10 +784,11 @@ fn read_outputs_for_tx(
                 to_account_uuid: row.get(4)?,
                 to_address: row.get(5)?,
                 sent_to_address: row.get(6)?,
-                to_key_scope: row.get(7)?,
-                value: row.get::<_, i64>(8)?.unsigned_abs(),
-                is_change: row.get(9)?,
-                memo: row.get(10)?,
+                transparent_receiver_address: row.get(7)?,
+                to_key_scope: row.get(8)?,
+                value: row.get::<_, i64>(9)?.unsigned_abs(),
+                is_change: row.get(10)?,
+                memo: row.get(11)?,
             })
         })
         .map_err(|e| format!("Query error: {e}"))?;
@@ -1541,6 +1555,25 @@ mod tests {
             ],
         )
         .unwrap();
+    }
+
+    fn set_cached_transparent_receiver_address(
+        db: &NamedTempFile,
+        account: uuid::Uuid,
+        address: &str,
+        transparent_address: &str,
+    ) {
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        let account_id = ensure_account_row(&conn, account);
+        let changed = conn
+            .execute(
+                "UPDATE addresses
+                 SET cached_transparent_receiver_address = ?3
+                 WHERE account_id = ?1 AND address = ?2",
+                rusqlite::params![account_id, address, transparent_address],
+            )
+            .unwrap();
+        assert_eq!(changed, 1);
     }
 
     fn mark_expired_unmined(db: &NamedTempFile, txid: &[u8]) {
@@ -2337,6 +2370,12 @@ mod tests {
             Some("u-merged-own-transparent-receiver"),
             Some(0),
         );
+        set_cached_transparent_receiver_address(
+            &db,
+            account,
+            "u-merged-own-transparent-receiver",
+            "t-recipient",
+        );
         insert_sent_note(
             &db,
             &txid,
@@ -2374,6 +2413,82 @@ mod tests {
         assert_eq!(got.outputs.len(), 1);
         assert_eq!(got.outputs[0].address.as_deref(), Some("t-recipient"));
         assert_eq!(got.outputs[0].amount_zatoshi, 1_200_000);
+        assert_eq!(got.outputs[0].pool, "transparent");
+    }
+
+    #[test]
+    fn detail_sent_to_transparent_pool_prefers_cached_transparent_receiver() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let txid = fake_txid(0xD9);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -15_000,
+            18_990_000,
+            18_975_000,
+            false,
+            Some("2026-05-14T13:14:15Z"),
+        );
+        let recipient_output_index = insert_output_with_address(
+            &db,
+            &txid,
+            0,
+            Some(account),
+            Some(account),
+            11_000_000,
+            false,
+            Some("u-known-receiver"),
+            Some(0),
+        );
+        set_cached_transparent_receiver_address(
+            &db,
+            account,
+            "u-known-receiver",
+            "t-known-receiver",
+        );
+        insert_sent_note(
+            &db,
+            &txid,
+            0,
+            recipient_output_index,
+            account,
+            None,
+            Some("u-known-receiver"),
+            11_000_000,
+            None,
+        );
+        insert_output_with_address_and_memo(
+            &db,
+            &txid,
+            3,
+            Some(account),
+            Some(account),
+            7_975_000,
+            true,
+            None,
+            None,
+            Some(&[0xF6]),
+        );
+
+        let got = get_transaction_detail(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            &account.to_string(),
+            &hex::encode(txid),
+            "sent",
+        )
+        .unwrap();
+
+        assert_eq!(got.primary_address.as_deref(), Some("t-known-receiver"));
+        assert_eq!(got.outputs.len(), 1);
+        assert_eq!(got.outputs[0].address.as_deref(), Some("t-known-receiver"));
+        assert_eq!(got.outputs[0].amount_zatoshi, 11_000_000);
         assert_eq!(got.outputs[0].pool, "transparent");
     }
 

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -2051,6 +2051,78 @@ mod tests {
     }
 
     #[test]
+    fn history_preserves_mixed_pool_for_visible_self_outputs() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let self_tx = fake_txid(0xC6);
+
+        insert_history_tx(
+            &db,
+            account,
+            &self_tx,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -15_000,
+            6_115_000,
+            6_100_000,
+            false,
+            Some("2026-04-28T16:40:00Z"),
+        );
+        insert_output_with_address(
+            &db,
+            &self_tx,
+            0,
+            Some(account),
+            Some(account),
+            100_000,
+            true,
+            Some("t-self"),
+            Some(0),
+        );
+        insert_output_with_address(
+            &db,
+            &self_tx,
+            3,
+            Some(account),
+            Some(account),
+            1_000_000,
+            true,
+            Some("u-self"),
+            Some(0),
+        );
+        insert_output_with_address(
+            &db,
+            &self_tx,
+            3,
+            Some(account),
+            Some(account),
+            5_000_000,
+            true,
+            Some("u-change"),
+            Some(1),
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].txid_hex, hex::encode(self_tx));
+        assert_eq!(got[0].tx_kind, "sent");
+        assert_eq!(got[0].display_amount, 1_100_000);
+        assert_eq!(got[0].display_pool, "mixed");
+        assert_eq!(got[1].txid_hex, hex::encode(self_tx));
+        assert_eq!(got[1].tx_kind, "received");
+        assert_eq!(got[1].display_amount, 1_100_000);
+        assert_eq!(got[1].display_pool, "mixed");
+    }
+
+    #[test]
     fn history_hides_change_only_internal_tx() {
         let db = fresh_history_db();
         let account = test_account_uuid();

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -275,7 +275,6 @@ struct TxOutput {
     transparent_receiver_address: Option<String>,
     to_key_scope: Option<i64>,
     value: u64,
-    is_change: bool,
     memo: Option<Vec<u8>>,
 }
 
@@ -669,7 +668,6 @@ fn read_history_outputs(
                 LIMIT 1
             ) AS to_key_scope,
             txo.value,
-            txo.is_change,
             txo.memo
         FROM v_tx_outputs txo
         JOIN (
@@ -696,8 +694,7 @@ fn read_history_outputs(
                 transparent_receiver_address: row.get(7)?,
                 to_key_scope: row.get(8)?,
                 value: row.get::<_, i64>(9)?.unsigned_abs(),
-                is_change: row.get(10)?,
-                memo: row.get(11)?,
+                memo: row.get(10)?,
             })
         })
         .map_err(|e| format!("Query error: {e}"))?;
@@ -762,7 +759,6 @@ fn read_outputs_for_tx(
                 LIMIT 1
             ) AS to_key_scope,
             txo.value,
-            txo.is_change,
             txo.memo
         FROM v_tx_outputs txo
         WHERE txo.txid = ?2
@@ -787,8 +783,7 @@ fn read_outputs_for_tx(
                 transparent_receiver_address: row.get(7)?,
                 to_key_scope: row.get(8)?,
                 value: row.get::<_, i64>(9)?.unsigned_abs(),
-                is_change: row.get(10)?,
-                memo: row.get(11)?,
+                memo: row.get(10)?,
             })
         })
         .map_err(|e| format!("Query error: {e}"))?;
@@ -871,18 +866,17 @@ fn output_pool_label(output_pool: i64) -> &'static str {
 }
 
 fn is_user_visible_self_output(output: &TxOutput) -> bool {
-    if output.is_change {
-        return false;
-    }
+    let has_external_or_foreign_scope = matches!(output.to_key_scope, Some(0) | Some(-1));
 
     match output.output_pool {
         // Transparent self outputs are user-visible only when they land on a
         // normal external/foreign receiver. Internal and ephemeral receivers
         // are change/funding mechanics.
-        0 => matches!(output.to_key_scope, Some(0) | Some(-1)),
-        // Shielded explicit self-sends preserve the recipient address in
-        // sent_notes. Wallet-internal change does not.
-        2 | 3 => output.to_address.is_some() || matches!(output.to_key_scope, Some(0) | Some(-1)),
+        0 => has_external_or_foreign_scope,
+        // `is_change` is best-effort for wallet-owned outputs and can also be
+        // set on explicit self-transfers. Treat external/foreign receivers and
+        // sent-note recipients as visible; keep internal change hidden.
+        2 | 3 => has_external_or_foreign_scope || output.sent_to_address.is_some(),
         _ => false,
     }
 }
@@ -2021,7 +2015,7 @@ mod tests {
             Some(account),
             Some(account),
             1_000_000,
-            false,
+            true,
             Some("u-self"),
             Some(0),
         );
@@ -2617,7 +2611,7 @@ mod tests {
             Some(account),
             Some(account),
             1_000_000,
-            false,
+            true,
             Some("u-self"),
             Some(0),
             Some(b"self memo"),

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -654,7 +654,18 @@ fn read_history_outputs(
             txo.from_account_uuid,
             txo.to_account_uuid,
             txo.to_address,
-            NULL AS sent_to_address,
+            (
+                SELECT sn.to_address
+                FROM sent_notes sn
+                JOIN transactions st ON st.id_tx = sn.transaction_id
+                JOIN accounts from_acc ON from_acc.id = sn.from_account_id
+                WHERE st.txid = txo.txid
+                  AND from_acc.uuid = ?1
+                  AND sn.output_pool = txo.output_pool
+                  AND sn.output_index = txo.output_index
+                  AND sn.to_address IS NOT NULL
+                LIMIT 1
+            ) AS sent_to_address,
             NULL AS transparent_receiver_address,
             (
                 SELECT a.key_scope
@@ -2029,6 +2040,67 @@ mod tests {
             true,
             Some("u-change"),
             Some(1),
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].txid_hex, hex::encode(self_tx));
+        assert_eq!(got[0].tx_kind, "sent");
+        assert_eq!(got[0].display_amount, 1_000_000);
+        assert_eq!(got[0].display_pool, "shielded");
+        assert_eq!(got[1].txid_hex, hex::encode(self_tx));
+        assert_eq!(got[1].tx_kind, "received");
+        assert_eq!(got[1].display_amount, 1_000_000);
+        assert_eq!(got[1].display_pool, "shielded");
+    }
+
+    #[test]
+    fn history_uses_sent_note_when_self_send_key_scope_is_unresolved() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let self_tx = fake_txid(0xC7);
+
+        insert_history_tx(
+            &db,
+            account,
+            &self_tx,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -15_000,
+            1_015_000,
+            1_000_000,
+            false,
+            Some("2026-04-28T16:36:00Z"),
+        );
+        let output_index = insert_output_with_address(
+            &db,
+            &self_tx,
+            3,
+            Some(account),
+            Some(account),
+            1_000_000,
+            true,
+            Some("u-self-unresolved"),
+            None,
+        );
+        insert_sent_note(
+            &db,
+            &self_tx,
+            3,
+            output_index,
+            account,
+            Some(account),
+            Some("u-self-unresolved"),
+            1_000_000,
+            None,
         );
 
         let got = get_transaction_history(

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -273,6 +273,7 @@ struct TxOutput {
     to_address: Option<String>,
     to_key_scope: Option<i64>,
     value: u64,
+    is_change: bool,
     memo: Option<Vec<u8>>,
 }
 
@@ -644,6 +645,7 @@ fn read_history_outputs(
                 LIMIT 1
             ) AS to_key_scope,
             txo.value,
+            txo.is_change,
             txo.memo
         FROM v_tx_outputs txo
         JOIN (
@@ -668,7 +670,8 @@ fn read_history_outputs(
                 to_address: row.get(5)?,
                 to_key_scope: row.get(6)?,
                 value: row.get::<_, i64>(7)?.unsigned_abs(),
-                memo: row.get(8)?,
+                is_change: row.get(8)?,
+                memo: row.get(9)?,
             })
         })
         .map_err(|e| format!("Query error: {e}"))?;
@@ -708,6 +711,7 @@ fn read_outputs_for_tx(
                 LIMIT 1
             ) AS to_key_scope,
             txo.value,
+            txo.is_change,
             txo.memo
         FROM v_tx_outputs txo
         WHERE txo.txid = ?2
@@ -730,7 +734,8 @@ fn read_outputs_for_tx(
                 to_address: row.get(5)?,
                 to_key_scope: row.get(6)?,
                 value: row.get::<_, i64>(7)?.unsigned_abs(),
-                memo: row.get(8)?,
+                is_change: row.get(8)?,
+                memo: row.get(9)?,
             })
         })
         .map_err(|e| format!("Query error: {e}"))?;
@@ -813,6 +818,10 @@ fn output_pool_label(output_pool: i64) -> &'static str {
 }
 
 fn is_user_visible_self_output(output: &TxOutput) -> bool {
+    if output.is_change {
+        return false;
+    }
+
     match output.output_pool {
         // Transparent self outputs are user-visible only when they land on a
         // normal external/foreign receiver. Internal and ephemeral receivers

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -271,10 +271,23 @@ struct TxOutput {
     from_account_uuid: Option<Vec<u8>>,
     to_account_uuid: Option<Vec<u8>>,
     to_address: Option<String>,
+    sent_to_address: Option<String>,
     to_key_scope: Option<i64>,
     value: u64,
     is_change: bool,
     memo: Option<Vec<u8>>,
+}
+
+impl TxOutput {
+    fn detail_address(&self, tx_kind: &str) -> Option<String> {
+        if tx_kind == "sent" {
+            self.sent_to_address
+                .clone()
+                .or_else(|| self.to_address.clone())
+        } else {
+            self.to_address.clone()
+        }
+    }
 }
 
 #[derive(Default, Clone)]
@@ -490,14 +503,14 @@ pub fn get_transaction_detail(
     let primary_address = if tx_kind == "sent" {
         visible_outputs
             .iter()
-            .find_map(|output| output.to_address.clone())
+            .find_map(|output| output.detail_address(tx_kind))
     } else {
         None
     };
     let outputs = visible_outputs
         .into_iter()
         .map(|output| TransactionDetailOutput {
-            address: output.to_address.clone(),
+            address: output.detail_address(tx_kind),
             amount_zatoshi: output.value,
             pool: output_pool_label(output.output_pool).to_string(),
         })
@@ -634,6 +647,18 @@ fn read_history_outputs(
             txo.to_account_uuid,
             txo.to_address,
             (
+                SELECT sn.to_address
+                FROM sent_notes sn
+                JOIN transactions st ON st.id_tx = sn.transaction_id
+                JOIN accounts from_acc ON from_acc.id = sn.from_account_id
+                WHERE st.txid = txo.txid
+                  AND from_acc.uuid = ?1
+                  AND sn.output_pool = txo.output_pool
+                  AND sn.output_index = txo.output_index
+                  AND sn.to_address IS NOT NULL
+                LIMIT 1
+            ) AS sent_to_address,
+            (
                 SELECT a.key_scope
                 FROM accounts acc
                 JOIN addresses a ON a.account_id = acc.id
@@ -668,10 +693,11 @@ fn read_history_outputs(
                 from_account_uuid: row.get(3)?,
                 to_account_uuid: row.get(4)?,
                 to_address: row.get(5)?,
-                to_key_scope: row.get(6)?,
-                value: row.get::<_, i64>(7)?.unsigned_abs(),
-                is_change: row.get(8)?,
-                memo: row.get(9)?,
+                sent_to_address: row.get(6)?,
+                to_key_scope: row.get(7)?,
+                value: row.get::<_, i64>(8)?.unsigned_abs(),
+                is_change: row.get(9)?,
+                memo: row.get(10)?,
             })
         })
         .map_err(|e| format!("Query error: {e}"))?;
@@ -699,6 +725,18 @@ fn read_outputs_for_tx(
             txo.from_account_uuid,
             txo.to_account_uuid,
             txo.to_address,
+            (
+                SELECT sn.to_address
+                FROM sent_notes sn
+                JOIN transactions st ON st.id_tx = sn.transaction_id
+                JOIN accounts from_acc ON from_acc.id = sn.from_account_id
+                WHERE st.txid = txo.txid
+                  AND from_acc.uuid = ?1
+                  AND sn.output_pool = txo.output_pool
+                  AND sn.output_index = txo.output_index
+                  AND sn.to_address IS NOT NULL
+                LIMIT 1
+            ) AS sent_to_address,
             (
                 SELECT a.key_scope
                 FROM accounts acc
@@ -732,10 +770,11 @@ fn read_outputs_for_tx(
                 from_account_uuid: row.get(3)?,
                 to_account_uuid: row.get(4)?,
                 to_address: row.get(5)?,
-                to_key_scope: row.get(6)?,
-                value: row.get::<_, i64>(7)?.unsigned_abs(),
-                is_change: row.get(8)?,
-                memo: row.get(9)?,
+                sent_to_address: row.get(6)?,
+                to_key_scope: row.get(7)?,
+                value: row.get::<_, i64>(8)?.unsigned_abs(),
+                is_change: row.get(9)?,
+                memo: row.get(10)?,
             })
         })
         .map_err(|e| format!("Query error: {e}"))?;
@@ -1268,8 +1307,19 @@ mod tests {
                  tx_index INTEGER
              );
              CREATE TABLE transactions (
-                 txid BLOB PRIMARY KEY,
+                 id_tx INTEGER PRIMARY KEY AUTOINCREMENT,
+                 txid BLOB NOT NULL UNIQUE,
                  created TEXT
+             );
+             CREATE TABLE sent_notes (
+                 transaction_id INTEGER NOT NULL,
+                 output_pool INTEGER NOT NULL,
+                 output_index INTEGER NOT NULL,
+                 from_account_id INTEGER NOT NULL,
+                 to_account_id INTEGER,
+                 to_address TEXT,
+                 value INTEGER NOT NULL,
+                 memo BLOB
              );
              CREATE TABLE v_tx_outputs (
                  txid BLOB NOT NULL,
@@ -1351,7 +1401,7 @@ mod tests {
         to_account: Option<uuid::Uuid>,
         value: i64,
         is_change: bool,
-    ) {
+    ) -> i64 {
         insert_output_with_address(
             db,
             txid,
@@ -1362,7 +1412,7 @@ mod tests {
             is_change,
             None,
             None,
-        );
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1376,7 +1426,7 @@ mod tests {
         is_change: bool,
         to_address: Option<&str>,
         to_key_scope: Option<i64>,
-    ) {
+    ) -> i64 {
         insert_output_with_address_and_memo(
             db,
             txid,
@@ -1388,7 +1438,7 @@ mod tests {
             to_address,
             to_key_scope,
             None,
-        );
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1403,7 +1453,7 @@ mod tests {
         to_address: Option<&str>,
         to_key_scope: Option<i64>,
         memo: Option<&[u8]>,
-    ) {
+    ) -> i64 {
         let conn = rusqlite::Connection::open(db.path()).unwrap();
         if let Some(account) = from_account {
             ensure_account_row(&conn, account);
@@ -1445,6 +1495,48 @@ mod tests {
                 to_address,
                 value,
                 is_change,
+                memo,
+            ],
+        )
+        .unwrap();
+        output_index
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_sent_note(
+        db: &NamedTempFile,
+        txid: &[u8],
+        output_pool: i64,
+        output_index: i64,
+        from_account: uuid::Uuid,
+        to_account: Option<uuid::Uuid>,
+        to_address: Option<&str>,
+        value: i64,
+        memo: Option<&[u8]>,
+    ) {
+        let conn = rusqlite::Connection::open(db.path()).unwrap();
+        let transaction_id = conn
+            .query_row(
+                "SELECT id_tx FROM transactions WHERE txid = ?1",
+                rusqlite::params![txid],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap();
+        let from_account_id = ensure_account_row(&conn, from_account);
+        let to_account_id = to_account.map(|account| ensure_account_row(&conn, account));
+        conn.execute(
+            "INSERT INTO sent_notes (
+                 transaction_id, output_pool, output_index, from_account_id,
+                 to_account_id, to_address, value, memo
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![
+                transaction_id,
+                output_pool,
+                output_index,
+                from_account_id,
+                to_account_id,
+                to_address,
+                value,
                 memo,
             ],
         )
@@ -2212,6 +2304,76 @@ mod tests {
         assert_eq!(got.outputs.len(), 1);
         assert_eq!(got.outputs[0].address.as_deref(), Some("t-recipient"));
         assert_eq!(got.outputs[0].amount_zatoshi, 100_000);
+        assert_eq!(got.outputs[0].pool, "transparent");
+    }
+
+    #[test]
+    fn detail_sent_to_own_transparent_receiver_uses_sent_note_address() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let txid = fake_txid(0xD8);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            None,
+            1,
+            Some(1_000_100),
+            -15_000,
+            6_980_000,
+            6_965_000,
+            false,
+            Some("2026-05-15T06:11:44Z"),
+        );
+        let recipient_output_index = insert_output_with_address(
+            &db,
+            &txid,
+            0,
+            Some(account),
+            Some(account),
+            1_200_000,
+            false,
+            Some("u-merged-own-transparent-receiver"),
+            Some(0),
+        );
+        insert_sent_note(
+            &db,
+            &txid,
+            0,
+            recipient_output_index,
+            account,
+            None,
+            Some("t-recipient"),
+            1_200_000,
+            None,
+        );
+        insert_output_with_address_and_memo(
+            &db,
+            &txid,
+            3,
+            Some(account),
+            Some(account),
+            5_765_000,
+            true,
+            None,
+            None,
+            Some(&[0xF6]),
+        );
+
+        let got = get_transaction_detail(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            &account.to_string(),
+            &hex::encode(txid),
+            "sent",
+        )
+        .unwrap();
+
+        assert_eq!(got.primary_address.as_deref(), Some("t-recipient"));
+        assert_eq!(got.outputs.len(), 1);
+        assert_eq!(got.outputs[0].address.as_deref(), Some("t-recipient"));
+        assert_eq!(got.outputs[0].amount_zatoshi, 1_200_000);
         assert_eq!(got.outputs[0].pool, "transparent");
     }
 

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -1887,11 +1887,11 @@ mod tests {
             Some(account),
             Some(account),
             1_000_000,
-            true,
+            false,
             Some("u-self"),
             Some(0),
         );
-        insert_output(
+        insert_output_with_address(
             &db,
             &self_tx,
             3,
@@ -1899,6 +1899,8 @@ mod tests {
             Some(account),
             16_237_101,
             true,
+            Some("u-change"),
+            Some(1),
         );
 
         let got = get_transaction_history(
@@ -1939,7 +1941,7 @@ mod tests {
             false,
             Some("2026-04-28T15:43:00Z"),
         );
-        insert_output(
+        insert_output_with_address(
             &db,
             &change_only_tx,
             3,
@@ -1947,8 +1949,10 @@ mod tests {
             Some(account),
             7_242_102,
             true,
+            Some("u-change-1"),
+            Some(1),
         );
-        insert_output(
+        insert_output_with_address(
             &db,
             &change_only_tx,
             3,
@@ -1956,6 +1960,8 @@ mod tests {
             Some(account),
             10_000_000,
             true,
+            Some("u-change-2"),
+            Some(1),
         );
 
         let got = get_transaction_history(
@@ -2014,6 +2020,73 @@ mod tests {
     }
 
     #[test]
+    fn history_sent_to_transparent_excludes_shielded_change() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let txid = fake_txid(0xC5);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -15_000,
+            1_265_000,
+            1_150_000,
+            false,
+            Some("2026-04-28T16:45:00Z"),
+        );
+        insert_output_with_address(
+            &db,
+            &txid,
+            0,
+            Some(account),
+            Some(account),
+            150_000,
+            false,
+            Some("t-ephemeral"),
+            Some(2),
+        );
+        insert_output_with_address(
+            &db,
+            &txid,
+            3,
+            Some(account),
+            Some(account),
+            1_000_000,
+            true,
+            Some("u-change"),
+            Some(1),
+        );
+        insert_output_with_address(
+            &db,
+            &txid,
+            0,
+            Some(account),
+            None,
+            100_000,
+            false,
+            Some("t-recipient"),
+            None,
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].tx_kind, "sent");
+        assert_eq!(got[0].display_amount, 100_000);
+        assert_eq!(got[0].display_pool, "transparent");
+    }
+
+    #[test]
     fn detail_sent_row_returns_recipient_address_and_memo() {
         let db = fresh_history_db();
         let account = test_account_uuid();
@@ -2062,6 +2135,75 @@ mod tests {
         assert_eq!(got.outputs[0].address.as_deref(), Some("u-recipient"));
         assert_eq!(got.outputs[0].amount_zatoshi, 1_000_000);
         assert_eq!(got.outputs[0].pool, "shielded");
+    }
+
+    #[test]
+    fn detail_sent_to_transparent_prefers_external_recipient_over_shielded_change() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let txid = fake_txid(0xD7);
+
+        insert_history_tx(
+            &db,
+            account,
+            &txid,
+            Some(1_000_000),
+            1,
+            Some(1_000_100),
+            -15_000,
+            1_265_000,
+            1_150_000,
+            false,
+            Some("2026-04-28T17:05:00Z"),
+        );
+        insert_output_with_address(
+            &db,
+            &txid,
+            0,
+            Some(account),
+            Some(account),
+            150_000,
+            false,
+            Some("t-ephemeral"),
+            Some(2),
+        );
+        insert_output_with_address(
+            &db,
+            &txid,
+            3,
+            Some(account),
+            Some(account),
+            1_000_000,
+            true,
+            Some("u-change"),
+            Some(1),
+        );
+        insert_output_with_address(
+            &db,
+            &txid,
+            0,
+            Some(account),
+            None,
+            100_000,
+            false,
+            Some("t-recipient"),
+            None,
+        );
+
+        let got = get_transaction_detail(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            &account.to_string(),
+            &hex::encode(txid),
+            "sent",
+        )
+        .unwrap();
+
+        assert_eq!(got.primary_address.as_deref(), Some("t-recipient"));
+        assert_eq!(got.outputs.len(), 1);
+        assert_eq!(got.outputs[0].address.as_deref(), Some("t-recipient"));
+        assert_eq!(got.outputs[0].amount_zatoshi, 100_000);
+        assert_eq!(got.outputs[0].pool, "transparent");
     }
 
     #[test]
@@ -2189,12 +2331,22 @@ mod tests {
             Some(account),
             Some(account),
             1_000_000,
-            true,
+            false,
             Some("u-self"),
             Some(0),
             Some(b"self memo"),
         );
-        insert_output(&db, &txid, 3, Some(account), Some(account), 500_000, true);
+        insert_output_with_address(
+            &db,
+            &txid,
+            3,
+            Some(account),
+            Some(account),
+            500_000,
+            true,
+            Some("u-change"),
+            Some(1),
+        );
 
         let sent = get_transaction_detail(
             db.path().to_str().unwrap(),
@@ -2250,8 +2402,8 @@ mod tests {
             Some(account),
             1_000_000,
             true,
-            None,
-            None,
+            Some("u-change"),
+            Some(1),
             Some(&[0xF6]),
         );
 


### PR DESCRIPTION
## Summary
- Fix activity detail recipient selection for transparent sends when wallet-owned outputs expose a unified address through `v_tx_outputs`.
- Hide wallet-internal change outputs from sent/received activity classification and detail rows.
- Prefer `sent_notes.to_address` and cached transparent receiver addresses for sent detail display.
- Add regression coverage for t-address sends, shielded change outputs, and transparent receiver fallback cases.

## Root Cause
`v_tx_outputs.to_address` can represent the wallet address associated with a received output, including change or a unified address row for a transparent receiver, rather than the recipient address the user expects in Activity detail.

## Validation
- `cargo test --lib detail_sent_to_transparent_pool_prefers_cached_transparent_receiver -- --nocapture`
- `cargo test --lib sent_to_transparent -- --nocapture`
- `cargo test --lib detail_sent_to_own_transparent_receiver_uses_sent_note_address -- --nocapture`
- `cargo test --lib hides_change -- --nocapture`
- `cargo test --lib wallet::sync::transactions::tests`
- `cargo test`