### PR TITLE
QR Phase 2:  Enable QR change for Keystone PCZT sends

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -833,7 +833,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -852,13 +852,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1552,7 +1552,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.6.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -2236,7 +2236,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -2586,7 +2586,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2979,7 +2979,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3761,7 +3761,7 @@ checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 [[package]]
 name = "zcash_address"
 version = "0.11.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "bech32",
  "bs58",
@@ -3774,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.22.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "async-trait",
  "base64",
@@ -3829,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.20.2"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "bip32",
  "bitflags",
@@ -3875,7 +3875,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "corez",
  "hex",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.13.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "bech32",
  "bip32",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.27.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -3957,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.27.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -3978,7 +3978,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.8.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "corez",
  "document-features",
@@ -4016,7 +4016,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.7.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "bip32",
  "bs58",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.7.0"
-source = "git+https://github.com/valargroup/librustzcash?rev=d39cbbea0323bbba6ad477e36b604025c4dbbf6f#d39cbbea0323bbba6ad477e36b604025c4dbbf6f"
+source = "git+https://github.com/valargroup/librustzcash?rev=56a6b33642c362892cff440c61451da3e15da640#56a6b33642c362892cff440c61451da3e15da640"
 dependencies = [
  "base64",
  "nom",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,13 +10,13 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 flutter_rust_bridge = "=2.11.1"
 
 # Zcash core
-zcash_primitives = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f" }
-zcash_address = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f" }
-zcash_keys = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f", features = ["orchard"] }
-zcash_protocol = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f" }
-transparent = { package = "zcash_transparent", git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f" }
+zcash_primitives = { git = "https://github.com/valargroup/librustzcash", rev = "56a6b33642c362892cff440c61451da3e15da640" }
+zcash_address = { git = "https://github.com/valargroup/librustzcash", rev = "56a6b33642c362892cff440c61451da3e15da640" }
+zcash_keys = { git = "https://github.com/valargroup/librustzcash", rev = "56a6b33642c362892cff440c61451da3e15da640", features = ["orchard"] }
+zcash_protocol = { git = "https://github.com/valargroup/librustzcash", rev = "56a6b33642c362892cff440c61451da3e15da640" }
+transparent = { package = "zcash_transparent", git = "https://github.com/valargroup/librustzcash", rev = "56a6b33642c362892cff440c61451da3e15da640" }
 zcash_script = "0.4.3"
-zcash_client_backend = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f", features = [
+zcash_client_backend = { git = "https://github.com/valargroup/librustzcash", rev = "56a6b33642c362892cff440c61451da3e15da640", features = [
     "orchard",
     "transparent-inputs",
     "lightwalletd-tonic",
@@ -25,7 +25,7 @@ zcash_client_backend = { git = "https://github.com/valargroup/librustzcash", rev
     "pczt",
     "unstable",
 ] }
-zcash_client_sqlite = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+zcash_client_sqlite = { git = "https://github.com/valargroup/librustzcash", rev = "56a6b33642c362892cff440c61451da3e15da640", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 # Must match versions used by zcash_client_sqlite to avoid type conflicts
 orchard = { git = "https://github.com/valargroup/qr_orchard", rev = "9f046f22a46dd644aeed070968e51add57478973" }
 sapling-crypto = { version = "0.7", default-features = false }
@@ -37,7 +37,7 @@ bls12_381 = "0.8"
 rand_core = "0.6"
 
 # Proofs
-zcash_proofs = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f" }
+zcash_proofs = { git = "https://github.com/valargroup/librustzcash", rev = "56a6b33642c362892cff440c61451da3e15da640" }
 
 # Key generation
 bip0039 = "0.12"
@@ -78,7 +78,7 @@ hex = "0.4"
 
 # Keystone hardware wallet
 ur = { git = "https://github.com/KeystoneHQ/ur-rs", tag = "0.3.3" }
-pczt = { git = "https://github.com/valargroup/librustzcash", rev = "d39cbbea0323bbba6ad477e36b604025c4dbbf6f" }
+pczt = { git = "https://github.com/valargroup/librustzcash", rev = "56a6b33642c362892cff440c61451da3e15da640" }
 ur-registry = { git = "https://github.com/KeystoneHQ/keystone-sdk-rust", package = "ur-registry", default-features = false, features = ["std"] }
 serde_json = "1"
 

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -12,6 +12,7 @@ use zcash_client_sqlite::{
     AccountUuid, FsBlockDb,
 };
 use zcash_primitives::block::BlockHash;
+use zcash_primitives::transaction::TxVersion;
 use zcash_protocol::consensus::BlockHeight;
 
 use crate::wallet::{
@@ -73,6 +74,13 @@ pub(crate) use transactions::{
     PendingTxInfo, TransactionDetail, TransactionDetailOutput, TransactionInfo, TxDataRequest,
     WalletBalance,
 };
+
+pub(super) fn qr_change_proposed_tx_version(network: WalletNetwork) -> Option<TxVersion> {
+    match network {
+        WalletNetwork::Main => Some(TxVersion::V5),
+        WalletNetwork::Test | WalletNetwork::Regtest => Some(TxVersion::V5_Qr),
+    }
+}
 
 pub(super) fn open_wallet_db(
     db_path: &str,

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -76,7 +76,9 @@ use zcash_proofs::prover::LocalTxProver;
 use crate::wallet::db::with_wallet_db_write_lock;
 use crate::wallet::network::WalletNetwork;
 
-use super::{consume_stored_proposal, discard_stored_proposal, open_wallet_db};
+use super::{
+    consume_stored_proposal, discard_stored_proposal, open_wallet_db, qr_change_proposed_tx_version,
+};
 
 pub struct ExtractAndBroadcastPcztResult {
     pub txid: String,
@@ -149,6 +151,7 @@ pub fn create_pczt_from_proposal(
             stored.account_id,
             OvkPolicy::Sender,
             &stored.proposal,
+            qr_change_proposed_tx_version(network),
         )
         .map_err(|e| format!("Create PCZT failed: {e}"))
     })?;

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -64,7 +64,7 @@ use zcash_primitives::transaction::{
     fees::{
         transparent::InputSize as TransparentInputSize, zip317::P2PKH_STANDARD_INPUT_SIZE, FeeRule,
     },
-    TxId, TxVersion,
+    TxId,
 };
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
@@ -142,13 +142,6 @@ const SHIELDING_THRESHOLD_ZATOSHI: u64 = 100_000;
 pub(in crate::wallet) struct ConservativeZip317FeeRule;
 
 pub(in crate::wallet) type WalletFeeRule = ConservativeZip317FeeRule;
-
-fn software_proposed_tx_version(network: WalletNetwork) -> Option<TxVersion> {
-    match network {
-        WalletNetwork::Main => Some(TxVersion::V5),
-        WalletNetwork::Test | WalletNetwork::Regtest => Some(TxVersion::V5_Qr),
-    }
-}
 
 impl FeeRule for ConservativeZip317FeeRule {
     type Error = <StandardFeeRule as FeeRule>::Error;
@@ -238,7 +231,7 @@ pub fn propose_send(
         &change_strategy,
         request,
         ConfirmationsPolicy::default(),
-        software_proposed_tx_version(network),
+        super::qr_change_proposed_tx_version(network),
     )
     .map_err(|e| format!("Propose failed: {e}"))?;
 
@@ -317,7 +310,7 @@ pub fn estimate_fee(
         &change_strategy,
         request,
         ConfirmationsPolicy::default(),
-        software_proposed_tx_version(network),
+        super::qr_change_proposed_tx_version(network),
     )
     .map_err(|e| format!("Propose failed: {e}"))?;
 
@@ -406,6 +399,7 @@ pub(crate) fn create_shield_transparent_pczt(
             account_id,
             OvkPolicy::Sender,
             &proposal,
+            super::qr_change_proposed_tx_version(network),
         )
         .map_err(|e| format!("Create shielding PCZT failed: {e}"))?;
 
@@ -465,7 +459,7 @@ pub(crate) async fn shield_transparent_balance(
                 &wallet::SpendingKeys::from_unified_spending_key(usk),
                 OvkPolicy::Sender,
                 &proposal,
-                software_proposed_tx_version(network),
+                super::qr_change_proposed_tx_version(network),
             )
             .map_err(|e| format!("Create shielding TX failed: {e}"))?;
 
@@ -582,7 +576,7 @@ async fn execute_stored_proposal(
                         &wallet::SpendingKeys::from_unified_spending_key(usk),
                         OvkPolicy::Sender,
                         &stored.proposal,
-                        software_proposed_tx_version(network),
+                        super::qr_change_proposed_tx_version(network),
                     )
                     .map_err(|e| format!("Create TX failed: {e}"))?
                 }
@@ -597,7 +591,7 @@ async fn execute_stored_proposal(
                         &wallet::SpendingKeys::from_unified_spending_key(usk),
                         OvkPolicy::Sender,
                         &stored.proposal,
-                        software_proposed_tx_version(network),
+                        super::qr_change_proposed_tx_version(network),
                     )
                     .map_err(|e| format!("Create TX failed: {e}"))?
                 }
@@ -1241,9 +1235,11 @@ impl OutputProver for NoOpOutputProver {
 mod tests {
     use super::*;
 
+    use pczt::orchard::NotePlaintextVersion;
     use transparent::bundle::{OutPoint, TxOut};
     use zcash_client_backend::{data_api::WalletWrite, wallet::WalletTransparentOutput};
     use zcash_keys::keys::{ReceiverRequirement, UnifiedSpendingKey};
+    use zcash_primitives::transaction::TxVersion;
     use zcash_protocol::consensus::BlockHeight;
 
     fn taddr(seed: u8) -> TransparentAddress {
@@ -1263,17 +1259,17 @@ mod tests {
     }
 
     #[test]
-    fn software_qr_policy_uses_qr_only_on_test_networks() {
+    fn qr_change_policy_uses_qr_only_on_test_networks() {
         assert_eq!(
-            software_proposed_tx_version(WalletNetwork::Main),
+            super::super::qr_change_proposed_tx_version(WalletNetwork::Main),
             Some(TxVersion::V5)
         );
         assert_eq!(
-            software_proposed_tx_version(WalletNetwork::Test),
+            super::super::qr_change_proposed_tx_version(WalletNetwork::Test),
             Some(TxVersion::V5_Qr)
         );
         assert_eq!(
-            software_proposed_tx_version(WalletNetwork::Regtest),
+            super::super::qr_change_proposed_tx_version(WalletNetwork::Regtest),
             Some(TxVersion::V5_Qr)
         );
     }
@@ -1369,14 +1365,11 @@ mod tests {
         let tip = BlockHeight::from_u32(1_000);
         db.update_chain_tip(tip).unwrap();
 
-        let ua_request = zcash_keys::keys::UnifiedAddressRequest::custom(
-            ReceiverRequirement::Require,
-            ReceiverRequirement::Require,
-            ReceiverRequirement::Require,
-        )
-        .unwrap();
-        let (ua, _) = db
-            .get_next_available_address(account_id, ua_request)
+        let ua = db
+            .get_last_generated_address_matching(
+                account_id,
+                zcash_keys::keys::UnifiedAddressRequest::AllAvailableKeys,
+            )
             .unwrap()
             .unwrap();
         let taddr = *ua.transparent().unwrap();
@@ -1407,7 +1400,7 @@ mod tests {
             &wallet::SpendingKeys::from_unified_spending_key(usk),
             OvkPolicy::Sender,
             &proposal,
-            software_proposed_tx_version(network),
+            super::super::qr_change_proposed_tx_version(network),
         )
         .expect("shielding transaction should build");
         drop(db);
@@ -1421,6 +1414,66 @@ mod tests {
             )
             .unwrap();
         assert_eq!(note_version, 3);
+    }
+
+    #[test]
+    fn hardware_shielding_pczt_internal_output_is_qr_on_regtest() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+        let network = WalletNetwork::Regtest;
+        let mnemonic = crate::wallet::keys::generate_mnemonic();
+        let seed = crate::wallet::keys::mnemonic_to_seed(&mnemonic).unwrap();
+        let (account_uuid, _) = crate::wallet::keys::init_db_and_create_account(
+            db_path,
+            network,
+            &seed,
+            Some(1),
+            "qr-hardware",
+        )
+        .unwrap();
+        let account_id = parse_account_uuid(&account_uuid).unwrap();
+
+        let mut db = open_wallet_db(db_path, network).unwrap();
+        let tip = BlockHeight::from_u32(1_000);
+        db.update_chain_tip(tip).unwrap();
+
+        let ua = db
+            .get_last_generated_address_matching(
+                account_id,
+                zcash_keys::keys::UnifiedAddressRequest::AllAvailableKeys,
+            )
+            .unwrap()
+            .unwrap();
+        let taddr = *ua.transparent().unwrap();
+        let value = Zatoshis::const_from_u64(1_000_000);
+
+        let mut txid = [0u8; 32];
+        txid[..4].copy_from_slice(&0xface_feed_u32.to_le_bytes());
+        let outpoint = OutPoint::new(txid, 0);
+        let txout = TxOut::new(value, taddr.script().into());
+        let utxo = WalletTransparentOutput::from_parts(outpoint, txout, Some(tip)).unwrap();
+        db.put_received_transparent_utxo(&utxo).unwrap();
+        drop(db);
+
+        let result = create_shield_transparent_pczt(db_path, network, &account_uuid)
+            .expect("hardware shielding PCZT should build");
+        let pczt = pczt::Pczt::parse(&result.pczt_bytes).expect("PCZT should parse");
+        let output_versions = pczt
+            .orchard()
+            .actions()
+            .iter()
+            .filter(|action| action.output().value().is_some())
+            .map(|action| *action.output().note_version())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            output_versions
+                .iter()
+                .filter(|version| **version == NotePlaintextVersion::V3)
+                .count(),
+            1
+        );
     }
 
     #[test]
@@ -1488,7 +1541,7 @@ mod tests {
             &wallet::SpendingKeys::from_unified_spending_key(usk),
             OvkPolicy::Sender,
             &proposal,
-            software_proposed_tx_version(network),
+            super::super::qr_change_proposed_tx_version(network),
         )
         .expect("many-UTXO shielding should build without a fee/change mismatch");
         let change_values = proposal


### PR DESCRIPTION
Summary
- Updates the QR Zcash dependency pin to the branch that lets PCZT creation receive a proposed transaction version.
- Shares the QR change transaction version policy between software sends, software shielding, Keystone sends, and hardware shielding.
- Keeps testnet and regtest internal wallet outputs on QR change, while mainnet remains ordinary V5.

Validation
- cd rust && cargo check
- cd rust && cargo test
- fvm flutter build macos --debug --dart-define=ZCASH_DEFAULT_NETWORK=test
- Local testnet Keystone simulator send produced a QR change output with note_version 3 and an ordinary external recipient output with note_version 2. Transaction DB hex: 29400880EDDE38FD8F087EC0317FCEE2A39E296F6A55F15D098DA5A284B85E47, mined at height 4030585.

Notes
- This is stacked on the Phase 1 QR Vizor branch.
- The dependency pin currently points at commit 56a6b33642c362892cff440c61451da3e15da640 while the PCZT proposed version support is being proven out.