### PR TITLE
[codex] Add first-run custom endpoint settings

### DIFF
--- a/lib/src/core/widgets/app_tooltip.dart
+++ b/lib/src/core/widgets/app_tooltip.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart' show Tooltip;
+import 'package:flutter/widgets.dart';
+
+import '../theme/app_theme.dart';
+
+class AppTooltip extends StatelessWidget {
+  const AppTooltip({
+    required this.child,
+    this.message,
+    this.richMessage,
+    super.key,
+  }) : assert(
+         (message == null) != (richMessage == null),
+         'Provide either message or richMessage.',
+       );
+
+  final String? message;
+  final InlineSpan? richMessage;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final isDark = context.appTheme == AppThemeData.dark;
+    final textStyle = AppTypography.bodySmall.copyWith(
+      color: isDark ? colors.text.accent : colors.text.inverse,
+      letterSpacing: 0,
+    );
+
+    return Tooltip(
+      message: message,
+      richMessage: richMessage == null
+          ? null
+          : TextSpan(style: textStyle, children: [richMessage!]),
+      textStyle: textStyle,
+      waitDuration: const Duration(milliseconds: 350),
+      showDuration: const Duration(seconds: 8),
+      preferBelow: false,
+      constraints: const BoxConstraints(maxWidth: 340),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.s,
+        vertical: AppSpacing.xs,
+      ),
+      decoration: BoxDecoration(
+        color: isDark ? colors.surface.tooltip : colors.background.inverse,
+        borderRadius: BorderRadius.circular(AppRadii.xSmall),
+        border: isDark ? Border.all(color: colors.border.regular) : null,
+      ),
+      child: child,
+    );
+  }
+}

--- a/lib/src/features/onboarding/welcome.dart
+++ b/lib/src/features/onboarding/welcome.dart
@@ -199,18 +199,19 @@ class _Pane extends StatelessWidget {
               top: AppSpacing.md,
               child: _BackRow(),
             ),
-          Positioned(
-            right: AppSpacing.md,
-            top: AppSpacing.md,
-            child: _WelcomeIconButton(
-              key: const ValueKey('welcome_endpoint_settings_button'),
-              icon: AppIcons.cog,
-              tooltip: 'Endpoint settings',
-              semanticLabel: 'Endpoint settings',
-              onTap: onShowEndpointSettings,
+          if (!showBackButton)
+            Positioned(
+              right: AppSpacing.md,
+              top: AppSpacing.md,
+              child: _WelcomeIconButton(
+                key: const ValueKey('welcome_endpoint_settings_button'),
+                icon: AppIcons.cog,
+                tooltip: 'Endpoint settings',
+                semanticLabel: 'Endpoint settings',
+                onTap: onShowEndpointSettings,
+              ),
             ),
-          ),
-          if (showEndpointSettings)
+          if (!showBackButton && showEndpointSettings)
             AppPaneModalOverlay(
               borderRadius: BorderRadius.circular(AppRadii.xSmall),
               onDismiss: onDismissEndpointSettings,

--- a/lib/src/features/onboarding/welcome.dart
+++ b/lib/src/features/onboarding/welcome.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart' show Colors, Scaffold, Tooltip;
+import 'package:flutter/material.dart' show Colors, Scaffold;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -8,6 +8,7 @@ import '../../core/theme/app_theme.dart';
 import '../../core/widgets/app_button.dart';
 import '../../core/widgets/app_icon.dart';
 import '../../core/widgets/app_pane_modal_overlay.dart';
+import '../../core/widgets/app_tooltip.dart';
 import '../settings/widgets/custom_endpoint_settings_panel.dart';
 import 'shared/onboarding_welcome_art.dart';
 
@@ -252,7 +253,7 @@ class _WelcomeIconButtonState extends State<_WelcomeIconButton> {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return Tooltip(
+    return AppTooltip(
       message: widget.tooltip,
       child: Semantics(
         button: true,

--- a/lib/src/features/onboarding/welcome.dart
+++ b/lib/src/features/onboarding/welcome.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart' show Colors, Scaffold;
+import 'package:flutter/material.dart' show Colors, Scaffold, Tooltip;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -7,6 +7,8 @@ import '../../core/layout/app_layout.dart';
 import '../../core/theme/app_theme.dart';
 import '../../core/widgets/app_button.dart';
 import '../../core/widgets/app_icon.dart';
+import '../../core/widgets/app_pane_modal_overlay.dart';
+import '../settings/widgets/custom_endpoint_settings_panel.dart';
 import 'shared/onboarding_welcome_art.dart';
 
 /// Welcome-specific button width. The redesigned Figma CTA stack is 256 dp
@@ -36,6 +38,8 @@ class WelcomeScreen extends ConsumerStatefulWidget {
 }
 
 class _WelcomeScreenState extends ConsumerState<WelcomeScreen> {
+  bool _showEndpointSettings = false;
+
   @override
   void initState() {
     super.initState();
@@ -61,6 +65,17 @@ class _WelcomeScreenState extends ConsumerState<WelcomeScreen> {
           padding: const EdgeInsets.all(AppSpacing.xs),
           child: _Pane(
             showBackButton: widget.showBackButton,
+            showEndpointSettings: _showEndpointSettings,
+            onShowEndpointSettings: () {
+              setState(() {
+                _showEndpointSettings = true;
+              });
+            },
+            onDismissEndpointSettings: () {
+              setState(() {
+                _showEndpointSettings = false;
+              });
+            },
             child: const _Content(),
           ),
         ),
@@ -104,10 +119,19 @@ class _WelcomeScreenState extends ConsumerState<WelcomeScreen> {
 /// team decided it adds no depth in the transparent-window + acrylic
 /// context the app actually runs in.
 class _Pane extends StatelessWidget {
-  const _Pane({required this.child, required this.showBackButton});
+  const _Pane({
+    required this.child,
+    required this.showBackButton,
+    required this.showEndpointSettings,
+    required this.onShowEndpointSettings,
+    required this.onDismissEndpointSettings,
+  });
 
   final Widget child;
   final bool showBackButton;
+  final bool showEndpointSettings;
+  final VoidCallback onShowEndpointSettings;
+  final VoidCallback onDismissEndpointSettings;
 
   /// Fixed foreground design-canvas dimensions pulled from Figma's Welcome BG
   /// frame (node 1300:34883). The 1080 × 720 desktop window leaves a
@@ -175,9 +199,102 @@ class _Pane extends StatelessWidget {
               top: AppSpacing.md,
               child: _BackRow(),
             ),
+          Positioned(
+            right: AppSpacing.md,
+            top: AppSpacing.md,
+            child: _WelcomeIconButton(
+              key: const ValueKey('welcome_endpoint_settings_button'),
+              icon: AppIcons.cog,
+              tooltip: 'Endpoint settings',
+              semanticLabel: 'Endpoint settings',
+              onTap: onShowEndpointSettings,
+            ),
+          ),
+          if (showEndpointSettings)
+            AppPaneModalOverlay(
+              borderRadius: BorderRadius.circular(AppRadii.xSmall),
+              onDismiss: onDismissEndpointSettings,
+              child: CustomEndpointSettingsPanel(
+                key: const ValueKey('welcome_endpoint_settings_modal'),
+                restartSyncAfterUpdate: false,
+                onClose: onDismissEndpointSettings,
+                onUpdated: onDismissEndpointSettings,
+              ),
+            ),
         ],
       ),
     );
+  }
+}
+
+class _WelcomeIconButton extends StatefulWidget {
+  const _WelcomeIconButton({
+    required this.icon,
+    required this.tooltip,
+    required this.semanticLabel,
+    required this.onTap,
+    super.key,
+  });
+
+  final String icon;
+  final String tooltip;
+  final String semanticLabel;
+  final VoidCallback onTap;
+
+  @override
+  State<_WelcomeIconButton> createState() => _WelcomeIconButtonState();
+}
+
+class _WelcomeIconButtonState extends State<_WelcomeIconButton> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Tooltip(
+      message: widget.tooltip,
+      child: Semantics(
+        button: true,
+        label: widget.semanticLabel,
+        child: ExcludeSemantics(
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            onEnter: (_) => _setHovered(true),
+            onExit: (_) => _setHovered(false),
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: widget.onTap,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: _hovered
+                      ? colors.button.ghost.bgHover
+                      : colors.background.ground.withValues(alpha: 0),
+                  shape: BoxShape.circle,
+                ),
+                child: SizedBox(
+                  width: 32,
+                  height: 32,
+                  child: Center(
+                    child: AppIcon(
+                      widget.icon,
+                      size: AppIconSize.medium,
+                      color: colors.icon.accent,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _setHovered(bool hovered) {
+    if (_hovered == hovered) return;
+    setState(() {
+      _hovered = hovered;
+    });
   }
 }
 

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -20,6 +20,7 @@ import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_decorative_divider.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_text_field.dart';
+import '../../../core/widgets/app_tooltip.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/privacy_mode_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
@@ -1051,14 +1052,9 @@ class _SendMaxBalanceControl extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final isDark = context.appTheme == AppThemeData.dark;
     final maxLabel = Text(
       'Max: $spendableText',
       style: AppTypography.labelMedium.copyWith(color: colors.text.secondary),
-    );
-    final tooltipTextStyle = AppTypography.bodySmall.copyWith(
-      color: isDark ? colors.text.accent : colors.text.inverse,
-      letterSpacing: 0,
     );
 
     return Row(
@@ -1079,29 +1075,15 @@ class _SendMaxBalanceControl extends StatelessWidget {
           ),
         ),
         const SizedBox(width: AppSpacing.xxs),
-        Tooltip(
+        AppTooltip(
           richMessage: TextSpan(
-            style: tooltipTextStyle,
             children: [
               TextSpan(
                 text: _tooltipTitle,
-                style: tooltipTextStyle.copyWith(fontWeight: FontWeight.bold),
+                style: const TextStyle(fontWeight: FontWeight.bold),
               ),
               const TextSpan(text: '\n\n$_tooltipBody'),
             ],
-          ),
-          waitDuration: const Duration(milliseconds: 350),
-          showDuration: const Duration(seconds: 8),
-          preferBelow: false,
-          constraints: const BoxConstraints(maxWidth: 340),
-          padding: const EdgeInsets.symmetric(
-            horizontal: AppSpacing.s,
-            vertical: AppSpacing.xs,
-          ),
-          decoration: BoxDecoration(
-            color: isDark ? colors.surface.tooltip : colors.background.inverse,
-            borderRadius: BorderRadius.circular(AppRadii.xSmall),
-            border: isDark ? Border.all(color: colors.border.regular) : null,
           ),
           child: SizedBox(
             width: 18,

--- a/lib/src/features/settings/screens/settings_endpoint_screen.dart
+++ b/lib/src/features/settings/screens/settings_endpoint_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart'
     show Scrollbar, ScrollbarTheme, ScrollbarThemeData;
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -12,10 +11,10 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
-import '../../../core/widgets/app_text_field.dart';
 import '../../../providers/rpc_endpoint_latency_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
+import '../widgets/custom_endpoint_settings_panel.dart';
 
 class SettingsEndpointScreen extends ConsumerStatefulWidget {
   const SettingsEndpointScreen({super.key});
@@ -257,7 +256,7 @@ class _SettingsEndpointPane extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: AppSpacing.xs),
-                  _CurrentEndpointText(
+                  CurrentEndpointText(
                     current: current,
                     latencyState: latencyState,
                   ),
@@ -302,47 +301,6 @@ class _SettingsEndpointPane extends StatelessWidget {
           ),
         ],
       ),
-    );
-  }
-}
-
-class _CurrentEndpointText extends StatelessWidget {
-  const _CurrentEndpointText({
-    required this.current,
-    required this.latencyState,
-  });
-
-  final RpcEndpointConfig current;
-  final RpcEndpointLatencyState latencyState;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    final preset = findRpcEndpointPresetByUrl(
-      current.normalizedLightwalletdUrl,
-      networkName: current.networkName,
-    );
-    final latency = latencyState.sampleForUrl(
-      current.normalizedLightwalletdUrl,
-    );
-    final suffix = [
-      if (latency != null) latency.label,
-      if (preset?.isDefault ?? false) '(Default)',
-    ].join(' ');
-
-    return Text.rich(
-      TextSpan(
-        text: 'Current: ',
-        children: [
-          TextSpan(
-            text: current.hostPort,
-            style: TextStyle(color: colors.text.brandCrimson),
-          ),
-          if (suffix.isNotEmpty) TextSpan(text: ' $suffix'),
-        ],
-      ),
-      textAlign: TextAlign.center,
-      style: AppTypography.bodyMedium.copyWith(color: colors.text.primary),
     );
   }
 }
@@ -415,7 +373,7 @@ class _EndpointSelector extends StatelessWidget {
                     AppSpacing.sm,
                     AppSpacing.xs,
                   ),
-                  child: _CustomEndpointForm(
+                  child: CustomEndpointForm(
                     controller: customController,
                     messageText: customMessageText,
                     onChanged: onCustomChanged,
@@ -691,83 +649,6 @@ class _PresetIndicator extends StatelessWidget {
               ),
             )
           : null,
-    );
-  }
-}
-
-class _CustomEndpointForm extends StatelessWidget {
-  const _CustomEndpointForm({
-    required this.controller,
-    required this.messageText,
-    required this.onChanged,
-    required this.onSubmit,
-  });
-
-  final TextEditingController controller;
-  final String? messageText;
-  final ValueChanged<String> onChanged;
-  final Future<void> Function() onSubmit;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          SizedBox(
-            height: 86,
-            child: AppTextField(
-              label: 'Custom Endpoint',
-              hintText: '<hostname>:<port>',
-              controller: controller,
-              autofocus: true,
-              leading: const AppIcon(AppIcons.endpoint),
-              leadingSlotWidth: 32,
-              trailingSlotWidth: 40,
-              inputHorizontalPadding: AppSpacing.s,
-              keyboardType: TextInputType.url,
-              textInputAction: TextInputAction.done,
-              messageText: messageText,
-              tone: messageText == null
-                  ? AppTextFieldTone.neutral
-                  : AppTextFieldTone.destructive,
-              onChanged: onChanged,
-              onSubmitted: (_) => onSubmit(),
-            ),
-          ),
-          const SizedBox(height: AppSpacing.sm),
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              AppIcon(AppIcons.book, size: 20, color: colors.icon.accent),
-              const SizedBox(width: AppSpacing.xs),
-              Expanded(
-                child: Text.rich(
-                  TextSpan(
-                    text:
-                        "If the endpoint is configured wrong, your wallet won't "
-                        'be able to sync with the Zcash network.\n',
-                    children: [
-                      TextSpan(
-                        text:
-                            "The wallet will show the balance from the last "
-                            "time it was successfully connected. It won't "
-                            'show any $kZcashDefaultCurrencyTicker you recently received.',
-                        style: TextStyle(color: colors.text.primary),
-                      ),
-                    ],
-                  ),
-                  style: AppTypography.bodyMedium.copyWith(
-                    color: colors.text.accent,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ],
-      ),
     );
   }
 }

--- a/lib/src/features/settings/widgets/custom_endpoint_settings_panel.dart
+++ b/lib/src/features/settings/widgets/custom_endpoint_settings_panel.dart
@@ -1,0 +1,399 @@
+import 'package:flutter/services.dart'
+    show SystemMouseCursors, TextInputAction, TextInputType;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/config/rpc_endpoint_config.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_text_field.dart';
+import '../../../providers/rpc_endpoint_latency_provider.dart';
+import '../../../providers/rpc_endpoint_provider.dart';
+import '../../../providers/sync_provider.dart';
+
+class CustomEndpointSettingsPanel extends ConsumerStatefulWidget {
+  const CustomEndpointSettingsPanel({
+    this.onClose,
+    this.onUpdated,
+    this.restartSyncAfterUpdate = true,
+    this.width = 424,
+    super.key,
+  });
+
+  final VoidCallback? onClose;
+  final VoidCallback? onUpdated;
+  final bool restartSyncAfterUpdate;
+  final double width;
+
+  @override
+  ConsumerState<CustomEndpointSettingsPanel> createState() =>
+      _CustomEndpointSettingsPanelState();
+}
+
+class _CustomEndpointSettingsPanelState
+    extends ConsumerState<CustomEndpointSettingsPanel> {
+  final _controller = TextEditingController();
+  bool _isSubmitting = false;
+  String? _submitError;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = rpcEndpointInputText(
+      ref.read(rpcEndpointProvider).lightwalletdUrl,
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  bool _canUpdate(RpcEndpointConfig current) {
+    if (_isSubmitting) return false;
+    try {
+      final normalized = normalizeRpcEndpointUrl(
+        _controller.text,
+        allowDefaultPort: true,
+      );
+      return normalized != current.normalizedLightwalletdUrl ||
+          current.effectivePresetId != kCustomRpcEndpointPresetId;
+    } on FormatException {
+      return false;
+    }
+  }
+
+  String? _customMessageText() {
+    if (_controller.text.trim().isEmpty) return null;
+    try {
+      normalizeRpcEndpointUrl(_controller.text, allowDefaultPort: true);
+      return null;
+    } on FormatException catch (e) {
+      return e.message;
+    }
+  }
+
+  Future<void> _submit() async {
+    final current = ref.read(rpcEndpointProvider);
+    if (!_canUpdate(current)) return;
+
+    setState(() {
+      _isSubmitting = true;
+      _submitError = null;
+    });
+
+    try {
+      await ref.read(rpcEndpointProvider.notifier).setCustom(_controller.text);
+      if (widget.restartSyncAfterUpdate) {
+        await ref.read(syncProvider.notifier).restartSync();
+      }
+      if (!mounted) return;
+      final next = ref.read(rpcEndpointProvider);
+      _controller.text = rpcEndpointInputText(next.lightwalletdUrl);
+      setState(() {
+        _isSubmitting = false;
+      });
+      widget.onUpdated?.call();
+    } on FormatException catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _submitError = e.message;
+        _isSubmitting = false;
+      });
+    } catch (e, st) {
+      log('CustomEndpointSettingsPanel._submit: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _submitError =
+            "Couldn't connect to that endpoint. Check the host and port.";
+        _isSubmitting = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final current = ref.watch(rpcEndpointProvider);
+    final latencyState = ref.watch(rpcEndpointLatencyProvider);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colors.background.ground,
+        borderRadius: BorderRadius.circular(AppRadii.large),
+        border: Border.all(color: colors.border.subtle),
+      ),
+      child: ConstrainedBox(
+        constraints: BoxConstraints.tightFor(width: widget.width),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _PanelHeader(onClose: widget.onClose),
+              const SizedBox(height: AppSpacing.xs),
+              CurrentEndpointText(current: current, latencyState: latencyState),
+              const SizedBox(height: AppSpacing.sm),
+              SizedBox(
+                width: 352,
+                child: CustomEndpointForm(
+                  controller: _controller,
+                  messageText: _customMessageText(),
+                  onChanged: (_) => setState(() {
+                    _submitError = null;
+                  }),
+                  onSubmit: _submit,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              if (_submitError != null) ...[
+                SizedBox(
+                  width: 352,
+                  child: Text(
+                    _submitError!,
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.destructive,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+              ],
+              AppButton(
+                onPressed: _canUpdate(current) ? _submit : null,
+                variant: AppButtonVariant.primary,
+                minWidth: 256,
+                trailing: const AppIcon(AppIcons.chevronForward),
+                child: Text(_isSubmitting ? 'Updating...' : 'Update'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PanelHeader extends StatelessWidget {
+  const _PanelHeader({required this.onClose});
+
+  final VoidCallback? onClose;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return SizedBox(
+      height: 32,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          Center(
+            child: Text(
+              'Endpoint',
+              style: AppTypography.headlineMedium.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+          ),
+          if (onClose != null)
+            Positioned(
+              right: 0,
+              child: _SmallIconButton(
+                icon: AppIcons.cross,
+                semanticLabel: 'Close endpoint settings',
+                onTap: onClose!,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class CurrentEndpointText extends StatelessWidget {
+  const CurrentEndpointText({
+    required this.current,
+    required this.latencyState,
+    super.key,
+  });
+
+  final RpcEndpointConfig current;
+  final RpcEndpointLatencyState latencyState;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final preset = findRpcEndpointPresetByUrl(
+      current.normalizedLightwalletdUrl,
+      networkName: current.networkName,
+    );
+    final latency = latencyState.sampleForUrl(
+      current.normalizedLightwalletdUrl,
+    );
+    final suffix = [
+      if (latency != null) latency.label,
+      if (preset?.isDefault ?? false) '(Default)',
+    ].join(' ');
+
+    return Text.rich(
+      TextSpan(
+        text: 'Current: ',
+        children: [
+          TextSpan(
+            text: current.hostPort,
+            style: TextStyle(color: colors.text.brandCrimson),
+          ),
+          if (suffix.isNotEmpty) TextSpan(text: ' $suffix'),
+        ],
+      ),
+      textAlign: TextAlign.center,
+      style: AppTypography.bodyMedium.copyWith(color: colors.text.primary),
+    );
+  }
+}
+
+class CustomEndpointForm extends StatelessWidget {
+  const CustomEndpointForm({
+    required this.controller,
+    required this.messageText,
+    required this.onChanged,
+    required this.onSubmit,
+    super.key,
+  });
+
+  final TextEditingController controller;
+  final String? messageText;
+  final ValueChanged<String> onChanged;
+  final Future<void> Function() onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            height: 86,
+            child: AppTextField(
+              label: 'Custom Endpoint',
+              hintText: '<hostname>:<port>',
+              controller: controller,
+              autofocus: true,
+              leading: const AppIcon(AppIcons.endpoint),
+              leadingSlotWidth: 32,
+              trailingSlotWidth: 40,
+              inputHorizontalPadding: AppSpacing.s,
+              keyboardType: TextInputType.url,
+              textInputAction: TextInputAction.done,
+              messageText: messageText,
+              tone: messageText == null
+                  ? AppTextFieldTone.neutral
+                  : AppTextFieldTone.destructive,
+              onChanged: onChanged,
+              onSubmitted: (_) => onSubmit(),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              AppIcon(AppIcons.book, size: 20, color: colors.icon.accent),
+              const SizedBox(width: AppSpacing.xs),
+              Expanded(
+                child: Text.rich(
+                  TextSpan(
+                    text:
+                        "If the endpoint is configured wrong, your wallet won't "
+                        'be able to sync with the Zcash network.\n',
+                    children: [
+                      TextSpan(
+                        text:
+                            "The wallet will show the balance from the last "
+                            "time it was successfully connected. It won't "
+                            'show any $kZcashDefaultCurrencyTicker you recently received.',
+                        style: TextStyle(color: colors.text.primary),
+                      ),
+                    ],
+                  ),
+                  style: AppTypography.bodyMedium.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SmallIconButton extends StatefulWidget {
+  const _SmallIconButton({
+    required this.icon,
+    required this.semanticLabel,
+    required this.onTap,
+  });
+
+  final String icon;
+  final String semanticLabel;
+  final VoidCallback onTap;
+
+  @override
+  State<_SmallIconButton> createState() => _SmallIconButtonState();
+}
+
+class _SmallIconButtonState extends State<_SmallIconButton> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Semantics(
+      button: true,
+      label: widget.semanticLabel,
+      child: ExcludeSemantics(
+        child: MouseRegion(
+          cursor: SystemMouseCursors.click,
+          onEnter: (_) => _setHovered(true),
+          onExit: (_) => _setHovered(false),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: widget.onTap,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: _hovered
+                    ? colors.button.ghost.bgHover
+                    : colors.background.ground.withValues(alpha: 0),
+                shape: BoxShape.circle,
+              ),
+              child: SizedBox(
+                width: 32,
+                height: 32,
+                child: Center(
+                  child: AppIcon(
+                    widget.icon,
+                    size: AppIconSize.medium,
+                    color: colors.icon.accent,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _setHovered(bool hovered) {
+    if (_hovered == hovered) return;
+    setState(() {
+      _hovered = hovered;
+    });
+  }
+}

--- a/test/features/onboarding/welcome_screen_test.dart
+++ b/test/features/onboarding/welcome_screen_test.dart
@@ -57,6 +57,10 @@ void main() {
     await tester.pumpWidget(_welcomeScreen(showBackButton: true));
 
     expect(find.text('Back'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('welcome_endpoint_settings_button')),
+      findsNothing,
+    );
   });
 
   testWidgets('Back returns to the pushed accounts route', (tester) async {

--- a/test/features/onboarding/welcome_screen_test.dart
+++ b/test/features/onboarding/welcome_screen_test.dart
@@ -2,7 +2,7 @@ import 'dart:ui' show Size;
 
 import 'package:flutter/material.dart' show MaterialApp, TextButton;
 import 'package:flutter/services.dart' show FontLoader, rootBundle;
-import 'package:flutter/widgets.dart' show Text, Widget;
+import 'package:flutter/widgets.dart' show Text, ValueKey, Widget;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -18,6 +18,36 @@ void main() {
     await tester.pumpWidget(_welcomeScreen());
 
     expect(find.text('Back'), findsNothing);
+  });
+
+  testWidgets('shows endpoint settings on first wallet creation entry', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_welcomeScreen());
+
+    expect(
+      find.byKey(const ValueKey('welcome_endpoint_settings_button')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('opens endpoint settings modal from welcome', (tester) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_welcomeScreen());
+
+    await tester.tap(
+      find.byKey(const ValueKey('welcome_endpoint_settings_button')),
+    );
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('welcome_endpoint_settings_modal')),
+      findsOneWidget,
+    );
+    expect(find.text('Endpoint'), findsOneWidget);
+    expect(find.text('Custom Endpoint'), findsOneWidget);
+    expect(find.text('Update'), findsOneWidget);
   });
 
   testWidgets('shows Back when adding an account to an existing wallet', (


### PR DESCRIPTION
## Summary

- Add a custom endpoint settings entry point to the first-run welcome screen.
- Reuse the existing custom endpoint UI in a modal so users can configure lightwalletd before creating their first account.
- Hide the welcome endpoint settings button when entering onboarding from an existing wallet, since those users can use the main Endpoint settings screen.
- Share the send screen tooltip styling through a common `AppTooltip` so the welcome settings tooltip matches the existing Max tooltip design.

## Why

Before this change, a first-time user had to create or import an account before they could configure a custom endpoint. From a privacy perspective, that meant initial wallet creation could contact the default endpoint before the user had a chance to choose their own lightwalletd server. This PR fixes that first-run privacy gap by making custom endpoint configuration available directly from the initial welcome screen.

## Validation

- `fvm flutter test test/features/onboarding/welcome_screen_test.dart`
- `fvm flutter analyze`