### PR TITLE
[Coinholder Voting][2]: Voting API + FRB Rust gen

### DIFF
--- a/flutter_rust_bridge.yaml
+++ b/flutter_rust_bridge.yaml
@@ -1,3 +1,3 @@
-rust_input: crate::api
+rust_input: crate::api,zcash_voting::wire
 rust_root: rust/
 dart_output: lib/src/rust

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -25,6 +25,10 @@ export 'account_models.dart';
 const _accountsKey = 'zcash_accounts';
 const _activeAccountKey = 'zcash_active_account';
 const _networkKey = 'zcash_wallet_network';
+// Keep in sync with zcash_voting::storage::VotingDb::wallet_sidecar_path,
+// which appends ".voting" to the wallet DB path for sidecar persistence.
+const _votingSidecarSuffix = '.voting';
+const _sqliteCompanionSuffixes = ['', '-journal', '-wal', '-shm'];
 
 const kWalletCreationCurrentBlockHeightErrorMessage =
     'We need the current Zcash block height to create your wallet. '
@@ -621,11 +625,11 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
   }
 
   Future<void> _deleteExistingDb(String dbPath) async {
-    final file = File(dbPath);
-    if (file.existsSync()) file.deleteSync();
-    for (final suffix in ['-journal', '-wal', '-shm']) {
-      final f = File('$dbPath$suffix');
-      if (f.existsSync()) f.deleteSync();
+    for (final path in walletDbCleanupPaths(dbPath)) {
+      final file = File(path);
+      if (file.existsSync()) {
+        file.deleteSync();
+      }
     }
   }
 }
@@ -649,4 +653,14 @@ String? resolveNextActiveAccountUuidAfterRemoval({
       .clamp(0, remainingAccounts.length - 1)
       .toInt();
   return remainingAccounts[nextIndex].uuid;
+}
+
+@visibleForTesting
+List<String> walletDbCleanupPaths(String dbPath) {
+  // Voting persists to a deterministic SQLite sidecar next to the wallet DB.
+  final targets = [dbPath, '$dbPath$_votingSidecarSuffix'];
+  return [
+    for (final target in targets)
+      for (final suffix in _sqliteCompanionSuffixes) '$target$suffix',
+  ];
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -460,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -893,7 +893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1507,9 +1507,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1525,6 +1525,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1676,6 +1692,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "imt-tree"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c378a3c5c44b985233906c966bd82a4f775a83aa4e1bde1635961c2eb8673d7b"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "hex",
+ "pasta_curves",
+ "rayon",
+]
+
+[[package]]
 name = "incrementalmerkletree"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,7 +1824,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1979,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2336,6 +2366,38 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pir-client"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18409a3bbbc58985c0ba79ec464c65e6ebab19cc1a82c5d4e184c3484520100"
+dependencies = [
+ "anyhow",
+ "ff",
+ "futures",
+ "hex",
+ "imt-tree",
+ "log",
+ "pasta_curves",
+ "pir-types",
+ "serde_json",
+ "tokio",
+ "valar-ypir",
+]
+
+[[package]]
+name = "pir-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd3d6025cac852a7b3b81d6d07d6e21cc03bb3d5873fc13144a74c56f325b9d"
+dependencies = [
+ "anyhow",
+ "ff",
+ "imt-tree",
+ "pasta_curves",
+ "serde",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2792,7 +2854,9 @@ dependencies = [
  "aes-gcm",
  "base64",
  "bip0039",
+ "blake2b_simd",
  "bls12_381",
+ "ff",
  "flutter_rust_bridge",
  "hex",
  "incrementalmerkletree",
@@ -2800,6 +2864,7 @@ dependencies = [
  "log",
  "nonempty",
  "orchard",
+ "pasta_curves",
  "pbkdf2",
  "pczt",
  "prost 0.14.3",
@@ -2820,6 +2885,7 @@ dependencies = [
  "ur-registry",
  "url",
  "uuid",
+ "vote-commitment-tree 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_address",
  "zcash_client_backend",
  "zcash_client_sqlite",
@@ -2829,6 +2895,7 @@ dependencies = [
  "zcash_protocol",
  "zcash_script",
  "zcash_transparent",
+ "zcash_voting",
  "zeroize",
  "zip32",
 ]
@@ -2871,7 +2938,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3163,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "sinsemilla"
@@ -3198,9 +3265,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3294,7 +3361,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3602,9 +3669,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uint"
@@ -3706,14 +3773,46 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "valar-spiral-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "208d4b69c6a9b7b0c7d856133009a514e10236cdc698ad0b6b87f2e3c4e6d9cb"
+dependencies = [
+ "fastrand",
+ "getrandom 0.2.17",
+ "rand",
+ "rand_chacha",
+ "serde_json",
+ "sha2 0.10.9",
+ "subtle",
+]
+
+[[package]]
+name = "valar-ypir"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c3852d9476a0e3efd6c3bfbfc54d3a21a68d8818c4779824ace78aec84a042"
+dependencies = [
+ "cc",
+ "fastrand",
+ "log",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "serde_json",
+ "sha1",
+ "valar-spiral-rs",
 ]
 
 [[package]]
@@ -3737,6 +3836,75 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "vote-commitment-tree"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "870b893a2c53ec015d46fd3a33cf91715a9a968d34531208144f48e46398321c"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "imt-tree",
+ "incrementalmerkletree",
+ "lazy_static",
+ "libc",
+ "pasta_curves",
+ "shardtree",
+]
+
+[[package]]
+name = "vote-commitment-tree"
+version = "0.3.1"
+source = "git+https://github.com/valargroup/zcash_voting?rev=8e9b69ff8639632932eb8a11420b17603589162e#8e9b69ff8639632932eb8a11420b17603589162e"
+dependencies = [
+ "anyhow",
+ "ff",
+ "halo2_gadgets",
+ "imt-tree",
+ "incrementalmerkletree",
+ "lazy_static",
+ "libc",
+ "pasta_curves",
+ "shardtree",
+]
+
+[[package]]
+name = "vote-commitment-tree-client"
+version = "0.5.1"
+source = "git+https://github.com/valargroup/zcash_voting?rev=8e9b69ff8639632932eb8a11420b17603589162e#8e9b69ff8639632932eb8a11420b17603589162e"
+dependencies = [
+ "base64",
+ "ff",
+ "hex",
+ "pasta_curves",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "vote-commitment-tree 0.3.1 (git+https://github.com/valargroup/zcash_voting?rev=8e9b69ff8639632932eb8a11420b17603589162e)",
+]
+
+[[package]]
+name = "voting-circuits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a5b61b6f99af50df900d839b9440fa36709166449c7fa831169391bc5f44bc"
+dependencies = [
+ "blake2b_simd",
+ "ff",
+ "group",
+ "halo2_gadgets",
+ "halo2_poseidon",
+ "halo2_proofs",
+ "incrementalmerkletree",
+ "itertools 0.14.0",
+ "lazy_static",
+ "orchard",
+ "pasta_curves",
+ "rand",
+ "sinsemilla",
 ]
 
 [[package]]
@@ -4375,9 +4543,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_script"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774d808ab619b0f1887d7b90cd815c356101698d16aa681f3d2d9dea063de475"
+checksum = "2f872800287d118be71bdf6fe8c869c6a6ff6fb0a5762f68fb2af54c97edf0f2"
 dependencies = [
  "bip32",
  "bitflags",
@@ -4425,19 +4593,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_voting"
+version = "0.10.1"
+source = "git+https://github.com/valargroup/zcash_voting?rev=8e9b69ff8639632932eb8a11420b17603589162e#8e9b69ff8639632932eb8a11420b17603589162e"
+dependencies = [
+ "anyhow",
+ "base64",
+ "blake2b_simd",
+ "bytes",
+ "ff",
+ "group",
+ "halo2_gadgets",
+ "halo2_proofs",
+ "hex",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "imt-tree",
+ "incrementalmerkletree",
+ "nonempty",
+ "orchard",
+ "pasta_curves",
+ "pczt",
+ "pir-client",
+ "pir-types",
+ "prost 0.14.3",
+ "rand",
+ "rusqlite",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sinsemilla",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "uuid",
+ "valar-spiral-rs",
+ "valar-ypir",
+ "vote-commitment-tree 0.3.1 (git+https://github.com/valargroup/zcash_voting?rev=8e9b69ff8639632932eb8a11420b17603589162e)",
+ "vote-commitment-tree-client",
+ "voting-circuits",
+ "zcash_client_backend",
+ "zcash_client_sqlite",
+ "zcash_keys",
+ "zcash_primitives",
+ "zcash_protocol",
+ "zeroize",
+ "zip32",
+]
+
+[[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust_lib_zcash_wallet"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.85.1"
 
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]
@@ -25,11 +26,15 @@ zcash_client_backend = { version = "0.22", features = [
     "pczt",
 ] }
 zcash_client_sqlite = { version = "0.20", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
+# Voting clients need PIR lookup support and vote-commitment-tree sync.
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "8e9b69ff8639632932eb8a11420b17603589162e", package = "zcash_voting" }
 # Must match versions used by zcash_client_sqlite to avoid type conflicts
-orchard = "0.13"
+orchard = { version = "=0.13.1", features = ["unstable-voting-circuits"] }
 sapling-crypto = { version = "0.7", default-features = false, features = ["circuit"] }
 uuid = "1.1"
 zip32 = "0.2"
+pasta_curves = "0.5"
+ff = "0.13"
 # Required by no-op Sapling prover trait impls
 jubjub = "0.10"
 bls12_381 = "0.8"
@@ -55,6 +60,7 @@ base64 = "0.22"
 pbkdf2 = "0.12"
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
+blake2b_simd = "1"
 
 # Random number generation
 rand = "0.8"
@@ -90,6 +96,7 @@ security-framework = { version = "3.7", features = ["OSX_10_15"] }
 [dev-dependencies]
 tempfile = "3"
 hex = "0.4"
+vote-commitment-tree = "0.3"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -2,4 +2,7 @@ pub mod keystone;
 pub mod secret;
 pub mod simple;
 pub mod sync;
+pub mod voting;
 pub mod wallet;
+
+mod voting_helpers;

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -472,8 +472,9 @@ fn require_len(bytes: &[u8], expected: usize, field: &str) -> Result<(), String>
     }
 }
 
+// Helper function to log when a sink is closed.
+// Log sink closure is non-fatal. Log so dropped listeners are visible in debug.
 fn log_sink_closed(context: &str, detail: &str) {
-    // Sink closure is non-fatal. Log so dropped listeners are visible in debug.
     log::warn!("{context}: {detail}");
 }
 

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1,9 +1,11 @@
 use std::{panic, sync::Arc};
 
 use super::voting_helpers::{
-    bundle_policy, delegation_static_inputs, prepare_delegation_bundle_params,
-    resolve_delegation_lwd_inputs, seed_from_mnemonic,
+    delegation_static_inputs, prepare_delegation_bundle_params, resolve_delegation_lwd_inputs,
+    seed_from_mnemonic,
 };
+#[cfg(test)]
+use super::voting_helpers::bundle_policy;
 use crate::frb_generated::StreamSink;
 use crate::wallet::{
     keys,
@@ -14,6 +16,7 @@ use secrecy::ExposeSecret;
 
 pub use zcash_voting::vote::{DraftVote, SignedVoteCommitments};
 
+// Shared phase labels emitted in streaming voting/delegation progress events.
 const PHASE_SELECTING_NOTES: &str = "selecting_notes";
 const PHASE_BUILDING_PCZT: &str = "building_pczt";
 const PHASE_BUILDING_PROOF: &str = "building_proof";
@@ -26,15 +29,18 @@ const PHASE_BUILDING_SHARE_PAYLOADS: &str = "building_share_payloads";
 const PHASE_SIGNING: &str = "signing";
 const PHASE_VOTE_COMMIT_STAGE: &str = "vote_commit_stage";
 
+// Fixed-width Keystone payload fields.
 const KEYSTONE_SIG_LEN: usize = 64;
 const KEYSTONE_SIGHASH_LEN: usize = 32;
 const KEYSTONE_RK_LEN: usize = 32;
 
+// Bit flags attached to share-tracking status records.
 const SHARE_TRACKING_FLAG_READY: u32 = 1;
 const SHARE_TRACKING_FLAG_OVERDUE: u32 = 1 << 1;
 #[cfg(test)]
 const MAX_SAFE_JSON_INTEGER: u64 = 0x1f_ffff_ffff_ffff;
 
+// Log-friendly stream labels and sink-drop diagnostics.
 const DELEGATION_STREAM_CONTEXT: &str = "voting delegation";
 const VOTE_STREAM_CONTEXT: &str = "voting vote";
 const SINK_PROGRESS_NOT_DELIVERED: &str = "StreamSink closed, progress not delivered";
@@ -88,14 +94,20 @@ pub struct ApiVotingRoundContext {
 pub fn delegation_submission_wire_json(
     submission: zcash_voting::wire::SignedDelegationPayloadView,
 ) -> Result<String, String> {
-    catch(|| submission.submission.to_json().map_err(|e| e.to_string()))
+    catch(|| {
+        // Serialize validated delegation payload into chain wire JSON.
+        submission.submission.to_json().map_err(|e| e.to_string())
+    })
 }
 
 /// Returns the vote-chain cast-vote submission body as validated wire JSON.
 pub fn vote_commitment_wire_json(
     commitment: zcash_voting::wire::VoteCommitmentWire,
 ) -> Result<String, String> {
-    catch(|| commitment.to_json().map_err(|e| e.to_string()))
+    catch(|| {
+        // Serialize validated cast-vote commitment into chain wire JSON.
+        commitment.to_json().map_err(|e| e.to_string())
+    })
 }
 
 /// Returns the helper-server encrypted-share submission body as wire JSON.
@@ -105,6 +117,7 @@ pub fn vote_share_wire_json(
     submit_at: u64,
 ) -> Result<String, String> {
     catch(|| {
+        // Bind late fields before emitting helper wire JSON.
         share
             .with_late_bound(vc_tree_position, submit_at)
             .and_then(|share| share.to_json())
@@ -131,8 +144,11 @@ pub fn plan_share_submissions(
     single_share: bool,
 ) -> Result<Vec<zcash_voting::wire::ShareSubmissionPlan>, String> {
     catch(|| {
+        // Convert to usize once for policy sizing and planner inputs.
         let share_count = usize::try_from(share_count)
             .map_err(|_| "share_count does not fit in usize".to_string())?;
+
+        // Ask crate policy how much CSPRNG entropy is required.
         let required = zcash_voting::share_policy::share_submission_random_bytes_required(
             share_count,
             server_urls.len(),
@@ -141,6 +157,8 @@ pub fn plan_share_submissions(
             last_moment_buffer_seconds,
             single_share,
         );
+
+        // Draw independent entropy streams for schedule and helper selection.
         let mut submit_at_random_bytes = vec![0u8; required.submit_at_random_bytes];
         let mut server_random_bytes = vec![0u8; required.server_random_bytes];
         OsRng
@@ -150,6 +168,7 @@ pub fn plan_share_submissions(
             .try_fill_bytes(&mut server_random_bytes)
             .map_err(|e| format!("failed to draw share-server entropy: {e}"))?;
 
+        // Build FRB-safe plans with fully materialized random inputs.
         let plans = zcash_voting::share_policy::plan_share_submissions(
             share_count,
             &server_urls,
@@ -169,6 +188,7 @@ pub fn plan_share_submissions(
 fn share_record(
     share: zcash_voting::wire::ShareDelegationRecordView,
 ) -> zcash_voting::ShareDelegationRecord {
+    // Convert API view type into core share-tracking record shape.
     zcash_voting::ShareDelegationRecord {
         round_id: share.round_id,
         bundle_index: share.bundle_index,
@@ -196,10 +216,14 @@ pub fn share_tracking_flags(
         let share = share_record(share);
         let policy = zcash_voting::share::ShareTimingPolicy::default();
         let mut flags = 0u32;
+
+        // Flag shares that are ready for helper status checks.
         if zcash_voting::share::policy::is_share_ready_for_status_check(&share, now_seconds, policy)
         {
             flags |= SHARE_TRACKING_FLAG_READY;
         }
+
+        // Flag shares that are overdue and should be retried.
         if vote_end_time_seconds
             .map(|vote_end_time_seconds| {
                 zcash_voting::share::policy::should_resubmit_share(
@@ -223,6 +247,7 @@ pub fn next_share_tracking_delay_seconds(
     now_seconds: u64,
 ) -> Result<Option<u64>, String> {
     catch(|| {
+        // Convert wire views into core records consumed by share policy.
         let shares = shares.into_iter().map(share_record).collect::<Vec<_>>();
         Ok(zcash_voting::share::policy::next_tracking_delay_seconds(
             &shares,
@@ -273,6 +298,7 @@ pub fn derive_voting_hotkey(
     network: String,
 ) -> Result<Vec<u8>, String> {
     catch(|| {
+        // Parse network and derive deterministic account/round-scoped hotkey.
         let network = keys::parse_network(&network)?;
         let seed = seed_from_mnemonic(mnemonic)?;
         hotkey::derive_hotkey(&seed, &round_id, &account_uuid, network).map(|hotkey| {
@@ -294,6 +320,7 @@ pub fn derive_voting_hotkey(
 /// Returns an error if network parsing fails or random hotkey generation fails.
 pub fn generate_voting_hotkey(network: String) -> Result<Vec<u8>, String> {
     catch(|| {
+        // Hardware accounts use randomized per-round voting hotkeys.
         let network = keys::parse_network(&network)?;
         zcash_voting::hotkey::generate_random_voting_hotkey(voting_network(network))
             .map_err(|e| format!("Voting hotkey generation failed: {e}"))
@@ -307,6 +334,7 @@ pub fn generate_voting_hotkey(network: String) -> Result<Vec<u8>, String> {
 
 impl From<DelegationProgress> for ApiDelegationProofEvent {
     fn from(progress: DelegationProgress) -> Self {
+        // Normalize crate-specific progress into stable FRB phase labels.
         match progress {
             DelegationProgress::SelectingNotes => Self {
                 phase: PHASE_SELECTING_NOTES.to_string(),
@@ -354,6 +382,7 @@ impl From<DelegationProgress> for ApiDelegationProofEvent {
 
 impl From<zcash_voting::vote::VoteCommitStage> for ApiVoteCommitEvent {
     fn from(event: zcash_voting::vote::VoteCommitStage) -> Self {
+        // Normalize vote commit stage details into API progress events.
         match event {
             zcash_voting::vote::VoteCommitStage::ProofStarting {
                 proposal_id,
@@ -412,6 +441,7 @@ impl From<zcash_voting::vote::VoteCommitStage> for ApiVoteCommitEvent {
 /// This preserves the existing `Result<T, String>` contract used by FRB entry
 /// points so callers receive a normal error instead of an unwind crossing FFI.
 fn catch<T>(f: impl FnOnce() -> Result<T, String> + panic::UnwindSafe) -> Result<T, String> {
+    // Convert unwind payloads into stable string errors for FFI callers.
     match panic::catch_unwind(f) {
         Ok(result) => result,
         Err(e) => {
@@ -431,6 +461,7 @@ fn catch<T>(f: impl FnOnce() -> Result<T, String> + panic::UnwindSafe) -> Result
 ///
 /// Returns an error naming `field` when the provided length differs.
 fn require_len(bytes: &[u8], expected: usize, field: &str) -> Result<(), String> {
+    // Keep fixed-size cryptographic fields strict at API boundaries.
     if bytes.len() == expected {
         Ok(())
     } else {
@@ -442,6 +473,7 @@ fn require_len(bytes: &[u8], expected: usize, field: &str) -> Result<(), String>
 }
 
 fn log_sink_closed(context: &str, detail: &str) {
+    // Sink closure is non-fatal. Log so dropped listeners are visible in debug.
     log::warn!("{context}: {detail}");
 }
 
@@ -453,6 +485,7 @@ fn emit_signed_delegation_result(
     sink: &StreamSink<ApiDelegationProofEvent>,
     signed_result: Result<zcash_voting::wire::SignedDelegationPayloadView, String>,
 ) -> Result<(), String> {
+    // Surface computation/signing errors through stream errors.
     let signed = match signed_result {
         Ok(signed) => signed,
         Err(error) => {
@@ -463,6 +496,7 @@ fn emit_signed_delegation_result(
         }
     };
 
+    // Emit the terminal result event when a payload is available.
     if sink
         .add(ApiDelegationProofEvent {
             phase: PHASE_RESULT.to_string(),
@@ -480,6 +514,7 @@ fn emit_signed_vote_result(
     sink: &StreamSink<ApiVoteCommitEvent>,
     signed_result: Result<zcash_voting::wire::SignedVoteCommitmentsView, String>,
 ) -> Result<(), String> {
+    // Surface computation/signing errors through stream errors.
     let commitments = match signed_result {
         Ok(commitments) => commitments,
         Err(error) => {
@@ -490,6 +525,7 @@ fn emit_signed_vote_result(
         }
     };
 
+    // Emit the terminal result event when commitments are available.
     if sink
         .add(ApiVoteCommitEvent {
             phase: PHASE_RESULT.to_string(),
@@ -517,15 +553,21 @@ fn emit_signed_vote_result(
 pub async fn setup_delegation_bundles(
     ctx: ApiVotingRoundContext,
 ) -> Result<zcash_voting::wire::BundleLayout, String> {
-    let bundle_policy = bundle_policy(ctx.max_real_notes_per_bundle)?;
+    // Resolve static network + bundle policy inputs and open the sidecar DB.
+    let (_, voting_network, bundle_policy) =
+        delegation_static_inputs(&ctx.network, ctx.max_real_notes_per_bundle)?;
     let voting_db = db::open_voting_db(&ctx.db_path, &ctx.account_uuid)?;
+
+    // Select and persist reusable delegation bundles for this round/account.
     delegation::setup_delegation_bundles(
         &voting_db,
         &ctx.db_path,
-        &ctx.lightwalletd_url,
-        &ctx.network,
-        ctx.round_params,
-        &ctx.round_name,
+        zcash_voting::delegate::ResolveDelegationLwdParams {
+            lightwalletd_url: &ctx.lightwalletd_url,
+            network: voting_network,
+            round_params: ctx.round_params,
+            round_name: &ctx.round_name,
+        },
         ctx.session_json.as_deref(),
         bundle_policy,
     )
@@ -547,11 +589,17 @@ pub async fn precompute_delegation_pir(
     mnemonic: String,
     bundle_index: u32,
 ) -> Result<zcash_voting::wire::DelegationPirPrecomputeResultView, String> {
+    // Resolve static network and bundling policy inputs from round context.
     let (wallet_network, voting_network, bundle_policy) =
         delegation_static_inputs(&ctx.network, ctx.max_real_notes_per_bundle)?;
+
+    // Derive wallet seed and round-scoped delegation hotkey from the mnemonic.
     let seed = seed_from_mnemonic(mnemonic)?;
     let round_id = ctx.round_params.vote_round_id.clone();
-    let hotkey_secret = hotkey::derive_hotkey(&seed, &round_id, &ctx.account_uuid, wallet_network)?;
+    let hotkey_secret =
+        hotkey::derive_hotkey(&seed, &round_id, &ctx.account_uuid, wallet_network)?;
+
+    // Fetch lightwalletd-backed round inputs used for delegation bundle prep.
     let lwd = resolve_delegation_lwd_inputs(
         &ctx.lightwalletd_url,
         ctx.round_params,
@@ -559,6 +607,8 @@ pub async fn precompute_delegation_pir(
         voting_network,
     )
     .await?;
+
+    // Assemble bundle preparation parameters for PIR precompute.
     let prepare_params = prepare_delegation_bundle_params(
         lwd,
         ctx.session_json.as_deref(),
@@ -568,6 +618,8 @@ pub async fn precompute_delegation_pir(
         bundle_index,
         bundle_policy,
     );
+
+    // Warm the PIR path by precomputing/caching delegation bundle artifacts.
     delegation::precompute_delegation_pir(&ctx.db_path, &pir_server_url, prepare_params)
         .await
         .map(zcash_voting::wire::DelegationPirPrecomputeResultView::from)
@@ -591,11 +643,15 @@ pub async fn build_prove_and_sign_delegation_payload_with_progress(
     bundle_index: u32,
     sink: StreamSink<ApiDelegationProofEvent>,
 ) -> Result<(), String> {
+    // Resolve static delegation inputs and derive the round-scoped hotkey.
     let (wallet_network, voting_network, bundle_policy) =
         delegation_static_inputs(&ctx.network, ctx.max_real_notes_per_bundle)?;
     let seed = seed_from_mnemonic(mnemonic)?;
     let round_id = ctx.round_params.vote_round_id.clone();
-    let hotkey_secret = hotkey::derive_hotkey(&seed, &round_id, &ctx.account_uuid, wallet_network)?;
+    let hotkey_secret =
+        hotkey::derive_hotkey(&seed, &round_id, &ctx.account_uuid, wallet_network)?;
+
+    // Resolve lightwalletd inputs and assemble delegation prepare parameters.
     let lwd = resolve_delegation_lwd_inputs(
         &ctx.lightwalletd_url,
         ctx.round_params,
@@ -612,6 +668,8 @@ pub async fn build_prove_and_sign_delegation_payload_with_progress(
         bundle_index,
         bundle_policy,
     );
+
+    // Stream local progress events and emit one final result/error event.
     let sink = Arc::new(sink);
     let progress_sink = sink.clone();
     let signed_result = delegation::build_prove_and_sign_delegation_payload(
@@ -627,7 +685,8 @@ pub async fn build_prove_and_sign_delegation_payload_with_progress(
     )
     .await
     .and_then(|bundle| {
-        zcash_voting::wire::SignedDelegationPayloadView::try_from(bundle).map_err(|e| e.to_string())
+        zcash_voting::wire::SignedDelegationPayloadView::try_from(bundle)
+            .map_err(|e| e.to_string())
     });
     emit_signed_delegation_result(sink.as_ref(), signed_result)
 }
@@ -643,9 +702,12 @@ pub async fn build_keystone_delegation_request(
     hotkey_seed: Vec<u8>,
     bundle_index: u32,
 ) -> Result<zcash_voting::wire::KeystoneSigningRequest, String> {
+    // Resolve static round inputs and validate Keystone-provided hotkey bytes.
     let (_, voting_network, bundle_policy) =
         delegation_static_inputs(&ctx.network, ctx.max_real_notes_per_bundle)?;
     let hotkey_secret = hotkey::validated_hotkey_seed(hotkey_seed, voting_network)?;
+
+    // Resolve lightwalletd-backed round inputs and build request parameters.
     let lwd = resolve_delegation_lwd_inputs(
         &ctx.lightwalletd_url,
         ctx.round_params,
@@ -662,6 +724,8 @@ pub async fn build_keystone_delegation_request(
         bundle_index,
         bundle_policy,
     );
+
+    // Build and redact the PCZT request that Keystone signs out of process.
     delegation::build_keystone_delegation_request(&ctx.db_path, &ctx.account_uuid, prepare_params)
         .await
 }
@@ -674,6 +738,7 @@ pub async fn build_keystone_delegation_request(
 /// spend authorization sighash.
 pub fn extract_pczt_sighash(pczt_bytes: Vec<u8>) -> Result<Vec<u8>, String> {
     catch(|| {
+        // Decode PCZT and expose its ZIP-244 spend authorization sighash bytes.
         zcash_voting::delegate::pczt_sighash(&pczt_bytes)
             .map(|sighash| sighash.to_vec())
             .map_err(|e| format!("extract_pczt_sighash failed: {e}"))
@@ -686,6 +751,7 @@ pub fn extract_spend_auth_signature_from_signed_pczt(
     action_index: u32,
 ) -> Result<Vec<u8>, String> {
     catch(|| {
+        // Convert FRB index to host index type for extraction helper.
         let action_index =
             usize::try_from(action_index).map_err(|_| "action_index does not fit in usize")?;
         zcash_voting::delegate::spend_auth_signature(&signed_pczt_bytes, action_index)
@@ -710,6 +776,7 @@ pub fn store_keystone_signature(
     rk: Vec<u8>,
 ) -> Result<(), String> {
     catch(|| {
+        // Validate fixed-size fields before persisting the signature tuple.
         require_len(&sig, KEYSTONE_SIG_LEN, "sig")?;
         require_len(&sighash, KEYSTONE_SIGHASH_LEN, "sighash")?;
         require_len(&rk, KEYSTONE_RK_LEN, "rk")?;
@@ -731,6 +798,7 @@ pub fn get_keystone_signatures(
     round_id: String,
 ) -> Result<Vec<zcash_voting::wire::KeystoneSignatureRecord>, String> {
     catch(|| {
+        // Load all persisted Keystone signatures for this round.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         db.get_keystone_signatures(&round_id)
             .map_err(|e| format!("get_keystone_signatures failed: {e}"))
@@ -752,9 +820,12 @@ pub async fn build_prove_delegation_payload_with_keystone_signature_with_progres
     keystone_sighash: Vec<u8>,
     sink: StreamSink<ApiDelegationProofEvent>,
 ) -> Result<(), String> {
+    // Resolve static inputs and validate the persisted Keystone hotkey seed.
     let (_, voting_network, bundle_policy) =
         delegation_static_inputs(&ctx.network, ctx.max_real_notes_per_bundle)?;
     let hotkey_secret = hotkey::validated_hotkey_seed(hotkey_seed, voting_network)?;
+
+    // Resolve round inputs and build delegation preparation parameters.
     let lwd = resolve_delegation_lwd_inputs(
         &ctx.lightwalletd_url,
         ctx.round_params,
@@ -771,6 +842,8 @@ pub async fn build_prove_delegation_payload_with_keystone_signature_with_progres
         bundle_index,
         bundle_policy,
     );
+
+    // Stream local progress and emit the terminal signed payload or error.
     let sink = Arc::new(sink);
     let progress_sink = sink.clone();
     let signed_result = delegation::build_prove_delegation_payload_with_keystone_signature(
@@ -788,7 +861,8 @@ pub async fn build_prove_delegation_payload_with_keystone_signature_with_progres
     )
     .await
     .and_then(|bundle| {
-        zcash_voting::wire::SignedDelegationPayloadView::try_from(bundle).map_err(|e| e.to_string())
+        zcash_voting::wire::SignedDelegationPayloadView::try_from(bundle)
+            .map_err(|e| e.to_string())
     });
     emit_signed_delegation_result(sink.as_ref(), signed_result)
 }
@@ -809,6 +883,7 @@ pub fn mark_delegation_submitted(
     tx_hash: String,
 ) -> Result<(), String> {
     catch(|| {
+        // Persist submission hash for this round/bundle key.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         db.mark_delegation_submitted(&round_id, bundle_index, &tx_hash)
             .map_err(|e| e.to_string())
@@ -830,6 +905,7 @@ pub fn confirm_delegation_submission(
     events: Vec<zcash_voting::wire::TxEvent>,
 ) -> Result<zcash_voting::wire::DelegationConfirmation, String> {
     catch(|| {
+        // Parse tx events and persist confirmation details for this bundle.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         zcash_voting::confirmation::confirm_delegation_submission(
             &db,
@@ -852,6 +928,7 @@ pub fn delete_skipped_bundles(
     keep_count: u32,
 ) -> Result<u32, String> {
     catch(|| {
+        // Delete skipped bundle rows and downcast deleted count for FRB.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         db.delete_skipped_bundles(&round_id, keep_count)
             .and_then(|deleted| {
@@ -880,6 +957,7 @@ pub fn sync_vote_tree(
     node_url: String,
 ) -> Result<u32, String> {
     catch(|| {
+        // Sync and cache vote tree state for this wallet/round.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         zcash_voting::precompute::sync_vote_tree(&db, &round_id, &node_url)
             .map_err(|e| format!("sync_vote_tree failed: {e}"))
@@ -904,6 +982,8 @@ pub fn generate_van_witness(
 ) -> Result<zcash_voting::wire::VanWitness, String> {
     catch(|| {
         let db = db::open_voting_db(&db_path, &account_uuid)?;
+
+        // Validate bundle index against persisted bundle count first.
         let bundle_count = db
             .get_bundle_count(&round_id)
             .map_err(|e| format!("get_bundle_count failed: {e}"))?;
@@ -926,6 +1006,7 @@ pub fn reset_voting_session_state(
     round_id: Option<String>,
 ) -> Result<(), String> {
     catch(|| {
+        // Empty/None round_id means clear account-wide cached vote tree state.
         let account_wide = round_id.as_deref().map(str::is_empty).unwrap_or(true);
         let tree_count = if account_wide {
             let db = db::open_voting_db(&db_path, &account_uuid)?;
@@ -960,6 +1041,7 @@ pub fn recover_vote_commitment(
     proposal_id: u32,
 ) -> Result<zcash_voting::wire::SignedVoteCommitmentsView, String> {
     catch(|| {
+        // Recover persisted commitments and convert to public wire view.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         zcash_voting::vote::recover_signed_commitments(&db, &round_id, bundle_index, proposal_id)
             .map_err(|e| format!("vote commitment recovery failed: {e}"))
@@ -985,8 +1067,11 @@ async fn build_vote_commitments_result<F>(
 where
     F: Fn(zcash_voting::vote::VoteCommitStage) + Send + Sync + 'static,
 {
+    // Parse network once and keep hotkey bytes in a secrecy wrapper.
     let network = keys::parse_network(&network)?;
     let hotkey_seed = secrecy::SecretVec::new(hotkey_seed);
+
+    // Commit/prove work is CPU-heavy; run it on a blocking worker thread.
     let commitment_result = tokio::task::spawn_blocking(move || {
         let reporter = zcash_voting::VoteCommitStageBridge::new(on_stage);
         let voting_db = db::open_voting_db(&db_path, &account_uuid)?;
@@ -1011,7 +1096,10 @@ where
     .map_err(|e| format!("vote commitment task failed: {e}"))
     .and_then(|result| result);
     let commitments = commitment_result?;
-    zcash_voting::wire::SignedVoteCommitmentsView::try_from(commitments).map_err(|e| e.to_string())
+
+    // Convert internal commitment type into the FRB wire view.
+    zcash_voting::wire::SignedVoteCommitmentsView::try_from(commitments)
+        .map_err(|e| e.to_string())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1030,6 +1118,7 @@ pub async fn build_vote_commitments_with_progress(
     draft_votes: Vec<zcash_voting::wire::DraftVote>,
     sink: StreamSink<ApiVoteCommitEvent>,
 ) -> Result<(), String> {
+    // Bridge stage callbacks into stream events for UI progress updates.
     let sink = Arc::new(sink);
     let progress_sink = sink.clone();
     let commitments = build_vote_commitments_result(
@@ -1059,6 +1148,7 @@ pub fn get_round_recovery_state(
     round_id: String,
 ) -> Result<zcash_voting::wire::RoundRecoveryStateView, String> {
     catch(|| {
+        // Load persisted round snapshot and expose wire-safe view fields.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         zcash_voting::recovery::round_snapshot(&db, &round_id)
             .map(zcash_voting::wire::RoundRecoveryStateView::from)
@@ -1083,6 +1173,7 @@ pub fn mark_vote_submitted(
     tx_hash: String,
 ) -> Result<(), String> {
     catch(|| {
+        // Persist submission hash for this round/bundle/proposal key.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         db.mark_vote_submitted(&round_id, bundle_index, proposal_id, &tx_hash)
             .map_err(|e| e.to_string())
@@ -1105,6 +1196,7 @@ pub fn confirm_vote_submission(
     events: Vec<zcash_voting::wire::TxEvent>,
 ) -> Result<zcash_voting::wire::VoteConfirmation, String> {
     catch(|| {
+        // Parse tx events and persist vote confirmation fields.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         zcash_voting::confirmation::confirm_vote_submission(
             &db,
@@ -1137,6 +1229,8 @@ pub fn record_share_delegation(
 ) -> Result<(), String> {
     catch(|| {
         let db = db::open_voting_db(&db_path, &account_uuid)?;
+
+        // Recover vote context first, then persist helper submission metadata.
         zcash_voting::vote::CommittedVote::recover(&db, &round_id, bundle_index, proposal_id)
             .map_err(|e| format!("recover committed vote failed: {e}"))?
             .record_share(&db, share_index, &sent_to_urls, submit_at)
@@ -1161,6 +1255,8 @@ pub fn mark_share_confirmed(
 ) -> Result<(), String> {
     catch(|| {
         let db = db::open_voting_db(&db_path, &account_uuid)?;
+
+        // Recover vote context first, then mark the specific share as confirmed.
         zcash_voting::vote::CommittedVote::recover(&db, &round_id, bundle_index, proposal_id)
             .map_err(|e| format!("recover committed vote failed: {e}"))?
             .confirm_share(&db, share_index)
@@ -1185,6 +1281,7 @@ pub fn add_sent_servers(
     new_urls: Vec<String>,
 ) -> Result<(), String> {
     catch(|| {
+        // Merge additional helper URLs into persisted share delivery state.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         zcash_voting::share::add_sent_servers(
             &db,
@@ -1208,6 +1305,7 @@ pub fn clear_recovery_state(
     round_id: String,
 ) -> Result<(), String> {
     catch(|| {
+        // Clear persisted recovery/share-tracking state for this round.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         zcash_voting::recovery::clear(&db, &round_id)
             .map_err(|e| format!("clear_recovery_state failed: {e}"))
@@ -1223,6 +1321,7 @@ pub fn get_round_plan(
     proposal_ids: Vec<u32>,
 ) -> Result<zcash_voting::wire::RoundPlanView, String> {
     catch(|| {
+        // Derive resumable next steps and convert to wire view.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         let plan = zcash_voting::session::resume_plan(&db, &round_id, &proposal_ids)
             .map_err(|e| format!("resume_plan failed: {e}"))?;
@@ -1244,6 +1343,8 @@ pub fn set_ballot_intent(
 ) -> Result<(), String> {
     catch(|| {
         let db = db::open_voting_db(&db_path, &account_uuid)?;
+
+        // `skipped` takes precedence; otherwise a concrete choice is required.
         let decision = if skipped {
             zcash_voting::session::Decision::Skipped
         } else {

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1,0 +1,2672 @@
+use std::{panic, sync::Arc};
+
+use super::voting_helpers::{
+    bundle_policy, delegation_static_inputs, prepare_delegation_bundle_params,
+    resolve_delegation_lwd_inputs, seed_from_mnemonic,
+};
+use crate::frb_generated::StreamSink;
+use crate::wallet::{
+    keys,
+    voting::{db, delegation, delegation::DelegationProgress, hotkey, network::voting_network},
+};
+use rand::{rngs::OsRng, RngCore};
+use secrecy::ExposeSecret;
+
+pub use zcash_voting::vote::{DraftVote, SignedVoteCommitments};
+
+const PHASE_SELECTING_NOTES: &str = "selecting_notes";
+const PHASE_BUILDING_PCZT: &str = "building_pczt";
+const PHASE_BUILDING_PROOF: &str = "building_proof";
+const PHASE_PROOF_PROGRESS: &str = "proof_progress";
+const PHASE_SIGNING_PAYLOAD: &str = "signing_payload";
+const PHASE_PAYLOAD_READY: &str = "payload_ready";
+const PHASE_RESULT: &str = "result";
+const PHASE_DELEGATION_PROGRESS: &str = "delegation_progress";
+const PHASE_BUILDING_SHARE_PAYLOADS: &str = "building_share_payloads";
+const PHASE_SIGNING: &str = "signing";
+const PHASE_VOTE_COMMIT_STAGE: &str = "vote_commit_stage";
+
+const KEYSTONE_SIG_LEN: usize = 64;
+const KEYSTONE_SIGHASH_LEN: usize = 32;
+const KEYSTONE_RK_LEN: usize = 32;
+
+const SHARE_TRACKING_FLAG_READY: u32 = 1;
+const SHARE_TRACKING_FLAG_OVERDUE: u32 = 1 << 1;
+#[cfg(test)]
+const MAX_SAFE_JSON_INTEGER: u64 = 0x1f_ffff_ffff_ffff;
+
+const DELEGATION_STREAM_CONTEXT: &str = "voting delegation";
+const VOTE_STREAM_CONTEXT: &str = "voting vote";
+const SINK_PROGRESS_NOT_DELIVERED: &str = "StreamSink closed, progress not delivered";
+const SINK_ERROR_NOT_DELIVERED: &str = "StreamSink closed before error delivery";
+const SINK_RESULT_NOT_DELIVERED: &str = "StreamSink closed before final result";
+
+#[derive(Clone, Debug, PartialEq)]
+/// Progress event emitted while building, proving, and signing a delegation payload.
+///
+/// A terminal `"result"` event carries `signed_delegation_payload`; earlier
+/// phase events only describe local preparation progress.
+pub struct ApiDelegationProofEvent {
+    pub phase: String,
+    pub proof_progress: Option<f64>,
+    pub signed_delegation_payload: Option<zcash_voting::wire::SignedDelegationPayloadView>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+/// Progress event emitted while building ZKP2 vote commitments.
+///
+/// A terminal `"result"` event carries the completed commitment set; earlier
+/// phase events include the active `(proposal_id, bundle_index)` pair.
+pub struct ApiVoteCommitEvent {
+    pub phase: String,
+    pub proposal_id: Option<u32>,
+    pub bundle_index: Option<u32>,
+    pub proof_progress: Option<f64>,
+    pub commitments: Option<zcash_voting::wire::SignedVoteCommitmentsView>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+/// Shared delegation/voting round context passed across the FRB boundary.
+///
+/// This bundles the reusable round and wallet scope required by delegation setup,
+/// proving, and keystone request flows.
+pub struct ApiVotingRoundContext {
+    pub db_path: String,
+    pub lightwalletd_url: String,
+    pub network: String,
+    pub round_params: zcash_voting::wire::VotingRoundParams,
+    pub round_name: String,
+    pub session_json: Option<String>,
+    pub account_uuid: String,
+    pub max_real_notes_per_bundle: Option<u32>,
+}
+
+/// Returns the vote-chain delegation submission body as validated wire JSON.
+///
+/// Binary fields are base64-encoded here so Dart does not duplicate protocol
+/// field names or byte encoding rules.
+pub fn delegation_submission_wire_json(
+    submission: zcash_voting::wire::SignedDelegationPayloadView,
+) -> Result<String, String> {
+    catch(|| submission.submission.to_json().map_err(|e| e.to_string()))
+}
+
+/// Returns the vote-chain cast-vote submission body as validated wire JSON.
+pub fn vote_commitment_wire_json(
+    commitment: zcash_voting::wire::VoteCommitmentWire,
+) -> Result<String, String> {
+    catch(|| commitment.to_json().map_err(|e| e.to_string()))
+}
+
+/// Returns the helper-server encrypted-share submission body as wire JSON.
+pub fn vote_share_wire_json(
+    share: zcash_voting::wire::VoteShareWire,
+    vc_tree_position: Option<u64>,
+    submit_at: u64,
+) -> Result<String, String> {
+    catch(|| {
+        share
+            .with_late_bound(vc_tree_position, submit_at)
+            .and_then(|share| share.to_json())
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// Plan independent helper-share timing and randomized helper targets.
+///
+/// This mirrors the zcash-swift-wallet-sdk wrapper around
+/// `zcash_voting::share_policy::plan_share_submissions`, with Rust drawing the
+/// policy-sized entropy from the OS CSPRNG before returning FRB-safe plans.
+///
+/// # Errors
+///
+/// Returns an error if `share_count` does not fit `usize`, entropy generation
+/// fails, or crate policy rejects the supplied timing/server inputs.
+pub fn plan_share_submissions(
+    share_count: u32,
+    server_urls: Vec<String>,
+    now_seconds: u64,
+    vote_end_time_seconds: u64,
+    last_moment_buffer_seconds: Option<u64>,
+    single_share: bool,
+) -> Result<Vec<zcash_voting::wire::ShareSubmissionPlan>, String> {
+    catch(|| {
+        let share_count = usize::try_from(share_count)
+            .map_err(|_| "share_count does not fit in usize".to_string())?;
+        let required = zcash_voting::share_policy::share_submission_random_bytes_required(
+            share_count,
+            server_urls.len(),
+            now_seconds,
+            vote_end_time_seconds,
+            last_moment_buffer_seconds,
+            single_share,
+        );
+        let mut submit_at_random_bytes = vec![0u8; required.submit_at_random_bytes];
+        let mut server_random_bytes = vec![0u8; required.server_random_bytes];
+        OsRng
+            .try_fill_bytes(&mut submit_at_random_bytes)
+            .map_err(|e| format!("failed to draw submit_at entropy: {e}"))?;
+        OsRng
+            .try_fill_bytes(&mut server_random_bytes)
+            .map_err(|e| format!("failed to draw share-server entropy: {e}"))?;
+
+        let plans = zcash_voting::share_policy::plan_share_submissions(
+            share_count,
+            &server_urls,
+            now_seconds,
+            vote_end_time_seconds,
+            last_moment_buffer_seconds,
+            single_share,
+            &submit_at_random_bytes,
+            &server_random_bytes,
+        )
+        .map_err(|e| e.to_string())?;
+
+        Ok(plans)
+    })
+}
+
+fn share_record(
+    share: zcash_voting::wire::ShareDelegationRecordView,
+) -> zcash_voting::ShareDelegationRecord {
+    zcash_voting::ShareDelegationRecord {
+        round_id: share.round_id,
+        bundle_index: share.bundle_index,
+        proposal_id: share.proposal_id,
+        share_index: share.share_index,
+        sent_to_urls: share.sent_to_urls,
+        nullifier: share.nullifier,
+        confirmed: share.confirmed,
+        submit_at: share.submit_at,
+        created_at: share.created_at,
+    }
+}
+
+/// Return share-tracking action flags using `zcash_voting::share_policy`.
+///
+/// [`SHARE_TRACKING_FLAG_READY`] means the share is ready for status polling.
+/// [`SHARE_TRACKING_FLAG_OVERDUE`] means it is overdue and should be retried
+/// against helpers that missed the initial submission.
+pub fn share_tracking_flags(
+    share: zcash_voting::wire::ShareDelegationRecordView,
+    now_seconds: u64,
+    vote_end_time_seconds: Option<u64>,
+) -> Result<u32, String> {
+    catch(|| {
+        let share = share_record(share);
+        let policy = zcash_voting::share::ShareTimingPolicy::default();
+        let mut flags = 0u32;
+        if zcash_voting::share::policy::is_share_ready_for_status_check(&share, now_seconds, policy)
+        {
+            flags |= SHARE_TRACKING_FLAG_READY;
+        }
+        if vote_end_time_seconds
+            .map(|vote_end_time_seconds| {
+                zcash_voting::share::policy::should_resubmit_share(
+                    &share,
+                    now_seconds,
+                    vote_end_time_seconds,
+                    policy,
+                )
+            })
+            .unwrap_or(false)
+        {
+            flags |= SHARE_TRACKING_FLAG_OVERDUE;
+        }
+        Ok(flags)
+    })
+}
+
+/// Return the next share-tracking delay in seconds using crate policy.
+pub fn next_share_tracking_delay_seconds(
+    shares: Vec<zcash_voting::wire::ShareDelegationRecordView>,
+    now_seconds: u64,
+) -> Result<Option<u64>, String> {
+    catch(|| {
+        let shares = shares.into_iter().map(share_record).collect::<Vec<_>>();
+        Ok(zcash_voting::share::policy::next_tracking_delay_seconds(
+            &shares,
+            now_seconds,
+            zcash_voting::share::ShareTimingPolicy::default(),
+        ))
+    })
+}
+
+/// Extract and validate one helper-share payload from stored recovery JSON.
+///
+/// The stored recovery blob is hex-encoded and also contains local-only
+/// recovery material. This helper emits only the public base64 wire shape that
+/// helper servers accept.
+pub fn recovered_vote_share_wire_json(
+    commitment_bundle_json: String,
+    proposal_id: u32,
+    share_index: u32,
+    vc_tree_position: u64,
+    submit_at: u64,
+) -> Result<String, String> {
+    catch(|| {
+        zcash_voting::share::recover_wire_json(
+            &commitment_bundle_json,
+            proposal_id,
+            share_index,
+            vc_tree_position,
+            submit_at,
+        )
+        .map_err(|e| e.to_string())
+    })
+}
+
+/// Derive the opaque per-account, per-round voting hotkey bytes.
+///
+/// Rust derives the wallet seed from the account mnemonic, then derives scoped
+/// hotkey seed material locally and returns bytes for secure storage.
+/// The returned `Vec<u8>` is an unavoidable FRB copy boundary
+///
+/// # Errors
+///
+/// Returns an error if network parsing fails, mnemonic decoding fails, or
+/// contextual hotkey derivation fails.
+pub fn derive_voting_hotkey(
+    mnemonic: String,
+    round_id: String,
+    account_uuid: String,
+    network: String,
+) -> Result<Vec<u8>, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        let seed = seed_from_mnemonic(mnemonic)?;
+        hotkey::derive_hotkey(&seed, &round_id, &account_uuid, network).map(|hotkey| {
+            // FRB returns owned bytes, so this copy cannot be zeroized by Rust
+            // after Dart receives it.
+            hotkey.expose_secret().to_vec()
+        })
+    })
+}
+
+/// Generate opaque voting hotkey bytes for a hardware account.
+///
+/// Hardware accounts cannot expose their wallet seed to derive the deterministic
+/// software hotkey, so the app persists this random per-round hotkey in secure
+/// storage and reuses it for vote commitment signing.
+///
+/// # Errors
+///
+/// Returns an error if network parsing fails or random hotkey generation fails.
+pub fn generate_voting_hotkey(network: String) -> Result<Vec<u8>, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        zcash_voting::hotkey::generate_random_voting_hotkey(voting_network(network))
+            .map_err(|e| format!("Voting hotkey generation failed: {e}"))
+            .map(|hotkey| {
+                // FRB returns owned bytes, so this copy cannot be zeroized by Rust
+                // after Dart receives it.
+                hotkey.secret_seed().to_vec()
+            })
+    })
+}
+
+impl From<DelegationProgress> for ApiDelegationProofEvent {
+    fn from(progress: DelegationProgress) -> Self {
+        match progress {
+            DelegationProgress::SelectingNotes => Self {
+                phase: PHASE_SELECTING_NOTES.to_string(),
+                proof_progress: None,
+                signed_delegation_payload: None,
+            },
+            DelegationProgress::PcztBuilding | DelegationProgress::PcztBuilt => Self {
+                phase: PHASE_BUILDING_PCZT.to_string(),
+                proof_progress: None,
+                signed_delegation_payload: None,
+            },
+            DelegationProgress::ProofStarting => Self {
+                phase: PHASE_BUILDING_PROOF.to_string(),
+                proof_progress: Some(0.0),
+                signed_delegation_payload: None,
+            },
+            DelegationProgress::ProofProgress(value) => Self {
+                phase: PHASE_PROOF_PROGRESS.to_string(),
+                proof_progress: Some(value),
+                signed_delegation_payload: None,
+            },
+            DelegationProgress::ProofComplete => Self {
+                phase: PHASE_PROOF_PROGRESS.to_string(),
+                proof_progress: Some(1.0),
+                signed_delegation_payload: None,
+            },
+            DelegationProgress::SigningPayload => Self {
+                phase: PHASE_SIGNING_PAYLOAD.to_string(),
+                proof_progress: Some(1.0),
+                signed_delegation_payload: None,
+            },
+            DelegationProgress::PayloadReady => Self {
+                phase: PHASE_PAYLOAD_READY.to_string(),
+                proof_progress: None,
+                signed_delegation_payload: None,
+            },
+            _ => Self {
+                phase: PHASE_DELEGATION_PROGRESS.to_string(),
+                proof_progress: None,
+                signed_delegation_payload: None,
+            },
+        }
+    }
+}
+
+impl From<zcash_voting::vote::VoteCommitStage> for ApiVoteCommitEvent {
+    fn from(event: zcash_voting::vote::VoteCommitStage) -> Self {
+        match event {
+            zcash_voting::vote::VoteCommitStage::ProofStarting {
+                proposal_id,
+                bundle_index,
+            } => Self {
+                phase: PHASE_BUILDING_PROOF.to_string(),
+                proposal_id: Some(proposal_id),
+                bundle_index: Some(bundle_index),
+                proof_progress: Some(0.0),
+                commitments: None,
+            },
+            zcash_voting::vote::VoteCommitStage::ProofProgress {
+                proposal_id,
+                bundle_index,
+                progress,
+            } => Self {
+                phase: PHASE_PROOF_PROGRESS.to_string(),
+                proposal_id: Some(proposal_id),
+                bundle_index: Some(bundle_index),
+                proof_progress: Some(progress),
+                commitments: None,
+            },
+            zcash_voting::vote::VoteCommitStage::SharePayloadsBuilding {
+                proposal_id,
+                bundle_index,
+            } => Self {
+                phase: PHASE_BUILDING_SHARE_PAYLOADS.to_string(),
+                proposal_id: Some(proposal_id),
+                bundle_index: Some(bundle_index),
+                proof_progress: Some(1.0),
+                commitments: None,
+            },
+            zcash_voting::vote::VoteCommitStage::Signing {
+                proposal_id,
+                bundle_index,
+            } => Self {
+                phase: PHASE_SIGNING.to_string(),
+                proposal_id: Some(proposal_id),
+                bundle_index: Some(bundle_index),
+                proof_progress: None,
+                commitments: None,
+            },
+            _ => Self {
+                phase: PHASE_VOTE_COMMIT_STAGE.to_string(),
+                proposal_id: None,
+                bundle_index: None,
+                proof_progress: None,
+                commitments: None,
+            },
+        }
+    }
+}
+
+/// Executes an API helper and converts Rust panics into string errors.
+///
+/// This preserves the existing `Result<T, String>` contract used by FRB entry
+/// points so callers receive a normal error instead of an unwind crossing FFI.
+fn catch<T>(f: impl FnOnce() -> Result<T, String> + panic::UnwindSafe) -> Result<T, String> {
+    match panic::catch_unwind(f) {
+        Ok(result) => result,
+        Err(e) => {
+            let msg = if let Some(s) = e.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = e.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic".to_string()
+            };
+            Err(format!("Rust panic: {msg}"))
+        }
+    }
+}
+
+/// Validates that `bytes` has exactly `expected` length.
+///
+/// Returns an error naming `field` when the provided length differs.
+fn require_len(bytes: &[u8], expected: usize, field: &str) -> Result<(), String> {
+    if bytes.len() == expected {
+        Ok(())
+    } else {
+        Err(format!(
+            "{field} must be exactly {expected} bytes, got {}",
+            bytes.len()
+        ))
+    }
+}
+
+fn log_sink_closed(context: &str, detail: &str) {
+    log::warn!("{context}: {detail}");
+}
+
+/// Emits the terminal `"result"` delegation event to a progress sink.
+///
+/// If signing failed, this forwards the error through `sink.add_error` and
+/// returns `Ok(())` so closed sinks do not fail the outer task.
+fn emit_signed_delegation_result(
+    sink: &StreamSink<ApiDelegationProofEvent>,
+    signed_result: Result<zcash_voting::wire::SignedDelegationPayloadView, String>,
+) -> Result<(), String> {
+    let signed = match signed_result {
+        Ok(signed) => signed,
+        Err(error) => {
+            if sink.add_error(error.clone()).is_err() {
+                log_sink_closed(DELEGATION_STREAM_CONTEXT, SINK_ERROR_NOT_DELIVERED);
+            }
+            return Ok(());
+        }
+    };
+
+    if sink
+        .add(ApiDelegationProofEvent {
+            phase: PHASE_RESULT.to_string(),
+            proof_progress: None,
+            signed_delegation_payload: Some(signed),
+        })
+        .is_err()
+    {
+        log_sink_closed(DELEGATION_STREAM_CONTEXT, SINK_RESULT_NOT_DELIVERED);
+    }
+    Ok(())
+}
+
+fn emit_signed_vote_result(
+    sink: &StreamSink<ApiVoteCommitEvent>,
+    signed_result: Result<zcash_voting::wire::SignedVoteCommitmentsView, String>,
+) -> Result<(), String> {
+    let commitments = match signed_result {
+        Ok(commitments) => commitments,
+        Err(error) => {
+            if sink.add_error(error.clone()).is_err() {
+                log_sink_closed(VOTE_STREAM_CONTEXT, SINK_ERROR_NOT_DELIVERED);
+            }
+            return Ok(());
+        }
+    };
+
+    if sink
+        .add(ApiVoteCommitEvent {
+            phase: PHASE_RESULT.to_string(),
+            proposal_id: None,
+            bundle_index: Some(commitments.bundle_index),
+            proof_progress: None,
+            commitments: Some(commitments),
+        })
+        .is_err()
+    {
+        log_sink_closed(VOTE_STREAM_CONTEXT, SINK_RESULT_NOT_DELIVERED);
+    }
+    Ok(())
+}
+
+/// Select notes and persist bundle rows for the delegation pipeline.
+///
+/// Reuses existing bundle rows for the same round/wallet, so callers can safely
+/// retry setup before proving a specific bundle.
+///
+/// # Errors
+///
+/// Returns an error if bundle policy parsing, opening the sidecar DB, round
+/// initialization, note selection, or bundle layout persistence fails.
+pub async fn setup_delegation_bundles(
+    ctx: ApiVotingRoundContext,
+) -> Result<zcash_voting::wire::BundleLayout, String> {
+    let bundle_policy = bundle_policy(ctx.max_real_notes_per_bundle)?;
+    let voting_db = db::open_voting_db(&ctx.db_path, &ctx.account_uuid)?;
+    delegation::setup_delegation_bundles(
+        &voting_db,
+        &ctx.db_path,
+        &ctx.lightwalletd_url,
+        &ctx.network,
+        ctx.round_params,
+        &ctx.round_name,
+        ctx.session_json.as_deref(),
+        bundle_policy,
+    )
+    .await
+}
+
+/// Build delegation PCZT material and prefetch/cache PIR-backed IMT proofs.
+///
+/// This is a background warm-up path. The normal proof path still fetches any
+/// missing PIR proofs if this was not run or did not complete in time.
+///
+/// # Errors
+///
+/// Returns an error if round input resolution, mnemonic-to-seed derivation,
+/// hotkey derivation, bundle preparation, or PIR precompute fails.
+pub async fn precompute_delegation_pir(
+    ctx: ApiVotingRoundContext,
+    pir_server_url: String,
+    mnemonic: String,
+    bundle_index: u32,
+) -> Result<zcash_voting::wire::DelegationPirPrecomputeResultView, String> {
+    let (wallet_network, voting_network, bundle_policy) =
+        delegation_static_inputs(&ctx.network, ctx.max_real_notes_per_bundle)?;
+    let seed = seed_from_mnemonic(mnemonic)?;
+    let round_id = ctx.round_params.vote_round_id.clone();
+    let hotkey_secret = hotkey::derive_hotkey(&seed, &round_id, &ctx.account_uuid, wallet_network)?;
+    let lwd = resolve_delegation_lwd_inputs(
+        &ctx.lightwalletd_url,
+        ctx.round_params,
+        &ctx.round_name,
+        voting_network,
+    )
+    .await?;
+    let prepare_params = prepare_delegation_bundle_params(
+        lwd,
+        ctx.session_json.as_deref(),
+        &ctx.account_uuid,
+        voting_network,
+        hotkey_secret.expose_secret(),
+        bundle_index,
+        bundle_policy,
+    );
+    delegation::precompute_delegation_pir(&ctx.db_path, &pir_server_url, prepare_params)
+        .await
+        .map(zcash_voting::wire::DelegationPirPrecomputeResultView::from)
+}
+
+/// Streaming variant of `build_prove_and_sign_delegation_payload`.
+///
+/// Emits local preparation phase events while work progresses, then emits a
+/// final `"result"` event containing `SignedDelegationPayloadView`. The function
+/// returns `Ok(())` after the terminal event is queued.
+///
+/// # Errors
+///
+/// Returns an error if round input resolution fails before the stream work
+/// starts. Runtime delegation/proving errors are forwarded into the sink as
+/// stream errors.
+pub async fn build_prove_and_sign_delegation_payload_with_progress(
+    ctx: ApiVotingRoundContext,
+    pir_server_url: String,
+    mnemonic: String,
+    bundle_index: u32,
+    sink: StreamSink<ApiDelegationProofEvent>,
+) -> Result<(), String> {
+    let (wallet_network, voting_network, bundle_policy) =
+        delegation_static_inputs(&ctx.network, ctx.max_real_notes_per_bundle)?;
+    let seed = seed_from_mnemonic(mnemonic)?;
+    let round_id = ctx.round_params.vote_round_id.clone();
+    let hotkey_secret = hotkey::derive_hotkey(&seed, &round_id, &ctx.account_uuid, wallet_network)?;
+    let lwd = resolve_delegation_lwd_inputs(
+        &ctx.lightwalletd_url,
+        ctx.round_params,
+        &ctx.round_name,
+        voting_network,
+    )
+    .await?;
+    let prepare_params = prepare_delegation_bundle_params(
+        lwd,
+        ctx.session_json.as_deref(),
+        &ctx.account_uuid,
+        voting_network,
+        hotkey_secret.expose_secret(),
+        bundle_index,
+        bundle_policy,
+    );
+    let sink = Arc::new(sink);
+    let progress_sink = sink.clone();
+    let signed_result = delegation::build_prove_and_sign_delegation_payload(
+        &ctx.db_path,
+        &pir_server_url,
+        &seed,
+        prepare_params,
+        move |event| {
+            if progress_sink.add(event.into()).is_err() {
+                log_sink_closed(DELEGATION_STREAM_CONTEXT, SINK_PROGRESS_NOT_DELIVERED);
+            }
+        },
+    )
+    .await
+    .and_then(|bundle| {
+        zcash_voting::wire::SignedDelegationPayloadView::try_from(bundle).map_err(|e| e.to_string())
+    });
+    emit_signed_delegation_result(sink.as_ref(), signed_result)
+}
+
+/// Build and redact a voting PCZT that Keystone must sign for one bundle.
+///
+/// # Errors
+///
+/// Returns an error if round input resolution fails or if PCZT construction and
+/// redaction for the requested bundle fails.
+pub async fn build_keystone_delegation_request(
+    ctx: ApiVotingRoundContext,
+    hotkey_seed: Vec<u8>,
+    bundle_index: u32,
+) -> Result<zcash_voting::wire::KeystoneSigningRequest, String> {
+    let (_, voting_network, bundle_policy) =
+        delegation_static_inputs(&ctx.network, ctx.max_real_notes_per_bundle)?;
+    let hotkey_secret = hotkey::validated_hotkey_seed(hotkey_seed, voting_network)?;
+    let lwd = resolve_delegation_lwd_inputs(
+        &ctx.lightwalletd_url,
+        ctx.round_params,
+        &ctx.round_name,
+        voting_network,
+    )
+    .await?;
+    let prepare_params = prepare_delegation_bundle_params(
+        lwd,
+        ctx.session_json.as_deref(),
+        &ctx.account_uuid,
+        voting_network,
+        hotkey_secret.expose_secret(),
+        bundle_index,
+        bundle_policy,
+    );
+    delegation::build_keystone_delegation_request(&ctx.db_path, &ctx.account_uuid, prepare_params)
+        .await
+}
+
+/// Extract the ZIP-244 sighash from PCZT bytes.
+///
+/// # Errors
+///
+/// Returns an error if `pczt_bytes` cannot be decoded or does not contain a
+/// spend authorization sighash.
+pub fn extract_pczt_sighash(pczt_bytes: Vec<u8>) -> Result<Vec<u8>, String> {
+    catch(|| {
+        zcash_voting::delegate::pczt_sighash(&pczt_bytes)
+            .map(|sighash| sighash.to_vec())
+            .map_err(|e| format!("extract_pczt_sighash failed: {e}"))
+    })
+}
+
+/// Extract a Keystone SpendAuth signature from signed PCZT bytes.
+pub fn extract_spend_auth_signature_from_signed_pczt(
+    signed_pczt_bytes: Vec<u8>,
+    action_index: u32,
+) -> Result<Vec<u8>, String> {
+    catch(|| {
+        let action_index =
+            usize::try_from(action_index).map_err(|_| "action_index does not fit in usize")?;
+        zcash_voting::delegate::spend_auth_signature(&signed_pczt_bytes, action_index)
+            .map(|sig| sig.to_vec())
+            .map_err(|e| format!("extract_spend_auth_sig failed: {e}"))
+    })
+}
+
+/// Persist a Keystone signature for one delegation bundle.
+///
+/// # Errors
+///
+/// Returns an error if signature lengths are invalid, opening the voting DB
+/// fails, or persisting the signature record fails.
+pub fn store_keystone_signature(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    bundle_index: u32,
+    sig: Vec<u8>,
+    sighash: Vec<u8>,
+    rk: Vec<u8>,
+) -> Result<(), String> {
+    catch(|| {
+        require_len(&sig, KEYSTONE_SIG_LEN, "sig")?;
+        require_len(&sighash, KEYSTONE_SIGHASH_LEN, "sighash")?;
+        require_len(&rk, KEYSTONE_RK_LEN, "rk")?;
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        db.store_keystone_signature(&round_id, bundle_index, &sig, &sighash, &rk)
+            .map_err(|e| format!("store_keystone_signature failed: {e}"))
+    })
+}
+
+/// Load persisted Keystone signatures for one voting round.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting DB fails or signature rows cannot be
+/// loaded.
+pub fn get_keystone_signatures(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+) -> Result<Vec<zcash_voting::wire::KeystoneSignatureRecord>, String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        db.get_keystone_signatures(&round_id)
+            .map_err(|e| format!("get_keystone_signatures failed: {e}"))
+    })
+}
+
+/// Streaming Keystone variant of `build_prove_and_sign_delegation_payload`.
+///
+/// # Errors
+///
+/// Returns an error if round input resolution fails before stream work starts.
+/// Runtime proving/signature errors are emitted through the sink.
+pub async fn build_prove_delegation_payload_with_keystone_signature_with_progress(
+    ctx: ApiVotingRoundContext,
+    pir_server_url: String,
+    hotkey_seed: Vec<u8>,
+    bundle_index: u32,
+    keystone_sig: Vec<u8>,
+    keystone_sighash: Vec<u8>,
+    sink: StreamSink<ApiDelegationProofEvent>,
+) -> Result<(), String> {
+    let (_, voting_network, bundle_policy) =
+        delegation_static_inputs(&ctx.network, ctx.max_real_notes_per_bundle)?;
+    let hotkey_secret = hotkey::validated_hotkey_seed(hotkey_seed, voting_network)?;
+    let lwd = resolve_delegation_lwd_inputs(
+        &ctx.lightwalletd_url,
+        ctx.round_params,
+        &ctx.round_name,
+        voting_network,
+    )
+    .await?;
+    let prepare_params = prepare_delegation_bundle_params(
+        lwd,
+        ctx.session_json.as_deref(),
+        &ctx.account_uuid,
+        voting_network,
+        hotkey_secret.expose_secret(),
+        bundle_index,
+        bundle_policy,
+    );
+    let sink = Arc::new(sink);
+    let progress_sink = sink.clone();
+    let signed_result = delegation::build_prove_delegation_payload_with_keystone_signature(
+        &ctx.db_path,
+        &pir_server_url,
+        &ctx.account_uuid,
+        prepare_params,
+        &keystone_sig,
+        &keystone_sighash,
+        move |event| {
+            if progress_sink.add(event.into()).is_err() {
+                log_sink_closed(DELEGATION_STREAM_CONTEXT, SINK_PROGRESS_NOT_DELIVERED);
+            }
+        },
+    )
+    .await
+    .and_then(|bundle| {
+        zcash_voting::wire::SignedDelegationPayloadView::try_from(bundle).map_err(|e| e.to_string())
+    });
+    emit_signed_delegation_result(sink.as_ref(), signed_result)
+}
+
+/// Record a submitted delegation transaction hash for one bundle.
+///
+/// Repeated calls are idempotent only for the same transaction hash.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting DB fails, the bundle key is missing,
+/// or the stored hash conflicts with `tx_hash`.
+pub fn mark_delegation_submitted(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    bundle_index: u32,
+    tx_hash: String,
+) -> Result<(), String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        db.mark_delegation_submitted(&round_id, bundle_index, &tx_hash)
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// Parse tx events and record a confirmed delegation submission.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting DB fails, the event payload does not
+/// match the expected round/type shape, or confirmation state cannot be stored.
+pub fn confirm_delegation_submission(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    bundle_index: u32,
+    tx_hash: String,
+    events: Vec<zcash_voting::wire::TxEvent>,
+) -> Result<zcash_voting::wire::DelegationConfirmation, String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        zcash_voting::confirmation::confirm_delegation_submission(
+            &db,
+            &round_id,
+            bundle_index,
+            &tx_hash,
+            &events,
+        )
+        .map_err(|e| e.to_string())
+    })
+}
+
+/// Delete bundle rows at or above `keep_count` for partial-bundle recovery.
+///
+/// Returns the number of deleted rows.
+pub fn delete_skipped_bundles(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    keep_count: u32,
+) -> Result<u32, String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        db.delete_skipped_bundles(&round_id, keep_count)
+            .and_then(|deleted| {
+                u32::try_from(deleted).map_err(|_| zcash_voting::VotingError::Internal {
+                    message: format!("deleted bundle count {deleted} does not fit in u32"),
+                })
+            })
+            .map_err(|e| format!("delete_skipped_bundles failed: {e}"))
+    })
+}
+
+/// Sync vote commitment tree state for a voting round.
+///
+/// Returns the latest synced tree height. The underlying tree client is cached
+/// per `(db_path, account_uuid)` so later VAN witness calls can reuse the synced
+/// in-memory tree state.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting DB fails or tree sync against
+/// `node_url` fails for `round_id`.
+pub fn sync_vote_tree(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    node_url: String,
+) -> Result<u32, String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        zcash_voting::precompute::sync_vote_tree(&db, &round_id, &node_url)
+            .map_err(|e| format!("sync_vote_tree failed: {e}"))
+    })
+}
+
+/// Generate a Vote Authority Note Merkle witness for a delegation bundle.
+///
+/// `anchor_height` is the vote-tree height where the witness should be anchored;
+/// callers must sync the same round before requesting the witness.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting DB fails, `bundle_index` is out of
+/// range for the round, or witness generation fails.
+pub fn generate_van_witness(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    bundle_index: u32,
+    anchor_height: u32,
+) -> Result<zcash_voting::wire::VanWitness, String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        let bundle_count = db
+            .get_bundle_count(&round_id)
+            .map_err(|e| format!("get_bundle_count failed: {e}"))?;
+        zcash_voting::validate_bundle_index(bundle_count, bundle_index, "voting")
+            .map_err(|e| e.to_string())?;
+        zcash_voting::precompute::van_witness(&db, &round_id, bundle_index, anchor_height)
+            .map_err(|e| format!("generate_van_witness failed: {e}"))
+    })
+}
+
+/// Clear process-local voting state for a wallet or round.
+///
+/// Passing a non-empty round ID clears round-scoped caches only. Passing `None`
+/// or an empty round ID also drops the cached vote-tree client for the wallet.
+/// This does not abort in-flight proof or vote work already running on worker
+/// threads.
+pub fn reset_voting_session_state(
+    db_path: String,
+    account_uuid: String,
+    round_id: Option<String>,
+) -> Result<(), String> {
+    catch(|| {
+        let account_wide = round_id.as_deref().map(str::is_empty).unwrap_or(true);
+        let tree_count = if account_wide {
+            let db = db::open_voting_db(&db_path, &account_uuid)?;
+            zcash_voting::precompute::reset_vote_tree(&db, "")
+                .map_err(|e| format!("clear_tree_sync_session failed: {e}"))?;
+            1
+        } else {
+            0
+        };
+        log::info!(
+            "voting: reset process-local session state \
+             (account_uuid={}, round_id={:?}, tree_entries={})",
+            account_uuid,
+            round_id,
+            tree_count
+        );
+        Ok(())
+    })
+}
+
+/// Recover a committed but unsubmitted vote from persisted local recovery data.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting DB fails, no matching commitment is
+/// recoverable, or wire conversion fails.
+pub fn recover_vote_commitment(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    bundle_index: u32,
+    proposal_id: u32,
+) -> Result<zcash_voting::wire::SignedVoteCommitmentsView, String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        zcash_voting::vote::recover_signed_commitments(&db, &round_id, bundle_index, proposal_id)
+            .map_err(|e| format!("vote commitment recovery failed: {e}"))
+            .and_then(|commitments| {
+                zcash_voting::wire::SignedVoteCommitmentsView::try_from(commitments)
+                    .map_err(|e| e.to_string())
+            })
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn build_vote_commitments_result<F>(
+    db_path: String,
+    account_uuid: String,
+    network: String,
+    round_id: String,
+    bundle_index: u32,
+    hotkey_seed: Vec<u8>,
+    van_witness: zcash_voting::wire::VanWitness,
+    draft_votes: Vec<zcash_voting::wire::DraftVote>,
+    on_stage: F,
+) -> Result<zcash_voting::wire::SignedVoteCommitmentsView, String>
+where
+    F: Fn(zcash_voting::vote::VoteCommitStage) + Send + Sync + 'static,
+{
+    let network = keys::parse_network(&network)?;
+    let hotkey_seed = secrecy::SecretVec::new(hotkey_seed);
+    let commitment_result = tokio::task::spawn_blocking(move || {
+        let reporter = zcash_voting::VoteCommitStageBridge::new(on_stage);
+        let voting_db = db::open_voting_db(&db_path, &account_uuid)?;
+        let voting_hotkey = zcash_voting::hotkey::voting_hotkey_from_seed(
+            hotkey_seed.expose_secret(),
+            voting_network(network),
+        )
+        .map_err(|e| format!("Voting hotkey reconstruction failed: {e}"))?;
+
+        zcash_voting::vote::commit_batch(
+            &voting_db,
+            &round_id,
+            bundle_index,
+            &draft_votes,
+            &van_witness,
+            zcash_voting::vote::VoteSigner::hotkey(&voting_hotkey),
+            &reporter,
+        )
+        .map_err(|e| format!("vote commit batch failed: {e}"))
+    })
+    .await
+    .map_err(|e| format!("vote commitment task failed: {e}"))
+    .and_then(|result| result);
+    let commitments = commitment_result?;
+    zcash_voting::wire::SignedVoteCommitmentsView::try_from(commitments).map_err(|e| e.to_string())
+}
+
+#[allow(clippy::too_many_arguments)]
+/// Streaming variant of `build_vote_commitments`.
+///
+/// Emits per-proposal progress events, then a terminal `"result"` event carrying
+/// `SignedVoteCommitmentsView`.
+pub async fn build_vote_commitments_with_progress(
+    db_path: String,
+    account_uuid: String,
+    network: String,
+    round_id: String,
+    bundle_index: u32,
+    hotkey_seed: Vec<u8>,
+    van_witness: zcash_voting::wire::VanWitness,
+    draft_votes: Vec<zcash_voting::wire::DraftVote>,
+    sink: StreamSink<ApiVoteCommitEvent>,
+) -> Result<(), String> {
+    let sink = Arc::new(sink);
+    let progress_sink = sink.clone();
+    let commitments = build_vote_commitments_result(
+        db_path,
+        account_uuid,
+        network,
+        round_id,
+        bundle_index,
+        hotkey_seed,
+        van_witness,
+        draft_votes,
+        move |stage| {
+            if progress_sink.add(stage.into()).is_err() {
+                log_sink_closed(VOTE_STREAM_CONTEXT, SINK_PROGRESS_NOT_DELIVERED);
+            }
+        },
+    )
+    .await;
+
+    emit_signed_vote_result(sink.as_ref(), commitments)
+}
+
+/// Load the full recovery/share-tracking summary for one voting round.
+pub fn get_round_recovery_state(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+) -> Result<zcash_voting::wire::RoundRecoveryStateView, String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        zcash_voting::recovery::round_snapshot(&db, &round_id)
+            .map(zcash_voting::wire::RoundRecoveryStateView::from)
+            .map_err(|e| format!("round_snapshot failed: {e}"))
+    })
+}
+
+/// Record a submitted cast-vote transaction hash for one bundle/proposal key.
+///
+/// Repeated calls are idempotent only for the same transaction hash.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting DB fails, the vote key is missing, or
+/// the stored hash conflicts with `tx_hash`.
+pub fn mark_vote_submitted(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    bundle_index: u32,
+    proposal_id: u32,
+    tx_hash: String,
+) -> Result<(), String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        db.mark_vote_submitted(&round_id, bundle_index, proposal_id, &tx_hash)
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// Parse tx events and record a confirmed vote submission.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting DB fails, the event payload does not
+/// match the expected round/type shape, or confirmation state cannot be stored.
+pub fn confirm_vote_submission(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    bundle_index: u32,
+    proposal_id: u32,
+    tx_hash: String,
+    events: Vec<zcash_voting::wire::TxEvent>,
+) -> Result<zcash_voting::wire::VoteConfirmation, String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        zcash_voting::confirmation::confirm_vote_submission(
+            &db,
+            &round_id,
+            bundle_index,
+            proposal_id,
+            &tx_hash,
+            &events,
+        )
+        .map_err(|e| e.to_string())
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+/// Record helper-server submission state for one encrypted vote share.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting DB fails, the vote cannot be
+/// recovered, or the share record cannot be persisted.
+pub fn record_share_delegation(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    bundle_index: u32,
+    proposal_id: u32,
+    share_index: u32,
+    sent_to_urls: Vec<String>,
+    submit_at: u64,
+) -> Result<(), String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        zcash_voting::vote::CommittedVote::recover(&db, &round_id, bundle_index, proposal_id)
+            .map_err(|e| format!("recover committed vote failed: {e}"))?
+            .record_share(&db, share_index, &sent_to_urls, submit_at)
+            .map_err(|e| format!("record_share_delegation failed: {e}"))?;
+        Ok(())
+    })
+}
+
+/// Mark one delegated share as confirmed on-chain.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting DB fails, the vote cannot be
+/// recovered, or share confirmation cannot be persisted.
+pub fn mark_share_confirmed(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    bundle_index: u32,
+    proposal_id: u32,
+    share_index: u32,
+) -> Result<(), String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        zcash_voting::vote::CommittedVote::recover(&db, &round_id, bundle_index, proposal_id)
+            .map_err(|e| format!("recover committed vote failed: {e}"))?
+            .confirm_share(&db, share_index)
+            .map_err(|e| format!("mark_share_confirmed failed: {e}"))?;
+        Ok(())
+    })
+}
+
+/// Merge additional helper-server URLs into one share delegation record.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting DB fails or the share record cannot
+/// be updated.
+pub fn add_sent_servers(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    bundle_index: u32,
+    proposal_id: u32,
+    share_index: u32,
+    new_urls: Vec<String>,
+) -> Result<(), String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        zcash_voting::share::add_sent_servers(
+            &db,
+            &round_id,
+            bundle_index,
+            proposal_id,
+            share_index,
+            &new_urls,
+        )
+        .map_err(|e| format!("add_sent_servers failed: {e}"))
+    })
+}
+
+/// Clear vote/delegation recovery columns and share-tracking rows for a round.
+///
+/// This is an explicit reset for finalized or abandoned rounds, not a normal
+/// retry step.
+pub fn clear_recovery_state(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+) -> Result<(), String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        zcash_voting::recovery::clear(&db, &round_id)
+            .map_err(|e| format!("clear_recovery_state failed: {e}"))
+    })
+}
+
+/// Compute the resumable voting-session plan for a round. The plan reports the
+/// ordered remaining work (`next_steps`) and which proposals are still open.
+pub fn get_round_plan(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    proposal_ids: Vec<u32>,
+) -> Result<zcash_voting::wire::RoundPlanView, String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        let plan = zcash_voting::session::resume_plan(&db, &round_id, &proposal_ids)
+            .map_err(|e| format!("resume_plan failed: {e}"))?;
+        zcash_voting::wire::RoundPlanView::try_from(plan).map_err(|e| e.to_string())
+    })
+}
+
+/// Persist (insert or replace) the voter's ballot intent for one proposal.
+/// Pass `skipped: true` for `Decision::Skipped`; otherwise `choice` must be set.
+/// `num_options` is the proposal's declared option count.
+pub fn set_ballot_intent(
+    db_path: String,
+    account_uuid: String,
+    round_id: String,
+    proposal_id: u32,
+    num_options: u32,
+    skipped: bool,
+    choice: Option<u32>,
+) -> Result<(), String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        let decision = if skipped {
+            zcash_voting::session::Decision::Skipped
+        } else {
+            let c = choice.ok_or_else(|| {
+                "set_ballot_intent: choice must be Some when skipped is false".to_string()
+            })?;
+            zcash_voting::session::Decision::Choice(c)
+        };
+        db.set_ballot_intent(&round_id, proposal_id, decision, num_options)
+            .map_err(|e| format!("set_ballot_intent failed: {e}"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wallet::network::WalletNetwork;
+    use crate::wallet::voting::test_support::{
+        test_api_round_params, test_note_info, ROUND_ID, TEST_ACCOUNT_UUID, TEST_MNEMONIC,
+    };
+    use base64::Engine as _;
+    use std::{
+        io::{Read, Write},
+        net::TcpListener,
+        thread,
+    };
+    use zcash_client_backend::proto::service::TreeState;
+    use zcash_voting::BundlePolicy;
+
+    fn b64(bytes: impl AsRef<[u8]>) -> String {
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    }
+
+    fn tx_event(event_type: &str, attributes: &[(&str, &str)]) -> zcash_voting::wire::TxEvent {
+        zcash_voting::wire::TxEvent {
+            event_type: event_type.to_string(),
+            attributes: attributes
+                .iter()
+                .map(|(key, value)| zcash_voting::wire::TxEventAttribute {
+                    key: (*key).to_string(),
+                    value: (*value).to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    fn test_round_context(
+        db_path: &std::path::Path,
+        network: &str,
+        account_uuid: &str,
+    ) -> ApiVotingRoundContext {
+        ApiVotingRoundContext {
+            db_path: db_path.to_str().unwrap().to_string(),
+            lightwalletd_url: "http://127.0.0.1:1".to_string(),
+            network: network.to_string(),
+            round_params: test_api_round_params(),
+            round_name: "Demo".to_string(),
+            session_json: None,
+            account_uuid: account_uuid.to_string(),
+            max_real_notes_per_bundle: None,
+        }
+    }
+
+    #[test]
+    fn derive_voting_hotkey_happy_path_is_deterministic() {
+        let hotkey_a = derive_voting_hotkey(
+            TEST_MNEMONIC.to_string(),
+            ROUND_ID.to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            "regtest".to_string(),
+        )
+        .unwrap();
+        let hotkey_b = derive_voting_hotkey(
+            TEST_MNEMONIC.to_string(),
+            ROUND_ID.to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            "regtest".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(hotkey_a, hotkey_b);
+        assert_eq!(hotkey_a.len(), 64);
+
+        let seed = seed_from_mnemonic(TEST_MNEMONIC.to_string()).unwrap();
+        let expected =
+            hotkey::derive_hotkey(&seed, ROUND_ID, TEST_ACCOUNT_UUID, WalletNetwork::Regtest)
+                .unwrap();
+        assert_eq!(hotkey_a, expected.expose_secret().to_vec());
+    }
+
+    #[test]
+    fn generate_voting_hotkey_happy_path_returns_valid_distinct_seeds() {
+        let hotkey_a = generate_voting_hotkey("regtest".to_string()).unwrap();
+        let hotkey_b = generate_voting_hotkey("regtest".to_string()).unwrap();
+        assert_eq!(hotkey_a.len(), 64);
+        assert_eq!(hotkey_b.len(), 64);
+        assert_ne!(hotkey_a, hotkey_b);
+    }
+
+    #[test]
+    fn bundle_policy_happy_path_maps_optional_limit() {
+        assert_eq!(
+            bundle_policy(None).unwrap(),
+            BundlePolicy::from_optional_max_real_notes_per_bundle(None).unwrap()
+        );
+        assert_eq!(
+            bundle_policy(Some(2)).unwrap(),
+            BundlePolicy::from_optional_max_real_notes_per_bundle(Some(2)).unwrap()
+        );
+    }
+
+    #[test]
+    fn api_round_params_convert_to_core_round_params() {
+        let api = test_api_round_params();
+
+        let core: zcash_voting::VotingRoundParams = api.clone();
+
+        assert_eq!(core.vote_round_id, api.vote_round_id);
+        assert_eq!(core.snapshot_height, api.snapshot_height);
+        assert_eq!(core.ea_pk, api.ea_pk);
+        assert_eq!(core.nc_root, api.nc_root);
+        assert_eq!(core.nullifier_imt_root, api.nullifier_imt_root);
+    }
+
+    #[test]
+    fn api_bundle_setup_result_preserves_core_fields() {
+        let api = zcash_voting::wire::BundleLayout {
+            bundle_count: 2,
+            eligible_weight: 50,
+            dropped_count: 0,
+        };
+
+        assert_eq!(api.bundle_count, 2);
+        assert_eq!(api.eligible_weight, 50);
+    }
+
+    #[test]
+    fn api_signed_delegation_payload_preserves_core_fields() {
+        let api = zcash_voting::wire::SignedDelegationPayloadView::try_from(
+            zcash_voting::delegate::SignedDelegationBundle {
+                submission: zcash_voting::delegate::DelegationSubmission {
+                    proof: vec![4],
+                    rk: [5; 32],
+                    nf_signed: [8; 32],
+                    cmx_new: [9; 32],
+                    gov_comm: [10; 32],
+                    gov_nullifiers: [[11; 32]; 5],
+                    alpha: [12; 32],
+                    vote_round_id: "00010203".to_string(),
+                    spend_auth_sig: [6; 64],
+                    sighash: [7; 32],
+                },
+                pczt_bytes: vec![1, 2, 3],
+                eligible_weight_zatoshi: 20,
+                delegated_weight_zatoshi: 10,
+                bundle_count: 2,
+                bundle_index: 1,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(api.pczt_bytes, vec![1, 2, 3]);
+        assert_eq!(api.status, "ready_for_submission");
+        assert_eq!(api.message, None);
+        assert_eq!(api.submission.proof, b64(vec![4]));
+        assert_eq!(api.submission.vote_round_id, b64([0, 1, 2, 3]));
+        assert_eq!(api.eligible_weight_zatoshi, 20);
+        assert_eq!(api.delegated_weight_zatoshi, 10);
+        assert_eq!(api.bundle_count, 2);
+        assert_eq!(api.bundle_index, 1);
+    }
+
+    #[test]
+    fn api_keystone_delegation_request_preserves_display_memo() {
+        let api = zcash_voting::wire::KeystoneSigningRequest {
+            pczt_bytes: vec![1],
+            redacted_pczt_bytes: vec![2],
+            pczt_sighash: vec![3; 32],
+            rk: vec![4; 32],
+            action_index: 5,
+            display_memo: "I am authorizing this hotkey.".to_string(),
+            eligible_weight_zatoshi: 20,
+            delegated_weight_zatoshi: 10,
+            bundle_count: 2,
+            bundle_index: 1,
+        };
+
+        assert_eq!(api.display_memo, "I am authorizing this hotkey.");
+        assert_eq!(api.bundle_count, 2);
+        assert_eq!(api.bundle_index, 1);
+    }
+
+    #[test]
+    fn delegation_wire_json_matches_vote_chain_shape() {
+        let wire =
+            delegation_submission_wire_json(zcash_voting::wire::SignedDelegationPayloadView {
+                pczt_bytes: vec![],
+                status: "ready".to_string(),
+                message: None,
+                submission: zcash_voting::wire::DelegationSubmissionWire {
+                    proof: b64(vec![8; 96]),
+                    rk: b64(vec![1; 32]),
+                    spend_auth_sig: b64(vec![2; 64]),
+                    sighash: b64(vec![3; 32]),
+                    nf_signed: b64(vec![4; 32]),
+                    cmx_new: b64(vec![5; 32]),
+                    gov_comm: b64(vec![6; 32]),
+                    gov_nullifiers: vec![b64(vec![7; 32]); zcash_voting::BUNDLE_NOTE_SLOTS],
+                    vote_round_id: b64([0, 1, 2, 3]),
+                },
+                eligible_weight_zatoshi: 0,
+                delegated_weight_zatoshi: 0,
+                bundle_count: 1,
+                bundle_index: 0,
+            })
+            .unwrap();
+
+        let wire: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert!(wire.get("signed_note_nullifier").is_some());
+        assert!(wire.get("van_cmx").is_some());
+        assert_eq!(
+            wire["gov_nullifiers"].as_array().unwrap().len(),
+            zcash_voting::BUNDLE_NOTE_SLOTS
+        );
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(wire["vote_round_id"].as_str().unwrap())
+                .unwrap(),
+            vec![0, 1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn cast_vote_wire_json_matches_vote_chain_shape() {
+        let wire = vote_commitment_wire_json(zcash_voting::wire::VoteCommitmentWire {
+            van_nullifier: b64(vec![1; 32]),
+            vote_authority_note_new: b64(vec![2; 32]),
+            vote_commitment: b64(vec![3; 32]),
+            proposal_id: 7,
+            proof: b64(vec![4; 96]),
+            vote_round_id: b64(vec![0, 1, 2, 3]),
+            anchor_height: 77,
+            r_vpk: b64(vec![5; 32]),
+            vote_auth_sig: b64(vec![6; 64]),
+        })
+        .unwrap();
+
+        let wire: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(wire["proposal_id"], 7);
+        assert_eq!(wire["vote_comm_tree_anchor_height"], 77);
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(wire["vote_round_id"].as_str().unwrap())
+                .unwrap(),
+            vec![0, 1, 2, 3]
+        );
+    }
+
+    #[test]
+    fn share_wire_json_matches_helper_shape_for_live_and_recovery_payloads() {
+        let live = vote_share_wire_json(
+            zcash_voting::wire::VoteShareWire {
+                shares_hash: "AQ==".to_string(),
+                proposal_id: 7,
+                vote_decision: 2,
+                encrypted_share: zcash_voting::wire::WireEncryptedShare {
+                    c1: vec![3],
+                    c2: vec![4],
+                    share_index: 1,
+                },
+                share_index: 1,
+                vc_tree_position: 55,
+                all_encrypted_shares: vec![
+                    zcash_voting::wire::WireEncryptedShare {
+                        c1: vec![3],
+                        c2: vec![4],
+                        share_index: 1,
+                    },
+                    zcash_voting::wire::WireEncryptedShare {
+                        c1: vec![5],
+                        c2: vec![6],
+                        share_index: 2,
+                    },
+                ],
+                share_comms: vec!["Bw==".to_string(), "CA==".to_string()],
+                primary_blind: "CQ==".to_string(),
+                submit_at: 0,
+            },
+            Some(99),
+            123,
+        )
+        .unwrap();
+        let expected = serde_json::json!({
+            "all_enc_shares": [
+                {"c1":"Aw==","c2":"BA==","share_index":1},
+                {"c1":"BQ==","c2":"Bg==","share_index":2}
+            ],
+            "enc_share": {"c1":"Aw==","c2":"BA==","share_index":1},
+            "primary_blind":"CQ==",
+            "proposal_id":7,
+            "share_comms":["Bw==","CA=="],
+            "share_index":1,
+            "shares_hash":"AQ==",
+            "submit_at":123,
+            "tree_position":99,
+            "vote_decision":2
+        });
+        let live: serde_json::Value = serde_json::from_str(&live).unwrap();
+        assert_eq!(live, expected);
+
+        let recovery_json =
+            zcash_voting::vote::serialize_recovery(&zcash_voting::vote::VoteRecoveryBundle {
+                vote_round_id: "00".repeat(32),
+                bundle_index: 0,
+                proposal_id: 7,
+                vote_decision: 2,
+                anchor_height: 10,
+                vc_tree_position: 55,
+                single_share: false,
+                num_options: 3,
+                van_nullifier: [0; 32],
+                vote_authority_note_new: [0; 32],
+                vote_commitment: [0; 32],
+                proof: vec![0],
+                shares_hash: [1; 32],
+                r_vpk: [0; 32],
+                alpha_v: [0; 32],
+                vote_auth_sig: [0; 64],
+                encrypted_shares: vec![
+                    zcash_voting::EncryptedShare {
+                        c1: vec![3],
+                        c2: vec![4],
+                        share_index: 1,
+                        plaintext_value: 1,
+                        randomness: vec![0],
+                    },
+                    zcash_voting::EncryptedShare {
+                        c1: vec![5],
+                        c2: vec![6],
+                        share_index: 2,
+                        plaintext_value: 2,
+                        randomness: vec![0],
+                    },
+                ],
+                share_blinds: vec![[9; 32], [10; 32]],
+                share_comms: vec![[7; 32], [8; 32]],
+            })
+            .unwrap();
+        let recovered = recovered_vote_share_wire_json(recovery_json, 7, 1, 99, 0).unwrap();
+        let recovered: serde_json::Value = serde_json::from_str(&recovered).unwrap();
+        assert_eq!(recovered["proposal_id"], 7);
+        assert_eq!(recovered["vote_decision"], 2);
+        assert_eq!(recovered["share_index"], 1);
+        assert_eq!(recovered["tree_position"], 99);
+        assert_eq!(recovered["submit_at"], 0);
+        assert_eq!(recovered["enc_share"]["c1"], "Aw==");
+        assert_eq!(recovered["all_enc_shares"].as_array().unwrap().len(), 2);
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(recovered["shares_hash"].as_str().unwrap())
+                .unwrap(),
+            vec![1; 32]
+        );
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(recovered["primary_blind"].as_str().unwrap())
+                .unwrap(),
+            vec![9; 32]
+        );
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(recovered["share_comms"][0].as_str().unwrap())
+                .unwrap(),
+            vec![7; 32]
+        );
+    }
+
+    #[test]
+    fn share_wire_json_rejects_json_unsafe_integer_fields() {
+        let err = vote_share_wire_json(
+            zcash_voting::wire::VoteShareWire {
+                shares_hash: "AQ==".to_string(),
+                proposal_id: 7,
+                vote_decision: 2,
+                encrypted_share: zcash_voting::wire::WireEncryptedShare {
+                    c1: vec![3],
+                    c2: vec![4],
+                    share_index: 1,
+                },
+                share_index: 1,
+                vc_tree_position: 0,
+                all_encrypted_shares: vec![],
+                share_comms: vec![],
+                primary_blind: "CQ==".to_string(),
+                submit_at: 0,
+            },
+            // JSON numbers are constrained to the IEEE-754 safe-integer range.
+            Some(MAX_SAFE_JSON_INTEGER + 1),
+            123,
+        )
+        .unwrap_err();
+        assert!(err.contains("tree_position"));
+    }
+
+    #[test]
+    fn share_tracking_flags_use_crate_policy() {
+        let share = zcash_voting::wire::ShareDelegationRecordView {
+            round_id: ROUND_ID.to_string(),
+            bundle_index: 0,
+            proposal_id: 7,
+            share_index: 0,
+            sent_to_urls: vec!["https://helper.example".to_string()],
+            nullifier: vec![1; 32],
+            phase: "submitted_share".to_string(),
+            confirmed: false,
+            submit_at: 100,
+            created_at: 50,
+        };
+
+        assert_eq!(
+            share_tracking_flags(share.clone(), 109, Some(500)).unwrap(),
+            0
+        );
+        assert_eq!(
+            share_tracking_flags(share.clone(), 110, Some(500)).unwrap(),
+            1
+        );
+        assert_eq!(share_tracking_flags(share, 200, Some(500)).unwrap(), 3);
+    }
+
+    #[test]
+    fn next_share_tracking_delay_uses_crate_ready_interval() {
+        let ready = zcash_voting::wire::ShareDelegationRecordView {
+            round_id: ROUND_ID.to_string(),
+            bundle_index: 0,
+            proposal_id: 7,
+            share_index: 0,
+            sent_to_urls: vec!["https://helper.example".to_string()],
+            nullifier: vec![1; 32],
+            phase: "submitted_share".to_string(),
+            confirmed: false,
+            submit_at: 100,
+            created_at: 50,
+        };
+        let future = zcash_voting::wire::ShareDelegationRecordView {
+            submit_at: 140,
+            ..ready.clone()
+        };
+
+        assert_eq!(
+            next_share_tracking_delay_seconds(vec![ready], 130).unwrap(),
+            Some(15)
+        );
+        assert_eq!(
+            next_share_tracking_delay_seconds(vec![future], 120).unwrap(),
+            Some(30)
+        );
+    }
+
+    #[test]
+    fn plan_share_submissions_happy_path_returns_helper_targets() {
+        let server_urls = vec![
+            "https://helper-a.example".to_string(),
+            "https://helper-b.example".to_string(),
+        ];
+        let plans =
+            plan_share_submissions(3, server_urls.clone(), 100, 600, Some(120), false).unwrap();
+
+        assert_eq!(plans.len(), 3);
+        for plan in plans {
+            assert!(plan.submit_at >= 100);
+            assert!(!plan.target_servers.is_empty());
+            assert!(plan.target_servers.len() <= plan.target_count as usize);
+            assert!(plan
+                .target_servers
+                .iter()
+                .all(|url| server_urls.contains(url)));
+        }
+    }
+
+    #[test]
+    fn api_van_witness_preserves_core_fields() {
+        let mut witness = vec![vec![0u8; 32]; zcash_voting::vote::VAN_AUTH_PATH_LEN];
+        witness[0] = vec![1; 32];
+        witness[1] = vec![2; 32];
+        let api = zcash_voting::wire::VanWitness {
+            auth_path: witness,
+            position: 7,
+            anchor_height: 123,
+        };
+
+        assert_eq!(api.auth_path[0], vec![1; 32]);
+        assert_eq!(api.auth_path[1], vec![2; 32]);
+        assert_eq!(api.position, 7);
+        assert_eq!(api.anchor_height, 123);
+    }
+
+    #[test]
+    fn api_delegation_proof_event_uses_stable_phase_names() {
+        assert_eq!(
+            ApiDelegationProofEvent::from(DelegationProgress::SelectingNotes).phase,
+            "selecting_notes"
+        );
+        assert_eq!(
+            ApiDelegationProofEvent::from(DelegationProgress::SigningPayload).phase,
+            "signing_payload"
+        );
+        let ready = ApiDelegationProofEvent::from(DelegationProgress::PayloadReady);
+        assert_eq!(ready.phase, "payload_ready");
+        assert_eq!(ready.proof_progress, None);
+        assert!(ready.signed_delegation_payload.is_none());
+
+        let proof = ApiDelegationProofEvent::from(DelegationProgress::ProofProgress(0.5));
+        assert_eq!(proof.phase, "proof_progress");
+        assert_eq!(proof.proof_progress, Some(0.5));
+
+        let result = ApiDelegationProofEvent {
+            phase: "result".to_string(),
+            proof_progress: None,
+            signed_delegation_payload: Some(zcash_voting::wire::SignedDelegationPayloadView {
+                pczt_bytes: vec![1],
+                status: "ready_for_submission".to_string(),
+                message: None,
+                submission: zcash_voting::wire::DelegationSubmissionWire {
+                    rk: "rk".to_string(),
+                    spend_auth_sig: "sig".to_string(),
+                    sighash: "sighash".to_string(),
+                    nf_signed: "nf".to_string(),
+                    cmx_new: "cmx".to_string(),
+                    gov_comm: "gov".to_string(),
+                    gov_nullifiers: vec!["nullifier".to_string()],
+                    proof: "proof".to_string(),
+                    vote_round_id: "round".to_string(),
+                },
+                eligible_weight_zatoshi: 10,
+                delegated_weight_zatoshi: 10,
+                bundle_count: 1,
+                bundle_index: 0,
+            }),
+        };
+        assert_eq!(result.phase, "result");
+        assert_eq!(
+            result.signed_delegation_payload.as_ref().unwrap().status,
+            "ready_for_submission"
+        );
+    }
+
+    #[test]
+    fn api_vote_commit_event_uses_stable_phase_names() {
+        let event = ApiVoteCommitEvent::from(zcash_voting::vote::VoteCommitStage::ProofStarting {
+            proposal_id: 1,
+            bundle_index: 2,
+        });
+
+        assert_eq!(event.phase, "building_proof");
+        assert_eq!(event.proposal_id, Some(1));
+        assert_eq!(event.bundle_index, Some(2));
+        assert_eq!(event.proof_progress, Some(0.0));
+        let proof = ApiVoteCommitEvent::from(zcash_voting::vote::VoteCommitStage::ProofProgress {
+            proposal_id: 1,
+            bundle_index: 2,
+            progress: 0.5,
+        });
+        assert_eq!(proof.phase, "proof_progress");
+        assert_eq!(proof.proof_progress, Some(0.5));
+
+        let result = ApiVoteCommitEvent {
+            phase: "result".to_string(),
+            proposal_id: None,
+            bundle_index: Some(2),
+            proof_progress: None,
+            commitments: Some(zcash_voting::wire::SignedVoteCommitmentsView {
+                bundle_index: 2,
+                commitments: vec![],
+            }),
+        };
+        assert_eq!(result.phase, "result");
+        assert_eq!(result.commitments.as_ref().unwrap().bundle_index, 2);
+    }
+
+    #[test]
+    fn api_signed_vote_commitments_preserve_public_wire_fields() {
+        let api = zcash_voting::wire::SignedVoteCommitmentsView::try_from(
+            zcash_voting::vote::SignedVoteCommitments {
+                bundle_index: 1,
+                commitments: vec![zcash_voting::vote::SignedVoteCommitment {
+                    proposal_id: 2,
+                    choice: 1,
+                    vote_round_id: ROUND_ID.to_string(),
+                    van_nullifier: [1; 32],
+                    vote_authority_note_new: [2; 32],
+                    vote_commitment: [3; 32],
+                    proof: vec![4; 10],
+                    encrypted_shares: vec![zcash_voting::WireEncryptedShare {
+                        c1: vec![5; 32],
+                        c2: vec![6; 32],
+                        share_index: 0,
+                    }],
+                    share_payloads: vec![zcash_voting::SharePayload {
+                        shares_hash: vec![7; 32],
+                        proposal_id: 2,
+                        vote_decision: 1,
+                        enc_share: zcash_voting::WireEncryptedShare {
+                            c1: vec![5; 32],
+                            c2: vec![6; 32],
+                            share_index: 0,
+                        },
+                        tree_position: 9,
+                        all_enc_shares: vec![],
+                        share_comms: vec![vec![8; 32]],
+                        primary_blind: vec![9; 32],
+                    }],
+                    anchor_height: 100,
+                    shares_hash: [7; 32],
+                    share_comms: vec![[8; 32]],
+                    r_vpk: [10; 32],
+                    vote_auth_sig: [9; 64],
+                    commitment_bundle_json: "{\"proposal_id\":2}".to_string(),
+                }],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(api.bundle_index, 1);
+        assert_eq!(api.commitments[0].proposal_id, 2);
+        assert_eq!(api.commitments[0].wire.proposal_id, 2);
+        assert_eq!(api.commitments[0].shares[0].encrypted_share.c1, vec![5; 32]);
+        assert_eq!(api.commitments[0].shares[0].primary_blind, b64(vec![9; 32]));
+        assert_eq!(api.commitments[0].wire.vote_auth_sig, b64(vec![9; 64]));
+    }
+
+    #[test]
+    fn api_note_selection_result_preserves_core_fields() {
+        let divisor = zcash_voting::governance::BALLOT_DIVISOR;
+        let selected = zcash_voting::SelectedNotes {
+            notes: vec![
+                test_note_ref(divisor / 2, divisor / 2, 3),
+                test_note_ref(divisor / 2, divisor / 2, 7),
+            ],
+            snapshot_height: 100,
+            anchor_tree_state: test_tree_state(100),
+        };
+
+        let api = zcash_voting::wire::VotingNoteSelectionResultView::from_selected(
+            selected,
+            BundlePolicy::default(),
+        )
+        .unwrap();
+
+        assert_eq!(api.note_count, 2);
+        assert_eq!(api.eligible_weight_zatoshi, divisor);
+        assert_eq!(api.snapshot_height, 100);
+        assert_eq!(api.anchor_height, 100);
+        assert_eq!(api.notes[0].commitment_tree_position, 3);
+        assert_eq!(api.notes[1].value_zatoshi, divisor / 2);
+        assert_eq!(api.notes[1].voting_weight_zatoshi, divisor / 2);
+    }
+
+    #[test]
+    fn delete_skipped_bundles_api_is_bundle_indexed() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let db = db::open_voting_db(db_path.to_str().unwrap(), "wallet-api-bundles").unwrap();
+        db.init_round(&test_api_round_params(), None).unwrap();
+        let notes: Vec<_> = (0..6).map(test_note_info).collect();
+        db.ensure_bundles(ROUND_ID, &notes).unwrap();
+
+        assert_eq!(
+            delete_skipped_bundles(
+                db_path.to_str().unwrap().to_string(),
+                "wallet-api-bundles".to_string(),
+                ROUND_ID.to_string(),
+                1,
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!(db.get_bundle_count(ROUND_ID).unwrap(), 1);
+    }
+
+    #[test]
+    fn sync_vote_tree_api_happy_path_accepts_empty_tree() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let server = start_tree_server(0, vec![], 1);
+
+        let height = sync_vote_tree(
+            db_path.to_str().unwrap().to_string(),
+            "wallet-api-empty-sync".to_string(),
+            ROUND_ID.to_string(),
+            server,
+        )
+        .unwrap();
+
+        assert_eq!(height, 0);
+    }
+
+    #[test]
+    fn generate_van_witness_api_happy_path_after_sync() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let db = db::open_voting_db(db_path.to_str().unwrap(), "wallet-api-witness").unwrap();
+        db.init_round(&test_api_round_params(), None).unwrap();
+        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        db.store_van_position(ROUND_ID, 0, 0).unwrap();
+        let server = start_tree_server(1, vec![fp_one_base64()], 3);
+
+        let height = sync_vote_tree(
+            db_path.to_str().unwrap().to_string(),
+            "wallet-api-witness".to_string(),
+            ROUND_ID.to_string(),
+            server,
+        )
+        .unwrap();
+        let witness = generate_van_witness(
+            db_path.to_str().unwrap().to_string(),
+            "wallet-api-witness".to_string(),
+            ROUND_ID.to_string(),
+            0,
+            height,
+        )
+        .unwrap();
+
+        assert_eq!(witness.position, 0);
+        assert_eq!(witness.anchor_height, 1);
+        assert_eq!(
+            witness.auth_path.len(),
+            zcash_voting::vote::VAN_AUTH_PATH_LEN
+        );
+        assert!(witness.auth_path.iter().all(|hash| hash.len() == 32));
+    }
+
+    #[test]
+    fn reset_voting_session_state_with_round_preserves_tree_sync() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let account_uuid = "wallet-api-round-reset";
+        let db = db::open_voting_db(db_path.to_str().unwrap(), account_uuid).unwrap();
+        db.init_round(&test_api_round_params(), None).unwrap();
+        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        db.store_van_position(ROUND_ID, 0, 0).unwrap();
+        let server = start_tree_server(1, vec![fp_one_base64()], 3);
+
+        let height = sync_vote_tree(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+            server,
+        )
+        .unwrap();
+
+        reset_voting_session_state(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            Some(ROUND_ID.to_string()),
+        )
+        .unwrap();
+
+        let witness = generate_van_witness(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+            0,
+            height,
+        )
+        .unwrap();
+        assert_eq!(witness.position, 0);
+    }
+
+    #[test]
+    fn reset_voting_session_state_without_round_drops_tree_sync() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let account_uuid = "wallet-api-account-reset";
+        let db = db::open_voting_db(db_path.to_str().unwrap(), account_uuid).unwrap();
+        db.init_round(&test_api_round_params(), None).unwrap();
+        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        db.store_van_position(ROUND_ID, 0, 0).unwrap();
+        let server = start_tree_server(1, vec![fp_one_base64()], 3);
+
+        let height = sync_vote_tree(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+            server,
+        )
+        .unwrap();
+
+        reset_voting_session_state(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            None,
+        )
+        .unwrap();
+
+        let err = generate_van_witness(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+            0,
+            height,
+        )
+        .unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn recover_vote_commitment_happy_path_returns_wire_commitment() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let db = db::open_voting_db(db_path.to_str().unwrap(), TEST_ACCOUNT_UUID).unwrap();
+        db.init_round(&test_api_round_params(), None).unwrap();
+        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        seed_recovery_vote(&db, TEST_ACCOUNT_UUID, 0, 7, 1, 88);
+
+        let recovered = recover_vote_commitment(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+            0,
+            7,
+        )
+        .unwrap();
+
+        assert_eq!(recovered.bundle_index, 0);
+        assert_eq!(recovered.commitments.len(), 1);
+        assert_eq!(recovered.commitments[0].proposal_id, 7);
+    }
+
+    #[test]
+    fn recovery_api_preserves_round_summary_and_share_records() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let account_uuid = "wallet-api-recovery";
+        let db = db::open_voting_db(db_path.to_str().unwrap(), account_uuid).unwrap();
+        db.init_round(&test_api_round_params(), None).unwrap();
+        let notes: Vec<_> = (0..6).map(test_note_info).collect();
+        db.ensure_bundles(ROUND_ID, &notes).unwrap();
+        db.store_delegation_tx_hash(ROUND_ID, 0, "delegation-tx-0")
+            .unwrap();
+        let conn = db.conn();
+        zcash_voting::storage::queries::store_vote(
+            &conn,
+            ROUND_ID,
+            account_uuid,
+            1,
+            2,
+            1,
+            b"vote-1",
+        )
+        .unwrap();
+        drop(conn);
+        mark_vote_submitted(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+            1,
+            2,
+            "vote-tx-1-2".to_string(),
+        )
+        .unwrap();
+        {
+            let conn = db.conn();
+            conn.execute(
+                "UPDATE votes SET commitment_bundle_json = :json, vc_tree_position = :pos
+                 WHERE round_id = :round_id AND wallet_id = :wallet_id
+                   AND bundle_index = :bundle_index AND proposal_id = :proposal_id",
+                rusqlite::named_params! {
+                    ":json": test_vote_recovery_json(1, 2, 1, 99),
+                    ":pos": 99i64,
+                    ":round_id": ROUND_ID,
+                    ":wallet_id": account_uuid,
+                    ":bundle_index": 1i64,
+                    ":proposal_id": 2i64,
+                },
+            )
+            .unwrap();
+        }
+        record_share_delegation(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+            1,
+            2,
+            0,
+            vec!["https://helper.example".to_string()],
+            123,
+        )
+        .unwrap();
+
+        let state = get_round_recovery_state(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(state.bundle_count, 2);
+        assert_eq!(
+            state.delegation[0].tx_hash.as_deref(),
+            Some("delegation-tx-0")
+        );
+        assert_eq!(state.votes[0].proposal_id, 2);
+        assert_eq!(state.votes[0].tx_hash.as_deref(), Some("vote-tx-1-2"));
+        assert_eq!(state.commitment_bundles[0].vc_tree_position, 99);
+        assert_eq!(state.share_delegations[0].sent_to_urls.len(), 1);
+        assert_eq!(state.unconfirmed_share_delegations.len(), 1);
+
+        mark_share_confirmed(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+            1,
+            2,
+            0,
+        )
+        .unwrap();
+        let confirmed_state = get_round_recovery_state(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+        )
+        .unwrap();
+        assert!(confirmed_state.unconfirmed_share_delegations.is_empty());
+
+        clear_recovery_state(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+        )
+        .unwrap();
+        let cleared_state = get_round_recovery_state(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+        )
+        .unwrap();
+        assert!(cleared_state.share_delegations.is_empty());
+    }
+
+    #[test]
+    fn keystone_signature_round_trip_and_length_validation() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let db = db::open_voting_db(db_path.to_str().unwrap(), TEST_ACCOUNT_UUID).unwrap();
+        db.init_round(&test_api_round_params(), None).unwrap();
+        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+
+        store_keystone_signature(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+            0,
+            vec![7; KEYSTONE_SIG_LEN],
+            vec![8; KEYSTONE_SIGHASH_LEN],
+            vec![9; KEYSTONE_RK_LEN],
+        )
+        .unwrap();
+        let records = get_keystone_signatures(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].bundle_index, 0);
+        assert_eq!(records[0].sig, vec![7; KEYSTONE_SIG_LEN]);
+
+        let err = store_keystone_signature(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+            0,
+            vec![7; KEYSTONE_SIG_LEN - 1],
+            vec![8; KEYSTONE_SIGHASH_LEN],
+            vec![9; KEYSTONE_RK_LEN],
+        )
+        .unwrap_err();
+        assert!(err.contains("sig must be exactly"));
+    }
+
+    #[test]
+    fn set_ballot_intent_persists_choice_and_skipped() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let db = db::open_voting_db(db_path.to_str().unwrap(), TEST_ACCOUNT_UUID).unwrap();
+        db.init_round(&test_api_round_params(), None).unwrap();
+
+        set_ballot_intent(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+            1,
+            3,
+            false,
+            Some(2),
+        )
+        .unwrap();
+        set_ballot_intent(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+            2,
+            3,
+            true,
+            None,
+        )
+        .unwrap();
+
+        let err = set_ballot_intent(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+            3,
+            3,
+            false,
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("choice must be Some"));
+    }
+
+    #[test]
+    fn round_plan_happy_path_returns_round_and_open_proposals() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let db = db::open_voting_db(db_path.to_str().unwrap(), TEST_ACCOUNT_UUID).unwrap();
+        db.init_round(&test_api_round_params(), None).unwrap();
+
+        let plan = get_round_plan(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+            vec![1, 2],
+        )
+        .unwrap();
+
+        assert_eq!(plan.round_id, ROUND_ID);
+        assert_eq!(plan.open_proposals, vec![1, 2]);
+    }
+
+    #[test]
+    fn mark_delegation_submitted_updates_recovery_snapshot() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let db = db::open_voting_db(db_path.to_str().unwrap(), TEST_ACCOUNT_UUID).unwrap();
+        db.init_round(&test_api_round_params(), None).unwrap();
+        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+
+        mark_delegation_submitted(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+            0,
+            "delegation-submitted-tx".to_string(),
+        )
+        .unwrap();
+
+        let snapshot = get_round_recovery_state(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+        )
+        .unwrap();
+        assert_eq!(snapshot.delegation.len(), 1);
+        assert_eq!(
+            snapshot.delegation[0].tx_hash.as_deref(),
+            Some("delegation-submitted-tx")
+        );
+    }
+
+    #[test]
+    fn confirm_submission_apis_record_expected_confirmation_fields() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let db = db::open_voting_db(db_path.to_str().unwrap(), TEST_ACCOUNT_UUID).unwrap();
+        db.init_round(&test_api_round_params(), None).unwrap();
+        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        seed_recovery_vote(&db, TEST_ACCOUNT_UUID, 0, 7, 1, 88);
+
+        let delegation = confirm_delegation_submission(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+            0,
+            "delegate-confirmed-tx".to_string(),
+            vec![tx_event(
+                "delegate_vote",
+                &[("vote_round_id", ROUND_ID), ("leaf_index", "42")],
+            )],
+        )
+        .unwrap();
+        assert_eq!(delegation.tx_hash, "delegate-confirmed-tx");
+        assert_eq!(delegation.van_leaf_position, 42);
+
+        let vote = confirm_vote_submission(
+            db_path.to_str().unwrap().to_string(),
+            TEST_ACCOUNT_UUID.to_string(),
+            ROUND_ID.to_string(),
+            0,
+            7,
+            "vote-confirmed-tx".to_string(),
+            vec![tx_event(
+                "cast_vote",
+                &[("vote_round_id", ROUND_ID), ("leaf_index", "42,88")],
+            )],
+        )
+        .unwrap();
+        assert_eq!(vote.tx_hash, "vote-confirmed-tx");
+        assert_eq!(vote.vc_tree_position, 88);
+    }
+
+    #[test]
+    fn setup_delegation_bundles_rejects_invalid_network_before_network_io() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let err = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(setup_delegation_bundles(test_round_context(
+                &db_path, "bogus", "wallet-1",
+            )))
+            .unwrap_err();
+
+        assert!(err.contains("Unknown network"));
+    }
+
+    #[test]
+    fn precompute_delegation_pir_rejects_invalid_network_before_network_io() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let err = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(precompute_delegation_pir(
+                test_round_context(&db_path, "bogus", "wallet-1"),
+                "http://127.0.0.1:2".to_string(),
+                "mnemonic".to_string(),
+                0,
+            ))
+            .unwrap_err();
+
+        assert!(err.contains("Unknown network"));
+    }
+
+    #[test]
+    fn precompute_delegation_pir_rejects_invalid_mnemonic_before_network_io() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let err = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(precompute_delegation_pir(
+                test_round_context(&db_path, "regtest", "wallet-1"),
+                "http://127.0.0.1:2".to_string(),
+                "mnemonic".to_string(),
+                0,
+            ))
+            .unwrap_err();
+
+        assert!(err.contains("Invalid mnemonic"));
+    }
+
+    #[test]
+    fn build_keystone_delegation_request_rejects_invalid_network_before_network_io() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let err = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(build_keystone_delegation_request(
+                test_round_context(&db_path, "bogus", "wallet-1"),
+                vec![9; 32],
+                0,
+            ))
+            .unwrap_err();
+
+        assert!(err.contains("Unknown network"));
+    }
+
+    #[test]
+    fn build_keystone_delegation_request_rejects_invalid_hotkey_before_network_io() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let err = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(build_keystone_delegation_request(
+                test_round_context(&db_path, "regtest", "wallet-1"),
+                vec![9; 1],
+                0,
+            ))
+            .unwrap_err();
+
+        assert!(err.contains("Voting hotkey reconstruction failed"));
+    }
+
+    fn test_vote_recovery_json(
+        bundle_index: u32,
+        proposal_id: u32,
+        vote_decision: u32,
+        vc_tree_position: u64,
+    ) -> String {
+        zcash_voting::vote::serialize_recovery(&zcash_voting::vote::VoteRecoveryBundle {
+            vote_round_id: ROUND_ID.to_string(),
+            bundle_index,
+            proposal_id,
+            vote_decision,
+            anchor_height: 100,
+            vc_tree_position,
+            single_share: false,
+            num_options: 2,
+            van_nullifier: [1u8; 32],
+            vote_authority_note_new: [2u8; 32],
+            vote_commitment: [3u8; 32],
+            proof: vec![4u8; 8],
+            shares_hash: [5u8; 32],
+            r_vpk: [6u8; 32],
+            alpha_v: [7u8; 32],
+            vote_auth_sig: [8u8; 64],
+            encrypted_shares: vec![zcash_voting::EncryptedShare {
+                c1: vec![9u8; 32],
+                c2: vec![10u8; 32],
+                share_index: 0,
+                plaintext_value: 1,
+                randomness: vec![11u8; 32],
+            }],
+            share_blinds: vec![[12u8; 32]],
+            share_comms: vec![[13u8; 32]],
+        })
+        .unwrap()
+    }
+
+    fn seed_recovery_vote(
+        db: &zcash_voting::storage::VotingDb,
+        account_uuid: &str,
+        bundle_index: u32,
+        proposal_id: u32,
+        vote_decision: u32,
+        vc_tree_position: u64,
+    ) {
+        let recovery_json =
+            test_vote_recovery_json(bundle_index, proposal_id, vote_decision, vc_tree_position);
+        let recovery = zcash_voting::vote::parse_recovery(&recovery_json).unwrap();
+        let commitment_bytes = serde_json::to_vec(&serde_json::json!({
+            "van_nullifier": hex::encode(recovery.van_nullifier),
+            "vote_authority_note_new": hex::encode(recovery.vote_authority_note_new),
+            "vote_commitment": hex::encode(recovery.vote_commitment),
+            "proof": hex::encode(recovery.proof),
+        }))
+        .unwrap();
+        zcash_voting::storage::queries::store_vote(
+            &db.conn(),
+            ROUND_ID,
+            account_uuid,
+            bundle_index,
+            proposal_id,
+            vote_decision,
+            &commitment_bytes,
+        )
+        .unwrap();
+        db.conn()
+            .execute(
+                "UPDATE votes SET commitment_bundle_json = :json
+                 WHERE round_id = :round_id AND wallet_id = :wallet_id
+                   AND bundle_index = :bundle_index AND proposal_id = :proposal_id",
+                rusqlite::named_params! {
+                    ":json": recovery_json,
+                    ":round_id": ROUND_ID,
+                    ":wallet_id": account_uuid,
+                    ":bundle_index": i64::from(bundle_index),
+                    ":proposal_id": i64::from(proposal_id),
+                },
+            )
+            .unwrap();
+    }
+
+    fn test_tree_state(height: u64) -> TreeState {
+        TreeState {
+            network: "test".to_string(),
+            height,
+            hash: String::new(),
+            time: 0,
+            sapling_tree: String::new(),
+            orchard_tree: String::new(),
+        }
+    }
+
+    fn test_note_ref(
+        value_zatoshi: u64,
+        voting_weight_zatoshi: u64,
+        commitment_tree_position: u64,
+    ) -> zcash_voting::NoteRef {
+        zcash_voting::NoteRef {
+            pool: "orchard".to_string(),
+            txid_hex: hex::encode([commitment_tree_position as u8; 32]),
+            output_index: commitment_tree_position as u32,
+            value_zatoshi,
+            voting_weight_zatoshi,
+            commitment: vec![0x01; 32],
+            nullifier: vec![0x02; 32],
+            diversifier: vec![0x03; 11],
+            rho: vec![0x04; 32],
+            rseed: vec![0x05; 32],
+            scope: 0,
+            ufvk_str: String::new(),
+            commitment_tree_position,
+            mined_height: 1,
+            anchor_height: 100,
+        }
+    }
+
+    struct MockTreeBlock {
+        height: u32,
+        start_index: usize,
+        leaf: String,
+        root: String,
+    }
+
+    fn start_tree_server(height: u32, leaves: Vec<String>, expected_requests: usize) -> String {
+        let (latest_root, blocks) = mock_tree_blocks(&leaves);
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        thread::spawn(move || {
+            for _ in 0..expected_requests {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut request = [0u8; 2048];
+                let len = stream.read(&mut request).unwrap();
+                let request = String::from_utf8_lossy(&request[..len]);
+                let path = request
+                    .lines()
+                    .next()
+                    .and_then(|line| line.split_whitespace().nth(1))
+                    .unwrap_or("/");
+                let body = tree_response_body(path, height, latest_root.as_deref(), &blocks);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+        });
+        url
+    }
+
+    fn tree_response_body(
+        path: &str,
+        height: u32,
+        latest_root: Option<&str>,
+        blocks: &[MockTreeBlock],
+    ) -> String {
+        if path.ends_with("/latest") {
+            match latest_root {
+                Some(root) => format!(
+                    r#"{{"tree":{{"next_index":{},"root":"{}","height":{}}}}}"#,
+                    blocks.len(),
+                    root,
+                    height
+                ),
+                None => format!(
+                    r#"{{"tree":{{"next_index":{},"height":{}}}}}"#,
+                    blocks.len(),
+                    height
+                ),
+            }
+        } else if path.contains("/leaves?") {
+            if height == 0 || blocks.is_empty() {
+                r#"{"blocks":[]}"#.to_string()
+            } else {
+                let from_height = query_u32(path, "from_height").unwrap_or(0);
+                let to_height = query_u32(path, "to_height").unwrap_or(height);
+                let Some(block) = blocks
+                    .iter()
+                    .find(|block| block.height >= from_height && block.height <= to_height)
+                else {
+                    return r#"{"blocks":[],"next_from_height":0}"#.to_string();
+                };
+                let next_from_height = blocks
+                    .iter()
+                    .find(|next| next.height > block.height && next.height <= to_height)
+                    .map(|next| format!(r#","next_from_height":{}"#, next.height))
+                    .unwrap_or_default();
+                format!(
+                    r#"{{"blocks":[{{"height":{},"start_index":{},"leaves":["{}"],"root":"{}"}}]{}}}"#,
+                    block.height, block.start_index, block.leaf, block.root, next_from_height
+                )
+            }
+        } else {
+            r#"{"tree":null}"#.to_string()
+        }
+    }
+
+    fn mock_tree_blocks(leaves: &[String]) -> (Option<String>, Vec<MockTreeBlock>) {
+        let mut server = vote_commitment_tree::MemoryTreeServer::empty();
+        let mut blocks = Vec::new();
+
+        for (idx, leaf_b64) in leaves.iter().enumerate() {
+            let leaf_bytes = base64::engine::general_purpose::STANDARD
+                .decode(leaf_b64)
+                .unwrap();
+            let leaf_bytes: [u8; 32] = leaf_bytes.try_into().unwrap();
+            let leaf = vote_commitment_tree::MerkleHashVote::from_bytes(&leaf_bytes).unwrap();
+            let height = (idx + 1) as u32;
+            server.append(leaf.inner()).unwrap();
+            server.checkpoint(height).unwrap();
+            let root = vote_commitment_tree::MerkleHashVote::from_fp(server.root());
+            blocks.push(MockTreeBlock {
+                height,
+                start_index: idx,
+                leaf: leaf_b64.clone(),
+                root: base64::engine::general_purpose::STANDARD.encode(root.to_bytes()),
+            });
+        }
+
+        let latest_root = blocks.last().map(|block| block.root.clone());
+        (latest_root, blocks)
+    }
+
+    fn query_u32(path: &str, key: &str) -> Option<u32> {
+        path.split('?').nth(1)?.split('&').find_map(|pair| {
+            let (name, value) = pair.split_once('=')?;
+            (name == key).then(|| value.parse().ok()).flatten()
+        })
+    }
+
+    fn fp_one_base64() -> String {
+        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".to_string()
+    }
+}

--- a/rust/src/api/voting_helpers.rs
+++ b/rust/src/api/voting_helpers.rs
@@ -3,6 +3,7 @@ use zeroize::Zeroizing;
 
 use crate::wallet::{keys, network::WalletNetwork, voting::network::voting_network};
 
+/// Convert API bundle-size input into a validated voting bundle policy.
 pub(super) fn bundle_policy(
     max_real_notes_per_bundle: Option<u32>,
 ) -> Result<zcash_voting::BundlePolicy, String> {
@@ -10,6 +11,7 @@ pub(super) fn bundle_policy(
         .map_err(|e| e.to_string())
 }
 
+/// Derive a wallet seed from a BIP-39 mnemonic while zeroizing mnemonic bytes.
 pub(super) fn seed_from_mnemonic(mnemonic: String) -> Result<SecretVec<u8>, String> {
     let mnemonic = Zeroizing::new(mnemonic.into_bytes());
     keys::mnemonic_bytes_to_seed(mnemonic.as_slice())

--- a/rust/src/api/voting_helpers.rs
+++ b/rust/src/api/voting_helpers.rs
@@ -1,0 +1,75 @@
+use secrecy::SecretVec;
+use zeroize::Zeroizing;
+
+use crate::wallet::{keys, network::WalletNetwork, voting::network::voting_network};
+
+pub(super) fn bundle_policy(
+    max_real_notes_per_bundle: Option<u32>,
+) -> Result<zcash_voting::BundlePolicy, String> {
+    zcash_voting::BundlePolicy::from_optional_max_real_notes_per_bundle(max_real_notes_per_bundle)
+        .map_err(|e| e.to_string())
+}
+
+pub(super) fn seed_from_mnemonic(mnemonic: String) -> Result<SecretVec<u8>, String> {
+    let mnemonic = Zeroizing::new(mnemonic.into_bytes());
+    keys::mnemonic_bytes_to_seed(mnemonic.as_slice())
+}
+
+/// Parse local delegation inputs that do not require lightwalletd network I/O.
+pub(super) fn delegation_static_inputs(
+    network: &str,
+    max_real_notes_per_bundle: Option<u32>,
+) -> Result<
+    (
+        WalletNetwork,
+        zcash_voting::Network,
+        zcash_voting::BundlePolicy,
+    ),
+    String,
+> {
+    let wallet_network = keys::parse_network(network)?;
+    let voting_network = voting_network(wallet_network);
+    let bundle_policy = bundle_policy(max_real_notes_per_bundle)?;
+    Ok((wallet_network, voting_network, bundle_policy))
+}
+
+/// Fetch lightwalletd-backed delegation inputs after local validation succeeds.
+pub(super) async fn resolve_delegation_lwd_inputs(
+    lightwalletd_url: &str,
+    round_params: zcash_voting::wire::VotingRoundParams,
+    round_name: &str,
+    voting_network: zcash_voting::Network,
+) -> Result<zcash_voting::delegate::DelegationLwdInputs, String> {
+    zcash_voting::delegate::gather_delegation_lwd_inputs(
+        zcash_voting::delegate::ResolveDelegationLwdParams {
+            lightwalletd_url,
+            network: voting_network,
+            round_params,
+            round_name,
+        },
+    )
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// Build the common `PrepareDelegationBundleParams` shape for wallet-layer
+/// delegation helpers from API-owned inputs.
+pub(super) fn prepare_delegation_bundle_params<'a>(
+    lwd: zcash_voting::delegate::DelegationLwdInputs,
+    session_json: Option<&'a str>,
+    account_uuid: &'a str,
+    network: zcash_voting::Network,
+    hotkey_seed: &'a [u8],
+    bundle_index: u32,
+    bundle_policy: zcash_voting::BundlePolicy,
+) -> zcash_voting::delegate::PrepareDelegationBundleParams<'a> {
+    zcash_voting::delegate::PrepareDelegationBundleParams {
+        lwd,
+        session_json,
+        account_uuid,
+        network,
+        hotkey_seed,
+        bundle_index,
+        bundle_policy,
+    }
+}

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -367991404;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -690171987;
 
 // Section: executor
 
@@ -127,6 +127,196 @@ fn wire__crate__api__sync__add_proofs_to_pczt_impl(
         },
     )
 }
+fn wire__crate__api__voting__add_sent_servers_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "add_sent_servers",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            let api_proposal_id = <u32>::sse_decode(&mut deserializer);
+            let api_share_index = <u32>::sse_decode(&mut deserializer);
+            let api_new_urls = <Vec<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::add_sent_servers(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_bundle_index,
+                        api_proposal_id,
+                        api_share_index,
+                        api_new_urls,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__build_keystone_delegation_request_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "build_keystone_delegation_request",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_ctx =
+                <crate::api::voting::ApiVotingRoundContext>::sse_decode(&mut deserializer);
+            let api_hotkey_seed = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, String>(
+                    (move || async move {
+                        let output_ok = crate::api::voting::build_keystone_delegation_request(
+                            api_ctx,
+                            api_hotkey_seed,
+                            api_bundle_index,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__build_prove_and_sign_delegation_payload_with_progress_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "build_prove_and_sign_delegation_payload_with_progress", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { 
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_ctx = <crate::api::voting::ApiVotingRoundContext>::sse_decode(&mut deserializer);
+let api_pir_server_url = <String>::sse_decode(&mut deserializer);
+let api_mnemonic = <String>::sse_decode(&mut deserializer);
+let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+let api_sink = <StreamSink<crate::api::voting::ApiDelegationProofEvent,flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, String>((move || async move {
+                         let output_ok = crate::api::voting::build_prove_and_sign_delegation_payload_with_progress(api_ctx, api_pir_server_url, api_mnemonic, api_bundle_index, api_sink).await?;   Ok(output_ok)
+                    })().await)
+                } })
+}
+fn wire__crate__api__voting__build_prove_delegation_payload_with_keystone_signature_with_progress_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec,_,_,_>(flutter_rust_bridge::for_generated::TaskInfo{ debug_name: "build_prove_delegation_payload_with_keystone_signature_with_progress", port: Some(port_), mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal }, move || { 
+            let message = unsafe { flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(ptr_, rust_vec_len_, data_len_) };
+            let mut deserializer = flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_ctx = <crate::api::voting::ApiVotingRoundContext>::sse_decode(&mut deserializer);
+let api_pir_server_url = <String>::sse_decode(&mut deserializer);
+let api_hotkey_seed = <Vec<u8>>::sse_decode(&mut deserializer);
+let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+let api_keystone_sig = <Vec<u8>>::sse_decode(&mut deserializer);
+let api_keystone_sighash = <Vec<u8>>::sse_decode(&mut deserializer);
+let api_sink = <StreamSink<crate::api::voting::ApiDelegationProofEvent,flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(&mut deserializer);deserializer.end(); move |context| async move {
+                    transform_result_sse::<_, String>((move || async move {
+                         let output_ok = crate::api::voting::build_prove_delegation_payload_with_keystone_signature_with_progress(api_ctx, api_pir_server_url, api_hotkey_seed, api_bundle_index, api_keystone_sig, api_keystone_sighash, api_sink).await?;   Ok(output_ok)
+                    })().await)
+                } })
+}
+fn wire__crate__api__voting__build_vote_commitments_with_progress_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "build_vote_commitments_with_progress",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            let api_hotkey_seed = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_van_witness = <zcash_voting::vote::VanWitness>::sse_decode(&mut deserializer);
+            let api_draft_votes =
+                <Vec<zcash_voting::wire::DraftVote>>::sse_decode(&mut deserializer);
+            let api_sink = <StreamSink<
+                crate::api::voting::ApiVoteCommitEvent,
+                flutter_rust_bridge::for_generated::SseCodec,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, String>(
+                    (move || async move {
+                        let output_ok = crate::api::voting::build_vote_commitments_with_progress(
+                            api_db_path,
+                            api_account_uuid,
+                            api_network,
+                            api_round_id,
+                            api_bundle_index,
+                            api_hotkey_seed,
+                            api_van_witness,
+                            api_draft_votes,
+                            api_sink,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__sync__cancel_full_sync_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -155,6 +345,137 @@ fn wire__crate__api__sync__cancel_full_sync_impl(
                 })?;
                 Ok(output_ok)
             })())
+        },
+    )
+}
+fn wire__crate__api__voting__clear_recovery_state_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "clear_recovery_state",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::clear_recovery_state(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__confirm_delegation_submission_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "confirm_delegation_submission",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            let api_tx_hash = <String>::sse_decode(&mut deserializer);
+            let api_events = <Vec<zcash_voting::wire::TxEvent>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::confirm_delegation_submission(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_bundle_index,
+                        api_tx_hash,
+                        api_events,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__confirm_vote_submission_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "confirm_vote_submission",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            let api_proposal_id = <u32>::sse_decode(&mut deserializer);
+            let api_tx_hash = <String>::sse_decode(&mut deserializer);
+            let api_events = <Vec<zcash_voting::wire::TxEvent>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::confirm_vote_submission(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_bundle_index,
+                        api_proposal_id,
+                        api_tx_hash,
+                        api_events,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
         },
     )
 }
@@ -526,6 +847,41 @@ fn wire__crate__api__secret__decrypt_secret_payload_impl(
         },
     )
 }
+fn wire__crate__api__voting__delegation_submission_wire_json_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "delegation_submission_wire_json",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_submission =
+                <zcash_voting::wire::SignedDelegationPayloadView>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok =
+                        crate::api::voting::delegation_submission_wire_json(api_submission)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet__delete_account_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -565,6 +921,47 @@ fn wire__crate__api__wallet__delete_account_impl(
         },
     )
 }
+fn wire__crate__api__voting__delete_skipped_bundles_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "delete_skipped_bundles",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_keep_count = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::delete_skipped_bundles(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_keep_count,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__secret__derive_secret_password_verifier_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -595,6 +992,47 @@ fn wire__crate__api__secret__derive_secret_password_verifier_impl(
                     let output_ok = crate::api::secret::derive_secret_password_verifier(
                         api_password,
                         api_salt_base64,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__derive_voting_hotkey_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "derive_voting_hotkey",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_mnemonic = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::derive_voting_hotkey(
+                        api_mnemonic,
+                        api_round_id,
+                        api_account_uuid,
+                        api_network,
                     )?;
                     Ok(output_ok)
                 })())
@@ -1015,6 +1453,77 @@ fn wire__crate__api__sync__extract_and_broadcast_pczt_impl(
         },
     )
 }
+fn wire__crate__api__voting__extract_pczt_sighash_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "extract_pczt_sighash",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_pczt_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::extract_pczt_sighash(api_pczt_bytes)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__extract_spend_auth_signature_from_signed_pczt_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "extract_spend_auth_signature_from_signed_pczt",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_signed_pczt_bytes = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_action_index = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok =
+                        crate::api::voting::extract_spend_auth_signature_from_signed_pczt(
+                            api_signed_pczt_bytes,
+                            api_action_index,
+                        )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet__generate_mnemonic_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -1041,6 +1550,82 @@ fn wire__crate__api__wallet__generate_mnemonic_impl(
                 let output_ok = Result::<_, ()>::Ok(crate::api::wallet::generate_mnemonic())?;
                 Ok(output_ok)
             })())
+        },
+    )
+}
+fn wire__crate__api__voting__generate_van_witness_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "generate_van_witness",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            let api_anchor_height = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::generate_van_witness(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_bundle_index,
+                        api_anchor_height,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__generate_voting_hotkey_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "generate_voting_hotkey",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::generate_voting_hotkey(api_network)?;
+                    Ok(output_ok)
+                })())
+            }
         },
     )
 }
@@ -1178,6 +1763,45 @@ fn wire__crate__api__sync__get_export_birthday_height_impl(
                         api_db_path,
                         api_network,
                         api_account_uuid,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__get_keystone_signatures_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_keystone_signatures",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::get_keystone_signatures(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
                     )?;
                     Ok(output_ok)
                 })())
@@ -1323,6 +1947,86 @@ fn wire__crate__api__sync__get_next_subtree_indices_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok =
                         crate::api::sync::get_next_subtree_indices(api_db_path, api_network)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__get_round_plan_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_round_plan",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_proposal_ids = <Vec<u32>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::get_round_plan(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_proposal_ids,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__get_round_recovery_state_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_round_recovery_state",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::get_round_recovery_state(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -1901,6 +2605,139 @@ fn wire__crate__api__wallet__list_accounts_impl(
         },
     )
 }
+fn wire__crate__api__voting__mark_delegation_submitted_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "mark_delegation_submitted",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            let api_tx_hash = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::mark_delegation_submitted(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_bundle_index,
+                        api_tx_hash,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__mark_share_confirmed_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "mark_share_confirmed",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            let api_proposal_id = <u32>::sse_decode(&mut deserializer);
+            let api_share_index = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::mark_share_confirmed(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_bundle_index,
+                        api_proposal_id,
+                        api_share_index,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__mark_vote_submitted_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "mark_vote_submitted",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            let api_proposal_id = <u32>::sse_decode(&mut deserializer);
+            let api_tx_hash = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::mark_vote_submitted(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_bundle_index,
+                        api_proposal_id,
+                        api_tx_hash,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet__mnemonic_word_list_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -1927,6 +2764,135 @@ fn wire__crate__api__wallet__mnemonic_word_list_impl(
                 let output_ok = Result::<_, ()>::Ok(crate::api::wallet::mnemonic_word_list())?;
                 Ok(output_ok)
             })())
+        },
+    )
+}
+fn wire__crate__api__voting__next_share_tracking_delay_seconds_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "next_share_tracking_delay_seconds",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_shares =
+                <Vec<zcash_voting::wire::ShareDelegationRecordView>>::sse_decode(&mut deserializer);
+            let api_now_seconds = <u64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::next_share_tracking_delay_seconds(
+                        api_shares,
+                        api_now_seconds,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__plan_share_submissions_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "plan_share_submissions",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_share_count = <u32>::sse_decode(&mut deserializer);
+            let api_server_urls = <Vec<String>>::sse_decode(&mut deserializer);
+            let api_now_seconds = <u64>::sse_decode(&mut deserializer);
+            let api_vote_end_time_seconds = <u64>::sse_decode(&mut deserializer);
+            let api_last_moment_buffer_seconds = <Option<u64>>::sse_decode(&mut deserializer);
+            let api_single_share = <bool>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::plan_share_submissions(
+                        api_share_count,
+                        api_server_urls,
+                        api_now_seconds,
+                        api_vote_end_time_seconds,
+                        api_last_moment_buffer_seconds,
+                        api_single_share,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__precompute_delegation_pir_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "precompute_delegation_pir",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_ctx =
+                <crate::api::voting::ApiVotingRoundContext>::sse_decode(&mut deserializer);
+            let api_pir_server_url = <String>::sse_decode(&mut deserializer);
+            let api_mnemonic = <String>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, String>(
+                    (move || async move {
+                        let output_ok = crate::api::voting::precompute_delegation_pir(
+                            api_ctx,
+                            api_pir_server_url,
+                            api_mnemonic,
+                            api_bundle_index,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
         },
     )
 }
@@ -2024,6 +2990,141 @@ fn wire__crate__api__sync__put_subtree_roots_impl(
         },
     )
 }
+fn wire__crate__api__voting__record_share_delegation_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "record_share_delegation",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            let api_proposal_id = <u32>::sse_decode(&mut deserializer);
+            let api_share_index = <u32>::sse_decode(&mut deserializer);
+            let api_sent_to_urls = <Vec<String>>::sse_decode(&mut deserializer);
+            let api_submit_at = <u64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::record_share_delegation(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_bundle_index,
+                        api_proposal_id,
+                        api_share_index,
+                        api_sent_to_urls,
+                        api_submit_at,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__recover_vote_commitment_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "recover_vote_commitment",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            let api_proposal_id = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::recover_vote_commitment(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_bundle_index,
+                        api_proposal_id,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__recovered_vote_share_wire_json_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "recovered_vote_share_wire_json",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_commitment_bundle_json = <String>::sse_decode(&mut deserializer);
+            let api_proposal_id = <u32>::sse_decode(&mut deserializer);
+            let api_share_index = <u32>::sse_decode(&mut deserializer);
+            let api_vc_tree_position = <u64>::sse_decode(&mut deserializer);
+            let api_submit_at = <u64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::recovered_vote_share_wire_json(
+                        api_commitment_bundle_json,
+                        api_proposal_id,
+                        api_share_index,
+                        api_vc_tree_position,
+                        api_submit_at,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__sync__redact_pczt_for_signer_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -2085,6 +3186,45 @@ fn wire__crate__api__keystone__reset_ur_session_impl(
                 })?;
                 Ok(output_ok)
             })())
+        },
+    )
+}
+fn wire__crate__api__voting__reset_voting_session_state_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "reset_voting_session_state",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::reset_voting_session_state(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
         },
     )
 }
@@ -2220,6 +3360,53 @@ fn wire__crate__api__sync__scan_blocks_impl(
         },
     )
 }
+fn wire__crate__api__voting__set_ballot_intent_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "set_ballot_intent",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_proposal_id = <u32>::sse_decode(&mut deserializer);
+            let api_num_options = <u32>::sse_decode(&mut deserializer);
+            let api_skipped = <bool>::sse_decode(&mut deserializer);
+            let api_choice = <Option<u32>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::set_ballot_intent(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_proposal_id,
+                        api_num_options,
+                        api_skipped,
+                        api_choice,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__sync__set_sync_mode_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -2286,6 +3473,84 @@ fn wire__crate__api__sync__set_transaction_status_impl(
                         api_network,
                         api_txid_hex,
                         api_status,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__setup_delegation_bundles_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "setup_delegation_bundles",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_ctx =
+                <crate::api::voting::ApiVotingRoundContext>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, String>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::voting::setup_delegation_bundles(api_ctx).await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__share_tracking_flags_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "share_tracking_flags",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_share =
+                <zcash_voting::wire::ShareDelegationRecordView>::sse_decode(&mut deserializer);
+            let api_now_seconds = <u64>::sse_decode(&mut deserializer);
+            let api_vote_end_time_seconds = <Option<u64>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::share_tracking_flags(
+                        api_share,
+                        api_now_seconds,
+                        api_vote_end_time_seconds,
                     )?;
                     Ok(output_ok)
                 })())
@@ -2501,6 +3766,53 @@ fn wire__crate__api__sync__stop_mempool_observer_impl(
         },
     )
 }
+fn wire__crate__api__voting__store_keystone_signature_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "store_keystone_signature",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_bundle_index = <u32>::sse_decode(&mut deserializer);
+            let api_sig = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_sighash = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_rk = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::store_keystone_signature(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_bundle_index,
+                        api_sig,
+                        api_sighash,
+                        api_rk,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__sync__suggest_scan_ranges_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -2530,6 +3842,47 @@ fn wire__crate__api__sync__suggest_scan_ranges_impl(
                 transform_result_sse::<_, String>((move || {
                     let output_ok =
                         crate::api::sync::suggest_scan_ranges(api_db_path, api_network)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__sync_vote_tree_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "sync_vote_tree",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <String>::sse_decode(&mut deserializer);
+            let api_node_url = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::sync_vote_tree(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                        api_node_url,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -2636,6 +3989,79 @@ fn wire__crate__api__wallet__validate_mnemonic_impl(
         },
     )
 }
+fn wire__crate__api__voting__vote_commitment_wire_json_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "vote_commitment_wire_json",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_commitment =
+                <zcash_voting::wire::VoteCommitmentWire>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::vote_commitment_wire_json(api_commitment)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__voting__vote_share_wire_json_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "vote_share_wire_json",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_share = <zcash_voting::wire::VoteShareWire>::sse_decode(&mut deserializer);
+            let api_vc_tree_position = <Option<u64>>::sse_decode(&mut deserializer);
+            let api_submit_at = <u64>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::vote_share_wire_json(
+                        api_share,
+                        api_vc_tree_position,
+                        api_submit_at,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__wallet__wallet_exists_impl(
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
     rust_vec_len_: i32,
@@ -2703,6 +4129,291 @@ fn wire__crate__api__sync__write_block_metadata_impl(
     )
 }
 
+// Section: static_checks
+
+#[allow(clippy::unnecessary_literal_unwrap)]
+const _: fn() = || {
+    {
+        let BundleLayout = None::<zcash_voting::round::BundleLayout>.unwrap();
+        let _: u32 = BundleLayout.bundle_count;
+        let _: u64 = BundleLayout.eligible_weight;
+        let _: u32 = BundleLayout.dropped_count;
+    }
+    {
+        let CompletedVoteChoiceView = None::<zcash_voting::wire::CompletedVoteChoiceView>.unwrap();
+        let _: u32 = CompletedVoteChoiceView.proposal_id;
+        let _: Option<u32> = CompletedVoteChoiceView.choice;
+    }
+    {
+        let CompletedVoteDisplayView =
+            None::<zcash_voting::wire::CompletedVoteDisplayView>.unwrap();
+        let _: Vec<zcash_voting::wire::CompletedVoteChoiceView> = CompletedVoteDisplayView.choices;
+        let _: Option<u64> = CompletedVoteDisplayView.voted_at;
+    }
+    {
+        let DelegationConfirmation = None::<zcash_voting::wire::DelegationConfirmation>.unwrap();
+        let _: String = DelegationConfirmation.tx_hash;
+        let _: u32 = DelegationConfirmation.van_leaf_position;
+    }
+    {
+        let DelegationPirPrecomputeResultView =
+            None::<zcash_voting::wire::DelegationPirPrecomputeResultView>.unwrap();
+        let _: u32 = DelegationPirPrecomputeResultView.cached_count;
+        let _: u32 = DelegationPirPrecomputeResultView.fetched_count;
+        let _: u32 = DelegationPirPrecomputeResultView.bundle_count;
+        let _: u32 = DelegationPirPrecomputeResultView.bundle_index;
+    }
+    {
+        let DelegationRecoveryView = None::<zcash_voting::wire::DelegationRecoveryView>.unwrap();
+        let _: u32 = DelegationRecoveryView.bundle_index;
+        let _: String = DelegationRecoveryView.phase;
+        let _: Option<String> = DelegationRecoveryView.tx_hash;
+        let _: Option<u32> = DelegationRecoveryView.van_leaf_position;
+    }
+    {
+        let DelegationRecoveryWorkView =
+            None::<zcash_voting::wire::DelegationRecoveryWorkView>.unwrap();
+        let _: String = DelegationRecoveryWorkView.kind;
+        let _: u32 = DelegationRecoveryWorkView.bundle_index;
+        let _: String = DelegationRecoveryWorkView.phase;
+        let _: Option<String> = DelegationRecoveryWorkView.tx_hash;
+    }
+    {
+        let DelegationStatusView = None::<zcash_voting::wire::DelegationStatusView>.unwrap();
+        let _: u32 = DelegationStatusView.bundle_index;
+        let _: String = DelegationStatusView.phase;
+        let _: Option<String> = DelegationStatusView.tx_hash;
+    }
+    {
+        let DelegationSubmissionWire =
+            None::<zcash_voting::wire::DelegationSubmissionWire>.unwrap();
+        let _: String = DelegationSubmissionWire.rk;
+        let _: String = DelegationSubmissionWire.spend_auth_sig;
+        let _: String = DelegationSubmissionWire.sighash;
+        let _: String = DelegationSubmissionWire.nf_signed;
+        let _: String = DelegationSubmissionWire.cmx_new;
+        let _: String = DelegationSubmissionWire.gov_comm;
+        let _: Vec<String> = DelegationSubmissionWire.gov_nullifiers;
+        let _: String = DelegationSubmissionWire.proof;
+        let _: String = DelegationSubmissionWire.vote_round_id;
+    }
+    {
+        let DraftVote = None::<zcash_voting::wire::DraftVote>.unwrap();
+        let _: u32 = DraftVote.proposal_id;
+        let _: u32 = DraftVote.choice;
+        let _: u32 = DraftVote.num_options;
+        let _: u64 = DraftVote.vc_tree_position;
+        let _: bool = DraftVote.single_share;
+    }
+    {
+        let KeystoneSignatureRecord = None::<zcash_voting::wire::KeystoneSignatureRecord>.unwrap();
+        let _: u32 = KeystoneSignatureRecord.bundle_index;
+        let _: Vec<u8> = KeystoneSignatureRecord.sig;
+        let _: Vec<u8> = KeystoneSignatureRecord.sighash;
+        let _: Vec<u8> = KeystoneSignatureRecord.rk;
+    }
+    {
+        let KeystoneSigningRequest =
+            None::<zcash_voting::delegate::KeystoneSigningRequest>.unwrap();
+        let _: Vec<u8> = KeystoneSigningRequest.pczt_bytes;
+        let _: Vec<u8> = KeystoneSigningRequest.redacted_pczt_bytes;
+        let _: Vec<u8> = KeystoneSigningRequest.pczt_sighash;
+        let _: Vec<u8> = KeystoneSigningRequest.rk;
+        let _: u32 = KeystoneSigningRequest.action_index;
+        let _: String = KeystoneSigningRequest.display_memo;
+        let _: u64 = KeystoneSigningRequest.eligible_weight_zatoshi;
+        let _: u64 = KeystoneSigningRequest.delegated_weight_zatoshi;
+        let _: u32 = KeystoneSigningRequest.bundle_count;
+        let _: u32 = KeystoneSigningRequest.bundle_index;
+    }
+    {
+        let NextStepView = None::<zcash_voting::wire::NextStepView>.unwrap();
+        let _: String = NextStepView.kind;
+        let _: u32 = NextStepView.bundle_index;
+        let _: u32 = NextStepView.proposal_id;
+        let _: u32 = NextStepView.choice;
+        let _: u32 = NextStepView.share_index;
+    }
+    {
+        let RecoverableCommitmentBundle =
+            None::<zcash_voting::wire::RecoverableCommitmentBundle>.unwrap();
+        let _: u32 = RecoverableCommitmentBundle.bundle_index;
+        let _: u32 = RecoverableCommitmentBundle.proposal_id;
+        let _: String = RecoverableCommitmentBundle.commitment_bundle_json;
+        let _: u64 = RecoverableCommitmentBundle.vc_tree_position;
+    }
+    {
+        let RoundPlanView = None::<zcash_voting::wire::RoundPlanView>.unwrap();
+        let _: String = RoundPlanView.round_id;
+        let _: bool = RoundPlanView.pending_recovery;
+        let _: bool = RoundPlanView.blocking_recovery;
+        let _: bool = RoundPlanView.blocking_share_work;
+        let _: bool = RoundPlanView.hotkey_bound;
+        let _: bool = RoundPlanView.completed_vote_artifact;
+        let _: bool = RoundPlanView.completed_for_display;
+        let _: Option<zcash_voting::wire::CompletedVoteDisplayView> =
+            RoundPlanView.completed_vote_display;
+        let _: bool = RoundPlanView.needs_draft_setup;
+        let _: String = RoundPlanView.primary_action;
+        let _: Vec<zcash_voting::wire::NextStepView> = RoundPlanView.next_steps;
+        let _: Vec<zcash_voting::wire::DelegationStatusView> = RoundPlanView.delegation_statuses;
+        let _: Vec<zcash_voting::wire::DelegationRecoveryWorkView> =
+            RoundPlanView.recovered_delegation_work;
+        let _: Vec<zcash_voting::wire::VoteRecoveryWorkView> = RoundPlanView.recovered_vote_work;
+        let _: Vec<u32> = RoundPlanView.open_proposals;
+        let _: bool = RoundPlanView.all_decided;
+    }
+    {
+        let RoundRecoveryStateView = None::<zcash_voting::wire::RoundRecoveryStateView>.unwrap();
+        let _: String = RoundRecoveryStateView.round_id;
+        let _: u32 = RoundRecoveryStateView.bundle_count;
+        let _: Vec<zcash_voting::wire::DelegationRecoveryView> = RoundRecoveryStateView.delegation;
+        let _: Vec<zcash_voting::wire::VoteRecoveryView> = RoundRecoveryStateView.votes;
+        let _: Vec<zcash_voting::wire::RecoverableCommitmentBundle> =
+            RoundRecoveryStateView.commitment_bundles;
+        let _: Vec<zcash_voting::wire::ShareWorkflowRecoveryView> = RoundRecoveryStateView.shares;
+        let _: Vec<zcash_voting::wire::ShareDelegationRecordView> =
+            RoundRecoveryStateView.share_delegations;
+        let _: Vec<zcash_voting::wire::ShareDelegationRecordView> =
+            RoundRecoveryStateView.unconfirmed_share_delegations;
+    }
+    {
+        let ShareDelegationRecordView =
+            None::<zcash_voting::wire::ShareDelegationRecordView>.unwrap();
+        let _: String = ShareDelegationRecordView.round_id;
+        let _: u32 = ShareDelegationRecordView.bundle_index;
+        let _: u32 = ShareDelegationRecordView.proposal_id;
+        let _: u32 = ShareDelegationRecordView.share_index;
+        let _: Vec<String> = ShareDelegationRecordView.sent_to_urls;
+        let _: Vec<u8> = ShareDelegationRecordView.nullifier;
+        let _: String = ShareDelegationRecordView.phase;
+        let _: bool = ShareDelegationRecordView.confirmed;
+        let _: u64 = ShareDelegationRecordView.submit_at;
+        let _: u64 = ShareDelegationRecordView.created_at;
+    }
+    {
+        let ShareSubmissionPlan = None::<zcash_voting::share_policy::ShareSubmissionPlan>.unwrap();
+        let _: u64 = ShareSubmissionPlan.submit_at;
+        let _: u32 = ShareSubmissionPlan.target_count;
+        let _: Vec<String> = ShareSubmissionPlan.target_servers;
+    }
+    {
+        let ShareWorkflowRecoveryView =
+            None::<zcash_voting::wire::ShareWorkflowRecoveryView>.unwrap();
+        let _: u32 = ShareWorkflowRecoveryView.bundle_index;
+        let _: u32 = ShareWorkflowRecoveryView.proposal_id;
+        let _: u32 = ShareWorkflowRecoveryView.share_index;
+        let _: String = ShareWorkflowRecoveryView.phase;
+    }
+    {
+        let SignedDelegationPayloadView =
+            None::<zcash_voting::wire::SignedDelegationPayloadView>.unwrap();
+        let _: Vec<u8> = SignedDelegationPayloadView.pczt_bytes;
+        let _: String = SignedDelegationPayloadView.status;
+        let _: Option<String> = SignedDelegationPayloadView.message;
+        let _: zcash_voting::wire::DelegationSubmissionWire =
+            SignedDelegationPayloadView.submission;
+        let _: u64 = SignedDelegationPayloadView.eligible_weight_zatoshi;
+        let _: u64 = SignedDelegationPayloadView.delegated_weight_zatoshi;
+        let _: u32 = SignedDelegationPayloadView.bundle_count;
+        let _: u32 = SignedDelegationPayloadView.bundle_index;
+    }
+    {
+        let SignedVoteCommitmentView =
+            None::<zcash_voting::wire::SignedVoteCommitmentView>.unwrap();
+        let _: u32 = SignedVoteCommitmentView.proposal_id;
+        let _: zcash_voting::wire::VoteCommitmentWire = SignedVoteCommitmentView.wire;
+        let _: Vec<zcash_voting::wire::VoteShareWire> = SignedVoteCommitmentView.shares;
+    }
+    {
+        let SignedVoteCommitmentsView =
+            None::<zcash_voting::wire::SignedVoteCommitmentsView>.unwrap();
+        let _: u32 = SignedVoteCommitmentsView.bundle_index;
+        let _: Vec<zcash_voting::wire::SignedVoteCommitmentView> =
+            SignedVoteCommitmentsView.commitments;
+    }
+    {
+        let TxEvent = None::<zcash_voting::wire::TxEvent>.unwrap();
+        let _: String = TxEvent.event_type;
+        let _: Vec<zcash_voting::wire::TxEventAttribute> = TxEvent.attributes;
+    }
+    {
+        let TxEventAttribute = None::<zcash_voting::wire::TxEventAttribute>.unwrap();
+        let _: String = TxEventAttribute.key;
+        let _: String = TxEventAttribute.value;
+    }
+    {
+        let VanWitness = None::<zcash_voting::vote::VanWitness>.unwrap();
+        let _: Vec<Vec<u8>> = VanWitness.auth_path;
+        let _: u32 = VanWitness.position;
+        let _: u32 = VanWitness.anchor_height;
+    }
+    {
+        let VoteCommitmentWire = None::<zcash_voting::wire::VoteCommitmentWire>.unwrap();
+        let _: String = VoteCommitmentWire.van_nullifier;
+        let _: String = VoteCommitmentWire.vote_authority_note_new;
+        let _: String = VoteCommitmentWire.vote_commitment;
+        let _: u32 = VoteCommitmentWire.proposal_id;
+        let _: String = VoteCommitmentWire.proof;
+        let _: String = VoteCommitmentWire.vote_round_id;
+        let _: u32 = VoteCommitmentWire.anchor_height;
+        let _: String = VoteCommitmentWire.r_vpk;
+        let _: String = VoteCommitmentWire.vote_auth_sig;
+    }
+    {
+        let VoteConfirmation = None::<zcash_voting::wire::VoteConfirmation>.unwrap();
+        let _: String = VoteConfirmation.tx_hash;
+        let _: u32 = VoteConfirmation.van_leaf_position;
+        let _: u64 = VoteConfirmation.vc_tree_position;
+    }
+    {
+        let VoteRecoveryView = None::<zcash_voting::wire::VoteRecoveryView>.unwrap();
+        let _: u32 = VoteRecoveryView.bundle_index;
+        let _: u32 = VoteRecoveryView.proposal_id;
+        let _: u32 = VoteRecoveryView.choice;
+        let _: String = VoteRecoveryView.phase;
+        let _: Option<String> = VoteRecoveryView.tx_hash;
+        let _: Option<u64> = VoteRecoveryView.vc_tree_position;
+        let _: bool = VoteRecoveryView.has_commitment_bundle;
+    }
+    {
+        let VoteRecoveryWorkView = None::<zcash_voting::wire::VoteRecoveryWorkView>.unwrap();
+        let _: String = VoteRecoveryWorkView.kind;
+        let _: u32 = VoteRecoveryWorkView.bundle_index;
+        let _: u32 = VoteRecoveryWorkView.proposal_id;
+        let _: Option<String> = VoteRecoveryWorkView.tx_hash;
+        let _: Option<u64> = VoteRecoveryWorkView.vc_tree_position;
+        let _: Vec<u32> = VoteRecoveryWorkView.share_indexes;
+    }
+    {
+        let VoteShareWire = None::<zcash_voting::wire::VoteShareWire>.unwrap();
+        let _: String = VoteShareWire.shares_hash;
+        let _: u32 = VoteShareWire.proposal_id;
+        let _: u32 = VoteShareWire.vote_decision;
+        let _: zcash_voting::types::WireEncryptedShare = VoteShareWire.encrypted_share;
+        let _: u32 = VoteShareWire.share_index;
+        let _: u64 = VoteShareWire.vc_tree_position;
+        let _: Vec<zcash_voting::types::WireEncryptedShare> = VoteShareWire.all_encrypted_shares;
+        let _: Vec<String> = VoteShareWire.share_comms;
+        let _: String = VoteShareWire.primary_blind;
+        let _: u64 = VoteShareWire.submit_at;
+    }
+    {
+        let VotingRoundParams = None::<zcash_voting::wire::VotingRoundParams>.unwrap();
+        let _: String = VotingRoundParams.vote_round_id;
+        let _: u64 = VotingRoundParams.snapshot_height;
+        let _: Vec<u8> = VotingRoundParams.ea_pk;
+        let _: Vec<u8> = VotingRoundParams.nc_root;
+        let _: Vec<u8> = VotingRoundParams.nullifier_imt_root;
+    }
+    {
+        let WireEncryptedShare = None::<zcash_voting::types::WireEncryptedShare>.unwrap();
+        let _: Vec<u8> = WireEncryptedShare.c1;
+        let _: Vec<u8> = WireEncryptedShare.c2;
+        let _: u32 = WireEncryptedShare.share_index;
+    }
+};
+
 // Section: dart2rust
 
 impl SseDecode for flutter_rust_bridge::for_generated::anyhow::Error {
@@ -2710,6 +4421,19 @@ impl SseDecode for flutter_rust_bridge::for_generated::anyhow::Error {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <String>::sse_decode(deserializer);
         return flutter_rust_bridge::for_generated::anyhow::anyhow!("{}", inner);
+    }
+}
+
+impl SseDecode
+    for StreamSink<
+        crate::api::voting::ApiDelegationProofEvent,
+        flutter_rust_bridge::for_generated::SseCodec,
+    >
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <String>::sse_decode(deserializer);
+        return StreamSink::deserialize(inner);
     }
 }
 
@@ -2729,6 +4453,19 @@ impl SseDecode
 impl SseDecode
     for StreamSink<
         crate::api::sync::ApiSyncProgressEvent,
+        flutter_rust_bridge::for_generated::SseCodec,
+    >
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <String>::sse_decode(deserializer);
+        return StreamSink::deserialize(inner);
+    }
+}
+
+impl SseDecode
+    for StreamSink<
+        crate::api::voting::ApiVoteCommitEvent,
         flutter_rust_bridge::for_generated::SseCodec,
     >
 {
@@ -2787,6 +4524,21 @@ impl SseDecode for crate::api::sync::AddressValidationResult {
     }
 }
 
+impl SseDecode for crate::api::voting::ApiDelegationProofEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_phase = <String>::sse_decode(deserializer);
+        let mut var_proofProgress = <Option<f64>>::sse_decode(deserializer);
+        let mut var_signedDelegationPayload =
+            <Option<zcash_voting::wire::SignedDelegationPayloadView>>::sse_decode(deserializer);
+        return crate::api::voting::ApiDelegationProofEvent {
+            phase: var_phase,
+            proof_progress: var_proofProgress,
+            signed_delegation_payload: var_signedDelegationPayload,
+        };
+    }
+}
+
 impl SseDecode for crate::api::sync::ApiMempoolTxEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2827,6 +4579,49 @@ impl SseDecode for crate::api::sync::ApiSyncProgressEvent {
     }
 }
 
+impl SseDecode for crate::api::voting::ApiVoteCommitEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_phase = <String>::sse_decode(deserializer);
+        let mut var_proposalId = <Option<u32>>::sse_decode(deserializer);
+        let mut var_bundleIndex = <Option<u32>>::sse_decode(deserializer);
+        let mut var_proofProgress = <Option<f64>>::sse_decode(deserializer);
+        let mut var_commitments =
+            <Option<zcash_voting::wire::SignedVoteCommitmentsView>>::sse_decode(deserializer);
+        return crate::api::voting::ApiVoteCommitEvent {
+            phase: var_phase,
+            proposal_id: var_proposalId,
+            bundle_index: var_bundleIndex,
+            proof_progress: var_proofProgress,
+            commitments: var_commitments,
+        };
+    }
+}
+
+impl SseDecode for crate::api::voting::ApiVotingRoundContext {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_dbPath = <String>::sse_decode(deserializer);
+        let mut var_lightwalletdUrl = <String>::sse_decode(deserializer);
+        let mut var_network = <String>::sse_decode(deserializer);
+        let mut var_roundParams = <zcash_voting::wire::VotingRoundParams>::sse_decode(deserializer);
+        let mut var_roundName = <String>::sse_decode(deserializer);
+        let mut var_sessionJson = <Option<String>>::sse_decode(deserializer);
+        let mut var_accountUuid = <String>::sse_decode(deserializer);
+        let mut var_maxRealNotesPerBundle = <Option<u32>>::sse_decode(deserializer);
+        return crate::api::voting::ApiVotingRoundContext {
+            db_path: var_dbPath,
+            lightwalletd_url: var_lightwalletdUrl,
+            network: var_network,
+            round_params: var_roundParams,
+            round_name: var_roundName,
+            session_json: var_sessionJson,
+            account_uuid: var_accountUuid,
+            max_real_notes_per_bundle: var_maxRealNotesPerBundle,
+        };
+    }
+}
+
 impl SseDecode for crate::api::sync::BlockMetaInfo {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2849,6 +4644,163 @@ impl SseDecode for bool {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         deserializer.cursor.read_u8().unwrap() != 0
+    }
+}
+
+impl SseDecode for zcash_voting::round::BundleLayout {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bundleCount = <u32>::sse_decode(deserializer);
+        let mut var_eligibleWeight = <u64>::sse_decode(deserializer);
+        let mut var_droppedCount = <u32>::sse_decode(deserializer);
+        return zcash_voting::round::BundleLayout {
+            bundle_count: var_bundleCount,
+            eligible_weight: var_eligibleWeight,
+            dropped_count: var_droppedCount,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::CompletedVoteChoiceView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_proposalId = <u32>::sse_decode(deserializer);
+        let mut var_choice = <Option<u32>>::sse_decode(deserializer);
+        return zcash_voting::wire::CompletedVoteChoiceView {
+            proposal_id: var_proposalId,
+            choice: var_choice,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::CompletedVoteDisplayView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_choices =
+            <Vec<zcash_voting::wire::CompletedVoteChoiceView>>::sse_decode(deserializer);
+        let mut var_votedAt = <Option<u64>>::sse_decode(deserializer);
+        return zcash_voting::wire::CompletedVoteDisplayView {
+            choices: var_choices,
+            voted_at: var_votedAt,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::DelegationConfirmation {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_txHash = <String>::sse_decode(deserializer);
+        let mut var_vanLeafPosition = <u32>::sse_decode(deserializer);
+        return zcash_voting::wire::DelegationConfirmation {
+            tx_hash: var_txHash,
+            van_leaf_position: var_vanLeafPosition,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::DelegationPirPrecomputeResultView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_cachedCount = <u32>::sse_decode(deserializer);
+        let mut var_fetchedCount = <u32>::sse_decode(deserializer);
+        let mut var_bundleCount = <u32>::sse_decode(deserializer);
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        return zcash_voting::wire::DelegationPirPrecomputeResultView {
+            cached_count: var_cachedCount,
+            fetched_count: var_fetchedCount,
+            bundle_count: var_bundleCount,
+            bundle_index: var_bundleIndex,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::DelegationRecoveryView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        let mut var_phase = <String>::sse_decode(deserializer);
+        let mut var_txHash = <Option<String>>::sse_decode(deserializer);
+        let mut var_vanLeafPosition = <Option<u32>>::sse_decode(deserializer);
+        return zcash_voting::wire::DelegationRecoveryView {
+            bundle_index: var_bundleIndex,
+            phase: var_phase,
+            tx_hash: var_txHash,
+            van_leaf_position: var_vanLeafPosition,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::DelegationRecoveryWorkView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_kind = <String>::sse_decode(deserializer);
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        let mut var_phase = <String>::sse_decode(deserializer);
+        let mut var_txHash = <Option<String>>::sse_decode(deserializer);
+        return zcash_voting::wire::DelegationRecoveryWorkView {
+            kind: var_kind,
+            bundle_index: var_bundleIndex,
+            phase: var_phase,
+            tx_hash: var_txHash,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::DelegationStatusView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        let mut var_phase = <String>::sse_decode(deserializer);
+        let mut var_txHash = <Option<String>>::sse_decode(deserializer);
+        return zcash_voting::wire::DelegationStatusView {
+            bundle_index: var_bundleIndex,
+            phase: var_phase,
+            tx_hash: var_txHash,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::DelegationSubmissionWire {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_rk = <String>::sse_decode(deserializer);
+        let mut var_spendAuthSig = <String>::sse_decode(deserializer);
+        let mut var_sighash = <String>::sse_decode(deserializer);
+        let mut var_nfSigned = <String>::sse_decode(deserializer);
+        let mut var_cmxNew = <String>::sse_decode(deserializer);
+        let mut var_govComm = <String>::sse_decode(deserializer);
+        let mut var_govNullifiers = <Vec<String>>::sse_decode(deserializer);
+        let mut var_proof = <String>::sse_decode(deserializer);
+        let mut var_voteRoundId = <String>::sse_decode(deserializer);
+        return zcash_voting::wire::DelegationSubmissionWire {
+            rk: var_rk,
+            spend_auth_sig: var_spendAuthSig,
+            sighash: var_sighash,
+            nf_signed: var_nfSigned,
+            cmx_new: var_cmxNew,
+            gov_comm: var_govComm,
+            gov_nullifiers: var_govNullifiers,
+            proof: var_proof,
+            vote_round_id: var_voteRoundId,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::DraftVote {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_proposalId = <u32>::sse_decode(deserializer);
+        let mut var_choice = <u32>::sse_decode(deserializer);
+        let mut var_numOptions = <u32>::sse_decode(deserializer);
+        let mut var_vcTreePosition = <u64>::sse_decode(deserializer);
+        let mut var_singleShare = <bool>::sse_decode(deserializer);
+        return zcash_voting::wire::DraftVote {
+            proposal_id: var_proposalId,
+            choice: var_choice,
+            num_options: var_numOptions,
+            vc_tree_position: var_vcTreePosition,
+            single_share: var_singleShare,
+        };
     }
 }
 
@@ -2914,6 +4866,50 @@ impl SseDecode for crate::wallet::keystone::KeystoneAccountInfo {
     }
 }
 
+impl SseDecode for zcash_voting::wire::KeystoneSignatureRecord {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        let mut var_sig = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_sighash = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_rk = <Vec<u8>>::sse_decode(deserializer);
+        return zcash_voting::wire::KeystoneSignatureRecord {
+            bundle_index: var_bundleIndex,
+            sig: var_sig,
+            sighash: var_sighash,
+            rk: var_rk,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::delegate::KeystoneSigningRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_pcztBytes = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_redactedPcztBytes = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_pcztSighash = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_rk = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_actionIndex = <u32>::sse_decode(deserializer);
+        let mut var_displayMemo = <String>::sse_decode(deserializer);
+        let mut var_eligibleWeightZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_delegatedWeightZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_bundleCount = <u32>::sse_decode(deserializer);
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        return zcash_voting::delegate::KeystoneSigningRequest {
+            pczt_bytes: var_pcztBytes,
+            redacted_pczt_bytes: var_redactedPcztBytes,
+            pczt_sighash: var_pcztSighash,
+            rk: var_rk,
+            action_index: var_actionIndex,
+            display_memo: var_displayMemo,
+            eligible_weight_zatoshi: var_eligibleWeightZatoshi,
+            delegated_weight_zatoshi: var_delegatedWeightZatoshi,
+            bundle_count: var_bundleCount,
+            bundle_index: var_bundleIndex,
+        };
+    }
+}
+
 impl SseDecode for Vec<String> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2950,6 +4946,72 @@ impl SseDecode for Vec<crate::api::sync::BlockMetaInfo> {
     }
 }
 
+impl SseDecode for Vec<zcash_voting::wire::CompletedVoteChoiceView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::CompletedVoteChoiceView>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::DelegationRecoveryView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::DelegationRecoveryView>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::DelegationRecoveryWorkView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::DelegationRecoveryWorkView>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::DelegationStatusView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::DelegationStatusView>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::DraftVote> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::DraftVote>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::wallet::keystone::KeystoneAccountInfo> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2959,6 +5021,56 @@ impl SseDecode for Vec<crate::wallet::keystone::KeystoneAccountInfo> {
             ans_.push(<crate::wallet::keystone::KeystoneAccountInfo>::sse_decode(
                 deserializer,
             ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::KeystoneSignatureRecord> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::KeystoneSignatureRecord>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<Vec<u8>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<Vec<u8>>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::NextStepView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::NextStepView>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<u32> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<u32>::sse_decode(deserializer));
         }
         return ans_;
     }
@@ -2976,6 +5088,18 @@ impl SseDecode for Vec<u8> {
     }
 }
 
+impl SseDecode for Vec<zcash_voting::wire::RecoverableCommitmentBundle> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::RecoverableCommitmentBundle>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::api::sync::ScanRangeInfo> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2983,6 +5107,60 @@ impl SseDecode for Vec<crate::api::sync::ScanRangeInfo> {
         let mut ans_ = vec![];
         for idx_ in 0..len_ {
             ans_.push(<crate::api::sync::ScanRangeInfo>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::ShareDelegationRecordView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::ShareDelegationRecordView>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::share_policy::ShareSubmissionPlan> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::share_policy::ShareSubmissionPlan>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::ShareWorkflowRecoveryView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::ShareWorkflowRecoveryView>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::SignedVoteCommitmentView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::SignedVoteCommitmentView>::sse_decode(
+                deserializer,
+            ));
         }
         return ans_;
     }
@@ -3040,11 +5218,161 @@ impl SseDecode for Vec<crate::api::sync::TxDataRequest> {
     }
 }
 
+impl SseDecode for Vec<zcash_voting::wire::TxEvent> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::TxEvent>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::TxEventAttribute> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::TxEventAttribute>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::VoteRecoveryView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::VoteRecoveryView>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::VoteRecoveryWorkView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::VoteRecoveryWorkView>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::wire::VoteShareWire> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::wire::VoteShareWire>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<zcash_voting::types::WireEncryptedShare> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<zcash_voting::types::WireEncryptedShare>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for zcash_voting::wire::NextStepView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_kind = <String>::sse_decode(deserializer);
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        let mut var_proposalId = <u32>::sse_decode(deserializer);
+        let mut var_choice = <u32>::sse_decode(deserializer);
+        let mut var_shareIndex = <u32>::sse_decode(deserializer);
+        return zcash_voting::wire::NextStepView {
+            kind: var_kind,
+            bundle_index: var_bundleIndex,
+            proposal_id: var_proposalId,
+            choice: var_choice,
+            share_index: var_shareIndex,
+        };
+    }
+}
+
 impl SseDecode for Option<String> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<String>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<zcash_voting::wire::CompletedVoteDisplayView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<zcash_voting::wire::CompletedVoteDisplayView>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<f64> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<f64>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<zcash_voting::wire::SignedDelegationPayloadView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(
+                <zcash_voting::wire::SignedDelegationPayloadView>::sse_decode(deserializer),
+            );
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<zcash_voting::wire::SignedVoteCommitmentsView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<zcash_voting::wire::SignedVoteCommitmentsView>::sse_decode(
+                deserializer,
+            ));
         } else {
             return None;
         }
@@ -3098,6 +5426,95 @@ impl SseDecode for crate::api::sync::ProposalResult {
     }
 }
 
+impl SseDecode for zcash_voting::wire::RecoverableCommitmentBundle {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        let mut var_proposalId = <u32>::sse_decode(deserializer);
+        let mut var_commitmentBundleJson = <String>::sse_decode(deserializer);
+        let mut var_vcTreePosition = <u64>::sse_decode(deserializer);
+        return zcash_voting::wire::RecoverableCommitmentBundle {
+            bundle_index: var_bundleIndex,
+            proposal_id: var_proposalId,
+            commitment_bundle_json: var_commitmentBundleJson,
+            vc_tree_position: var_vcTreePosition,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::RoundPlanView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_roundId = <String>::sse_decode(deserializer);
+        let mut var_pendingRecovery = <bool>::sse_decode(deserializer);
+        let mut var_blockingRecovery = <bool>::sse_decode(deserializer);
+        let mut var_blockingShareWork = <bool>::sse_decode(deserializer);
+        let mut var_hotkeyBound = <bool>::sse_decode(deserializer);
+        let mut var_completedVoteArtifact = <bool>::sse_decode(deserializer);
+        let mut var_completedForDisplay = <bool>::sse_decode(deserializer);
+        let mut var_completedVoteDisplay =
+            <Option<zcash_voting::wire::CompletedVoteDisplayView>>::sse_decode(deserializer);
+        let mut var_needsDraftSetup = <bool>::sse_decode(deserializer);
+        let mut var_primaryAction = <String>::sse_decode(deserializer);
+        let mut var_nextSteps = <Vec<zcash_voting::wire::NextStepView>>::sse_decode(deserializer);
+        let mut var_delegationStatuses =
+            <Vec<zcash_voting::wire::DelegationStatusView>>::sse_decode(deserializer);
+        let mut var_recoveredDelegationWork =
+            <Vec<zcash_voting::wire::DelegationRecoveryWorkView>>::sse_decode(deserializer);
+        let mut var_recoveredVoteWork =
+            <Vec<zcash_voting::wire::VoteRecoveryWorkView>>::sse_decode(deserializer);
+        let mut var_openProposals = <Vec<u32>>::sse_decode(deserializer);
+        let mut var_allDecided = <bool>::sse_decode(deserializer);
+        return zcash_voting::wire::RoundPlanView {
+            round_id: var_roundId,
+            pending_recovery: var_pendingRecovery,
+            blocking_recovery: var_blockingRecovery,
+            blocking_share_work: var_blockingShareWork,
+            hotkey_bound: var_hotkeyBound,
+            completed_vote_artifact: var_completedVoteArtifact,
+            completed_for_display: var_completedForDisplay,
+            completed_vote_display: var_completedVoteDisplay,
+            needs_draft_setup: var_needsDraftSetup,
+            primary_action: var_primaryAction,
+            next_steps: var_nextSteps,
+            delegation_statuses: var_delegationStatuses,
+            recovered_delegation_work: var_recoveredDelegationWork,
+            recovered_vote_work: var_recoveredVoteWork,
+            open_proposals: var_openProposals,
+            all_decided: var_allDecided,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::RoundRecoveryStateView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_roundId = <String>::sse_decode(deserializer);
+        let mut var_bundleCount = <u32>::sse_decode(deserializer);
+        let mut var_delegation =
+            <Vec<zcash_voting::wire::DelegationRecoveryView>>::sse_decode(deserializer);
+        let mut var_votes = <Vec<zcash_voting::wire::VoteRecoveryView>>::sse_decode(deserializer);
+        let mut var_commitmentBundles =
+            <Vec<zcash_voting::wire::RecoverableCommitmentBundle>>::sse_decode(deserializer);
+        let mut var_shares =
+            <Vec<zcash_voting::wire::ShareWorkflowRecoveryView>>::sse_decode(deserializer);
+        let mut var_shareDelegations =
+            <Vec<zcash_voting::wire::ShareDelegationRecordView>>::sse_decode(deserializer);
+        let mut var_unconfirmedShareDelegations =
+            <Vec<zcash_voting::wire::ShareDelegationRecordView>>::sse_decode(deserializer);
+        return zcash_voting::wire::RoundRecoveryStateView {
+            round_id: var_roundId,
+            bundle_count: var_bundleCount,
+            delegation: var_delegation,
+            votes: var_votes,
+            commitment_bundles: var_commitmentBundles,
+            shares: var_shares,
+            share_delegations: var_shareDelegations,
+            unconfirmed_share_delegations: var_unconfirmedShareDelegations,
+        };
+    }
+}
+
 impl SseDecode for crate::api::sync::ScanRangeInfo {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3132,6 +5549,64 @@ impl SseDecode for crate::api::sync::SendMaxEstimateResult {
             amount_zatoshi: var_amountZatoshi,
             fee_zatoshi: var_feeZatoshi,
             needs_sapling_params: var_needsSaplingParams,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::ShareDelegationRecordView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_roundId = <String>::sse_decode(deserializer);
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        let mut var_proposalId = <u32>::sse_decode(deserializer);
+        let mut var_shareIndex = <u32>::sse_decode(deserializer);
+        let mut var_sentToUrls = <Vec<String>>::sse_decode(deserializer);
+        let mut var_nullifier = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_phase = <String>::sse_decode(deserializer);
+        let mut var_confirmed = <bool>::sse_decode(deserializer);
+        let mut var_submitAt = <u64>::sse_decode(deserializer);
+        let mut var_createdAt = <u64>::sse_decode(deserializer);
+        return zcash_voting::wire::ShareDelegationRecordView {
+            round_id: var_roundId,
+            bundle_index: var_bundleIndex,
+            proposal_id: var_proposalId,
+            share_index: var_shareIndex,
+            sent_to_urls: var_sentToUrls,
+            nullifier: var_nullifier,
+            phase: var_phase,
+            confirmed: var_confirmed,
+            submit_at: var_submitAt,
+            created_at: var_createdAt,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::share_policy::ShareSubmissionPlan {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_submitAt = <u64>::sse_decode(deserializer);
+        let mut var_targetCount = <u32>::sse_decode(deserializer);
+        let mut var_targetServers = <Vec<String>>::sse_decode(deserializer);
+        return zcash_voting::share_policy::ShareSubmissionPlan {
+            submit_at: var_submitAt,
+            target_count: var_targetCount,
+            target_servers: var_targetServers,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::ShareWorkflowRecoveryView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        let mut var_proposalId = <u32>::sse_decode(deserializer);
+        let mut var_shareIndex = <u32>::sse_decode(deserializer);
+        let mut var_phase = <String>::sse_decode(deserializer);
+        return zcash_voting::wire::ShareWorkflowRecoveryView {
+            bundle_index: var_bundleIndex,
+            proposal_id: var_proposalId,
+            share_index: var_shareIndex,
+            phase: var_phase,
         };
     }
 }
@@ -3186,6 +5661,58 @@ impl SseDecode for crate::api::sync::ShieldTransparentStatus {
             fee_zatoshi: var_feeZatoshi,
             shielded_zatoshi: var_shieldedZatoshi,
             reason: var_reason,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::SignedDelegationPayloadView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_pcztBytes = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_status = <String>::sse_decode(deserializer);
+        let mut var_message = <Option<String>>::sse_decode(deserializer);
+        let mut var_submission =
+            <zcash_voting::wire::DelegationSubmissionWire>::sse_decode(deserializer);
+        let mut var_eligibleWeightZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_delegatedWeightZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_bundleCount = <u32>::sse_decode(deserializer);
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        return zcash_voting::wire::SignedDelegationPayloadView {
+            pczt_bytes: var_pcztBytes,
+            status: var_status,
+            message: var_message,
+            submission: var_submission,
+            eligible_weight_zatoshi: var_eligibleWeightZatoshi,
+            delegated_weight_zatoshi: var_delegatedWeightZatoshi,
+            bundle_count: var_bundleCount,
+            bundle_index: var_bundleIndex,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::SignedVoteCommitmentView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_proposalId = <u32>::sse_decode(deserializer);
+        let mut var_wire = <zcash_voting::wire::VoteCommitmentWire>::sse_decode(deserializer);
+        let mut var_shares = <Vec<zcash_voting::wire::VoteShareWire>>::sse_decode(deserializer);
+        return zcash_voting::wire::SignedVoteCommitmentView {
+            proposal_id: var_proposalId,
+            wire: var_wire,
+            shares: var_shares,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::SignedVoteCommitmentsView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        let mut var_commitments =
+            <Vec<zcash_voting::wire::SignedVoteCommitmentView>>::sse_decode(deserializer);
+        return zcash_voting::wire::SignedVoteCommitmentsView {
+            bundle_index: var_bundleIndex,
+            commitments: var_commitments,
         };
     }
 }
@@ -3309,6 +5836,31 @@ impl SseDecode for crate::api::sync::TxDataRequest {
     }
 }
 
+impl SseDecode for zcash_voting::wire::TxEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_eventType = <String>::sse_decode(deserializer);
+        let mut var_attributes =
+            <Vec<zcash_voting::wire::TxEventAttribute>>::sse_decode(deserializer);
+        return zcash_voting::wire::TxEvent {
+            event_type: var_eventType,
+            attributes: var_attributes,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::TxEventAttribute {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_key = <String>::sse_decode(deserializer);
+        let mut var_value = <String>::sse_decode(deserializer);
+        return zcash_voting::wire::TxEventAttribute {
+            key: var_key,
+            value: var_value,
+        };
+    }
+}
+
 impl SseDecode for u32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3355,6 +5907,150 @@ impl SseDecode for usize {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         deserializer.cursor.read_u64::<NativeEndian>().unwrap() as _
+    }
+}
+
+impl SseDecode for zcash_voting::vote::VanWitness {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_authPath = <Vec<Vec<u8>>>::sse_decode(deserializer);
+        let mut var_position = <u32>::sse_decode(deserializer);
+        let mut var_anchorHeight = <u32>::sse_decode(deserializer);
+        return zcash_voting::vote::VanWitness {
+            auth_path: var_authPath,
+            position: var_position,
+            anchor_height: var_anchorHeight,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::VoteCommitmentWire {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_vanNullifier = <String>::sse_decode(deserializer);
+        let mut var_voteAuthorityNoteNew = <String>::sse_decode(deserializer);
+        let mut var_voteCommitment = <String>::sse_decode(deserializer);
+        let mut var_proposalId = <u32>::sse_decode(deserializer);
+        let mut var_proof = <String>::sse_decode(deserializer);
+        let mut var_voteRoundId = <String>::sse_decode(deserializer);
+        let mut var_anchorHeight = <u32>::sse_decode(deserializer);
+        let mut var_rVpk = <String>::sse_decode(deserializer);
+        let mut var_voteAuthSig = <String>::sse_decode(deserializer);
+        return zcash_voting::wire::VoteCommitmentWire {
+            van_nullifier: var_vanNullifier,
+            vote_authority_note_new: var_voteAuthorityNoteNew,
+            vote_commitment: var_voteCommitment,
+            proposal_id: var_proposalId,
+            proof: var_proof,
+            vote_round_id: var_voteRoundId,
+            anchor_height: var_anchorHeight,
+            r_vpk: var_rVpk,
+            vote_auth_sig: var_voteAuthSig,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::VoteConfirmation {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_txHash = <String>::sse_decode(deserializer);
+        let mut var_vanLeafPosition = <u32>::sse_decode(deserializer);
+        let mut var_vcTreePosition = <u64>::sse_decode(deserializer);
+        return zcash_voting::wire::VoteConfirmation {
+            tx_hash: var_txHash,
+            van_leaf_position: var_vanLeafPosition,
+            vc_tree_position: var_vcTreePosition,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::VoteRecoveryView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        let mut var_proposalId = <u32>::sse_decode(deserializer);
+        let mut var_choice = <u32>::sse_decode(deserializer);
+        let mut var_phase = <String>::sse_decode(deserializer);
+        let mut var_txHash = <Option<String>>::sse_decode(deserializer);
+        let mut var_vcTreePosition = <Option<u64>>::sse_decode(deserializer);
+        let mut var_hasCommitmentBundle = <bool>::sse_decode(deserializer);
+        return zcash_voting::wire::VoteRecoveryView {
+            bundle_index: var_bundleIndex,
+            proposal_id: var_proposalId,
+            choice: var_choice,
+            phase: var_phase,
+            tx_hash: var_txHash,
+            vc_tree_position: var_vcTreePosition,
+            has_commitment_bundle: var_hasCommitmentBundle,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::VoteRecoveryWorkView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_kind = <String>::sse_decode(deserializer);
+        let mut var_bundleIndex = <u32>::sse_decode(deserializer);
+        let mut var_proposalId = <u32>::sse_decode(deserializer);
+        let mut var_txHash = <Option<String>>::sse_decode(deserializer);
+        let mut var_vcTreePosition = <Option<u64>>::sse_decode(deserializer);
+        let mut var_shareIndexes = <Vec<u32>>::sse_decode(deserializer);
+        return zcash_voting::wire::VoteRecoveryWorkView {
+            kind: var_kind,
+            bundle_index: var_bundleIndex,
+            proposal_id: var_proposalId,
+            tx_hash: var_txHash,
+            vc_tree_position: var_vcTreePosition,
+            share_indexes: var_shareIndexes,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::VoteShareWire {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_sharesHash = <String>::sse_decode(deserializer);
+        let mut var_proposalId = <u32>::sse_decode(deserializer);
+        let mut var_voteDecision = <u32>::sse_decode(deserializer);
+        let mut var_encryptedShare =
+            <zcash_voting::types::WireEncryptedShare>::sse_decode(deserializer);
+        let mut var_shareIndex = <u32>::sse_decode(deserializer);
+        let mut var_vcTreePosition = <u64>::sse_decode(deserializer);
+        let mut var_allEncryptedShares =
+            <Vec<zcash_voting::types::WireEncryptedShare>>::sse_decode(deserializer);
+        let mut var_shareComms = <Vec<String>>::sse_decode(deserializer);
+        let mut var_primaryBlind = <String>::sse_decode(deserializer);
+        let mut var_submitAt = <u64>::sse_decode(deserializer);
+        return zcash_voting::wire::VoteShareWire {
+            shares_hash: var_sharesHash,
+            proposal_id: var_proposalId,
+            vote_decision: var_voteDecision,
+            encrypted_share: var_encryptedShare,
+            share_index: var_shareIndex,
+            vc_tree_position: var_vcTreePosition,
+            all_encrypted_shares: var_allEncryptedShares,
+            share_comms: var_shareComms,
+            primary_blind: var_primaryBlind,
+            submit_at: var_submitAt,
+        };
+    }
+}
+
+impl SseDecode for zcash_voting::wire::VotingRoundParams {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_voteRoundId = <String>::sse_decode(deserializer);
+        let mut var_snapshotHeight = <u64>::sse_decode(deserializer);
+        let mut var_eaPk = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_ncRoot = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_nullifierImtRoot = <Vec<u8>>::sse_decode(deserializer);
+        return zcash_voting::wire::VotingRoundParams {
+            vote_round_id: var_voteRoundId,
+            snapshot_height: var_snapshotHeight,
+            ea_pk: var_eaPk,
+            nc_root: var_ncRoot,
+            nullifier_imt_root: var_nullifierImtRoot,
+        };
     }
 }
 
@@ -3408,6 +6104,20 @@ impl SseDecode for crate::api::wallet::WalletImportResult {
     }
 }
 
+impl SseDecode for zcash_voting::types::WireEncryptedShare {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_c1 = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_c2 = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_shareIndex = <u32>::sse_decode(deserializer);
+        return zcash_voting::types::WireEncryptedShare {
+            c1: var_c1,
+            c2: var_c2,
+            share_index: var_shareIndex,
+        };
+    }
+}
+
 impl SseDecode for i32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -3424,177 +6134,99 @@ fn pde_ffi_dispatcher_primary_impl(
 ) {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        1 => wire__crate__api__wallet__add_account_impl(port, ptr, rust_vec_len, data_len),
-        2 => wire__crate__api__sync__add_proofs_to_pczt_impl(port, ptr, rust_vec_len, data_len),
-        4 => wire__crate__api__sync__create_pczt_from_proposal_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        5 => wire__crate__api__sync__create_shield_transparent_pczt_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        6 => wire__crate__api__wallet__create_wallet_impl(port, ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__keystone__decode_accounts_from_cbor_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        8 => wire__crate__api__keystone__decode_accounts_ur_impl(port, ptr, rust_vec_len, data_len),
-        9 => wire__crate__api__keystone__decode_pczt_from_cbor_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        10 => wire__crate__api__keystone__decode_ur_part_impl(port, ptr, rust_vec_len, data_len),
-        11 => wire__crate__api__keystone__decode_ur_to_pczt_impl(port, ptr, rust_vec_len, data_len),
-        12 => wire__crate__api__sync__decrypt_and_store_transaction_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        13 => {
-            wire__crate__api__secret__decrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len)
-        }
-        14 => wire__crate__api__wallet__delete_account_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__secret__derive_secret_password_verifier_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        16 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
-        18 => {
-            wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len)
-        }
-        19 => {
-            wire__crate__api__secret__encrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len)
-        }
-        20 => wire__crate__api__wallet__ensure_wallet_db_migrated_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        21 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
-        22 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        25 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        27 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__sync__get_export_birthday_height_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        31 => wire__crate__api__wallet__get_latest_block_height_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        32 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        33 => wire__crate__api__sync__get_next_available_address_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        34 => {
-            wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len)
-        }
-        35 => wire__crate__api__sync__get_shield_transparent_status_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        37 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__sync__get_transaction_data_requests_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        40 => {
-            wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len)
-        }
-        41 => wire__crate__api__wallet__get_transparent_address_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        42 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__wallet__import_hardware_account_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        45 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-        50 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-        52 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-        54 => {
-            wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len)
-        }
-        56 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-        57 => {
-            wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len)
-        }
-        58 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-        60 => {
-            wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len)
-        }
-        61 => wire__crate__api__sync__shield_transparent_balance_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        62 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        63 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-        64 => {
-            wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len)
-        }
-        66 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-        71 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
-        _ => unreachable!(),
-    }
+                        1 => wire__crate__api__wallet__add_account_impl(port, ptr, rust_vec_len, data_len),
+2 => wire__crate__api__sync__add_proofs_to_pczt_impl(port, ptr, rust_vec_len, data_len),
+3 => wire__crate__api__voting__add_sent_servers_impl(port, ptr, rust_vec_len, data_len),
+4 => wire__crate__api__voting__build_keystone_delegation_request_impl(port, ptr, rust_vec_len, data_len),
+5 => wire__crate__api__voting__build_prove_and_sign_delegation_payload_with_progress_impl(port, ptr, rust_vec_len, data_len),
+6 => wire__crate__api__voting__build_prove_delegation_payload_with_keystone_signature_with_progress_impl(port, ptr, rust_vec_len, data_len),
+7 => wire__crate__api__voting__build_vote_commitments_with_progress_impl(port, ptr, rust_vec_len, data_len),
+9 => wire__crate__api__voting__clear_recovery_state_impl(port, ptr, rust_vec_len, data_len),
+10 => wire__crate__api__voting__confirm_delegation_submission_impl(port, ptr, rust_vec_len, data_len),
+11 => wire__crate__api__voting__confirm_vote_submission_impl(port, ptr, rust_vec_len, data_len),
+12 => wire__crate__api__sync__create_pczt_from_proposal_impl(port, ptr, rust_vec_len, data_len),
+13 => wire__crate__api__sync__create_shield_transparent_pczt_impl(port, ptr, rust_vec_len, data_len),
+14 => wire__crate__api__wallet__create_wallet_impl(port, ptr, rust_vec_len, data_len),
+15 => wire__crate__api__keystone__decode_accounts_from_cbor_impl(port, ptr, rust_vec_len, data_len),
+16 => wire__crate__api__keystone__decode_accounts_ur_impl(port, ptr, rust_vec_len, data_len),
+17 => wire__crate__api__keystone__decode_pczt_from_cbor_impl(port, ptr, rust_vec_len, data_len),
+18 => wire__crate__api__keystone__decode_ur_part_impl(port, ptr, rust_vec_len, data_len),
+19 => wire__crate__api__keystone__decode_ur_to_pczt_impl(port, ptr, rust_vec_len, data_len),
+20 => wire__crate__api__sync__decrypt_and_store_transaction_impl(port, ptr, rust_vec_len, data_len),
+21 => wire__crate__api__secret__decrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
+22 => wire__crate__api__voting__delegation_submission_wire_json_impl(port, ptr, rust_vec_len, data_len),
+23 => wire__crate__api__wallet__delete_account_impl(port, ptr, rust_vec_len, data_len),
+24 => wire__crate__api__voting__delete_skipped_bundles_impl(port, ptr, rust_vec_len, data_len),
+25 => wire__crate__api__secret__derive_secret_password_verifier_impl(port, ptr, rust_vec_len, data_len),
+26 => wire__crate__api__voting__derive_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
+27 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
+28 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
+29 => wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len),
+30 => wire__crate__api__secret__encrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
+31 => wire__crate__api__wallet__ensure_wallet_db_migrated_impl(port, ptr, rust_vec_len, data_len),
+32 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
+33 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
+34 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+35 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+36 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
+37 => wire__crate__api__voting__extract_pczt_sighash_impl(port, ptr, rust_vec_len, data_len),
+38 => wire__crate__api__voting__extract_spend_auth_signature_from_signed_pczt_impl(port, ptr, rust_vec_len, data_len),
+40 => wire__crate__api__voting__generate_van_witness_impl(port, ptr, rust_vec_len, data_len),
+41 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
+42 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+43 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
+45 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
+46 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
+47 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
+48 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
+49 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
+50 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
+51 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
+52 => wire__crate__api__voting__get_round_recovery_state_impl(port, ptr, rust_vec_len, data_len),
+53 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
+55 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+56 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
+58 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
+59 => wire__crate__api__wallet__get_transparent_address_impl(port, ptr, rust_vec_len, data_len),
+60 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+62 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
+63 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+64 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+68 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+69 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+70 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
+71 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+73 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+74 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
+75 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+76 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+77 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+78 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+80 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+92 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+99 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+101 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+104 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+106 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+                        _ => unreachable!(),
+                    }
 }
 
 fn pde_ffi_dispatcher_sync_impl(
@@ -3605,21 +6237,21 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        3 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        49 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        8 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
+        39 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        65 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
+        66 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        67 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        72 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        88 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        102 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        105 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -3692,6 +6324,28 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::AddressValidationResult
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::voting::ApiDelegationProofEvent {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.phase.into_into_dart().into_dart(),
+            self.proof_progress.into_into_dart().into_dart(),
+            self.signed_delegation_payload.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::voting::ApiDelegationProofEvent
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::voting::ApiDelegationProofEvent>
+    for crate::api::voting::ApiDelegationProofEvent
+{
+    fn into_into_dart(self) -> crate::api::voting::ApiDelegationProofEvent {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::sync::ApiMempoolTxEvent {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -3742,6 +6396,57 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ApiSyncProgressEvent>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::voting::ApiVoteCommitEvent {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.phase.into_into_dart().into_dart(),
+            self.proposal_id.into_into_dart().into_dart(),
+            self.bundle_index.into_into_dart().into_dart(),
+            self.proof_progress.into_into_dart().into_dart(),
+            self.commitments.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::voting::ApiVoteCommitEvent
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::voting::ApiVoteCommitEvent>
+    for crate::api::voting::ApiVoteCommitEvent
+{
+    fn into_into_dart(self) -> crate::api::voting::ApiVoteCommitEvent {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::voting::ApiVotingRoundContext {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.db_path.into_into_dart().into_dart(),
+            self.lightwalletd_url.into_into_dart().into_dart(),
+            self.network.into_into_dart().into_dart(),
+            self.round_params.into_into_dart().into_dart(),
+            self.round_name.into_into_dart().into_dart(),
+            self.session_json.into_into_dart().into_dart(),
+            self.account_uuid.into_into_dart().into_dart(),
+            self.max_real_notes_per_bundle.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::voting::ApiVotingRoundContext
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::voting::ApiVotingRoundContext>
+    for crate::api::voting::ApiVotingRoundContext
+{
+    fn into_into_dart(self) -> crate::api::voting::ApiVotingRoundContext {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::sync::BlockMetaInfo {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -3763,6 +6468,238 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::BlockMetaInfo>
 {
     fn into_into_dart(self) -> crate::api::sync::BlockMetaInfo {
         self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::round::BundleLayout> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.bundle_count.into_into_dart().into_dart(),
+            self.0.eligible_weight.into_into_dart().into_dart(),
+            self.0.dropped_count.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::round::BundleLayout>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::round::BundleLayout>>
+    for zcash_voting::round::BundleLayout
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::round::BundleLayout> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::CompletedVoteChoiceView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.proposal_id.into_into_dart().into_dart(),
+            self.0.choice.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::CompletedVoteChoiceView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::CompletedVoteChoiceView>>
+    for zcash_voting::wire::CompletedVoteChoiceView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::CompletedVoteChoiceView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::CompletedVoteDisplayView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.choices.into_into_dart().into_dart(),
+            self.0.voted_at.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::CompletedVoteDisplayView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::CompletedVoteDisplayView>>
+    for zcash_voting::wire::CompletedVoteDisplayView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::CompletedVoteDisplayView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::DelegationConfirmation> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.tx_hash.into_into_dart().into_dart(),
+            self.0.van_leaf_position.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::DelegationConfirmation>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::DelegationConfirmation>>
+    for zcash_voting::wire::DelegationConfirmation
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::DelegationConfirmation> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart
+    for FrbWrapper<zcash_voting::wire::DelegationPirPrecomputeResultView>
+{
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.cached_count.into_into_dart().into_dart(),
+            self.0.fetched_count.into_into_dart().into_dart(),
+            self.0.bundle_count.into_into_dart().into_dart(),
+            self.0.bundle_index.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::DelegationPirPrecomputeResultView>
+{
+}
+impl
+    flutter_rust_bridge::IntoIntoDart<
+        FrbWrapper<zcash_voting::wire::DelegationPirPrecomputeResultView>,
+    > for zcash_voting::wire::DelegationPirPrecomputeResultView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::DelegationPirPrecomputeResultView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::DelegationRecoveryView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.phase.into_into_dart().into_dart(),
+            self.0.tx_hash.into_into_dart().into_dart(),
+            self.0.van_leaf_position.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::DelegationRecoveryView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::DelegationRecoveryView>>
+    for zcash_voting::wire::DelegationRecoveryView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::DelegationRecoveryView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::DelegationRecoveryWorkView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.kind.into_into_dart().into_dart(),
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.phase.into_into_dart().into_dart(),
+            self.0.tx_hash.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::DelegationRecoveryWorkView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::DelegationRecoveryWorkView>>
+    for zcash_voting::wire::DelegationRecoveryWorkView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::DelegationRecoveryWorkView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::DelegationStatusView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.phase.into_into_dart().into_dart(),
+            self.0.tx_hash.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::DelegationStatusView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::DelegationStatusView>>
+    for zcash_voting::wire::DelegationStatusView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::DelegationStatusView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::DelegationSubmissionWire> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.rk.into_into_dart().into_dart(),
+            self.0.spend_auth_sig.into_into_dart().into_dart(),
+            self.0.sighash.into_into_dart().into_dart(),
+            self.0.nf_signed.into_into_dart().into_dart(),
+            self.0.cmx_new.into_into_dart().into_dart(),
+            self.0.gov_comm.into_into_dart().into_dart(),
+            self.0.gov_nullifiers.into_into_dart().into_dart(),
+            self.0.proof.into_into_dart().into_dart(),
+            self.0.vote_round_id.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::DelegationSubmissionWire>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::DelegationSubmissionWire>>
+    for zcash_voting::wire::DelegationSubmissionWire
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::DelegationSubmissionWire> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::DraftVote> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.proposal_id.into_into_dart().into_dart(),
+            self.0.choice.into_into_dart().into_dart(),
+            self.0.num_options.into_into_dart().into_dart(),
+            self.0.vc_tree_position.into_into_dart().into_dart(),
+            self.0.single_share.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::DraftVote>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::DraftVote>>
+    for zcash_voting::wire::DraftVote
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::DraftVote> {
+        self.into()
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -3835,6 +6772,82 @@ impl flutter_rust_bridge::IntoIntoDart<crate::wallet::keystone::KeystoneAccountI
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::KeystoneSignatureRecord> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.sig.into_into_dart().into_dart(),
+            self.0.sighash.into_into_dart().into_dart(),
+            self.0.rk.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::KeystoneSignatureRecord>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::KeystoneSignatureRecord>>
+    for zcash_voting::wire::KeystoneSignatureRecord
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::KeystoneSignatureRecord> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::delegate::KeystoneSigningRequest> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.pczt_bytes.into_into_dart().into_dart(),
+            self.0.redacted_pczt_bytes.into_into_dart().into_dart(),
+            self.0.pczt_sighash.into_into_dart().into_dart(),
+            self.0.rk.into_into_dart().into_dart(),
+            self.0.action_index.into_into_dart().into_dart(),
+            self.0.display_memo.into_into_dart().into_dart(),
+            self.0.eligible_weight_zatoshi.into_into_dart().into_dart(),
+            self.0.delegated_weight_zatoshi.into_into_dart().into_dart(),
+            self.0.bundle_count.into_into_dart().into_dart(),
+            self.0.bundle_index.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::delegate::KeystoneSigningRequest>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::delegate::KeystoneSigningRequest>>
+    for zcash_voting::delegate::KeystoneSigningRequest
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::delegate::KeystoneSigningRequest> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::NextStepView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.kind.into_into_dart().into_dart(),
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.proposal_id.into_into_dart().into_dart(),
+            self.0.choice.into_into_dart().into_dart(),
+            self.0.share_index.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::NextStepView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::NextStepView>>
+    for zcash_voting::wire::NextStepView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::NextStepView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::sync::ProposalResult {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -3854,6 +6867,97 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ProposalResult>
 {
     fn into_into_dart(self) -> crate::api::sync::ProposalResult {
         self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RecoverableCommitmentBundle> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.proposal_id.into_into_dart().into_dart(),
+            self.0.commitment_bundle_json.into_into_dart().into_dart(),
+            self.0.vc_tree_position.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::RecoverableCommitmentBundle>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RecoverableCommitmentBundle>>
+    for zcash_voting::wire::RecoverableCommitmentBundle
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RecoverableCommitmentBundle> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundPlanView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.round_id.into_into_dart().into_dart(),
+            self.0.pending_recovery.into_into_dart().into_dart(),
+            self.0.blocking_recovery.into_into_dart().into_dart(),
+            self.0.blocking_share_work.into_into_dart().into_dart(),
+            self.0.hotkey_bound.into_into_dart().into_dart(),
+            self.0.completed_vote_artifact.into_into_dart().into_dart(),
+            self.0.completed_for_display.into_into_dart().into_dart(),
+            self.0.completed_vote_display.into_into_dart().into_dart(),
+            self.0.needs_draft_setup.into_into_dart().into_dart(),
+            self.0.primary_action.into_into_dart().into_dart(),
+            self.0.next_steps.into_into_dart().into_dart(),
+            self.0.delegation_statuses.into_into_dart().into_dart(),
+            self.0
+                .recovered_delegation_work
+                .into_into_dart()
+                .into_dart(),
+            self.0.recovered_vote_work.into_into_dart().into_dart(),
+            self.0.open_proposals.into_into_dart().into_dart(),
+            self.0.all_decided.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::RoundPlanView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundPlanView>>
+    for zcash_voting::wire::RoundPlanView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundPlanView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::RoundRecoveryStateView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.round_id.into_into_dart().into_dart(),
+            self.0.bundle_count.into_into_dart().into_dart(),
+            self.0.delegation.into_into_dart().into_dart(),
+            self.0.votes.into_into_dart().into_dart(),
+            self.0.commitment_bundles.into_into_dart().into_dart(),
+            self.0.shares.into_into_dart().into_dart(),
+            self.0.share_delegations.into_into_dart().into_dart(),
+            self.0
+                .unconfirmed_share_delegations
+                .into_into_dart()
+                .into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::RoundRecoveryStateView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::RoundRecoveryStateView>>
+    for zcash_voting::wire::RoundRecoveryStateView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::RoundRecoveryStateView> {
+        self.into()
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -3912,6 +7016,80 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::SendMaxEstimateResult>
 {
     fn into_into_dart(self) -> crate::api::sync::SendMaxEstimateResult {
         self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::ShareDelegationRecordView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.round_id.into_into_dart().into_dart(),
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.proposal_id.into_into_dart().into_dart(),
+            self.0.share_index.into_into_dart().into_dart(),
+            self.0.sent_to_urls.into_into_dart().into_dart(),
+            self.0.nullifier.into_into_dart().into_dart(),
+            self.0.phase.into_into_dart().into_dart(),
+            self.0.confirmed.into_into_dart().into_dart(),
+            self.0.submit_at.into_into_dart().into_dart(),
+            self.0.created_at.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::ShareDelegationRecordView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::ShareDelegationRecordView>>
+    for zcash_voting::wire::ShareDelegationRecordView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::ShareDelegationRecordView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::share_policy::ShareSubmissionPlan> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.submit_at.into_into_dart().into_dart(),
+            self.0.target_count.into_into_dart().into_dart(),
+            self.0.target_servers.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::share_policy::ShareSubmissionPlan>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::share_policy::ShareSubmissionPlan>>
+    for zcash_voting::share_policy::ShareSubmissionPlan
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::share_policy::ShareSubmissionPlan> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::ShareWorkflowRecoveryView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.proposal_id.into_into_dart().into_dart(),
+            self.0.share_index.into_into_dart().into_dart(),
+            self.0.phase.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::ShareWorkflowRecoveryView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::ShareWorkflowRecoveryView>>
+    for zcash_voting::wire::ShareWorkflowRecoveryView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::ShareWorkflowRecoveryView> {
+        self.into()
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -3984,6 +7162,76 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::ShieldTransparentStatus
 {
     fn into_into_dart(self) -> crate::api::sync::ShieldTransparentStatus {
         self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::SignedDelegationPayloadView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.pczt_bytes.into_into_dart().into_dart(),
+            self.0.status.into_into_dart().into_dart(),
+            self.0.message.into_into_dart().into_dart(),
+            self.0.submission.into_into_dart().into_dart(),
+            self.0.eligible_weight_zatoshi.into_into_dart().into_dart(),
+            self.0.delegated_weight_zatoshi.into_into_dart().into_dart(),
+            self.0.bundle_count.into_into_dart().into_dart(),
+            self.0.bundle_index.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::SignedDelegationPayloadView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::SignedDelegationPayloadView>>
+    for zcash_voting::wire::SignedDelegationPayloadView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::SignedDelegationPayloadView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::SignedVoteCommitmentView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.proposal_id.into_into_dart().into_dart(),
+            self.0.wire.into_into_dart().into_dart(),
+            self.0.shares.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::SignedVoteCommitmentView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::SignedVoteCommitmentView>>
+    for zcash_voting::wire::SignedVoteCommitmentView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::SignedVoteCommitmentView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::SignedVoteCommitmentsView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.commitments.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::SignedVoteCommitmentsView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::SignedVoteCommitmentsView>>
+    for zcash_voting::wire::SignedVoteCommitmentsView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::SignedVoteCommitmentsView> {
+        self.into()
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -4148,6 +7396,48 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::TxDataRequest>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::TxEvent> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.event_type.into_into_dart().into_dart(),
+            self.0.attributes.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::TxEvent>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::TxEvent>>
+    for zcash_voting::wire::TxEvent
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::TxEvent> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::TxEventAttribute> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.key.into_into_dart().into_dart(),
+            self.0.value.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::TxEventAttribute>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::TxEventAttribute>>
+    for zcash_voting::wire::TxEventAttribute
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::TxEventAttribute> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::wallet::keystone::UrDecodeResult {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -4168,6 +7458,182 @@ impl flutter_rust_bridge::IntoIntoDart<crate::wallet::keystone::UrDecodeResult>
 {
     fn into_into_dart(self) -> crate::wallet::keystone::UrDecodeResult {
         self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::vote::VanWitness> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.auth_path.into_into_dart().into_dart(),
+            self.0.position.into_into_dart().into_dart(),
+            self.0.anchor_height.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::vote::VanWitness>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::vote::VanWitness>>
+    for zcash_voting::vote::VanWitness
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::vote::VanWitness> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::VoteCommitmentWire> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.van_nullifier.into_into_dart().into_dart(),
+            self.0.vote_authority_note_new.into_into_dart().into_dart(),
+            self.0.vote_commitment.into_into_dart().into_dart(),
+            self.0.proposal_id.into_into_dart().into_dart(),
+            self.0.proof.into_into_dart().into_dart(),
+            self.0.vote_round_id.into_into_dart().into_dart(),
+            self.0.anchor_height.into_into_dart().into_dart(),
+            self.0.r_vpk.into_into_dart().into_dart(),
+            self.0.vote_auth_sig.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::VoteCommitmentWire>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::VoteCommitmentWire>>
+    for zcash_voting::wire::VoteCommitmentWire
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::VoteCommitmentWire> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::VoteConfirmation> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.tx_hash.into_into_dart().into_dart(),
+            self.0.van_leaf_position.into_into_dart().into_dart(),
+            self.0.vc_tree_position.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::VoteConfirmation>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::VoteConfirmation>>
+    for zcash_voting::wire::VoteConfirmation
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::VoteConfirmation> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::VoteRecoveryView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.proposal_id.into_into_dart().into_dart(),
+            self.0.choice.into_into_dart().into_dart(),
+            self.0.phase.into_into_dart().into_dart(),
+            self.0.tx_hash.into_into_dart().into_dart(),
+            self.0.vc_tree_position.into_into_dart().into_dart(),
+            self.0.has_commitment_bundle.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::VoteRecoveryView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::VoteRecoveryView>>
+    for zcash_voting::wire::VoteRecoveryView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::VoteRecoveryView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::VoteRecoveryWorkView> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.kind.into_into_dart().into_dart(),
+            self.0.bundle_index.into_into_dart().into_dart(),
+            self.0.proposal_id.into_into_dart().into_dart(),
+            self.0.tx_hash.into_into_dart().into_dart(),
+            self.0.vc_tree_position.into_into_dart().into_dart(),
+            self.0.share_indexes.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::VoteRecoveryWorkView>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::VoteRecoveryWorkView>>
+    for zcash_voting::wire::VoteRecoveryWorkView
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::VoteRecoveryWorkView> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::VoteShareWire> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.shares_hash.into_into_dart().into_dart(),
+            self.0.proposal_id.into_into_dart().into_dart(),
+            self.0.vote_decision.into_into_dart().into_dart(),
+            self.0.encrypted_share.into_into_dart().into_dart(),
+            self.0.share_index.into_into_dart().into_dart(),
+            self.0.vc_tree_position.into_into_dart().into_dart(),
+            self.0.all_encrypted_shares.into_into_dart().into_dart(),
+            self.0.share_comms.into_into_dart().into_dart(),
+            self.0.primary_blind.into_into_dart().into_dart(),
+            self.0.submit_at.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::VoteShareWire>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::VoteShareWire>>
+    for zcash_voting::wire::VoteShareWire
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::VoteShareWire> {
+        self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::VotingRoundParams> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.vote_round_id.into_into_dart().into_dart(),
+            self.0.snapshot_height.into_into_dart().into_dart(),
+            self.0.ea_pk.into_into_dart().into_dart(),
+            self.0.nc_root.into_into_dart().into_dart(),
+            self.0.nullifier_imt_root.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::wire::VotingRoundParams>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::VotingRoundParams>>
+    for zcash_voting::wire::VotingRoundParams
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::VotingRoundParams> {
+        self.into()
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -4240,11 +7706,45 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::WalletImportResult>
         self
     }
 }
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::types::WireEncryptedShare> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.0.c1.into_into_dart().into_dart(),
+            self.0.c2.into_into_dart().into_dart(),
+            self.0.share_index.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<zcash_voting::types::WireEncryptedShare>
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::types::WireEncryptedShare>>
+    for zcash_voting::types::WireEncryptedShare
+{
+    fn into_into_dart(self) -> FrbWrapper<zcash_voting::types::WireEncryptedShare> {
+        self.into()
+    }
+}
 
 impl SseEncode for flutter_rust_bridge::for_generated::anyhow::Error {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(format!("{:?}", self), serializer);
+    }
+}
+
+impl SseEncode
+    for StreamSink<
+        crate::api::voting::ApiDelegationProofEvent,
+        flutter_rust_bridge::for_generated::SseCodec,
+    >
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        unimplemented!("")
     }
 }
 
@@ -4263,6 +7763,18 @@ impl SseEncode
 impl SseEncode
     for StreamSink<
         crate::api::sync::ApiSyncProgressEvent,
+        flutter_rust_bridge::for_generated::SseCodec,
+    >
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        unimplemented!("")
+    }
+}
+
+impl SseEncode
+    for StreamSink<
+        crate::api::voting::ApiVoteCommitEvent,
         flutter_rust_bridge::for_generated::SseCodec,
     >
 {
@@ -4305,6 +7817,18 @@ impl SseEncode for crate::api::sync::AddressValidationResult {
     }
 }
 
+impl SseEncode for crate::api::voting::ApiDelegationProofEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.phase, serializer);
+        <Option<f64>>::sse_encode(self.proof_progress, serializer);
+        <Option<zcash_voting::wire::SignedDelegationPayloadView>>::sse_encode(
+            self.signed_delegation_payload,
+            serializer,
+        );
+    }
+}
+
 impl SseEncode for crate::api::sync::ApiMempoolTxEvent {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -4329,6 +7853,34 @@ impl SseEncode for crate::api::sync::ApiSyncProgressEvent {
     }
 }
 
+impl SseEncode for crate::api::voting::ApiVoteCommitEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.phase, serializer);
+        <Option<u32>>::sse_encode(self.proposal_id, serializer);
+        <Option<u32>>::sse_encode(self.bundle_index, serializer);
+        <Option<f64>>::sse_encode(self.proof_progress, serializer);
+        <Option<zcash_voting::wire::SignedVoteCommitmentsView>>::sse_encode(
+            self.commitments,
+            serializer,
+        );
+    }
+}
+
+impl SseEncode for crate::api::voting::ApiVotingRoundContext {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.db_path, serializer);
+        <String>::sse_encode(self.lightwalletd_url, serializer);
+        <String>::sse_encode(self.network, serializer);
+        <zcash_voting::wire::VotingRoundParams>::sse_encode(self.round_params, serializer);
+        <String>::sse_encode(self.round_name, serializer);
+        <Option<String>>::sse_encode(self.session_json, serializer);
+        <String>::sse_encode(self.account_uuid, serializer);
+        <Option<u32>>::sse_encode(self.max_real_notes_per_bundle, serializer);
+    }
+}
+
 impl SseEncode for crate::api::sync::BlockMetaInfo {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -4344,6 +7896,104 @@ impl SseEncode for bool {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         serializer.cursor.write_u8(self as _).unwrap();
+    }
+}
+
+impl SseEncode for zcash_voting::round::BundleLayout {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.bundle_count, serializer);
+        <u64>::sse_encode(self.eligible_weight, serializer);
+        <u32>::sse_encode(self.dropped_count, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::CompletedVoteChoiceView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.proposal_id, serializer);
+        <Option<u32>>::sse_encode(self.choice, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::CompletedVoteDisplayView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<zcash_voting::wire::CompletedVoteChoiceView>>::sse_encode(self.choices, serializer);
+        <Option<u64>>::sse_encode(self.voted_at, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::DelegationConfirmation {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.tx_hash, serializer);
+        <u32>::sse_encode(self.van_leaf_position, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::DelegationPirPrecomputeResultView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.cached_count, serializer);
+        <u32>::sse_encode(self.fetched_count, serializer);
+        <u32>::sse_encode(self.bundle_count, serializer);
+        <u32>::sse_encode(self.bundle_index, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::DelegationRecoveryView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.bundle_index, serializer);
+        <String>::sse_encode(self.phase, serializer);
+        <Option<String>>::sse_encode(self.tx_hash, serializer);
+        <Option<u32>>::sse_encode(self.van_leaf_position, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::DelegationRecoveryWorkView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.kind, serializer);
+        <u32>::sse_encode(self.bundle_index, serializer);
+        <String>::sse_encode(self.phase, serializer);
+        <Option<String>>::sse_encode(self.tx_hash, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::DelegationStatusView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.bundle_index, serializer);
+        <String>::sse_encode(self.phase, serializer);
+        <Option<String>>::sse_encode(self.tx_hash, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::DelegationSubmissionWire {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.rk, serializer);
+        <String>::sse_encode(self.spend_auth_sig, serializer);
+        <String>::sse_encode(self.sighash, serializer);
+        <String>::sse_encode(self.nf_signed, serializer);
+        <String>::sse_encode(self.cmx_new, serializer);
+        <String>::sse_encode(self.gov_comm, serializer);
+        <Vec<String>>::sse_encode(self.gov_nullifiers, serializer);
+        <String>::sse_encode(self.proof, serializer);
+        <String>::sse_encode(self.vote_round_id, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::DraftVote {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.proposal_id, serializer);
+        <u32>::sse_encode(self.choice, serializer);
+        <u32>::sse_encode(self.num_options, serializer);
+        <u64>::sse_encode(self.vc_tree_position, serializer);
+        <bool>::sse_encode(self.single_share, serializer);
     }
 }
 
@@ -4391,6 +8041,32 @@ impl SseEncode for crate::wallet::keystone::KeystoneAccountInfo {
     }
 }
 
+impl SseEncode for zcash_voting::wire::KeystoneSignatureRecord {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.bundle_index, serializer);
+        <Vec<u8>>::sse_encode(self.sig, serializer);
+        <Vec<u8>>::sse_encode(self.sighash, serializer);
+        <Vec<u8>>::sse_encode(self.rk, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::delegate::KeystoneSigningRequest {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<u8>>::sse_encode(self.pczt_bytes, serializer);
+        <Vec<u8>>::sse_encode(self.redacted_pczt_bytes, serializer);
+        <Vec<u8>>::sse_encode(self.pczt_sighash, serializer);
+        <Vec<u8>>::sse_encode(self.rk, serializer);
+        <u32>::sse_encode(self.action_index, serializer);
+        <String>::sse_encode(self.display_memo, serializer);
+        <u64>::sse_encode(self.eligible_weight_zatoshi, serializer);
+        <u64>::sse_encode(self.delegated_weight_zatoshi, serializer);
+        <u32>::sse_encode(self.bundle_count, serializer);
+        <u32>::sse_encode(self.bundle_index, serializer);
+    }
+}
+
 impl SseEncode for Vec<String> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -4421,12 +8097,102 @@ impl SseEncode for Vec<crate::api::sync::BlockMetaInfo> {
     }
 }
 
+impl SseEncode for Vec<zcash_voting::wire::CompletedVoteChoiceView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::CompletedVoteChoiceView>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::DelegationRecoveryView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::DelegationRecoveryView>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::DelegationRecoveryWorkView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::DelegationRecoveryWorkView>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::DelegationStatusView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::DelegationStatusView>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::DraftVote> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::DraftVote>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<crate::wallet::keystone::KeystoneAccountInfo> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <crate::wallet::keystone::KeystoneAccountInfo>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::KeystoneSignatureRecord> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::KeystoneSignatureRecord>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<Vec<u8>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <Vec<u8>>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::NextStepView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::NextStepView>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<u32> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <u32>::sse_encode(item, serializer);
         }
     }
 }
@@ -4441,12 +8207,62 @@ impl SseEncode for Vec<u8> {
     }
 }
 
+impl SseEncode for Vec<zcash_voting::wire::RecoverableCommitmentBundle> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::RecoverableCommitmentBundle>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<crate::api::sync::ScanRangeInfo> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <crate::api::sync::ScanRangeInfo>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::ShareDelegationRecordView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::ShareDelegationRecordView>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::share_policy::ShareSubmissionPlan> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::share_policy::ShareSubmissionPlan>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::ShareWorkflowRecoveryView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::ShareWorkflowRecoveryView>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::SignedVoteCommitmentView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::SignedVoteCommitmentView>::sse_encode(item, serializer);
         }
     }
 }
@@ -4491,12 +8307,123 @@ impl SseEncode for Vec<crate::api::sync::TxDataRequest> {
     }
 }
 
+impl SseEncode for Vec<zcash_voting::wire::TxEvent> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::TxEvent>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::TxEventAttribute> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::TxEventAttribute>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::VoteRecoveryView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::VoteRecoveryView>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::VoteRecoveryWorkView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::VoteRecoveryWorkView>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::wire::VoteShareWire> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::wire::VoteShareWire>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<zcash_voting::types::WireEncryptedShare> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <zcash_voting::types::WireEncryptedShare>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for zcash_voting::wire::NextStepView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.kind, serializer);
+        <u32>::sse_encode(self.bundle_index, serializer);
+        <u32>::sse_encode(self.proposal_id, serializer);
+        <u32>::sse_encode(self.choice, serializer);
+        <u32>::sse_encode(self.share_index, serializer);
+    }
+}
+
 impl SseEncode for Option<String> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <String>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<zcash_voting::wire::CompletedVoteDisplayView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <zcash_voting::wire::CompletedVoteDisplayView>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<f64> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <f64>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<zcash_voting::wire::SignedDelegationPayloadView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <zcash_voting::wire::SignedDelegationPayloadView>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<zcash_voting::wire::SignedVoteCommitmentsView> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <zcash_voting::wire::SignedVoteCommitmentsView>::sse_encode(value, serializer);
         }
     }
 }
@@ -4540,6 +8467,73 @@ impl SseEncode for crate::api::sync::ProposalResult {
     }
 }
 
+impl SseEncode for zcash_voting::wire::RecoverableCommitmentBundle {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.bundle_index, serializer);
+        <u32>::sse_encode(self.proposal_id, serializer);
+        <String>::sse_encode(self.commitment_bundle_json, serializer);
+        <u64>::sse_encode(self.vc_tree_position, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::RoundPlanView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.round_id, serializer);
+        <bool>::sse_encode(self.pending_recovery, serializer);
+        <bool>::sse_encode(self.blocking_recovery, serializer);
+        <bool>::sse_encode(self.blocking_share_work, serializer);
+        <bool>::sse_encode(self.hotkey_bound, serializer);
+        <bool>::sse_encode(self.completed_vote_artifact, serializer);
+        <bool>::sse_encode(self.completed_for_display, serializer);
+        <Option<zcash_voting::wire::CompletedVoteDisplayView>>::sse_encode(
+            self.completed_vote_display,
+            serializer,
+        );
+        <bool>::sse_encode(self.needs_draft_setup, serializer);
+        <String>::sse_encode(self.primary_action, serializer);
+        <Vec<zcash_voting::wire::NextStepView>>::sse_encode(self.next_steps, serializer);
+        <Vec<zcash_voting::wire::DelegationStatusView>>::sse_encode(
+            self.delegation_statuses,
+            serializer,
+        );
+        <Vec<zcash_voting::wire::DelegationRecoveryWorkView>>::sse_encode(
+            self.recovered_delegation_work,
+            serializer,
+        );
+        <Vec<zcash_voting::wire::VoteRecoveryWorkView>>::sse_encode(
+            self.recovered_vote_work,
+            serializer,
+        );
+        <Vec<u32>>::sse_encode(self.open_proposals, serializer);
+        <bool>::sse_encode(self.all_decided, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::RoundRecoveryStateView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.round_id, serializer);
+        <u32>::sse_encode(self.bundle_count, serializer);
+        <Vec<zcash_voting::wire::DelegationRecoveryView>>::sse_encode(self.delegation, serializer);
+        <Vec<zcash_voting::wire::VoteRecoveryView>>::sse_encode(self.votes, serializer);
+        <Vec<zcash_voting::wire::RecoverableCommitmentBundle>>::sse_encode(
+            self.commitment_bundles,
+            serializer,
+        );
+        <Vec<zcash_voting::wire::ShareWorkflowRecoveryView>>::sse_encode(self.shares, serializer);
+        <Vec<zcash_voting::wire::ShareDelegationRecordView>>::sse_encode(
+            self.share_delegations,
+            serializer,
+        );
+        <Vec<zcash_voting::wire::ShareDelegationRecordView>>::sse_encode(
+            self.unconfirmed_share_delegations,
+            serializer,
+        );
+    }
+}
+
 impl SseEncode for crate::api::sync::ScanRangeInfo {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -4562,6 +8556,41 @@ impl SseEncode for crate::api::sync::SendMaxEstimateResult {
         <u64>::sse_encode(self.amount_zatoshi, serializer);
         <u64>::sse_encode(self.fee_zatoshi, serializer);
         <bool>::sse_encode(self.needs_sapling_params, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::ShareDelegationRecordView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.round_id, serializer);
+        <u32>::sse_encode(self.bundle_index, serializer);
+        <u32>::sse_encode(self.proposal_id, serializer);
+        <u32>::sse_encode(self.share_index, serializer);
+        <Vec<String>>::sse_encode(self.sent_to_urls, serializer);
+        <Vec<u8>>::sse_encode(self.nullifier, serializer);
+        <String>::sse_encode(self.phase, serializer);
+        <bool>::sse_encode(self.confirmed, serializer);
+        <u64>::sse_encode(self.submit_at, serializer);
+        <u64>::sse_encode(self.created_at, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::share_policy::ShareSubmissionPlan {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u64>::sse_encode(self.submit_at, serializer);
+        <u32>::sse_encode(self.target_count, serializer);
+        <Vec<String>>::sse_encode(self.target_servers, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::ShareWorkflowRecoveryView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.bundle_index, serializer);
+        <u32>::sse_encode(self.proposal_id, serializer);
+        <u32>::sse_encode(self.share_index, serializer);
+        <String>::sse_encode(self.phase, serializer);
     }
 }
 
@@ -4595,6 +8624,40 @@ impl SseEncode for crate::api::sync::ShieldTransparentStatus {
         <u64>::sse_encode(self.fee_zatoshi, serializer);
         <u64>::sse_encode(self.shielded_zatoshi, serializer);
         <String>::sse_encode(self.reason, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::SignedDelegationPayloadView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<u8>>::sse_encode(self.pczt_bytes, serializer);
+        <String>::sse_encode(self.status, serializer);
+        <Option<String>>::sse_encode(self.message, serializer);
+        <zcash_voting::wire::DelegationSubmissionWire>::sse_encode(self.submission, serializer);
+        <u64>::sse_encode(self.eligible_weight_zatoshi, serializer);
+        <u64>::sse_encode(self.delegated_weight_zatoshi, serializer);
+        <u32>::sse_encode(self.bundle_count, serializer);
+        <u32>::sse_encode(self.bundle_index, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::SignedVoteCommitmentView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.proposal_id, serializer);
+        <zcash_voting::wire::VoteCommitmentWire>::sse_encode(self.wire, serializer);
+        <Vec<zcash_voting::wire::VoteShareWire>>::sse_encode(self.shares, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::SignedVoteCommitmentsView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.bundle_index, serializer);
+        <Vec<zcash_voting::wire::SignedVoteCommitmentView>>::sse_encode(
+            self.commitments,
+            serializer,
+        );
     }
 }
 
@@ -4671,6 +8734,22 @@ impl SseEncode for crate::api::sync::TxDataRequest {
     }
 }
 
+impl SseEncode for zcash_voting::wire::TxEvent {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.event_type, serializer);
+        <Vec<zcash_voting::wire::TxEventAttribute>>::sse_encode(self.attributes, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::TxEventAttribute {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.key, serializer);
+        <String>::sse_encode(self.value, serializer);
+    }
+}
+
 impl SseEncode for u32 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -4717,6 +8796,94 @@ impl SseEncode for usize {
     }
 }
 
+impl SseEncode for zcash_voting::vote::VanWitness {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<Vec<u8>>>::sse_encode(self.auth_path, serializer);
+        <u32>::sse_encode(self.position, serializer);
+        <u32>::sse_encode(self.anchor_height, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::VoteCommitmentWire {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.van_nullifier, serializer);
+        <String>::sse_encode(self.vote_authority_note_new, serializer);
+        <String>::sse_encode(self.vote_commitment, serializer);
+        <u32>::sse_encode(self.proposal_id, serializer);
+        <String>::sse_encode(self.proof, serializer);
+        <String>::sse_encode(self.vote_round_id, serializer);
+        <u32>::sse_encode(self.anchor_height, serializer);
+        <String>::sse_encode(self.r_vpk, serializer);
+        <String>::sse_encode(self.vote_auth_sig, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::VoteConfirmation {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.tx_hash, serializer);
+        <u32>::sse_encode(self.van_leaf_position, serializer);
+        <u64>::sse_encode(self.vc_tree_position, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::VoteRecoveryView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.bundle_index, serializer);
+        <u32>::sse_encode(self.proposal_id, serializer);
+        <u32>::sse_encode(self.choice, serializer);
+        <String>::sse_encode(self.phase, serializer);
+        <Option<String>>::sse_encode(self.tx_hash, serializer);
+        <Option<u64>>::sse_encode(self.vc_tree_position, serializer);
+        <bool>::sse_encode(self.has_commitment_bundle, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::VoteRecoveryWorkView {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.kind, serializer);
+        <u32>::sse_encode(self.bundle_index, serializer);
+        <u32>::sse_encode(self.proposal_id, serializer);
+        <Option<String>>::sse_encode(self.tx_hash, serializer);
+        <Option<u64>>::sse_encode(self.vc_tree_position, serializer);
+        <Vec<u32>>::sse_encode(self.share_indexes, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::VoteShareWire {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.shares_hash, serializer);
+        <u32>::sse_encode(self.proposal_id, serializer);
+        <u32>::sse_encode(self.vote_decision, serializer);
+        <zcash_voting::types::WireEncryptedShare>::sse_encode(self.encrypted_share, serializer);
+        <u32>::sse_encode(self.share_index, serializer);
+        <u64>::sse_encode(self.vc_tree_position, serializer);
+        <Vec<zcash_voting::types::WireEncryptedShare>>::sse_encode(
+            self.all_encrypted_shares,
+            serializer,
+        );
+        <Vec<String>>::sse_encode(self.share_comms, serializer);
+        <String>::sse_encode(self.primary_blind, serializer);
+        <u64>::sse_encode(self.submit_at, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::wire::VotingRoundParams {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.vote_round_id, serializer);
+        <u64>::sse_encode(self.snapshot_height, serializer);
+        <Vec<u8>>::sse_encode(self.ea_pk, serializer);
+        <Vec<u8>>::sse_encode(self.nc_root, serializer);
+        <Vec<u8>>::sse_encode(self.nullifier_imt_root, serializer);
+    }
+}
+
 impl SseEncode for crate::api::sync::WalletBalance {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -4745,6 +8912,15 @@ impl SseEncode for crate::api::wallet::WalletImportResult {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <String>::sse_encode(self.unified_address, serializer);
         <String>::sse_encode(self.account_uuid, serializer);
+    }
+}
+
+impl SseEncode for zcash_voting::types::WireEncryptedShare {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<u8>>::sse_encode(self.c1, serializer);
+        <Vec<u8>>::sse_encode(self.c2, serializer);
+        <u32>::sse_encode(self.share_index, serializer);
     }
 }
 

--- a/rust/src/wallet/mod.rs
+++ b/rust/src/wallet/mod.rs
@@ -6,3 +6,4 @@ pub mod secret_payload;
 pub mod secret_store;
 pub mod sync;
 pub mod sync_engine;
+pub mod voting;

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -309,8 +309,7 @@ pub(crate) struct SyncProgress {
     pub is_syncing: bool,
 }
 
-pub fn get_sync_progress(db_path: &str, network: WalletNetwork) -> Result<SyncProgress, String> {
-    let db = open_wallet_db_for_read(db_path, network)?;
+pub(crate) fn get_sync_progress_from_db(db: &WalletDatabase) -> Result<SyncProgress, String> {
     match db
         .get_wallet_summary(ConfirmationsPolicy::default())
         .map_err(|e| format!("{e}"))?
@@ -326,6 +325,11 @@ pub fn get_sync_progress(db_path: &str, network: WalletNetwork) -> Result<SyncPr
             is_syncing: false,
         }),
     }
+}
+
+pub fn get_sync_progress(db_path: &str, network: WalletNetwork) -> Result<SyncProgress, String> {
+    let db = open_wallet_db_for_read(db_path, network)?;
+    get_sync_progress_from_db(&db)
 }
 
 // ======================== Rewind ========================

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -309,7 +309,8 @@ pub(crate) struct SyncProgress {
     pub is_syncing: bool,
 }
 
-pub(crate) fn get_sync_progress_from_db(db: &WalletDatabase) -> Result<SyncProgress, String> {
+pub fn get_sync_progress(db_path: &str, network: WalletNetwork) -> Result<SyncProgress, String> {
+    let db = open_wallet_db_for_read(db_path, network)?;
     match db
         .get_wallet_summary(ConfirmationsPolicy::default())
         .map_err(|e| format!("{e}"))?
@@ -325,11 +326,6 @@ pub(crate) fn get_sync_progress_from_db(db: &WalletDatabase) -> Result<SyncProgr
             is_syncing: false,
         }),
     }
-}
-
-pub fn get_sync_progress(db_path: &str, network: WalletNetwork) -> Result<SyncProgress, String> {
-    let db = open_wallet_db_for_read(db_path, network)?;
-    get_sync_progress_from_db(&db)
 }
 
 // ======================== Rewind ========================

--- a/rust/src/wallet/voting.rs
+++ b/rust/src/wallet/voting.rs
@@ -1,0 +1,7 @@
+pub mod db;
+pub mod delegation;
+pub mod hotkey;
+pub mod network;
+
+#[cfg(test)]
+pub(crate) mod test_support;

--- a/rust/src/wallet/voting/README.md
+++ b/rust/src/wallet/voting/README.md
@@ -1,0 +1,184 @@
+# Vizor Voting Integration (Rust)
+
+This module integrates the [`zcash_voting`](https://github.com/valargroup/zcash_voting)
+crate into Vizor. It owns the wallet-side concerns the crate intentionally leaves
+to the host app: seed handling and hotkey derivation, the voting sidecar
+database, delegation signing, and the Flutter Rust Bridge (FRB) surface that
+exposes the crate lifecycle to Dart.
+
+`zcash_voting` owns the protocol and the durable recovery state machine. Vizor
+adds no parallel workflow tables. All phases and recovery are derived from the
+crate's own `bundles`, `votes`, and `share_delegations` rows. For the canonical
+setup -> precompute -> delegate -> vote -> share lifecycle, the per-bundle phase
+definitions, and the restart planner, see the crate docs:
+
+- Crate README: [`zcash_voting/zcash_voting/README.md`](https://github.com/valargroup/zcash_voting/blob/main/zcash_voting/README.md)
+- Reference usage: [`wallet-example/src`](https://github.com/valargroup/zcash_voting/tree/main/wallet-example/src)
+  (`example_delegation.rs`, `example_vote.rs`, `example_recovery.rs`)
+
+This document focuses on what Vizor's integration is responsible for.
+
+## Module Map
+
+| File | Responsibility |
+| --- | --- |
+| `db.rs` | Opens the voting sidecar DB via `VotingDb::open_wallet_sidecar` at the deterministic path next to the wallet DB. The voting schema is isolated from the wallet `user_version`. |
+| `network.rs` | Converts between wallet-layer network enums and `zcash_voting::Network` so wallet modules do not depend on API-layer helpers. |
+| `hotkey.rs` | Derives scoped, opaque voting hotkey seed material from the wallet seed for software accounts. The derived secret is never persisted by Rust. |
+| `delegation.rs` | Prepares, proves, and signs delegation bundles (software and Keystone paths), forwarding `DelegationProgress` to callers. Wallet seed signing stays here. |
+| `../../api/voting.rs` | FRB boundary. Thin wrappers that open the sidecar DB and call crate lifecycle APIs (`delegate::*`, `vote::*`, `share::*`, `confirmation::*`, `session::*`, `precompute::*`). |
+| `../../api/voting_helpers.rs` | API-only helper glue for delegation input resolution and bundle-parameter construction used by the FRB boundary. |
+
+## Account Invariants And Secret Boundaries
+
+Coinholder voting uses a crate-owned voting hotkey for delegation outputs and
+vote signing.
+
+- Software accounts derive the hotkey seed from the active account seed, round,
+  account UUID, and network via `hotkey::derive_hotkey`, then hand it to
+  `zcash_voting::hotkey::voting_hotkey_from_seed`. The same tuple always yields
+  the same material; changing any member produces independent material.
+- Hardware accounts generate and store a random per-round hotkey seed because
+  the wallet seed is not available to the host app.
+- Locked wallets and software accounts without a stored mnemonic must fail
+  before any proof or recovery work starts.
+
+The wallet seed never leaves the wallet boundary. Delegation signing in
+`delegation.rs::sign_delegation_request` consumes a crate-provided
+`DelegationSigningRequest`, verifies the seed fingerprint, derives the account
+SpendAuth key, randomizes it with `alpha`, and returns only the detached
+signature plus sighash. The crate never receives root seed material.
+
+### Session Pinning
+
+A `votingSessionProvider(roundId)` instance is pinned to the active account UUID
+captured when the session is built. All later context reloads, recovery reads,
+delegation setup, vote-tree sync, vote submission, and share recovery must
+continue to use that session account, even if the user switches accounts while
+the round screen is open. Do not re-read the active account inside individual
+session actions except through the session-pinned account helper.
+
+## Durable vs Process-Local State
+
+Two kinds of state exist, and they are both account scoped:
+
+- **Durable** state lives in the `zcash_voting` sidecar tables (delegation
+  bundles, signed artifacts, transaction hashes, VAN/VC positions, share
+  submission history). This is the recovery source of truth.
+- **Process-local** state is Rust memory and cached clients owned by the current
+  app process, including the crate-owned vote-tree client.
+
+Any durable key or process-local cache that touches prepared PCZTs, vote-tree
+sync state, hotkeys, recovery rows, or share-delegation history must include the
+wallet DB path plus the session account UUID where applicable.
+
+### Reset Semantics
+
+`reset_voting_session_state(db_path, account_uuid, round_id)` clears only
+process-local state. It does not delete durable recovery rows, signed artifacts,
+transaction hashes, or share history, and it does not abort in-flight proof or
+vote jobs already running on worker threads.
+
+- A non-empty `round_id` clears round-scoped caches only.
+- `None` or an empty `round_id` is an account-wide reset and additionally drops
+  the cached vote-tree client by calling
+  `zcash_voting::precompute::reset_vote_tree`.
+
+Vote-tree sync and reset are owned by the crate
+(`zcash_voting::precompute::{sync_vote_tree, reset_vote_tree}`); Vizor does not
+maintain its own tree-sync registry. The tree client is account/DB scoped, not
+round scoped, so a round-scoped reset must not drop it.
+
+Account-wide reset runs when switching away from the active account, removing an
+account, resetting the wallet, or locking/signing out. These lifecycle
+boundaries invalidate the owner of the process-local tree client but never
+delete durable `zcash_voting` recovery rows.
+
+## Lifecycle And Recovery
+
+Vizor calls the crate's stage-oriented APIs rather than writing storage rows
+directly. The mapping from FRB functions to crate APIs:
+
+| Stage | FRB entry (`api/voting.rs`) | Crate API |
+| --- | --- | --- |
+| Bundle setup | `setup_delegation_bundles` | `delegate::ensure_round_context`, `VotingDb::ensure_bundles_with_skipped_suffix_with_policy` |
+| Delegation prove/sign | `build_prove_and_sign_delegation_payload_with_progress`, Keystone variant | `delegate::{prepare_delegation_bundle, setup, prove, signing_request, signed_bundle, keystone_request}` |
+| Delegation submit/confirm | `mark_delegation_submitted`, `confirm_delegation_submission` | `VotingDb::mark_delegation_submitted`, `confirmation::confirm_delegation_submission` |
+| Vote commit | `build_vote_commitments_with_progress`, `recover_vote_commitment` | `vote::commit_batch`, `vote::recover_signed_commitments` |
+| Vote submit/confirm | `mark_vote_submitted`, `confirm_vote_submission` | `VotingDb::mark_vote_submitted`, `confirmation::confirm_vote_submission` |
+| Share submit/confirm | `record_share_delegation`, `mark_share_confirmed`, `add_sent_servers` | `vote::CommittedVote::{record_share, confirm_share}`, `share::add_sent_servers` |
+| Ballot intent / restart | `set_ballot_intent`, `get_round_plan`, `get_round_recovery_state` | `VotingDb::set_ballot_intent`, `session::resume_plan`, `recovery::round_snapshot` |
+
+The `confirmation::*` APIs parse chain `tx` events and atomically record tx
+hashes, VAN positions, and VC positions. Restart recovery is driven by
+`session::resume_plan`, which returns the ordered remaining `NextStep`s and the
+proposals still open. Vizor's Dart recovery code consumes the crate's phase
+strings; it does not derive its own phases.
+
+```mermaid
+stateDiagram-v2
+    state "Delegation Bundle" as Delegation {
+        [*] --> Prepared
+        Prepared --> Signed: prove + sign
+        Signed --> Submitted: mark_delegation_submitted
+        Submitted --> Confirmed: confirm_delegation_submission
+        Confirmed --> [*]
+    }
+    state "Vote Commitment" as Vote {
+        [*] --> Committed
+        Committed --> Submitted2: mark_vote_submitted
+        Submitted2 --> Confirmed2: confirm_vote_submission
+        Confirmed2 --> [*]
+    }
+    state "Helper Share" as Share {
+        [*] --> SubmittedShare
+        SubmittedShare --> ConfirmedShare: confirm_share
+        ConfirmedShare --> [*]
+    }
+```
+
+### Helper Share Scheduling
+
+Helper-share `submit_at` (the Unix-second reveal time sent to the helper server)
+is computed in Dart from round timing before calling `record_share_delegation`:
+
+- The last-moment buffer is 40% of the round duration from `ceremony_phase_start`
+  to `vote_end_time`, capped at six hours.
+- Before that buffer, each share samples a randomized `submit_at` uniformly in
+  `[now, vote_end_time - buffer)`.
+- Inside the buffer, the vote commitment uses single-share mode and shares use
+  `submit_at = 0` (immediate submission).
+- If round timing is missing or invalid, Vizor uses `submit_at = 0`.
+
+Retry/resubmission paths submit immediately (`submit_at = 0`); the original
+scheduled value remains part of the durable record for the first accepted
+submission. The canonical scheduling/retry/polling policy lives in the crate's
+`share_policy` module; Dart mirrors it via the `plan_share_submissions`,
+`share_tracking_flags`, and `next_share_tracking_delay_seconds` helpers exposed
+through `api/voting.rs`.
+
+## Wire Types And FRB Scanning
+
+`zcash_voting::wire` is the canonical owner of protocol wire JSON and wallet view
+DTOs (field names, `serde` renames, base64/hex shaping, JSON-safe integer
+bounds), for example `DelegationSubmissionWire`, `VoteCommitmentWire`,
+`VanWitness`, `DraftVote`, `SignedVoteCommitmentsView`, and `RoundPlanView`. See
+`zcash_voting::wire` for the full set.
+
+Vizor keeps no FRB-local `Api*Wire` mirrors for these types. FRB codegen scans
+the shared crate module directly via `flutter_rust_bridge.yaml`:
+
+```yaml
+rust_input: crate::api,zcash_voting::wire
+```
+
+That scan emits Dart value classes under
+`lib/src/rust/third_party/zcash_voting/wire.dart` and generates the
+`SseEncode` / `SseDecode` glue in Vizor's bridge code. The `zcash_voting` crate
+stays framework-agnostic and does not depend on FRB.
+
+FRB third-party scanning expects a struct-only module surface, so the DTO structs
+stay in `zcash_voting::wire` while serialization helpers and conversions that
+pull richer crate internals (`VotingError`, payload transforms) live in
+`zcash_voting::wire_codec`. Call sites import canonical structs from
+`zcash_voting::wire::*`.

--- a/rust/src/wallet/voting/db.rs
+++ b/rust/src/wallet/voting/db.rs
@@ -1,0 +1,51 @@
+/// Opens the voting sidecar database for a wallet and binds it to `account_uuid`.
+///
+/// `db_path` is the main wallet database path; the voting DB is opened at the
+/// deterministic sidecar path returned by
+/// [`zcash_voting::round::VotingDb::wallet_sidecar_path`].
+///
+/// # Errors
+///
+/// Returns an error if the upstream voting database cannot be opened or
+/// initialized.
+pub fn open_voting_db(
+    db_path: &str,
+    account_uuid: &str,
+) -> Result<zcash_voting::storage::VotingDb, String> {
+    zcash_voting::storage::VotingDb::open_wallet_sidecar(
+        std::path::Path::new(db_path),
+        account_uuid,
+    )
+    .map_err(|e| format!("Error opening voting database: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_voting_db_initializes_upstream_schema() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("zcash_wallet.db");
+        let db = open_voting_db(db_path.to_str().unwrap(), "wallet-1").unwrap();
+
+        assert!(db.list_rounds().unwrap().is_empty());
+        assert!(zcash_voting::storage::VotingDb::wallet_sidecar_path(&db_path).exists());
+    }
+
+    #[test]
+    fn open_voting_db_uses_sidecar_path_not_wallet_user_version() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("zcash_wallet.db");
+        let wallet_conn = rusqlite::Connection::open(&db_path).unwrap();
+        wallet_conn.pragma_update(None, "user_version", 8).unwrap();
+
+        let db = open_voting_db(db_path.to_str().unwrap(), "wallet-1").unwrap();
+
+        assert!(db.list_rounds().unwrap().is_empty());
+        let wallet_version: u32 = wallet_conn
+            .pragma_query_value(None, "user_version", |row| row.get(0))
+            .unwrap();
+        assert_eq!(wallet_version, 8);
+    }
+}

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -1,0 +1,447 @@
+use std::sync::Arc;
+
+use ff::PrimeField;
+use secrecy::{ExposeSecret, SecretVec};
+use zcash_keys::keys::UnifiedSpendingKey;
+use zeroize::Zeroizing;
+use zip32::{fingerprint::SeedFingerprint, AccountId};
+
+use crate::wallet::voting::network::{voting_network, wallet_network};
+use crate::wallet::{keys, sync::open_wallet_db_for_read};
+
+use super::db::open_voting_db;
+
+pub use zcash_voting::delegate::DelegationProgress;
+use zcash_voting::delegate::{
+    DelegationSigningRequest, PrepareDelegationBundleParams, PreparedDelegationBundle,
+};
+use zcash_voting::selection::select_notes_with_lwd;
+use zcash_voting::storage::VotingDb;
+use zcash_voting::BundlePolicy;
+
+/// Completes the proof phase for a previously prepared delegation bundle.
+///
+/// Opens the voting database for `account_uuid`, connects to `pir_server_url`,
+/// then runs bundle proving on a blocking worker thread while forwarding
+/// `DelegationProgress` updates to `on_progress`.
+///
+/// # Errors
+///
+/// Returns an error if opening the voting database fails, connecting to the PIR
+/// server fails, the underlying `PreparedDelegationBundle::prove` call fails, or
+/// the spawned blocking task is cancelled or panics.
+async fn prove_delegation_bundle<F>(
+    db_path: &str,
+    pir_server_url: &str,
+    account_uuid: &str,
+    prepared: &PreparedDelegationBundle,
+    on_progress: Arc<F>,
+) -> Result<(), String>
+where
+    F: Fn(DelegationProgress) + Send + Sync + 'static,
+{
+    let proof_db_path = db_path.to_string();
+    let proof_pir_server_url = pir_server_url.to_string();
+    let proof_account_uuid = account_uuid.to_string();
+    let prepared = prepared.clone();
+    let proof_progress = on_progress.clone();
+    tokio::task::spawn_blocking(move || {
+        let proof_voting_db = open_voting_db(&proof_db_path, &proof_account_uuid)?;
+        let pir_client = zcash_voting::PirClientBlocking::with_transport(
+            &proof_pir_server_url,
+            Arc::new(zcash_voting::HyperTransport::new()),
+        )
+        .map_err(|e| format!("connect to PIR server failed: {e}"))?;
+        let reporter = zcash_voting::DelegationProgressBridge::new(move |progress| {
+            proof_progress(progress);
+        });
+        prepared
+            .prove(&proof_voting_db, &pir_client, &reporter)
+            .map(|_| ())
+            .map_err(|e| format!("delegate::prove failed: {e}"))
+    })
+    .await
+    .map_err(|e| format!("delegation proof task failed: {e}"))??;
+    Ok(())
+}
+
+/// Select notes and create/reuse delegation bundle rows for a round.
+///
+/// The selected notes are taken at the round snapshot height. Existing bundle
+/// rows are reused only when they match the current eligible note set.
+///
+/// # Errors
+///
+/// Returns an error if round initialization, lightwalletd note selection, or
+/// bundle setup/validation fails.
+#[allow(clippy::too_many_arguments)]
+pub async fn setup_delegation_bundles(
+    voting_db: &VotingDb,
+    db_path: &str,
+    lightwalletd_url: &str,
+    network: &str,
+    round_params: zcash_voting::VotingRoundParams,
+    round_name: &str,
+    session_json: Option<&str>,
+    bundle_policy: BundlePolicy,
+) -> Result<zcash_voting::round::BundleLayout, String> {
+    let network = keys::parse_network(network)?;
+    let round_context = zcash_voting::delegate::ensure_round_context(
+        voting_db,
+        &round_params,
+        round_name,
+        session_json,
+    )
+    .map_err(|e| e.to_string())?;
+    let selected = select_notes_with_lwd(
+        voting_db,
+        db_path,
+        lightwalletd_url,
+        voting_network(network),
+        round_context.snapshot_height,
+    )
+    .await
+    .map_err(|e| e.to_string())?;
+    let note_infos = selected.voting_note_infos();
+    voting_db
+        .ensure_bundles_with_skipped_suffix_with_policy(
+            round_params.vote_round_id.as_str(),
+            &note_infos,
+            bundle_policy,
+        )
+        .map_err(|e| format!("ensure_bundles_with_skipped_suffix failed: {e}"))
+}
+
+/// Warms PIR state for a single delegation bundle.
+///
+/// Validates the PIR endpoint against the round snapshot, persists witnesses,
+/// initializes padded-note secrets, and precomputes delegation PIR rows for
+/// `bundle_index`.
+///
+/// # Errors
+///
+/// Returns an error if the round, endpoint, note selection, bundle index,
+/// witness generation, padded-secret initialization, or PIR precompute step
+/// fails.
+pub async fn precompute_delegation_pir(
+    db_path: &str,
+    pir_server_url: &str,
+    prepare_params: PrepareDelegationBundleParams<'_>,
+) -> Result<zcash_voting::delegate::PreparedDelegationReport, String> {
+    let PrepareDelegationBundleParams {
+        lwd,
+        session_json,
+        account_uuid,
+        network,
+        hotkey_seed,
+        bundle_index,
+        bundle_policy,
+    } = prepare_params;
+
+    let db_path = db_path.to_string();
+    let pir_server_url = pir_server_url.to_string();
+    let account_uuid = account_uuid.to_string();
+    let session_json = session_json.map(str::to_string);
+    // Keep the copied hotkey seed zeroized after the blocking task returns.
+    let hotkey_seed = Zeroizing::new(hotkey_seed.to_vec());
+
+    tokio::task::spawn_blocking(move || {
+        let voting_db = open_voting_db(&db_path, &account_uuid)?;
+        let wallet_db = open_wallet_db_for_read(&db_path, wallet_network(network))?;
+        let prepared = zcash_voting::delegate::prepare_delegation_bundle(
+            &voting_db,
+            &wallet_db,
+            PrepareDelegationBundleParams {
+                lwd,
+                session_json: session_json.as_deref(),
+                account_uuid: &account_uuid,
+                network,
+                hotkey_seed: hotkey_seed.as_slice(),
+                bundle_index,
+                bundle_policy,
+            },
+        )
+        .map_err(|e| e.to_string())?;
+        let pir_client = zcash_voting::PirClientBlocking::with_transport(
+            &pir_server_url,
+            Arc::new(zcash_voting::HyperTransport::new()),
+        )
+        .map_err(|e| format!("connect to PIR server failed: {e}"))?;
+        prepared
+            .precompute(&voting_db, &wallet_db, &pir_client)
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("delegation PIR precompute task failed: {e}"))?
+}
+
+/// Build, prove, and sign one delegation payload.
+///
+/// Emits progress phases through `on_progress`. The returned value is a signed
+/// delegation payload ready for Dart-side submission.
+///
+/// # Errors
+///
+/// Returns an error if note/bundle validation, witness
+/// generation, PCZT construction, PIR proof generation, or delegation signing
+/// fails.
+pub async fn build_prove_and_sign_delegation_payload<F>(
+    db_path: &str,
+    pir_server_url: &str,
+    seed: &SecretVec<u8>,
+    prepare_params: PrepareDelegationBundleParams<'_>,
+    on_progress: F,
+) -> Result<zcash_voting::delegate::SignedDelegationBundle, String>
+where
+    F: Fn(DelegationProgress) + Send + Sync + 'static,
+{
+    let on_progress = Arc::new(on_progress);
+    let account_uuid = prepare_params.account_uuid;
+
+    zcash_voting::validate_round_params(&prepare_params.lwd.round_params)
+        .map_err(|e| format!("Invalid voting round params: {e}"))?;
+    on_progress(DelegationProgress::SelectingNotes);
+    let voting_db = open_voting_db(db_path, account_uuid)?;
+    let wallet_db = open_wallet_db_for_read(db_path, wallet_network(prepare_params.network))?;
+
+    let prepared_bundle =
+        zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
+            .map_err(|e| e.to_string())?;
+
+    let pczt_progress = on_progress.clone();
+    let setup_stages = zcash_voting::DelegationProgressBridge::new(move |progress| {
+        pczt_progress(progress);
+    });
+    let delegation_setup = prepared_bundle
+        .setup(&voting_db, &setup_stages)
+        .map_err(|e| format!("delegate::setup failed: {e}"))?;
+
+    prove_delegation_bundle(
+        db_path,
+        pir_server_url,
+        account_uuid,
+        &prepared_bundle,
+        on_progress.clone(),
+    )
+    .await?;
+
+    on_progress(DelegationProgress::SigningPayload);
+    let signing_request = prepared_bundle
+        .signing_request(&voting_db)
+        .map_err(|e| format!("delegation signing request failed: {e}"))?;
+    let (sig, sighash) = sign_delegation_request(seed, signing_request)
+        .map_err(|e| format!("delegation signing failed: {e}"))?;
+    let signer = zcash_voting::delegate::PreparedSigner::signature(sig, sighash);
+    let signed_bundle = prepared_bundle
+        .signed_bundle(&voting_db, delegation_setup.pczt_bytes, signer)
+        .map_err(|e| format!("delegate::signed_bundle failed: {e}"))?;
+
+    on_progress(DelegationProgress::PayloadReady);
+    Ok(signed_bundle)
+}
+
+/// Signs a delegation request with the Orchard spend authorizing key derived from
+/// the wallet seed and account in the request.
+///
+/// Returns the detached signature bytes plus the original sighash when the seed,
+/// account index, and randomizer all validate.
+fn sign_delegation_request(
+    seed: &SecretVec<u8>,
+    request: DelegationSigningRequest,
+) -> Result<([u8; 64], [u8; 32]), String> {
+    let seed = seed.expose_secret();
+    // Bind the request to this exact wallet seed before deriving any keys.
+    let seed_fingerprint = SeedFingerprint::from_seed(seed)
+        .ok_or_else(|| "wallet seed length is not valid for ZIP-32".to_string())?;
+    if seed_fingerprint.to_bytes() != request.seed_fingerprint {
+        return Err(
+            "wallet seed fingerprint does not match delegation signing request".to_string(),
+        );
+    }
+
+    // Derive the account Orchard signing key specified by the request metadata.
+    let account = AccountId::try_from(request.account_index)
+        .map_err(|_| format!("invalid account_index {}", request.account_index))?;
+    let usk = UnifiedSpendingKey::from_seed(&request.network, seed, account)
+        .map_err(|e| format!("derive account unified spending key failed: {e}"))?;
+    let sk = *usk.orchard();
+    let ask = orchard::keys::SpendAuthorizingKey::from(&sk);
+    // The alpha randomizer must decode as a canonical Pallas scalar.
+    let alpha = Option::<pasta_curves::pallas::Scalar>::from(
+        pasta_curves::pallas::Scalar::from_repr(request.alpha),
+    )
+    .ok_or_else(|| "delegation alpha is not a valid Pallas scalar".to_string())?;
+    // Sign the request-specific sighash with the randomized spend auth key.
+    let rsk = ask.randomize(&alpha);
+    let rng = rand::rngs::OsRng;
+    let sig = rsk.sign(rng, &request.sighash);
+    Ok(((&sig).into(), request.sighash))
+}
+
+/// Build one voting PCZT request for Keystone signing.
+///
+/// The full PCZT is persisted only in Rust-side voting state. `redacted_pczt_bytes`
+/// is the payload that should be UR-encoded for Keystone.
+///
+/// # Errors
+///
+/// Returns an error if note selection, witness generation, account metadata,
+/// PCZT construction, or redaction fails.
+pub async fn build_keystone_delegation_request(
+    db_path: &str,
+    account_uuid: &str,
+    prepare_params: PrepareDelegationBundleParams<'_>,
+) -> Result<zcash_voting::delegate::KeystoneSigningRequest, String> {
+    let voting_db = open_voting_db(db_path, account_uuid)?;
+    let wallet_db = open_wallet_db_for_read(db_path, wallet_network(prepare_params.network))?;
+    let prepared =
+        zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
+            .map_err(|e| e.to_string())?;
+    let noop_stages = zcash_voting::NoopProgressReporter;
+    prepared
+        .keystone_request(&voting_db, &noop_stages)
+        .map_err(|e| format!("delegate::keystone_request failed: {e}"))
+}
+
+/// Build a delegation proof and assemble the submission using a Keystone signature.
+///
+/// This path intentionally does not rebuild the governance PCZT. The signed PCZT
+/// request already persisted the sighash and delegation fields; rebuilding here
+/// would overwrite that state with a fresh PCZT that the device did not sign.
+///
+/// # Errors
+///
+/// Returns an error if proof generation fails, the Keystone signature does not
+/// match the stored PCZT sighash, or submission payload reconstruction fails.
+pub async fn build_prove_delegation_payload_with_keystone_signature<F>(
+    db_path: &str,
+    pir_server_url: &str,
+    account_uuid: &str,
+    prepare_params: PrepareDelegationBundleParams<'_>,
+    keystone_sig: &[u8],
+    keystone_sighash: &[u8],
+    on_progress: F,
+) -> Result<zcash_voting::delegate::SignedDelegationBundle, String>
+where
+    F: Fn(DelegationProgress) + Send + Sync + 'static,
+{
+    let on_progress = Arc::new(on_progress);
+
+    on_progress(DelegationProgress::SelectingNotes);
+    let voting_db = open_voting_db(db_path, account_uuid)?;
+    let wallet_db = open_wallet_db_for_read(db_path, wallet_network(prepare_params.network))?;
+    let prepared_bundle =
+        zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
+            .map_err(|e| e.to_string())?;
+    prove_delegation_bundle(
+        db_path,
+        pir_server_url,
+        account_uuid,
+        &prepared_bundle,
+        on_progress.clone(),
+    )
+    .await?;
+
+    on_progress(DelegationProgress::SigningPayload);
+    let signer = zcash_voting::delegate::PreparedSigner::signature_from_bytes(
+        keystone_sig,
+        keystone_sighash,
+    )
+    .map_err(|e| format!("invalid Keystone signature fields: {e}"))?;
+    let signed_bundle = prepared_bundle
+        .signed_bundle(&voting_db, Vec::new(), signer)
+        .map_err(|e| format!("delegate::signed_bundle failed: {e}"))?;
+    on_progress(DelegationProgress::PayloadReady);
+
+    Ok(signed_bundle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wallet::voting::test_support::{ROUND_ID, TEST_ACCOUNT_UUID};
+    use ff::PrimeField;
+    use orchard::{
+        keys::SpendAuthorizingKey,
+        primitives::redpallas::{Signature, SpendAuth, VerificationKey},
+    };
+    use secrecy::ExposeSecret;
+    use std::sync::{Arc, Mutex};
+    use zip32::{fingerprint::SeedFingerprint, AccountId};
+
+    #[test]
+    fn build_prove_and_sign_delegation_payload_rejects_invalid_round_params_before_progress() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("zcash_wallet.db");
+        let seed = SecretVec::new(vec![7; 32]);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let events_for_callback = events.clone();
+        let round_params = zcash_voting::VotingRoundParams {
+            vote_round_id: ROUND_ID.to_string(),
+            snapshot_height: 100,
+            ea_pk: vec![1],
+            nc_root: vec![2; 32],
+            nullifier_imt_root: vec![3; 32],
+        };
+        let err = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(build_prove_and_sign_delegation_payload(
+                db_path.to_str().unwrap(),
+                "http://127.0.0.1:2",
+                &seed,
+                PrepareDelegationBundleParams {
+                    lwd: zcash_voting::delegate::DelegationLwdInputs {
+                        round_params,
+                        resolved_round_name: "Demo".to_string(),
+                        anchor_tree_state_bytes: Vec::new(),
+                        branch_id_provider:
+                            zcash_voting::delegate::LightwalletdBranchIdProvider::resolved(0),
+                    },
+                    session_json: None,
+                    account_uuid: TEST_ACCOUNT_UUID,
+                    network: zcash_voting::Network::Regtest,
+                    hotkey_seed: &[9; 32],
+                    bundle_index: 0,
+                    bundle_policy: BundlePolicy::default(),
+                },
+                move |event| events_for_callback.lock().unwrap().push(event),
+            ))
+            .unwrap_err();
+
+        assert!(err.contains("Invalid voting round params"));
+        assert!(events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn sign_delegation_request_happy_path_signs_and_verifies() {
+        let seed = SecretVec::new(vec![0x42; 32]);
+        let account_index = 0u32;
+        let account = AccountId::try_from(account_index).unwrap();
+        let usk = UnifiedSpendingKey::from_seed(
+            &zcash_voting::Network::Testnet,
+            seed.expose_secret(),
+            account,
+        )
+        .unwrap();
+        let ask = SpendAuthorizingKey::from(usk.orchard());
+        let alpha = pasta_curves::pallas::Scalar::from(7);
+        let sighash = [0xAB; 32];
+        let request = DelegationSigningRequest {
+            account_index,
+            network: zcash_voting::Network::Testnet,
+            seed_fingerprint: SeedFingerprint::from_seed(seed.expose_secret())
+                .unwrap()
+                .to_bytes(),
+            sighash,
+            alpha: alpha.to_repr(),
+        };
+
+        let (sig_bytes, returned_sighash) = sign_delegation_request(&seed, request).unwrap();
+
+        let verification_key = VerificationKey::from(&ask.randomize(&alpha));
+        verification_key
+            .verify(&sighash, &Signature::<SpendAuth>::from(sig_bytes))
+            .unwrap();
+        assert_eq!(returned_sighash, sighash);
+    }
+}

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -6,8 +6,8 @@ use zcash_keys::keys::UnifiedSpendingKey;
 use zeroize::Zeroizing;
 use zip32::{fingerprint::SeedFingerprint, AccountId};
 
-use crate::wallet::voting::network::{voting_network, wallet_network};
-use crate::wallet::{keys, sync::open_wallet_db_for_read};
+use crate::wallet::sync::open_wallet_db_for_read;
+use crate::wallet::voting::network::wallet_network;
 
 use super::db::open_voting_db;
 
@@ -74,18 +74,19 @@ where
 ///
 /// Returns an error if round initialization, lightwalletd note selection, or
 /// bundle setup/validation fails.
-#[allow(clippy::too_many_arguments)]
 pub async fn setup_delegation_bundles(
     voting_db: &VotingDb,
     db_path: &str,
-    lightwalletd_url: &str,
-    network: &str,
-    round_params: zcash_voting::VotingRoundParams,
-    round_name: &str,
+    lwd_params: zcash_voting::delegate::ResolveDelegationLwdParams<'_>,
     session_json: Option<&str>,
     bundle_policy: BundlePolicy,
 ) -> Result<zcash_voting::round::BundleLayout, String> {
-    let network = keys::parse_network(network)?;
+    let zcash_voting::delegate::ResolveDelegationLwdParams {
+        lightwalletd_url,
+        network,
+        round_params,
+        round_name,
+    } = lwd_params;
     let round_context = zcash_voting::delegate::ensure_round_context(
         voting_db,
         &round_params,
@@ -97,7 +98,7 @@ pub async fn setup_delegation_bundles(
         voting_db,
         db_path,
         lightwalletd_url,
-        voting_network(network),
+        network,
         round_context.snapshot_height,
     )
     .await

--- a/rust/src/wallet/voting/hotkey.rs
+++ b/rust/src/wallet/voting/hotkey.rs
@@ -1,0 +1,191 @@
+use blake2b_simd::Params;
+use secrecy::{ExposeSecret, SecretVec};
+use zeroize::Zeroizing;
+
+use crate::wallet::network::WalletNetwork;
+use crate::wallet::voting::network::voting_network;
+
+const HOTKEY_CONTEXT_PREFIX: &[u8] = b"ZcashVotingHotkeyV1";
+const HOTKEY_SEED_PERSONALIZATION: &[u8] = b"ZcashVotingHotKy";
+const HOTKEY_SEED_LEN: usize = 64;
+
+/// Derives opaque voting hotkey bytes for a wallet account in a voting round.
+///
+/// `seed` is the platform-owned wallet seed material, while `round_id`,
+/// `account_uuid`, and `network` are the voting context. The same tuple always
+/// returns the same hotkey bytes; changing any tuple member produces
+/// independent material.
+///
+/// The returned secret is not persisted by Rust.
+///
+/// # Errors
+///
+/// Returns an error when `seed` or the voting context cannot be converted into
+/// scoped hotkey material.
+pub fn derive_hotkey(
+    seed: &SecretVec<u8>,
+    round_id: &str,
+    account_uuid: &str,
+    network: WalletNetwork,
+) -> Result<SecretVec<u8>, String> {
+    let hotkey_secret =
+        derive_contextual_hotkey_seed(seed.expose_secret(), round_id, account_uuid, network)?;
+    zcash_voting::hotkey::voting_hotkey_from_seed(
+        hotkey_secret.expose_secret(),
+        voting_network(network),
+    )
+    .map_err(|e| format!("Voting hotkey reconstruction failed: {e}"))?;
+    Ok(hotkey_secret)
+}
+
+/// Wraps hotkey seed bytes and verifies they reconstruct for `network`.
+///
+/// Returns the seed as a `SecretVec` when it is accepted by `zcash_voting`.
+///
+/// # Errors
+///
+/// Returns an error if the seed bytes are not valid hotkey material for the
+/// supplied voting network.
+pub fn validated_hotkey_seed(
+    hotkey_seed: Vec<u8>,
+    network: zcash_voting::Network,
+) -> Result<SecretVec<u8>, String> {
+    let hotkey_secret = SecretVec::new(hotkey_seed);
+    zcash_voting::hotkey::voting_hotkey_from_seed(hotkey_secret.expose_secret(), network)
+        .map_err(|e| format!("Voting hotkey reconstruction failed: {e}"))?;
+    Ok(hotkey_secret)
+}
+
+/// Derives deterministic, round-scoped hotkey seed material from wallet context.
+///
+/// The returned seed is bound to the wallet seed, round ID, account UUID, and
+/// network. It is suitable only after reconstruction succeeds through
+/// `validated_hotkey_seed` or the caller's equivalent validation.
+///
+/// # Errors
+///
+/// Returns an error if the wallet seed is too short or any context field cannot
+/// be length-prefixed for domain-separated hashing.
+fn derive_contextual_hotkey_seed(
+    seed: &[u8],
+    round_id: &str,
+    account_uuid: &str,
+    network: WalletNetwork,
+) -> Result<SecretVec<u8>, String> {
+    if seed.len() < 32 {
+        return Err(format!(
+            "wallet seed must be at least 32 bytes, got {}",
+            seed.len()
+        ));
+    }
+
+    let mut material = Zeroizing::new(Vec::new());
+    material.extend_from_slice(HOTKEY_CONTEXT_PREFIX);
+    append_context_part(&mut material, seed)?;
+    append_context_part(&mut material, round_id.as_bytes())?;
+    append_context_part(&mut material, account_uuid.as_bytes())?;
+    append_context_part(&mut material, network_tag(network))?;
+
+    let hash = Params::new()
+        .hash_length(HOTKEY_SEED_LEN)
+        .personal(HOTKEY_SEED_PERSONALIZATION)
+        .hash(&material);
+
+    Ok(SecretVec::new(hash.as_bytes().to_vec()))
+}
+
+fn append_context_part(material: &mut Vec<u8>, part: &[u8]) -> Result<(), String> {
+    let len = u32::try_from(part.len())
+        .map_err(|_| "voting hotkey context part length exceeds u32::MAX".to_string())?;
+    material.extend_from_slice(&len.to_be_bytes());
+    material.extend_from_slice(part);
+    Ok(())
+}
+
+fn network_tag(network: WalletNetwork) -> &'static [u8] {
+    match network {
+        WalletNetwork::Main => b"mainnet",
+        WalletNetwork::Test => b"testnet",
+        WalletNetwork::Regtest => b"regtest",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACCOUNT_UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
+    const OTHER_ACCOUNT_UUID: &str = "550e8400-e29b-41d4-a716-446655440001";
+    const ROUND_ID: &str = "round-1";
+    const OTHER_ROUND_ID: &str = "round-2";
+
+    fn test_seed() -> SecretVec<u8> {
+        SecretVec::new(vec![0xAB; 64])
+    }
+
+    #[test]
+    fn hotkey_determinism() {
+        let seed = test_seed();
+        let expected =
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
+
+        for _ in 0..100 {
+            assert_eq!(
+                derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+                    .unwrap()
+                    .expose_secret(),
+                expected.expose_secret()
+            );
+        }
+    }
+
+    #[test]
+    fn hotkey_round_independence() {
+        let seed = test_seed();
+
+        assert_ne!(
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+                .unwrap()
+                .expose_secret(),
+            derive_hotkey(&seed, OTHER_ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+                .unwrap()
+                .expose_secret()
+        );
+    }
+
+    #[test]
+    fn hotkey_account_independence() {
+        let seed = test_seed();
+
+        assert_ne!(
+            derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest)
+                .unwrap()
+                .expose_secret(),
+            derive_hotkey(&seed, ROUND_ID, OTHER_ACCOUNT_UUID, WalletNetwork::Regtest)
+                .unwrap()
+                .expose_secret()
+        );
+    }
+
+    #[test]
+    fn local_hotkey_seed_matches_legacy_vector() {
+        let seed = test_seed();
+        let local = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
+        let expected = hex::decode(
+            "20e3dada1183f1ef8c797348fd543c7e8f63d9f776ec84183f66845ee2a0b0ec\
+             0a6efc9c803785bb8f07106428e71e1f65066e40052b15844813a1de82f65c7c",
+        )
+        .unwrap();
+
+        assert_eq!(local.expose_secret(), expected.as_slice());
+    }
+
+    #[test]
+    fn hotkey_is_bound_to_network() {
+        let seed = test_seed();
+        let regtest = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Regtest).unwrap();
+        let mainnet = derive_hotkey(&seed, ROUND_ID, ACCOUNT_UUID, WalletNetwork::Main).unwrap();
+
+        assert_ne!(regtest.expose_secret(), mainnet.expose_secret());
+    }
+}

--- a/rust/src/wallet/voting/hotkey.rs
+++ b/rust/src/wallet/voting/hotkey.rs
@@ -5,9 +5,14 @@ use zeroize::Zeroizing;
 use crate::wallet::network::WalletNetwork;
 use crate::wallet::voting::network::voting_network;
 
+/// Domain-separation prefix for wallet-scoped hotkey seed derivation.
 const HOTKEY_CONTEXT_PREFIX: &[u8] = b"ZcashVotingHotkeyV1";
+/// Blake2b personalization string for deterministic hotkey seed hashing.
 const HOTKEY_SEED_PERSONALIZATION: &[u8] = b"ZcashVotingHotKy";
+/// Output length (bytes) of derived hotkey seed material.
 const HOTKEY_SEED_LEN: usize = 64;
+/// Minimum wallet seed bytes accepted by ZIP-32 spending-key derivation.
+const HOTKEY_MIN_WALLET_SEED_LEN: usize = 32;
 
 /// Derives opaque voting hotkey bytes for a wallet account in a voting round.
 ///
@@ -72,9 +77,10 @@ fn derive_contextual_hotkey_seed(
     account_uuid: &str,
     network: WalletNetwork,
 ) -> Result<SecretVec<u8>, String> {
-    if seed.len() < 32 {
+    if seed.len() < HOTKEY_MIN_WALLET_SEED_LEN {
         return Err(format!(
-            "wallet seed must be at least 32 bytes, got {}",
+            "wallet seed must be at least {} bytes, got {}",
+            HOTKEY_MIN_WALLET_SEED_LEN,
             seed.len()
         ));
     }

--- a/rust/src/wallet/voting/network.rs
+++ b/rust/src/wallet/voting/network.rs
@@ -1,0 +1,56 @@
+use crate::wallet::network::WalletNetwork;
+
+/// Convert wallet-network enum values to vote-protocol network values.
+pub(crate) fn voting_network(network: WalletNetwork) -> zcash_voting::Network {
+    match network {
+        WalletNetwork::Main => zcash_voting::Network::Mainnet,
+        WalletNetwork::Test => zcash_voting::Network::Testnet,
+        WalletNetwork::Regtest => zcash_voting::Network::Regtest,
+    }
+}
+
+/// Convert vote-protocol network enum values back to wallet network values.
+pub(crate) fn wallet_network(network: zcash_voting::Network) -> WalletNetwork {
+    match network {
+        zcash_voting::Network::Mainnet => WalletNetwork::Main,
+        zcash_voting::Network::Testnet => WalletNetwork::Test,
+        zcash_voting::Network::Regtest => WalletNetwork::Regtest,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_wallet_network_to_voting_network() {
+        assert_eq!(
+            voting_network(WalletNetwork::Main),
+            zcash_voting::Network::Mainnet
+        );
+        assert_eq!(
+            voting_network(WalletNetwork::Test),
+            zcash_voting::Network::Testnet
+        );
+        assert_eq!(
+            voting_network(WalletNetwork::Regtest),
+            zcash_voting::Network::Regtest
+        );
+    }
+
+    #[test]
+    fn converts_voting_network_to_wallet_network() {
+        assert_eq!(
+            wallet_network(zcash_voting::Network::Mainnet),
+            WalletNetwork::Main
+        );
+        assert_eq!(
+            wallet_network(zcash_voting::Network::Testnet),
+            WalletNetwork::Test
+        );
+        assert_eq!(
+            wallet_network(zcash_voting::Network::Regtest),
+            WalletNetwork::Regtest
+        );
+    }
+}

--- a/rust/src/wallet/voting/test_support.rs
+++ b/rust/src/wallet/voting/test_support.rs
@@ -1,0 +1,35 @@
+#![cfg(test)]
+//! Shared voting test fixtures used across Rust unit tests.
+//!
+//! This module is intentionally test-only so fixture values do not leak into
+//! non-test builds.
+
+pub(crate) const ROUND_ID: &str =
+    "0000000000000000000000000000000000000000000000000000000000000001";
+pub(crate) const TEST_ACCOUNT_UUID: &str = "550e8400-e29b-41d4-a716-446655440000";
+pub(crate) const TEST_MNEMONIC: &str =
+    "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+pub(crate) fn test_api_round_params() -> zcash_voting::wire::VotingRoundParams {
+    zcash_voting::wire::VotingRoundParams {
+        vote_round_id: ROUND_ID.to_string(),
+        snapshot_height: 100,
+        ea_pk: vec![0xEA; 32],
+        nc_root: vec![2; 32],
+        nullifier_imt_root: vec![3; 32],
+    }
+}
+
+pub(crate) fn test_note_info(position: u64) -> zcash_voting::NoteInfo {
+    zcash_voting::NoteInfo {
+        commitment: vec![1; 32],
+        nullifier: vec![2; 32],
+        value: zcash_voting::governance::BALLOT_DIVISOR,
+        position,
+        diversifier: vec![3; 11],
+        rho: vec![4; 32],
+        rseed: vec![5; 32],
+        scope: 0,
+        ufvk_str: "uviewtest".to_string(),
+    }
+}

--- a/test/providers/account_provider_test.dart
+++ b/test/providers/account_provider_test.dart
@@ -2,6 +2,38 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 
 void main() {
+  test('wallet db cleanup paths include main db and voting sidecar files', () {
+    const dbPath = '/tmp/zcash_wallet.db';
+
+    final cleanupPaths = walletDbCleanupPaths(dbPath);
+
+    expect(cleanupPaths, [
+      '/tmp/zcash_wallet.db',
+      '/tmp/zcash_wallet.db-journal',
+      '/tmp/zcash_wallet.db-wal',
+      '/tmp/zcash_wallet.db-shm',
+      '/tmp/zcash_wallet.db.voting',
+      '/tmp/zcash_wallet.db.voting-journal',
+      '/tmp/zcash_wallet.db.voting-wal',
+      '/tmp/zcash_wallet.db.voting-shm',
+    ]);
+  });
+
+  test('wallet db cleanup paths are stable for empty db path', () {
+    final cleanupPaths = walletDbCleanupPaths('');
+
+    expect(cleanupPaths, [
+      '',
+      '-journal',
+      '-wal',
+      '-shm',
+      '.voting',
+      '.voting-journal',
+      '.voting-wal',
+      '.voting-shm',
+    ]);
+  });
+
   test(
     'next active account stays unchanged when removing a non-active account',
     () {


### PR DESCRIPTION


## Summary

- add the FRB/API wiring layer for the Rust voting integration
- includes exactly:
  - `rust/src/api/voting.rs`
  - `rust/src/api/mod.rs` (voting export line)
  - `rust/src/frb_generated.rs`
  - `flutter_rust_bridge.yaml`

## Useful Links

- [Design Document Draft](https://docs.google.com/document/d/1O2l_dfvSNA0lQuM7jApWOcJeDjiSh5eq4rqcoUtwf-0/edit?tab=t.0)
- [Integration README](https://github.com/chainapsis/vizor-wallet/blob/6eb026b61ccb39166caada206a5c11b22332a918/rust/src/wallet/voting/README.md)
- [Voting Library Usage Examples](https://github.com/valargroup/zcash_voting/tree/main/wallet-example/src)
- [Documentation](https://valargroup.gitbook.io/shielded-vote-docs)

## Relevant PRs


Full integration working branch: https://github.com/valargroup/vizor-wallet/pull/1

### PR Splits

Splitting for ease of review

1. https://github.com/chainapsis/vizor-wallet/pull/142
2. https://github.com/chainapsis/vizor-wallet/pull/143

## Notes

- We made it so that Rust FRB code-gen is created from [zcash_voting::wire](https://github.com/valargroup/zcash_voting/blob/main/zcash_voting/src/wire.rs)
- `rust/src/api/voting.rs` is the key file sitting between the wallet UI and the voting library.
- Vizor's Rust layer aims to be state-less and minimal, simply propagating the execution into `zcash_voting`

## Demo

https://github.com/user-attachments/assets/d9390667-95f9-4547-b8f7-16b7a6d1e5ae

## Verification
- [x] `cargo build --manifest-path rust/Cargo.toml`