### PR TITLE
Handle retryable shield broadcast failures

### DIFF
--- a/integration_test/regtest_shield_transparent_retry_test.dart
+++ b/integration_test/regtest_shield_transparent_retry_test.dart
@@ -1,0 +1,654 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/formatting/zec_amount.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
+
+import 'support/regtest_lightwalletd_proxy.dart';
+
+final _network = kZcashDefaultNetworkName;
+const _driverUrl = String.fromEnvironment('ZCASH_E2E_DRIVER_URL');
+const _password = 'Vizor123!';
+const _primaryProxyUrl = 'http://127.0.0.1:19068';
+const _transparentFundingAmount = '0.75';
+final _transparentFundingZatoshi = BigInt.from(75_000_000);
+const _fallbackToast =
+    'Selected endpoint is unstable. Switched to fallback endpoint.';
+const _retryQueuedMessage = 'Shielding queued for retry. Check Activity.';
+const _legacyBroadcastFailureMessage =
+    "Couldn't broadcast your shielding transaction. Try again.";
+final _currencyTicker = kZcashDefaultCurrencyTicker;
+final _currencyTickerLower = _currencyTicker.toLowerCase();
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeZcashWalletRuntime();
+  });
+
+  testWidgets(
+    'retries shielding after first broadcast failure and completes',
+    (tester) async {
+      if (_driverUrl.isEmpty) {
+        fail('ZCASH_E2E_DRIVER_URL is required.');
+      }
+
+      addTearDown(() async {
+        await _cleanupE2eWalletState();
+      });
+
+      await _cleanupE2eWalletState();
+      final proxy = RegtestLightwalletdProxy(log: _log);
+      await proxy.start();
+      addTearDown(proxy.stop);
+      await _configureProxyPresetPrimary();
+
+      _log('pumping app with proxy primary endpoint');
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+
+      await _createFirstWallet(tester);
+      final accountUuid = await _accountUuidAtOrder(0);
+      final transparentAddress = await _transparentAddressForAccount(
+        accountUuid,
+      );
+      expect(transparentAddress, startsWith('t'));
+      _log('created account $accountUuid transparent=$transparentAddress');
+
+      final fundingTxid = await _fundConfirmed(
+        transparentAddress,
+        _transparentFundingAmount,
+      );
+      _log('external confirmed transparent funding txid=$fundingTxid');
+
+      await _waitForBalance(
+        tester,
+        transparent:
+            'Transparent balance: ${_formatBalance(_transparentFundingZatoshi)} '
+            '$_currencyTicker',
+        timeout: const Duration(minutes: 5),
+      );
+      await _waitForShieldBalanceUi(tester);
+
+      final dbPath = await getWalletDbPath();
+      final shieldStatus = await rust_sync.getShieldTransparentStatus(
+        dbPath: dbPath,
+        network: _network,
+        accountUuid: accountUuid,
+      );
+      expect(shieldStatus.canShield, isTrue);
+      expect(shieldStatus.shieldedZatoshi, greaterThan(BigInt.zero));
+      final expectedShielded = shieldStatus.shieldedZatoshi;
+      _log(
+        'shield status fee=${shieldStatus.feeZatoshi} '
+        'shielded=$expectedShielded',
+      );
+
+      proxy.failNextSendTransactions(1);
+      await _tapWidget(tester, const ValueKey('home_shield_balance_button'));
+
+      await _pumpUntil(
+        tester,
+        () => proxy.failedSendTransactionCount == 1,
+        description: 'first shielding broadcast to be forced through failure',
+        timeout: const Duration(minutes: 2),
+      );
+      await _pumpUntil(
+        tester,
+        () => tester.any(find.text(_fallbackToast)),
+        description: 'fallback endpoint toast after forced broadcast failure',
+        timeout: const Duration(minutes: 2),
+      );
+      await _pumpUntil(
+        tester,
+        () => tester.any(find.text(_retryQueuedMessage)),
+        description: 'retry queued shield notice',
+        timeout: const Duration(minutes: 2),
+      );
+      expect(tester.any(find.text(_legacyBroadcastFailureMessage)), isFalse);
+
+      await _waitForHistoryEntry(
+        tester,
+        accountUuid: accountUuid,
+        txKind: 'shielded',
+        displayAmount: expectedShielded,
+        pending: true,
+        timeout: const Duration(minutes: 4),
+      );
+      await _expectAnyActivityRow(
+        tester,
+        rowKeyPrefix: 'home_activity',
+        title: 'Shielded',
+        amount: _formatActivity(expectedShielded),
+        status: 'In progress',
+        timeout: const Duration(minutes: 2),
+      );
+
+      await _mineUntilHistoryEntryMined(
+        tester,
+        accountUuid: accountUuid,
+        txKind: 'shielded',
+        displayAmount: expectedShielded,
+        timeout: const Duration(minutes: 5),
+      );
+      await _waitForBalance(
+        tester,
+        shielded: '${_formatBalance(expectedShielded)} $_currencyTickerLower',
+        timeout: const Duration(minutes: 5),
+      );
+      await _waitForTransparentBalanceCleared(tester);
+
+      await _expectAnyActivityRow(
+        tester,
+        rowKeyPrefix: 'home_activity',
+        title: 'Shielded',
+        amount: _formatActivity(expectedShielded),
+        status: 'Completed',
+        timeout: const Duration(minutes: 2),
+      );
+      await _openActivity(tester);
+      await _expectAnyActivityRow(
+        tester,
+        rowKeyPrefix: 'activity_screen',
+        title: 'Shielded',
+        amount: _formatActivity(expectedShielded),
+        status: 'Completed',
+        timeout: const Duration(minutes: 2),
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 15)),
+  );
+}
+
+Future<void> _mineUntilHistoryEntryMined(
+  WidgetTester tester, {
+  required String accountUuid,
+  required String txKind,
+  required BigInt displayAmount,
+  Duration timeout = const Duration(minutes: 5),
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  Object? lastError;
+  var rounds = 0;
+
+  while (DateTime.now().isBefore(deadline)) {
+    rounds += 1;
+    await _mineRegtestBlocks(2);
+    try {
+      await _waitForHistoryEntry(
+        tester,
+        accountUuid: accountUuid,
+        txKind: txKind,
+        displayAmount: displayAmount,
+        pending: false,
+        timeout: const Duration(seconds: 10),
+      );
+      _log('history mined after $rounds mining round(s)');
+      return;
+    } catch (e) {
+      lastError = e;
+    }
+  }
+
+  fail(
+    'Timed out waiting for mined $txKind retry tx amount=$displayAmount. '
+    'Last error: $lastError',
+  );
+}
+
+Future<void> _configureProxyPresetPrimary() async {
+  final storage = AppSecureStore.instance;
+  await storage.writePlain(kRpcEndpointUrlKey, _primaryProxyUrl);
+  await storage.writePlain(
+    kRpcEndpointPresetKey,
+    kRegtestSlowRpcEndpointPresetId,
+  );
+}
+
+Future<void> _createFirstWallet(WidgetTester tester) async {
+  _log('creating first wallet');
+  await _tapAppButton(tester, const ValueKey('welcome_create_wallet_button'));
+  await _tapText(tester, 'I know how to use Zcash');
+  await _tapAppButton(
+    tester,
+    const ValueKey('create_secret_phrase_primary_button'),
+    timeout: const Duration(minutes: 1),
+  );
+  await _tapAppButton(
+    tester,
+    const ValueKey('create_secret_phrase_primary_button'),
+  );
+  await _enterText(
+    tester,
+    const ValueKey('set_password_password_field'),
+    _password,
+  );
+  await _enterText(
+    tester,
+    const ValueKey('set_password_confirm_field'),
+    _password,
+  );
+  await _tapAppButton(
+    tester,
+    const ValueKey('set_password_submit_button'),
+    timeout: const Duration(minutes: 4),
+  );
+  await _waitForHome(tester, timeout: const Duration(minutes: 4));
+  _log('first wallet created');
+}
+
+Future<String> _transparentAddressForAccount(String accountUuid) async {
+  final dbPath = await getWalletDbPath();
+  return rust_wallet.getTransparentAddress(
+    dbPath: dbPath,
+    network: _network,
+    accountUuid: accountUuid,
+  );
+}
+
+Future<String> _fundConfirmed(String address, String amount) async {
+  _log('requesting confirmed transparent funding of $amount $_currencyTicker');
+  final response = await _postDriver('/fund-confirmed', {
+    'address': address,
+    'amount': amount,
+    'confirmations': 10,
+  }, timeout: const Duration(minutes: 10));
+  final txid = response['txid'] as String? ?? '';
+  if (txid.isEmpty) fail('E2E driver did not return a txid.');
+  return txid;
+}
+
+Future<void> _mineRegtestBlocks(int blocks) async {
+  _log('requesting external mining of $blocks regtest blocks');
+  await _postDriver('/mine', {'blocks': blocks});
+}
+
+Future<Map<String, Object?>> _postDriver(
+  String path,
+  Map<String, Object?> payload, {
+  Duration timeout = const Duration(minutes: 2),
+}) async {
+  final client = HttpClient();
+  try {
+    final request = await client
+        .postUrl(Uri.parse('$_driverUrl$path'))
+        .timeout(timeout);
+    final bodyBytes = utf8.encode(jsonEncode(payload));
+    request.headers.contentType = ContentType.json;
+    request.contentLength = bodyBytes.length;
+    request.add(bodyBytes);
+
+    final response = await request.close().timeout(timeout);
+    final body = await utf8.decoder.bind(response).join().timeout(timeout);
+    if (response.statusCode != HttpStatus.ok) {
+      throw StateError(
+        'E2E driver $path failed: HTTP ${response.statusCode}\n$body',
+      );
+    }
+    return jsonDecode(body) as Map<String, Object?>;
+  } finally {
+    client.close(force: true);
+  }
+}
+
+Future<String> _accountUuidAtOrder(int order) async {
+  final dbPath = await getWalletDbPath();
+  final accounts = await rust_wallet.listAccounts(
+    dbPath: dbPath,
+    network: _network,
+  );
+  if (order >= accounts.length) {
+    fail('Expected account order $order, got ${accounts.length} accounts.');
+  }
+  return accounts[order].uuid;
+}
+
+Future<void> _openActivity(WidgetTester tester) async {
+  await _tapWidget(tester, const ValueKey('sidebar_activity_button'));
+  await _pumpUntil(
+    tester,
+    () => tester.any(find.byKey(const ValueKey('activity_screen_row_0'))),
+    description: 'activity screen rows to render',
+    timeout: const Duration(minutes: 1),
+  );
+}
+
+Future<void> _waitForHome(
+  WidgetTester tester, {
+  Duration timeout = const Duration(minutes: 1),
+}) async {
+  await _pumpUntil(
+    tester,
+    () => tester.any(find.byKey(const ValueKey('home_shielded_balance_text'))),
+    description: 'home balance card to render',
+    timeout: timeout,
+  );
+}
+
+Future<void> _waitForShieldBalanceUi(WidgetTester tester) async {
+  await _pumpUntil(
+    tester,
+    () {
+      final button = find.byKey(const ValueKey('home_shield_balance_button'));
+      return tester.any(button) &&
+          tester.any(
+            find.descendant(of: button, matching: find.text('Shield Balance')),
+          );
+    },
+    description: 'shield balance action to render',
+    timeout: const Duration(minutes: 2),
+  );
+}
+
+Future<void> _waitForTransparentBalanceCleared(WidgetTester tester) async {
+  await _pumpUntil(
+    tester,
+    () =>
+        !tester.any(find.byKey(const ValueKey('transparent-balance-strip'))) ||
+        _keyedTextEquals(
+          tester,
+          const ValueKey('home_transparent_balance_text'),
+          'Transparent balance: 0.00 $_currencyTicker',
+        ),
+    description: 'transparent balance to clear after shielding',
+    timeout: const Duration(minutes: 5),
+  );
+}
+
+Future<void> _waitForHistoryEntry(
+  WidgetTester tester, {
+  required String accountUuid,
+  required String txKind,
+  required BigInt displayAmount,
+  required bool pending,
+  Duration timeout = const Duration(minutes: 2),
+}) async {
+  final dbPath = await getWalletDbPath();
+  final deadline = DateTime.now().add(timeout);
+  Object? lastError;
+  var lastHistorySummary = '<not read>';
+
+  while (DateTime.now().isBefore(deadline)) {
+    try {
+      final history = await rust_sync.getTransactionHistory(
+        dbPath: dbPath,
+        network: _network,
+        limit: 20,
+        accountUuid: accountUuid,
+      );
+      lastHistorySummary = history
+          .map(
+            (tx) =>
+                '${tx.txidHex}:${tx.txKind}:${tx.displayAmount}:'
+                'mined=${tx.minedHeight}:expired=${tx.expiredUnmined}',
+          )
+          .join(', ');
+      if (history.any(
+        (tx) =>
+            tx.txKind == txKind &&
+            tx.displayAmount == displayAmount &&
+            (tx.minedHeight == BigInt.zero) == pending &&
+            !tx.expiredUnmined,
+      )) {
+        _log('history matched $txKind tx amount=$displayAmount');
+        return;
+      }
+    } catch (e) {
+      lastError = e;
+    }
+
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail(
+    'Timed out waiting for history $txKind amount=$displayAmount '
+    'pending=$pending. Observed history: $lastHistorySummary.$error',
+  );
+}
+
+Future<void> _waitForBalance(
+  WidgetTester tester, {
+  String? shielded,
+  String? transparent,
+  Duration timeout = const Duration(minutes: 4),
+}) async {
+  if (shielded != null) {
+    await _pumpUntil(
+      tester,
+      () => _keyedTextEquals(
+        tester,
+        const ValueKey('home_shielded_balance_text'),
+        shielded,
+      ),
+      description: 'shielded balance to show $shielded',
+      timeout: timeout,
+    );
+    _log('shielded balance matched: $shielded');
+  }
+  if (transparent != null) {
+    await _pumpUntil(
+      tester,
+      () => _keyedTextEquals(
+        tester,
+        const ValueKey('home_transparent_balance_text'),
+        transparent,
+      ),
+      description: 'transparent balance to show $transparent',
+      timeout: timeout,
+    );
+    _log('transparent balance matched: $transparent');
+  }
+}
+
+Future<void> _expectAnyActivityRow(
+  WidgetTester tester, {
+  required String rowKeyPrefix,
+  required String title,
+  required String amount,
+  required String status,
+  Duration timeout = const Duration(minutes: 2),
+}) async {
+  await _pumpUntil(
+    tester,
+    () {
+      for (var i = 0; i < 10; i++) {
+        final texts = _textSetIn(
+          tester,
+          find.byKey(ValueKey('${rowKeyPrefix}_row_$i')),
+        );
+        if (texts.contains(title) &&
+            texts.contains(amount) &&
+            texts.contains(status)) {
+          return true;
+        }
+      }
+      return false;
+    },
+    description: '$rowKeyPrefix row to show $title $amount $status',
+    timeout: timeout,
+  );
+  _log('activity row matched: $title $amount $status');
+}
+
+Future<void> _tapAppButton(
+  WidgetTester tester,
+  Key key, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () =>
+        tester.any(finder) &&
+        tester.widget<AppButton>(finder).onPressed != null,
+    description: '$key button to be enabled',
+    timeout: timeout,
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _tapWidget(WidgetTester tester, Key key) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () => tester.any(finder),
+    description: '$key widget to render',
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _tapText(WidgetTester tester, String text) async {
+  final finder = find.text(text);
+  await _pumpUntil(
+    tester,
+    () => tester.any(finder),
+    description: '$text text to render',
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped text "$text"');
+}
+
+Future<void> _enterText(WidgetTester tester, Key key, String text) async {
+  final editable = find.descendant(
+    of: find.byKey(key),
+    matching: find.byType(EditableText),
+  );
+  await _pumpUntil(
+    tester,
+    () => tester.any(editable),
+    description: '$key editable text field',
+  );
+  await tester.tap(editable);
+  await tester.enterText(editable, text);
+  await tester.pump(const Duration(milliseconds: 100));
+  _log('entered text into $key');
+}
+
+bool _keyedTextEquals(WidgetTester tester, Key key, String expected) {
+  return _textForKey(tester, key) == expected;
+}
+
+String? _textForKey(WidgetTester tester, Key key) {
+  final finder = find.byKey(key);
+  if (!tester.any(finder)) return null;
+  final widget = tester.widget<Text>(finder);
+  return widget.data;
+}
+
+Set<String> _textSetIn(WidgetTester tester, Finder root) {
+  if (!tester.any(root)) return const {};
+  final texts = <String>{};
+  for (final element
+      in find.descendant(of: root, matching: find.byType(Text)).evaluate()) {
+    final widget = element.widget;
+    if (widget is Text) {
+      final value = widget.data ?? widget.textSpan?.toPlainText();
+      if (value != null) texts.add(value);
+    }
+  }
+  return texts;
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  required String description,
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final end = DateTime.now().add(timeout);
+  Object? lastError;
+  var polls = 0;
+  while (DateTime.now().isBefore(end)) {
+    try {
+      if (condition()) return;
+    } catch (e) {
+      lastError = e;
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    polls++;
+    if (polls % 25 == 0) {
+      _log('still waiting for $description');
+    }
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail('Timed out waiting for $description.$error');
+}
+
+String _formatBalance(BigInt zatoshi) {
+  return ZecAmount.fromZatoshi(zatoshi).balance.amountText;
+}
+
+String _formatActivity(BigInt zatoshi) {
+  return ZecAmount.fromZatoshi(zatoshi).activity.toString();
+}
+
+Future<void> _cleanupE2eWalletState() async {
+  if (kZcashDefaultNetworkName != ZcashNetwork.regtest.name) {
+    throw StateError(
+      'Refusing to clean wallet state without ZCASH_DEFAULT_NETWORK=regtest.',
+    );
+  }
+
+  final storage = AppSecureStore.instance;
+  final dbName = await getWalletDbName();
+
+  _log('cleaning regtest wallet state');
+  await _stopRustWorkForCleanup();
+
+  await storage.deleteAll();
+
+  final supportDir = await getWalletSupportDirectory();
+  if (!supportDir.existsSync()) return;
+
+  for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
+    final file = File('${supportDir.path}${Platform.pathSeparator}$name');
+    if (file.existsSync()) file.deleteSync();
+  }
+}
+
+Future<void> _stopRustWorkForCleanup() async {
+  rust_sync.setSyncMode(mode: 0);
+  rust_sync.cancelFullSync();
+  rust_sync.stopMempoolObserver();
+
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  while ((rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) &&
+      DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  if (rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) {
+    _log(
+      'timed out waiting for Rust work to stop; continuing E2E storage cleanup',
+    );
+  }
+}
+
+void _log(String message) {
+  // ignore: avoid_print
+  print('[regtest_shield_transparent_retry_test] $message');
+}

--- a/integration_test/support/regtest_lightwalletd_proxy.dart
+++ b/integration_test/support/regtest_lightwalletd_proxy.dart
@@ -33,8 +33,11 @@ class RegtestLightwalletdProxy
   grpc.Server? _server;
   _ProxyMode _mode = _ProxyMode.healthy;
   int? _slowHeight;
+  int _sendTransactionFailuresRemaining = 0;
+  int _failedSendTransactionCount = 0;
 
   String get url => 'http://127.0.0.1:$listenPort';
+  int get failedSendTransactionCount => _failedSendTransactionCount;
 
   Future<void> start() async {
     _server = grpc.Server.create(services: [this]);
@@ -65,6 +68,14 @@ class RegtestLightwalletdProxy
   void setDown() {
     _mode = _ProxyMode.down;
     _log('primary proxy mode=down');
+  }
+
+  void failNextSendTransactions(int count) {
+    if (count < 0) {
+      throw ArgumentError.value(count, 'count', 'must not be negative');
+    }
+    _sendTransactionFailuresRemaining = count;
+    _log('primary proxy will fail next $count SendTransaction call(s)');
   }
 
   void _throwIfDown() {
@@ -152,6 +163,15 @@ class RegtestLightwalletdProxy
     service.RawTransaction request,
   ) {
     _throwIfDown();
+    if (_sendTransactionFailuresRemaining > 0) {
+      _sendTransactionFailuresRemaining -= 1;
+      _failedSendTransactionCount += 1;
+      _log(
+        'primary proxy forced SendTransaction failure '
+        '(failed=$_failedSendTransactionCount)',
+      );
+      throw grpc.GrpcError.unavailable('forced SendTransaction failure');
+    }
     return _client.sendTransaction(request);
   }
 

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -34,6 +34,15 @@ import '../widgets/keystone_shield_signing_overlay.dart';
 
 const _shieldErrorTooltipIconSize = 14.0;
 const _shieldErrorTooltipGap = AppSpacing.xxs;
+const shieldBalancePendingBroadcastMessage =
+    'Shielding queued for retry. Check Activity.';
+
+String? shieldBalanceBroadcastStatusMessage(
+  rust_sync.ShieldTransparentResult result,
+) {
+  if (result.status == 'broadcasted') return null;
+  return shieldBalancePendingBroadcastMessage;
+}
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -160,13 +169,42 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       result = await resultFuture;
       log(
         'HomeScreen: shielded transparent balance txids=${result.txids} '
+        'status=${result.status} '
+        'broadcasted=${result.broadcastedCount}/${result.totalCount} '
         'fee=${result.feeZatoshi} shielded=${result.shieldedZatoshi}',
       );
+
+      final broadcastStatusMessage = shieldBalanceBroadcastStatusMessage(
+        result,
+      );
+      final broadcastDetailMessage = result.message?.trim();
+      if (broadcastStatusMessage != null &&
+          broadcastDetailMessage != null &&
+          broadcastDetailMessage.isNotEmpty) {
+        final switched = await ref
+            .read(rpcEndpointFailoverProvider.notifier)
+            .switchToFallbackFor(
+              broadcastDetailMessage,
+              endpoint: attemptedEndpoint,
+              operation: 'shield transparent balance broadcast',
+            );
+        if (switched) {
+          unawaited(ref.read(syncProvider.notifier).restartSync());
+        }
+      }
 
       try {
         await ref.read(syncProvider.notifier).refreshAfterSend();
       } catch (e) {
         log('HomeScreen: refreshAfterSend after shielding failed: $e');
+      }
+
+      if (broadcastStatusMessage != null) {
+        if (!mounted) return;
+        setState(() {
+          _shieldBalanceError = broadcastStatusMessage;
+          _shieldBalanceErrorDetail = null;
+        });
       }
     } catch (e, st) {
       log('HomeScreen: shield transparent balance failed: $e\n$st');
@@ -217,6 +255,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   String? _shieldBalanceErrorDetails(Object error) {
     final message = error.toString().trim();
+    final lower = message.toLowerCase();
+    if (lower.contains('broadcast') || lower.contains('sendtransaction')) {
+      return null;
+    }
     return message.isEmpty ? null : message;
   }
 

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -859,18 +859,32 @@ class ShieldTransparentPcztResult {
 
 class ShieldTransparentResult {
   final String txids;
+  final String status;
+  final int broadcastedCount;
+  final int totalCount;
+  final String? message;
   final BigInt feeZatoshi;
   final BigInt shieldedZatoshi;
 
   const ShieldTransparentResult({
     required this.txids,
+    required this.status,
+    required this.broadcastedCount,
+    required this.totalCount,
+    this.message,
     required this.feeZatoshi,
     required this.shieldedZatoshi,
   });
 
   @override
   int get hashCode =>
-      txids.hashCode ^ feeZatoshi.hashCode ^ shieldedZatoshi.hashCode;
+      txids.hashCode ^
+      status.hashCode ^
+      broadcastedCount.hashCode ^
+      totalCount.hashCode ^
+      message.hashCode ^
+      feeZatoshi.hashCode ^
+      shieldedZatoshi.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -878,6 +892,10 @@ class ShieldTransparentResult {
       other is ShieldTransparentResult &&
           runtimeType == other.runtimeType &&
           txids == other.txids &&
+          status == other.status &&
+          broadcastedCount == other.broadcastedCount &&
+          totalCount == other.totalCount &&
+          message == other.message &&
           feeZatoshi == other.feeZatoshi &&
           shieldedZatoshi == other.shieldedZatoshi;
 }

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -3402,12 +3402,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ShieldTransparentResult dco_decode_shield_transparent_result(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3)
-      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return ShieldTransparentResult(
       txids: dco_decode_String(arr[0]),
-      feeZatoshi: dco_decode_u_64(arr[1]),
-      shieldedZatoshi: dco_decode_u_64(arr[2]),
+      status: dco_decode_String(arr[1]),
+      broadcastedCount: dco_decode_u_32(arr[2]),
+      totalCount: dco_decode_u_32(arr[3]),
+      message: dco_decode_opt_String(arr[4]),
+      feeZatoshi: dco_decode_u_64(arr[5]),
+      shieldedZatoshi: dco_decode_u_64(arr[6]),
     );
   }
 
@@ -4073,10 +4077,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_txids = sse_decode_String(deserializer);
+    var var_status = sse_decode_String(deserializer);
+    var var_broadcastedCount = sse_decode_u_32(deserializer);
+    var var_totalCount = sse_decode_u_32(deserializer);
+    var var_message = sse_decode_opt_String(deserializer);
     var var_feeZatoshi = sse_decode_u_64(deserializer);
     var var_shieldedZatoshi = sse_decode_u_64(deserializer);
     return ShieldTransparentResult(
       txids: var_txids,
+      status: var_status,
+      broadcastedCount: var_broadcastedCount,
+      totalCount: var_totalCount,
+      message: var_message,
       feeZatoshi: var_feeZatoshi,
       shieldedZatoshi: var_shieldedZatoshi,
     );
@@ -4728,6 +4740,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(self.txids, serializer);
+    sse_encode_String(self.status, serializer);
+    sse_encode_u_32(self.broadcastedCount, serializer);
+    sse_encode_u_32(self.totalCount, serializer);
+    sse_encode_opt_String(self.message, serializer);
     sse_encode_u_64(self.feeZatoshi, serializer);
     sse_encode_u_64(self.shieldedZatoshi, serializer);
   }

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -603,6 +603,10 @@ pub struct SendMaxEstimateResult {
 
 pub struct ShieldTransparentResult {
     pub txids: String,
+    pub status: String,
+    pub broadcasted_count: u32,
+    pub total_count: u32,
+    pub message: Option<String>,
     pub fee_zatoshi: u64,
     pub shielded_zatoshi: u64,
 }
@@ -835,6 +839,10 @@ pub fn shield_transparent_balance(
         ))?;
         Ok(ShieldTransparentResult {
             txids: r.txids,
+            status: r.status,
+            broadcasted_count: r.broadcasted_count,
+            total_count: r.total_count,
+            message: r.message,
             fee_zatoshi: r.fee_zatoshi,
             shielded_zatoshi: r.shielded_zatoshi,
         })
@@ -866,6 +874,10 @@ pub fn shield_transparent_balance_with_macos_stored_mnemonic(
         ))?;
         Ok(ShieldTransparentResult {
             txids: r.txids,
+            status: r.status,
+            broadcasted_count: r.broadcasted_count,
+            total_count: r.total_count,
+            message: r.message,
             fee_zatoshi: r.fee_zatoshi,
             shielded_zatoshi: r.shielded_zatoshi,
         })

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -3121,10 +3121,18 @@ impl SseDecode for crate::api::sync::ShieldTransparentResult {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_txids = <String>::sse_decode(deserializer);
+        let mut var_status = <String>::sse_decode(deserializer);
+        let mut var_broadcastedCount = <u32>::sse_decode(deserializer);
+        let mut var_totalCount = <u32>::sse_decode(deserializer);
+        let mut var_message = <Option<String>>::sse_decode(deserializer);
         let mut var_feeZatoshi = <u64>::sse_decode(deserializer);
         let mut var_shieldedZatoshi = <u64>::sse_decode(deserializer);
         return crate::api::sync::ShieldTransparentResult {
             txids: var_txids,
+            status: var_status,
+            broadcasted_count: var_broadcastedCount,
+            total_count: var_totalCount,
+            message: var_message,
             fee_zatoshi: var_feeZatoshi,
             shielded_zatoshi: var_shieldedZatoshi,
         };
@@ -3893,6 +3901,10 @@ impl flutter_rust_bridge::IntoDart for crate::api::sync::ShieldTransparentResult
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.txids.into_into_dart().into_dart(),
+            self.status.into_into_dart().into_dart(),
+            self.broadcasted_count.into_into_dart().into_dart(),
+            self.total_count.into_into_dart().into_dart(),
+            self.message.into_into_dart().into_dart(),
             self.fee_zatoshi.into_into_dart().into_dart(),
             self.shielded_zatoshi.into_into_dart().into_dart(),
         ]
@@ -4526,6 +4538,10 @@ impl SseEncode for crate::api::sync::ShieldTransparentResult {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.txids, serializer);
+        <String>::sse_encode(self.status, serializer);
+        <u32>::sse_encode(self.broadcasted_count, serializer);
+        <u32>::sse_encode(self.total_count, serializer);
+        <Option<String>>::sse_encode(self.message, serializer);
         <u64>::sse_encode(self.fee_zatoshi, serializer);
         <u64>::sse_encode(self.shielded_zatoshi, serializer);
     }

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -110,6 +110,10 @@ pub(crate) struct SendMaxEstimateResult {
 
 pub(crate) struct ShieldTransparentResult {
     pub txids: String,
+    pub status: String,
+    pub broadcasted_count: u32,
+    pub total_count: u32,
+    pub message: Option<String>,
     pub fee_zatoshi: u64,
     pub shielded_zatoshi: u64,
 }
@@ -459,14 +463,11 @@ pub(crate) async fn shield_transparent_balance(
     )?;
 
     let txids: Vec<TxId> = txids.iter().cloned().collect();
-    let txids = broadcast_created_transactions(db_path, lightwalletd_url, &txids, "shield")
-        .await
-        .into_legacy_result()?;
-    Ok(ShieldTransparentResult {
-        txids,
-        fee_zatoshi,
-        shielded_zatoshi,
-    })
+    Ok(
+        broadcast_created_transactions(db_path, lightwalletd_url, &txids, "shield")
+            .await
+            .into_shield_transparent_result(fee_zatoshi, shielded_zatoshi),
+    )
 }
 
 /// Execute a previously proposed transfer, then broadcast to the
@@ -783,13 +784,19 @@ impl CreatedBroadcastResult {
         }
     }
 
-    fn into_legacy_result(self) -> Result<String, String> {
-        if self.status == Self::BROADCASTED {
-            Ok(self.txids)
-        } else {
-            Err(self
-                .message
-                .unwrap_or_else(|| "Broadcast did not complete".to_string()))
+    fn into_shield_transparent_result(
+        self,
+        fee_zatoshi: u64,
+        shielded_zatoshi: u64,
+    ) -> ShieldTransparentResult {
+        ShieldTransparentResult {
+            txids: self.txids,
+            status: self.status.to_string(),
+            broadcasted_count: self.broadcasted_count,
+            total_count: self.total_count,
+            message: self.message,
+            fee_zatoshi,
+            shielded_zatoshi,
         }
     }
 }
@@ -1232,6 +1239,26 @@ mod tests {
 
     fn receiver(value: u64, scope: TransparentKeyScope) -> (TransparentKeyScope, Balance) {
         (scope, balance(value))
+    }
+
+    #[test]
+    fn shield_result_preserves_pending_broadcast_status() {
+        let result = CreatedBroadcastResult {
+            txids: "abc123".to_string(),
+            status: CreatedBroadcastResult::PENDING_BROADCAST,
+            broadcasted_count: 0,
+            total_count: 1,
+            message: Some("Broadcast could not start".to_string()),
+        }
+        .into_shield_transparent_result(10_000, 90_000);
+
+        assert_eq!(result.txids, "abc123");
+        assert_eq!(result.status, CreatedBroadcastResult::PENDING_BROADCAST);
+        assert_eq!(result.broadcasted_count, 0);
+        assert_eq!(result.total_count, 1);
+        assert_eq!(result.message.as_deref(), Some("Broadcast could not start"));
+        assert_eq!(result.fee_zatoshi, 10_000);
+        assert_eq!(result.shielded_zatoshi, 90_000);
     }
 
     #[test]

--- a/scripts/e2e/flutter-macos-regtest-full.sh
+++ b/scripts/e2e/flutter-macos-regtest-full.sh
@@ -27,31 +27,34 @@ require_cmd python3
 cd "$ROOT_DIR"
 
 # Keep this ordered from the narrowest smoke test to broader user flows.
-run_test "1/9 import funded wallet and sync balances" \
+run_test "1/10 import funded wallet and sync balances" \
   "scripts/e2e/flutter-macos-regtest-import-sync.sh"
 
-run_test "2/9 fallback from unavailable endpoint and sync balances" \
+run_test "2/10 fallback from unavailable endpoint and sync balances" \
   "scripts/e2e/flutter-macos-regtest-fallback-endpoint.sh"
 
-run_test "3/9 keep custom endpoint failures private" \
+run_test "3/10 keep custom endpoint failures private" \
   "scripts/e2e/flutter-macos-regtest-custom-endpoint-no-fallback.sh"
 
-run_test "4/9 fallback from slow-height primary and recover" \
+run_test "4/10 fallback from slow-height primary and recover" \
   "scripts/e2e/flutter-macos-regtest-slow-height-fallback.sh"
 
-run_test "5/9 create wallet and shield transparent funds" \
+run_test "5/10 create wallet and shield transparent funds" \
   "scripts/e2e/flutter-macos-regtest-shield-transparent.sh"
 
-run_test "6/9 import two accounts and send shielded funds" \
+run_test "6/10 retry shield transparent broadcast failure" \
+  "scripts/e2e/flutter-macos-regtest-shield-transparent-retry.sh"
+
+run_test "7/10 import two accounts and send shielded funds" \
   "scripts/e2e/flutter-macos-regtest-multi-account-send.sh"
 
-run_test "7/9 show mempool receives in activity history" \
+run_test "8/10 show mempool receives in activity history" \
   "scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh"
 
-run_test "8/9 show mempool receives while sync is running" \
+run_test "9/10 show mempool receives while sync is running" \
   "scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh"
 
-run_test "9/9 expire unmined mempool receives" \
+run_test "10/10 expire unmined mempool receives" \
   "scripts/e2e/flutter-macos-regtest-mempool-expiry.sh"
 
 echo

--- a/scripts/e2e/flutter-macos-regtest-shield-transparent-retry.sh
+++ b/scripts/e2e/flutter-macos-regtest-shield-transparent-retry.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+DRIVER_PORT="${E2E_DRIVER_PORT:-39069}"
+DRIVER_URL="http://127.0.0.1:${DRIVER_PORT}"
+DRIVER_LOG="$ROOT_DIR/.regtest/shield-transparent-retry-driver.log"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd fvm
+require_cmd python3
+
+cd "$ROOT_DIR"
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+mkdir -p "$ROOT_DIR/.regtest"
+: > "$DRIVER_LOG"
+
+python3 -u scripts/e2e/mempool-receive-history-driver.py \
+  --repo-root "$ROOT_DIR" \
+  --port "$DRIVER_PORT" \
+  >"$DRIVER_LOG" 2>&1 &
+driver_pid="$!"
+
+cleanup() {
+  kill "$driver_pid" >/dev/null 2>&1 || true
+  wait "$driver_pid" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+python3 - "$DRIVER_URL" <<'PY'
+import sys
+import time
+import urllib.request
+
+url = sys.argv[1] + "/health"
+for _ in range(50):
+    try:
+        with urllib.request.urlopen(url, timeout=1) as response:
+            if response.status == 200:
+                raise SystemExit(0)
+    except Exception:
+        time.sleep(0.1)
+
+raise SystemExit("Timed out waiting for shield transparent retry E2E driver")
+PY
+
+echo "running Flutter macOS shield-transparent retry integration test"
+set +e
+fvm flutter test \
+  integration_test/regtest_shield_transparent_retry_test.dart \
+  -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
+  --dart-define=ZCASH_E2E_DRIVER_URL="$DRIVER_URL"
+status="$?"
+set -e
+
+if [[ "$status" -ne 0 ]]; then
+  echo "shield transparent retry driver log:" >&2
+  sed -n '1,220p' "$DRIVER_LOG" >&2 || true
+fi
+
+exit "$status"

--- a/test/features/home/home_shield_balance_message_test.dart
+++ b/test/features/home/home_shield_balance_message_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/home/screens/home_screen.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+void main() {
+  group('shieldBalanceBroadcastStatusMessage', () {
+    test('returns null after completed broadcast', () {
+      expect(
+        shieldBalanceBroadcastStatusMessage(
+          _shieldResult(status: 'broadcasted'),
+        ),
+        isNull,
+      );
+    });
+
+    test('describes pending broadcast as automatic retry, not failure', () {
+      final message = shieldBalanceBroadcastStatusMessage(
+        _shieldResult(status: 'pending_broadcast'),
+      );
+
+      expect(message, shieldBalancePendingBroadcastMessage);
+      expect(message, isNot(contains('failed')));
+      expect(message, isNot(contains('Try again')));
+      expect(message, contains('queued for retry'));
+      expect(message, contains('Check Activity'));
+    });
+
+    test('describes partial broadcast the same as pending broadcast', () {
+      final message = shieldBalanceBroadcastStatusMessage(
+        _shieldResult(status: 'partial_broadcast'),
+      );
+
+      expect(message, shieldBalancePendingBroadcastMessage);
+      expect(message, isNot(contains('Try again')));
+      expect(message, contains('Check Activity'));
+    });
+  });
+}
+
+rust_sync.ShieldTransparentResult _shieldResult({required String status}) {
+  return rust_sync.ShieldTransparentResult(
+    txids: 'txid',
+    status: status,
+    broadcastedCount: status == 'broadcasted' ? 1 : 0,
+    totalCount: 1,
+    feeZatoshi: BigInt.from(10_000),
+    shieldedZatoshi: BigInt.from(90_000),
+  );
+}


### PR DESCRIPTION
## Summary
- Treat a successfully created shielding transaction with a failed first broadcast as a retrying state, not a final failure.
- Show a clear retry-queued message instead of a failed broadcast banner, so users are not told the action failed while Activity shows it in progress.
- Keep true pre-broadcast shielding failures on the existing error path.

## Why
A shielding transaction can be created and stored locally even if the initial broadcast fails. Sync can later resubmit that pending transaction, so showing a failure message is misleading and can make users think they need to retry manually. The UI now communicates that shielding is still being attempted and points users to Activity for status.

## Scope
This PR does not try to eliminate the initial broadcast failure itself. That can still happen for transient network or lightwalletd conditions, and the existing sync resubmit path is responsible for retrying pending wallet-created transactions. This change only makes the recoverable state explicit instead of presenting it as a final shielding failure.

## Validation
- `fvm flutter test test/features/home/home_shield_balance_message_test.dart`
- `cd rust && cargo test shield_result_preserves_pending_broadcast_status`
- `fvm flutter analyze`
- Local regtest flow: forced the first shielding broadcast to fail, verified the retry-queued message, resubmit, and final Completed activity state.