### PR TITLE
Add address format validation and swap deposit tx failover handling

### DIFF
--- a/lib/src/core/crypto/base58check.dart
+++ b/lib/src/core/crypto/base58check.dart
@@ -1,0 +1,56 @@
+/// Base58Check decoding with double-SHA256 checksum verification, used to
+/// validate legacy (base58) Bitcoin addresses. Pure Dart over the `crypto`
+/// package (already a dependency) — no new dependency, web-safe.
+///
+/// Returns the decoded payload (version byte(s) + data, without the 4-byte
+/// checksum) when the checksum is valid, or `null` when the input is not a
+/// well-formed Base58Check string.
+library;
+
+import 'package:crypto/crypto.dart';
+
+const _alphabet =
+    '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+List<int>? _base58Decode(String input) {
+  if (input.isEmpty) return null;
+  final big58 = BigInt.from(58);
+  var num = BigInt.zero;
+  for (final unit in input.codeUnits) {
+    final idx = _alphabet.indexOf(String.fromCharCode(unit));
+    if (idx < 0) return null;
+    num = num * big58 + BigInt.from(idx);
+  }
+
+  final bytes = <int>[];
+  var n = num;
+  final mask = BigInt.from(0xff);
+  while (n > BigInt.zero) {
+    bytes.insert(0, (n & mask).toInt());
+    n = n >> 8;
+  }
+
+  // Each leading '1' in base58 represents a leading zero byte.
+  for (final unit in input.codeUnits) {
+    if (unit == 0x31 /* '1' */ ) {
+      bytes.insert(0, 0);
+    } else {
+      break;
+    }
+  }
+  return bytes;
+}
+
+/// Decodes [input] and verifies its 4-byte double-SHA256 checksum.
+/// Returns the payload (everything before the checksum) or `null` if invalid.
+List<int>? base58CheckDecode(String input) {
+  final raw = _base58Decode(input);
+  if (raw == null || raw.length < 5) return null;
+  final payload = raw.sublist(0, raw.length - 4);
+  final checksum = raw.sublist(raw.length - 4);
+  final hash = sha256.convert(sha256.convert(payload).bytes).bytes;
+  for (var i = 0; i < 4; i++) {
+    if (hash[i] != checksum[i]) return null;
+  }
+  return payload;
+}

--- a/lib/src/core/crypto/bech32.dart
+++ b/lib/src/core/crypto/bech32.dart
@@ -1,0 +1,120 @@
+/// Bech32 / Bech32m decoding with checksum verification, for validating
+/// Bitcoin native SegWit addresses (BIP-173 for witness v0, BIP-350 for v1+).
+///
+/// Faithful in-tree port of the BIP-173 / BIP-350 reference `bech32` /
+/// `segwit_addr` implementations, kept dependency-free and verified against the
+/// BIP test vectors in `test/core/crypto/bech32_test.dart`. The polymod works
+/// on values below 2^30, so it is safe on both the native and web int models.
+///
+/// References:
+///   - BIP-173 — https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+///   - BIP-350 — https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki
+library;
+
+const _charset = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l';
+const _bech32Const = 1;
+const _bech32mConst = 0x2bc830a3;
+
+int _polymod(List<int> values) {
+  const gen = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3];
+  var chk = 1;
+  for (final v in values) {
+    final b = chk >> 25;
+    chk = ((chk & 0x1ffffff) << 5) ^ v;
+    for (var i = 0; i < 5; i++) {
+      if (((b >> i) & 1) != 0) chk ^= gen[i];
+    }
+  }
+  return chk;
+}
+
+List<int> _hrpExpand(String hrp) {
+  final high = <int>[];
+  final low = <int>[];
+  for (final c in hrp.codeUnits) {
+    high.add(c >> 5);
+    low.add(c & 31);
+  }
+  return [...high, 0, ...low];
+}
+
+/// Returns the matched constant (bech32 or bech32m) or null on a bad checksum.
+int? _verifyChecksum(String hrp, List<int> data) {
+  final m = _polymod([..._hrpExpand(hrp), ...data]);
+  if (m == _bech32Const) return _bech32Const;
+  if (m == _bech32mConst) return _bech32mConst;
+  return null;
+}
+
+({String hrp, List<int> data, int spec})? _bech32Decode(String bech) {
+  for (final c in bech.codeUnits) {
+    if (c < 33 || c > 126) return null;
+  }
+  final lower = bech.toLowerCase();
+  final upper = bech.toUpperCase();
+  if (bech != lower && bech != upper) return null; // mixed case
+  final s = lower;
+  if (s.length > 90) return null;
+  final pos = s.lastIndexOf('1');
+  if (pos < 1 || pos + 7 > s.length) return null;
+  final hrp = s.substring(0, pos);
+  final data = <int>[];
+  for (final ch in s.substring(pos + 1).split('')) {
+    final v = _charset.indexOf(ch);
+    if (v == -1) return null;
+    data.add(v);
+  }
+  final spec = _verifyChecksum(hrp, data);
+  if (spec == null) return null;
+  return (hrp: hrp, data: data.sublist(0, data.length - 6), spec: spec);
+}
+
+List<int>? _convertBits(List<int> data, int from, int to, {required bool pad}) {
+  var acc = 0;
+  var bits = 0;
+  final ret = <int>[];
+  final maxv = (1 << to) - 1;
+  final maxAcc = (1 << (from + to - 1)) - 1;
+  for (final value in data) {
+    if (value < 0 || (value >> from) != 0) return null;
+    acc = ((acc << from) | value) & maxAcc;
+    bits += from;
+    while (bits >= to) {
+      bits -= to;
+      ret.add((acc >> bits) & maxv);
+    }
+  }
+  if (pad) {
+    if (bits > 0) ret.add((acc << (to - bits)) & maxv);
+  } else if (bits >= from || ((acc << (to - bits)) & maxv) != 0) {
+    return null;
+  }
+  return ret;
+}
+
+/// Decodes and checksum-validates a SegWit address for [hrp] (default `bc`,
+/// Bitcoin mainnet). Returns the witness version (0-16) and decoded program
+/// bytes, or `null` if the address is not a valid SegWit address for [hrp].
+({int version, List<int> program})? decodeSegwitAddress(
+  String address, {
+  String hrp = 'bc',
+}) {
+  final decoded = _bech32Decode(address);
+  if (decoded == null || decoded.hrp != hrp || decoded.data.isEmpty) {
+    return null;
+  }
+  final version = decoded.data[0];
+  if (version > 16) return null;
+  final program = _convertBits(decoded.data.sublist(1), 5, 8, pad: false);
+  if (program == null || program.length < 2 || program.length > 40) {
+    return null;
+  }
+  // v0 must be 20 (P2WPKH) or 32 (P2WSH) bytes.
+  if (version == 0 && program.length != 20 && program.length != 32) {
+    return null;
+  }
+  // v0 uses bech32; v1+ uses bech32m.
+  final expected = version == 0 ? _bech32Const : _bech32mConst;
+  if (decoded.spec != expected) return null;
+  return (version: version, program: program);
+}

--- a/lib/src/core/crypto/keccak256.dart
+++ b/lib/src/core/crypto/keccak256.dart
@@ -1,0 +1,110 @@
+/// Keccak-256 (the original Keccak with 0x01 domain padding used by Ethereum —
+/// NOT the standardized SHA3-256, which pads with 0x06).
+///
+/// This is a faithful in-tree port of the canonical Keccak-f[1600] sponge
+/// reference (Keccak Team reference / FIPS-202 PUB 202 specification), with the
+/// same round constants, rho rotation offsets, and rate=136 sponge as
+/// pointycastle's `KeccakDigest(256)`. It is kept dependency-free and verified
+/// against the official Keccak test vectors and the EIP-55 reference addresses
+/// in `test/core/crypto/keccak256_test.dart` /
+/// `test/features/address_book/address_format_validator_test.dart`.
+///
+/// References:
+///   - FIPS-202 (SHA-3 / Keccak) — https://doi.org/10.6028/NIST.FIPS.202
+///   - Keccak Team reference — https://keccak.team/keccak_specs_summary.html
+///
+/// Used for EIP-55 address checksum verification. Targets the native 64-bit int
+/// VM (iOS/Android/macOS); not safe on the web int model.
+library;
+
+const List<int> _roundConstants = [
+  0x0000000000000001, 0x0000000000008082,
+  0x800000000000808a, 0x8000000080008000,
+  0x000000000000808b, 0x0000000080000001,
+  0x8000000080008081, 0x8000000000008009,
+  0x000000000000008a, 0x0000000000000088,
+  0x0000000080008009, 0x000000008000000a,
+  0x000000008000808b, 0x800000000000008b,
+  0x8000000000008089, 0x8000000000008003,
+  0x8000000000008002, 0x8000000000000080,
+  0x000000000000800a, 0x800000008000000a,
+  0x8000000080008081, 0x8000000000008080,
+  0x0000000080000001, 0x8000000080008008,
+];
+
+const List<int> _rotationOffsets = [
+  0, 1, 62, 28, 27, //
+  36, 44, 6, 55, 20, //
+  3, 10, 43, 25, 39, //
+  41, 45, 15, 21, 8, //
+  18, 2, 61, 56, 14, //
+];
+
+int _rotl(int x, int n) {
+  if (n == 0) return x;
+  return (x << n) | (x >>> (64 - n));
+}
+
+void _keccakF1600(List<int> a) {
+  final c = List<int>.filled(5, 0);
+  final d = List<int>.filled(5, 0);
+  final b = List<int>.filled(25, 0);
+
+  for (var round = 0; round < 24; round++) {
+    for (var x = 0; x < 5; x++) {
+      c[x] = a[x] ^ a[x + 5] ^ a[x + 10] ^ a[x + 15] ^ a[x + 20];
+    }
+    for (var x = 0; x < 5; x++) {
+      d[x] = c[(x + 4) % 5] ^ _rotl(c[(x + 1) % 5], 1);
+    }
+    for (var x = 0; x < 5; x++) {
+      for (var y = 0; y < 25; y += 5) {
+        a[x + y] ^= d[x];
+      }
+    }
+
+    for (var x = 0; x < 5; x++) {
+      for (var y = 0; y < 5; y++) {
+        final idx = x + 5 * y;
+        final newIdx = y + 5 * ((2 * x + 3 * y) % 5);
+        b[newIdx] = _rotl(a[idx], _rotationOffsets[idx]);
+      }
+    }
+
+    for (var y = 0; y < 25; y += 5) {
+      for (var x = 0; x < 5; x++) {
+        a[x + y] = b[x + y] ^ ((~b[(x + 1) % 5 + y]) & b[(x + 2) % 5 + y]);
+      }
+    }
+
+    a[0] ^= _roundConstants[round];
+  }
+}
+
+/// Computes the Keccak-256 digest (32 bytes) of [input].
+List<int> keccak256(List<int> input) {
+  const rate = 136; // 1088-bit rate, 512-bit capacity
+  final state = List<int>.filled(25, 0);
+
+  final padLen = rate - (input.length % rate);
+  final padded = List<int>.from(input)..addAll(List<int>.filled(padLen, 0));
+  padded[input.length] ^= 0x01;
+  padded[padded.length - 1] ^= 0x80;
+
+  for (var off = 0; off < padded.length; off += rate) {
+    for (var i = 0; i < rate; i++) {
+      final lane = i ~/ 8;
+      final shift = 8 * (i % 8);
+      state[lane] ^= (padded[off + i] & 0xff) << shift;
+    }
+    _keccakF1600(state);
+  }
+
+  final out = List<int>.filled(32, 0);
+  for (var i = 0; i < 32; i++) {
+    final lane = i ~/ 8;
+    final shift = 8 * (i % 8);
+    out[i] = (state[lane] >>> shift) & 0xff;
+  }
+  return out;
+}

--- a/lib/src/features/address_book/models/address_book_contact.dart
+++ b/lib/src/features/address_book/models/address_book_contact.dart
@@ -62,8 +62,6 @@ enum AddressBookNetwork {
   static AddressBookNetwork? tryFromChainTicker(String chainTicker) {
     return tryFromId(chainTicker);
   }
-
-  static AddressBookNetwork? fromId(String id) => tryFromId(id);
 }
 
 class AddressBookContact {
@@ -135,15 +133,6 @@ class AddressBookContact {
     );
   }
 
-  static AddressBookContact fromJson(Map<String, Object?> json) {
-    final contact = tryFromJson(json);
-    if (contact == null) {
-      throw FormatException(
-        'Unsupported address book network: ${json['network']}',
-      );
-    }
-    return contact;
-  }
 }
 
 String previewAddress(String address) {

--- a/lib/src/features/address_book/models/address_format_validator.dart
+++ b/lib/src/features/address_book/models/address_format_validator.dart
@@ -1,0 +1,140 @@
+import 'dart:convert';
+
+import '../../../core/config/network_config.dart';
+import '../../../core/crypto/base58check.dart';
+import '../../../core/crypto/bech32.dart';
+import '../../../core/crypto/keccak256.dart';
+import 'address_book_contact.dart';
+
+/// Conservative, best-effort address format check keyed on [network].
+///
+/// Returns `null` when the address looks plausible for [network], when the
+/// address is empty (emptiness is handled by the dedicated non-empty
+/// validators), or when [network] has no validator — we never block a chain we
+/// do not understand. Returns a short reason otherwise.
+///
+/// The reason names the address *family*, not the chain: every EVM chain
+/// (Ethereum, Base, Arbitrum, …) shares the same 0x hex address, so the message
+/// reads "Invalid EVM address" rather than "Invalid Base address".
+///
+/// Scope: EVM family (0x + 40 hex, with EIP-55 checksum enforced on mixed-case
+/// input), Bitcoin, Solana, NEAR, and Zcash. Every other network passes
+/// through unchecked. Zcash uses a best-effort prefix/charset check restricted
+/// to the active [zcashNetwork] (defaults to the build's network), so a testnet
+/// address is rejected on mainnet and vice versa; the authoritative checksum
+/// validation lives in the Rust-backed send flow.
+String? addressFormatIssue(
+  AddressBookNetwork network,
+  String address, {
+  ZcashNetwork? zcashNetwork,
+}) {
+  final trimmed = address.trim();
+  if (trimmed.isEmpty) return null;
+
+  final (ok, kind) = switch (network) {
+    AddressBookNetwork.ethereum ||
+    AddressBookNetwork.base ||
+    AddressBookNetwork.arbitrum ||
+    AddressBookNetwork.optimism ||
+    AddressBookNetwork.polygon ||
+    AddressBookNetwork.binanceSmartChain ||
+    AddressBookNetwork.avalanche ||
+    AddressBookNetwork.gnosis ||
+    AddressBookNetwork.scroll ||
+    AddressBookNetwork.xLayer ||
+    AddressBookNetwork.plasma ||
+    AddressBookNetwork.abstractChain ||
+    AddressBookNetwork.monad ||
+    AddressBookNetwork.bera => (_isEvmAddress(trimmed), 'EVM'),
+    AddressBookNetwork.bitcoin => (_isBitcoinAddress(trimmed), 'Bitcoin'),
+    AddressBookNetwork.solana => (_isSolanaAddress(trimmed), 'Solana'),
+    AddressBookNetwork.near => (_isNearAddress(trimmed), 'NEAR'),
+    AddressBookNetwork.zcash => (
+      _isZcashAddress(
+        trimmed,
+        zcashNetwork ?? zcashNetworkFromName(kZcashDefaultNetworkName),
+      ),
+      'Zcash',
+    ),
+    _ => (true, ''),
+  };
+
+  if (ok) return null;
+  return 'Invalid $kind address';
+}
+
+final _evm = RegExp(r'^0x[0-9a-fA-F]{40}$');
+final _base58 = RegExp(r'^[1-9A-HJ-NP-Za-km-z]+$');
+final _btcLegacy = RegExp(r'^[13][a-km-zA-HJ-NP-Z1-9]{25,34}$');
+final _nearImplicit = RegExp(r'^[0-9a-f]{64}$');
+// Named accounts: lowercase alphanumeric runs joined by single separators
+// (`.`, `-`, `_`); no leading/trailing/consecutive separators.
+final _nearNamed = RegExp(r'^[a-z0-9]+([._-][a-z0-9]+)*$');
+final _bech32Body = RegExp(r'^[a-z0-9]+$');
+
+bool _isEvmAddress(String value) {
+  if (!_evm.hasMatch(value)) return false;
+  final body = value.substring(2);
+  // All-lowercase / all-uppercase carry no checksum information, so they can
+  // only be format-checked. Mixed case must satisfy the EIP-55 checksum.
+  if (body == body.toLowerCase() || body == body.toUpperCase()) return true;
+  return _isEip55Checksummed(body);
+}
+
+bool _isEip55Checksummed(String body) {
+  final hash = keccak256(ascii.encode(body.toLowerCase()));
+  for (var i = 0; i < 40; i++) {
+    final ch = body.codeUnitAt(i);
+    final isUpper = ch >= 0x41 && ch <= 0x46; // A-F
+    final isLower = ch >= 0x61 && ch <= 0x66; // a-f
+    if (!isUpper && !isLower) continue; // digits are case-agnostic
+    final hashByte = hash[i >> 1];
+    final nibble = (i & 1) == 0 ? (hashByte >> 4) : (hashByte & 0x0f);
+    final shouldBeUpper = nibble >= 8;
+    if (shouldBeUpper != isUpper) return false;
+  }
+  return true;
+}
+
+bool _isBitcoinAddress(String value) {
+  // Legacy P2PKH/P2SH: base58 format gate + base58check (double-SHA256) checksum.
+  if (_btcLegacy.hasMatch(value)) return base58CheckDecode(value) != null;
+  // Native SegWit (bech32/bech32m): full checksum verification.
+  if (value.toLowerCase().startsWith('bc1')) {
+    return decodeSegwitAddress(value) != null;
+  }
+  return false;
+}
+
+bool _isSolanaAddress(String value) =>
+    value.length >= 32 && value.length <= 44 && _base58.hasMatch(value);
+
+bool _isNearAddress(String value) {
+  if (_nearImplicit.hasMatch(value)) return true;
+  return value.length >= 2 && value.length <= 64 && _nearNamed.hasMatch(value);
+}
+
+bool _isZcashAddress(String value, ZcashNetwork net) {
+  final lower = value.toLowerCase();
+  // Bech32(m): unified + sapling addresses for this network only.
+  final bechPrefixes = [net.uaPrefix, '${net.saplingPrefix}1'];
+  for (final prefix in bechPrefixes) {
+    if (lower.startsWith(prefix)) {
+      return value.length >= 8 && _bech32Body.hasMatch(lower);
+    }
+  }
+  // Transparent base58check: P2PKH + P2SH prefixes for this network only.
+  final tPrefixes = switch (net) {
+    ZcashNetwork.mainnet => const ['t1', 't3'],
+    ZcashNetwork.testnet || ZcashNetwork.regtest => const ['tm', 't2'],
+  };
+  for (final prefix in tPrefixes) {
+    if (value.startsWith(prefix)) {
+      final body = value.substring(prefix.length);
+      if (body.length >= 25 && body.length <= 40 && _base58.hasMatch(body)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/lib/src/features/address_book/screens/address_book_screen.dart
+++ b/lib/src/features/address_book/screens/address_book_screen.dart
@@ -22,6 +22,7 @@ import '../../../core/widgets/app_toast.dart';
 import '../../send/models/send_prefill_args.dart';
 import '../../address_scan/widgets/address_qr_scan_modal.dart';
 import '../models/address_book_contact.dart';
+import '../models/address_format_validator.dart';
 import '../providers/address_book_provider.dart';
 import '../widgets/address_book_network_icon.dart';
 
@@ -1148,6 +1149,13 @@ class _ContactFormModalState extends State<_ContactFormModal> {
     final showAddressError =
         widget.draft.address.trim().isEmpty &&
         _addressController.text.trim().isNotEmpty;
+    // Soft warning: surface a chain format mismatch without blocking save.
+    final addressFormatWarning = addressFormatIssue(
+      widget.draft.network,
+      widget.draft.address,
+    );
+    final addressMessage = showAddressError ? addressError : addressFormatWarning;
+    final addressHasIssue = showAddressError || addressFormatWarning != null;
 
     return _AddressBookModalCard(
       header: _EditableContactAvatar(
@@ -1204,8 +1212,8 @@ class _ContactFormModalState extends State<_ContactFormModal> {
               ),
               trailingSlotWidth: 40,
               inputHorizontalPadding: AppSpacing.s,
-              messageText: showAddressError ? addressError : null,
-              tone: showAddressError
+              messageText: addressMessage,
+              tone: addressHasIssue
                   ? AppTextFieldTone.destructive
                   : AppTextFieldTone.neutral,
               onChanged: _emitAddress,

--- a/lib/src/features/swap/domain/swap_address_plan.dart
+++ b/lib/src/features/swap/domain/swap_address_plan.dart
@@ -50,28 +50,6 @@ class SwapAddressPlan {
   final String oneClickRecipient;
   final String oneClickRefundTo;
 
-  bool get zecDeliveryIsDirectShielded => !direction.sendsZec;
-
-  String get userInputLabel => direction.sendsZec
-      ? 'Destination'
-      : '${externalAsset.symbol} refund address';
-
-  String get userInputHint => direction.sendsZec
-      ? 'External ${externalAsset.symbol} address or account'
-      : 'Refund address on the ${externalAsset.symbol} source chain';
-
-  String get deliverySummary {
-    if (zecDeliveryIsDirectShielded) {
-      return 'ZEC arrives at your shielded address';
-    }
-    return '${externalAsset.symbol} is delivered to the external destination';
-  }
-
-  String get reviewDeliveryValue {
-    if (zecDeliveryIsDirectShielded) return 'shielded wallet address';
-    return userExternalAddress;
-  }
-
   SwapQuoteRequest toQuoteRequest({
     double? amount,
     double? sellAmount,

--- a/lib/src/features/swap/domain/swap_direction.dart
+++ b/lib/src/features/swap/domain/swap_direction.dart
@@ -18,8 +18,6 @@ extension SwapDirectionLabels on SwapDirection {
   SwapDirection get toggled =>
       sendsZec ? SwapDirection.externalToZec : SwapDirection.zecToExternal;
 
-  String get segmentLabel => sendsZec ? 'Send ZEC' : 'Receive ZEC';
-
   SwapAsset fromAsset(SwapAsset externalAsset) {
     return sendsZec ? SwapAsset.zec : externalAsset;
   }
@@ -31,9 +29,4 @@ extension SwapDirectionLabels on SwapDirection {
   String fromSymbol(SwapAsset externalAsset) => fromAsset(externalAsset).symbol;
 
   String toSymbol(SwapAsset externalAsset) => toAsset(externalAsset).symbol;
-
-  String get destinationLabel => sendsZec ? 'Destination' : 'ZEC destination';
-
-  String get destinationHint =>
-      sendsZec ? 'External address or account' : 'Account or unified address';
 }

--- a/lib/src/features/swap/models/swap_activity_status_mapper.dart
+++ b/lib/src/features/swap/models/swap_activity_status_mapper.dart
@@ -563,16 +563,6 @@ class SwapActivityDepositQrInstruction {
   final String reuseWarning;
 }
 
-bool swapActivityShowDepositControls(SwapIntentStatus status) {
-  return switch (status) {
-    SwapIntentStatus.complete ||
-    SwapIntentStatus.refunded ||
-    SwapIntentStatus.expired ||
-    SwapIntentStatus.providerStatusUnknown ||
-    SwapIntentStatus.failed => false,
-    _ => true,
-  };
-}
 
 bool canRefreshSwapIntentStatus(SwapIntentStatus status) {
   return status != SwapIntentStatus.complete;

--- a/lib/src/features/swap/models/swap_models.dart
+++ b/lib/src/features/swap/models/swap_models.dart
@@ -2,4 +2,5 @@ export '../domain/swap_address_plan.dart';
 export '../domain/swap_contract.dart';
 export 'swap_intent.dart';
 export 'swap_presentation_models.dart';
+export 'swap_slippage_formatting.dart';
 export 'swap_state.dart';

--- a/lib/src/features/swap/models/swap_slippage_formatting.dart
+++ b/lib/src/features/swap/models/swap_slippage_formatting.dart
@@ -1,0 +1,10 @@
+String formatSwapSlippage(int bps) {
+  return '${formatSwapSlippageValue(bps)}%';
+}
+
+String formatSwapSlippageValue(int bps) {
+  final value = bps / 100;
+  if (value == value.roundToDouble()) return value.toStringAsFixed(0);
+  if (bps % 10 == 0) return value.toStringAsFixed(1);
+  return value.toStringAsFixed(2);
+}

--- a/lib/src/features/swap/models/swap_state.dart
+++ b/lib/src/features/swap/models/swap_state.dart
@@ -120,10 +120,6 @@ class SwapState {
     return intent;
   }
 
-  int get openIntentCount {
-    return intents.where((intent) => !intent.status.isTerminal).length;
-  }
-
   String get walletZecPlaceholderAddress =>
       direction.sendsZec
           ? 'u1wallet-refund-placeholder'

--- a/lib/src/features/swap/models/swap_state.dart
+++ b/lib/src/features/swap/models/swap_state.dart
@@ -1,3 +1,5 @@
+import '../../address_book/models/address_book_contact.dart';
+import '../../address_book/models/address_format_validator.dart';
 import '../domain/swap_address_plan.dart';
 import '../domain/swap_contract.dart';
 import 'swap_intent.dart';
@@ -177,10 +179,26 @@ class SwapState {
           ? 'External ${externalAsset.symbol} address or account'
           : 'Refund address on the ${externalAsset.symbol} source chain';
 
+  /// Best-effort format check of [destinationText] against the external asset's
+  /// chain. Returns null when empty, when the chain has no validator, or when
+  /// the address looks valid; otherwise a short reason. Used as a hard gate on
+  /// the swap review path so a malformed recipient/refund address cannot be
+  /// committed into a 1Click quote.
+  String? get destinationAddressFormatError {
+    final trimmed = destinationText.trim();
+    if (trimmed.isEmpty) return null;
+    final network = AddressBookNetwork.tryFromChainTicker(
+      externalAsset.chainTicker,
+    );
+    if (network == null) return null;
+    return addressFormatIssue(network, trimmed);
+  }
+
   bool get canReviewQuote =>
       quoteAmount != null &&
       quoteAmountPrecisionError == null &&
       draftAddressPlan != null &&
+      destinationAddressFormatError == null &&
       !quoteLoading;
 
   bool get canSubmitDepositTx =>

--- a/lib/src/features/swap/providers/swap_deposit_sender.dart
+++ b/lib/src/features/swap/providers/swap_deposit_sender.dart
@@ -6,7 +6,7 @@ import '../../../../main.dart' show log;
 import '../../../core/storage/wallet_paths.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
-import '../../../providers/rpc_endpoint_provider.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../domain/swap_contract.dart';
@@ -44,7 +44,7 @@ class RustSwapDepositSender implements SwapDepositSender {
 
     final amountZatoshi = zecDepositAmountZatoshiForQuote(quote);
     final dbPath = await getWalletDbPath();
-    final endpoint = _ref.read(rpcEndpointProvider);
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
 
     log(
       'SwapDepositSender: preflight begin '
@@ -73,7 +73,7 @@ class RustSwapDepositSender implements SwapDepositSender {
 
     final amountZatoshi = zecDepositAmountZatoshiForQuote(quote);
     final dbPath = await getWalletDbPath();
-    final endpoint = _ref.read(rpcEndpointProvider);
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
     final sendFlowId = _newSwapSendFlowId();
     BigInt? proposalId;
     var proposalConsumed = false;

--- a/lib/src/features/swap/providers/swap_hardware_signing_service.dart
+++ b/lib/src/features/swap/providers/swap_hardware_signing_service.dart
@@ -2,7 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/storage/wallet_paths.dart';
-import '../../../providers/rpc_endpoint_provider.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../rust/api/sync.dart' as rust_sync;
@@ -68,7 +68,7 @@ class RustSwapHardwareSigningService implements SwapHardwareSigningService {
 
     final amountZatoshi = zecDepositAmountZatoshiForIntent(intent);
     final dbPath = await getWalletDbPath();
-    final endpoint = _ref.read(rpcEndpointProvider);
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
     final sendFlowId = _newSwapHardwareFlowId('deposit');
     BigInt? proposalId;
     var proposalConsumed = false;
@@ -158,7 +158,7 @@ class RustSwapHardwareSigningService implements SwapHardwareSigningService {
     String? outputParamsPath,
   }) async {
     final dbPath = await getWalletDbPath();
-    final endpoint = _ref.read(rpcEndpointProvider);
+    final endpoint = _ref.read(rpcEndpointFailoverProvider).current;
     final result = await rust_sync.extractAndBroadcastPczt(
       dbPath: dbPath,
       lightwalletdUrl: endpoint.normalizedLightwalletdUrl,

--- a/lib/src/features/swap/providers/swap_state_provider.dart
+++ b/lib/src/features/swap/providers/swap_state_provider.dart
@@ -9,6 +9,8 @@ import '../models/swap_deposit_broadcast_result.dart';
 import '../models/swap_intent_presentation_mapper.dart';
 import '../models/swap_models.dart';
 import '../../../providers/account_provider.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
+import '../../../providers/sync_provider.dart';
 import 'swap_activity_tracker.dart';
 import 'swap_deposit_sender.dart';
 import 'swap_failure_policy.dart';
@@ -466,6 +468,15 @@ class SwapNotifier extends Notifier<SwapState> {
       );
       return false;
     }
+    final quoteExpiresAt = quote.quoteExpiresAt;
+    if (quoteExpiresAt != null &&
+        !DateTime.now()
+            .toUtc()
+            .isBefore(quoteExpiresAt.subtract(const Duration(seconds: 5)))) {
+      log('Swap: start blocked; quote expired at $quoteExpiresAt');
+      expireReviewQuote();
+      return false;
+    }
     if (state.startSubmitting) {
       log('Swap: duplicate start ignored while start is already in flight');
       return false;
@@ -754,6 +765,9 @@ class SwapNotifier extends Notifier<SwapState> {
     final submitProviderStatus = _shouldSubmitProviderDepositStatus(
       broadcastStatus,
     );
+    if (!submitProviderStatus) {
+      await _switchEndpointAfterUncertainBroadcast(broadcastMessage);
+    }
     if (selected == null) {
       await _submitDepositTransactionForStoredIntent(
         accountUuid: accountUuid,
@@ -1067,6 +1081,7 @@ class SwapNotifier extends Notifier<SwapState> {
     await _persistCurrentIntents();
 
     if (!broadcast.isCertain) {
+      await _switchEndpointAfterUncertainBroadcast(broadcast.message);
       state = state.copyWith(
         depositSubmitting: false,
         intents: state.intents.replaceSwapIntent(intentId, checkpointed),
@@ -1408,6 +1423,27 @@ class SwapNotifier extends Notifier<SwapState> {
     final accountUuid = _accountUuidForIntent(intent);
     if (accountUuid == null || accountUuid.trim().isEmpty) return false;
     return ref.read(accountProvider.notifier).isHardwareAccount(accountUuid);
+  }
+
+  /// Fails over to a healthy lightwalletd endpoint after an uncertain deposit
+  /// broadcast, mirroring `send_status_screen.dart`.
+  ///
+  /// [message] MUST be the raw broadcast error detail (the `message` field
+  /// straight off the Rust broadcast result), not a remapped/friendly notice
+  /// such as the output of [_depositBroadcastNotice]. `switchToFallbackFor`
+  /// classifies the string via `shouldFallbackFromLightwalletdError`, which
+  /// keyword-matches transport errors ("connection refused", "timeout", …);
+  /// passing a localized/friendly string would silently stop failover from
+  /// ever triggering.
+  Future<void> _switchEndpointAfterUncertainBroadcast(String? message) async {
+    final trimmed = message?.trim();
+    if (trimmed == null || trimmed.isEmpty) return;
+    final switched = await ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .switchToFallbackFor(trimmed, operation: 'swap deposit broadcast');
+    if (switched) {
+      unawaited(ref.read(syncProvider.notifier).restartSync());
+    }
   }
 
   String? _depositBroadcastNotice({String? status, String? message}) {

--- a/lib/src/features/swap/screens/swap_screen.dart
+++ b/lib/src/features/swap/screens/swap_screen.dart
@@ -589,6 +589,7 @@ class _SwapReviewFooter extends StatelessWidget {
       zecAvailableZatoshi,
     );
     final needsDestinationAddress = state.destinationText.trim().isEmpty;
+    final destinationFormatError = state.destinationAddressFormatError;
     final canReview = state.canReviewQuote && !balanceExceeded;
     final onPressed = needsDestinationAddress
         ? onOpenDestinationAddress
@@ -597,11 +598,12 @@ class _SwapReviewFooter extends StatelessWidget {
         : null;
     final label = needsDestinationAddress
         ? _destinationAddressActionLabel(state)
-        : balanceExceeded
-        ? 'Not enough ZEC'
-        : state.quoteLoading
-        ? 'Getting quote'
-        : 'Get a quote';
+        : destinationFormatError ??
+              (balanceExceeded
+                  ? 'Not enough ZEC'
+                  : state.quoteLoading
+                  ? 'Getting quote'
+                  : 'Get a quote');
 
     return Center(
       child: SizedBox(

--- a/lib/src/features/swap/screens/swap_screen.dart
+++ b/lib/src/features/swap/screens/swap_screen.dart
@@ -268,7 +268,6 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                                 swapNotifier.updateReceiveAmountFiat,
                             onToggleFiatInputMode:
                                 swapNotifier.toggleFiatInputMode,
-                            onDirectionChanged: swapNotifier.selectDirection,
                             onToggleDirection: swapNotifier.toggleDirection,
                             onOpenExternalAssetPicker: _openAssetSelector,
                             onOpenDestinationAddress: _openAddressEditor,
@@ -412,7 +411,6 @@ class _SwapComposerStack extends StatelessWidget {
     required this.onReceiveAmountChanged,
     required this.onReceiveAmountFiatChanged,
     required this.onToggleFiatInputMode,
-    required this.onDirectionChanged,
     required this.onToggleDirection,
     required this.onOpenExternalAssetPicker,
     required this.onOpenDestinationAddress,
@@ -432,7 +430,6 @@ class _SwapComposerStack extends StatelessWidget {
   final ValueChanged<String> onReceiveAmountChanged;
   final ValueChanged<String> onReceiveAmountFiatChanged;
   final ValueChanged<SwapAmountInputSide> onToggleFiatInputMode;
-  final ValueChanged<SwapDirection> onDirectionChanged;
   final VoidCallback onToggleDirection;
   final VoidCallback onOpenExternalAssetPicker;
   final VoidCallback onOpenDestinationAddress;
@@ -461,7 +458,6 @@ class _SwapComposerStack extends StatelessWidget {
           onReceiveAmountChanged: onReceiveAmountChanged,
           onReceiveAmountFiatChanged: onReceiveAmountFiatChanged,
           onToggleFiatInputMode: onToggleFiatInputMode,
-          onDirectionChanged: onDirectionChanged,
           onToggleDirection: onToggleDirection,
           onOpenExternalAssetPicker: onOpenExternalAssetPicker,
           onOpenDestinationAddress: onOpenDestinationAddress,

--- a/lib/src/features/swap/widgets/swap_address_edit_modal.dart
+++ b/lib/src/features/swap/widgets/swap_address_edit_modal.dart
@@ -4,6 +4,8 @@ import 'package:flutter/widgets.dart';
 
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
+import '../../address_book/models/address_book_contact.dart';
+import '../../address_book/models/address_format_validator.dart';
 import '../models/swap_models.dart';
 import 'swap_modal_controls.dart';
 
@@ -67,7 +69,20 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
   }
 
   void _submit() {
+    // Guard the keyboard "done"/enter path the same way the primary button is
+    // gated, so a malformed address cannot be committed by pressing enter.
+    if (_formatError != null) return;
     widget.onSubmitted(_controller.text.trim(), _rememberAddress);
+  }
+
+  String? get _formatError {
+    final trimmed = _controller.text.trim();
+    if (trimmed.isEmpty) return null;
+    final network = AddressBookNetwork.tryFromChainTicker(
+      widget.state.externalAsset.chainTicker,
+    );
+    if (network == null) return null;
+    return addressFormatIssue(network, trimmed);
   }
 
   @override
@@ -86,6 +101,7 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
     final rememberLabel = sendsZec
         ? 'Remember this address for recipients'
         : 'Remember this address for refunds';
+    final formatError = _formatError;
 
     return Container(
       key: const ValueKey('swap_address_modal'),
@@ -157,6 +173,7 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
                                 focusNode: _focusNode,
                                 textInputAction: TextInputAction.done,
                                 onSubmitted: (_) => _submit(),
+                                onChanged: (_) => setState(() {}),
                                 style: AppTypography.labelLarge.copyWith(
                                   color: colors.text.accent,
                                 ),
@@ -196,6 +213,16 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
                         ],
                       ),
                     ),
+                    if (formatError != null) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        formatError,
+                        key: const ValueKey('swap_destination_format_error'),
+                        style: AppTypography.bodyMedium.copyWith(
+                          color: colors.text.destructive,
+                        ),
+                      ),
+                    ],
                     const SizedBox(height: 12),
                     Text(
                       description,
@@ -221,6 +248,7 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
             cancelKey: const ValueKey('swap_address_cancel_button'),
             onPrimary: _submit,
             onCancel: widget.onCancel,
+            primaryEnabled: formatError == null,
           ),
         ],
       ),

--- a/lib/src/features/swap/widgets/swap_composer_panel.dart
+++ b/lib/src/features/swap/widgets/swap_composer_panel.dart
@@ -18,7 +18,6 @@ class SwapComposerPanel extends StatefulWidget {
     required this.onReceiveAmountChanged,
     required this.onReceiveAmountFiatChanged,
     required this.onToggleFiatInputMode,
-    required this.onDirectionChanged,
     required this.onToggleDirection,
     required this.onOpenExternalAssetPicker,
     required this.onOpenDestinationAddress,
@@ -37,7 +36,6 @@ class SwapComposerPanel extends StatefulWidget {
   final ValueChanged<String> onReceiveAmountChanged;
   final ValueChanged<String> onReceiveAmountFiatChanged;
   final ValueChanged<SwapAmountInputSide> onToggleFiatInputMode;
-  final ValueChanged<SwapDirection> onDirectionChanged;
   final VoidCallback onToggleDirection;
   final VoidCallback onOpenExternalAssetPicker;
   final VoidCallback onOpenDestinationAddress;
@@ -321,7 +319,7 @@ class _SwapTicketFooter extends StatelessWidget {
           Expanded(child: _SwapRateInline(rateText: rateText)),
           const SizedBox(width: 8),
           _SlippageControl(
-            label: _formatSlippage(slippageBps),
+            label: formatSwapSlippage(slippageBps),
             selected: settingsOpen,
             onTap: onSettingsTap,
           ),
@@ -980,15 +978,4 @@ class _SlippageControl extends StatelessWidget {
       ),
     );
   }
-}
-
-String _formatSlippage(int bps) {
-  return '${_formatSlippageValue(bps)}%';
-}
-
-String _formatSlippageValue(int bps) {
-  final value = bps / 100;
-  if (value == value.roundToDouble()) return value.toStringAsFixed(0);
-  if (bps % 10 == 0) return value.toStringAsFixed(1);
-  return value.toStringAsFixed(2);
 }

--- a/lib/src/features/swap/widgets/swap_slippage_modal.dart
+++ b/lib/src/features/swap/widgets/swap_slippage_modal.dart
@@ -73,7 +73,7 @@ class _SwapSlippageModalState extends State<SwapSlippageModal> {
     }
     _selectedPresetBps = null;
     _customController = TextEditingController(
-      text: _formatSlippageValue(normalized),
+      text: formatSwapSlippageValue(normalized),
     );
   }
 
@@ -237,7 +237,7 @@ class _SlippageRadioCard extends StatelessWidget {
                     vertical: 4,
                   ),
                   child: Text(
-                    _formatSlippage(bps),
+                    formatSwapSlippage(bps),
                     style: AppTypography.labelLarge.copyWith(
                       color: colors.text.accent,
                     ),
@@ -450,13 +450,3 @@ class _SlippageCustomInputFormatter extends TextInputFormatter {
   }
 }
 
-String _formatSlippage(int bps) {
-  return '${_formatSlippageValue(bps)}%';
-}
-
-String _formatSlippageValue(int bps) {
-  final value = bps / 100;
-  if (value == value.roundToDouble()) return value.toStringAsFixed(0);
-  if (bps % 10 == 0) return value.toStringAsFixed(1);
-  return value.toStringAsFixed(2);
-}

--- a/lib/widgetbook/swap_use_cases.dart
+++ b/lib/widgetbook/swap_use_cases.dart
@@ -1717,9 +1717,6 @@ class _SwapComposerPreviewState extends State<_SwapComposerPreview> {
           onReceiveAmountChanged: _updateReceiveAmount,
           onReceiveAmountFiatChanged: _updateReceiveAmountFiat,
           onToggleFiatInputMode: _toggleFiatInputMode,
-          onDirectionChanged: (direction) {
-            setState(() => _state = _state.copyWith(direction: direction));
-          },
           onToggleDirection: _toggleDirection,
           onOpenExternalAssetPicker: () {
             setState(() => _assetSelectorOpen = !_assetSelectorOpen);

--- a/test/core/crypto/base58check_test.dart
+++ b/test/core/crypto/base58check_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/crypto/base58check.dart';
+
+void main() {
+  group('base58CheckDecode', () {
+    test('decodes the genesis P2PKH address (version 0x00)', () {
+      final payload = base58CheckDecode('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
+      expect(payload, isNotNull);
+      expect(payload!.first, 0x00); // mainnet P2PKH version byte
+      expect(payload, hasLength(21)); // 1 version + 20 hash160
+    });
+
+    test('decodes a P2SH address (version 0x05)', () {
+      final payload = base58CheckDecode('3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy');
+      expect(payload, isNotNull);
+      expect(payload!.first, 0x05); // mainnet P2SH version byte
+    });
+
+    test('rejects a tampered checksum', () {
+      // Genesis address with the last character changed.
+      expect(
+        base58CheckDecode('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNb'),
+        isNull,
+      );
+    });
+
+    test('rejects non-base58 characters', () {
+      expect(base58CheckDecode('1A1zP10OIl'), isNull);
+    });
+
+    test('rejects too-short input', () {
+      expect(base58CheckDecode('1111'), isNull);
+    });
+  });
+}

--- a/test/core/crypto/bech32_test.dart
+++ b/test/core/crypto/bech32_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/crypto/bech32.dart';
+
+void main() {
+  group('decodeSegwitAddress (mainnet bc)', () {
+    test('accepts a valid P2WPKH (bech32, v0)', () {
+      final r = decodeSegwitAddress(
+        'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+      );
+      expect(r, isNotNull);
+      expect(r!.version, 0);
+      expect(r.program, hasLength(20));
+    });
+
+    test('accepts a valid P2WSH (bech32, v0, 32-byte program)', () {
+      final r = decodeSegwitAddress(
+        'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3',
+      );
+      expect(r, isNotNull);
+      expect(r!.version, 0);
+      expect(r.program, hasLength(32));
+    });
+
+    test('accepts the all-uppercase form', () {
+      expect(
+        decodeSegwitAddress('BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4'),
+        isNotNull,
+      );
+    });
+
+    test('rejects a tampered checksum', () {
+      expect(
+        decodeSegwitAddress(
+          'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5',
+        ),
+        isNull,
+      );
+    });
+
+    test('rejects mixed case', () {
+      expect(
+        decodeSegwitAddress(
+          'bc1qw508d6qejxtdg4y5r3zarvarY0c5xw7kv8f3t4',
+        ),
+        isNull,
+      );
+    });
+
+    test('rejects the wrong human-readable prefix (tb = testnet)', () {
+      expect(
+        decodeSegwitAddress(
+          'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+        ),
+        isNull,
+      );
+    });
+
+    test('honours an explicit hrp override', () {
+      expect(
+        decodeSegwitAddress(
+          'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+          hrp: 'tb',
+        ),
+        isNotNull,
+      );
+    });
+  });
+}

--- a/test/core/crypto/keccak256_test.dart
+++ b/test/core/crypto/keccak256_test.dart
@@ -1,0 +1,33 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/crypto/keccak256.dart';
+
+String _hex(List<int> bytes) =>
+    bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+
+void main() {
+  group('keccak256', () {
+    test('hashes the empty input', () {
+      expect(
+        _hex(keccak256(const [])),
+        'c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470',
+      );
+    });
+
+    test('hashes "abc"', () {
+      expect(
+        _hex(keccak256(utf8.encode('abc'))),
+        '4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45',
+      );
+    });
+
+    test('hashes a multi-word message', () {
+      expect(
+        _hex(keccak256(utf8.encode('The quick brown fox jumps over the '
+            'lazy dog'))),
+        '4d741b6f1eb29cb2a9b9911c82f56fa8d73b04959d3d9d222895df6c0b28aa15',
+      );
+    });
+  });
+}

--- a/test/features/address_book/address_book_contact_test.dart
+++ b/test/features/address_book/address_book_contact_test.dart
@@ -45,11 +45,14 @@ void main() {
   });
 
   test('address book network aliases migrate earlier persisted ids', () {
-    expect(AddressBookNetwork.fromId('zcash'), AddressBookNetwork.zcash);
-    expect(AddressBookNetwork.fromId('solana'), AddressBookNetwork.solana);
-    expect(AddressBookNetwork.fromId('ethereum'), AddressBookNetwork.ethereum);
-    expect(AddressBookNetwork.fromId('usdc'), AddressBookNetwork.ethereum);
-    expect(AddressBookNetwork.fromId('futurechain'), isNull);
+    expect(AddressBookNetwork.tryFromId('zcash'), AddressBookNetwork.zcash);
+    expect(AddressBookNetwork.tryFromId('solana'), AddressBookNetwork.solana);
+    expect(
+      AddressBookNetwork.tryFromId('ethereum'),
+      AddressBookNetwork.ethereum,
+    );
+    expect(AddressBookNetwork.tryFromId('usdc'), AddressBookNetwork.ethereum);
+    expect(AddressBookNetwork.tryFromId('futurechain'), isNull);
   });
 
   test('address book contact JSON rejects unknown persisted networks', () {

--- a/test/features/address_book/address_book_screen_test.dart
+++ b/test/features/address_book/address_book_screen_test.dart
@@ -71,6 +71,66 @@ void main() {
     expect(find.text('No contacts yet'), findsNothing);
   });
 
+  testWidgets('warns about a malformed address but still allows saving', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final repo = _FakeAddressBookRepository();
+
+    await tester.pumpWidget(_addressBookHarness(repo));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey('address_book_add_contact_button')),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('address_book_contact_label_field')),
+      'Eve',
+    );
+    await tester.pump();
+
+    await tester.tap(
+      find.byKey(const ValueKey('address_book_network_selector_button')),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('address_book_network_search_field')),
+      'ethereu',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Ethereum'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('address_book_contact_address_field')),
+      '0xnope',
+    );
+    await tester.pump();
+
+    expect(
+      find.text("Invalid EVM address"),
+      findsOneWidget,
+    );
+    // Soft warning: the save button stays enabled.
+    expect(
+      tester
+          .widget<AppButton>(
+            find.byKey(const ValueKey('address_book_contact_submit_button')),
+          )
+          .onPressed,
+      isNotNull,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('address_book_contact_submit_button')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(repo.contacts, hasLength(1));
+    expect(repo.contacts.single.address, '0xnope');
+  });
+
   testWidgets('edit contact label x clears the draft label', (tester) async {
     await _setDesktopViewport(tester);
     final repo = _FakeAddressBookRepository([

--- a/test/features/address_book/address_format_validator_test.dart
+++ b/test/features/address_book/address_format_validator_test.dart
@@ -1,0 +1,483 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
+import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
+import 'package:zcash_wallet/src/features/address_book/models/address_format_validator.dart';
+
+void main() {
+  group('addressFormatIssue', () {
+    test('empty address has no opinion (handled by emptiness validators)', () {
+      expect(addressFormatIssue(AddressBookNetwork.ethereum, ''), isNull);
+      expect(addressFormatIssue(AddressBookNetwork.ethereum, '   '), isNull);
+    });
+
+    test('unsupported networks always pass', () {
+      for (final network in [
+        AddressBookNetwork.ton,
+        AddressBookNetwork.cardano,
+        AddressBookNetwork.stellar,
+        AddressBookNetwork.xrp,
+        AddressBookNetwork.sui,
+        AddressBookNetwork.dogecoin,
+      ]) {
+        expect(
+          addressFormatIssue(network, 'literally anything goes here'),
+          isNull,
+          reason: '${network.id} has no validator',
+        );
+      }
+    });
+
+    group('EVM family', () {
+      const valid = '0x52908400098527886E0F7030069857D2E4169EE7';
+      for (final network in [
+        AddressBookNetwork.ethereum,
+        AddressBookNetwork.base,
+        AddressBookNetwork.arbitrum,
+        AddressBookNetwork.optimism,
+        AddressBookNetwork.polygon,
+        AddressBookNetwork.binanceSmartChain,
+        AddressBookNetwork.avalanche,
+        AddressBookNetwork.gnosis,
+        AddressBookNetwork.scroll,
+        AddressBookNetwork.xLayer,
+        AddressBookNetwork.plasma,
+        AddressBookNetwork.abstractChain,
+        AddressBookNetwork.monad,
+        AddressBookNetwork.bera,
+      ]) {
+        test('${network.id} accepts a 0x + 40 hex address', () {
+          expect(addressFormatIssue(network, valid), isNull);
+        });
+      }
+
+      test('rejects missing 0x prefix', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.ethereum,
+            '52908400098527886E0F7030069857D2E4169EE7',
+          ),
+          contains('EVM'),
+        );
+      });
+
+      test('rejects wrong length', () {
+        expect(addressFormatIssue(AddressBookNetwork.ethereum, '0x1234'),
+            isNotNull);
+      });
+
+      test('rejects non-hex characters', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.ethereum,
+            '0xZZ908400098527886E0F7030069857D2E4169EE7',
+          ),
+          isNotNull,
+        );
+      });
+
+      test('accepts all-lowercase (no checksum info to verify)', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.ethereum,
+            '0xde709f2102306220921060314715629080e2fb77',
+          ),
+          isNull,
+        );
+      });
+
+      test('accepts correctly EIP-55 checksummed addresses', () {
+        for (final addr in [
+          '0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+          '0xfB6916095ca1df60bB79Ce92cE3Ea74c37c5d359',
+          '0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB',
+          '0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb',
+        ]) {
+          expect(
+            addressFormatIssue(AddressBookNetwork.ethereum, addr),
+            isNull,
+            reason: addr,
+          );
+        }
+      });
+
+      test('rejects a mixed-case address with a broken checksum', () {
+        // Valid address with one letter's case flipped.
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.ethereum,
+            '0x5AAeb6053F3E94C9b9A09f33669435E7Ef1BeAed',
+          ),
+          contains('EVM'),
+        );
+      });
+
+      test('accepts real-world checksummed mainnet addresses', () {
+        for (final addr in [
+          '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045', // vitalik.eth
+          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', // USDC
+          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // WETH
+          '0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D', // Uniswap V2 router
+        ]) {
+          expect(
+            addressFormatIssue(AddressBookNetwork.base, addr),
+            isNull,
+            reason: addr,
+          );
+        }
+      });
+
+      test('accepts the lowercase form of a real address', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.ethereum,
+            '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          ),
+          isNull,
+        );
+      });
+
+      test('rejects 39- and 41-hex lengths', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.ethereum,
+            '0x52908400098527886E0F7030069857D2E4169EE',
+          ),
+          isNotNull,
+        );
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.ethereum,
+            '0x52908400098527886E0F7030069857D2E4169EE77',
+          ),
+          isNotNull,
+        );
+      });
+    });
+
+    group('Bitcoin', () {
+      test('accepts P2PKH (1...)', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.bitcoin,
+            '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2',
+          ),
+          isNull,
+        );
+      });
+
+      test('accepts P2SH (3...)', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.bitcoin,
+            '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy',
+          ),
+          isNull,
+        );
+      });
+
+      test('accepts bech32 (bc1...)', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.bitcoin,
+            'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+          ),
+          isNull,
+        );
+      });
+
+      test('accepts taproot (bc1p...)', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.bitcoin,
+            'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr',
+          ),
+          isNull,
+        );
+      });
+
+      test('accepts the genesis P2PKH address', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.bitcoin,
+            '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa',
+          ),
+          isNull,
+        );
+      });
+
+      test('rejects a legacy address with a bad base58check checksum', () {
+        // Genesis P2PKH with the last character flipped (a -> b): valid base58
+        // charset and length, but the double-SHA256 checksum no longer holds.
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.bitcoin,
+            '1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNb',
+          ),
+          contains('Bitcoin'),
+        );
+      });
+
+      test('rejects a native segwit address with a bad checksum', () {
+        // Last character flipped (…f3t4 -> …f3t5): valid charset/length but the
+        // bech32 checksum no longer holds, so it must be rejected.
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.bitcoin,
+            'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5',
+          ),
+          contains('Bitcoin'),
+        );
+      });
+
+      test('rejects a testnet segwit address (tb1...) on mainnet', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.bitcoin,
+            'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
+          ),
+          isNotNull,
+        );
+      });
+
+      test('rejects mixed-case bech32', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.bitcoin,
+            'bc1qw508d6qejxtdg4y5r3zarvarY0c5xw7kv8f3t4',
+          ),
+          isNotNull,
+        );
+      });
+
+      test('rejects an EVM address', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.bitcoin,
+            '0x52908400098527886E0F7030069857D2E4169EE7',
+          ),
+          contains('Bitcoin'),
+        );
+      });
+    });
+
+    group('Zcash', () {
+      test('accepts a unified address (u1...)', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            'u1l9f0l4348negsncgr9pxd9d3qaxagmqv3lnexcplmrfn8vnnlnzfm4hd2gxn'
+            'wrdwy55q9xs8dwd56tppd0aqgg9k4n2x9p3zg3sx',
+          ),
+          isNull,
+        );
+      });
+
+      test('accepts a transparent address (t1...)', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            't1RT8gKM9Q5b3VgVbNFhUgGfYwhzaQ4r7d',
+          ),
+          isNull,
+        );
+      });
+
+      test('accepts a sapling address (zs1...)', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            'zs1z7rejlpsa98s2rrrfkwmaxu53e4ue0ulcrw0h4x5g8jl04tak0d3mm47'
+            'vdtahatqrlkngh9sly',
+          ),
+          isNull,
+        );
+      });
+
+      test('accepts a P2SH transparent address (t3...)', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            't3Vz22vK5z2LcKEdg16Yv4FFneEL1zg9ojd',
+          ),
+          isNull,
+        );
+      });
+
+      test('rejects an EVM address tagged as Zcash', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            '0x52908400098527886E0F7030069857D2E4169EE7',
+          ),
+          contains('Zcash'),
+        );
+      });
+
+      test('rejects obvious garbage', () {
+        expect(
+          addressFormatIssue(AddressBookNetwork.zcash, 'not an address'),
+          isNotNull,
+        );
+      });
+
+      test('on mainnet, rejects testnet-prefixed addresses', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            'utest1qpw508d6qejxtdg4y5r3zarvary0c5xw7kqqqqqq',
+            zcashNetwork: ZcashNetwork.mainnet,
+          ),
+          isNotNull,
+        );
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            'tmRT8gKM9Q5b3VgVbNFhUgGfYwhzaQ4r7d',
+            zcashNetwork: ZcashNetwork.mainnet,
+          ),
+          isNotNull,
+        );
+      });
+
+      test('honours the active Zcash network for its own prefixes', () {
+        const testnetUa =
+            'utest1qpw508d6qejxtdg4y5r3zarvary0c5xw7kqqqqqq';
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            testnetUa,
+            zcashNetwork: ZcashNetwork.testnet,
+          ),
+          isNull,
+        );
+        // A mainnet UA is not valid on testnet.
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            't1RT8gKM9Q5b3VgVbNFhUgGfYwhzaQ4r7d',
+            zcashNetwork: ZcashNetwork.testnet,
+          ),
+          isNotNull,
+        );
+      });
+    });
+
+    group('Solana', () {
+      test('accepts a base58 32-44 char address', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.solana,
+            '7EYnhQoR9YM3N7UoaKRoA44Uy8JeaZV3qyouov87awMs',
+          ),
+          isNull,
+        );
+      });
+
+      test('rejects an EVM 0x address', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.solana,
+            '0x52908400098527886E0F7030069857D2E4169EE7',
+          ),
+          contains('Solana'),
+        );
+      });
+
+      test('accepts real-world mint addresses', () {
+        for (final addr in [
+          'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v', // USDC mint
+          'So11111111111111111111111111111111111111112', // wrapped SOL
+        ]) {
+          expect(
+            addressFormatIssue(AddressBookNetwork.solana, addr),
+            isNull,
+            reason: addr,
+          );
+        }
+      });
+
+      test('rejects too-short input', () {
+        expect(addressFormatIssue(AddressBookNetwork.solana, 'abc'), isNotNull);
+      });
+
+      test('rejects input longer than 44 chars', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.solana,
+            '7EYnhQoR9YM3N7UoaKRoA44Uy8JeaZV3qyouov87awMs7EYnh',
+          ),
+          isNotNull,
+        );
+      });
+
+      test('rejects non-base58 characters (0, O, I, l)', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.solana,
+            '0OIl00000000000000000000000000000000',
+          ),
+          isNotNull,
+        );
+      });
+    });
+
+    group('NEAR', () {
+      test('accepts an implicit 64-hex account', () {
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.near,
+            '98793cd91a3f870fb126f66285808c7e094afcfc4eda8a970f6648cdf0dbdb24',
+          ),
+          isNull,
+        );
+      });
+
+      test('accepts named and sub-accounts', () {
+        for (final acct in [
+          'alice.near',
+          'app.sub.near',
+          'aurora',
+          'token.sweat',
+          'app.nearcrowd.near',
+          'root.near',
+          'a.b',
+        ]) {
+          expect(
+            addressFormatIssue(AddressBookNetwork.near, acct),
+            isNull,
+            reason: acct,
+          );
+        }
+      });
+
+      test('rejects uppercase / invalid characters', () {
+        expect(
+            addressFormatIssue(AddressBookNetwork.near, 'Alice.NEAR'), isNotNull);
+        expect(addressFormatIssue(AddressBookNetwork.near, 'a'), isNotNull);
+      });
+
+      test('rejects an over-long named account (>64)', () {
+        expect(
+          addressFormatIssue(AddressBookNetwork.near, '${'a' * 65}.near'),
+          isNotNull,
+        );
+      });
+
+      test('rejects consecutive / leading / trailing separators', () {
+        for (final acct in [
+          'foo..bar.near', // consecutive dots
+          'a--b', // consecutive dashes
+          'app_.near', // separator adjacent to dot
+          '.alice.near', // leading separator
+          'alice.near.', // trailing separator
+        ]) {
+          expect(
+            addressFormatIssue(AddressBookNetwork.near, acct),
+            isNotNull,
+            reason: acct,
+          );
+        }
+      });
+    });
+  });
+}

--- a/test/features/swap/support/swap_screen_test_fakes.dart
+++ b/test/features/swap/support/swap_screen_test_fakes.dart
@@ -24,6 +24,7 @@ class _FakeSwapSyncNotifier extends SyncNotifier {
   _FakeSwapSyncNotifier(this.spendableBalance);
 
   final BigInt spendableBalance;
+  var restartCount = 0;
 
   @override
   Future<SyncState> build() async => SyncState(
@@ -32,6 +33,11 @@ class _FakeSwapSyncNotifier extends SyncNotifier {
     spendableBalance: spendableBalance,
     totalBalance: spendableBalance,
   );
+
+  @override
+  Future<void> restartSync() async {
+    restartCount++;
+  }
 }
 
 class _FakeSwapMaxAmountEstimator implements SwapMaxAmountEstimator {
@@ -64,8 +70,11 @@ class _CompletingSwapMaxAmountEstimator implements SwapMaxAmountEstimator {
 }
 
 class _FakeSwapProvider implements SwapProvider {
-  _FakeSwapProvider({List<SwapAsset>? supportedAssets, this.submitDepositError})
-    : supportedAssets = supportedAssets ?? swapExternalAssets;
+  _FakeSwapProvider({
+    List<SwapAsset>? supportedAssets,
+    this.submitDepositError,
+    this.quoteExpiresAt,
+  }) : supportedAssets = supportedAssets ?? swapExternalAssets;
 
   final requests = <SwapQuoteRequest>[];
   final startedQuotes = <SwapQuote>[];
@@ -73,6 +82,10 @@ class _FakeSwapProvider implements SwapProvider {
   final submittedDeposits = <_SubmittedDeposit>[];
   final List<SwapAsset> supportedAssets;
   final Object? submitDepositError;
+
+  /// When set, every quote carries this expiry so tests can exercise the
+  /// review-quote expiry guard in [SwapNotifier.startIntent].
+  final DateTime? quoteExpiresAt;
 
   @override
   String get providerLabel => 'NEAR Intents';
@@ -109,6 +122,7 @@ class _FakeSwapProvider implements SwapProvider {
         estimate.sellAmount,
       ),
       providerQuoteId: 'quote-live',
+      quoteExpiresAt: quoteExpiresAt,
       providerRefundInfo:
           request.mode == SwapQuoteMode.exactOutput
               ? const SwapProviderRefundInfo(

--- a/test/features/swap/swap_activity_status_mapper_test.dart
+++ b/test/features/swap/swap_activity_status_mapper_test.dart
@@ -328,11 +328,6 @@ void main() {
       isTrue,
     );
 
-    expect(swapActivityShowDepositControls(SwapIntentStatus.processing), true);
-    expect(
-      swapActivityShowDepositControls(SwapIntentStatus.providerStatusUnknown),
-      false,
-    );
     expect(canRefreshSwapIntentStatus(SwapIntentStatus.complete), false);
     expect(canRefreshSwapIntentStatus(SwapIntentStatus.failed), true);
   });

--- a/test/features/swap/swap_address_plan_test.dart
+++ b/test/features/swap/swap_address_plan_test.dart
@@ -15,12 +15,6 @@ void main() {
 
       expect(plan.oneClickRecipient, '0xrecipient');
       expect(plan.oneClickRefundTo, 'u1wallet-refund');
-      expect(plan.userInputLabel, 'Destination');
-      expect(plan.userInputHint, 'External USDC address or account');
-      expect(
-        plan.deliverySummary,
-        'USDC is delivered to the external destination',
-      );
       expect(plan.toQuoteRequest(sellAmount: 1.5).destination, '0xrecipient');
       expect(
         plan.toQuoteRequest(sellAmount: 1.5).refundAddress,
@@ -47,14 +41,6 @@ void main() {
 
     expect(plan.oneClickRecipient, 'u1wallet-recipient');
     expect(plan.oneClickRefundTo, '0xrefund');
-    expect(plan.userInputLabel, 'USDC refund address');
-    expect(plan.userInputHint, 'Refund address on the USDC source chain');
-    expect(plan.zecDeliveryIsDirectShielded, isTrue);
-    expect(
-      plan.deliverySummary,
-      'ZEC arrives at your shielded address',
-    );
-    expect(plan.reviewDeliveryValue, 'shielded wallet address');
     expect(
       plan.toQuoteRequest(sellAmount: 140.35).destination,
       'u1wallet-recipient',

--- a/test/features/swap/swap_contract_test.dart
+++ b/test/features/swap/swap_contract_test.dart
@@ -2,12 +2,14 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
 
 void main() {
+  const validEvmRecipient = '0x52908400098527886E0F7030069857D2E4169EE7';
+
   test('blocks review when token amount exceeds asset decimals', () {
     const state = SwapState(
       direction: SwapDirection.zecToExternal,
       amountText: '',
       receiveAmountText: '105.1234567',
-      destinationText: '0xrecipient',
+      destinationText: validEvmRecipient,
       externalAsset: SwapAsset.usdc,
       reviewVisible: false,
       intents: [],
@@ -24,6 +26,28 @@ void main() {
 
     expect(valid.quoteAmountPrecisionError, isNull);
     expect(valid.canReviewQuote, isTrue);
+  });
+
+  test('blocks review when destination address format is invalid for chain',
+      () {
+    const state = SwapState(
+      direction: SwapDirection.zecToExternal,
+      amountText: '',
+      receiveAmountText: '105.123456',
+      destinationText: '0xrecipient',
+      externalAsset: SwapAsset.usdc,
+      reviewVisible: false,
+      intents: [],
+      quoteMode: SwapQuoteMode.exactOutput,
+    );
+
+    expect(state.destinationAddressFormatError, isNotNull);
+    expect(state.canReviewQuote, isFalse);
+
+    final fixed = state.copyWith(destinationText: validEvmRecipient);
+
+    expect(fixed.destinationAddressFormatError, isNull);
+    expect(fixed.canReviewQuote, isTrue);
   });
 
   test(

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -42,6 +42,7 @@ import 'package:zcash_wallet/src/features/swap/widgets/swap_status_page_content.
 import 'package:zcash_wallet/src/features/swap/widgets/swap_summary_amount_text.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/receive_address_provider.dart';
+import 'package:zcash_wallet/src/providers/rpc_endpoint_failover_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
@@ -1529,6 +1530,125 @@ void main() {
     );
   });
 
+  testWidgets('swap address modal blocks a malformed recipient address', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        seedSwapActivityFixtures: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_destination_field')),
+      '0xnope',
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text("Invalid EVM address"),
+      findsOneWidget,
+    );
+    final blockedButton = tester.widget<AppButton>(
+      find.byKey(const ValueKey('swap_address_update_button')),
+    );
+    expect(blockedButton.onPressed, isNull);
+
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_destination_field')),
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text("Invalid EVM address"),
+      findsNothing,
+    );
+    final allowedButton = tester.widget<AppButton>(
+      find.byKey(const ValueKey('swap_address_update_button')),
+    );
+    expect(allowedButton.onPressed, isNotNull);
+
+    await tester.tap(find.byKey(const ValueKey('swap_address_update_button')));
+    await tester.pumpAndSettle();
+
+    expect(_destinationSummaryText(tester), '0x529084...169ee7');
+  });
+
+  testWidgets('swap address modal ignores keyboard submit of a bad address', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        seedSwapActivityFixtures: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_destination_field')),
+      '0xnope',
+    );
+    await tester.pumpAndSettle();
+
+    // Pressing keyboard "done" must not commit the malformed address.
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('swap_address_modal')), findsOneWidget);
+    expect(_destinationSummaryText(tester), isEmpty);
+  });
+
+  testWidgets('swap review button surfaces an invalid destination address', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        seedSwapActivityFixtures: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Simulate a non-modal path (contact picker / retry) setting a malformed
+    // address directly into state.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(SwapScreen)),
+      listen: false,
+    );
+    container.read(swapStateProvider.notifier).updateDestination('0xnope');
+    await tester.pumpAndSettle();
+
+    expect(find.text('Invalid EVM address'), findsOneWidget);
+    final button = tester.widget<AppButton>(
+      find.byKey(const ValueKey('swap_review_button')),
+    );
+    expect(button.onPressed, isNull);
+  });
+
   testWidgets('swap address modal loads recipient address from contacts', (
     tester,
   ) async {
@@ -1546,7 +1666,7 @@ void main() {
             id: 'usdc',
             label: 'USDC Friend',
             network: AddressBookNetwork.ethereum,
-            address: '0xusdc-recipient',
+            address: '0xd1220a0cf47c7b9be7a2e6ba89f429762e7b9adb',
           ),
           _addressBookContact(
             id: 'zcash',
@@ -1582,7 +1702,7 @@ void main() {
       find.byKey(const ValueKey('address_book_contact_picker_modal')),
       findsNothing,
     );
-    expect(_destinationSummaryText(tester), '0xusdc-recipient');
+    expect(_destinationSummaryText(tester), '0xd1220a...7b9adb');
   });
 
   testWidgets('swap address modal remembers submitted recipient', (
@@ -1607,7 +1727,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.enterText(
       find.byKey(const ValueKey('swap_destination_field')),
-      '0xremembered-recipient',
+      '0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb',
     );
     await tester.tap(
       find.byKey(const ValueKey('swap_address_remember_toggle')),
@@ -1619,7 +1739,7 @@ void main() {
     expect(addressBookRepository.contacts, hasLength(1));
     expect(
       addressBookRepository.contacts.single.address,
-      '0xremembered-recipient',
+      '0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb',
     );
     expect(
       addressBookRepository.contacts.single.network,
@@ -1652,13 +1772,13 @@ void main() {
             id: 'base',
             label: 'Base USDC Friend',
             network: AddressBookNetwork.base,
-            address: '0xbase-usdc-recipient',
+            address: '0xdc2d3454f7baf9f15c98e8f5d6a3cb5a5f1b2c3d',
           ),
           _addressBookContact(
             id: 'ethereum',
             label: 'Ethereum USDC Friend',
             network: AddressBookNetwork.ethereum,
-            address: '0xeth-usdc-recipient',
+            address: '0x583031d1113ad414f02576bd6afabfb302140225',
           ),
         ]),
       ),
@@ -1829,7 +1949,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -1895,7 +2015,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await container.read(accountProvider.notifier).switchAccount('account-2');
@@ -2117,7 +2237,7 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '1',
       );
-      await _enterDestinationText(tester, '0xrecipient');
+      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
       await tester.pumpAndSettle();
 
       expect(find.text('Max: 1 ZEC'), findsOneWidget);
@@ -2444,7 +2564,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -2529,7 +2649,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -2626,7 +2746,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '0.01',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     expect(swapProvider.pricingRequests, 1);
@@ -2661,7 +2781,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     expect(_fieldText(tester, 'swap_receive_amount_field'), '100.00');
@@ -2699,7 +2819,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     expect(_fieldText(tester, 'swap_receive_amount_field'), '100.00');
@@ -2737,7 +2857,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4042,7 +4162,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
@@ -4086,7 +4206,7 @@ void main() {
       depositMemo:
           'memo-with-a-long-routing-tag-and-provider-reference-9876543210',
       oneClickRefundTo:
-          '0xrefund-address-with-a-very-long-source-chain-suffix-abcdef1234567890',
+          '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359',
     );
 
     await tester.pumpWidget(
@@ -4142,7 +4262,7 @@ void main() {
     );
     await _enterDestinationText(
       tester,
-      '0xrefund-address-with-a-very-long-source-chain-suffix-abcdef1234567890',
+      '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359',
     );
     await tester.pumpAndSettle();
 
@@ -4189,7 +4309,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '0.002',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4239,7 +4359,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xabc123');
+    await _enterDestinationText(tester, '0xde709f2102306220921060314715629080e2fb77');
     await tester.pumpAndSettle();
 
     expect(_fieldText(tester, 'swap_receive_amount_field'), '105.26');
@@ -4247,7 +4367,7 @@ void main() {
     expect(find.byKey(const ValueKey('swap_rate_line')), findsOneWidget);
     expect(find.byKey(const ValueKey('swap_address_summary')), findsOneWidget);
     expect(find.text('Ethereum recipient'), findsNothing);
-    expect(find.text('0xabc123'), findsWidgets);
+    expect(find.text('0xde709f...e2fb77'), findsWidgets);
     expect(find.text('Settlement path'), findsNothing);
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4406,7 +4526,7 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '1.5',
       );
-      await _enterDestinationText(tester, '0xrecipient');
+      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4419,7 +4539,7 @@ void main() {
       expect(request.externalAsset, SwapAsset.usdc);
       expect(request.sellAmount, 1.5);
       expect(request.sellAmountText, '1.5');
-      expect(request.destination, '0xrecipient');
+      expect(request.destination, '0x52908400098527886e0f7030069857d2e4169ee7');
       expect(request.refundAddress, 'u1actualshieldedrecipient');
 
       expect(find.byKey(const ValueKey('swap_review_panel')), findsOneWidget);
@@ -4448,7 +4568,7 @@ void main() {
       final reviewDetails = find.byKey(const ValueKey('swap_review_details'));
       final reviewDetailsRect = tester.getRect(reviewDetails);
       final recipientValueRect = tester.getRect(
-        find.descendant(of: reviewDetails, matching: find.text('0xrecipient')),
+        find.descendant(of: reviewDetails, matching: find.text('0x5290840 ... 4169ee7')),
       );
       final feeValueRect = tester.getRect(
         find.descendant(
@@ -4502,7 +4622,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '105',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     expect(_fieldText(tester, 'swap_amount_field'), '105');
@@ -4519,7 +4639,7 @@ void main() {
     expect(liveRequest.amount, 1.5);
     expect(liveRequest.amountText, '1.5000');
     expect(liveRequest.amountAsset, SwapAsset.zec);
-    expect(liveRequest.destination, '0xrecipient');
+    expect(liveRequest.destination, '0x52908400098527886e0f7030069857d2e4169ee7');
   });
 
   testWidgets('token amount fields cap fractional digits by asset decimals', (
@@ -4593,7 +4713,7 @@ void main() {
       find.byKey(const ValueKey('swap_receive_amount_field')),
       '105.26',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     expect(_fieldText(tester, 'swap_receive_amount_field'), '105.26');
@@ -4624,7 +4744,7 @@ void main() {
         find.byKey(const ValueKey('swap_receive_amount_field')),
         '105.27',
       );
-      await _enterDestinationText(tester, '0xrecipient');
+      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
       await tester.pumpAndSettle();
 
       expect(_fieldText(tester, 'swap_receive_amount_field'), '105.27');
@@ -4640,7 +4760,7 @@ void main() {
       expect(liveRequest.mode, SwapQuoteMode.exactOutput);
       expect(liveRequest.amount, 105.27);
       expect(liveRequest.amountText, '105.27');
-      expect(liveRequest.destination, '0xrecipient');
+      expect(liveRequest.destination, '0x52908400098527886e0f7030069857d2e4169ee7');
       expect(liveRequest.refundAddress, 'u1actualshieldedrecipient');
       expect(find.text('Review swap'), findsOneWidget);
       expect(find.text('Slippage tolerance'), findsOneWidget);
@@ -4670,7 +4790,7 @@ void main() {
         find.byKey(const ValueKey('swap_receive_amount_field')),
         '105.26',
       );
-      await _enterDestinationText(tester, '0xrecipient');
+      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4727,7 +4847,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4773,7 +4893,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4790,7 +4910,7 @@ void main() {
 
     expect(find.text('Review swap'), findsNothing);
     expect(_fieldText(tester, 'swap_amount_field'), '1.5');
-    expect(_destinationSummaryText(tester), '0xrecipient');
+    expect(_destinationSummaryText(tester), '0x529084...169ee7');
   });
 
   testWidgets('quote loading separates draft estimate from live review', (
@@ -4814,7 +4934,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('swap_rate_line')), findsOneWidget);
@@ -4886,7 +5006,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4919,6 +5039,142 @@ void main() {
     expect(find.text('Confirm swap'), findsOneWidget);
   });
 
+  testWidgets('startIntent blocks a quote whose deadline has already passed', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final swapProvider = _FakeSwapProvider(
+      quoteExpiresAt: DateTime.utc(2020, 1, 1),
+    );
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        swapProvider: swapProvider,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_amount_field')),
+      '1.5',
+    );
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_review_button')));
+    await tester.pumpAndSettle();
+    expect(swapProvider.requests, hasLength(1));
+
+    final notifier = ProviderScope.containerOf(
+      tester.element(find.byType(SwapReviewScreen)),
+    ).read(swapStateProvider.notifier);
+
+    final started = await notifier.startIntent();
+    await tester.pumpAndSettle();
+
+    expect(started, isFalse);
+    expect(swapProvider.startedQuotes, isEmpty);
+    expect(
+      find.text('Quote expired. Review again for an updated rate.'),
+      findsOneWidget,
+    );
+    expect(find.byType(SwapActivityDetailScreen), findsNothing);
+  });
+
+  testWidgets('startIntent blocks a quote inside the expiry safety buffer', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    // Within the 5s pre-deadline buffer in SwapNotifier.startIntent.
+    final swapProvider = _FakeSwapProvider(
+      quoteExpiresAt: DateTime.now().toUtc().add(const Duration(seconds: 2)),
+    );
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        swapProvider: swapProvider,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_amount_field')),
+      '1.5',
+    );
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_review_button')));
+    await tester.pumpAndSettle();
+
+    final notifier = ProviderScope.containerOf(
+      tester.element(find.byType(SwapReviewScreen)),
+    ).read(swapStateProvider.notifier);
+
+    final started = await notifier.startIntent();
+    await tester.pumpAndSettle();
+
+    expect(started, isFalse);
+    expect(swapProvider.startedQuotes, isEmpty);
+  });
+
+  testWidgets('startIntent allows a quote whose deadline is in the future', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final swapProvider = _FakeSwapProvider(
+      quoteExpiresAt: DateTime.now().toUtc().add(const Duration(hours: 1)),
+    );
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        swapProvider: swapProvider,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_amount_field')),
+      '1.5',
+    );
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_review_button')));
+    await tester.pumpAndSettle();
+
+    final notifier = ProviderScope.containerOf(
+      tester.element(find.byType(SwapReviewScreen)),
+    ).read(swapStateProvider.notifier);
+
+    final started = await notifier.startIntent();
+    await tester.pumpAndSettle();
+
+    expect(started, isTrue);
+    expect(swapProvider.startedQuotes, hasLength(1));
+  });
+
   testWidgets('quote failure shows an inline error and preserves the draft', (
     tester,
   ) async {
@@ -4939,7 +5195,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4956,7 +5212,7 @@ void main() {
       findsOneWidget,
     );
     expect(_fieldText(tester, 'swap_amount_field'), '1.5');
-    expect(_destinationSummaryText(tester), '0xrecipient');
+    expect(_destinationSummaryText(tester), '0x529084...169ee7');
   });
 
   testWidgets('start failure stays on review and shows an inline error', (
@@ -4980,7 +5236,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5028,12 +5284,12 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '140.35',
     );
-    await _enterDestinationText(tester, '0xexternal-refund');
+    await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
     await tester.pumpAndSettle();
 
     expect(find.text('Ethereum refund'), findsNothing);
     expect(find.byKey(const ValueKey('swap_address_summary')), findsOneWidget);
-    expect(find.text('0xexternal-refund'), findsWidgets);
+    expect(find.text('0x8617e3...38070d'), findsWidgets);
     expect(find.text('ZEC delivery'), findsNothing);
     expect(find.text('u1wallet-refund-placeholder'), findsNothing);
     expect(find.text('USDC source deposit'), findsNothing);
@@ -5106,7 +5362,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5145,7 +5401,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '140.35',
     );
-    await _enterDestinationText(tester, '0xexternal-refund');
+    await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5157,7 +5413,7 @@ void main() {
       swapProvider.requests.single.destination,
       'u1actualshieldedrecipient',
     );
-    expect(swapProvider.requests.single.refundAddress, '0xexternal-refund');
+    expect(swapProvider.requests.single.refundAddress, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
     expect(find.text('Review swap'), findsOneWidget);
     expect(
       find.textContaining('ZEC arrives at your shielded address'),
@@ -5190,7 +5446,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '140.35',
     );
-    await _enterDestinationText(tester, '0xexternal-refund');
+    await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5206,7 +5462,7 @@ void main() {
       swapProvider.requests.single.destination,
       isNot(_hardwareBootstrap.initialAccountState.activeAddress),
     );
-    expect(swapProvider.requests.single.refundAddress, '0xexternal-refund');
+    expect(swapProvider.requests.single.refundAddress, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
   });
 
   testWidgets('started swap can refresh status from provider', (tester) async {
@@ -5228,7 +5484,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5276,7 +5532,7 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '140.35',
       );
-      await _enterDestinationText(tester, '0xexternal-refund');
+      await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5342,7 +5598,7 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '140.35',
       );
-      await _enterDestinationText(tester, '0xexternal-refund');
+      await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5427,7 +5683,7 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '140.35',
       );
-      await _enterDestinationText(tester, '0xexternal-refund');
+      await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5550,7 +5806,7 @@ void main() {
       );
       expect(
         sessionStore.savedIntents.single.oneClickRefundTo,
-        '0xexternal-refund',
+        '0x8617e340b3d01fa5f11f306f4090fd50e238070d',
       );
     },
   );
@@ -5580,7 +5836,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5616,14 +5872,14 @@ void main() {
       sessionStore.savedIntents.single.direction,
       SwapDirection.zecToExternal,
     );
-    expect(sessionStore.savedIntents.single.oneClickRecipient, '0xrecipient');
+    expect(sessionStore.savedIntents.single.oneClickRecipient, '0x52908400098527886e0f7030069857d2e4169ee7');
     expect(
       sessionStore.savedIntents.single.oneClickRefundTo,
       'u1actualshieldedrecipient',
     );
     await _openSwapStatusDetails(tester, expand: true);
     expect(find.text('USDC recipient'), findsOneWidget);
-    expect(find.text('0xrecipient'), findsOneWidget);
+    expect(find.text('0x5290840 ... 4169ee7'), findsOneWidget);
     expect(find.text('t1live-deposit'), findsWidgets);
     expect(find.text('ZEC deposit tx hash'), findsNothing);
     expect(find.text('Submit ZEC deposit'), findsNothing);
@@ -5658,7 +5914,7 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '1.5',
       );
-      await _enterDestinationText(tester, '0xrecipient');
+      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5687,6 +5943,73 @@ void main() {
     },
   );
 
+  testWidgets(
+    'pending ZEC deposit broadcast switches to a fallback endpoint',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      final swapProvider = _FakeSwapProvider();
+      final depositSender = _FakeSwapDepositSender(
+        broadcastStatus: SwapDepositBroadcastStatus.pendingBroadcast,
+        broadcastMessage: 'gRPC connect failed: connection refused',
+      );
+      final sessionStore = _FakeSwapPersistenceStore();
+      final primary = defaultRpcEndpointConfig('main');
+      final fallback = fallbackRpcEndpointCandidatesFor(primary).first;
+
+      await tester.pumpWidget(
+        _routerHarness(
+          GoRouter(
+            initialLocation: '/swap',
+            routes: [_swapRoute(), _swapActivityRoute()],
+          ),
+          swapProvider: swapProvider,
+          depositSender: depositSender,
+          sessionStore: sessionStore,
+          failoverChainNameGetter: (url) async => 'main',
+          failoverHeightGetter: (url) async =>
+              url == fallback.normalizedLightwalletdUrl
+              ? BigInt.from(100)
+              : BigInt.from(100),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const ValueKey('swap_amount_field')),
+        '1.5',
+      );
+      await _enterDestinationText(
+        tester,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(SwapScreen)),
+      );
+
+      await tester.tap(find.byKey(const ValueKey('swap_review_button')));
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(
+        find.byKey(const ValueKey('swap_start_button')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('swap_start_button')));
+      await tester.pumpAndSettle();
+
+      final failoverState = container.read(rpcEndpointFailoverProvider);
+      expect(depositSender.requests, hasLength(1));
+      expect(failoverState.isUsingFallback, isTrue);
+      expect(
+        failoverState.current.normalizedLightwalletdUrl,
+        fallback.normalizedLightwalletdUrl,
+      );
+      final syncNotifier =
+          container.read(syncProvider.notifier) as _FakeSwapSyncNotifier;
+      expect(syncNotifier.restartCount, 1);
+    },
+  );
+
   testWidgets('ZEC swap opens activity before deposit broadcast finishes', (
     tester,
   ) async {
@@ -5712,7 +6035,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5769,7 +6092,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5818,7 +6141,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '0.002',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5869,7 +6192,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '0.003',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5964,7 +6287,7 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '0.003',
       );
-      await _enterDestinationText(tester, '0xrecipient');
+      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6032,7 +6355,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '0.003',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6100,7 +6423,7 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '0.003',
       );
-      await _enterDestinationText(tester, '0xrecipient');
+      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6202,7 +6525,7 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '0.003',
       );
-      await _enterDestinationText(tester, '0xrecipient');
+      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6269,6 +6592,120 @@ void main() {
     },
   );
 
+  testWidgets(
+    'hardware unknown ZEC broadcast switches to a fallback endpoint',
+    (tester) async {
+      // pending_broadcast/partial_broadcast are dropped by the Keystone
+      // overlay's _hasBroadcastTxid gate (no txid to forward), so the only
+      // non-certain status that reaches submitDepositTransactionForIntent on
+      // the hardware path is broadcast_unknown.
+      await _setDesktopViewport(tester);
+      final swapProvider = _FakeSwapProvider();
+      final depositSender = _FakeSwapDepositSender();
+      final hardwareSigningService = _FakeSwapHardwareSigningService(
+        broadcastStatus: SwapDepositBroadcastStatus.broadcastUnknown,
+        broadcastMessage: 'gRPC connect failed: connection refused',
+      );
+      final sessionStore = _FakeSwapPersistenceStore();
+      final primary = defaultRpcEndpointConfig('main');
+      final fallback = fallbackRpcEndpointCandidatesFor(primary).first;
+
+      await tester.pumpWidget(
+        _routerHarness(
+          GoRouter(
+            initialLocation: '/swap',
+            routes: [
+              _swapRoute(),
+              _swapActivityRoute(),
+              GoRoute(
+                path: '/send/keystone/scan',
+                builder: (_, _) => const _FakeKeystoneScanScreen(),
+              ),
+            ],
+          ),
+          bootstrap: _hardwareBootstrap,
+          swapProvider: swapProvider,
+          depositSender: depositSender,
+          hardwareSigningService: hardwareSigningService,
+          sessionStore: sessionStore,
+          failoverChainNameGetter: (_) async => 'main',
+          failoverHeightGetter: (_) async => BigInt.from(100),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(SwapScreen)),
+      );
+
+      await tester.enterText(
+        find.byKey(const ValueKey('swap_amount_field')),
+        '0.003',
+      );
+      await _enterDestinationText(
+        tester,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('swap_review_button')));
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(
+        find.byKey(const ValueKey('swap_start_button')),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(const ValueKey('swap_start_button')));
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('swap_deposit_confirm_button')),
+      );
+      await tester.pump();
+      for (
+        var i = 0;
+        i < 20 && hardwareSigningService.proofDrafts.isEmpty;
+        i++
+      ) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      expect(hardwareSigningService.proofDrafts, hasLength(1));
+      await tester.pump();
+
+      await tester.tap(find.text('Get signature'));
+      for (
+        var i = 0;
+        i < 20 &&
+            find
+                .byKey(const ValueKey('fake_keystone_signature_done'))
+                .evaluate()
+                .isEmpty;
+        i++
+      ) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+      expect(
+        find.byKey(const ValueKey('fake_keystone_signature_done')),
+        findsOneWidget,
+      );
+      await tester.tap(
+        find.byKey(const ValueKey('fake_keystone_signature_done')),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+      await tester.pump();
+
+      expect(hardwareSigningService.broadcasts, hasLength(1));
+      final failoverState = container.read(rpcEndpointFailoverProvider);
+      expect(failoverState.isUsingFallback, isTrue);
+      expect(
+        failoverState.current.normalizedLightwalletdUrl,
+        fallback.normalizedLightwalletdUrl,
+      );
+      final syncNotifier =
+          container.read(syncProvider.notifier) as _FakeSwapSyncNotifier;
+      expect(syncNotifier.restartCount, 1);
+    },
+  );
+
   testWidgets('hardware receive-ZEC swaps start without automatic signing', (
     tester,
   ) async {
@@ -6300,7 +6737,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '8.5',
     );
-    await _enterDestinationText(tester, '0xexternal-refund');
+    await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6364,7 +6801,7 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xrecipient');
+    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6406,6 +6843,8 @@ Widget _routerHarness(
   AppBootstrapState? bootstrap,
   AccountNotifier Function()? accountNotifier,
   AddressBookRepository? addressBookRepository,
+  RpcEndpointChainNameGetter? failoverChainNameGetter,
+  RpcEndpointLatestBlockHeightGetter? failoverHeightGetter,
 }) {
   final fixtureIntents =
       seedSwapActivityFixtures
@@ -6471,6 +6910,16 @@ Widget _routerHarness(
         ),
       if (statusPollInterval != null)
         swapStatusPollIntervalProvider.overrideWithValue(statusPollInterval),
+      // Always override the failover health probes so no test reaches real
+      // FFI/network. The defaults report a non-matching chain, so fallback
+      // health checks fail and failover stays inert unless a test opts in
+      // with passing getters.
+      rpcEndpointFailoverChainNameGetterProvider.overrideWithValue(
+        failoverChainNameGetter ?? (_) async => 'inert-no-failover',
+      ),
+      rpcEndpointFailoverLatestBlockHeightGetterProvider.overrideWithValue(
+        failoverHeightGetter ?? (_) async => BigInt.zero,
+      ),
     ],
     child: MaterialApp.router(
       routerConfig: router,
@@ -6618,7 +7067,7 @@ Widget _reviewTestPage({
     addressPlan: SwapAddressPlan.fromUserInput(
       direction: direction,
       externalAsset: externalAsset,
-      userExternalAddress: '0xrecipient',
+      userExternalAddress: '0x52908400098527886e0f7030069857d2e4169ee7',
       walletZecAddress: 'u1wallet',
     ),
     accountLabel: 'John',
@@ -6746,7 +7195,7 @@ SwapIntent _persistedIntent({
     depositMemo: 'memo-7',
     depositTxHash: txHash,
     providerQuoteId: 'quote-1',
-    oneClickRecipient: '0xrecipient',
+    oneClickRecipient: '0x52908400098527886e0f7030069857d2e4169ee7',
     oneClickRefundTo: 'u1refund',
     accountUuid: accountUuid,
   );

--- a/test/features/swap/swap_zec_staging_address_service_test.dart
+++ b/test/features/swap/swap_zec_staging_address_service_test.dart
@@ -40,7 +40,6 @@ void main() {
     );
     expect(plan.oneClickRecipient, '0xrecipient');
     expect(plan.oneClickRefundTo, 'u1fresh-shielded-refund');
-    expect(plan.reviewDeliveryValue, '0xrecipient');
   });
 
   test('uses shielded unified address for external to ZEC delivery', () async {
@@ -64,6 +63,5 @@ void main() {
     );
     expect(plan.oneClickRecipient, 'u1fresh-shielded-recipient');
     expect(plan.oneClickRefundTo, '0xrefund');
-    expect(plan.zecDeliveryIsDirectShielded, isTrue);
   });
 }


### PR DESCRIPTION
## Summary

Three related changes layered on the swap feature: per-chain address format validation, RPC failover for uncertain swap deposit broadcasts plus an expired-quote guard, and a dead-code/duplication cleanup pass over the swap and address-book code.

## Changes

### Address format validation
- Add per-chain address format validation so contact/destination entry rejects addresses that don't match the selected network.

### Swap deposit broadcast failover + expired-quote guard
- On an uncertain swap deposit broadcast, fail over to a fallback RPC endpoint and restart sync.
- Block `startIntent()` when the review quote deadline has already passed (with a 5s safety buffer) so an expired quote is never broadcast. Surfaces the expired state via the previously dead `expireReviewQuote()`, which the review UI already renders.
- Add `startIntent` expiry-guard tests: expired deadline, within-buffer, and valid-future cases.

### Dead-code & duplication cleanup
- Remove unused symbols: `SwapState.openIntentCount`, `AddressBookContact.fromJson`, `AddressBookNetwork.fromId`, `SwapDirection.{segmentLabel,destinationLabel,destinationHint}`, `swapActivityShowDepositControls`, and the unused `SwapAddressPlan` presentation getters.
- Drop the dead `SwapComposerPanel.onDirectionChanged` callback and its plumbing.
- Extract shared `formatSwapSlippage`/`formatSwapSlippageValue` helpers, removing the duplicated copies in `swap_composer_panel` and `swap_slippage_modal`.
- Update affected tests (drop dead-getter assertions, switch `fromId` → `tryFromId`).

## Validation
- `fvm flutter analyze` — clean.
- `fvm flutter test test/features/swap test/features/address_book` — passing.
