### PR TITLE
Copy QA fixes: swap review + address book

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ migrate_working_dir/
 # UI copy QA review artifacts — local-only, never push to remote.
 qa-copy-review.csv
 copy-review-*.csv
+copy-review.json
+copy-review-viewer.html
 
 # Rust
 rust/target/

--- a/lib/src/features/address_book/screens/address_book_screen.dart
+++ b/lib/src/features/address_book/screens/address_book_screen.dart
@@ -186,7 +186,7 @@ class _AddressBookScreenState extends ConsumerState<AddressBookScreen> {
       _closeModal();
     } catch (_) {
       if (!mounted) return;
-      setState(() => _submitError = "Couldn't save contact.");
+      setState(() => _submitError = "Couldn't save contact. Try again.");
     }
   }
 
@@ -199,7 +199,7 @@ class _AddressBookScreenState extends ConsumerState<AddressBookScreen> {
       _closeModal();
     } catch (_) {
       if (!mounted) return;
-      setState(() => _submitError = "Couldn't remove contact.");
+      setState(() => _submitError = "Couldn't remove contact. Try again.");
     }
   }
 
@@ -249,7 +249,7 @@ class _AddressBookScreenState extends ConsumerState<AddressBookScreen> {
                 loading: () => buildPane(
                   contactsAsync.asData?.value ?? const AddressBookState(),
                 ),
-                error: (error, _) => _AddressBookError(error: error),
+                error: (_, _) => const _AddressBookError(),
                 data: buildPane,
               ),
             ),
@@ -398,7 +398,7 @@ class _AddressBookPane extends StatelessWidget {
               child: Column(
                 children: [
                   Text(
-                    'Contacts',
+                    'Address book',
                     textAlign: TextAlign.center,
                     style: AppTypography.headlineLarge.copyWith(
                       color: colors.text.accent,
@@ -535,7 +535,7 @@ class _AddressBookSearchFieldState extends State<_AddressBookSearchField> {
       showLabel: false,
       controller: _controller,
       focusNode: _focusNode,
-      hintText: 'Search for an address or label ...',
+      hintText: 'Search name or address',
       leading: const AppIcon(AppIcons.search),
       leadingSlotWidth: 40,
       trailingSlotWidth: 40,
@@ -967,7 +967,7 @@ class _AddressBookNoContacts extends StatelessWidget {
                     child: Column(
                       children: [
                         Text(
-                          "It's empty here...",
+                          'No contacts yet',
                           textAlign: TextAlign.center,
                           style: AppTypography.headlineSmall.copyWith(
                             color: context.colors.text.accent,
@@ -975,7 +975,7 @@ class _AddressBookNoContacts extends StatelessWidget {
                         ),
                         const SizedBox(height: AppSpacing.xxs),
                         Text(
-                          'How about adding your first Contact?',
+                          'Add your first contact to get started.',
                           textAlign: TextAlign.center,
                           style: AppTypography.bodyMedium.copyWith(
                             color: context.colors.text.secondary,
@@ -1026,7 +1026,7 @@ class _EmptySearchResult extends StatelessWidget {
               child: Column(
                 children: [
                   Text(
-                    'No contacts were found',
+                    'No contacts found',
                     textAlign: TextAlign.center,
                     style: AppTypography.headlineSmall.copyWith(
                       color: context.colors.text.accent,
@@ -1034,7 +1034,7 @@ class _EmptySearchResult extends StatelessWidget {
                   ),
                   const SizedBox(height: AppSpacing.xxs),
                   Text(
-                    'Try to modify your search',
+                    'Try a different search',
                     textAlign: TextAlign.center,
                     style: AppTypography.bodyMedium.copyWith(
                       color: context.colors.text.secondary,
@@ -1161,10 +1161,10 @@ class _ContactFormModalState extends State<_ContactFormModal> {
             height: widget.editing ? 66 : 86,
             child: AppTextField(
               key: const ValueKey('address_book_contact_label_field'),
-              label: 'Address label',
+              label: 'Label',
               showLabel: !widget.editing,
               controller: _labelController,
-              hintText: 'Add label 1-20 characters',
+              hintText: 'Add a label (1-20 characters)',
               trailing: widget.editing
                   ? _IconButtonLike(
                       semanticLabel: 'Clear contact label',
@@ -1196,7 +1196,7 @@ class _ContactFormModalState extends State<_ContactFormModal> {
               label: 'Address',
               showLabel: false,
               controller: _addressController,
-              hintText: 'Add Address',
+              hintText: 'Add address',
               trailing: _IconButtonLike(
                 semanticLabel: 'Scan address QR',
                 onTap: widget.onScanAddress,
@@ -1303,7 +1303,7 @@ class _ChainAddressSelector extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.only(left: AppSpacing.xxs),
               child: Text(
-                'Chain & Address',
+                'Chain & address',
                 style: AppTypography.labelMedium.copyWith(
                   color: colors.text.secondary,
                 ),
@@ -1399,7 +1399,7 @@ class _ContactAvatarPickerModalState extends State<_ContactAvatarPickerModal> {
           ),
           const SizedBox(height: AppSpacing.sm),
           Text(
-            'New Contact',
+            'New contact',
             overflow: TextOverflow.ellipsis,
             style: AppTypography.bodyLarge.copyWith(
               color: context.colors.text.accent,
@@ -1438,7 +1438,7 @@ class _ContactAvatarPickerModalState extends State<_ContactAvatarPickerModal> {
             onPressed: hasChanged ? () => widget.onSelected(selected.id) : null,
             variant: AppButtonVariant.primary,
             minWidth: 280,
-            child: const Text('Update'),
+            child: const Text('Use this picture'),
           ),
           const SizedBox(height: AppSpacing.s),
           AppButton(
@@ -1856,17 +1856,14 @@ class _IconButtonLike extends StatelessWidget {
 }
 
 class _AddressBookError extends StatelessWidget {
-  const _AddressBookError({required this.error});
-
-  final Object error;
+  const _AddressBookError();
 
   @override
   Widget build(BuildContext context) {
     return Center(
       child: Text(
         "Couldn't load your address book. "
-        'Try again, or contact support if this keeps happening.\n\n'
-        'Details: $error',
+        'Try again, or contact support if this keeps happening.',
         textAlign: TextAlign.center,
         style: AppTypography.bodyMedium.copyWith(
           color: context.colors.text.destructive,

--- a/lib/src/features/address_book/widgets/address_book_contact_picker_modal.dart
+++ b/lib/src/features/address_book/widgets/address_book_contact_picker_modal.dart
@@ -158,7 +158,7 @@ class _AddressBookContactPickerModalState
                 ),
               ),
               error: (_, _) => const _ContactPickerEmptyResult(
-                title: "Couldn't load contacts",
+                title: "Couldn't load contacts. Try again.",
               ),
               data: (state) {
                 final contacts = _filteredContacts(state);

--- a/lib/src/features/swap/models/swap_detail_tooltips.dart
+++ b/lib/src/features/swap/models/swap_detail_tooltips.dart
@@ -7,8 +7,8 @@ const swapGenericMinimumReceiveTooltip =
     'You may get more, never less.';
 
 const swapFeeTooltip =
-    'Fee for us and the route providers to process this swap. '
-    'Already included in the rate shown above.';
+    "Covers our fee and the route providers' costs to process this swap. "
+    'Already included in the rate above.';
 
 const swapTotalFeesTooltip = swapFeeTooltip;
 

--- a/lib/src/features/swap/models/swap_state.dart
+++ b/lib/src/features/swap/models/swap_state.dart
@@ -215,7 +215,7 @@ class SwapState {
       absoluteDelta >= 0.1 ? 0 : 1,
     );
     final directionLabel = delta < 0 ? 'lower' : 'higher';
-    return 'Live quote is $percent% $directionLabel than the latest estimate. Check the minimum receive before starting.';
+    return 'Live quote is $percent% $directionLabel than the earlier estimate. Check the guaranteed minimum before you continue.';
   }
 
   List<SwapDetailField> get draftExposure {

--- a/lib/src/features/swap/screens/swap_review_screen.dart
+++ b/lib/src/features/swap/screens/swap_review_screen.dart
@@ -136,7 +136,7 @@ class _SwapReviewScreenState extends ConsumerState<SwapReviewScreen> {
     );
     final startBlockedReason =
         _reviewQuoteExceedsAvailableZec(quote, sync.spendableBalance)
-        ? 'Required pay exceeds available ZEC. Review a smaller target amount.'
+        ? "You don't have enough ZEC for this swap. Try a smaller amount."
         : null;
 
     return AppDesktopShell(

--- a/lib/src/features/swap/screens/swap_screen.dart
+++ b/lib/src/features/swap/screens/swap_screen.dart
@@ -599,7 +599,7 @@ class _SwapReviewFooter extends StatelessWidget {
     final label = needsDestinationAddress
         ? _destinationAddressActionLabel(state)
         : balanceExceeded
-        ? 'Insufficient ZEC'
+        ? 'Not enough ZEC'
         : state.quoteLoading
         ? 'Getting quote'
         : 'Get a quote';

--- a/lib/src/features/swap/widgets/swap_review_page_content.dart
+++ b/lib/src/features/swap/widgets/swap_review_page_content.dart
@@ -84,7 +84,7 @@ class SwapReviewPageContent extends StatelessWidget {
           if (expired) ...[
             const SizedBox(height: AppSpacing.xs),
             const _ReviewNotice(
-              message: 'Quote expired. Review again for a fresh route.',
+              message: 'Quote expired. Review again for an updated rate.',
             ),
           ],
           if (startError != null) ...[
@@ -180,10 +180,10 @@ class SwapReviewPageActions extends StatelessWidget {
     final primaryLabel = expired
         ? 'Review again'
         : startBlockedReason != null
-        ? 'Insufficient ZEC'
+        ? 'Not enough ZEC'
         : starting
         ? startingLabel
-        : 'Review & swap';
+        : 'Confirm swap';
     final showPrimaryArrow =
         !expired && !starting && startBlockedReason == null;
     return SizedBox(
@@ -612,19 +612,24 @@ class _ReviewNotice extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final textStyle = AppTypography.bodySmall.copyWith(
+      color: colors.text.destructive,
+    );
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        AppIcon(AppIcons.warning, size: 16, color: colors.icon.destructive),
-        const SizedBox(width: AppSpacing.xs),
-        Expanded(
-          child: Text(
-            message,
-            style: AppTypography.bodySmall.copyWith(
-              color: colors.text.destructive,
+        SizedBox(
+          height: textStyle.fontSize! * textStyle.height!,
+          child: Center(
+            child: AppIcon(
+              AppIcons.warning,
+              size: 16,
+              color: colors.icon.destructive,
             ),
           ),
         ),
+        const SizedBox(width: AppSpacing.xs),
+        Expanded(child: Text(message, style: textStyle)),
       ],
     );
   }

--- a/lib/src/features/swap/widgets/swap_status_page_content.dart
+++ b/lib/src/features/swap/widgets/swap_status_page_content.dart
@@ -489,7 +489,7 @@ class _StatusBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final label = switch (kind) {
-      SwapStatusBadgeKind.liveQuote => 'Live Quote',
+      SwapStatusBadgeKind.liveQuote => 'In progress',
       SwapStatusBadgeKind.completed => 'Completed',
       SwapStatusBadgeKind.failed => 'Failed',
     };

--- a/lib/widgetbook/address_book_use_cases.dart
+++ b/lib/widgetbook/address_book_use_cases.dart
@@ -279,7 +279,7 @@ class _AddressBookPane extends StatelessWidget {
               child: Column(
                 children: [
                   Text(
-                    'Contacts',
+                    'Address book',
                     textAlign: TextAlign.center,
                     style: AppTypography.headlineLarge.copyWith(
                       color: colors.text.accent,
@@ -528,7 +528,7 @@ class _AddressBookNoContacts extends StatelessWidget {
                     child: Column(
                       children: [
                         Text(
-                          "It's empty here...",
+                          'No contacts yet',
                           textAlign: TextAlign.center,
                           style: AppTypography.headlineSmall.copyWith(
                             color: context.colors.text.accent,
@@ -536,7 +536,7 @@ class _AddressBookNoContacts extends StatelessWidget {
                         ),
                         const SizedBox(height: AppSpacing.xxs),
                         Text(
-                          'How about adding your first Contact?',
+                          'Add your first contact to get started.',
                           textAlign: TextAlign.center,
                           style: AppTypography.bodyMedium.copyWith(
                             color: context.colors.text.secondary,
@@ -807,7 +807,7 @@ class _EmptySearchResult extends StatelessWidget {
               child: Column(
                 children: [
                   Text(
-                    'No contacts were found',
+                    'No contacts found',
                     textAlign: TextAlign.center,
                     style: AppTypography.headlineSmall.copyWith(
                       color: context.colors.text.accent,
@@ -815,7 +815,7 @@ class _EmptySearchResult extends StatelessWidget {
                   ),
                   const SizedBox(height: AppSpacing.xxs),
                   Text(
-                    'Try to modify your search',
+                    'Try a different search',
                     textAlign: TextAlign.center,
                     style: AppTypography.bodyMedium.copyWith(
                       color: context.colors.text.secondary,
@@ -875,10 +875,10 @@ class _ContactFormModal extends StatelessWidget {
           SizedBox(
             height: _isEdit ? 66 : 86,
             child: AppTextField(
-              label: 'Address label',
+              label: 'Label',
               showLabel: !_isEdit,
               initialValue: _isEdit ? 'Mike' : null,
-              hintText: 'Add label 1-20 characters',
+              hintText: 'Add a label (1-20 characters)',
               trailing: _isEdit ? const AppIcon(AppIcons.cross) : null,
               trailingSlotWidth: 40,
               inputHorizontalPadding: AppSpacing.s,
@@ -893,7 +893,7 @@ class _ContactFormModal extends StatelessWidget {
               label: 'Address',
               showLabel: false,
               initialValue: _isEdit ? 'u1x12adas3l512...31235129812' : null,
-              hintText: 'Add Address',
+              hintText: 'Add address',
               trailing: const AppIcon(AppIcons.qr),
               trailingSlotWidth: 40,
               inputHorizontalPadding: AppSpacing.s,
@@ -976,7 +976,7 @@ class _ChainAddressSelector extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.only(left: AppSpacing.xxs),
               child: Text(
-                'Chain & Address',
+                'Chain & address',
                 style: AppTypography.labelMedium.copyWith(
                   color: colors.text.secondary,
                 ),
@@ -1034,7 +1034,7 @@ class _ContactAvatarPickerModal extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.sm),
           Text(
-            'New Contact',
+            'New contact',
             overflow: TextOverflow.ellipsis,
             style: AppTypography.bodyLarge.copyWith(
               color: context.colors.text.accent,
@@ -1070,7 +1070,7 @@ class _ContactAvatarPickerModal extends StatelessWidget {
             onPressed: null,
             variant: AppButtonVariant.primary,
             minWidth: 280,
-            child: Text('Update'),
+            child: Text('Use this picture'),
           ),
           const SizedBox(height: AppSpacing.s),
           AppButton(

--- a/test/features/address_book/address_book_screen_test.dart
+++ b/test/features/address_book/address_book_screen_test.dart
@@ -27,13 +27,13 @@ void main() {
     await tester.pump();
 
     expect(find.byType(CircularProgressIndicator), findsNothing);
-    expect(find.text("It's empty here..."), findsOneWidget);
+    expect(find.text('No contacts yet'), findsOneWidget);
 
     repo.complete(const []);
     await tester.pumpAndSettle();
 
     expect(find.byType(CircularProgressIndicator), findsNothing);
-    expect(find.text("It's empty here..."), findsOneWidget);
+    expect(find.text('No contacts yet'), findsOneWidget);
   });
 
   testWidgets('renders empty state and creates a contact from the form', (
@@ -45,7 +45,7 @@ void main() {
     await tester.pumpWidget(_addressBookHarness(repo));
     await tester.pumpAndSettle();
 
-    expect(find.text("It's empty here..."), findsOneWidget);
+    expect(find.text('No contacts yet'), findsOneWidget);
 
     await tester.tap(
       find.byKey(const ValueKey('address_book_add_contact_button')),
@@ -68,7 +68,7 @@ void main() {
     expect(repo.contacts, hasLength(1));
     expect(find.text('Alice'), findsOneWidget);
     expect(find.text('u1alice'), findsOneWidget);
-    expect(find.text("It's empty here..."), findsNothing);
+    expect(find.text('No contacts yet'), findsNothing);
   });
 
   testWidgets('edit contact label x clears the draft label', (tester) async {
@@ -122,7 +122,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('No contacts were found'), findsOneWidget);
+    expect(find.text('No contacts found'), findsOneWidget);
     expect(find.text('Mike'), findsNothing);
   });
 
@@ -143,7 +143,9 @@ void main() {
     await tester.pumpAndSettle();
 
     AppButton updateButton() {
-      return tester.widget<AppButton>(find.widgetWithText(AppButton, 'Update'));
+      return tester.widget<AppButton>(
+        find.widgetWithText(AppButton, 'Use this picture'),
+      );
     }
 
     expect(updateButton().onPressed, isNull);

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -1930,7 +1930,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Max: 1 ZEC'), findsOneWidget);
-      expect(find.text('Insufficient ZEC'), findsOneWidget);
+      expect(find.text('Not enough ZEC'), findsOneWidget);
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
       await tester.pumpAndSettle();
@@ -3996,8 +3996,8 @@ void main() {
     expect(find.text('Price protection'), findsNothing);
     expect(
       _tooltipWithMessage(
-        'Fee for us and the route providers to process this swap. '
-        'Already included in the rate shown above.',
+        "Covers our fee and the route providers' costs to process this swap. "
+        'Already included in the rate above.',
       ),
       findsOneWidget,
     );
@@ -4153,7 +4153,7 @@ void main() {
     expect(find.text('Slippage tolerance'), findsOneWidget);
     expect(find.text('Guaranteed minimum'), findsOneWidget);
     expect(find.text('Swap fee'), findsOneWidget);
-    expect(find.text('Review & swap'), findsOneWidget);
+    expect(find.text('Confirm swap'), findsOneWidget);
 
     await tester.ensureVisible(find.byKey(const ValueKey('swap_start_button')));
     await tester.pumpAndSettle();
@@ -4480,11 +4480,11 @@ void main() {
       );
       expect(
         find.text(
-          'Required pay exceeds available ZEC. Review a smaller target amount.',
+          "You don't have enough ZEC for this swap. Try a smaller amount.",
         ),
         findsOneWidget,
       );
-      expect(find.text('Insufficient ZEC'), findsOneWidget);
+      expect(find.text('Not enough ZEC'), findsOneWidget);
       expect(swapProvider.startedQuotes, isEmpty);
     },
   );
@@ -4680,7 +4680,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text('Quote expired. Review again for a fresh route.'),
+      find.text('Quote expired. Review again for an updated rate.'),
       findsOneWidget,
     );
     expect(find.text('Review again required'), findsNothing);
@@ -4693,10 +4693,10 @@ void main() {
 
     expect(swapProvider.requests, hasLength(2));
     expect(
-      find.text('Quote expired. Review again for a fresh route.'),
+      find.text('Quote expired. Review again for an updated rate.'),
       findsNothing,
     );
-    expect(find.text('Review & swap'), findsOneWidget);
+    expect(find.text('Confirm swap'), findsOneWidget);
   });
 
   testWidgets('quote failure shows an inline error and preserves the draft', (
@@ -5233,9 +5233,9 @@ void main() {
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
       await tester.pumpAndSettle();
-      await tester.ensureVisible(find.text('Review & swap'));
+      await tester.ensureVisible(find.text('Confirm swap'));
       await tester.pumpAndSettle();
-      await tester.tap(find.text('Review & swap'));
+      await tester.tap(find.text('Confirm swap'));
       await tester.pumpAndSettle();
 
       expect(find.text('Deposit tokens'), findsOneWidget);

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -379,7 +379,7 @@ void main() {
       final liveQuoteBadgeRect = tester.getRect(
         find.byKey(const ValueKey('swap_status_badge_liveQuote')),
       );
-      final liveQuoteTextRect = tester.getRect(find.text('Live Quote'));
+      final liveQuoteTextRect = tester.getRect(find.text('In progress'));
       expect(
         (liveQuoteTextRect.top - liveQuoteBadgeRect.top).abs(),
         lessThan(1),


### PR DESCRIPTION
## What

Applies the approved UX-copy QA findings for the **swap review** flow and the **address book / contacts** feature. Copy-only changes plus the matching widgetbook fixtures and test assertions.

## Swap review / composer
- `Review & swap` → **`Confirm swap`** (you're already on the review screen; the button starts the swap).
- `Insufficient ZEC` → **`Not enough ZEC`** (review screen **and** composer, kept consistent).
- Insufficient-balance notice → **"You don't have enough ZEC for this swap. Try a smaller amount."**
- Quote-expired notice → **"…Review again for an updated rate."**
- Live-quote-difference warning → plainer wording, and it now says "guaranteed minimum" to match the detail-row label.
- Swap-fee tooltip → smoother phrasing.

## Address book / contacts
- **Page title `Contacts` → `Address book`**, matching the sidebar nav, back link, route, and body copy. Individual entries stay "contacts" (the *Address book* contains *contacts*) — that hierarchy is intentional, so `Add contact` / `Edit contact` etc. are unchanged.
- Sentence-case fixes: `Chain & Address` → `Chain & address`, `Add Address` → `Add address`, `New Contact` → `New contact`, "…your first **Contact**?" → lowercase.
- Empty states: friendlier-but-vague headline → `No contacts yet`; standardized "No contacts found"; "Try a different search".
- Form: name field `Address label` → `Label` with a smoother hint; avatar confirm `Update` → `Use this picture`.
- Errors: "Couldn't save/remove contact." now add **"Try again."**; the address-book load error **no longer renders the raw `Details: $error`** into the UI.

## Held back (need product input — not in this PR)
- **"Guaranteed minimum"** label + the "never less" tooltip refund clause — depends on whether the protocol truly guarantees the floor (or refunds) on partial/failed fills.
- The refund address labeled **"From"** when receiving ZEC (likely "Refund to").
- **"Locking quote"** submitting label — depends on what that step actually does.
- **Chain vs. network** terminology unification on the contact form.
- Avatar picker showing **"New contact"** when *editing* an existing contact (logic/context change, not pure copy).
- **"Binance Smart Chain" → "BNB Chain"** — held because that label is coupled to swap chain identifiers (asserted in `near_intents_one_click_swap_adapter_test.dart`); needs confirmation it won't mismatch the provider.

## Also included
- A pre-existing `_ReviewNotice` icon-alignment fix that was already in the working tree on the source branch.
- `.gitignore` entries for the local copy-review artifacts (`copy-review.json`, `copy-review-viewer.html`).

## Verification
- `flutter analyze` on the touched code + tests → **No issues found**.
- `flutter test` on `address_book_screen_test.dart`, `swap_screen_test.dart`, `address_book_use_cases_test.dart` → **all pass** (117 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
