### PR TITLE
fix: enable Keystone address renewal

### DIFF
--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -267,9 +267,6 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
       }
     });
 
-    final accountState = ref.watch(accountProvider).value;
-    final canRenewShieldedAddress =
-        accountState?.activeAccount?.isHardware != true;
     final address = _selectedAddress;
     final isShielded = _selectedType == _ReceiveAddressType.shielded;
     final isLoadingSelectedAddress = isShielded
@@ -291,11 +288,8 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
               errorText: selectedErrorText,
               isLoading: isLoadingSelectedAddress,
               isRenewingShielded: _isRenewingShielded,
-              canRenewShieldedAddress: canRenewShieldedAddress,
               onTypeChanged: _selectAddressType,
-              onRenewShielded: isShielded && canRenewShieldedAddress
-                  ? _renewShieldedAddress
-                  : null,
+              onRenewShielded: isShielded ? _renewShieldedAddress : null,
               onCopy: _copySelectedAddress,
               onShowHelp: () => _showAddressInfo(_selectedType),
             ),
@@ -304,7 +298,6 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
                 onDismiss: _dismissAddressInfo,
                 child: _ReceiveInfoDialog(
                   type: infoDialogType,
-                  canRenewShieldedAddress: canRenewShieldedAddress,
                   onClose: _dismissAddressInfo,
                 ),
               ),
@@ -322,7 +315,6 @@ class _ReceivePane extends StatelessWidget {
     required this.errorText,
     required this.isLoading,
     required this.isRenewingShielded,
-    required this.canRenewShieldedAddress,
     required this.onTypeChanged,
     required this.onRenewShielded,
     required this.onCopy,
@@ -334,7 +326,6 @@ class _ReceivePane extends StatelessWidget {
   final String? errorText;
   final bool isLoading;
   final bool isRenewingShielded;
-  final bool canRenewShieldedAddress;
   final ValueChanged<_ReceiveAddressType> onTypeChanged;
   final VoidCallback? onRenewShielded;
   final VoidCallback onCopy;
@@ -366,7 +357,6 @@ class _ReceivePane extends StatelessWidget {
                           address: address,
                           isLoading: isLoading,
                           isRenewingShielded: isRenewingShielded,
-                          canRenewShieldedAddress: canRenewShieldedAddress,
                           onTypeChanged: onTypeChanged,
                           onRenewShielded: onRenewShielded,
                           onShowHelp: onShowHelp,
@@ -414,7 +404,6 @@ class _ReceiveMainContent extends StatelessWidget {
     required this.address,
     required this.isLoading,
     required this.isRenewingShielded,
-    required this.canRenewShieldedAddress,
     required this.onTypeChanged,
     required this.onRenewShielded,
     required this.onShowHelp,
@@ -424,7 +413,6 @@ class _ReceiveMainContent extends StatelessWidget {
   final String address;
   final bool isLoading;
   final bool isRenewingShielded;
-  final bool canRenewShieldedAddress;
   final ValueChanged<_ReceiveAddressType> onTypeChanged;
   final VoidCallback? onRenewShielded;
   final VoidCallback onShowHelp;
@@ -506,7 +494,6 @@ class _ReceiveMainContent extends StatelessWidget {
                             address: address,
                             renewing: isRenewingShielded,
                             metrics: metrics,
-                            canRenewShieldedAddress: canRenewShieldedAddress,
                             onRenew: onRenewShielded,
                             onShowHelp: onShowHelp,
                           ),
@@ -775,7 +762,6 @@ class _ReceiveQrBlock extends StatelessWidget {
     required this.address,
     required this.renewing,
     required this.metrics,
-    required this.canRenewShieldedAddress,
     required this.onRenew,
     required this.onShowHelp,
     super.key,
@@ -785,7 +771,6 @@ class _ReceiveQrBlock extends StatelessWidget {
   final String address;
   final bool renewing;
   final _ReceiveQrMetrics metrics;
-  final bool canRenewShieldedAddress;
   final VoidCallback? onRenew;
   final VoidCallback onShowHelp;
 
@@ -815,7 +800,7 @@ class _ReceiveQrBlock extends StatelessWidget {
                     type: type,
                   ),
                 ),
-                if (_isShielded && canRenewShieldedAddress)
+                if (_isShielded)
                   Positioned(
                     top: metrics.renewTop,
                     child: _RenewButton(
@@ -1302,14 +1287,9 @@ class _CopyAddressButton extends StatelessWidget {
 }
 
 class _ReceiveInfoDialog extends StatelessWidget {
-  const _ReceiveInfoDialog({
-    required this.type,
-    required this.canRenewShieldedAddress,
-    required this.onClose,
-  });
+  const _ReceiveInfoDialog({required this.type, required this.onClose});
 
   final _ReceiveAddressType type;
-  final bool canRenewShieldedAddress;
   final VoidCallback onClose;
 
   bool get _isShielded => type == _ReceiveAddressType.shielded;
@@ -1318,36 +1298,23 @@ class _ReceiveInfoDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final items = _isShielded
-        ? canRenewShieldedAddress
-              ? const [
-                  _InfoItemData(
-                    iconName: AppIcons.lock,
-                    text:
-                        'Tx details - sender, receiver, and amount - are encrypted on-chain & hidden.',
-                  ),
-                  _InfoItemData(
-                    iconName: AppIcons.renew,
-                    text:
-                        'A new Zcash Shielded address is generated only when you click the Renew button.',
-                  ),
-                  _InfoItemData(
-                    iconName: AppIcons.wallet,
-                    text:
-                        'Each new address is a diversified address derived from the same key. They all receive to the same wallet.',
-                  ),
-                ]
-              : const [
-                  _InfoItemData(
-                    iconName: AppIcons.lock,
-                    text:
-                        'Tx details - sender, receiver, and amount - are encrypted on-chain & hidden.',
-                  ),
-                  _InfoItemData(
-                    iconName: AppIcons.keystone,
-                    text:
-                        "Keystone accounts use one fixed shielded address, so Renew isn't available.",
-                  ),
-                ]
+        ? const [
+            _InfoItemData(
+              iconName: AppIcons.lock,
+              text:
+                  'Tx details - sender, receiver, and amount - are encrypted on-chain & hidden.',
+            ),
+            _InfoItemData(
+              iconName: AppIcons.renew,
+              text:
+                  'A new Zcash Shielded address is generated only when you click the Renew button.',
+            ),
+            _InfoItemData(
+              iconName: AppIcons.wallet,
+              text:
+                  'Each new address is a diversified address derived from the same key. They all receive to the same wallet.',
+            ),
+          ]
         : [
             const _InfoItemData(
               iconName: AppIcons.unlock,

--- a/lib/src/providers/receive_address_provider.dart
+++ b/lib/src/providers/receive_address_provider.dart
@@ -25,6 +25,15 @@ class ReceiveAddressBusyException implements Exception {
   }
 }
 
+enum ReceiveAddressRequest {
+  shielded('shielded'),
+  orchard('orchard');
+
+  const ReceiveAddressRequest(this.wireName);
+
+  final String wireName;
+}
+
 class ReceiveAddressService {
   ReceiveAddressService(this._ref);
 
@@ -85,6 +94,10 @@ class ReceiveAddressService {
   Future<String> renewShieldedAddress({required String accountUuid}) async {
     final dbPath = await getWalletDbPath();
     final network = _network;
+    final accountNotifier = _ref.read(accountProvider.notifier);
+    final addressRequest = accountNotifier.isHardwareAccount(accountUuid)
+        ? ReceiveAddressRequest.orchard
+        : ReceiveAddressRequest.shielded;
 
     final address = await _withDatabaseLockRetry(
       operationName: 'renew shielded receive address',
@@ -92,12 +105,11 @@ class ReceiveAddressService {
         dbPath: dbPath,
         network: network,
         accountUuid: accountUuid,
+        addressRequest: addressRequest.wireName,
       ),
     );
 
-    _ref
-        .read(accountProvider.notifier)
-        .updateActiveAddressForAccount(accountUuid, address);
+    accountNotifier.updateActiveAddressForAccount(accountUuid, address);
     return address;
   }
 

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -354,10 +354,12 @@ Future<String> getNextAvailableAddress({
   required String dbPath,
   required String network,
   required String accountUuid,
+  required String addressRequest,
 }) => RustLib.instance.api.crateApiSyncGetNextAvailableAddress(
   dbPath: dbPath,
   network: network,
   accountUuid: accountUuid,
+  addressRequest: addressRequest,
 );
 
 Future<List<TxDataRequest>> getTransactionDataRequests({

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -260,6 +260,7 @@ abstract class RustLibApi extends BaseApi {
     required String dbPath,
     required String network,
     required String accountUuid,
+    required String addressRequest,
   });
 
   Future<SubtreeIndices> crateApiSyncGetNextSubtreeIndices({
@@ -1644,6 +1645,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String dbPath,
     required String network,
     required String accountUuid,
+    required String addressRequest,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1652,6 +1654,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(dbPath, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
+          sse_encode_String(addressRequest, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1664,7 +1667,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncGetNextAvailableAddressConstMeta,
-        argValues: [dbPath, network, accountUuid],
+        argValues: [dbPath, network, accountUuid, addressRequest],
         apiImpl: this,
       ),
     );
@@ -1673,7 +1676,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiSyncGetNextAvailableAddressConstMeta =>
       const TaskConstMeta(
         debugName: "get_next_available_address",
-        argNames: ["dbPath", "network", "accountUuid"],
+        argNames: ["dbPath", "network", "accountUuid", "addressRequest"],
       );
 
   @override

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -878,10 +878,12 @@ pub fn get_next_available_address(
     db_path: String,
     network: String,
     account_uuid: String,
+    address_request: String,
 ) -> Result<String, String> {
     catch(|| {
         let network = keys::parse_network(&network)?;
-        wallet_sync::get_next_available_address(&db_path, network, &account_uuid)
+        let address_request = wallet_sync::parse_address_request_kind(&address_request)?;
+        wallet_sync::get_next_available_address(&db_path, network, &account_uuid, address_request)
     })
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -1243,6 +1243,7 @@ fn wire__crate__api__sync__get_next_available_address_impl(
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_address_request = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -1250,6 +1251,7 @@ fn wire__crate__api__sync__get_next_available_address_impl(
                         api_db_path,
                         api_network,
                         api_account_uuid,
+                        api_address_request,
                     )?;
                     Ok(output_ok)
                 })())

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -693,6 +693,7 @@ mod tests {
             db_path_str,
             WalletNetwork::Main,
             &uuid,
+            crate::wallet::sync::AddressRequestKind::Shielded,
         )
         .unwrap();
 
@@ -710,6 +711,82 @@ mod tests {
                 .unwrap()
                 .unified_address
         );
+    }
+
+    #[test]
+    fn test_get_next_available_address_rotates_keystone_style_imported_account() {
+        use zcash_address::unified::{Encoding, Fvk, Ufvk};
+        use zcash_protocol::consensus::NetworkType;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let phrase = generate_mnemonic();
+        let seed = mnemonic_to_seed(&phrase).unwrap();
+        let account_index = zip32::AccountId::ZERO;
+        let usk = UnifiedSpendingKey::from_seed(
+            &WalletNetwork::Main,
+            seed.expose_secret(),
+            account_index,
+        )
+        .unwrap();
+        let full_ufvk = usk.to_unified_full_viewing_key();
+        let orchard_fvk = full_ufvk.orchard().unwrap().to_bytes();
+        let transparent_fvk = full_ufvk
+            .transparent()
+            .unwrap()
+            .serialize()
+            .try_into()
+            .unwrap();
+        let keystone_style_ufvk =
+            Ufvk::try_from_items(vec![Fvk::Orchard(orchard_fvk), Fvk::P2pkh(transparent_fvk)])
+                .unwrap()
+                .encode(&NetworkType::Main);
+        let seed_fingerprint = SeedFingerprint::from_seed(seed.expose_secret())
+            .unwrap()
+            .to_bytes();
+
+        let (uuid, default_address) = import_hardware_account(
+            db_path_str,
+            WalletNetwork::Main,
+            "Keystone",
+            &keystone_style_ufvk,
+            &seed_fingerprint,
+            u32::from(account_index),
+            None,
+        )
+        .unwrap();
+
+        crate::wallet::sync::update_chain_tip(db_path_str, WalletNetwork::Main, 2_500_000).unwrap();
+        let shielded_error = crate::wallet::sync::get_next_available_address(
+            db_path_str,
+            WalletNetwork::Main,
+            &uuid,
+            crate::wallet::sync::AddressRequestKind::Shielded,
+        )
+        .unwrap_err();
+        assert!(shielded_error.contains("Sapling"));
+
+        let renewed_address = crate::wallet::sync::get_next_available_address(
+            db_path_str,
+            WalletNetwork::Main,
+            &uuid,
+            crate::wallet::sync::AddressRequestKind::Orchard,
+        )
+        .unwrap();
+
+        assert_ne!(default_address, renewed_address);
+        assert_eq!(
+            renewed_address,
+            get_address_from_db(db_path_str, WalletNetwork::Main, Some(&uuid)).unwrap()
+        );
+
+        let za = zcash_address::ZcashAddress::try_from_encoded(&renewed_address).unwrap();
+        let debug = format!("{:?}", za);
+        assert!(debug.contains("Orchard"));
+        assert!(!debug.contains("Sapling"));
+        assert!(!debug.contains("P2pkh"));
     }
 
     #[test]

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -64,7 +64,8 @@ pub(crate) use send::ShieldTransparentStatus;
 pub use transactions::{
     check_tx_mined, decrypt_and_store_transaction, get_next_available_address,
     get_pending_transactions, get_transaction_data_requests, get_transaction_detail,
-    get_transaction_history, get_wallet_balance, set_transaction_status,
+    get_transaction_history, get_wallet_balance, parse_address_request_kind,
+    set_transaction_status, AddressRequestKind,
 };
 #[allow(unused_imports)] // ditto
 pub(crate) use transactions::{

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -97,15 +97,11 @@ pub fn get_next_available_address(
     db_path: &str,
     network: WalletNetwork,
     account_uuid: &str,
+    address_request: AddressRequestKind,
 ) -> Result<String, String> {
-    use zcash_keys::keys::{ReceiverRequirement, UnifiedAddressRequest};
     let account_id = parse_account_uuid(account_uuid)?;
-    let req = UnifiedAddressRequest::custom(
-        ReceiverRequirement::Require,
-        ReceiverRequirement::Require,
-        ReceiverRequirement::Omit,
-    )
-    .map_err(|_| "bad request")?;
+    let req = address_request.to_unified_address_request()?;
+
     let (ua, _) = with_wallet_db_write_lock("transactions.get_next_available_address", || {
         let mut db = open_wallet_db(db_path, network)?;
         db.get_next_available_address(account_id, req)
@@ -113,6 +109,46 @@ pub fn get_next_available_address(
             .ok_or_else(|| "No address available".to_string())
     })?;
     Ok(ua.encode(&network))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AddressRequestKind {
+    Shielded,
+    Orchard,
+}
+
+pub fn parse_address_request_kind(request: &str) -> Result<AddressRequestKind, String> {
+    match request {
+        "shielded" => Ok(AddressRequestKind::Shielded),
+        "orchard" => Ok(AddressRequestKind::Orchard),
+        _ => Err(format!(
+            "Unsupported address request '{request}'. Expected 'shielded' or 'orchard'."
+        )),
+    }
+}
+
+impl AddressRequestKind {
+    fn to_unified_address_request(self) -> Result<zcash_keys::keys::UnifiedAddressRequest, String> {
+        match self {
+            AddressRequestKind::Shielded => shielded_address_request(),
+            AddressRequestKind::Orchard => Ok(orchard_address_request()),
+        }
+    }
+}
+
+fn shielded_address_request() -> Result<zcash_keys::keys::UnifiedAddressRequest, String> {
+    use zcash_keys::keys::{ReceiverRequirement, UnifiedAddressRequest};
+
+    UnifiedAddressRequest::custom(
+        ReceiverRequirement::Require,
+        ReceiverRequirement::Require,
+        ReceiverRequirement::Omit,
+    )
+    .map_err(|_| "bad shielded address request".to_string())
+}
+
+fn orchard_address_request() -> zcash_keys::keys::UnifiedAddressRequest {
+    zcash_keys::keys::UnifiedAddressRequest::ORCHARD
 }
 
 // ======================== Transaction Enhancement Requests ========================

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -32,7 +32,7 @@ void main() {
     expect(_findAppIcon(AppIcons.renew), findsOneWidget);
   });
 
-  testWidgets('hides shielded renew button for hardware accounts', (
+  testWidgets('shows shielded renew button for hardware accounts', (
     tester,
   ) async {
     await tester.binding.setSurfaceSize(const Size(1512, 982));
@@ -44,7 +44,32 @@ void main() {
     await tester.pump();
     await tester.pump();
 
-    expect(_findAppIcon(AppIcons.renew), findsNothing);
+    expect(_findAppIcon(AppIcons.renew), findsOneWidget);
+  });
+
+  testWidgets('renews shielded address for hardware accounts', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    late _RecordingReceiveAddressService service;
+    await tester.pumpWidget(
+      _receiveHarness(
+        bootstrap: _hardwareBootstrap,
+        receiveAddressService: (ref) {
+          service = _RecordingReceiveAddressService(ref);
+          return service;
+        },
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(_findAppIcon(AppIcons.renew));
+    await tester.pump();
+
+    expect(service.renewedAccountUuid, 'account-1');
   });
 
   testWidgets('uses Keystone shielded help copy for hardware accounts', (
@@ -65,11 +90,11 @@ void main() {
     expect(find.text('Shielded Address'), findsOneWidget);
     expect(
       find.text(
-        "Keystone accounts use one fixed shielded address, so Renew isn't available.",
+        'A new Zcash Shielded address is generated only when you click the Renew button.',
       ),
       findsOneWidget,
     );
-    expect(find.textContaining('Renew button'), findsNothing);
+    expect(find.textContaining('fixed shielded address'), findsNothing);
   });
 
   testWidgets('receive info modal does not block sidebar navigation', (
@@ -284,6 +309,8 @@ final _hardwareBootstrap = AppBootstrapState(
 
 const _shieldedAddress =
     'u1testshieldedaddress000000000000000000000000000000000000000000000000000';
+const _renewedShieldedAddress =
+    'u1testrenewedshieldedaddress0000000000000000000000000000000000000000000';
 const _accountOneAddress = 'u1accountone-stale';
 const _accountTwoAddress = 'u1accounttwo-current';
 
@@ -311,6 +338,18 @@ class _FakeReceiveAddressService extends ReceiveAddressService {
   @override
   Future<String> renewShieldedAddress({required String accountUuid}) async {
     return _shieldedAddress;
+  }
+}
+
+class _RecordingReceiveAddressService extends _FakeReceiveAddressService {
+  _RecordingReceiveAddressService(super.ref);
+
+  String? renewedAccountUuid;
+
+  @override
+  Future<String> renewShieldedAddress({required String accountUuid}) async {
+    renewedAccountUuid = accountUuid;
+    return _renewedShieldedAddress;
   }
 }
 


### PR DESCRIPTION
## What changed

- Enables shielded address renewal for Keystone accounts on the receive screen.
- Adds an explicit address request selection: software accounts request Sapling+Orchard shielded addresses, while Keystone accounts request Orchard-only addresses.
- Threads the new address request through the FRB sync API and generated bindings.
- Adds coverage for Keystone-shaped imported UFVKs and receive-screen renewal behavior.

## Why

Keystone accounts do not have a Sapling receiver, so the old Sapling+Orchard renewal request could not work for them. The UI hid renewal for hardware accounts as a workaround, but Keystone can still derive diversified Orchard receive addresses from the paired viewing key.

## Validation

- `flutter_rust_bridge_codegen generate`
- `cargo test --lib`
- `fvm flutter test test/features/receive/receive_screen_test.dart`
- `fvm flutter analyze`
- `git diff --check`