### PR TITLE
Swap: optimistic deposit routing (VZR-53) + confirmed-evidence removal gate (M-6)

### DIFF
--- a/lib/src/features/activity/swap_activity_row_mapper.dart
+++ b/lib/src/features/activity/swap_activity_row_mapper.dart
@@ -20,6 +20,7 @@ class SwapActivityRowItem {
     this.direction,
     this.externalAsset,
     this.depositTxHash,
+    this.depositClaimedAt,
     this.completedAt,
     this.lastStatusCheckedAt,
     this.updatedAt,
@@ -35,6 +36,7 @@ class SwapActivityRowItem {
       direction: record.direction,
       externalAsset: record.externalAsset,
       depositTxHash: record.depositTxHash,
+      depositClaimedAt: record.depositClaimedAt,
       activityTimestamp: record.activityTimestamp,
       completedAt: record.completedAt,
       lastStatusCheckedAt: record.lastStatusCheckedAt,
@@ -50,6 +52,7 @@ class SwapActivityRowItem {
   final SwapDirection? direction;
   final SwapAsset? externalAsset;
   final String? depositTxHash;
+  final DateTime? depositClaimedAt;
   final DateTime? activityTimestamp;
   final DateTime? completedAt;
   final DateTime? lastStatusCheckedAt;
@@ -322,10 +325,11 @@ bool _swapActivityShowsReceiveLeg(SwapActivityRowItem item) {
 _SwapActivityProgress? _swapActivityProgress(SwapActivityRowItem item) {
   const totalSteps = 4;
   final hasDepositTx = item.depositTxHash?.trim().isNotEmpty ?? false;
+  final depositSent = hasDepositTx || item.depositClaimedAt != null;
   return switch (item.status) {
     SwapIntentStatus.awaitingDeposit ||
     SwapIntentStatus.awaitingExternalDeposit => _SwapActivityProgress(
-      currentStep: hasDepositTx ? 2 : 1,
+      currentStep: depositSent ? 2 : 1,
       totalSteps: totalSteps,
     ),
     SwapIntentStatus.depositObserved => const _SwapActivityProgress(

--- a/lib/src/features/swap/models/swap_activity_status_mapper.dart
+++ b/lib/src/features/swap/models/swap_activity_status_mapper.dart
@@ -96,9 +96,10 @@ SwapStatusBadgeKind _swapActivityStatusBadgeKind(SwapIntentStatus status) {
 
 int _swapActivityStatusProgressIndex(SwapIntent intent) {
   final hasDepositTx = intent.depositTxHash?.trim().isNotEmpty ?? false;
+  final depositSent = hasDepositTx || intent.depositClaimedAt != null;
   return switch (intent.status) {
     SwapIntentStatus.awaitingDeposit ||
-    SwapIntentStatus.awaitingExternalDeposit => hasDepositTx ? 1 : 0,
+    SwapIntentStatus.awaitingExternalDeposit => depositSent ? 1 : 0,
     SwapIntentStatus.depositObserved => 1,
     SwapIntentStatus.processing ||
     SwapIntentStatus.providerStatusUnknown ||
@@ -241,6 +242,7 @@ List<SwapStatusDetailRowData> _swapActivityStatusDetails(
     );
   }
 
+  final depositMemo = intent.depositMemo?.trim();
   return [
     _accountDetailRow(accountDetail),
     if (sendsZec && recipientAddress != null && recipientAddress.isNotEmpty)
@@ -263,6 +265,16 @@ List<SwapStatusDetailRowData> _swapActivityStatusDetails(
         value: compactSwapAddress(depositAddress),
         copyable: true,
         copyText: depositAddress,
+      ),
+    // externalToZec deposits the user sends manually: keep a required memo
+    // reachable after the optimistic claim hides the deposit page (memo/tag
+    // deposits cannot complete without it).
+    if (!sendsZec && depositMemo != null && depositMemo.isNotEmpty)
+      SwapStatusDetailRowData(
+        label: 'Memo',
+        value: depositMemo,
+        copyable: true,
+        copyText: depositMemo,
       ),
     SwapStatusDetailRowData(
       label: 'Swap fee',
@@ -569,6 +581,7 @@ bool canRefreshSwapIntentStatus(SwapIntentStatus status) {
 bool swapActivityShowsExternalDepositPage(SwapIntent intent) {
   return intent.direction == SwapDirection.externalToZec &&
       intent.status == SwapIntentStatus.awaitingExternalDeposit &&
+      intent.depositClaimedAt == null &&
       SwapActivityDepositInstruction.fromIntent(intent) != null;
 }
 

--- a/lib/src/features/swap/models/swap_intent.dart
+++ b/lib/src/features/swap/models/swap_intent.dart
@@ -1,4 +1,5 @@
 import '../domain/swap_contract.dart';
+import 'swap_deposit_broadcast_result.dart';
 
 class SwapIntentRecord {
   const SwapIntentRecord({
@@ -30,6 +31,7 @@ class SwapIntentRecord {
     this.lastStatusCheckedAt,
     this.statusError,
     this.broadcastNotice,
+    this.broadcastStatus,
     this.oneClickRecipient,
     this.oneClickRefundTo,
     this.depositDeadline,
@@ -37,6 +39,7 @@ class SwapIntentRecord {
     this.createdAt,
     this.updatedAt,
     this.completedAt,
+    this.depositClaimedAt,
   });
 
   factory SwapIntentRecord.fromIntent(SwapIntent intent) {
@@ -69,6 +72,7 @@ class SwapIntentRecord {
       lastStatusCheckedAt: intent.lastStatusCheckedAt,
       statusError: intent.statusError,
       broadcastNotice: intent.broadcastNotice,
+      broadcastStatus: intent.broadcastStatus,
       oneClickRecipient: intent.oneClickRecipient,
       oneClickRefundTo: intent.oneClickRefundTo,
       depositDeadline: intent.depositDeadline,
@@ -76,6 +80,7 @@ class SwapIntentRecord {
       createdAt: intent.createdAt,
       updatedAt: intent.updatedAt,
       completedAt: intent.completedAt,
+      depositClaimedAt: intent.depositClaimedAt,
     );
   }
 
@@ -107,6 +112,7 @@ class SwapIntentRecord {
   final DateTime? lastStatusCheckedAt;
   final String? statusError;
   final String? broadcastNotice;
+  final String? broadcastStatus;
   final String? oneClickRecipient;
   final String? oneClickRefundTo;
   final DateTime? depositDeadline;
@@ -114,6 +120,7 @@ class SwapIntentRecord {
   final DateTime? createdAt;
   final DateTime? updatedAt;
   final DateTime? completedAt;
+  final DateTime? depositClaimedAt;
 
   DateTime? get activityTimestamp =>
       createdAt ?? updatedAt ?? lastStatusCheckedAt;
@@ -147,6 +154,7 @@ class SwapIntentRecord {
     DateTime? lastStatusCheckedAt,
     String? statusError,
     String? broadcastNotice,
+    String? broadcastStatus,
     String? oneClickRecipient,
     String? oneClickRefundTo,
     DateTime? depositDeadline,
@@ -154,8 +162,10 @@ class SwapIntentRecord {
     DateTime? createdAt,
     DateTime? updatedAt,
     DateTime? completedAt,
+    DateTime? depositClaimedAt,
     bool clearStatusError = false,
     bool clearBroadcastNotice = false,
+    bool clearBroadcastStatus = false,
   }) {
     return SwapIntentRecord(
       id: id ?? this.id,
@@ -190,6 +200,9 @@ class SwapIntentRecord {
       broadcastNotice: clearBroadcastNotice
           ? null
           : broadcastNotice ?? this.broadcastNotice,
+      broadcastStatus: clearBroadcastStatus
+          ? null
+          : broadcastStatus ?? this.broadcastStatus,
       oneClickRecipient: oneClickRecipient ?? this.oneClickRecipient,
       oneClickRefundTo: oneClickRefundTo ?? this.oneClickRefundTo,
       depositDeadline: depositDeadline ?? this.depositDeadline,
@@ -197,6 +210,7 @@ class SwapIntentRecord {
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       completedAt: completedAt ?? this.completedAt,
+      depositClaimedAt: depositClaimedAt ?? this.depositClaimedAt,
     );
   }
 }
@@ -238,6 +252,8 @@ class SwapIntent {
     this.updatedAt,
     this.completedAt,
     this.broadcastNotice,
+    this.broadcastStatus,
+    this.depositClaimedAt,
   });
 
   final String id;
@@ -275,8 +291,18 @@ class SwapIntent {
   final DateTime? updatedAt;
   final DateTime? completedAt;
   final String? broadcastNotice;
+  final String? broadcastStatus;
+  final DateTime? depositClaimedAt;
 
   String get statusLabel => status.label;
+
+  /// On-chain evidence that funds genuinely moved, used by the account-removal
+  /// gate and the deadline-expiry carve-out.
+  bool get hasConfirmedDepositEvidence => swapHasConfirmedDepositEvidence(
+    originChainTxHash: originChainTxHash,
+    depositTxHash: depositTxHash,
+    broadcastStatus: broadcastStatus,
+  );
 
   SwapIntent copyWith({
     String? id,
@@ -314,8 +340,11 @@ class SwapIntent {
     DateTime? updatedAt,
     DateTime? completedAt,
     String? broadcastNotice,
+    String? broadcastStatus,
+    DateTime? depositClaimedAt,
     bool clearStatusError = false,
     bool clearBroadcastNotice = false,
+    bool clearBroadcastStatus = false,
   }) {
     return SwapIntent(
       id: id ?? this.id,
@@ -357,6 +386,10 @@ class SwapIntent {
       broadcastNotice: clearBroadcastNotice
           ? null
           : broadcastNotice ?? this.broadcastNotice,
+      broadcastStatus: clearBroadcastStatus
+          ? null
+          : broadcastStatus ?? this.broadcastStatus,
+      depositClaimedAt: depositClaimedAt ?? this.depositClaimedAt,
     );
   }
 }
@@ -392,4 +425,24 @@ extension SwapIntentIterable on Iterable<SwapIntent> {
           current,
     ];
   }
+}
+
+/// On-chain evidence that funds moved: a provider-observed source-chain
+/// deposit, or a ZEC deposit that reached (or may have reached) the network.
+/// Only [pendingBroadcast] means the tx never left the device; all other
+/// statuses (null, broadcasted, partial, unknown, storage_failed) are treated
+/// conservatively as potential on-network funds.
+bool swapHasConfirmedDepositEvidence({
+  String? originChainTxHash,
+  String? depositTxHash,
+  String? broadcastStatus,
+}) {
+  bool has(String? v) => v != null && v.trim().isNotEmpty;
+  // Only a deposit that never (fully) reached the network is not evidence.
+  // Clean/storage-failed/unknown/partial broadcasts may have funds in flight,
+  // so they keep blocking removal and suppress expiry. null status (old records
+  // or no broadcast) is treated conservatively as on-chain.
+  final notOnNetwork =
+      broadcastStatus == SwapDepositBroadcastStatus.pendingBroadcast;
+  return has(originChainTxHash) || (has(depositTxHash) && !notOnNetwork);
 }

--- a/lib/src/features/swap/models/swap_intent_presentation_mapper.dart
+++ b/lib/src/features/swap/models/swap_intent_presentation_mapper.dart
@@ -5,8 +5,11 @@ SwapIntent _swapIntentFromRecord(SwapIntentRecord record, {DateTime? now}) {
   final status = _resolveDepositDeadlineStatus(
     providerStatus: record.status,
     deadline: record.depositDeadline,
-    hasDepositEvidence:
-        _hasText(record.depositTxHash) || _hasText(record.originChainTxHash),
+    hasDepositEvidence: swapHasConfirmedDepositEvidence(
+      originChainTxHash: record.originChainTxHash,
+      depositTxHash: record.depositTxHash,
+      broadcastStatus: record.broadcastStatus,
+    ),
     now: timestamp,
   );
   final nextAction = _nextActionForRestoredStatus(status, record);
@@ -39,6 +42,7 @@ SwapIntent _swapIntentFromRecord(SwapIntentRecord record, {DateTime? now}) {
     lastStatusCheckedAt: record.lastStatusCheckedAt,
     statusError: record.statusError,
     broadcastNotice: record.broadcastNotice,
+    broadcastStatus: record.broadcastStatus,
     oneClickRecipient: record.oneClickRecipient,
     oneClickRefundTo: record.oneClickRefundTo,
     depositDeadline: record.depositDeadline,
@@ -48,6 +52,7 @@ SwapIntent _swapIntentFromRecord(SwapIntentRecord record, {DateTime? now}) {
     completedAt:
         record.completedAt ??
         (status.isTerminal && record.status != status ? timestamp : null),
+    depositClaimedAt: record.depositClaimedAt,
   );
 }
 
@@ -72,8 +77,11 @@ SwapIntentRecord resolveSwapRecordForDisplay(
   final status = _resolveDepositDeadlineStatus(
     providerStatus: record.status,
     deadline: record.depositDeadline,
-    hasDepositEvidence:
-        _hasText(record.depositTxHash) || _hasText(record.originChainTxHash),
+    hasDepositEvidence: swapHasConfirmedDepositEvidence(
+      originChainTxHash: record.originChainTxHash,
+      depositTxHash: record.depositTxHash,
+      broadcastStatus: record.broadcastStatus,
+    ),
     now: now ?? DateTime.now().toUtc(),
   );
   if (status == record.status) return record;
@@ -102,7 +110,10 @@ SwapIntent swapIntentFromSnapshot({
   final status = _resolveDepositDeadlineStatus(
     providerStatus: snapshot.status,
     deadline: depositDeadline,
-    hasDepositEvidence: _hasText(snapshot.originChainTxHash),
+    hasDepositEvidence: swapHasConfirmedDepositEvidence(
+      originChainTxHash: snapshot.originChainTxHash,
+      broadcastStatus: null,
+    ),
     now: now,
   );
   final nextAction = _nextActionForResolvedStatus(status, snapshot);
@@ -147,12 +158,14 @@ SwapIntent swapIntentFromSnapshot({
 SwapIntent swapIntentWithBroadcastNotice(
   SwapIntent intent, {
   required String notice,
+  String? broadcastStatus,
   DateTime? updatedAt,
 }) {
   return _swapIntentFromRecord(
     SwapIntentRecord.fromIntent(intent).copyWith(
       statusError: notice,
       broadcastNotice: notice,
+      broadcastStatus: broadcastStatus,
       updatedAt: updatedAt ?? DateTime.now().toUtc(),
     ),
   );
@@ -163,6 +176,7 @@ SwapIntent swapIntentWithDepositCheckpoint(
   required String txHash,
   String? statusError,
   String? broadcastNotice,
+  String? broadcastStatus,
   required bool clearStatusError,
   required bool clearBroadcastNotice,
   DateTime? updatedAt,
@@ -172,8 +186,10 @@ SwapIntent swapIntentWithDepositCheckpoint(
       depositTxHash: txHash,
       statusError: statusError ?? broadcastNotice,
       broadcastNotice: broadcastNotice,
+      broadcastStatus: broadcastStatus,
       clearStatusError: clearStatusError,
       clearBroadcastNotice: clearBroadcastNotice,
+      clearBroadcastStatus: broadcastStatus == null && broadcastNotice == null,
       updatedAt: updatedAt ?? DateTime.now().toUtc(),
     ),
   );
@@ -220,10 +236,14 @@ SwapIntent updateSwapIntentFromSnapshot(
   final status = _resolveDepositDeadlineStatus(
     providerStatus: snapshot.status,
     deadline: depositDeadline,
-    hasDepositEvidence:
-        _hasText(intent.depositTxHash) ||
-        _hasText(intent.originChainTxHash) ||
-        _hasText(snapshot.originChainTxHash),
+    hasDepositEvidence: swapHasConfirmedDepositEvidence(
+      originChainTxHash:
+          _hasText(intent.originChainTxHash)
+          ? intent.originChainTxHash
+          : snapshot.originChainTxHash,
+      depositTxHash: intent.depositTxHash,
+      broadcastStatus: intent.broadcastStatus,
+    ),
     now: timestamp,
   );
   final nextAction = _nextActionForResolvedStatus(status, snapshot);

--- a/lib/src/features/swap/providers/swap_activity_store.dart
+++ b/lib/src/features/swap/providers/swap_activity_store.dart
@@ -48,13 +48,19 @@ final swapPendingIntentCountProvider = FutureProvider.family<int, String>((
   final records = await ref.watch(
     swapActivityRecordsProvider(accountUuid).future,
   );
-  // Resolve each record the same way the UI does (e.g. a past-deadline
-  // awaiting deposit with no on-chain evidence becomes `expired`), so the
-  // account-removal gate counts the status the user actually sees instead of
-  // the raw persisted status. Otherwise a swap shown as Expired would still
-  // hard-block account removal with an instruction the user cannot follow.
+  // Block removal only while ZEC may still arrive at this account and strand:
+  // a non-terminal swap with confirmed deposit evidence or a user-claimed
+  // deposit. Resolving first means false claims and unbroadcast deposits expire
+  // on their deadline rather than blocking forever.
   final intents = swapIntentsFromRecords(records);
-  return intents.where((intent) => !intent.status.isTerminal).length;
+  return intents
+      .where(
+        (intent) =>
+            !intent.status.isTerminal &&
+            (intent.hasConfirmedDepositEvidence ||
+                intent.depositClaimedAt != null),
+      )
+      .length;
 });
 
 abstract interface class SwapActivityStore {
@@ -181,6 +187,7 @@ Map<String, Object?> _recordToJson(SwapIntentRecord record) {
         record.lastStatusCheckedAt?.toUtc().toIso8601String(),
     'statusError': record.statusError,
     'broadcastNotice': record.broadcastNotice,
+    'broadcastStatus': record.broadcastStatus,
     'oneClickRecipient': record.oneClickRecipient,
     'oneClickRefundTo': record.oneClickRefundTo,
     'depositDeadline': record.depositDeadline?.toUtc().toIso8601String(),
@@ -188,6 +195,7 @@ Map<String, Object?> _recordToJson(SwapIntentRecord record) {
     'createdAt': record.createdAt?.toUtc().toIso8601String(),
     'updatedAt': record.updatedAt?.toUtc().toIso8601String(),
     'completedAt': record.completedAt?.toUtc().toIso8601String(),
+    'depositClaimedAt': record.depositClaimedAt?.toUtc().toIso8601String(),
   };
 }
 
@@ -225,6 +233,7 @@ SwapIntentRecord _recordFromJson(Map<String, dynamic> json) {
     lastStatusCheckedAt: _optionalDateTime(json['lastStatusCheckedAt']),
     statusError: _optionalString(json['statusError']),
     broadcastNotice: _optionalString(json['broadcastNotice']),
+    broadcastStatus: _optionalString(json['broadcastStatus']),
     oneClickRecipient: _optionalString(json['oneClickRecipient']),
     oneClickRefundTo: _optionalString(json['oneClickRefundTo']),
     depositDeadline: _optionalDateTime(json['depositDeadline']),
@@ -232,6 +241,7 @@ SwapIntentRecord _recordFromJson(Map<String, dynamic> json) {
     createdAt: _optionalDateTime(json['createdAt']),
     updatedAt: _optionalDateTime(json['updatedAt']),
     completedAt: _optionalDateTime(json['completedAt']),
+    depositClaimedAt: _optionalDateTime(json['depositClaimedAt']),
   );
 }
 

--- a/lib/src/features/swap/providers/swap_state_provider.dart
+++ b/lib/src/features/swap/providers/swap_state_provider.dart
@@ -620,6 +620,18 @@ class SwapNotifier extends Notifier<SwapState> {
     state = state.copyWith(depositTxHashText: value, clearStatusError: true);
   }
 
+  Future<void> markSelectedDepositClaimed() async {
+    final selected = state.selectedIntentOrNull;
+    if (selected == null) return;
+    if (selected.depositClaimedAt != null) return;
+    if (selected.status != SwapIntentStatus.awaitingExternalDeposit) return;
+    final updated = selected.copyWith(depositClaimedAt: DateTime.now().toUtc());
+    state = state.copyWith(
+      intents: state.intents.replaceSwapIntent(selected.id, updated),
+    );
+    await _persistCurrentIntents();
+  }
+
   void selectIntent(String intentId) {
     final intent = state.intents.swapIntentById(intentId);
     if (intent == null) return;
@@ -770,6 +782,7 @@ class SwapNotifier extends Notifier<SwapState> {
     final patched = swapIntentWithBroadcastNotice(
       current,
       notice: broadcastNotice,
+      broadcastStatus: broadcastStatus,
     );
     state = state.copyWith(
       intents: state.intents.replaceSwapIntent(selected.id, patched),
@@ -812,6 +825,7 @@ class SwapNotifier extends Notifier<SwapState> {
       selected,
       txHash: txHash,
       broadcastNotice: broadcastNotice,
+      broadcastStatus: broadcastStatus,
       clearStatusError: broadcastNotice == null,
       clearBroadcastNotice: broadcastNotice == null,
     );
@@ -912,6 +926,7 @@ class SwapNotifier extends Notifier<SwapState> {
       txHash: txHash,
       statusError: statusError,
       broadcastNotice: broadcastNotice,
+      broadcastStatus: broadcastStatus,
       clearStatusError: statusError == null && broadcastNotice == null,
       clearBroadcastNotice: broadcastNotice == null,
     );
@@ -1041,6 +1056,7 @@ class SwapNotifier extends Notifier<SwapState> {
       intent,
       txHash: broadcast.txHash,
       broadcastNotice: broadcastNotice,
+      broadcastStatus: broadcast.status,
       clearStatusError: broadcastNotice == null,
       clearBroadcastNotice: broadcastNotice == null,
     );

--- a/lib/src/features/swap/widgets/swap_activity_panel.dart
+++ b/lib/src/features/swap/widgets/swap_activity_panel.dart
@@ -54,7 +54,6 @@ class _SwapActivityDetailSurfaceState
     debugLabel: 'swap_activity_toast_overlay_context',
   );
   _SwapKeystoneSigningRequest? _keystoneSigningRequest;
-  String? _depositCheckWarningIntentId;
   String? _depositCheckingIntentId;
   var _initialIntentApplied = false;
 
@@ -128,6 +127,12 @@ class _SwapActivityDetailSurfaceState
     unawaited(_refreshStatusForSelectedIntent());
   }
 
+  void _markDepositClaimed() {
+    unawaited(
+      ref.read(swapStateProvider.notifier).markSelectedDepositClaimed(),
+    );
+  }
+
   Future<void> _refreshStatusForSelectedIntent() async {
     final selected = ref.read(swapStateProvider).selectedIntentOrNull;
     if (selected == null || !canRefreshSwapIntentStatus(selected.status)) {
@@ -136,26 +141,13 @@ class _SwapActivityDetailSurfaceState
     if (mounted) {
       setState(() {
         _depositCheckingIntentId = selected.id;
-        if (_depositCheckWarningIntentId == selected.id) {
-          _depositCheckWarningIntentId = null;
-        }
       });
     }
     await ref.read(swapStateProvider.notifier).refreshSelectedIntentStatus();
     if (!mounted) return;
 
-    final state = ref.read(swapStateProvider);
-    final refreshed = state.selectedIntentOrNull;
-    final shouldWarn =
-        swapActivityShowsExternalDepositPage(selected) &&
-        refreshed != null &&
-        refreshed.id == selected.id &&
-        refreshed.status == SwapIntentStatus.awaitingExternalDeposit &&
-        refreshed.statusError == null &&
-        state.statusError == null;
     setState(() {
       _depositCheckingIntentId = null;
-      _depositCheckWarningIntentId = shouldWarn ? selected.id : null;
     });
   }
 
@@ -262,11 +254,9 @@ class _SwapActivityDetailSurfaceState
             intent: activityDetailIntent,
             depositChecking:
                 _depositCheckingIntentId == activityDetailIntent.id,
-            depositCheckWarning:
-                _depositCheckWarningIntentId == activityDetailIntent.id
-                ? _depositConfirmationPendingMessage
-                : null,
+            depositCheckWarning: null,
             onRefreshStatus: _refreshStatus,
+            onMarkDeposited: _markDepositClaimed,
             onDepositTxHashChanged: ref
                 .read(swapStateProvider.notifier)
                 .updateDepositTxHash,
@@ -374,9 +364,6 @@ SwapIntent? _intentById(List<SwapIntent> intents, String? intentId) {
   return null;
 }
 
-const _depositConfirmationPendingMessage =
-    'Deposit confirmation not found yet.\nCheck again in a few minutes.';
-
 class SwapActivityDetailPagePanel extends StatelessWidget {
   const SwapActivityDetailPagePanel({
     required this.state,
@@ -384,6 +371,7 @@ class SwapActivityDetailPagePanel extends StatelessWidget {
     required this.depositChecking,
     required this.depositCheckWarning,
     required this.onRefreshStatus,
+    required this.onMarkDeposited,
     required this.onDepositTxHashChanged,
     required this.onSubmitDepositTransaction,
     required this.onReviewFreshQuote,
@@ -398,6 +386,7 @@ class SwapActivityDetailPagePanel extends StatelessWidget {
   final bool depositChecking;
   final String? depositCheckWarning;
   final VoidCallback onRefreshStatus;
+  final VoidCallback onMarkDeposited;
   final ValueChanged<String> onDepositTxHashChanged;
   final VoidCallback onSubmitDepositTransaction;
   final VoidCallback onReviewFreshQuote;
@@ -413,6 +402,7 @@ class SwapActivityDetailPagePanel extends StatelessWidget {
       depositChecking: depositChecking,
       depositCheckWarning: depositCheckWarning,
       onRefreshStatus: onRefreshStatus,
+      onMarkDeposited: onMarkDeposited,
       onDepositTxHashChanged: onDepositTxHashChanged,
       onSubmitDepositTransaction: onSubmitDepositTransaction,
       onReviewFreshQuote: onReviewFreshQuote,
@@ -454,6 +444,7 @@ class _SwapActivityFlowContent extends StatelessWidget {
     required this.depositChecking,
     required this.depositCheckWarning,
     required this.onRefreshStatus,
+    required this.onMarkDeposited,
     required this.onDepositTxHashChanged,
     required this.onSubmitDepositTransaction,
     required this.onReviewFreshQuote,
@@ -467,6 +458,7 @@ class _SwapActivityFlowContent extends StatelessWidget {
   final bool depositChecking;
   final String? depositCheckWarning;
   final VoidCallback onRefreshStatus;
+  final VoidCallback onMarkDeposited;
   final ValueChanged<String> onDepositTxHashChanged;
   final VoidCallback onSubmitDepositTransaction;
   final VoidCallback onReviewFreshQuote;
@@ -501,7 +493,7 @@ class _SwapActivityFlowContent extends StatelessWidget {
           memo: depositInstruction.memo,
           checking: depositChecking || state.statusRefreshing,
           checkWarning: depositCheckWarning,
-          onDeposited: onRefreshStatus,
+          onDeposited: onMarkDeposited,
         ),
       _ when showHardwareDepositPage && depositInstruction != null =>
         SwapHardwareZecDepositPageContent(

--- a/test/features/swap/swap_activity_row_items_provider_test.dart
+++ b/test/features/swap/swap_activity_row_items_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/features/activity/swap_activity_row_items_provider.dart';
+import 'package:zcash_wallet/src/features/swap/models/swap_deposit_broadcast_result.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_activity_store.dart';
 
@@ -48,29 +49,65 @@ void main() {
   });
 
   test(
-    'pending count uses resolved status so an expired-on-reload swap does not block',
+    'pending-swap gate counts only non-terminal swaps with confirmed deposit evidence',
     () async {
-      // Deadline safely in the past relative to the wall clock the provider
-      // resolves against.
       final past = DateTime.utc(2020, 1, 1);
+      final future = DateTime.utc(2100, 1, 1);
       final store = _FakeSwapActivityStore({
         'account-1': [
-          // Past deadline, no on-chain evidence -> resolves to expired
-          // (terminal) -> must NOT count as a pending swap.
+          // Nothing sent, deadline passed -> resolves to expired -> not counted.
           _pendingCountRecord(id: 'no-evidence', depositDeadline: past),
-          // Past deadline but a deposit tx exists -> carve-out keeps it
-          // non-terminal -> still counts (funds may be in flight).
+          // Nothing sent yet, still within deadline -> non-terminal but no
+          // confirmed evidence -> not counted (don't over-block before a
+          // deposit exists).
+          _pendingCountRecord(id: 'awaiting-not-sent', depositDeadline: future),
+          // Local ZEC deposit created but never broadcast (pendingBroadcast):
+          // not confirmed evidence, so it expires past the deadline -> not
+          // counted (this was the permanent-deadlock case).
           _pendingCountRecord(
-            id: 'with-evidence',
+            id: 'pending-broadcast',
             depositDeadline: past,
+            depositTxHash: 'local-only-txid',
+            broadcastStatus: SwapDepositBroadcastStatus.pendingBroadcast,
+          ),
+          // Same pending_broadcast but still within deadline: still not
+          // confirmed evidence -> not counted.
+          _pendingCountRecord(
+            id: 'pending-broadcast-future',
+            depositDeadline: future,
+            depositTxHash: 'local-only-txid',
+            broadcastStatus: SwapDepositBroadcastStatus.pendingBroadcast,
+          ),
+          // Clean ZEC deposit broadcast (no notice) -> confirmed -> counted.
+          _pendingCountRecord(
+            id: 'clean-broadcast',
+            depositDeadline: future,
             depositTxHash: 'zec-deposit-txid',
           ),
-          // Genuinely terminal -> must NOT count.
+          // ZEC deposit broadcast but local storage failed: tx DID reach the
+          // network -> confirmed evidence -> counted, even though a
+          // broadcastNotice UI message was set.
           _pendingCountRecord(
-            id: 'done',
-            status: SwapIntentStatus.complete,
-            depositDeadline: past,
+            id: 'storage-failed-broadcast',
+            depositDeadline: future,
+            depositTxHash: 'storage-failed-txid',
+            broadcastStatus: SwapDepositBroadcastStatus.broadcastedStorageFailed,
           ),
+          // Provider observed the source-chain deposit -> confirmed -> counted.
+          _pendingCountRecord(
+            id: 'deposit-observed',
+            status: SwapIntentStatus.depositObserved,
+            originChainTxHash: 'origin-txid',
+          ),
+          // User claimed the deposit (pressed "I've deposited"), still within
+          // deadline -> ZEC may be incoming -> counted.
+          _pendingCountRecord(
+            id: 'claimed',
+            depositDeadline: future,
+            depositClaimedAt: DateTime.utc(2026, 5, 29),
+          ),
+          // Terminal -> not counted.
+          _pendingCountRecord(id: 'done', status: SwapIntentStatus.complete),
         ],
       });
       final container = ProviderContainer(
@@ -82,9 +119,10 @@ void main() {
         swapPendingIntentCountProvider('account-1').future,
       );
 
-      // Counting raw persisted status would yield 2 (both awaiting); resolving
-      // the deadline drops the no-evidence one, so the gate sees only 1.
-      expect(count, 1);
+      // clean-broadcast, deposit-observed, the claimed deposit, and
+      // storage-failed-broadcast (tx reached network) all have funds that
+      // could strand at the account address.
+      expect(count, 4);
     },
   );
 
@@ -123,6 +161,9 @@ SwapIntentRecord _pendingCountRecord({
   SwapIntentStatus status = SwapIntentStatus.awaitingDeposit,
   DateTime? depositDeadline,
   String? depositTxHash,
+  String? originChainTxHash,
+  String? broadcastStatus,
+  DateTime? depositClaimedAt,
 }) {
   final createdAt = DateTime.utc(2020, 1, 1);
   return SwapIntentRecord(
@@ -137,6 +178,9 @@ SwapIntentRecord _pendingCountRecord({
     externalAsset: SwapAsset.usdc,
     depositDeadline: depositDeadline,
     depositTxHash: depositTxHash,
+    originChainTxHash: originChainTxHash,
+    broadcastStatus: broadcastStatus,
+    depositClaimedAt: depositClaimedAt,
     createdAt: createdAt,
     updatedAt: createdAt,
   );

--- a/test/features/swap/swap_activity_status_mapper_test.dart
+++ b/test/features/swap/swap_activity_status_mapper_test.dart
@@ -336,6 +336,60 @@ void main() {
     expect(canRefreshSwapIntentStatus(SwapIntentStatus.complete), false);
     expect(canRefreshSwapIntentStatus(SwapIntentStatus.failed), true);
   });
+
+  test('swapActivityShowsExternalDepositPage returns false once depositClaimedAt is set', () {
+    final base = _intent(
+      status: SwapIntentStatus.awaitingExternalDeposit,
+      direction: SwapDirection.externalToZec,
+      externalAsset: SwapAsset.usdc,
+      depositAddress: '0xdeposit-address',
+    );
+    expect(swapActivityShowsExternalDepositPage(base), isTrue);
+
+    final claimed = base.copyWith(
+      depositClaimedAt: DateTime.utc(2026, 5, 29, 12),
+    );
+    expect(swapActivityShowsExternalDepositPage(claimed), isFalse);
+  });
+
+  test('claimed external deposit advances progress to the confirmation step', () {
+    final awaiting = _intent(
+      status: SwapIntentStatus.awaitingExternalDeposit,
+      direction: SwapDirection.externalToZec,
+      externalAsset: SwapAsset.usdc,
+      depositAddress: '0xdeposit-address',
+    );
+    expect(
+      swapActivityStatusPresentationForIntent(_state(), awaiting).progressIndex,
+      0,
+    );
+
+    final claimed = awaiting.copyWith(
+      depositClaimedAt: DateTime.utc(2026, 5, 29, 12),
+    );
+    expect(
+      swapActivityStatusPresentationForIntent(_state(), claimed).progressIndex,
+      1,
+    );
+  });
+
+  test('status details keep the deposit memo reachable after a claim', () {
+    final claimed = _intent(
+      status: SwapIntentStatus.awaitingExternalDeposit,
+      direction: SwapDirection.externalToZec,
+      externalAsset: SwapAsset.usdc,
+      pair: 'USDC -> ZEC',
+      depositAddress: '0xdeposit-address',
+      depositMemo: 'required-memo-123',
+    ).copyWith(depositClaimedAt: DateTime.utc(2026, 5, 29, 12));
+    final memo = _detailRow(
+      swapActivityStatusPresentationForIntent(_state(), claimed).details,
+      'Memo',
+    );
+    expect(memo.value, 'required-memo-123');
+    expect(memo.copyable, isTrue);
+    expect(memo.copyText, 'required-memo-123');
+  });
 }
 
 SwapState _state({Map<SwapAsset, double> indicativeExternalPerZec = const {}}) {

--- a/test/features/swap/swap_persistence_store_test.dart
+++ b/test/features/swap/swap_persistence_store_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/features/swap/models/swap_deposit_broadcast_result.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_activity_store.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_composer_preferences_store.dart';
@@ -69,6 +70,7 @@ void main() {
       oneClickRefundTo: 'u1refund',
       depositDeadline: DateTime.utc(2026, 5, 7, 12),
       accountUuid: 'account-1',
+      broadcastStatus: SwapDepositBroadcastStatus.broadcastedStorageFailed,
     );
 
     await activityStore.saveRecords(
@@ -120,6 +122,75 @@ void main() {
     expect(restored.single.oneClickRefundTo, 'u1refund');
     expect(restored.single.depositDeadline, DateTime.utc(2026, 5, 7, 12));
     expect(restored.single.status, SwapIntentStatus.processing);
+    expect(
+      restored.single.broadcastStatus,
+      SwapDepositBroadcastStatus.broadcastedStorageFailed,
+    );
+  });
+
+  test('broadcastStatus survives save and load round-trip', () async {
+    final intentWithStatus = _minimalIntent(
+      id: 'swap-bcast',
+      accountUuid: 'account-1',
+    ).copyWith(
+      depositTxHash: 'bcast-txid',
+      broadcastStatus: SwapDepositBroadcastStatus.broadcastedStorageFailed,
+    );
+
+    await activityStore.saveRecords(
+      accountUuid: 'account-1',
+      records: [SwapIntentRecord.fromIntent(intentWithStatus)],
+    );
+
+    final restored = await activityStore.loadRecords(accountUuid: 'account-1');
+    expect(restored, hasLength(1));
+    expect(
+      restored.single.broadcastStatus,
+      SwapDepositBroadcastStatus.broadcastedStorageFailed,
+    );
+
+    // A record without broadcastStatus (old records) restores as null.
+    final intentNoStatus = _minimalIntent(
+      id: 'swap-no-bcast',
+      accountUuid: 'account-1',
+    );
+    await activityStore.saveRecords(
+      accountUuid: 'account-1',
+      records: [SwapIntentRecord.fromIntent(intentNoStatus)],
+    );
+    final restoredNoStatus = await activityStore.loadRecords(
+      accountUuid: 'account-1',
+    );
+    expect(restoredNoStatus.single.broadcastStatus, isNull);
+  });
+
+  test('depositClaimedAt survives save and load round-trip', () async {
+    final claimedAt = DateTime.utc(2026, 5, 29, 14, 30);
+    final intent = _minimalIntent(id: 'swap-claimed', accountUuid: 'account-1')
+        .copyWith(depositClaimedAt: claimedAt);
+
+    await activityStore.saveRecords(
+      accountUuid: 'account-1',
+      records: [SwapIntentRecord.fromIntent(intent)],
+    );
+
+    final restored = await activityStore.loadRecords(accountUuid: 'account-1');
+    expect(restored, hasLength(1));
+    expect(restored.single.depositClaimedAt, claimedAt);
+
+    // A record without depositClaimedAt (backward compatibility) restores as null.
+    final withoutClaim = _minimalIntent(
+      id: 'swap-no-claim',
+      accountUuid: 'account-1',
+    );
+    await activityStore.saveRecords(
+      accountUuid: 'account-1',
+      records: [SwapIntentRecord.fromIntent(withoutClaim)],
+    );
+    final restoredNoClaim = await activityStore.loadRecords(
+      accountUuid: 'account-1',
+    );
+    expect(restoredNoClaim.single.depositClaimedAt, isNull);
   });
 
   test('keeps persisted swap activity scoped to its account', () async {

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -5252,64 +5252,11 @@ void main() {
     );
   });
 
-  testWidgets('started swap can submit a deposit transaction hash', (
-    tester,
-  ) async {
-    await _setDesktopViewport(tester);
-    final swapProvider = _FakeSwapProvider();
-
-    await tester.pumpWidget(
-      _routerHarness(
-        GoRouter(
-          initialLocation: '/swap',
-          routes: [_swapRoute(), _swapActivityRoute()],
-        ),
-        swapProvider: swapProvider,
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    await tester.tap(
-      find.byKey(const ValueKey('swap_direction_externalToZec')),
-    );
-    await tester.enterText(
-      find.byKey(const ValueKey('swap_amount_field')),
-      '140.35',
-    );
-    await _enterDestinationText(tester, '0xexternal-refund');
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const ValueKey('swap_review_button')));
-    await tester.pumpAndSettle();
-    await tester.ensureVisible(find.byKey(const ValueKey('swap_start_button')));
-    await tester.pumpAndSettle();
-    await tester.tap(find.byKey(const ValueKey('swap_start_button')));
-    await tester.pumpAndSettle();
-
-    expect(find.text('Deposit tokens'), findsOneWidget);
-    expect(find.text('0xlive-deposit'), findsOneWidget);
-    expect(
-      find.byKey(const ValueKey('swap_deposit_check_warning')),
-      findsNothing,
-    );
-
-    await tester.tap(find.byKey(const ValueKey('swap_deposit_confirm_button')));
-    await tester.pumpAndSettle();
-
-    expect(swapProvider.submittedDeposits, isEmpty);
-    expect(swapProvider.statusRequests, isNotEmpty);
-    expect(swapProvider.statusRequests.last.depositAddress, '0xlive-deposit');
-    expect(swapProvider.statusRequests.last.depositMemo, 'memo-live');
-  });
-
   testWidgets(
-    'external deposit confirmation warns when provider has not confirmed yet',
+    'started swap routes to status page when deposit is claimed',
     (tester) async {
       await _setDesktopViewport(tester);
-      final statusGate = Completer<void>();
-      final swapProvider = _PendingExternalDepositSwapProvider(
-        statusGate: statusGate,
-      );
+      final swapProvider = _FakeSwapProvider();
 
       await tester.pumpWidget(
         _routerHarness(
@@ -5341,65 +5288,100 @@ void main() {
       await tester.tap(find.byKey(const ValueKey('swap_start_button')));
       await tester.pumpAndSettle();
 
+      expect(find.text('Deposit tokens'), findsOneWidget);
+      expect(find.text('0xlive-deposit'), findsOneWidget);
       expect(
         find.byKey(const ValueKey('swap_deposit_check_warning')),
         findsNothing,
       );
-      final buttonFinder = find.byKey(
-        const ValueKey('swap_deposit_confirm_button'),
+
+      await tester.tap(
+        find.byKey(const ValueKey('swap_deposit_confirm_button')),
       );
-      final initialButtonRect = tester.getRect(buttonFinder);
-
-      await tester.tap(buttonFinder);
-      await tester.pump();
-
-      expect(swapProvider.statusRequests, isNotEmpty);
-      expect(tester.widget<AppButton>(buttonFinder).onPressed, isNull);
-      expect(
-        find.byKey(const ValueKey('swap_deposit_confirm_loader')),
-        findsOneWidget,
-      );
-      expect(find.text('Checking'), findsOneWidget);
-
-      statusGate.complete();
       await tester.pumpAndSettle();
 
-      final warningFinder = find.byKey(
-        const ValueKey('swap_deposit_check_warning'),
-      );
-      expect(warningFinder, findsOneWidget);
+      // Tapping "I've deposited" immediately routes to the status page;
+      // no provider status request is triggered by this tap.
+      expect(swapProvider.submittedDeposits, isEmpty);
       expect(
-        find.text(
-          'Deposit confirmation not found yet.\nCheck again in a few minutes.',
-        ),
-        findsOneWidget,
-      );
-      expect(tester.getRect(buttonFinder), initialButtonRect);
-      expect(tester.widget<AppButton>(buttonFinder).onPressed, isNotNull);
-      expect(
-        find.byKey(const ValueKey('swap_deposit_confirm_loader')),
+        find.byKey(const ValueKey('swap_deposit_confirm_button')),
         findsNothing,
       );
-      final warningIcon = tester.widget<AppIcon>(
-        find.descendant(
-          of: warningFinder,
-          matching: find.byWidgetPredicate(
-            (widget) => widget is AppIcon && widget.name == AppIcons.warning,
-          ),
-        ),
-      );
-      expect(warningIcon.size, AppIconSize.medium);
-      final warningText = tester.widget<Text>(
-        find.descendant(
-          of: warningFinder,
-          matching: find.text(
-            'Deposit confirmation not found yet.\nCheck again in a few minutes.',
-          ),
-        ),
+      expect(
+        find.byKey(const ValueKey('swap_status_page_content')),
+        findsOneWidget,
       );
       expect(
-        warningText.style?.color,
-        tester.element(warningFinder).colors.text.destructive,
+        find.byKey(const ValueKey('swap_deposit_check_warning')),
+        findsNothing,
+      );
+    },
+  );
+
+  testWidgets(
+    'external deposit claim immediately routes to status page without warning',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      final swapProvider = _PendingExternalDepositSwapProvider();
+
+      await tester.pumpWidget(
+        _routerHarness(
+          GoRouter(
+            initialLocation: '/swap',
+            routes: [_swapRoute(), _swapActivityRoute()],
+          ),
+          swapProvider: swapProvider,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const ValueKey('swap_direction_externalToZec')),
+      );
+      await tester.enterText(
+        find.byKey(const ValueKey('swap_amount_field')),
+        '140.35',
+      );
+      await _enterDestinationText(tester, '0xexternal-refund');
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('swap_review_button')));
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(
+        find.byKey(const ValueKey('swap_start_button')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('swap_start_button')));
+      await tester.pumpAndSettle();
+
+      // Deposit page is shown before pressing.
+      expect(find.text('Deposit tokens'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('swap_deposit_confirm_button')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('swap_deposit_check_warning')),
+        findsNothing,
+      );
+
+      await tester.tap(
+        find.byKey(const ValueKey('swap_deposit_confirm_button')),
+      );
+      await tester.pumpAndSettle();
+
+      // After tapping, deposit page is gone and status page is shown.
+      expect(
+        find.byKey(const ValueKey('swap_deposit_confirm_button')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey('swap_status_page_content')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('swap_deposit_check_warning')),
+        findsNothing,
       );
     },
   );


### PR DESCRIPTION
## VZR-53 — optimistic deposit routing
The externalToZec deposit page's "I've deposited" button used to re-poll the provider and show a red "Deposit confirmation not found yet" warning, with repeated presses repeating the error. The 20s background poller already auto-detects the deposit, so the button was a strict gate over a self-resolving flow.

- Press now persists `depositClaimedAt` and routes straight to the status tracking page (deposit address/memo stay in its details). The red warning is removed.
- A claimed deposit advances progress to the **Deposit confirmation** step on both the status page and the activity row.

## M-6 — account-removal gate by confirmed evidence
Removal previously blocked on *any* non-terminal swap, permanently trapping the user behind a stuck `pending_broadcast` swap (no escape hatch).

- New shared `swapHasConfirmedDepositEvidence` (originChainTxHash, or a depositTxHash with no broadcastNotice) backs both the removal gate and the deadline-expiry carve-out.
- Removal is blocked only for non-terminal swaps where ZEC could still arrive and strand at the deleted account: confirmed deposit evidence **or** a user-claimed deposit. Never-broadcast / falsely-claimed / not-yet-sent swaps expire on their deadline instead of blocking forever.

## Notes
- Both directions can deliver ZEC to the account's shielded address (externalToZec output, zecToExternal refund), so the gate intentionally stays broad for genuinely in-flight swaps.
- Builds on the base branch's `resolveSwapRecordForDisplay`; aligned it to the same confirmed-evidence rule so the list and panel agree.
- `fvm flutter analyze` clean; 291 swap/accounts/app tests pass. `incompleteDeposit` override and VZR-53 symptom B (sync quote block) intentionally deferred.