### PR TITLE
[Coinholder Voting][1]: Rust integration foundation, integration README (no API or FRB generation) 

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -893,7 +893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1507,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1525,6 +1525,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1676,6 +1692,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "imt-tree"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c378a3c5c44b985233906c966bd82a4f775a83aa4e1bde1635961c2eb8673d7b"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "hex",
+ "pasta_curves",
+ "rayon",
+]
+
+[[package]]
 name = "incrementalmerkletree"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,7 +1824,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1979,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2336,6 +2366,38 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pir-client"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18409a3bbbc58985c0ba79ec464c65e6ebab19cc1a82c5d4e184c3484520100"
+dependencies = [
+ "anyhow",
+ "ff",
+ "futures",
+ "hex",
+ "imt-tree",
+ "log",
+ "pasta_curves",
+ "pir-types",
+ "serde_json",
+ "tokio",
+ "valar-ypir",
+]
+
+[[package]]
+name = "pir-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd3d6025cac852a7b3b81d6d07d6e21cc03bb3d5873fc13144a74c56f325b9d"
+dependencies = [
+ "anyhow",
+ "ff",
+ "imt-tree",
+ "pasta_curves",
+ "serde",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2792,7 +2854,9 @@ dependencies = [
  "aes-gcm",
  "base64",
  "bip0039",
+ "blake2b_simd",
  "bls12_381",
+ "ff",
  "flutter_rust_bridge",
  "hex",
  "incrementalmerkletree",
@@ -2800,6 +2864,7 @@ dependencies = [
  "log",
  "nonempty",
  "orchard",
+ "pasta_curves",
  "pbkdf2",
  "pczt",
  "prost 0.14.3",
@@ -2820,6 +2885,7 @@ dependencies = [
  "ur-registry",
  "url",
  "uuid",
+ "vote-commitment-tree 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_address",
  "zcash_client_backend",
  "zcash_client_sqlite",
@@ -2829,6 +2895,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
+ "zcash_voting",
  "zeroize",
  "zip32",
 ]
@@ -2871,7 +2938,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3163,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sinsemilla"
@@ -3198,9 +3265,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3294,7 +3361,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3602,9 +3669,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uint"
@@ -3706,14 +3773,46 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "valar-spiral-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "208d4b69c6a9b7b0c7d856133009a514e10236cdc698ad0b6b87f2e3c4e6d9cb"
+dependencies = [
+ "fastrand",
+ "getrandom 0.2.17",
+ "rand",
+ "rand_chacha",
+ "serde_json",
+ "sha2 0.10.9",
+ "subtle",
+]
+
+[[package]]
+name = "valar-ypir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c3852d9476a0e3efd6c3bfbfc54d3a21a68d8818c4779824ace78aec84a042"
+dependencies = [
+ "cc",
+ "fastrand",
+ "log",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "serde_json",
+ "sha1",
+ "valar-spiral-rs",
 ]
 
 [[package]]
@@ -3737,6 +3836,75 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "vote-commitment-tree"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "870b893a2c53ec015d46fd3a33cf91715a9a968d34531208144f48e46398321c"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "imt-tree",
+ "incrementalmerkletree",
+ "lazy_static",
+ "libc",
+ "pasta_curves",
+ "shardtree",
+]
+
+[[package]]
+name = "vote-commitment-tree"
+version = "0.3.1"
+source = "git+https://github.com/valargroup/zcash_voting?rev=8e9b69ff8639632932eb8a11420b17603589162e#8e9b69ff8639632932eb8a11420b17603589162e"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "imt-tree",
+ "incrementalmerkletree",
+ "lazy_static",
+ "libc",
+ "pasta_curves",
+ "shardtree",
+]
+
+[[package]]
+name = "vote-commitment-tree-client"
+version = "0.5.1"
+source = "git+https://github.com/valargroup/zcash_voting?rev=8e9b69ff8639632932eb8a11420b17603589162e#8e9b69ff8639632932eb8a11420b17603589162e"
+dependencies = [
+ "base64",
+ "ff",
+ "hex",
+ "pasta_curves",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "vote-commitment-tree 0.3.1 (git+https://github.com/valargroup/zcash_voting?rev=8e9b69ff8639632932eb8a11420b17603589162e)",
+]
+
+[[package]]
+name = "voting-circuits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a5b61b6f99af50df900d839b9440fa36709166449c7fa831169391bc5f44bc"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2_gadgets",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "incrementalmerkletree",
+ "itertools 0.14.0",
+ "lazy_static",
+ "orchard",
+ "pasta_curves",
+ "rand",
+ "sinsemilla",
 ]
 
 [[package]]
@@ -4375,9 +4543,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774d808ab619b0f1887d7b90cd815c356101698d16aa681f3d2d9dea063de475"
+checksum = "2f872800287d118be71bdf6fe8c869c6a6ff6fb0a5762f68fb2af54c97edf0f2"
 dependencies = [
  "bip32",
  "bitflags",
@@ -4425,19 +4593,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_voting"
+version = "0.10.1"
+source = "git+https://github.com/valargroup/zcash_voting?rev=8e9b69ff8639632932eb8a11420b17603589162e#8e9b69ff8639632932eb8a11420b17603589162e"
+dependencies = [
+ "anyhow",
+ "base64",
+ "blake2b_simd",
+ "bytes",
+ "ff",
+ "group",
+ "halo2_gadgets",
+ "halo2_proofs",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "imt-tree",
+ "incrementalmerkletree",
+ "nonempty",
+ "orchard",
+ "pasta_curves",
+ "pczt",
+ "pir-client",
+ "pir-types",
+ "prost 0.14.3",
+ "rand",
+ "rusqlite",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sinsemilla",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "uuid",
+ "valar-spiral-rs",
+ "valar-ypir",
+ "vote-commitment-tree 0.3.1 (git+https://github.com/valargroup/zcash_voting?rev=8e9b69ff8639632932eb8a11420b17603589162e)",
+ "vote-commitment-tree-client",
+ "voting-circuits",
+ "zcash_client_backend",
+ "zcash_client_sqlite",
+ "zcash_keys",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zeroize",
+ "zip32",
+]
+
+[[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust_lib_zcash_wallet"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.85.1"
 
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]
@@ -25,11 +26,15 @@ zcash_client_backend = { version = "0.22", features = [
     "pczt",
 ] }
 zcash_client_sqlite = { version = "0.20", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+# Voting clients need PIR lookup support and vote-commitment-tree sync.
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "8e9b69ff8639632932eb8a11420b17603589162e", package = "zcash_voting" }
 # Must match versions used by zcash_client_sqlite to avoid type conflicts
-orchard = "0.13"
+orchard = { version = "=0.13.1", features = ["unstable-voting-circuits"] }
 sapling-crypto = { version = "0.7", default-features = false, features = ["circuit"] }
 uuid = "1.1"
 zip32 = "0.2"
+pasta_curves = "0.5"
+ff = "0.13"
 # Required by no-op Sapling prover trait impls
 jubjub = "0.10"
 bls12_381 = "0.8"
@@ -55,6 +60,7 @@ base64 = "0.22"
 pbkdf2 = "0.12"
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
+blake2b_simd = "1"
 
 # Random number generation
 rand = "0.8"
@@ -90,6 +96,7 @@ security-framework = { version = "3.7", features = ["OSX_10_15"] }
 [dev-dependencies]
 tempfile = "3"
 hex = "0.4"
+vote-commitment-tree = "0.3"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/api/voting_helpers.rs
+++ b/rust/src/api/voting_helpers.rs
@@ -3,6 +3,7 @@ use zeroize::Zeroizing;
 
 use crate::wallet::{keys, network::WalletNetwork, voting::network::voting_network};
 
+/// Convert API bundle-size input into a validated voting bundle policy.
 pub(super) fn bundle_policy(
     max_real_notes_per_bundle: Option<u32>,
 ) -> Result<zcash_voting::BundlePolicy, String> {
@@ -10,6 +11,7 @@ pub(super) fn bundle_policy(
         .map_err(|e| e.to_string())
 }
 
+/// Derive a wallet seed from a BIP-39 mnemonic while zeroizing mnemonic bytes.
 pub(super) fn seed_from_mnemonic(mnemonic: String) -> Result<SecretVec<u8>, String> {
     let mnemonic = Zeroizing::new(mnemonic.into_bytes());
     keys::mnemonic_bytes_to_seed(mnemonic.as_slice())

--- a/rust/src/api/voting_helpers.rs
+++ b/rust/src/api/voting_helpers.rs
@@ -1,0 +1,75 @@
+use secrecy::SecretVec;
+use zeroize::Zeroizing;
+
+use crate::wallet::{keys, network::WalletNetwork, voting::network::voting_network};
+
+pub(super) fn bundle_policy(
+    max_real_notes_per_bundle: Option<u32>,
+) -> Result<zcash_voting::BundlePolicy, String> {
+    zcash_voting::BundlePolicy::from_optional_max_real_notes_per_bundle(max_real_notes_per_bundle)
+        .map_err(|e| e.to_string())
+}
+
+pub(super) fn seed_from_mnemonic(mnemonic: String) -> Result<SecretVec<u8>, String> {
+    let mnemonic = Zeroizing::new(mnemonic.into_bytes());
+    keys::mnemonic_bytes_to_seed(mnemonic.as_slice())
+}
+
+/// Parse local delegation inputs that do not require lightwalletd network I/O.
+pub(super) fn delegation_static_inputs(
+    network: &str,
+    max_real_notes_per_bundle: Option<u32>,
+) -> Result<
+    (
+        WalletNetwork,
+        zcash_voting::Network,
+        zcash_voting::BundlePolicy,
+    ),
+    String,
+> {
+    let wallet_network = keys::parse_network(network)?;
+    let voting_network = voting_network(wallet_network);
+    let bundle_policy = bundle_policy(max_real_notes_per_bundle)?;
+    Ok((wallet_network, voting_network, bundle_policy))
+}
+
+/// Fetch lightwalletd-backed delegation inputs after local validation succeeds.
+pub(super) async fn resolve_delegation_lwd_inputs(
+    lightwalletd_url: &str,
+    round_params: zcash_voting::wire::VotingRoundParams,
+    round_name: &str,
+    voting_network: zcash_voting::Network,
+) -> Result<zcash_voting::delegate::DelegationLwdInputs, String> {
+    zcash_voting::delegate::gather_delegation_lwd_inputs(
+        zcash_voting::delegate::ResolveDelegationLwdParams {
+            lightwalletd_url,
+            network: voting_network,
+            round_params,
+            round_name,
+        },
+    )
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// Build the common `PrepareDelegationBundleParams` shape for wallet-layer
+/// delegation helpers from API-owned inputs.
+pub(super) fn prepare_delegation_bundle_params<'a>(
+    lwd: zcash_voting::delegate::DelegationLwdInputs,
+    session_json: Option<&'a str>,
+    account_uuid: &'a str,
+    network: zcash_voting::Network,
+    hotkey_seed: &'a [u8],
+    bundle_index: u32,
+    bundle_policy: zcash_voting::BundlePolicy,
+) -> zcash_voting::delegate::PrepareDelegationBundleParams<'a> {
+    zcash_voting::delegate::PrepareDelegationBundleParams {
+        lwd,
+        session_json,
+        account_uuid,
+        network,
+        hotkey_seed,
+        bundle_index,
+        bundle_policy,
+    }
+}

--- a/rust/src/wallet/mod.rs
+++ b/rust/src/wallet/mod.rs
@@ -6,3 +6,4 @@ pub mod secret_payload;
 pub mod secret_store;
 pub mod sync;
 pub mod sync_engine;
+pub mod voting;

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -309,8 +309,7 @@ pub(crate) struct SyncProgress {
     pub is_syncing: bool,
 }
 
-pub fn get_sync_progress(db_path: &str, network: WalletNetwork) -> Result<SyncProgress, String> {
-    let db = open_wallet_db_for_read(db_path, network)?;
+pub(crate) fn get_sync_progress_from_db(db: &WalletDatabase) -> Result<SyncProgress, String> {
     match db
         .get_wallet_summary(ConfirmationsPolicy::default())
         .map_err(|e| format!("{e}"))?
@@ -326,6 +325,11 @@ pub fn get_sync_progress(db_path: &str, network: WalletNetwork) -> Result<SyncPr
             is_syncing: false,
         }),
     }
+}
+
+pub fn get_sync_progress(db_path: &str, network: WalletNetwork) -> Result<SyncProgress, String> {
+    let db = open_wallet_db_for_read(db_path, network)?;
+    get_sync_progress_from_db(&db)
 }
 
 // ======================== Rewind ========================

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -309,7 +309,8 @@ pub(crate) struct SyncProgress {
     pub is_syncing: bool,
 }
 
-pub(crate) fn get_sync_progress_from_db(db: &WalletDatabase) -> Result<SyncProgress, String> {
+pub fn get_sync_progress(db_path: &str, network: WalletNetwork) -> Result<SyncProgress, String> {
+    let db = open_wallet_db_for_read(db_path, network)?;
     match db
         .get_wallet_summary(ConfirmationsPolicy::default())
         .map_err(|e| format!("{e}"))?
@@ -325,11 +326,6 @@ pub(crate) fn get_sync_progress_from_db(db: &WalletDatabase) -> Result<SyncProgr
             is_syncing: false,
         }),
     }
-}
-
-pub fn get_sync_progress(db_path: &str, network: WalletNetwork) -> Result<SyncProgress, String> {
-    let db = open_wallet_db_for_read(db_path, network)?;
-    get_sync_progress_from_db(&db)
 }
 
 // ======================== Rewind ========================

--- a/rust/src/wallet/voting.rs
+++ b/rust/src/wallet/voting.rs
@@ -1,0 +1,7 @@
+pub mod db;
+pub mod delegation;
+pub mod hotkey;
+pub mod network;
+
+#[cfg(test)]
+pub(crate) mod test_support;

--- a/rust/src/wallet/voting/README.md
+++ b/rust/src/wallet/voting/README.md
@@ -1,0 +1,184 @@
+# Vizor Voting Integration (Rust)
+
+This module integrates the [`zcash_voting`](https://github.com/valargroup/zcash_voting)
+crate into Vizor. It owns the wallet-side concerns the crate intentionally leaves
+to the host app: seed handling and hotkey derivation, the voting sidecar
+database, delegation signing, and the Flutter Rust Bridge (FRB) surface that
+exposes the crate lifecycle to Dart.
+
+`zcash_voting` owns the protocol and the durable recovery state machine. Vizor
+adds no parallel workflow tables. All phases and recovery are derived from the
+crate's own `bundles`, `votes`, and `share_delegations` rows. For the canonical
+setup -> precompute -> delegate -> vote -> share lifecycle, the per-bundle phase
+definitions, and the restart planner, see the crate docs:
+
+- Crate README: [`zcash_voting/zcash_voting/README.md`](https://github.com/valargroup/zcash_voting/blob/main/zcash_voting/README.md)
+- Reference usage: [`wallet-example/src`](https://github.com/valargroup/zcash_voting/tree/main/wallet-example/src)
+  (`example_delegation.rs`, `example_vote.rs`, `example_recovery.rs`)
+
+This document focuses on what Vizor's integration is responsible for.
+
+## Module Map
+
+| File | Responsibility |
+| --- | --- |
+| `db.rs` | Opens the voting sidecar DB via `VotingDb::open_wallet_sidecar` at the deterministic path next to the wallet DB. The voting schema is isolated from the wallet `user_version`. |
+| `network.rs` | Converts between wallet-layer network enums and `zcash_voting::Network` so wallet modules do not depend on API-layer helpers. |
+| `hotkey.rs` | Derives scoped, opaque voting hotkey seed material from the wallet seed for software accounts. The derived secret is never persisted by Rust. |
+| `delegation.rs` | Prepares, proves, and signs delegation bundles (software and Keystone paths), forwarding `DelegationProgress` to callers. Wallet seed signing stays here. |
+| `../../api/voting.rs` | FRB boundary. Thin wrappers that open the sidecar DB and call crate lifecycle APIs (`delegate::*`, `vote::*`, `share::*`, `confirmation::*`, `session::*`, `precompute::*`). |
+| `../../api/voting_helpers.rs` | API-only helper glue for delegation input resolution and bundle-parameter construction used by the FRB boundary. |
+
+## Account Invariants And Secret Boundaries
+
+Coinholder voting uses a crate-owned voting hotkey for delegation outputs and
+vote signing.
+
+- Software accounts derive the hotkey seed from the active account seed, round,
+  account UUID, and network via `hotkey::derive_hotkey`, then hand it to
+  `zcash_voting::hotkey::voting_hotkey_from_seed`. The same tuple always yields
+  the same material; changing any member produces independent material.
+- Hardware accounts generate and store a random per-round hotkey seed because
+  the wallet seed is not available to the host app.
+- Locked wallets and software accounts without a stored mnemonic must fail
+  before any proof or recovery work starts.
+
+The wallet seed never leaves the wallet boundary. Delegation signing in
+`delegation.rs::sign_delegation_request` consumes a crate-provided
+`DelegationSigningRequest`, verifies the seed fingerprint, derives the account
+SpendAuth key, randomizes it with `alpha`, and returns only the detached
+signature plus sighash. The crate never receives root seed material.
+
+### Session Pinning
+
+A `votingSessionProvider(roundId)` instance is pinned to the active account UUID
+captured when the session is built. All later context reloads, recovery reads,
+delegation setup, vote-tree sync, vote submission, and share recovery must
+continue to use that session account, even if the user switches accounts while
+the round screen is open. Do not re-read the active account inside individual
+session actions except through the session-pinned account helper.
+
+## Durable vs Process-Local State
+
+Two kinds of state exist, and they are both account scoped:
+
+- **Durable** state lives in the `zcash_voting` sidecar tables (delegation
+  bundles, signed artifacts, transaction hashes, VAN/VC positions, share
+  submission history). This is the recovery source of truth.
+- **Process-local** state is Rust memory and cached clients owned by the current
+  app process, including the crate-owned vote-tree client.
+
+Any durable key or process-local cache that touches prepared PCZTs, vote-tree
+sync state, hotkeys, recovery rows, or share-delegation history must include the
+wallet DB path plus the session account UUID where applicable.
+
+### Reset Semantics
+
+`reset_voting_session_state(db_path, account_uuid, round_id)` clears only
+process-local state. It does not delete durable recovery rows, signed artifacts,
+transaction hashes, or share history, and it does not abort in-flight proof or
+vote jobs already running on worker threads.
+
+- A non-empty `round_id` clears round-scoped caches only.
+- `None` or an empty `round_id` is an account-wide reset and additionally drops
+  the cached vote-tree client by calling
+  `zcash_voting::precompute::reset_vote_tree`.
+
+Vote-tree sync and reset are owned by the crate
+(`zcash_voting::precompute::{sync_vote_tree, reset_vote_tree}`); Vizor does not
+maintain its own tree-sync registry. The tree client is account/DB scoped, not
+round scoped, so a round-scoped reset must not drop it.
+
+Account-wide reset runs when switching away from the active account, removing an
+account, resetting the wallet, or locking/signing out. These lifecycle
+boundaries invalidate the owner of the process-local tree client but never
+delete durable `zcash_voting` recovery rows.
+
+## Lifecycle And Recovery
+
+Vizor calls the crate's stage-oriented APIs rather than writing storage rows
+directly. The mapping from FRB functions to crate APIs:
+
+| Stage | FRB entry (`api/voting.rs`) | Crate API |
+| --- | --- | --- |
+| Bundle setup | `setup_delegation_bundles` | `delegate::ensure_round_context`, `VotingDb::ensure_bundles_with_skipped_suffix_with_policy` |
+| Delegation prove/sign | `build_prove_and_sign_delegation_payload_with_progress`, Keystone variant | `delegate::{prepare_delegation_bundle, setup, prove, signing_request, signed_bundle, keystone_request}` |
+| Delegation submit/confirm | `mark_delegation_submitted`, `confirm_delegation_submission` | `VotingDb::mark_delegation_submitted`, `confirmation::confirm_delegation_submission` |
+| Vote commit | `build_vote_commitments_with_progress`, `recover_vote_commitment` | `vote::commit_batch`, `vote::recover_signed_commitments` |
+| Vote submit/confirm | `mark_vote_submitted`, `confirm_vote_submission` | `VotingDb::mark_vote_submitted`, `confirmation::confirm_vote_submission` |
+| Share submit/confirm | `record_share_delegation`, `mark_share_confirmed`, `add_sent_servers` | `vote::CommittedVote::{record_share, confirm_share}`, `share::add_sent_servers` |
+| Ballot intent / restart | `set_ballot_intent`, `get_round_plan`, `get_round_recovery_state` | `VotingDb::set_ballot_intent`, `session::resume_plan`, `recovery::round_snapshot` |
+
+The `confirmation::*` APIs parse chain `tx` events and atomically record tx
+hashes, VAN positions, and VC positions. Restart recovery is driven by
+`session::resume_plan`, which returns the ordered remaining `NextStep`s and the
+proposals still open. Vizor's Dart recovery code consumes the crate's phase
+strings; it does not derive its own phases.
+
+```mermaid
+stateDiagram-v2
+    state "Delegation Bundle" as Delegation {
+        [*] --> Prepared
+        Prepared --> Signed: prove + sign
+        Signed --> Submitted: mark_delegation_submitted
+        Submitted --> Confirmed: confirm_delegation_submission
+        Confirmed --> [*]
+    }
+    state "Vote Commitment" as Vote {
+        [*] --> Committed
+        Committed --> Submitted2: mark_vote_submitted
+        Submitted2 --> Confirmed2: confirm_vote_submission
+        Confirmed2 --> [*]
+    }
+    state "Helper Share" as Share {
+        [*] --> SubmittedShare
+        SubmittedShare --> ConfirmedShare: confirm_share
+        ConfirmedShare --> [*]
+    }
+```
+
+### Helper Share Scheduling
+
+Helper-share `submit_at` (the Unix-second reveal time sent to the helper server)
+is computed in Dart from round timing before calling `record_share_delegation`:
+
+- The last-moment buffer is 40% of the round duration from `ceremony_phase_start`
+  to `vote_end_time`, capped at six hours.
+- Before that buffer, each share samples a randomized `submit_at` uniformly in
+  `[now, vote_end_time - buffer)`.
+- Inside the buffer, the vote commitment uses single-share mode and shares use
+  `submit_at = 0` (immediate submission).
+- If round timing is missing or invalid, Vizor uses `submit_at = 0`.
+
+Retry/resubmission paths submit immediately (`submit_at = 0`); the original
+scheduled value remains part of the durable record for the first accepted
+submission. The canonical scheduling/retry/polling policy lives in the crate's
+`share_policy` module; Dart mirrors it via the `plan_share_submissions`,
+`share_tracking_flags`, and `next_share_tracking_delay_seconds` helpers exposed
+through `api/voting.rs`.
+
+## Wire Types And FRB Scanning
+
+`zcash_voting::wire` is the canonical owner of protocol wire JSON and wallet view
+DTOs (field names, `serde` renames, base64/hex shaping, JSON-safe integer
+bounds), for example `DelegationSubmissionWire`, `VoteCommitmentWire`,
+`VanWitness`, `DraftVote`, `SignedVoteCommitmentsView`, and `RoundPlanView`. See
+`zcash_voting::wire` for the full set.
+
+Vizor keeps no FRB-local `Api*Wire` mirrors for these types. FRB codegen scans
+the shared crate module directly via `flutter_rust_bridge.yaml`:
+
+```yaml
+rust_input: crate::api,zcash_voting::wire
+```
+
+That scan emits Dart value classes under
+`lib/src/rust/third_party/zcash_voting/wire.dart` and generates the
+`SseEncode` / `SseDecode` glue in Vizor's bridge code. The `zcash_voting` crate
+stays framework-agnostic and does not depend on FRB.
+
+FRB third-party scanning expects a struct-only module surface, so the DTO structs
+stay in `zcash_voting::wire` while serialization helpers and conversions that
+pull richer crate internals (`VotingError`, payload transforms) live in
+`zcash_voting::wire_codec`. Call sites import canonical structs from
+`zcash_voting::wire::*`.

--- a/rust/src/wallet/voting/README.md
+++ b/rust/src/wallet/voting/README.md
@@ -35,7 +35,7 @@ Coinholder voting uses a crate-owned voting hotkey for delegation outputs and
 vote signing.
 
 - Software accounts derive the hotkey seed from the active account seed, round,
-  account UUID, and network via `hotkey::derive_hotkey`, then hand it to
+  ZIP-32 account index, and network via `hotkey::derive_hotkey`, then hand it to
   `zcash_voting::hotkey::voting_hotkey_from_seed`. The same tuple always yields
   the same material; changing any member produces independent material.
 - Hardware accounts generate and store a random per-round hotkey seed because

--- a/rust/src/wallet/voting/README.md
+++ b/rust/src/wallet/voting/README.md
@@ -35,7 +35,7 @@ Coinholder voting uses a crate-owned voting hotkey for delegation outputs and
 vote signing.
 
 - Software accounts derive the hotkey seed from the active account seed, round,
-  account UUID, and network via `hotkey::derive_hotkey`, then hand it to
+  and network via `hotkey::derive_hotkey`, then hand it to
   `zcash_voting::hotkey::voting_hotkey_from_seed`. The same tuple always yields
   the same material; changing any member produces independent material.
 - Hardware accounts generate and store a random per-round hotkey seed because

--- a/rust/src/wallet/voting/README.md
+++ b/rust/src/wallet/voting/README.md
@@ -35,7 +35,7 @@ Coinholder voting uses a crate-owned voting hotkey for delegation outputs and
 vote signing.
 
 - Software accounts derive the hotkey seed from the active account seed, round,
-  ZIP-32 account index, and network via `hotkey::derive_hotkey`, then hand it to
+  account UUID, and network via `hotkey::derive_hotkey`, then hand it to
   `zcash_voting::hotkey::voting_hotkey_from_seed`. The same tuple always yields
   the same material; changing any member produces independent material.
 - Hardware accounts generate and store a random per-round hotkey seed because

--- a/rust/src/wallet/voting/db.rs
+++ b/rust/src/wallet/voting/db.rs
@@ -1,0 +1,51 @@
+/// Opens the voting sidecar database for a wallet and binds it to `account_uuid`.
+///
+/// `db_path` is the main wallet database path; the voting DB is opened at the
+/// deterministic sidecar path returned by
+/// [`zcash_voting::round::VotingDb::wallet_sidecar_path`].
+///
+/// # Errors
+///
+/// Returns an error if the upstream voting database cannot be opened or
+/// initialized.
+pub fn open_voting_db(
+    db_path: &str,
+    account_uuid: &str,
+) -> Result<zcash_voting::storage::VotingDb, String> {
+    zcash_voting::storage::VotingDb::open_wallet_sidecar(
+        std::path::Path::new(db_path),
+        account_uuid,
+    )
+    .map_err(|e| format!("Error opening voting database: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_voting_db_initializes_upstream_schema() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("zcash_wallet.db");
+        let db = open_voting_db(db_path.to_str().unwrap(), "wallet-1").unwrap();
+
+        assert!(db.list_rounds().unwrap().is_empty());
+        assert!(zcash_voting::storage::VotingDb::wallet_sidecar_path(&db_path).exists());
+    }
+
+    #[test]
+    fn open_voting_db_uses_sidecar_path_not_wallet_user_version() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("zcash_wallet.db");
+        let wallet_conn = rusqlite::Connection::open(&db_path).unwrap();
+        wallet_conn.pragma_update(None, "user_version", 8).unwrap();
+
+        let db = open_voting_db(db_path.to_str().unwrap(), "wallet-1").unwrap();
+
+        assert!(db.list_rounds().unwrap().is_empty());
+        let wallet_version: u32 = wallet_conn
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .unwrap();
+        assert_eq!(wallet_version, 8);
+    }
+}

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -1,0 +1,447 @@
+use std::sync::Arc;
+
+use ff::PrimeField;
+use secrecy::{ExposeSecret, SecretVec};
+use zcash_keys::keys::UnifiedSpendingKey;
+use zeroize::Zeroizing;
+use zip32::{fingerprint::SeedFingerprint, AccountId};
+
+use crate::wallet::voting::network::{voting_network, wallet_network};
+use crate::wallet::{keys, sync::open_wallet_db_for_read};
+
+use super::db::open_voting_db;
+
+pub use zcash_voting::delegate::DelegationProgress;
+use zcash_voting::delegate::{
+    DelegationSigningRequest, PrepareDelegationBundleParams, PreparedDelegationBundle,
+};
+use zcash_voting::selection::select_notes_with_lwd;
+use zcash_voting::storage::VotingDb;
+use zcash_voting::BundlePolicy;
+
+/// Completes the proof phase for a previously prepared delegation bundle.
+///
+/// Opens the voting database for `account_uuid`, connects to `pir_server_url`,
+/// then runs bundle proving on a blocking worker thread while forwarding
+/// `DelegationProgress` updates to `on_progress`.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting database fails, connecting to the PIR
+/// server fails, the underlying `PreparedDelegationBundle::prove` call fails, or
+/// the spawned blocking task is cancelled or panics.
+async fn prove_delegation_bundle<F>(
+    db_path: &str,
+    pir_server_url: &str,
+    account_uuid: &str,
+    prepared: &PreparedDelegationBundle,
+    on_progress: Arc<F>,
+) -> Result<(), String>
+where
+    F: Fn(DelegationProgress) + Send + Sync + 'static,
+{
+    let proof_db_path = db_path.to_string();
+    let proof_pir_server_url = pir_server_url.to_string();
+    let proof_account_uuid = account_uuid.to_string();
+    let prepared = prepared.clone();
+    let proof_progress = on_progress.clone();
+    tokio::task::spawn_blocking(move || {
+        let proof_voting_db = open_voting_db(&proof_db_path, &proof_account_uuid)?;
+        let pir_client = zcash_voting::PirClientBlocking::with_transport(
+            &proof_pir_server_url,
+            Arc::new(zcash_voting::HyperTransport::new()),
+        )
+        .map_err(|e| format!("connect to PIR server failed: {e}"))?;
+        let reporter = zcash_voting::DelegationProgressBridge::new(move |progress| {
+            proof_progress(progress);
+        });
+        prepared
+            .prove(&proof_voting_db, &pir_client, &reporter)
+            .map(|_| ())
+            .map_err(|e| format!("delegate::prove failed: {e}"))
+    })
+    .await
+    .map_err(|e| format!("delegation proof task failed: {e}"))??;
+    Ok(())
+}
+
+/// Select notes and create/reuse delegation bundle rows for a round.
+///
+/// The selected notes are taken at the round snapshot height. Existing bundle
+/// rows are reused only when they match the current eligible note set.
+///
+/// # Errors
+///
+/// Returns an error if round initialization, lightwalletd note selection, or
+/// bundle setup/validation fails.
+#[allow(clippy::too_many_arguments)]
+pub async fn setup_delegation_bundles(
+    voting_db: &VotingDb,
+    db_path: &str,
+    lightwalletd_url: &str,
+    network: &str,
+    round_params: zcash_voting::VotingRoundParams,
+    round_name: &str,
+    session_json: Option<&str>,
+    bundle_policy: BundlePolicy,
+) -> Result<zcash_voting::round::BundleLayout, String> {
+    let network = keys::parse_network(network)?;
+    let round_context = zcash_voting::delegate::ensure_round_context(
+        voting_db,
+        &round_params,
+        round_name,
+        session_json,
+    )
+    .map_err(|e| e.to_string())?;
+    let selected = select_notes_with_lwd(
+        voting_db,
+        db_path,
+        lightwalletd_url,
+        voting_network(network),
+        round_context.snapshot_height,
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+    let note_infos = selected.voting_note_infos();
+    voting_db
+        .ensure_bundles_with_skipped_suffix_with_policy(
+            round_params.vote_round_id.as_str(),
+            &note_infos,
+            bundle_policy,
+        )
+        .map_err(|e| format!("ensure_bundles_with_skipped_suffix failed: {e}"))
+}
+
+/// Warms PIR state for a single delegation bundle.
+///
+/// Validates the PIR endpoint against the round snapshot, persists witnesses,
+/// initializes padded-note secrets, and precomputes delegation PIR rows for
+/// `bundle_index`.
+///
+/// # Errors
+///
+/// Returns an error if the round, endpoint, note selection, bundle index,
+/// witness generation, padded-secret initialization, or PIR precompute step
+/// fails.
+pub async fn precompute_delegation_pir(
+    db_path: &str,
+    pir_server_url: &str,
+    prepare_params: PrepareDelegationBundleParams<'_>,
+) -> Result<zcash_voting::delegate::PreparedDelegationReport, String> {
+    let PrepareDelegationBundleParams {
+        lwd,
+        session_json,
+        account_uuid,
+        network,
+        hotkey_seed,
+        bundle_index,
+        bundle_policy,
+    } = prepare_params;
+
+    let db_path = db_path.to_string();
+    let pir_server_url = pir_server_url.to_string();
+    let account_uuid = account_uuid.to_string();
+    let session_json = session_json.map(str::to_string);
+    // Keep the copied hotkey seed zeroized after the blocking task returns.
+    let hotkey_seed = Zeroizing::new(hotkey_seed.to_vec());
+
+    tokio::task::spawn_blocking(move || {
+        let voting_db = open_voting_db(&db_path, &account_uuid)?;
+        let wallet_db = open_wallet_db_for_read(&db_path, wallet_network(network))?;
+        let prepared = zcash_voting::delegate::prepare_delegation_bundle(
+            &voting_db,
+            &wallet_db,
+            PrepareDelegationBundleParams {
+                lwd,
+                session_json: session_json.as_deref(),
+                account_uuid: &account_uuid,
+                network,
+                hotkey_seed: hotkey_seed.as_slice(),
+                bundle_index,
+                bundle_policy,
+            },
+        )
+        .map_err(|e| e.to_string())?;
+        let pir_client = zcash_voting::PirClientBlocking::with_transport(
+            &pir_server_url,
+            Arc::new(zcash_voting::HyperTransport::new()),
+        )
+        .map_err(|e| format!("connect to PIR server failed: {e}"))?;
+        prepared
+            .precompute(&voting_db, &wallet_db, &pir_client)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("delegation PIR precompute task failed: {e}"))?
+}
+
+/// Build, prove, and sign one delegation payload.
+///
+/// Emits progress phases through `on_progress`. The returned value is a signed
+/// delegation payload ready for Dart-side submission.
+///
+/// # Errors
+///
+/// Returns an error if note/bundle validation, witness
+/// generation, PCZT construction, PIR proof generation, or delegation signing
+/// fails.
+pub async fn build_prove_and_sign_delegation_payload<F>(
+    db_path: &str,
+    pir_server_url: &str,
+    seed: &SecretVec<u8>,
+    prepare_params: PrepareDelegationBundleParams<'_>,
+    on_progress: F,
+) -> Result<zcash_voting::delegate::SignedDelegationBundle, String>
+where
+    F: Fn(DelegationProgress) + Send + Sync + 'static,
+{
+    let on_progress = Arc::new(on_progress);
+    let account_uuid = prepare_params.account_uuid;
+
+    zcash_voting::validate_round_params(&prepare_params.lwd.round_params)
+        .map_err(|e| format!("Invalid voting round params: {e}"))?;
+    on_progress(DelegationProgress::SelectingNotes);
+    let voting_db = open_voting_db(db_path, account_uuid)?;
+    let wallet_db = open_wallet_db_for_read(db_path, wallet_network(prepare_params.network))?;
+
+    let prepared_bundle =
+        zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
+            .map_err(|e| e.to_string())?;
+
+    let pczt_progress = on_progress.clone();
+    let setup_stages = zcash_voting::DelegationProgressBridge::new(move |progress| {
+        pczt_progress(progress);
+    });
+    let delegation_setup = prepared_bundle
+        .setup(&voting_db, &setup_stages)
+        .map_err(|e| format!("delegate::setup failed: {e}"))?;
+
+    prove_delegation_bundle(
+        db_path,
+        pir_server_url,
+        account_uuid,
+        &prepared_bundle,
+        on_progress.clone(),
+    )
+    .await?;
+
+    on_progress(DelegationProgress::SigningPayload);
+    let signing_request = prepared_bundle
+        .signing_request(&voting_db)
+        .map_err(|e| format!("delegation signing request failed: {e}"))?;
+    let (sig, sighash) = sign_delegation_request(seed, signing_request)
+        .map_err(|e| format!("delegation signing failed: {e}"))?;
+    let signer = zcash_voting::delegate::PreparedSigner::signature(sig, sighash);
+    let signed_bundle = prepared_bundle
+        .signed_bundle(&voting_db, delegation_setup.pczt_bytes, signer)
+        .map_err(|e| format!("delegate::signed_bundle failed: {e}"))?;
+
+    on_progress(DelegationProgress::PayloadReady);
+    Ok(signed_bundle)
+}
+
+/// Signs a delegation request with the Orchard spend authorizing key derived from
+/// the wallet seed and account in the request.
+///
+/// Returns the detached signature bytes plus the original sighash when the seed,
+/// account index, and randomizer all validate.
+fn sign_delegation_request(
+    seed: &SecretVec<u8>,
+    request: DelegationSigningRequest,
+) -> Result<([u8; 64], [u8; 32]), String> {
+    let seed = seed.expose_secret();
+    // Bind the request to this exact wallet seed before deriving any keys.
+    let seed_fingerprint = SeedFingerprint::from_seed(seed)
+        .ok_or_else(|| "wallet seed length is not valid for ZIP-32".to_string())?;
+    if seed_fingerprint.to_bytes() != request.seed_fingerprint {
+        return Err(
+            "wallet seed fingerprint does not match delegation signing request".to_string(),
+        );
+    }
+
+    // Derive the account Orchard signing key specified by the request metadata.
+    let account = AccountId::try_from(request.account_index)
+        .map_err(|_| format!("invalid account_index {}", request.account_index))?;
+    let usk = UnifiedSpendingKey::from_seed(&request.network, seed, account)
+        .map_err(|e| format!("derive account unified spending key failed: {e}"))?;
+    let sk = *usk.orchard();
+    let ask = orchard::keys::SpendAuthorizingKey::from(&sk);
+    // The alpha randomizer must decode as a canonical Pallas scalar.
+    let alpha = Option::<pasta_curves::pallas::Scalar>::from(
+        pasta_curves::pallas::Scalar::from_repr(request.alpha),
+    )
+    .ok_or_else(|| "delegation alpha is not a valid Pallas scalar".to_string())?;
+    // Sign the request-specific sighash with the randomized spend auth key.
+    let rsk = ask.randomize(&alpha);
+    let rng = rand::rngs::OsRng;
+    let sig = rsk.sign(rng, &request.sighash);
+    Ok(((&sig).into(), request.sighash))
+}
+
+/// Build one voting PCZT request for Keystone signing.
+///
+/// The full PCZT is persisted only in Rust-side voting state. `redacted_pczt_bytes`
+/// is the payload that should be UR-encoded for Keystone.
+///
+/// # Errors
+///
+/// Returns an error if note selection, witness generation, account metadata,
+/// PCZT construction, or redaction fails.
+pub async fn build_keystone_delegation_request(
+    db_path: &str,
+    account_uuid: &str,
+    prepare_params: PrepareDelegationBundleParams<'_>,
+) -> Result<zcash_voting::delegate::KeystoneSigningRequest, String> {
+    let voting_db = open_voting_db(db_path, account_uuid)?;
+    let wallet_db = open_wallet_db_for_read(db_path, wallet_network(prepare_params.network))?;
+    let prepared =
+        zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
+            .map_err(|e| e.to_string())?;
+    let noop_stages = zcash_voting::NoopProgressReporter;
+    prepared
+        .keystone_request(&voting_db, &noop_stages)
+        .map_err(|e| format!("delegate::keystone_request failed: {e}"))
+}
+
+/// Build a delegation proof and assemble the submission using a Keystone signature.
+///
+/// This path intentionally does not rebuild the governance PCZT. The signed PCZT
+/// request already persisted the sighash and delegation fields; rebuilding here
+/// would overwrite that state with a fresh PCZT that the device did not sign.
+///
+/// # Errors
+///
+/// Returns an error if proof generation fails, the Keystone signature does not
+/// match the stored PCZT sighash, or submission payload reconstruction fails.
+pub async fn build_prove_delegation_payload_with_keystone_signature<F>(
+    db_path: &str,
+    pir_server_url: &str,
+    account_uuid: &str,
+    prepare_params: PrepareDelegationBundleParams<'_>,
+    keystone_sig: &[u8],
+    keystone_sighash: &[u8],
+    on_progress: F,
+) -> Result<zcash_voting::delegate::SignedDelegationBundle, String>
+where
+    F: Fn(DelegationProgress) + Send + Sync + 'static,
+{
+    let on_progress = Arc::new(on_progress);
+
+    on_progress(DelegationProgress::SelectingNotes);
+    let voting_db = open_voting_db(db_path, account_uuid)?;
+    let wallet_db = open_wallet_db_for_read(db_path, wallet_network(prepare_params.network))?;
+    let prepared_bundle =
+        zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
+            .map_err(|e| e.to_string())?;
+    prove_delegation_bundle(
+        db_path,
+        pir_server_url,
+        account_uuid,
+        &prepared_bundle,
+        on_progress.clone(),
+    )
+    .await?;
+
+    on_progress(DelegationProgress::SigningPayload);
+    let signer = zcash_voting::delegate::PreparedSigner::signature_from_bytes(
+        keystone_sig,
+        keystone_sighash,
+    )
+    .map_err(|e| format!("invalid Keystone signature fields: {e}"))?;
+    let signed_bundle = prepared_bundle
+        .signed_bundle(&voting_db, Vec::new(), signer)
+        .map_err(|e| format!("delegate::signed_bundle failed: {e}"))?;
+    on_progress(DelegationProgress::PayloadReady);
+
+    Ok(signed_bundle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wallet::voting::test_support::{ROUND_ID, TEST_ACCOUNT_UUID};
+    use ff::PrimeField;
+    use orchard::{
+        keys::SpendAuthorizingKey,
+        primitives::redpallas::{Signature, SpendAuth, VerificationKey},
+    };
+    use secrecy::ExposeSecret;
+    use std::sync::{Arc, Mutex};
+    use zip32::{fingerprint::SeedFingerprint, AccountId};
+
+    #[test]
+    fn build_prove_and_sign_delegation_payload_rejects_invalid_round_params_before_progress() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("zcash_wallet.db");
+        let seed = SecretVec::new(vec![7; 32]);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let events_for_callback = events.clone();
+        let round_params = zcash_voting::VotingRoundParams {
+            vote_round_id: ROUND_ID.to_string(),
+            snapshot_height: 100,
+            ea_pk: vec![1],
+            nc_root: vec![2; 32],
+            nullifier_imt_root: vec![3; 32],
+        };
+        let err = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(build_prove_and_sign_delegation_payload(
+                db_path.to_str().unwrap(),
+                "http://127.0.0.1:2",
+                &seed,
+                PrepareDelegationBundleParams {
+                    lwd: zcash_voting::delegate::DelegationLwdInputs {
+                        round_params,
+                        resolved_round_name: "Demo".to_string(),
+                        anchor_tree_state_bytes: Vec::new(),
+                        branch_id_provider:
+                            zcash_voting::delegate::LightwalletdBranchIdProvider::resolved(0),
+                    },
+                    session_json: None,
+                    account_uuid: TEST_ACCOUNT_UUID,
+                    network: zcash_voting::Network::Regtest,
+                    hotkey_seed: &[9; 32],
+                    bundle_index: 0,
+                    bundle_policy: BundlePolicy::default(),
+                },
+                move |event| events_for_callback.lock().unwrap().push(event),
+            ))
+            .unwrap_err();
+
+        assert!(err.contains("Invalid voting round params"));
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn sign_delegation_request_happy_path_signs_and_verifies() {
+        let seed = SecretVec::new(vec![0x42; 32]);
+        let account_index = 0u32;
+        let account = AccountId::try_from(account_index).unwrap();
+        let usk = UnifiedSpendingKey::from_seed(
+            &zcash_voting::Network::Testnet,
+            seed.expose_secret(),
+            account,
+        )
+        .unwrap();
+        let ask = SpendAuthorizingKey::from(usk.orchard());
+        let alpha = pasta_curves::pallas::Scalar::from(7);
+        let sighash = [0xAB; 32];
+        let request = DelegationSigningRequest {
+            account_index,
+            network: zcash_voting::Network::Testnet,
+            seed_fingerprint: SeedFingerprint::from_seed(seed.expose_secret())
+                .unwrap()
+                .to_bytes(),
+            sighash,
+            alpha: alpha.to_repr(),
+        };
+
+        let (sig_bytes, returned_sighash) = sign_delegation_request(&seed, request).unwrap();
+
+        let verification_key = VerificationKey::from(&ask.randomize(&alpha));
+        verification_key
+            .verify(&sighash, &Signature::<SpendAuth>::from(sig_bytes))
+            .unwrap();
+        assert_eq!(returned_sighash, sighash);
+    }
+}

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -6,8 +6,8 @@ use zcash_keys::keys::UnifiedSpendingKey;
 use zeroize::Zeroizing;
 use zip32::{fingerprint::SeedFingerprint, AccountId};
 
-use crate::wallet::voting::network::{voting_network, wallet_network};
-use crate::wallet::{keys, sync::open_wallet_db_for_read};
+use crate::wallet::sync::open_wallet_db_for_read;
+use crate::wallet::voting::network::wallet_network;
 
 use super::db::open_voting_db;
 
@@ -74,18 +74,19 @@ where
 ///
 /// Returns an error if round initialization, lightwalletd note selection, or
 /// bundle setup/validation fails.
-#[allow(clippy::too_many_arguments)]
 pub async fn setup_delegation_bundles(
     voting_db: &VotingDb,
     db_path: &str,
-    lightwalletd_url: &str,
-    network: &str,
-    round_params: zcash_voting::VotingRoundParams,
-    round_name: &str,
+    lwd_params: zcash_voting::delegate::ResolveDelegationLwdParams<'_>,
     session_json: Option<&str>,
     bundle_policy: BundlePolicy,
 ) -> Result<zcash_voting::round::BundleLayout, String> {
-    let network = keys::parse_network(network)?;
+    let zcash_voting::delegate::ResolveDelegationLwdParams {
+        lightwalletd_url,
+        network,
+        round_params,
+        round_name,
+    } = lwd_params;
     let round_context = zcash_voting::delegate::ensure_round_context(
         voting_db,
         &round_params,
@@ -97,7 +98,7 @@ pub async fn setup_delegation_bundles(
         voting_db,
         db_path,
         lightwalletd_url,
-        voting_network(network),
+        network,
         round_context.snapshot_height,
     )
     .await

--- a/rust/src/wallet/voting/hotkey.rs
+++ b/rust/src/wallet/voting/hotkey.rs
@@ -1,0 +1,191 @@
+use blake2b_simd::Params;
+use secrecy::{ExposeSecret, SecretVec};
+use zeroize::Zeroizing;
+
+use crate::wallet::network::WalletNetwork;
+use crate::wallet::voting::network::voting_network;
+
+const HOTKEY_CONTEXT_PREFIX: &[u8] = b"ZcashVotingHotkeyV1";
+const HOTKEY_SEED_PERSONALIZATION: &[u8] = b"ZcashVotingHotKy";
+const HOTKEY_SEED_LEN: usize = 64;
+
+/// Derives opaque voting hotkey bytes for a wallet account in a voting round.
+///
+/// `seed` is the platform-owned wallet seed material, while `round_id`,
+/// `account_uuid`, and `network` are the voting context. The same tuple always
+/// returns the same hotkey bytes; changing any tuple member produces
+/// independent material.
+///
+/// The returned secret is not persisted by Rust.
+///
+/// # Errors
+///
+/// Returns an error when `seed` or the voting context cannot be converted into
+/// scoped hotkey material.
+pub fn derive_hotkey(
+    seed: &SecretVec<u8>,
+    round_id: &str,
+    account_uuid: &str,
+    network: WalletNetwork,
+) -> Result<SecretVec<u8>, String> {
+    let hotkey_secret =
+        derive_contextual_hotkey_seed(seed.expose_secret(), round_id, account_uuid, network)?;
+    zcash_voting::hotkey::voting_hotkey_from_seed(
+        hotkey_secret.expose_secret(),
+        voting_network(network),
+    )
+    .map_err(|e| format!("Voting hotkey reconstruction failed: {e}"))?;
+    Ok(hotkey_secret)
+}
+
+/// Wraps hotkey seed bytes and verifies they reconstruct for `network`.
+///
+/// Returns the seed as a `SecretVec` when it is accepted by `zcash_voting`.
+///
+/// # Errors
+///
+/// Returns an error if the seed bytes are not valid hotkey material for the
+/// supplied voting network.
+pub fn validated_hotkey_seed(
+    hotkey_seed: Vec<u8>,
+    network: zcash_voting::Network,
+) -> Result<SecretVec<u8>, String> {
+    let hotkey_secret = SecretVec::new(hotkey_seed);
+    zcash_voting::hotkey::voting_hotkey_from_seed(hotkey_secret.expose_secret(), network)
+        .map_err(|e| format!("Voting hotkey reconstruction failed: {e}"))?;
+    Ok(hotkey_secret)
+}
+
+/// Derives deterministic, round-scoped hotkey seed material from wallet context.
+///
+/// The returned seed is bound to the wallet seed, round ID, account UUID, and
+/// network. It is suitable only after reconstruction succeeds through
+/// `validated_hotkey_seed` or the caller's equivalent validation.
+///
+/// # Errors
+///
+/// Returns an error if the wallet seed is too short or any context field cannot
+/// be length-prefixed for domain-separated hashing.
+fn derive_contextual_hotkey_seed(
+    seed: &[u8],
+    round_id: &str,
+    account_uuid: &str,
+    network: WalletNetwork,
+) -> Result<SecretVec<u8>, String> {
+    if seed.len() < 32 {
+        return Err(format!(
+            "wallet seed must be at least 32 bytes, got {}",
+            seed.len()
+        ));
+    }
+
+    let mut material = Zeroizing::new(Vec::new());
+    material.extend_from_slice(HOTKEY_CONTEXT_PREFIX);
+    append_context_part(&mut material, seed)?;
+    append_context_part(&mut material, round_id.as_bytes())?;
+    append_context_part(&mut material, account_uuid.as_bytes())?;
+    append_context_part(&mut material, network_tag(network))?;
+
+    let hash = Params::new()
+        .hash_length(HOTKEY_SEED_LEN)
+        .personal(HOTKEY_SEED_PERSONALIZATION)
+        .hash(&material);
+
+    Ok(SecretVec::new(hash.as_bytes().to_vec()))
+}
+
+fn append_context_part(material: &mut Vec<u8>, part: &[u8]) -> Result<(), String> {
+    let len = u32::try_from(part.len())
+        .map_err(|_| "voting hotkey context part length exceeds u32::MAX".to_string())?;
+    material.extend_from_slice(&len.to_be_bytes());
+    material.extend_from_slice(part);
+    Ok(())
+}
+
+fn network_tag(network: WalletNetwork) -> &'static [u8] {
+    match network {
+        WalletNetwork::Main => b"mainnet",
+        WalletNetwork::Test => b"testnet",
+        WalletNetwork::Regtest => b"regtest",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACCOUNT_UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
+    const OTHER_ACCOUNT_UUID: &str = "550e8400-e29b-41d4-a716-446655440001";
+    const ROUND_ID: &str = "round-1";
+    const OTHER_ROUND_ID: &str = "round-2";
+
+    fn test_seed() -> SecretVec<u8> {
+        SecretVec::new(vec![0xAB; 64])
+    }
+
+    #[test]
+    fn hotkey_determinism() {
+        let seed = test_seed();
+        let expected =
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
+
+        for _ in 0..100 {
+            assert_eq!(
+                derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+                    .unwrap()
+                    .expose_secret(),
+                expected.expose_secret()
+            );
+        }
+    }
+
+    #[test]
+    fn hotkey_round_independence() {
+        let seed = test_seed();
+
+        assert_ne!(
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+                .unwrap()
+                .expose_secret(),
+            derive_hotkey(&seed, OTHER_ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+                .unwrap()
+                .expose_secret()
+        );
+    }
+
+    #[test]
+    fn hotkey_account_independence() {
+        let seed = test_seed();
+
+        assert_ne!(
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+                .unwrap()
+                .expose_secret(),
+            derive_hotkey(&seed, ROUND_ID, OTHER_ACCOUNT_UUID, WalletNetwork::Regtest)
+                .unwrap()
+                .expose_secret()
+        );
+    }
+
+    #[test]
+    fn local_hotkey_seed_matches_legacy_vector() {
+        let seed = test_seed();
+        let local = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
+        let expected = hex::decode(
+            "20e3dada1183f1ef8c797348fd543c7e8f63d9f776ec84183f66845ee2a0b0ec\
+             0a6efc9c803785bb8f07106428e71e1f65066e40052b15844813a1de82f65c7c",
+        )
+        .unwrap();
+
+        assert_eq!(local.expose_secret(), expected.as_slice());
+    }
+
+    #[test]
+    fn hotkey_is_bound_to_network() {
+        let seed = test_seed();
+        let regtest = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
+        let mainnet = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Main).unwrap();
+
+        assert_ne!(regtest.expose_secret(), mainnet.expose_secret());
+    }
+}

--- a/rust/src/wallet/voting/hotkey.rs
+++ b/rust/src/wallet/voting/hotkey.rs
@@ -17,7 +17,7 @@ const HOTKEY_MIN_WALLET_SEED_LEN: usize = 32;
 /// Derives opaque voting hotkey bytes for a wallet account in a voting round.
 ///
 /// `seed` is the platform-owned wallet seed material, while `round_id`,
-/// `account_index`, and `network` are the voting context. The same tuple always
+/// `account_uuid`, and `network` are the voting context. The same tuple always
 /// returns the same hotkey bytes; changing any tuple member produces
 /// independent material.
 ///
@@ -30,11 +30,11 @@ const HOTKEY_MIN_WALLET_SEED_LEN: usize = 32;
 pub fn derive_hotkey(
     seed: &SecretVec<u8>,
     round_id: &str,
-    account_index: u32,
+    account_uuid: &str,
     network: WalletNetwork,
 ) -> Result<SecretVec<u8>, String> {
     let hotkey_secret =
-        derive_contextual_hotkey_seed(seed.expose_secret(), round_id, account_index, network)?;
+        derive_contextual_hotkey_seed(seed.expose_secret(), round_id, account_uuid, network)?;
     zcash_voting::hotkey::voting_hotkey_from_seed(
         hotkey_secret.expose_secret(),
         voting_network(network),
@@ -63,8 +63,8 @@ pub fn validated_hotkey_seed(
 
 /// Derives deterministic, round-scoped hotkey seed material from wallet context.
 ///
-/// The returned seed is bound to the wallet seed, round ID, ZIP-32 account
-/// index, and network. It is suitable only after reconstruction succeeds through
+/// The returned seed is bound to the wallet seed, round ID, account UUID, and
+/// network. It is suitable only after reconstruction succeeds through
 /// `validated_hotkey_seed` or the caller's equivalent validation.
 ///
 /// # Errors
@@ -74,7 +74,7 @@ pub fn validated_hotkey_seed(
 fn derive_contextual_hotkey_seed(
     seed: &[u8],
     round_id: &str,
-    account_index: u32,
+    account_uuid: &str,
     network: WalletNetwork,
 ) -> Result<SecretVec<u8>, String> {
     if seed.len() < HOTKEY_MIN_WALLET_SEED_LEN {
@@ -89,7 +89,7 @@ fn derive_contextual_hotkey_seed(
     material.extend_from_slice(HOTKEY_CONTEXT_PREFIX);
     append_context_part(&mut material, seed)?;
     append_context_part(&mut material, round_id.as_bytes())?;
-    append_context_part(&mut material, &account_index.to_be_bytes())?;
+    append_context_part(&mut material, account_uuid.as_bytes())?;
     append_context_part(&mut material, network_tag(network))?;
 
     let hash = Params::new()
@@ -120,8 +120,8 @@ fn network_tag(network: WalletNetwork) -> &'static [u8] {
 mod tests {
     use super::*;
 
-    const ACCOUNT_INDEX: u32 = 0;
-    const OTHER_ACCOUNT_INDEX: u32 = 1;
+    const ACCOUNT_UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
+    const OTHER_ACCOUNT_UUID: &str = "550e8400-e29b-41d4-a716-446655440001";
     const ROUND_ID: &str = "round-1";
     const OTHER_ROUND_ID: &str = "round-2";
 
@@ -133,11 +133,11 @@ mod tests {
     fn hotkey_determinism() {
         let seed = test_seed();
         let expected =
-            derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest).unwrap();
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
 
         for _ in 0..100 {
             assert_eq!(
-                derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest)
+                derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
                     .unwrap()
                     .expose_secret(),
                 expected.expose_secret()
@@ -150,10 +150,10 @@ mod tests {
         let seed = test_seed();
 
         assert_ne!(
-            derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest)
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
                 .unwrap()
                 .expose_secret(),
-            derive_hotkey(&seed, OTHER_ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest)
+            derive_hotkey(&seed, OTHER_ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
                 .unwrap()
                 .expose_secret()
         );
@@ -164,22 +164,22 @@ mod tests {
         let seed = test_seed();
 
         assert_ne!(
-            derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest)
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
                 .unwrap()
                 .expose_secret(),
-            derive_hotkey(&seed, ROUND_ID, OTHER_ACCOUNT_INDEX, WalletNetwork::Regtest)
+            derive_hotkey(&seed, ROUND_ID, OTHER_ACCOUNT_UUID, WalletNetwork::Regtest)
                 .unwrap()
                 .expose_secret()
         );
     }
 
     #[test]
-    fn local_hotkey_seed_matches_reference_vector() {
+    fn local_hotkey_seed_matches_legacy_vector() {
         let seed = test_seed();
-        let local = derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest).unwrap();
+        let local = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
         let expected = hex::decode(
-            "910d43c8430510ae0367504d587d966bfd6a2b0891a11efc1fb660931ca954af\
-             f2f6dd68dd0c5ec9b5a463a07b43ae00a33685a9945e281b7026abed42c96a9d",
+            "20e3dada1183f1ef8c797348fd543c7e8f63d9f776ec84183f66845ee2a0b0ec\
+             0a6efc9c803785bb8f07106428e71e1f65066e40052b15844813a1de82f65c7c",
         )
         .unwrap();
 
@@ -189,9 +189,8 @@ mod tests {
     #[test]
     fn hotkey_is_bound_to_network() {
         let seed = test_seed();
-        let regtest =
-            derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest).unwrap();
-        let mainnet = derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Main).unwrap();
+        let regtest = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
+        let mainnet = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Main).unwrap();
 
         assert_ne!(regtest.expose_secret(), mainnet.expose_secret());
     }

--- a/rust/src/wallet/voting/hotkey.rs
+++ b/rust/src/wallet/voting/hotkey.rs
@@ -17,7 +17,7 @@ const HOTKEY_MIN_WALLET_SEED_LEN: usize = 32;
 /// Derives opaque voting hotkey bytes for a wallet account in a voting round.
 ///
 /// `seed` is the platform-owned wallet seed material, while `round_id`,
-/// `account_uuid`, and `network` are the voting context. The same tuple always
+/// `account_index`, and `network` are the voting context. The same tuple always
 /// returns the same hotkey bytes; changing any tuple member produces
 /// independent material.
 ///
@@ -30,11 +30,11 @@ const HOTKEY_MIN_WALLET_SEED_LEN: usize = 32;
 pub fn derive_hotkey(
     seed: &SecretVec<u8>,
     round_id: &str,
-    account_uuid: &str,
+    account_index: u32,
     network: WalletNetwork,
 ) -> Result<SecretVec<u8>, String> {
     let hotkey_secret =
-        derive_contextual_hotkey_seed(seed.expose_secret(), round_id, account_uuid, network)?;
+        derive_contextual_hotkey_seed(seed.expose_secret(), round_id, account_index, network)?;
     zcash_voting::hotkey::voting_hotkey_from_seed(
         hotkey_secret.expose_secret(),
         voting_network(network),
@@ -63,8 +63,8 @@ pub fn validated_hotkey_seed(
 
 /// Derives deterministic, round-scoped hotkey seed material from wallet context.
 ///
-/// The returned seed is bound to the wallet seed, round ID, account UUID, and
-/// network. It is suitable only after reconstruction succeeds through
+/// The returned seed is bound to the wallet seed, round ID, ZIP-32 account
+/// index, and network. It is suitable only after reconstruction succeeds through
 /// `validated_hotkey_seed` or the caller's equivalent validation.
 ///
 /// # Errors
@@ -74,7 +74,7 @@ pub fn validated_hotkey_seed(
 fn derive_contextual_hotkey_seed(
     seed: &[u8],
     round_id: &str,
-    account_uuid: &str,
+    account_index: u32,
     network: WalletNetwork,
 ) -> Result<SecretVec<u8>, String> {
     if seed.len() < HOTKEY_MIN_WALLET_SEED_LEN {
@@ -89,7 +89,7 @@ fn derive_contextual_hotkey_seed(
     material.extend_from_slice(HOTKEY_CONTEXT_PREFIX);
     append_context_part(&mut material, seed)?;
     append_context_part(&mut material, round_id.as_bytes())?;
-    append_context_part(&mut material, account_uuid.as_bytes())?;
+    append_context_part(&mut material, &account_index.to_be_bytes())?;
     append_context_part(&mut material, network_tag(network))?;
 
     let hash = Params::new()
@@ -120,8 +120,8 @@ fn network_tag(network: WalletNetwork) -> &'static [u8] {
 mod tests {
     use super::*;
 
-    const ACCOUNT_UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
-    const OTHER_ACCOUNT_UUID: &str = "550e8400-e29b-41d4-a716-446655440001";
+    const ACCOUNT_INDEX: u32 = 0;
+    const OTHER_ACCOUNT_INDEX: u32 = 1;
     const ROUND_ID: &str = "round-1";
     const OTHER_ROUND_ID: &str = "round-2";
 
@@ -133,11 +133,11 @@ mod tests {
     fn hotkey_determinism() {
         let seed = test_seed();
         let expected =
-            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest).unwrap();
 
         for _ in 0..100 {
             assert_eq!(
-                derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+                derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest)
                     .unwrap()
                     .expose_secret(),
                 expected.expose_secret()
@@ -150,10 +150,10 @@ mod tests {
         let seed = test_seed();
 
         assert_ne!(
-            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest)
                 .unwrap()
                 .expose_secret(),
-            derive_hotkey(&seed, OTHER_ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+            derive_hotkey(&seed, OTHER_ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest)
                 .unwrap()
                 .expose_secret()
         );
@@ -164,22 +164,22 @@ mod tests {
         let seed = test_seed();
 
         assert_ne!(
-            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest)
                 .unwrap()
                 .expose_secret(),
-            derive_hotkey(&seed, ROUND_ID, OTHER_ACCOUNT_UUID, WalletNetwork::Regtest)
+            derive_hotkey(&seed, ROUND_ID, OTHER_ACCOUNT_INDEX, WalletNetwork::Regtest)
                 .unwrap()
                 .expose_secret()
         );
     }
 
     #[test]
-    fn local_hotkey_seed_matches_legacy_vector() {
+    fn local_hotkey_seed_matches_reference_vector() {
         let seed = test_seed();
-        let local = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
+        let local = derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest).unwrap();
         let expected = hex::decode(
-            "20e3dada1183f1ef8c797348fd543c7e8f63d9f776ec84183f66845ee2a0b0ec\
-             0a6efc9c803785bb8f07106428e71e1f65066e40052b15844813a1de82f65c7c",
+            "910d43c8430510ae0367504d587d966bfd6a2b0891a11efc1fb660931ca954af\
+             f2f6dd68dd0c5ec9b5a463a07b43ae00a33685a9945e281b7026abed42c96a9d",
         )
         .unwrap();
 
@@ -189,8 +189,9 @@ mod tests {
     #[test]
     fn hotkey_is_bound_to_network() {
         let seed = test_seed();
-        let regtest = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
-        let mainnet = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Main).unwrap();
+        let regtest =
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Regtest).unwrap();
+        let mainnet = derive_hotkey(&seed, ROUND_ID, ACCOUNT_INDEX, WalletNetwork::Main).unwrap();
 
         assert_ne!(regtest.expose_secret(), mainnet.expose_secret());
     }

--- a/rust/src/wallet/voting/hotkey.rs
+++ b/rust/src/wallet/voting/hotkey.rs
@@ -16,9 +16,11 @@ const HOTKEY_MIN_WALLET_SEED_LEN: usize = 32;
 
 /// Derives opaque voting hotkey bytes for a wallet account in a voting round.
 ///
-/// `seed` is the platform-owned wallet seed material, while `round_id`,
-/// `account_uuid`, and `network` are the voting context. The same tuple always
-/// returns the same hotkey bytes; changing any tuple member produces
+/// `seed` is the platform-owned wallet seed material, while `round_id` and
+/// `network` are the voting context.
+///
+/// The same tuple always returns the same hotkey bytes; changing any tuple
+/// member produces
 /// independent material.
 ///
 /// The returned secret is not persisted by Rust.
@@ -30,11 +32,10 @@ const HOTKEY_MIN_WALLET_SEED_LEN: usize = 32;
 pub fn derive_hotkey(
     seed: &SecretVec<u8>,
     round_id: &str,
-    account_uuid: &str,
     network: WalletNetwork,
 ) -> Result<SecretVec<u8>, String> {
     let hotkey_secret =
-        derive_contextual_hotkey_seed(seed.expose_secret(), round_id, account_uuid, network)?;
+        derive_contextual_hotkey_seed(seed.expose_secret(), round_id, network)?;
     zcash_voting::hotkey::voting_hotkey_from_seed(
         hotkey_secret.expose_secret(),
         voting_network(network),
@@ -63,8 +64,8 @@ pub fn validated_hotkey_seed(
 
 /// Derives deterministic, round-scoped hotkey seed material from wallet context.
 ///
-/// The returned seed is bound to the wallet seed, round ID, account UUID, and
-/// network. It is suitable only after reconstruction succeeds through
+/// The returned seed is bound to the wallet seed, round ID, and network.
+/// It is suitable only after reconstruction succeeds through
 /// `validated_hotkey_seed` or the caller's equivalent validation.
 ///
 /// # Errors
@@ -74,7 +75,6 @@ pub fn validated_hotkey_seed(
 fn derive_contextual_hotkey_seed(
     seed: &[u8],
     round_id: &str,
-    account_uuid: &str,
     network: WalletNetwork,
 ) -> Result<SecretVec<u8>, String> {
     if seed.len() < HOTKEY_MIN_WALLET_SEED_LEN {
@@ -89,7 +89,6 @@ fn derive_contextual_hotkey_seed(
     material.extend_from_slice(HOTKEY_CONTEXT_PREFIX);
     append_context_part(&mut material, seed)?;
     append_context_part(&mut material, round_id.as_bytes())?;
-    append_context_part(&mut material, account_uuid.as_bytes())?;
     append_context_part(&mut material, network_tag(network))?;
 
     let hash = Params::new()
@@ -120,8 +119,6 @@ fn network_tag(network: WalletNetwork) -> &'static [u8] {
 mod tests {
     use super::*;
 
-    const ACCOUNT_UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
-    const OTHER_ACCOUNT_UUID: &str = "550e8400-e29b-41d4-a716-446655440001";
     const ROUND_ID: &str = "round-1";
     const OTHER_ROUND_ID: &str = "round-2";
 
@@ -132,12 +129,11 @@ mod tests {
     #[test]
     fn hotkey_determinism() {
         let seed = test_seed();
-        let expected =
-            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
+        let expected = derive_hotkey(&seed, ROUND_ID, WalletNetwork::Regtest).unwrap();
 
         for _ in 0..100 {
             assert_eq!(
-                derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+                derive_hotkey(&seed, ROUND_ID, WalletNetwork::Regtest)
                     .unwrap()
                     .expose_secret(),
                 expected.expose_secret()
@@ -150,36 +146,30 @@ mod tests {
         let seed = test_seed();
 
         assert_ne!(
-            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+            derive_hotkey(&seed, ROUND_ID, WalletNetwork::Regtest)
                 .unwrap()
                 .expose_secret(),
-            derive_hotkey(&seed, OTHER_ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+            derive_hotkey(&seed, OTHER_ROUND_ID, WalletNetwork::Regtest)
                 .unwrap()
                 .expose_secret()
         );
     }
 
     #[test]
-    fn hotkey_account_independence() {
+    fn hotkey_is_stable_for_same_inputs() {
         let seed = test_seed();
-
-        assert_ne!(
-            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
-                .unwrap()
-                .expose_secret(),
-            derive_hotkey(&seed, ROUND_ID, OTHER_ACCOUNT_UUID, WalletNetwork::Regtest)
-                .unwrap()
-                .expose_secret()
-        );
+        let first = derive_hotkey(&seed, ROUND_ID, WalletNetwork::Regtest).unwrap();
+        let second = derive_hotkey(&seed, ROUND_ID, WalletNetwork::Regtest).unwrap();
+        assert_eq!(first.expose_secret(), second.expose_secret());
     }
 
     #[test]
     fn local_hotkey_seed_matches_legacy_vector() {
         let seed = test_seed();
-        let local = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
+        let local = derive_hotkey(&seed, ROUND_ID, WalletNetwork::Regtest).unwrap();
         let expected = hex::decode(
-            "20e3dada1183f1ef8c797348fd543c7e8f63d9f776ec84183f66845ee2a0b0ec\
-             0a6efc9c803785bb8f07106428e71e1f65066e40052b15844813a1de82f65c7c",
+            "ce3392dd798d84e1f31ea3de76c78b0f3d0f452db3a09c7044d7aa0b6467abbe\
+             1c0cfc1677a257c1f42ff371db0f393f2e0a42ca41201018c4b3d202fb54fc05",
         )
         .unwrap();
 
@@ -189,8 +179,8 @@ mod tests {
     #[test]
     fn hotkey_is_bound_to_network() {
         let seed = test_seed();
-        let regtest = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
-        let mainnet = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Main).unwrap();
+        let regtest = derive_hotkey(&seed, ROUND_ID, WalletNetwork::Regtest).unwrap();
+        let mainnet = derive_hotkey(&seed, ROUND_ID, WalletNetwork::Main).unwrap();
 
         assert_ne!(regtest.expose_secret(), mainnet.expose_secret());
     }

--- a/rust/src/wallet/voting/hotkey.rs
+++ b/rust/src/wallet/voting/hotkey.rs
@@ -5,9 +5,14 @@ use zeroize::Zeroizing;
 use crate::wallet::network::WalletNetwork;
 use crate::wallet::voting::network::voting_network;
 
+/// Domain-separation prefix for wallet-scoped hotkey seed derivation.
 const HOTKEY_CONTEXT_PREFIX: &[u8] = b"ZcashVotingHotkeyV1";
+/// Blake2b personalization string for deterministic hotkey seed hashing.
 const HOTKEY_SEED_PERSONALIZATION: &[u8] = b"ZcashVotingHotKy";
+/// Output length (bytes) of derived hotkey seed material.
 const HOTKEY_SEED_LEN: usize = 64;
+/// Minimum wallet seed bytes accepted by ZIP-32 spending-key derivation.
+const HOTKEY_MIN_WALLET_SEED_LEN: usize = 32;
 
 /// Derives opaque voting hotkey bytes for a wallet account in a voting round.
 ///
@@ -72,9 +77,10 @@ fn derive_contextual_hotkey_seed(
     account_uuid: &str,
     network: WalletNetwork,
 ) -> Result<SecretVec<u8>, String> {
-    if seed.len() < 32 {
+    if seed.len() < HOTKEY_MIN_WALLET_SEED_LEN {
         return Err(format!(
-            "wallet seed must be at least 32 bytes, got {}",
+            "wallet seed must be at least {} bytes, got {}",
+            HOTKEY_MIN_WALLET_SEED_LEN,
             seed.len()
         ));
     }

--- a/rust/src/wallet/voting/network.rs
+++ b/rust/src/wallet/voting/network.rs
@@ -1,0 +1,56 @@
+use crate::wallet::network::WalletNetwork;
+
+/// Convert wallet-network enum values to vote-protocol network values.
+pub(crate) fn voting_network(network: WalletNetwork) -> zcash_voting::Network {
+    match network {
+        WalletNetwork::Main => zcash_voting::Network::Mainnet,
+        WalletNetwork::Test => zcash_voting::Network::Testnet,
+        WalletNetwork::Regtest => zcash_voting::Network::Regtest,
+    }
+}
+
+/// Convert vote-protocol network enum values back to wallet network values.
+pub(crate) fn wallet_network(network: zcash_voting::Network) -> WalletNetwork {
+    match network {
+        zcash_voting::Network::Mainnet => WalletNetwork::Main,
+        zcash_voting::Network::Testnet => WalletNetwork::Test,
+        zcash_voting::Network::Regtest => WalletNetwork::Regtest,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_wallet_network_to_voting_network() {
+        assert_eq!(
+            voting_network(WalletNetwork::Main),
+            zcash_voting::Network::Mainnet
+        );
+        assert_eq!(
+            voting_network(WalletNetwork::Test),
+            zcash_voting::Network::Testnet
+        );
+        assert_eq!(
+            voting_network(WalletNetwork::Regtest),
+            zcash_voting::Network::Regtest
+        );
+    }
+
+    #[test]
+    fn converts_voting_network_to_wallet_network() {
+        assert_eq!(
+            wallet_network(zcash_voting::Network::Mainnet),
+            WalletNetwork::Main
+        );
+        assert_eq!(
+            wallet_network(zcash_voting::Network::Testnet),
+            WalletNetwork::Test
+        );
+        assert_eq!(
+            wallet_network(zcash_voting::Network::Regtest),
+            WalletNetwork::Regtest
+        );
+    }
+}

--- a/rust/src/wallet/voting/test_support.rs
+++ b/rust/src/wallet/voting/test_support.rs
@@ -1,0 +1,35 @@
+#![cfg(test)]
+//! Shared voting test fixtures used across Rust unit tests.
+//!
+//! This module is intentionally test-only so fixture values do not leak into
+//! non-test builds.
+
+pub(crate) const ROUND_ID: &str =
+    "0000000000000000000000000000000000000000000000000000000000000001";
+pub(crate) const TEST_ACCOUNT_UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
+pub(crate) const TEST_MNEMONIC: &str =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+pub(crate) fn test_api_round_params() -> zcash_voting::wire::VotingRoundParams {
+    zcash_voting::wire::VotingRoundParams {
+        vote_round_id: ROUND_ID.to_string(),
+        snapshot_height: 100,
+        ea_pk: vec![0xEA; 32],
+        nc_root: vec![2; 32],
+        nullifier_imt_root: vec![3; 32],
+    }
+}
+
+pub(crate) fn test_note_info(position: u64) -> zcash_voting::NoteInfo {
+    zcash_voting::NoteInfo {
+        commitment: vec![1; 32],
+        nullifier: vec![2; 32],
+        value: zcash_voting::governance::BALLOT_DIVISOR,
+        position,
+        diversifier: vec![3; 11],
+        rho: vec![4; 32],
+        rseed: vec![5; 32],
+        scope: 0,
+        ufvk_str: "uviewtest".to_string(),
+    }
+}


### PR DESCRIPTION
## Summary

- isolate the Rust voting integration core into a standalone review slice
- include wallet voting modules, integration README, and Rust dependency updates
- intentionally exclude FRB-facing files (`rust/src/api/voting.rs`, `rust/src/api/mod.rs` voting export, `rust/src/frb_generated.rs`, `flutter_rust_bridge.yaml`)

## Useful Links

- [Design Document Draft](https://docs.google.com/document/d/1O2l_dfvSNA0lQuM7jApWOcJeDjiSh5eq4rqcoUtwf-0/edit?tab=t.0)
- [Integration README](https://github.com/chainapsis/vizor-wallet/blob/6eb026b61ccb39166caada206a5c11b22332a918/rust/src/wallet/voting/README.md) (start here)
- [Voting Library Usage Examples](https://github.com/valargroup/zcash_voting/tree/main/wallet-example/src)
- [Documentation](https://valargroup.gitbook.io/shielded-vote-docs)

## Relevant PRs


Full integration working branch: https://github.com/valargroup/vizor-wallet/pull/1

### PR Splits

Splitting for ease of review

1. https://github.com/chainapsis/vizor-wallet/pull/142
2. https://github.com/chainapsis/vizor-wallet/pull/143

## Notes

- We made it so that Rust FRB code-gen is created from [zcash_voting::wire](https://github.com/valargroup/zcash_voting/blob/main/zcash_voting/src/wire.rs)
- `rust/src/api/voting.rs` is the key file sitting between the wallet UI and the voting library.
- Vizor's Rust layer aims to be state-less and minimal, simply propagating the execution into `zcash_voting`

## Demo

https://github.com/user-attachments/assets/d9390667-95f9-4547-b8f7-16b7a6d1e5ae

## Verification
- [x] `cargo build --manifest-path rust/Cargo.toml`