### PR TITLE
QR Phase 1: Enable QR Orchard change on testnet software sends

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -767,7 +767,10 @@ class _WindowsUpdatePromptHostState
 
   void _handleRouteChanged() {
     if (!mounted) return;
-    setState(() {});
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() {});
+    });
   }
 
   String get _currentPath {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -572,6 +572,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "corez"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4df6f98652d30167eaeea34d77b730e07c8caba6df17bd4551842b9b8da01deb"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,12 +832,11 @@ dependencies = [
 
 [[package]]
 name = "equihash"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4f333d4ccc9d23c06593733673026efa71a332e028b00f12cf427b9677dce9"
+version = "0.3.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
  "blake2b_simd",
- "core2",
+ "corez",
 ]
 
 [[package]]
@@ -847,14 +852,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1181,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a5e510d58a07d8ed238a5a8a436fe6c2c79e1bb2611f62688bc65007b4e6e7"
+checksum = "45824ce0dd12e91ec0c68ebae2a7ed8ae19b70946624c849add59f1d1a62a143"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -1501,15 +1505,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,7 +1552,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1749,12 +1744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,14 +1833,13 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "orchard"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ef66fcf99348242a20d582d7434da381a867df8dc155b3a980eca767c56137"
+version = "0.13.1"
+source = "git+https://github.com/valargroup/qr_orchard?rev=9f046f22a46dd644aeed070968e51add57478973#9f046f22a46dd644aeed070968e51add57478973"
 dependencies = [
  "aes",
  "bitvec",
  "blake2b_simd",
- "core2",
+ "corez",
  "ff",
  "fpe",
  "getset",
@@ -1866,6 +1854,7 @@ dependencies = [
  "nonempty 0.11.0",
  "pasta_curves",
  "rand",
+ "rand_core",
  "reddsa",
  "serde",
  "sinsemilla",
@@ -1955,9 +1944,8 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea1cd05607eee33d320860c8e1159e78770f1d1909748c72f53959e106c6899"
+version = "0.6.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -2228,10 +2216,10 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck 0.4.1",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "log",
- "multimap 0.8.3",
+ "multimap",
  "petgraph 0.6.5",
  "prettyplease 0.1.25",
  "prost 0.11.9",
@@ -2248,10 +2236,10 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools",
  "log",
- "multimap 0.10.1",
+ "multimap",
  "petgraph 0.8.3",
  "prettyplease 0.2.37",
  "prost 0.14.3",
@@ -2268,7 +2256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -2281,7 +2269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2598,7 +2586,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2646,9 +2634,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "sapling-crypto"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d3c081c83f1dc87403d9d71a06f52301c0aa9ea4c17da2a3435bbf493ffba4"
+checksum = "2d70756ede56b5e4dd417979777bd87ddb83dfcbd0815dbf8175a9920537f8a0"
 dependencies = [
  "aes",
  "bellman",
@@ -2656,7 +2644,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "bls12_381",
- "core2",
+ "corez",
  "document-features",
  "ff",
  "fpe",
@@ -2991,7 +2979,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3766,19 +3754,18 @@ dependencies = [
 
 [[package]]
 name = "xdg"
-version = "2.5.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "zcash_address"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4491dddd232de02df42481757054dc19c8bc51cf709cfec58feebfef7c3c9a"
+version = "0.11.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
  "bech32",
  "bs58",
- "core2",
+ "corez",
  "f4jumble",
  "zcash_encoding",
  "zcash_protocol",
@@ -3786,9 +3773,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b5eca509a516dbd9e4d13c1f5befd6d9fa25c7e62460444ef1b3f62122f323"
+version = "0.22.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
  "async-trait",
  "base64",
@@ -3842,9 +3828,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7a9df18ba97b49647cc52cc7d72e5966507cc220fb46f26822dea92f00c47b"
+version = "0.20.2"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
  "bip32",
  "bitflags",
@@ -3889,19 +3874,18 @@ dependencies = [
 
 [[package]]
 name = "zcash_encoding"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca38087e6524e5f51a5b0fb3fc18f36d7b84bf67b2056f494ca0c281590953d"
+version = "0.4.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
- "core2",
+ "corez",
+ "hex",
  "nonempty 0.11.0",
 ]
 
 [[package]]
 name = "zcash_keys"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c115531caa1b7ca5ccd82dc26dbe3ba44b7542e928a3f77cd04abbe3cde4a4f2"
+version = "0.13.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
  "bech32",
  "bip32",
@@ -3909,7 +3893,7 @@ dependencies = [
  "bls12_381",
  "bs58",
  "byteorder",
- "core2",
+ "corez",
  "document-features",
  "group",
  "memuse",
@@ -3942,52 +3926,38 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9ff256fb298a7e94a73c1adad6c7e0b4b194b902e777ee9f5f2e12c4c4776"
+version = "0.27.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
- "bip32",
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
- "bs58",
- "core2",
+ "corez",
  "crypto-common 0.2.0-rc.1",
  "document-features",
  "equihash",
  "ff",
- "fpe",
- "getset",
- "group",
  "hex",
  "incrementalmerkletree",
  "jubjub",
  "memuse",
  "nonempty 0.11.0",
  "orchard",
- "rand",
  "rand_core",
  "redjubjub",
- "ripemd 0.1.3",
  "sapling-crypto",
  "secp256k1",
  "sha2 0.10.9",
- "subtle",
- "tracing",
- "zcash_address",
  "zcash_encoding",
  "zcash_note_encryption",
  "zcash_protocol",
  "zcash_script",
- "zcash_spec",
  "zcash_transparent",
- "zip32",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2c13bb673d542608a0e6502ac5494136e7ce4ce97e92dd239489b2523eed9"
+version = "0.27.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -3997,7 +3967,6 @@ dependencies = [
  "home",
  "jubjub",
  "known-folders",
- "lazy_static",
  "rand_core",
  "redjubjub",
  "sapling-crypto",
@@ -4008,14 +3977,14 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b1a337bbc9a7d55ae35d31189f03507dbc7934e9a4bee5c1d5c47464860e48"
+version = "0.8.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
- "core2",
+ "corez",
  "document-features",
  "hex",
  "memuse",
+ "zcash_encoding",
 ]
 
 [[package]]
@@ -4046,14 +4015,12 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9b7b4bc11d8bb20833d1b8ab6807f4dca941b381f1129e5bbd72a84e391991"
+version = "0.7.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
  "bip32",
- "blake2b_simd",
  "bs58",
- "core2",
+ "corez",
  "document-features",
  "getset",
  "hex",
@@ -4125,9 +4092,8 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3090953750ce1d56aa213710765eb14997868f463c45dae115cf1ebe09fe39eb"
+version = "0.7.0"
+source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
 dependencies = [
  "base64",
  "nom",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,24 +10,25 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 flutter_rust_bridge = "=2.11.1"
 
 # Zcash core
-zcash_primitives = "0.26.4"
-zcash_address = "0.10.1"
-zcash_keys = { version = "0.12.0", features = ["orchard"] }
-zcash_protocol = "0.7.2"
-transparent = { package = "zcash_transparent", version = "0.6.3" }
+zcash_primitives = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f" }
+zcash_address = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f" }
+zcash_keys = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f", features = ["orchard"] }
+zcash_protocol = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f" }
+transparent = { package = "zcash_transparent", git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f" }
 zcash_script = "0.4.3"
-zcash_client_backend = { version = "0.21.2", features = [
+zcash_client_backend = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f", features = [
     "orchard",
     "transparent-inputs",
     "lightwalletd-tonic",
     "lightwalletd-tonic-tls-webpki-roots",
     "sync",
     "pczt",
+    "unstable",
 ] }
-zcash_client_sqlite = { version = "0.19.5", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 # Must match versions used by zcash_client_sqlite to avoid type conflicts
-orchard = "0.11"
-sapling-crypto = { version = "0.5", default-features = false }
+orchard = { git = "https://github.com/valargroup/qr_orchard", rev = "9f046f22a46dd644aeed070968e51add57478973" }
+sapling-crypto = { version = "0.7", default-features = false }
 uuid = "1.1"
 zip32 = "0.2"
 # Required by no-op Sapling prover trait impls
@@ -36,7 +37,7 @@ bls12_381 = "0.8"
 rand_core = "0.6"
 
 # Proofs
-zcash_proofs = "0.26.1"
+zcash_proofs = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f" }
 
 # Key generation
 bip0039 = "0.12"
@@ -77,7 +78,7 @@ hex = "0.4"
 
 # Keystone hardware wallet
 ur = { git = "https://github.com/KeystoneHQ/ur-rs", tag = "0.3.3" }
-pczt = "0.5"
+pczt = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f" }
 ur-registry = { git = "https://github.com/KeystoneHQ/keystone-sdk-rust", package = "ur-registry", default-features = false, features = ["std"] }
 serde_json = "1"
 

--- a/rust/QR_PHASE1.md
+++ b/rust/QR_PHASE1.md
@@ -132,7 +132,12 @@ Birthday height: `4000000`.
 Known Account A/B live validation completed against
 `https://testnet.zec.rocks:443`:
 
-- Account A -> Account B send, creating Account A QR change:
+- Account A -> Account B send, creating Account A QR change and funding the
+  Account B spend:
+  `f0250cb22adc07fc56c9c273654bb2978c41780abfe400b4871221f8cc5accb8`
+  mined at height `4028955`.
+- Follow-up Account A -> Account B send during the artifact run, also creating
+  Account A QR change:
   `4210b0f959b7e519eaabec412bac8838fb5a119bdf1b397d1f0cb17c8e9bfffd`
   mined at height `4028964`.
 - Account B -> Account A send, creating Account B QR change:

--- a/rust/QR_PHASE1.md
+++ b/rust/QR_PHASE1.md
@@ -109,6 +109,7 @@ Run the live test explicitly:
 ```bash
 cd rust
 VIZOR_QR_TESTNET_LIVE=1 \
+VIZOR_QR_TESTNET_ARTIFACT_DIR=target/qr-phase1-live/known-accounts-latest \
 VIZOR_QR_TESTNET_CONFIRM_TIMEOUT_SECS=3600 \
 VIZOR_QR_TESTNET_CONFIRM_POLL_SECS=75 \
 cargo test --test testnet_qr_phase1 -- --ignored --nocapture
@@ -127,6 +128,42 @@ powder bronze skirt because truly bonus link gloom cluster quantum birth mutual 
 ```
 
 Birthday height: `4000000`.
+
+Known Account A/B live validation completed against
+`https://testnet.zec.rocks:443`:
+
+- Account A -> Account B send, creating Account A QR change:
+  `4210b0f959b7e519eaabec412bac8838fb5a119bdf1b397d1f0cb17c8e9bfffd`
+  mined at height `4028964`.
+- Account B -> Account A send, creating Account B QR change:
+  `373f2e36c83178ad70c8d9bf67a7de333fc42f6dd5f4583249bcc5b3ce0e6446`
+  mined at height `4028969`.
+- The saved artifact DBs from this run are written under
+  `rust/target/qr-phase1-live/known-accounts-latest/`.
+
+Inspect note versions in the saved DBs:
+
+```bash
+sqlite3 -header -column target/qr-phase1-live/known-accounts-latest/account-a.db \
+  "SELECT rn.id, lower(hex(t.txid)) AS txid_db_order, rn.action_index,
+          rn.value, rn.note_version, rn.is_change,
+          CASE WHEN s.transaction_id IS NULL THEN 0 ELSE 1 END AS spent,
+          IFNULL(t.mined_height, 0) AS mined_height
+   FROM orchard_received_notes rn
+   JOIN transactions t ON t.id_tx = rn.transaction_id
+   LEFT JOIN orchard_received_note_spends s ON s.orchard_received_note_id = rn.id
+   ORDER BY rn.id;"
+
+sqlite3 -header -column target/qr-phase1-live/known-accounts-latest/account-b.db \
+  "SELECT rn.id, lower(hex(t.txid)) AS txid_db_order, rn.action_index,
+          rn.value, rn.note_version, rn.is_change,
+          CASE WHEN s.transaction_id IS NULL THEN 0 ELSE 1 END AS spent,
+          IFNULL(t.mined_height, 0) AS mined_height
+   FROM orchard_received_notes rn
+   JOIN transactions t ON t.id_tx = rn.transaction_id
+   LEFT JOIN orchard_received_note_spends s ON s.orchard_received_note_id = rn.id
+   ORDER BY rn.id;"
+```
 
 ## Validation checklist
 

--- a/rust/QR_PHASE1.md
+++ b/rust/QR_PHASE1.md
@@ -1,0 +1,153 @@
+# ZIP-2005 QR Orchard Phase 1
+
+This branch enables ZIP-2005 Phase 1 QR Orchard internal outputs for Vizor
+software wallets on testnet and regtest only.
+
+## Dependency refs
+
+- `zcash_client_backend`, `zcash_client_sqlite`, `zcash_primitives`,
+  `zcash_keys`, `zcash_protocol`, `zcash_proofs`, `zcash_transparent`, and
+  `pczt` are pinned to `valargroup/librustzcash` at:
+  `d39cbbea0323bbba6ad477e36b604025c4dbbf6f`
+- That ref is based on the librustzcash QR branch whose reviewed head was:
+  `ccdb50eeb0271483659fe580110af30906a66dda`
+- `orchard` is pinned to `valargroup/qr_orchard` at:
+  `9f046f22a46dd644aeed070968e51add57478973`
+- The reviewed Orchard QR branch head was:
+  `52da377f23e63407f7ca9c1c623aadd8429dc221`
+
+The librustzcash dependency ref is a Vizor Stage 1 validation branch. No
+upstream PR, issue, review, or discussion comment has been opened for that
+branch.
+
+## Persistence checkpoint
+
+The initial QR dependency branch could parse QR Orchard notes, but
+`zcash_client_sqlite` still reconstructed persisted Orchard notes with
+`Note::from_parts`, which defaults to ordinary V2 notes. That would make a QR
+note parse during scan but be reconstructed incorrectly after restart.
+
+The pinned `valargroup/librustzcash` ref fixes this in
+`zcash_client_sqlite`:
+
+- `zcash_client_sqlite/src/wallet/db.rs` adds
+  `orchard_received_notes.note_version INTEGER NOT NULL DEFAULT 2`.
+- `zcash_client_sqlite/src/wallet/init/migrations/orchard_note_versions.rs`
+  adds the same column for existing wallet databases.
+- `zcash_client_sqlite/src/wallet/orchard.rs` stores
+  `output.note().version()` when inserting or updating received Orchard notes.
+- Orchard note queries now select `note_version` in reconstruction paths.
+- Orchard note reconstruction uses `Note::from_parts_with_version`.
+
+This satisfies the Phase 1 persistence checkpoint for the selected dependency
+set. The selected ref also fixes a SQL alias issue found by the Vizor live test
+while selecting spendable Orchard notes after the persistence patch.
+
+## Vizor policy
+
+- Software sends on `WalletNetwork::Test` and `WalletNetwork::Regtest` pass
+  `Some(TxVersion::V5_Qr)` into librustzcash proposal and transaction
+  construction.
+- Software sends on `WalletNetwork::Main` pass `Some(TxVersion::V5)`.
+- Software transparent shielding follows the same software policy. On testnet
+  and regtest, its internal Orchard output is QR.
+- Keystone send PCZT construction remains ordinary V5/default.
+- Hardware transparent shielding PCZT construction remains ordinary V5/default.
+- External Orchard recipient outputs remain ordinary V2. The QR selector is
+  only used for internal wallet outputs handled by librustzcash.
+- No Flutter Rust Bridge API files changed, so bindings were not regenerated.
+- No UI, setting, banner, or opt-in flow was added.
+
+## Tests
+
+Focused local checks:
+
+```bash
+cd rust
+cargo test software_
+cargo test funded_testnet_seed_can_create_reopen_and_spend_qr_change --no-run
+```
+
+The `software_shielding_internal_output_is_qr_on_regtest` unit test builds a
+regtest software shielding transaction with the QR policy and asserts the
+stored internal Orchard note has `note_version = 3`.
+
+The ignored live test imports the provided funded testnet seed into a temporary
+wallet DB, creates a temporary receiver wallet, sends a small amount to force
+QR change, waits for the first transaction to mine, reopens through normal API
+calls, spends the QR change in a second transaction, and verifies external
+recipient notes stayed V2. It accepts both transaction display byte order and
+wallet DB byte order when matching mined history rows.
+
+The companion ignored test `existing_testnet_db_can_spend_qr_change` can finish
+validation from an existing temporary sender DB that already contains unspent QR
+change:
+
+```bash
+cd rust
+VIZOR_QR_TESTNET_LIVE=1 \
+VIZOR_QR_TESTNET_EXISTING_SENDER_DB=/path/to/zcash_wallet.db \
+VIZOR_QR_TESTNET_CONFIRM_TIMEOUT_SECS=3600 \
+VIZOR_QR_TESTNET_CONFIRM_POLL_SECS=75 \
+cargo test --test testnet_qr_phase1 existing_testnet_db_can_spend_qr_change -- --ignored --nocapture
+```
+
+Live testnet validation completed against `https://testnet.zec.rocks:443`:
+
+- Existing DB QR spend:
+  `e016f41a1b1a2b534c5c103ca83d75e12a798967a747cd8728ad7b82f8429895`
+  mined at height `4028555`.
+- Full funded-seed run first send:
+  `3d66e4f88acb5aaef4f520c23a2ab9554e460c7b42ec526d2a9bc55dfdb65bbf`
+  mined at height `4028558`.
+- Full funded-seed run second QR-change spend:
+  `b23db05262a14d5b8524e18e65861ca7d178682a8e122c390ba5ed4730783564`
+  mined at height `4028561`.
+
+Run the live test explicitly:
+
+```bash
+cd rust
+VIZOR_QR_TESTNET_LIVE=1 \
+VIZOR_QR_TESTNET_CONFIRM_TIMEOUT_SECS=3600 \
+VIZOR_QR_TESTNET_CONFIRM_POLL_SECS=75 \
+cargo test --test testnet_qr_phase1 -- --ignored --nocapture
+```
+
+Optional endpoint override:
+
+```bash
+VIZOR_QR_TESTNET_LIGHTWALLETD_URL=https://testnet.zec.rocks:443
+```
+
+Testnet validation seed:
+
+```text
+powder bronze skirt because truly bonus link gloom cluster quantum birth mutual limit veteran garden almost trophy potato twelve win crush surface decline uphold
+```
+
+Birthday height: `4000000`.
+
+## Validation checklist
+
+Run from the repo root unless noted:
+
+```bash
+cd rust && cargo check
+cd rust && cargo test
+cd rust && cargo tree -d
+cd rust && cargo tree -i orchard
+cd rust && cargo tree -i zcash_client_backend
+cd rust && cargo tree -i zcash_client_sqlite
+cd rust && cargo tree -i zcash_primitives
+fvm flutter analyze
+fvm flutter test
+fvm flutter build macos --release --dart-define=ZCASH_DEFAULT_NETWORK=test
+```
+
+The macOS release build command is locally blocked by Xcode signing
+configuration:
+
+```text
+"Runner" requires a provisioning profile.
+```

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -47,7 +47,8 @@ use zcash_client_backend::{
             self, create_proposed_transactions, propose_send_max_transfer, propose_shielding,
             propose_transfer, ConfirmationsPolicy,
         },
-        Account as _, Balance, InputSource, MaxSpendMode, WalletRead,
+        Account as _, Balance, InputSource, MaxSpendMode, TransparentKeyOrigin,
+        TransparentOutputFilter, WalletRead,
     },
     fees::{
         zip317::{MultiOutputChangeStrategy, Zip317FeeRule},
@@ -63,7 +64,7 @@ use zcash_primitives::transaction::{
     fees::{
         transparent::InputSize as TransparentInputSize, zip317::P2PKH_STANDARD_INPUT_SIZE, FeeRule,
     },
-    TxId,
+    TxId, TxVersion,
 };
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
@@ -142,6 +143,13 @@ pub(in crate::wallet) struct ConservativeZip317FeeRule;
 
 pub(in crate::wallet) type WalletFeeRule = ConservativeZip317FeeRule;
 
+fn software_proposed_tx_version(network: WalletNetwork) -> Option<TxVersion> {
+    match network {
+        WalletNetwork::Main => Some(TxVersion::V5),
+        WalletNetwork::Test | WalletNetwork::Regtest => Some(TxVersion::V5_Qr),
+    }
+}
+
 impl FeeRule for ConservativeZip317FeeRule {
     type Error = <StandardFeeRule as FeeRule>::Error;
 
@@ -218,8 +226,8 @@ pub fn propose_send(
     };
 
     let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None);
-    let payment = Payment::new(to, value, memo_bytes, None, None, vec![])
-        .ok_or("Cannot send memo to this address type")?;
+    let payment = Payment::new(to, Some(value), memo_bytes, None, None, vec![])
+        .map_err(|e| format!("Payment failed: {e:?}"))?;
     let request = TransactionRequest::new(vec![payment]).map_err(|e| format!("{e:?}"))?;
 
     let proposal = propose_transfer::<_, _, _, _, Infallible>(
@@ -230,6 +238,7 @@ pub fn propose_send(
         &change_strategy,
         request,
         ConfirmationsPolicy::default(),
+        software_proposed_tx_version(network),
     )
     .map_err(|e| format!("Propose failed: {e}"))?;
 
@@ -296,8 +305,8 @@ pub fn estimate_fee(
     };
 
     let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None);
-    let payment = Payment::new(to, value, memo_bytes, None, None, vec![])
-        .ok_or("Cannot send memo to this address type")?;
+    let payment = Payment::new(to, Some(value), memo_bytes, None, None, vec![])
+        .map_err(|e| format!("Payment failed: {e:?}"))?;
     let request = TransactionRequest::new(vec![payment]).map_err(|e| format!("{e:?}"))?;
 
     let proposal = propose_transfer::<_, _, _, _, Infallible>(
@@ -308,6 +317,7 @@ pub fn estimate_fee(
         &change_strategy,
         request,
         ConfirmationsPolicy::default(),
+        software_proposed_tx_version(network),
     )
     .map_err(|e| format!("Propose failed: {e}"))?;
 
@@ -455,6 +465,7 @@ pub(crate) async fn shield_transparent_balance(
                 &wallet::SpendingKeys::from_unified_spending_key(usk),
                 OvkPolicy::Sender,
                 &proposal,
+                software_proposed_tx_version(network),
             )
             .map_err(|e| format!("Create shielding TX failed: {e}"))?;
 
@@ -571,6 +582,7 @@ async fn execute_stored_proposal(
                         &wallet::SpendingKeys::from_unified_spending_key(usk),
                         OvkPolicy::Sender,
                         &stored.proposal,
+                        software_proposed_tx_version(network),
                     )
                     .map_err(|e| format!("Create TX failed: {e}"))?
                 }
@@ -585,6 +597,7 @@ async fn execute_stored_proposal(
                         &wallet::SpendingKeys::from_unified_spending_key(usk),
                         OvkPolicy::Sender,
                         &stored.proposal,
+                        software_proposed_tx_version(network),
                     )
                     .map_err(|e| format!("Create TX failed: {e}"))?
                 }
@@ -635,6 +648,7 @@ fn build_shielding_proposal(
         &from_addrs,
         account_id,
         ConfirmationsPolicy::MIN,
+        TransparentOutputFilter::All,
     )
     .map_err(|e| format!("Shield proposal failed: {e}"))?;
 
@@ -683,6 +697,8 @@ fn summarize_send_max_proposal<NoteRef>(
             .transaction_request()
             .total()
             .map_err(|e| format!("Max amount calculation failed: {e}"))?;
+        let step_total =
+            step_total.ok_or_else(|| "Max amount calculation missing amount".to_string())?;
         acc.checked_add(u64::from(step_total))
             .ok_or_else(|| "Max amount overflow".to_string())
     })?;
@@ -699,16 +715,21 @@ fn summarize_send_max_proposal<NoteRef>(
 }
 
 fn select_shielding_sources(
-    account_receivers: HashMap<TransparentAddress, (TransparentKeyScope, Balance)>,
+    account_receivers: HashMap<TransparentAddress, (TransparentKeyOrigin, Balance)>,
     shielding_threshold: Zatoshis,
 ) -> Result<(Vec<TransparentAddress>, Zatoshis), String> {
     let mut ephemeral = Vec::new();
     let mut non_ephemeral = Vec::new();
 
-    for (address, (scope, balance)) in account_receivers {
+    for (address, (origin, balance)) in account_receivers {
         let spendable = balance.spendable_value();
         if spendable > Zatoshis::ZERO {
-            if scope == TransparentKeyScope::EPHEMERAL {
+            if matches!(
+                origin,
+                TransparentKeyOrigin::Derived {
+                    scope: TransparentKeyScope::EPHEMERAL
+                }
+            ) {
                 ephemeral.push((address, spendable));
             } else {
                 non_ephemeral.push((address, spendable));
@@ -1220,9 +1241,9 @@ impl OutputProver for NoOpOutputProver {
 mod tests {
     use super::*;
 
+    use transparent::bundle::{OutPoint, TxOut};
     use zcash_client_backend::{data_api::WalletWrite, wallet::WalletTransparentOutput};
     use zcash_keys::keys::{ReceiverRequirement, UnifiedSpendingKey};
-    use zcash_primitives::transaction::components::transparent::{OutPoint, TxOut};
     use zcash_protocol::consensus::BlockHeight;
 
     fn taddr(seed: u8) -> TransparentAddress {
@@ -1237,8 +1258,24 @@ mod tests {
         balance
     }
 
-    fn receiver(value: u64, scope: TransparentKeyScope) -> (TransparentKeyScope, Balance) {
-        (scope, balance(value))
+    fn receiver(value: u64, scope: TransparentKeyScope) -> (TransparentKeyOrigin, Balance) {
+        (TransparentKeyOrigin::Derived { scope }, balance(value))
+    }
+
+    #[test]
+    fn software_qr_policy_uses_qr_only_on_test_networks() {
+        assert_eq!(
+            software_proposed_tx_version(WalletNetwork::Main),
+            Some(TxVersion::V5)
+        );
+        assert_eq!(
+            software_proposed_tx_version(WalletNetwork::Test),
+            Some(TxVersion::V5_Qr)
+        );
+        assert_eq!(
+            software_proposed_tx_version(WalletNetwork::Regtest),
+            Some(TxVersion::V5_Qr)
+        );
     }
 
     #[test]
@@ -1316,6 +1353,77 @@ mod tests {
     }
 
     #[test]
+    fn software_shielding_internal_output_is_qr_on_regtest() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+        let network = WalletNetwork::Regtest;
+        let mnemonic = crate::wallet::keys::generate_mnemonic();
+        let seed = crate::wallet::keys::mnemonic_to_seed(&mnemonic).unwrap();
+        let (account_uuid, _) =
+            crate::wallet::keys::init_db_and_create_account(db_path, network, &seed, Some(1), "qr")
+                .unwrap();
+        let account_id = parse_account_uuid(&account_uuid).unwrap();
+
+        let mut db = open_wallet_db(db_path, network).unwrap();
+        let tip = BlockHeight::from_u32(1_000);
+        db.update_chain_tip(tip).unwrap();
+
+        let ua_request = zcash_keys::keys::UnifiedAddressRequest::custom(
+            ReceiverRequirement::Require,
+            ReceiverRequirement::Require,
+            ReceiverRequirement::Require,
+        )
+        .unwrap();
+        let (ua, _) = db
+            .get_next_available_address(account_id, ua_request)
+            .unwrap()
+            .unwrap();
+        let taddr = *ua.transparent().unwrap();
+        let value = Zatoshis::const_from_u64(1_000_000);
+
+        let mut txid = [0u8; 32];
+        txid[..4].copy_from_slice(&0xfeed_beefu32.to_le_bytes());
+        let outpoint = OutPoint::new(txid, 0);
+        let txout = TxOut::new(value, taddr.script().into());
+        let utxo = WalletTransparentOutput::from_parts(outpoint, txout, Some(tip)).unwrap();
+        db.put_received_transparent_utxo(&utxo).unwrap();
+
+        let shielding_threshold = Zatoshis::const_from_u64(SHIELDING_THRESHOLD_ZATOSHI);
+        let (proposal, _) =
+            build_shielding_proposal(&mut db, network, account_id, shielding_threshold).unwrap();
+
+        let seed = SecretVec::new(seed.expose_secret().to_vec());
+        let usk =
+            UnifiedSpendingKey::from_seed(&network, seed.expose_secret(), zip32::AccountId::ZERO)
+                .unwrap();
+        let spend_prover = NoOpSpendProver;
+        let output_prover = NoOpOutputProver;
+        create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+            &mut db,
+            &network,
+            &spend_prover,
+            &output_prover,
+            &wallet::SpendingKeys::from_unified_spending_key(usk),
+            OvkPolicy::Sender,
+            &proposal,
+            software_proposed_tx_version(network),
+        )
+        .expect("shielding transaction should build");
+        drop(db);
+
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        let note_version = conn
+            .query_row(
+                "SELECT note_version FROM orchard_received_notes LIMIT 1",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap();
+        assert_eq!(note_version, 3);
+    }
+
+    #[test]
     #[ignore = "slow librustzcash transaction-construction regression (~100s); run explicitly when touching shielding transaction construction"]
     fn many_utxo_shielding_builds_with_conservative_zip317_fee() {
         let temp_dir = tempfile::tempdir().unwrap();
@@ -1380,6 +1488,7 @@ mod tests {
             &wallet::SpendingKeys::from_unified_spending_key(usk),
             OvkPolicy::Sender,
             &proposal,
+            software_proposed_tx_version(network),
         )
         .expect("many-UTXO shielding should build without a fee/change mismatch");
         let change_values = proposal

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -236,6 +236,7 @@ pub(super) async fn get_taddress_txids(
                     height: end_height,
                     hash: vec![],
                 }),
+                pool_types: vec![],
             }),
         })),
     )
@@ -434,6 +435,7 @@ pub(super) async fn download_blocks(
                 height: u32::from(end) as u64,
                 hash: vec![],
             }),
+            pool_types: vec![],
         })),
     )
     .await

--- a/rust/tests/testnet_qr_phase1.rs
+++ b/rust/tests/testnet_qr_phase1.rs
@@ -1,5 +1,7 @@
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use rust_lib_zcash_wallet::api::{sync as sync_api, wallet as wallet_api};
 
@@ -67,6 +69,106 @@ fn orchard_note_versions(db_path: &Path, is_change: bool) -> Vec<i64> {
         .expect("query note versions")
         .map(|row| row.expect("note version row"))
         .collect()
+}
+
+fn log_orchard_note_snapshot(db_path: &Path, label: &str) {
+    let conn = rusqlite::Connection::open(db_path).expect("open wallet db");
+    let mut stmt = conn
+        .prepare(
+            "SELECT rn.id,
+                    lower(hex(t.txid)) AS txid,
+                    rn.action_index,
+                    rn.value,
+                    rn.note_version,
+                    rn.is_change,
+                    CASE WHEN s.transaction_id IS NULL THEN 0 ELSE 1 END AS spent,
+                    IFNULL(t.mined_height, 0) AS mined_height
+             FROM orchard_received_notes rn
+             JOIN transactions t ON t.id_tx = rn.transaction_id
+             LEFT JOIN orchard_received_note_spends s
+               ON s.orchard_received_note_id = rn.id
+             ORDER BY rn.id",
+        )
+        .expect("prepare note snapshot query");
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, i64>(2)?,
+                row.get::<_, i64>(3)?,
+                row.get::<_, i64>(4)?,
+                row.get::<_, i64>(5)?,
+                row.get::<_, i64>(6)?,
+                row.get::<_, i64>(7)?,
+            ))
+        })
+        .expect("query note snapshot");
+
+    eprintln!("Orchard note snapshot for {label} at {}", db_path.display());
+    for row in rows {
+        let (id, txid, action_index, value, note_version, is_change, spent, mined_height) =
+            row.expect("note snapshot row");
+        eprintln!(
+            "  id={id} txid={txid} action={action_index} value={value} note_version={note_version} is_change={is_change} spent={spent} mined_height={mined_height}"
+        );
+    }
+}
+
+fn live_artifact_dir() -> PathBuf {
+    std::env::var("VIZOR_QR_TESTNET_ARTIFACT_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let now = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("system clock before Unix epoch")
+                .as_secs();
+            PathBuf::from("target")
+                .join("qr-phase1-live")
+                .join(format!("known-accounts-{now}"))
+        })
+}
+
+fn vacuum_db_copy(db_path: &Path, dest: &Path) {
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent).expect("create artifact directory");
+    }
+    if dest.exists() {
+        fs::remove_file(dest).expect("remove stale artifact DB");
+    }
+    let conn = rusqlite::Connection::open(db_path).expect("open wallet db for artifact copy");
+    conn.execute("VACUUM INTO ?1", [path_str(dest)])
+        .expect("vacuum wallet db artifact");
+}
+
+fn write_known_account_artifacts(
+    account_a_db: &Path,
+    account_b_db: &Path,
+    a_to_b_txid: &str,
+    b_to_a_txid: &str,
+) {
+    let artifact_dir = live_artifact_dir();
+    fs::create_dir_all(&artifact_dir).expect("create artifact directory");
+    let account_a_copy = artifact_dir.join("account-a.db");
+    let account_b_copy = artifact_dir.join("account-b.db");
+    vacuum_db_copy(account_a_db, &account_a_copy);
+    vacuum_db_copy(account_b_db, &account_b_copy);
+
+    let txid_file = artifact_dir.join("txids.txt");
+    fs::write(
+        &txid_file,
+        format!(
+            "A -> B QR change creation: {a_to_b_txid}\nB -> A QR change creation: {b_to_a_txid}\nAccount A DB: {}\nAccount B DB: {}\n",
+            account_a_copy.display(),
+            account_b_copy.display(),
+        ),
+    )
+    .expect("write txid artifact");
+
+    eprintln!("QR Phase 1 artifact directory: {}", artifact_dir.display());
+    eprintln!("QR Phase 1 txid file: {}", txid_file.display());
+    eprintln!("QR Phase 1 Account A DB copy: {}", account_a_copy.display());
+    eprintln!("QR Phase 1 Account B DB copy: {}", account_b_copy.display());
 }
 
 fn qr_change_count(db_path: &Path) -> i64 {
@@ -212,6 +314,35 @@ fn wait_for_mined_tx(
         assert!(
             start.elapsed() < timeout,
             "timed out waiting for testnet tx {txid} to mine"
+        );
+        std::thread::sleep(poll);
+    }
+}
+
+fn wait_for_spendable_balance(
+    db_path: &Path,
+    lightwalletd_url: &str,
+    account_uuid: &str,
+    min_spendable: u64,
+    timeout: Duration,
+    poll: Duration,
+) -> sync_api::WalletBalance {
+    let start = Instant::now();
+    loop {
+        sync_wallet(db_path, lightwalletd_url);
+        let current = balance(db_path, account_uuid);
+        if current.spendable > min_spendable {
+            return current;
+        }
+
+        eprintln!(
+            "waiting for spendable balance > {min_spendable}; current={} elapsed={}s",
+            current.spendable,
+            start.elapsed().as_secs()
+        );
+        assert!(
+            start.elapsed() < timeout,
+            "timed out waiting for spendable balance > {min_spendable}"
         );
         std::thread::sleep(poll);
     }
@@ -482,6 +613,7 @@ fn known_test_accounts_create_qr_change_on_both_sides() {
         "Account A starting spendable balance: {} zatoshi",
         account_a_starting_balance.spendable
     );
+    log_orchard_note_snapshot(&account_a_db, "Account A before A -> B");
     assert!(
         account_a_starting_balance.spendable
             > A_TO_B_SEND_ZATOSHI + B_TO_A_SEND_ZATOSHI + MIN_POST_A_TO_B_CHANGE_ZATOSHI,
@@ -500,6 +632,7 @@ fn known_test_accounts_create_qr_change_on_both_sides() {
         "testnet-qr-a-to-b",
     );
     eprintln!("Account A -> Account B broadcast: {a_to_b_txid}");
+    log_orchard_note_snapshot(&account_a_db, "Account A after A -> B broadcast");
     assert!(
         qr_change_count(&account_a_db) > account_a_qr_change_before,
         "A -> B did not persist Account A QR Orchard change"
@@ -518,13 +651,21 @@ fn known_test_accounts_create_qr_change_on_both_sides() {
     );
 
     sync_wallet(&account_b_db, &lightwalletd_url);
+    log_orchard_note_snapshot(&account_b_db, "Account B after A -> B mined");
     let account_b_external_versions = orchard_note_versions(&account_b_db, false);
     assert!(
         account_b_external_versions.iter().all(|v| *v == 2),
         "A -> B external Orchard output should remain ordinary V2, got {:?}",
         account_b_external_versions
     );
-    let account_b_balance = balance(&account_b_db, &account_b.account_uuid);
+    let account_b_balance = wait_for_spendable_balance(
+        &account_b_db,
+        &lightwalletd_url,
+        &account_b.account_uuid,
+        B_TO_A_SEND_ZATOSHI,
+        timeout,
+        poll,
+    );
     eprintln!(
         "Account B spendable balance after A -> B: {} zatoshi",
         account_b_balance.spendable
@@ -546,6 +687,7 @@ fn known_test_accounts_create_qr_change_on_both_sides() {
         "testnet-qr-b-to-a",
     );
     eprintln!("Account B -> Account A broadcast: {b_to_a_txid}");
+    log_orchard_note_snapshot(&account_b_db, "Account B after B -> A broadcast");
     assert!(
         qr_change_count(&account_b_db) > account_b_qr_change_before,
         "B -> A did not persist Account B QR Orchard change"
@@ -564,6 +706,7 @@ fn known_test_accounts_create_qr_change_on_both_sides() {
     );
 
     sync_wallet(&account_a_db, &lightwalletd_url);
+    log_orchard_note_snapshot(&account_a_db, "Account A after B -> A mined");
     let account_a_external_versions = orchard_note_versions(&account_a_db, false);
     assert!(
         account_a_external_versions.iter().all(|v| *v == 2),
@@ -574,4 +717,5 @@ fn known_test_accounts_create_qr_change_on_both_sides() {
     eprintln!("QR Phase 1 known-account txids:");
     eprintln!("A -> B QR change creation: {a_to_b_txid}");
     eprintln!("B -> A QR change creation: {b_to_a_txid}");
+    write_known_account_artifacts(&account_a_db, &account_b_db, &a_to_b_txid, &b_to_a_txid);
 }

--- a/rust/tests/testnet_qr_phase1.rs
+++ b/rust/tests/testnet_qr_phase1.rs
@@ -5,11 +5,18 @@ use rust_lib_zcash_wallet::api::{sync as sync_api, wallet as wallet_api};
 
 const NETWORK: &str = "test";
 const DEFAULT_LIGHTWALLETD_URL: &str = "https://testnet.zec.rocks:443";
-const TESTNET_QR_SEED: &str = "powder bronze skirt because truly bonus link gloom cluster quantum birth mutual limit veteran garden almost trophy potato twelve win crush surface decline uphold";
-const TESTNET_QR_BIRTHDAY: u64 = 4_000_000;
+const ACCOUNT_A_SEED: &str = "powder bronze skirt because truly bonus link gloom cluster quantum birth mutual limit veteran garden almost trophy potato twelve win crush surface decline uphold";
+const ACCOUNT_A_ADDRESS: &str = "utest1zvyhrax68yzq3wz62ftap46y7xhak206pp7kl4uu3un8ywk042d2j8mynhj49j2j2hlqlufu3z43tru3kkkmhd0s9dyug0vef6v7hz8fr9gasw0lw09lw23fq56egk26lp542wq6h5d72ylllentu443vdxzpm0ldh2r8ncj3qh4f5xx";
+const ACCOUNT_A_BIRTHDAY: u64 = 4_000_000;
+const ACCOUNT_B_SEED: &str = "monkey develop pass obey like melt furnace announce cradle spin sign school grit gloom enact wall neither intact squeeze soon scatter obvious gauge record";
+const ACCOUNT_B_ADDRESS: &str = "utest1vgmc0w4avv06k9cfzv0x0td9zautetx88tl0qtacvmcxm4e80x2udxz05ar0mds2cfrluhyremqzze62myuqcedl8pc8wd02ayyuh0sftsjpnn034jxq25dcaj3ynsnpurz8t23fe5jr86xelxgjr95kpvz23c20w8eyt4zpq5ja7agr";
+const ACCOUNT_B_BIRTHDAY: u64 = 4_000_000;
 const FIRST_SEND_ZATOSHI: u64 = 50_000;
 const SECOND_SEND_ZATOSHI: u64 = 20_000;
 const MIN_POST_FIRST_CHANGE_ZATOSHI: u64 = 30_000;
+const A_TO_B_SEND_ZATOSHI: u64 = 5_000_000;
+const B_TO_A_SEND_ZATOSHI: u64 = 2_500_000;
+const MIN_POST_A_TO_B_CHANGE_ZATOSHI: u64 = 2_600_000;
 
 fn path_str(path: &Path) -> String {
     path.to_str().expect("utf-8 path").to_string()
@@ -110,6 +117,7 @@ fn execute_send(
     db_path: &Path,
     lightwalletd_url: &str,
     account_uuid: &str,
+    seed_phrase: &str,
     to_address: &str,
     amount_zatoshi: u64,
     flow_id: &str,
@@ -134,7 +142,7 @@ fn execute_send(
         lightwalletd_url.to_string(),
         proposal.proposal_id,
         flow_id.to_string(),
-        TESTNET_QR_SEED.as_bytes().to_vec(),
+        seed_phrase.as_bytes().to_vec(),
         None,
         None,
     )
@@ -245,6 +253,25 @@ fn create_receiver(lightwalletd_url: &str) -> (tempfile::TempDir, PathBuf, Strin
     (receiver_dir, receiver_db, receiver_orchard_address)
 }
 
+fn import_test_account(
+    seed_phrase: &str,
+    birthday: u64,
+    label: &str,
+) -> (tempfile::TempDir, PathBuf, wallet_api::WalletImportResult) {
+    let dir = tempfile::tempdir().expect("account tempdir");
+    let db = dir.path().join("zcash_wallet.db");
+    let account = wallet_api::import_wallet(
+        seed_phrase.to_string(),
+        Some(birthday),
+        NETWORK.to_string(),
+        path_str(&db),
+        Some(label.to_string()),
+    )
+    .expect("import test account");
+
+    (dir, db, account)
+}
+
 #[test]
 #[ignore = "requires the funded testnet QR seed and waits for public testnet confirmations"]
 fn funded_testnet_seed_can_create_reopen_and_spend_qr_change() {
@@ -265,8 +292,8 @@ fn funded_testnet_seed_can_create_reopen_and_spend_qr_change() {
     let sender_dir = tempfile::tempdir().expect("sender tempdir");
     let sender_db = sender_dir.path().join("zcash_wallet.db");
     let sender = wallet_api::import_wallet(
-        TESTNET_QR_SEED.to_string(),
-        Some(TESTNET_QR_BIRTHDAY),
+        ACCOUNT_A_SEED.to_string(),
+        Some(ACCOUNT_A_BIRTHDAY),
         NETWORK.to_string(),
         path_str(&sender_db),
         Some("QR funded testnet seed".to_string()),
@@ -307,6 +334,7 @@ fn funded_testnet_seed_can_create_reopen_and_spend_qr_change() {
         &sender_db,
         &lightwalletd_url,
         &sender.account_uuid,
+        ACCOUNT_A_SEED,
         &receiver_orchard_address,
         FIRST_SEND_ZATOSHI,
         "testnet-qr-first-send",
@@ -348,6 +376,7 @@ fn funded_testnet_seed_can_create_reopen_and_spend_qr_change() {
         &sender_db,
         &lightwalletd_url,
         &sender.account_uuid,
+        ACCOUNT_A_SEED,
         &receiver_orchard_address,
         SECOND_SEND_ZATOSHI,
         "testnet-qr-second-send",
@@ -403,6 +432,7 @@ fn existing_testnet_db_can_spend_qr_change() {
         &sender_db,
         &lightwalletd_url,
         &sender_account.uuid,
+        ACCOUNT_A_SEED,
         &receiver_orchard_address,
         SECOND_SEND_ZATOSHI,
         "testnet-qr-existing-db-send",
@@ -422,4 +452,126 @@ fn existing_testnet_db_can_spend_qr_change() {
     );
     sync_wallet(&receiver_db, &lightwalletd_url);
     assert_receiver_outputs_are_v2(&receiver_db);
+}
+
+#[test]
+#[ignore = "requires funded Account A and waits for public testnet confirmations"]
+fn known_test_accounts_create_qr_change_on_both_sides() {
+    if std::env::var("VIZOR_QR_TESTNET_LIVE").as_deref() != Ok("1") {
+        eprintln!("set VIZOR_QR_TESTNET_LIVE=1 to run the live QR Phase 1 test");
+        return;
+    }
+
+    let lightwalletd_url = lightwalletd_url();
+    let timeout = Duration::from_secs(env_u64("VIZOR_QR_TESTNET_CONFIRM_TIMEOUT_SECS", 3600));
+    let poll = Duration::from_secs(env_u64("VIZOR_QR_TESTNET_CONFIRM_POLL_SECS", 75));
+    eprintln!("using testnet lightwalletd endpoint {lightwalletd_url}");
+    assert_eq!(
+        wallet_api::get_lightwalletd_chain_name(lightwalletd_url.clone()).expect("chain name"),
+        "test"
+    );
+
+    let (_account_a_dir, account_a_db, account_a) =
+        import_test_account(ACCOUNT_A_SEED, ACCOUNT_A_BIRTHDAY, "QR Account A");
+    let (_account_b_dir, account_b_db, account_b) =
+        import_test_account(ACCOUNT_B_SEED, ACCOUNT_B_BIRTHDAY, "QR Account B");
+
+    sync_wallet(&account_a_db, &lightwalletd_url);
+    let account_a_starting_balance = balance(&account_a_db, &account_a.account_uuid);
+    eprintln!(
+        "Account A starting spendable balance: {} zatoshi",
+        account_a_starting_balance.spendable
+    );
+    assert!(
+        account_a_starting_balance.spendable
+            > A_TO_B_SEND_ZATOSHI + B_TO_A_SEND_ZATOSHI + MIN_POST_A_TO_B_CHANGE_ZATOSHI,
+        "Account A needs more spendable balance, got {} zatoshi",
+        account_a_starting_balance.spendable
+    );
+
+    let account_a_qr_change_before = qr_change_count(&account_a_db);
+    let a_to_b_txid = execute_send(
+        &account_a_db,
+        &lightwalletd_url,
+        &account_a.account_uuid,
+        ACCOUNT_A_SEED,
+        ACCOUNT_B_ADDRESS,
+        A_TO_B_SEND_ZATOSHI,
+        "testnet-qr-a-to-b",
+    );
+    eprintln!("Account A -> Account B broadcast: {a_to_b_txid}");
+    assert!(
+        qr_change_count(&account_a_db) > account_a_qr_change_before,
+        "A -> B did not persist Account A QR Orchard change"
+    );
+    assert!(
+        unspent_qr_change_count(&account_a_db) > 0,
+        "A -> B did not leave Account A unspent QR Orchard change"
+    );
+    wait_for_mined_tx(
+        &account_a_db,
+        &lightwalletd_url,
+        &account_a.account_uuid,
+        &a_to_b_txid,
+        timeout,
+        poll,
+    );
+
+    sync_wallet(&account_b_db, &lightwalletd_url);
+    let account_b_external_versions = orchard_note_versions(&account_b_db, false);
+    assert!(
+        account_b_external_versions.iter().all(|v| *v == 2),
+        "A -> B external Orchard output should remain ordinary V2, got {:?}",
+        account_b_external_versions
+    );
+    let account_b_balance = balance(&account_b_db, &account_b.account_uuid);
+    eprintln!(
+        "Account B spendable balance after A -> B: {} zatoshi",
+        account_b_balance.spendable
+    );
+    assert!(
+        account_b_balance.spendable > B_TO_A_SEND_ZATOSHI,
+        "Account B needs spendable balance for B -> A, got {} zatoshi",
+        account_b_balance.spendable
+    );
+
+    let account_b_qr_change_before = qr_change_count(&account_b_db);
+    let b_to_a_txid = execute_send(
+        &account_b_db,
+        &lightwalletd_url,
+        &account_b.account_uuid,
+        ACCOUNT_B_SEED,
+        ACCOUNT_A_ADDRESS,
+        B_TO_A_SEND_ZATOSHI,
+        "testnet-qr-b-to-a",
+    );
+    eprintln!("Account B -> Account A broadcast: {b_to_a_txid}");
+    assert!(
+        qr_change_count(&account_b_db) > account_b_qr_change_before,
+        "B -> A did not persist Account B QR Orchard change"
+    );
+    assert!(
+        unspent_qr_change_count(&account_b_db) > 0,
+        "B -> A did not leave Account B unspent QR Orchard change"
+    );
+    wait_for_mined_tx(
+        &account_b_db,
+        &lightwalletd_url,
+        &account_b.account_uuid,
+        &b_to_a_txid,
+        timeout,
+        poll,
+    );
+
+    sync_wallet(&account_a_db, &lightwalletd_url);
+    let account_a_external_versions = orchard_note_versions(&account_a_db, false);
+    assert!(
+        account_a_external_versions.iter().all(|v| *v == 2),
+        "B -> A external Orchard output should remain ordinary V2, got {:?}",
+        account_a_external_versions
+    );
+
+    eprintln!("QR Phase 1 known-account txids:");
+    eprintln!("A -> B QR change creation: {a_to_b_txid}");
+    eprintln!("B -> A QR change creation: {b_to_a_txid}");
 }

--- a/rust/tests/testnet_qr_phase1.rs
+++ b/rust/tests/testnet_qr_phase1.rs
@@ -1,0 +1,425 @@
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use rust_lib_zcash_wallet::api::{sync as sync_api, wallet as wallet_api};
+
+const NETWORK: &str = "test";
+const DEFAULT_LIGHTWALLETD_URL: &str = "https://testnet.zec.rocks:443";
+const TESTNET_QR_SEED: &str = "powder bronze skirt because truly bonus link gloom cluster quantum birth mutual limit veteran garden almost trophy potato twelve win crush surface decline uphold";
+const TESTNET_QR_BIRTHDAY: u64 = 4_000_000;
+const FIRST_SEND_ZATOSHI: u64 = 50_000;
+const SECOND_SEND_ZATOSHI: u64 = 20_000;
+const MIN_POST_FIRST_CHANGE_ZATOSHI: u64 = 30_000;
+
+fn path_str(path: &Path) -> String {
+    path.to_str().expect("utf-8 path").to_string()
+}
+
+fn lightwalletd_url() -> String {
+    std::env::var("VIZOR_QR_TESTNET_LIGHTWALLETD_URL")
+        .unwrap_or_else(|_| DEFAULT_LIGHTWALLETD_URL.to_string())
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn sync_wallet(db_path: &Path, lightwalletd_url: &str) {
+    sync_api::run_full_sync_blocking(
+        path_str(db_path),
+        lightwalletd_url.to_string(),
+        NETWORK.to_string(),
+        1,
+    )
+    .expect("sync wallet");
+}
+
+fn balance(db_path: &Path, account_uuid: &str) -> sync_api::WalletBalance {
+    sync_api::get_balance(
+        path_str(db_path),
+        NETWORK.to_string(),
+        account_uuid.to_string(),
+    )
+    .expect("get balance")
+}
+
+fn orchard_note_versions(db_path: &Path, is_change: bool) -> Vec<i64> {
+    let conn = rusqlite::Connection::open(db_path).expect("open wallet db");
+    let mut stmt = conn
+        .prepare(
+            "SELECT note_version
+             FROM orchard_received_notes
+             WHERE is_change = ?1
+             ORDER BY id",
+        )
+        .expect("prepare note version query");
+    stmt.query_map([if is_change { 1 } else { 0 }], |row| row.get(0))
+        .expect("query note versions")
+        .map(|row| row.expect("note version row"))
+        .collect()
+}
+
+fn qr_change_count(db_path: &Path) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).expect("open wallet db");
+    conn.query_row(
+        "SELECT COUNT(*)
+         FROM orchard_received_notes
+         WHERE note_version = 3
+           AND is_change = 1",
+        [],
+        |row| row.get(0),
+    )
+    .expect("query QR change")
+}
+
+fn unspent_qr_change_count(db_path: &Path) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).expect("open wallet db");
+    conn.query_row(
+        "SELECT COUNT(*)
+         FROM orchard_received_notes rn
+         LEFT JOIN orchard_received_note_spends s
+           ON s.orchard_received_note_id = rn.id
+         WHERE rn.note_version = 3
+           AND rn.is_change = 1
+           AND s.transaction_id IS NULL",
+        [],
+        |row| row.get(0),
+    )
+    .expect("query unspent QR change")
+}
+
+fn spent_qr_change_count(db_path: &Path) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).expect("open wallet db");
+    conn.query_row(
+        "SELECT COUNT(DISTINCT rn.id)
+         FROM orchard_received_notes rn
+         JOIN orchard_received_note_spends s
+           ON s.orchard_received_note_id = rn.id
+         WHERE rn.note_version = 3
+           AND rn.is_change = 1",
+        [],
+        |row| row.get(0),
+    )
+    .expect("query spent QR change")
+}
+
+fn execute_send(
+    db_path: &Path,
+    lightwalletd_url: &str,
+    account_uuid: &str,
+    to_address: &str,
+    amount_zatoshi: u64,
+    flow_id: &str,
+) -> String {
+    let proposal = sync_api::propose_send(
+        path_str(db_path),
+        NETWORK.to_string(),
+        account_uuid.to_string(),
+        flow_id.to_string(),
+        to_address.to_string(),
+        amount_zatoshi,
+        None,
+    )
+    .expect("propose send");
+    assert!(
+        !proposal.needs_sapling_params,
+        "testnet QR test should use Orchard-only recipients"
+    );
+
+    let result = sync_api::execute_proposal(
+        path_str(db_path),
+        lightwalletd_url.to_string(),
+        proposal.proposal_id,
+        flow_id.to_string(),
+        TESTNET_QR_SEED.as_bytes().to_vec(),
+        None,
+        None,
+    )
+    .expect("execute proposal");
+    assert_eq!(result.status, "broadcasted", "{:?}", result.message);
+    result
+        .txids
+        .split(',')
+        .next()
+        .expect("at least one txid")
+        .to_string()
+}
+
+fn reversed_txid_hex(txid: &str) -> String {
+    let mut bytes = hex::decode(txid).expect("txid hex");
+    bytes.reverse();
+    hex::encode(bytes)
+}
+
+fn wait_for_mined_tx(
+    db_path: &Path,
+    lightwalletd_url: &str,
+    account_uuid: &str,
+    txid: &str,
+    timeout: Duration,
+    poll: Duration,
+) {
+    let start = Instant::now();
+    let reversed_txid = reversed_txid_hex(txid);
+    loop {
+        sync_wallet(db_path, lightwalletd_url);
+        let history = sync_api::get_transaction_history(
+            path_str(db_path),
+            NETWORK.to_string(),
+            Some(50),
+            account_uuid.to_string(),
+        )
+        .expect("transaction history");
+        if let Some(tx) = history.iter().find(|tx| {
+            (tx.txid_hex == txid || tx.txid_hex == reversed_txid)
+                && tx.mined_height > 0
+                && !tx.expired_unmined
+        }) {
+            eprintln!(
+                "mined tx {txid} matched history {} at height {}",
+                tx.txid_hex, tx.mined_height
+            );
+            return;
+        }
+
+        let recent: Vec<String> = history
+            .iter()
+            .take(5)
+            .map(|tx| {
+                format!(
+                    "{}:height={}:expired={}",
+                    tx.txid_hex, tx.mined_height, tx.expired_unmined
+                )
+            })
+            .collect();
+        eprintln!(
+            "waiting for mined tx {txid} or {reversed_txid}; elapsed={}s recent=[{}]",
+            start.elapsed().as_secs(),
+            recent.join(", ")
+        );
+
+        assert!(
+            start.elapsed() < timeout,
+            "timed out waiting for testnet tx {txid} to mine"
+        );
+        std::thread::sleep(poll);
+    }
+}
+
+fn assert_receiver_outputs_are_v2(receiver_db: &Path) {
+    let receiver_external_versions = orchard_note_versions(receiver_db, false);
+    assert!(
+        !receiver_external_versions.is_empty(),
+        "receiver should decrypt the external Orchard output"
+    );
+    assert!(
+        receiver_external_versions.iter().all(|v| *v == 2),
+        "external recipient Orchard outputs should remain ordinary V2, got {:?}",
+        receiver_external_versions
+    );
+}
+
+fn create_receiver(lightwalletd_url: &str) -> (tempfile::TempDir, PathBuf, String) {
+    let receiver_birthday =
+        wallet_api::get_latest_block_height(lightwalletd_url.to_string()).expect("testnet tip");
+    let receiver_dir = tempfile::tempdir().expect("receiver tempdir");
+    let receiver_db = receiver_dir.path().join("zcash_wallet.db");
+    let receiver = wallet_api::create_wallet(
+        NETWORK.to_string(),
+        path_str(&receiver_db),
+        Some(receiver_birthday),
+        Some("QR receiver".to_string()),
+    )
+    .expect("create receiver");
+    let receiver_orchard_address = sync_api::get_next_available_address(
+        path_str(&receiver_db),
+        NETWORK.to_string(),
+        receiver.account_uuid,
+        "orchard".to_string(),
+    )
+    .expect("receiver Orchard address");
+
+    (receiver_dir, receiver_db, receiver_orchard_address)
+}
+
+#[test]
+#[ignore = "requires the funded testnet QR seed and waits for public testnet confirmations"]
+fn funded_testnet_seed_can_create_reopen_and_spend_qr_change() {
+    if std::env::var("VIZOR_QR_TESTNET_LIVE").as_deref() != Ok("1") {
+        eprintln!("set VIZOR_QR_TESTNET_LIVE=1 to run the live QR Phase 1 test");
+        return;
+    }
+
+    let lightwalletd_url = lightwalletd_url();
+    let timeout = Duration::from_secs(env_u64("VIZOR_QR_TESTNET_CONFIRM_TIMEOUT_SECS", 3600));
+    let poll = Duration::from_secs(env_u64("VIZOR_QR_TESTNET_CONFIRM_POLL_SECS", 75));
+    eprintln!("using testnet lightwalletd endpoint {lightwalletd_url}");
+    assert_eq!(
+        wallet_api::get_lightwalletd_chain_name(lightwalletd_url.clone()).expect("chain name"),
+        "test"
+    );
+
+    let sender_dir = tempfile::tempdir().expect("sender tempdir");
+    let sender_db = sender_dir.path().join("zcash_wallet.db");
+    let sender = wallet_api::import_wallet(
+        TESTNET_QR_SEED.to_string(),
+        Some(TESTNET_QR_BIRTHDAY),
+        NETWORK.to_string(),
+        path_str(&sender_db),
+        Some("QR funded testnet seed".to_string()),
+    )
+    .expect("import funded sender");
+    let (_receiver_dir, receiver_db, receiver_orchard_address) = create_receiver(&lightwalletd_url);
+
+    sync_wallet(&sender_db, &lightwalletd_url);
+    let starting_balance = balance(&sender_db, &sender.account_uuid);
+    eprintln!(
+        "starting spendable balance: {} zatoshi",
+        starting_balance.spendable
+    );
+    assert!(
+        starting_balance.spendable
+            > FIRST_SEND_ZATOSHI + SECOND_SEND_ZATOSHI + MIN_POST_FIRST_CHANGE_ZATOSHI,
+        "funded testnet seed needs more spendable balance, got {} zatoshi",
+        starting_balance.spendable
+    );
+
+    let send_max = sync_api::estimate_send_max(
+        path_str(&sender_db),
+        NETWORK.to_string(),
+        sender.account_uuid.clone(),
+        receiver_orchard_address.clone(),
+        None,
+    )
+    .expect("estimate send max");
+    assert!(
+        send_max.amount_zatoshi
+            > FIRST_SEND_ZATOSHI + SECOND_SEND_ZATOSHI + MIN_POST_FIRST_CHANGE_ZATOSHI,
+        "send-max amount too small for QR change test: {}",
+        send_max.amount_zatoshi
+    );
+
+    let qr_change_before = qr_change_count(&sender_db);
+    let first_txid = execute_send(
+        &sender_db,
+        &lightwalletd_url,
+        &sender.account_uuid,
+        &receiver_orchard_address,
+        FIRST_SEND_ZATOSHI,
+        "testnet-qr-first-send",
+    );
+    eprintln!("first send broadcast: {first_txid}");
+    assert!(
+        qr_change_count(&sender_db) > qr_change_before,
+        "first send did not persist a new QR Orchard change note"
+    );
+    assert!(
+        unspent_qr_change_count(&sender_db) > 0,
+        "first send did not leave an unspent QR Orchard change note"
+    );
+
+    wait_for_mined_tx(
+        &sender_db,
+        &lightwalletd_url,
+        &sender.account_uuid,
+        &first_txid,
+        timeout,
+        poll,
+    );
+    sync_wallet(&receiver_db, &lightwalletd_url);
+    assert_receiver_outputs_are_v2(&receiver_db);
+
+    let reopened_balance = balance(&sender_db, &sender.account_uuid);
+    eprintln!(
+        "reopened spendable balance after first send: {} zatoshi",
+        reopened_balance.spendable
+    );
+    assert!(
+        reopened_balance.spendable >= SECOND_SEND_ZATOSHI + 20_000,
+        "reopened sender should have spendable QR change, got {}",
+        reopened_balance.spendable
+    );
+
+    let spent_qr_before = spent_qr_change_count(&sender_db);
+    let second_txid = execute_send(
+        &sender_db,
+        &lightwalletd_url,
+        &sender.account_uuid,
+        &receiver_orchard_address,
+        SECOND_SEND_ZATOSHI,
+        "testnet-qr-second-send",
+    );
+    eprintln!("second send broadcast: {second_txid}");
+    assert!(
+        spent_qr_change_count(&sender_db) > spent_qr_before,
+        "second send did not spend a persisted QR Orchard change note"
+    );
+
+    wait_for_mined_tx(
+        &sender_db,
+        &lightwalletd_url,
+        &sender.account_uuid,
+        &second_txid,
+        timeout,
+        poll,
+    );
+    sync_wallet(&receiver_db, &lightwalletd_url);
+    assert_receiver_outputs_are_v2(&receiver_db);
+}
+
+#[test]
+#[ignore = "requires an existing sender DB with unspent QR change and waits for public testnet confirmations"]
+fn existing_testnet_db_can_spend_qr_change() {
+    if std::env::var("VIZOR_QR_TESTNET_LIVE").as_deref() != Ok("1") {
+        eprintln!("set VIZOR_QR_TESTNET_LIVE=1 to run the live QR Phase 1 test");
+        return;
+    }
+
+    let sender_db = match std::env::var("VIZOR_QR_TESTNET_EXISTING_SENDER_DB") {
+        Ok(path) => PathBuf::from(path),
+        Err(_) => {
+            eprintln!("set VIZOR_QR_TESTNET_EXISTING_SENDER_DB to run existing DB QR spend");
+            return;
+        }
+    };
+    let lightwalletd_url = lightwalletd_url();
+    let timeout = Duration::from_secs(env_u64("VIZOR_QR_TESTNET_CONFIRM_TIMEOUT_SECS", 3600));
+    let poll = Duration::from_secs(env_u64("VIZOR_QR_TESTNET_CONFIRM_POLL_SECS", 75));
+    let accounts = wallet_api::list_accounts(path_str(&sender_db), NETWORK.to_string())
+        .expect("list sender accounts");
+    let sender_account = accounts.first().expect("sender account");
+    let (_receiver_dir, receiver_db, receiver_orchard_address) = create_receiver(&lightwalletd_url);
+
+    sync_wallet(&sender_db, &lightwalletd_url);
+    assert!(
+        unspent_qr_change_count(&sender_db) > 0,
+        "existing sender DB should contain unspent QR change"
+    );
+    let spent_qr_before = spent_qr_change_count(&sender_db);
+    let txid = execute_send(
+        &sender_db,
+        &lightwalletd_url,
+        &sender_account.uuid,
+        &receiver_orchard_address,
+        SECOND_SEND_ZATOSHI,
+        "testnet-qr-existing-db-send",
+    );
+    eprintln!("existing DB QR spend broadcast: {txid}");
+    assert!(
+        spent_qr_change_count(&sender_db) > spent_qr_before,
+        "existing DB send did not spend a persisted QR Orchard change note"
+    );
+    wait_for_mined_tx(
+        &sender_db,
+        &lightwalletd_url,
+        &sender_account.uuid,
+        &txid,
+        timeout,
+        poll,
+    );
+    sync_wallet(&receiver_db, &lightwalletd_url);
+    assert_receiver_outputs_are_v2(&receiver_db);
+}

--- a/test/features/about/about_legal_pages_test.dart
+++ b/test/features/about/about_legal_pages_test.dart
@@ -12,7 +12,6 @@ import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_back_link.dart';
 import 'package:zcash_wallet/src/core/widgets/app_decorative_divider.dart';
 import 'package:zcash_wallet/src/features/about/screens/about_screen.dart';
-import 'package:zcash_wallet/src/features/onboarding/welcome.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 


### PR DESCRIPTION
## Summary

- Pins the Zcash Rust stack to exact validation fork refs with QR transaction selection and Orchard note-version persistence.
- Enables QR Orchard internal outputs for software testnet/regtest sends and software shielding while keeping mainnet, Keystone sends, and hardware shielding on ordinary V5/default behavior.
- Adds `rust/QR_PHASE1.md` plus ignored live tests that create QR change, reopen the wallet DB, spend QR change, verify external recipient outputs remain ordinary V2, and save Account A/B DB artifacts for note-version inspection.

## Dependency refs

- librustzcash validation fork: `d39cbbea0323bbba6ad477e36b604025c4dbbf6f`
- QR Orchard fork: `9f046f22a46dd644aeed070968e51add57478973`

No upstream PRs, issues, comments, or review comments were opened.

## Validation

- `cd rust && cargo check`
- `cd rust && cargo test`
- `cd rust && cargo tree -d`
- `cd rust && cargo tree -i orchard`
- `cd rust && cargo tree -i zcash_client_backend`
- `cd rust && cargo tree -i zcash_client_sqlite`
- `cd rust && cargo tree -i zcash_primitives`
- `fvm flutter analyze`
- `fvm flutter test`
- Live existing-DB QR spend passed. Tx `e016f41a1b1a2b534c5c103ca83d75e12a798967a747cd8728ad7b82f8429895` mined at height `4028555`.
- Live funded-seed QR creation/spend passed. First tx `3d66e4f88acb5aaef4f520c23a2ab9554e460c7b42ec526d2a9bc55dfdb65bbf` mined at height `4028558`; second QR-change spend tx `b23db05262a14d5b8524e18e65861ca7d178682a8e122c390ba5ed4730783564` mined at height `4028561`.
- Live known Account A/B flow passed. Initial Account A -> Account B tx `f0250cb22adc07fc56c9c273654bb2978c41780abfe400b4871221f8cc5accb8` mined at height `4028955` and funded the Account B spend; artifact-run Account A -> Account B tx `4210b0f959b7e519eaabec412bac8838fb5a119bdf1b397d1f0cb17c8e9bfffd` mined at height `4028964`; Account B -> Account A tx `373f2e36c83178ad70c8d9bf67a7de333fc42f6dd5f4583249bcc5b3ce0e6446` mined at height `4028969`. Saved local artifact DBs show external recipient outputs as `note_version = 2` and internal change outputs as `note_version = 3`.
- `cargo fmt --check`
- `cargo test --test testnet_qr_phase1 --no-run`
- `VIZOR_QR_TESTNET_LIVE=1 VIZOR_QR_TESTNET_ARTIFACT_DIR=target/qr-phase1-live/known-accounts-latest VIZOR_QR_TESTNET_CONFIRM_TIMEOUT_SECS=5400 VIZOR_QR_TESTNET_CONFIRM_POLL_SECS=75 cargo test --test testnet_qr_phase1 known_test_accounts_create_qr_change_on_both_sides -- --ignored --nocapture`

`fvm flutter build macos --release --dart-define=ZCASH_DEFAULT_NETWORK=test` is blocked locally by Xcode signing because the Runner target requires a provisioning profile.
