### PR TITLE
Route voting confirmation tx events through JSON parser

### DIFF
--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -348,7 +348,7 @@ abstract interface class VotingRustApi {
     required String roundId,
     required int bundleIndex,
     required String txHash,
-    required List<rust_voting.TxEvent> events,
+    required String eventsJson,
   });
 
   Future<int> syncVoteTree({
@@ -450,7 +450,7 @@ abstract interface class VotingRustApi {
     required int bundleIndex,
     required int proposalId,
     required String txHash,
-    required List<rust_voting.TxEvent> events,
+    required String eventsJson,
   });
 
   Future<void> recordShareDelegation({
@@ -653,7 +653,7 @@ class FrbVotingRustApi implements VotingRustApi {
     required String roundId,
     required int bundleIndex,
     required String txHash,
-    required List<rust_voting.TxEvent> events,
+    required String eventsJson,
   }) {
     return rust_api.confirmDelegationSubmission(
       dbPath: dbPath,
@@ -661,7 +661,7 @@ class FrbVotingRustApi implements VotingRustApi {
       roundId: roundId,
       bundleIndex: bundleIndex,
       txHash: txHash,
-      events: events,
+      eventsJson: eventsJson,
     );
   }
 
@@ -857,7 +857,7 @@ class FrbVotingRustApi implements VotingRustApi {
     required int bundleIndex,
     required int proposalId,
     required String txHash,
-    required List<rust_voting.TxEvent> events,
+    required String eventsJson,
   }) {
     return rust_api.confirmVoteSubmission(
       dbPath: dbPath,
@@ -866,7 +866,7 @@ class FrbVotingRustApi implements VotingRustApi {
       bundleIndex: bundleIndex,
       proposalId: proposalId,
       txHash: txHash,
-      events: events,
+      eventsJson: eventsJson,
     );
   }
 

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -836,7 +836,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           bundleIndex: key.bundleIndex,
           proposalId: key.proposalId,
           txHash: txHash,
-          events: _txEvents(confirmation),
+          eventsJson: confirmation.eventsJson,
         );
         progress[key] = VotingSessionProgress(
           phase: 'confirmed',
@@ -1567,7 +1567,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         bundleIndex: commitments.bundleIndex,
         proposalId: commitment.proposalId,
         txHash: result.txHash,
-        events: _txEvents(confirmation),
+        eventsJson: confirmation.eventsJson,
       );
       debugPrint(
         '[zcash] Voting: cast-vote confirmed '
@@ -1633,7 +1633,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         roundId: context.round.roundId,
         bundleIndex: bundleIndex,
         txHash: txHash,
-        events: _txEvents(confirmation),
+        eventsJson: confirmation.eventsJson,
       );
       completedBundleIndexes.add(bundleIndex);
       progress[bundleIndex] = VotingSessionProgress(
@@ -1707,7 +1707,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       roundId: context.round.roundId,
       bundleIndex: bundleIndex,
       txHash: result.txHash,
-      events: _txEvents(confirmation),
+      eventsJson: confirmation.eventsJson,
     );
     return (
       txHash: result.txHash,
@@ -2847,22 +2847,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     final decoded = jsonDecode(await wireJson);
     if (decoded is Map<String, dynamic>) return decoded;
     throw const FormatException('Rust voting wire JSON is not an object.');
-  }
-
-  static List<rust_wire.TxEvent> _txEvents(VotingTxConfirmation confirmation) {
-    return [
-      for (final event in confirmation.events)
-        rust_wire.TxEvent(
-          eventType: event.type,
-          attributes: [
-            for (final attribute in event.attributes)
-              rust_wire.TxEventAttribute(
-                key: attribute.key,
-                value: attribute.value,
-              ),
-          ],
-        ),
-    ];
   }
 
   static void _verifyKeystoneDelegationSignature({

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -12,7 +12,7 @@ import '../third_party/zcash_voting/vote.dart';
 import '../third_party/zcash_voting/wire.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `build_vote_commitments_result`, `catch`, `emit_signed_delegation_result`, `emit_signed_vote_result`, `log_sink_closed`, `require_len`, `share_record`
+// These functions are ignored because they are not marked as `pub`: `build_vote_commitments_result`, `catch`, `emit_signed_delegation_result`, `emit_signed_vote_result`, `log_sink_closed`, `parse_tx_events_json`, `require_len`, `share_record`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`
 
 /// Returns the vote-chain delegation submission body as validated wire JSON.
@@ -331,14 +331,14 @@ Future<DelegationConfirmation> confirmDelegationSubmission({
   required String roundId,
   required int bundleIndex,
   required String txHash,
-  required List<TxEvent> events,
+  required String eventsJson,
 }) => RustLib.instance.api.crateApiVotingConfirmDelegationSubmission(
   dbPath: dbPath,
   accountUuid: accountUuid,
   roundId: roundId,
   bundleIndex: bundleIndex,
   txHash: txHash,
-  events: events,
+  eventsJson: eventsJson,
 );
 
 /// Delete bundle rows at or above `keep_count` for partial-bundle recovery.
@@ -509,7 +509,7 @@ Future<VoteConfirmation> confirmVoteSubmission({
   required int bundleIndex,
   required int proposalId,
   required String txHash,
-  required List<TxEvent> events,
+  required String eventsJson,
 }) => RustLib.instance.api.crateApiVotingConfirmVoteSubmission(
   dbPath: dbPath,
   accountUuid: accountUuid,
@@ -517,7 +517,7 @@ Future<VoteConfirmation> confirmVoteSubmission({
   bundleIndex: bundleIndex,
   proposalId: proposalId,
   txHash: txHash,
-  events: events,
+  eventsJson: eventsJson,
 );
 
 /// Record helper-server submission state for one encrypted vote share.

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -162,7 +162,7 @@ abstract class RustLibApi extends BaseApi {
     required String roundId,
     required int bundleIndex,
     required String txHash,
-    required List<TxEvent> events,
+    required String eventsJson,
   });
 
   Future<VoteConfirmation> crateApiVotingConfirmVoteSubmission({
@@ -172,7 +172,7 @@ abstract class RustLibApi extends BaseApi {
     required int bundleIndex,
     required int proposalId,
     required String txHash,
-    required List<TxEvent> events,
+    required String eventsJson,
   });
 
   Future<Uint8List> crateApiSyncCreatePcztFromProposal({
@@ -1171,7 +1171,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String roundId,
     required int bundleIndex,
     required String txHash,
-    required List<TxEvent> events,
+    required String eventsJson,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1182,7 +1182,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(roundId, serializer);
           sse_encode_u_32(bundleIndex, serializer);
           sse_encode_String(txHash, serializer);
-          sse_encode_list_tx_event(events, serializer);
+          sse_encode_String(eventsJson, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1195,7 +1195,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiVotingConfirmDelegationSubmissionConstMeta,
-        argValues: [dbPath, accountUuid, roundId, bundleIndex, txHash, events],
+        argValues: [
+          dbPath,
+          accountUuid,
+          roundId,
+          bundleIndex,
+          txHash,
+          eventsJson,
+        ],
         apiImpl: this,
       ),
     );
@@ -1210,7 +1217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "roundId",
           "bundleIndex",
           "txHash",
-          "events",
+          "eventsJson",
         ],
       );
 
@@ -1222,7 +1229,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required int bundleIndex,
     required int proposalId,
     required String txHash,
-    required List<TxEvent> events,
+    required String eventsJson,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1234,7 +1241,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_32(bundleIndex, serializer);
           sse_encode_u_32(proposalId, serializer);
           sse_encode_String(txHash, serializer);
-          sse_encode_list_tx_event(events, serializer);
+          sse_encode_String(eventsJson, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1254,7 +1261,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           bundleIndex,
           proposalId,
           txHash,
-          events,
+          eventsJson,
         ],
         apiImpl: this,
       ),
@@ -1271,7 +1278,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "bundleIndex",
           "proposalId",
           "txHash",
-          "events",
+          "eventsJson",
         ],
       );
 
@@ -5614,18 +5621,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  List<TxEvent> dco_decode_list_tx_event(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_tx_event).toList();
-  }
-
-  @protected
-  List<TxEventAttribute> dco_decode_list_tx_event_attribute(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    return (raw as List<dynamic>).map(dco_decode_tx_event_attribute).toList();
-  }
-
-  @protected
   List<VoteRecoveryView> dco_decode_list_vote_recovery_view(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_vote_recovery_view).toList();
@@ -6093,30 +6088,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       address: dco_decode_opt_String(arr[2]),
       blockRangeStart: dco_decode_opt_box_autoadd_u_64(arr[3]),
       blockRangeEnd: dco_decode_opt_box_autoadd_u_64(arr[4]),
-    );
-  }
-
-  @protected
-  TxEvent dco_decode_tx_event(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-    return TxEvent(
-      eventType: dco_decode_String(arr[0]),
-      attributes: dco_decode_list_tx_event_attribute(arr[1]),
-    );
-  }
-
-  @protected
-  TxEventAttribute dco_decode_tx_event_attribute(dynamic raw) {
-    // Codec=Dco (DartCObject based), see doc to use other codecs
-    final arr = raw as List<dynamic>;
-    if (arr.length != 2)
-      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
-    return TxEventAttribute(
-      key: dco_decode_String(arr[0]),
-      value: dco_decode_String(arr[1]),
     );
   }
 
@@ -7227,32 +7198,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  List<TxEvent> sse_decode_list_tx_event(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-
-    var len_ = sse_decode_i_32(deserializer);
-    var ans_ = <TxEvent>[];
-    for (var idx_ = 0; idx_ < len_; ++idx_) {
-      ans_.add(sse_decode_tx_event(deserializer));
-    }
-    return ans_;
-  }
-
-  @protected
-  List<TxEventAttribute> sse_decode_list_tx_event_attribute(
-    SseDeserializer deserializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-
-    var len_ = sse_decode_i_32(deserializer);
-    var ans_ = <TxEventAttribute>[];
-    for (var idx_ = 0; idx_ < len_; ++idx_) {
-      ans_.add(sse_decode_tx_event_attribute(deserializer));
-    }
-    return ans_;
-  }
-
-  @protected
   List<VoteRecoveryView> sse_decode_list_vote_recovery_view(
     SseDeserializer deserializer,
   ) {
@@ -7865,22 +7810,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       blockRangeStart: var_blockRangeStart,
       blockRangeEnd: var_blockRangeEnd,
     );
-  }
-
-  @protected
-  TxEvent sse_decode_tx_event(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_eventType = sse_decode_String(deserializer);
-    var var_attributes = sse_decode_list_tx_event_attribute(deserializer);
-    return TxEvent(eventType: var_eventType, attributes: var_attributes);
-  }
-
-  @protected
-  TxEventAttribute sse_decode_tx_event_attribute(SseDeserializer deserializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    var var_key = sse_decode_String(deserializer);
-    var var_value = sse_decode_String(deserializer);
-    return TxEventAttribute(key: var_key, value: var_value);
   }
 
   @protected
@@ -8933,27 +8862,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_list_tx_event(List<TxEvent> self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_i_32(self.length, serializer);
-    for (final item in self) {
-      sse_encode_tx_event(item, serializer);
-    }
-  }
-
-  @protected
-  void sse_encode_list_tx_event_attribute(
-    List<TxEventAttribute> self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_i_32(self.length, serializer);
-    for (final item in self) {
-      sse_encode_tx_event_attribute(item, serializer);
-    }
-  }
-
-  @protected
   void sse_encode_list_vote_recovery_view(
     List<VoteRecoveryView> self,
     SseSerializer serializer,
@@ -9415,23 +9323,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_String(self.address, serializer);
     sse_encode_opt_box_autoadd_u_64(self.blockRangeStart, serializer);
     sse_encode_opt_box_autoadd_u_64(self.blockRangeEnd, serializer);
-  }
-
-  @protected
-  void sse_encode_tx_event(TxEvent self, SseSerializer serializer) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.eventType, serializer);
-    sse_encode_list_tx_event_attribute(self.attributes, serializer);
-  }
-
-  @protected
-  void sse_encode_tx_event_attribute(
-    TxEventAttribute self,
-    SseSerializer serializer,
-  ) {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    sse_encode_String(self.key, serializer);
-    sse_encode_String(self.value, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -277,12 +277,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<TxDataRequest> dco_decode_list_tx_data_request(dynamic raw);
 
   @protected
-  List<TxEvent> dco_decode_list_tx_event(dynamic raw);
-
-  @protected
-  List<TxEventAttribute> dco_decode_list_tx_event_attribute(dynamic raw);
-
-  @protected
   List<VoteRecoveryView> dco_decode_list_vote_recovery_view(dynamic raw);
 
   @protected
@@ -409,12 +403,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   TxDataRequest dco_decode_tx_data_request(dynamic raw);
-
-  @protected
-  TxEvent dco_decode_tx_event(dynamic raw);
-
-  @protected
-  TxEventAttribute dco_decode_tx_event_attribute(dynamic raw);
 
   @protected
   int dco_decode_u_32(dynamic raw);
@@ -776,14 +764,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  List<TxEvent> sse_decode_list_tx_event(SseDeserializer deserializer);
-
-  @protected
-  List<TxEventAttribute> sse_decode_list_tx_event_attribute(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   List<VoteRecoveryView> sse_decode_list_vote_recovery_view(
     SseDeserializer deserializer,
   );
@@ -938,12 +918,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   TxDataRequest sse_decode_tx_data_request(SseDeserializer deserializer);
-
-  @protected
-  TxEvent sse_decode_tx_event(SseDeserializer deserializer);
-
-  @protected
-  TxEventAttribute sse_decode_tx_event_attribute(SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_32(SseDeserializer deserializer);
@@ -1393,15 +1367,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_list_tx_event(List<TxEvent> self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_list_tx_event_attribute(
-    List<TxEventAttribute> self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_list_vote_recovery_view(
     List<VoteRecoveryView> self,
     SseSerializer serializer,
@@ -1589,15 +1554,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_tx_data_request(TxDataRequest self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_tx_event(TxEvent self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_tx_event_attribute(
-    TxEventAttribute self,
-    SseSerializer serializer,
-  );
 
   @protected
   void sse_encode_u_32(int self, SseSerializer serializer);

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -279,12 +279,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<TxDataRequest> dco_decode_list_tx_data_request(dynamic raw);
 
   @protected
-  List<TxEvent> dco_decode_list_tx_event(dynamic raw);
-
-  @protected
-  List<TxEventAttribute> dco_decode_list_tx_event_attribute(dynamic raw);
-
-  @protected
   List<VoteRecoveryView> dco_decode_list_vote_recovery_view(dynamic raw);
 
   @protected
@@ -411,12 +405,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   TxDataRequest dco_decode_tx_data_request(dynamic raw);
-
-  @protected
-  TxEvent dco_decode_tx_event(dynamic raw);
-
-  @protected
-  TxEventAttribute dco_decode_tx_event_attribute(dynamic raw);
 
   @protected
   int dco_decode_u_32(dynamic raw);
@@ -778,14 +766,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  List<TxEvent> sse_decode_list_tx_event(SseDeserializer deserializer);
-
-  @protected
-  List<TxEventAttribute> sse_decode_list_tx_event_attribute(
-    SseDeserializer deserializer,
-  );
-
-  @protected
   List<VoteRecoveryView> sse_decode_list_vote_recovery_view(
     SseDeserializer deserializer,
   );
@@ -940,12 +920,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   TxDataRequest sse_decode_tx_data_request(SseDeserializer deserializer);
-
-  @protected
-  TxEvent sse_decode_tx_event(SseDeserializer deserializer);
-
-  @protected
-  TxEventAttribute sse_decode_tx_event_attribute(SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_32(SseDeserializer deserializer);
@@ -1395,15 +1369,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_list_tx_event(List<TxEvent> self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_list_tx_event_attribute(
-    List<TxEventAttribute> self,
-    SseSerializer serializer,
-  );
-
-  @protected
   void sse_encode_list_vote_recovery_view(
     List<VoteRecoveryView> self,
     SseSerializer serializer,
@@ -1591,15 +1556,6 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_tx_data_request(TxDataRequest self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_tx_event(TxEvent self, SseSerializer serializer);
-
-  @protected
-  void sse_encode_tx_event_attribute(
-    TxEventAttribute self,
-    SseSerializer serializer,
-  );
 
   @protected
   void sse_encode_u_32(int self, SseSerializer serializer);

--- a/lib/src/rust/third_party/zcash_voting/wire.dart
+++ b/lib/src/rust/third_party/zcash_voting/wire.dart
@@ -7,7 +7,7 @@ import '../../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'types.dart';
 
-// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `BoundedU32`, `VoteCommitStage`, `VoteRecord`, `VotingNoteRefView`, `VotingNoteSelectionResultView`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `BoundedU32`, `TxEventAttribute`, `TxEvent`, `VoteCommitStage`, `VoteRecord`, `VotingNoteRefView`, `VotingNoteSelectionResultView`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `try_from`, `try_from`
 
 class CompletedVoteChoiceView {
@@ -667,50 +667,6 @@ class SignedVoteCommitmentsView {
           runtimeType == other.runtimeType &&
           bundleIndex == other.bundleIndex &&
           commitments == other.commitments;
-}
-
-/// One chain transaction event returned by a wallet's chain client.
-class TxEvent {
-  /// Event type, for example `delegate_vote` or `cast_vote`.
-  final String eventType;
-
-  /// Event attributes in the order returned by the chain client.
-  final List<TxEventAttribute> attributes;
-
-  const TxEvent({required this.eventType, required this.attributes});
-
-  @override
-  int get hashCode => eventType.hashCode ^ attributes.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is TxEvent &&
-          runtimeType == other.runtimeType &&
-          eventType == other.eventType &&
-          attributes == other.attributes;
-}
-
-/// One key/value attribute inside a chain transaction event.
-class TxEventAttribute {
-  /// Attribute key.
-  final String key;
-
-  /// Attribute value.
-  final String value;
-
-  const TxEventAttribute({required this.key, required this.value});
-
-  @override
-  int get hashCode => key.hashCode ^ value.hashCode;
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is TxEventAttribute &&
-          runtimeType == other.runtimeType &&
-          key == other.key &&
-          value == other.value;
 }
 
 class VoteCommitmentWire {

--- a/lib/src/services/voting/voting_models.dart
+++ b/lib/src/services/voting/voting_models.dart
@@ -222,7 +222,7 @@ class VotingTxConfirmation {
   final int height;
   final int code;
   final String log;
-  final List<VotingTxEvent> events;
+  final List<Map<String, dynamic>> events;
 
   const VotingTxConfirmation({
     required this.height,
@@ -238,57 +238,32 @@ class VotingTxConfirmation {
       log: _optionalStringFromJson(json, const ['log']) ?? '',
       events: _optionalListFromJson(json, const ['events'])
           .map(_objectFromValue)
-          .map(VotingTxEvent.fromJson)
+          .map(_txEventJsonFromApi)
           .toList(growable: false),
     );
   }
 
-  VotingTxEvent? event(String type) {
-    for (final event in events) {
-      if (event.type == type) return event;
-    }
-    return null;
-  }
+  String get eventsJson => jsonEncode(events);
 }
 
-/// Event emitted by the vote chain for a confirmed voting transaction.
-class VotingTxEvent {
-  final String type;
-  final List<VotingTxEventAttribute> attributes;
-
-  const VotingTxEvent({required this.type, required this.attributes});
-
-  factory VotingTxEvent.fromJson(Map<String, dynamic> json) {
-    return VotingTxEvent(
-      type: _stringFromJson(json, const ['type']),
-      attributes: _optionalListFromJson(json, const ['attributes'])
-          .map(_objectFromValue)
-          .map(VotingTxEventAttribute.fromJson)
-          .toList(growable: false),
-    );
-  }
-
-  String? attribute(String key) {
-    for (final attribute in attributes) {
-      if (attribute.key == key) return attribute.value;
-    }
-    return null;
-  }
+// Validate tx-event fields once and keep only the wire keys Rust consumes.
+Map<String, dynamic> _txEventJsonFromApi(Map<String, dynamic> event) {
+  return <String, dynamic>{
+    'type': _stringFromJson(event, const ['type']),
+    'attributes': _optionalListFromJson(event, const ['attributes'])
+        .map(_objectFromValue)
+        .map(_txEventAttributeJsonFromApi)
+        .toList(growable: false),
+  };
 }
 
-/// Key/value attribute attached to a voting transaction event.
-class VotingTxEventAttribute {
-  final String key;
-  final String value;
-
-  const VotingTxEventAttribute({required this.key, required this.value});
-
-  factory VotingTxEventAttribute.fromJson(Map<String, dynamic> json) {
-    return VotingTxEventAttribute(
-      key: _stringFromJson(json, const ['key']),
-      value: _stringFromJson(json, const ['value']),
-    );
-  }
+Map<String, dynamic> _txEventAttributeJsonFromApi(
+  Map<String, dynamic> attribute,
+) {
+  return <String, dynamic>{
+    'key': _stringFromJson(attribute, const ['key']),
+    'value': _stringFromJson(attribute, const ['value']),
+  };
 }
 
 /// Base URL plus optional label for a vote server or PIR endpoint.

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -903,9 +903,10 @@ pub fn confirm_delegation_submission(
     round_id: String,
     bundle_index: u32,
     tx_hash: String,
-    events: Vec<zcash_voting::wire::TxEvent>,
+    events_json: String,
 ) -> Result<zcash_voting::wire::DelegationConfirmation, String> {
     catch(|| {
+        let events = parse_tx_events_json(&events_json)?;
         // Parse tx events and persist confirmation details for this bundle.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         zcash_voting::confirmation::confirm_delegation_submission(
@@ -1193,9 +1194,10 @@ pub fn confirm_vote_submission(
     bundle_index: u32,
     proposal_id: u32,
     tx_hash: String,
-    events: Vec<zcash_voting::wire::TxEvent>,
+    events_json: String,
 ) -> Result<zcash_voting::wire::VoteConfirmation, String> {
     catch(|| {
+        let events = parse_tx_events_json(&events_json)?;
         // Parse tx events and persist vote confirmation fields.
         let db = db::open_voting_db(&db_path, &account_uuid)?;
         zcash_voting::confirmation::confirm_vote_submission(
@@ -1208,6 +1210,12 @@ pub fn confirm_vote_submission(
         )
         .map_err(|e| e.to_string())
     })
+}
+
+fn parse_tx_events_json(events_json: &str) -> Result<Vec<zcash_voting::wire::TxEvent>, String> {
+    let events: Vec<zcash_voting::wire::TxEvent> =
+        serde_json::from_str(events_json).map_err(|e| format!("invalid tx events JSON: {e}"))?;
+    Ok(events)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1378,16 +1386,39 @@ mod tests {
         base64::engine::general_purpose::STANDARD.encode(bytes)
     }
 
-    fn tx_event(event_type: &str, attributes: &[(&str, &str)]) -> zcash_voting::wire::TxEvent {
+    fn tx_events_json(events: Vec<zcash_voting::wire::TxEvent>) -> String {
+        serde_json::to_string(&events).unwrap()
+    }
+
+    fn delegate_event(round_id: &str, leaf_index: u32) -> zcash_voting::wire::TxEvent {
         zcash_voting::wire::TxEvent {
-            event_type: event_type.to_string(),
-            attributes: attributes
-                .iter()
-                .map(|(key, value)| zcash_voting::wire::TxEventAttribute {
-                    key: (*key).to_string(),
-                    value: (*value).to_string(),
-                })
-                .collect(),
+            event_type: "delegate_vote".to_string(),
+            attributes: vec![
+                zcash_voting::wire::TxEventAttribute {
+                    key: "vote_round_id".to_string(),
+                    value: round_id.to_string(),
+                },
+                zcash_voting::wire::TxEventAttribute {
+                    key: "leaf_index".to_string(),
+                    value: leaf_index.to_string(),
+                },
+            ],
+        }
+    }
+
+    fn cast_vote_event(round_id: &str, van_position: u32, vc_tree_position: u64) -> zcash_voting::wire::TxEvent {
+        zcash_voting::wire::TxEvent {
+            event_type: "cast_vote".to_string(),
+            attributes: vec![
+                zcash_voting::wire::TxEventAttribute {
+                    key: "vote_round_id".to_string(),
+                    value: round_id.to_string(),
+                },
+                zcash_voting::wire::TxEventAttribute {
+                    key: "leaf_index".to_string(),
+                    value: format!("{van_position},{vc_tree_position}"),
+                },
+            ],
         }
     }
 
@@ -2428,10 +2459,7 @@ mod tests {
             ROUND_ID.to_string(),
             0,
             "delegate-confirmed-tx".to_string(),
-            vec![tx_event(
-                "delegate_vote",
-                &[("vote_round_id", ROUND_ID), ("leaf_index", "42")],
-            )],
+            tx_events_json(vec![delegate_event(ROUND_ID, 42)]),
         )
         .unwrap();
         assert_eq!(delegation.tx_hash, "delegate-confirmed-tx");
@@ -2444,10 +2472,7 @@ mod tests {
             0,
             7,
             "vote-confirmed-tx".to_string(),
-            vec![tx_event(
-                "cast_vote",
-                &[("vote_round_id", ROUND_ID), ("leaf_index", "42,88")],
-            )],
+            tx_events_json(vec![cast_vote_event(ROUND_ID, 42, 88)]),
         )
         .unwrap();
         assert_eq!(vote.tx_hash, "vote-confirmed-tx");

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -414,7 +414,7 @@ fn wire__crate__api__voting__confirm_delegation_submission_impl(
             let api_round_id = <String>::sse_decode(&mut deserializer);
             let api_bundle_index = <u32>::sse_decode(&mut deserializer);
             let api_tx_hash = <String>::sse_decode(&mut deserializer);
-            let api_events = <Vec<zcash_voting::wire::TxEvent>>::sse_decode(&mut deserializer);
+            let api_events_json = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -424,7 +424,7 @@ fn wire__crate__api__voting__confirm_delegation_submission_impl(
                         api_round_id,
                         api_bundle_index,
                         api_tx_hash,
-                        api_events,
+                        api_events_json,
                     )?;
                     Ok(output_ok)
                 })())
@@ -460,7 +460,7 @@ fn wire__crate__api__voting__confirm_vote_submission_impl(
             let api_bundle_index = <u32>::sse_decode(&mut deserializer);
             let api_proposal_id = <u32>::sse_decode(&mut deserializer);
             let api_tx_hash = <String>::sse_decode(&mut deserializer);
-            let api_events = <Vec<zcash_voting::wire::TxEvent>>::sse_decode(&mut deserializer);
+            let api_events_json = <String>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -471,7 +471,7 @@ fn wire__crate__api__voting__confirm_vote_submission_impl(
                         api_bundle_index,
                         api_proposal_id,
                         api_tx_hash,
-                        api_events,
+                        api_events_json,
                     )?;
                     Ok(output_ok)
                 })())
@@ -4297,16 +4297,6 @@ const _: fn() = || {
             SignedVoteCommitmentsView.commitments;
     }
     {
-        let TxEvent = None::<zcash_voting::wire::TxEvent>.unwrap();
-        let _: String = TxEvent.event_type;
-        let _: Vec<zcash_voting::wire::TxEventAttribute> = TxEvent.attributes;
-    }
-    {
-        let TxEventAttribute = None::<zcash_voting::wire::TxEventAttribute>.unwrap();
-        let _: String = TxEventAttribute.key;
-        let _: String = TxEventAttribute.value;
-    }
-    {
         let VanWitness = None::<zcash_voting::vote::VanWitness>.unwrap();
         let _: Vec<Vec<u8>> = VanWitness.auth_path;
         let _: u32 = VanWitness.position;
@@ -5182,32 +5172,6 @@ impl SseDecode for Vec<crate::api::sync::TxDataRequest> {
     }
 }
 
-impl SseDecode for Vec<zcash_voting::wire::TxEvent> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut len_ = <i32>::sse_decode(deserializer);
-        let mut ans_ = vec![];
-        for idx_ in 0..len_ {
-            ans_.push(<zcash_voting::wire::TxEvent>::sse_decode(deserializer));
-        }
-        return ans_;
-    }
-}
-
-impl SseDecode for Vec<zcash_voting::wire::TxEventAttribute> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut len_ = <i32>::sse_decode(deserializer);
-        let mut ans_ = vec![];
-        for idx_ in 0..len_ {
-            ans_.push(<zcash_voting::wire::TxEventAttribute>::sse_decode(
-                deserializer,
-            ));
-        }
-        return ans_;
-    }
-}
-
 impl SseDecode for Vec<zcash_voting::wire::VoteRecoveryView> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -5808,31 +5772,6 @@ impl SseDecode for crate::api::sync::TxDataRequest {
             address: var_address,
             block_range_start: var_blockRangeStart,
             block_range_end: var_blockRangeEnd,
-        };
-    }
-}
-
-impl SseDecode for zcash_voting::wire::TxEvent {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_eventType = <String>::sse_decode(deserializer);
-        let mut var_attributes =
-            <Vec<zcash_voting::wire::TxEventAttribute>>::sse_decode(deserializer);
-        return zcash_voting::wire::TxEvent {
-            event_type: var_eventType,
-            attributes: var_attributes,
-        };
-    }
-}
-
-impl SseDecode for zcash_voting::wire::TxEventAttribute {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut var_key = <String>::sse_decode(deserializer);
-        let mut var_value = <String>::sse_decode(deserializer);
-        return zcash_voting::wire::TxEventAttribute {
-            key: var_key,
-            value: var_value,
         };
     }
 }
@@ -7392,48 +7331,6 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::TxDataRequest>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::TxEvent> {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.0.event_type.into_into_dart().into_dart(),
-            self.0.attributes.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for FrbWrapper<zcash_voting::wire::TxEvent>
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::TxEvent>>
-    for zcash_voting::wire::TxEvent
-{
-    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::TxEvent> {
-        self.into()
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
-impl flutter_rust_bridge::IntoDart for FrbWrapper<zcash_voting::wire::TxEventAttribute> {
-    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        [
-            self.0.key.into_into_dart().into_dart(),
-            self.0.value.into_into_dart().into_dart(),
-        ]
-        .into_dart()
-    }
-}
-impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
-    for FrbWrapper<zcash_voting::wire::TxEventAttribute>
-{
-}
-impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::TxEventAttribute>>
-    for zcash_voting::wire::TxEventAttribute
-{
-    fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::TxEventAttribute> {
-        self.into()
-    }
-}
-// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::wallet::keystone::UrDecodeResult {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -8303,26 +8200,6 @@ impl SseEncode for Vec<crate::api::sync::TxDataRequest> {
     }
 }
 
-impl SseEncode for Vec<zcash_voting::wire::TxEvent> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <i32>::sse_encode(self.len() as _, serializer);
-        for item in self {
-            <zcash_voting::wire::TxEvent>::sse_encode(item, serializer);
-        }
-    }
-}
-
-impl SseEncode for Vec<zcash_voting::wire::TxEventAttribute> {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <i32>::sse_encode(self.len() as _, serializer);
-        for item in self {
-            <zcash_voting::wire::TxEventAttribute>::sse_encode(item, serializer);
-        }
-    }
-}
-
 impl SseEncode for Vec<zcash_voting::wire::VoteRecoveryView> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -8735,22 +8612,6 @@ impl SseEncode for crate::api::sync::TxDataRequest {
         <Option<String>>::sse_encode(self.address, serializer);
         <Option<u64>>::sse_encode(self.block_range_start, serializer);
         <Option<u64>>::sse_encode(self.block_range_end, serializer);
-    }
-}
-
-impl SseEncode for zcash_voting::wire::TxEvent {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.event_type, serializer);
-        <Vec<zcash_voting::wire::TxEventAttribute>>::sse_encode(self.attributes, serializer);
-    }
-}
-
-impl SseEncode for zcash_voting::wire::TxEventAttribute {
-    // Codec=Sse (Serialization based), see doc to use other codecs
-    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <String>::sse_encode(self.key, serializer);
-        <String>::sse_encode(self.value, serializer);
     }
 }
 

--- a/test/features/voting/tx_event_json_test_utils.dart
+++ b/test/features/voting/tx_event_json_test_utils.dart
@@ -1,0 +1,87 @@
+import 'dart:convert';
+
+/// Shared test-only helpers for extracting fields from tx-event JSON payloads.
+///
+/// The production voting flow now forwards tx events as raw JSON into Rust for
+/// confirmation parsing. Multiple test suites still need to assert on specific
+/// event attributes (for example `leaf_index`) before/after fake Rust calls.
+/// Keeping this logic in one place avoids copy/paste parsers that can drift.
+int eventIntFromTxEventsJson(
+  String eventsJson,
+  String eventType,
+  String roundId,
+  String key,
+) {
+  final value = eventAttributeFromTxEventsJson(eventsJson, eventType, roundId, key);
+  final parsed = int.tryParse(value ?? '');
+  if (parsed == null) {
+    throw StateError('Missing $eventType $key.');
+  }
+  return parsed;
+}
+
+/// Parses `cast_vote` leaf-index payloads encoded as `"van,vc_tree_position"`.
+({int vanPosition, BigInt vcTreePosition}) castVoteLeafPositionsFromTxEventsJson(
+  String eventsJson,
+  String roundId,
+) {
+  final raw = eventAttributeFromTxEventsJson(
+    eventsJson,
+    'cast_vote',
+    roundId,
+    'leaf_index',
+  );
+  if (raw == null) {
+    throw StateError('Missing cast_vote leaf_index.');
+  }
+  final parts = raw.split(',');
+  if (parts.length != 2) {
+    throw StateError('Malformed cast_vote leaf_index: $raw');
+  }
+  final vanPosition = int.tryParse(parts[0].trim());
+  final vcTreePosition = BigInt.tryParse(parts[1].trim());
+  if (vanPosition == null || vcTreePosition == null) {
+    throw StateError('Malformed cast_vote leaf_index: $raw');
+  }
+  return (vanPosition: vanPosition, vcTreePosition: vcTreePosition);
+}
+
+/// Finds one event attribute by `(eventType, roundId, key)` in tx-event JSON.
+///
+/// `roundId` filtering mirrors confirmation behavior where multiple event kinds
+/// can appear and only the target round's attributes are meaningful.
+String? eventAttributeFromTxEventsJson(
+  String eventsJson,
+  String eventType,
+  String roundId,
+  String key,
+) {
+  final decoded = jsonDecode(eventsJson);
+  if (decoded is! List<dynamic>) return null;
+  for (final event in decoded) {
+    if (event is! Map<String, dynamic>) continue;
+    if (event['type'] != eventType) continue;
+    final eventRoundId = _eventRoundId(event);
+    if (eventRoundId != roundId) continue;
+    final attributes = event['attributes'];
+    if (attributes is! List<dynamic>) continue;
+    for (final attribute in attributes) {
+      if (attribute is! Map<String, dynamic>) continue;
+      if (attribute['key'] == key) return attribute['value'] as String?;
+    }
+  }
+  return null;
+}
+
+String? _eventRoundId(Map<String, dynamic> event) {
+  final attributes = event['attributes'];
+  if (attributes is! List<dynamic>) return null;
+  for (final attribute in attributes) {
+    if (attribute is! Map<String, dynamic>) continue;
+    final key = attribute['key'];
+    if (key == 'vote_round_id' || key == 'round_id') {
+      return attribute['value'] as String?;
+    }
+  }
+  return null;
+}

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -43,13 +43,12 @@ import 'package:zcash_wallet/src/rust/third_party/zcash_voting/vote.dart'
 import 'package:zcash_wallet/src/rust/third_party/zcash_voting/wire.dart'
     as rust_frb_types;
 import 'package:zcash_wallet/src/rust/third_party/zcash_voting/wire.dart'
-    as rust_voting;
-import 'package:zcash_wallet/src/rust/third_party/zcash_voting/wire.dart'
     as rust_wire;
 import 'package:zcash_wallet/src/services/voting/voting_config_loader.dart';
 import 'package:zcash_wallet/src/services/voting/pir_snapshot_resolver.dart';
 
 import 'round_plan_test_utils.dart';
+import 'tx_event_json_test_utils.dart';
 import '../../services/voting/fake_voting_http.dart';
 
 void main() {
@@ -2574,10 +2573,10 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
     required String roundId,
     required int bundleIndex,
     required String txHash,
-    required List<rust_voting.TxEvent> events,
+    required String eventsJson,
   }) async {
-    final vanLeafPosition = _eventInt(
-      events,
+    final vanLeafPosition = eventIntFromTxEventsJson(
+      eventsJson,
       'delegate_vote',
       roundId,
       'leaf_index',
@@ -2805,9 +2804,12 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
     required int bundleIndex,
     required int proposalId,
     required String txHash,
-    required List<rust_voting.TxEvent> events,
+    required String eventsJson,
   }) async {
-    final leafPositions = _castVoteLeafPositions(events, roundId);
+    final leafPositions = castVoteLeafPositionsFromTxEventsJson(
+      eventsJson,
+      roundId,
+    );
     _recordVoteConfirmed(
       bundleIndex: bundleIndex,
       proposalId: proposalId,
@@ -2928,66 +2930,6 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
     );
     recoveryApi.roundPlan = null;
   }
-}
-
-int _eventInt(
-  List<rust_voting.TxEvent> events,
-  String eventType,
-  String roundId,
-  String key,
-) {
-  final value = _eventAttribute(events, eventType, roundId, key);
-  final parsed = int.tryParse(value ?? '');
-  if (parsed == null) {
-    throw StateError('Missing $eventType $key.');
-  }
-  return parsed;
-}
-
-({int vanPosition, BigInt vcTreePosition}) _castVoteLeafPositions(
-  List<rust_voting.TxEvent> events,
-  String roundId,
-) {
-  final raw = _eventAttribute(events, 'cast_vote', roundId, 'leaf_index');
-  if (raw == null) {
-    throw StateError('Missing cast_vote leaf_index.');
-  }
-  final parts = raw.split(',');
-  if (parts.length != 2) {
-    throw StateError('Malformed cast_vote leaf_index: $raw');
-  }
-  final vanPosition = int.tryParse(parts[0].trim());
-  final vcTreePosition = BigInt.tryParse(parts[1].trim());
-  if (vanPosition == null || vcTreePosition == null) {
-    throw StateError('Malformed cast_vote leaf_index: $raw');
-  }
-  return (vanPosition: vanPosition, vcTreePosition: vcTreePosition);
-}
-
-String? _eventAttribute(
-  List<rust_voting.TxEvent> events,
-  String eventType,
-  String roundId,
-  String key,
-) {
-  for (final event in events) {
-    if (event.eventType != eventType) continue;
-    final eventRoundId = _eventRoundId(event);
-    if (eventRoundId != roundId) continue;
-    for (final attribute in event.attributes) {
-      if (attribute.key == key) return attribute.value;
-    }
-  }
-  return null;
-}
-
-String? _eventRoundId(rust_voting.TxEvent event) {
-  for (final attribute in event.attributes) {
-    if (attribute.key == 'vote_round_id' || attribute.key == 'round_id') {
-      return attribute.value;
-    }
-  }
-  return null;
 }
 
 List<int> _bytesFromHex(String hex) {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -33,8 +33,6 @@ import 'package:zcash_wallet/src/rust/third_party/zcash_voting/vote.dart'
 import 'package:zcash_wallet/src/rust/third_party/zcash_voting/wire.dart'
     as rust_frb_types;
 import 'package:zcash_wallet/src/rust/third_party/zcash_voting/wire.dart'
-    as rust_voting;
-import 'package:zcash_wallet/src/rust/third_party/zcash_voting/wire.dart'
     as rust_wire;
 import 'package:zcash_wallet/src/services/voting/pir_snapshot_resolver.dart';
 import 'package:zcash_wallet/src/services/voting/voting_config_loader.dart';
@@ -42,6 +40,7 @@ import 'package:zcash_wallet/src/services/voting/voting_http.dart';
 import 'package:zcash_wallet/src/services/voting/voting_models.dart';
 
 import '../../features/voting/round_plan_test_utils.dart';
+import '../../features/voting/tx_event_json_test_utils.dart';
 import '../../services/voting/fake_voting_http.dart';
 
 void main() {
@@ -4207,10 +4206,10 @@ class FakeVotingRustApi implements VotingRustApi {
     required String roundId,
     required int bundleIndex,
     required String txHash,
-    required List<rust_voting.TxEvent> events,
+    required String eventsJson,
   }) async {
-    final vanLeafPosition = _eventInt(
-      events,
+    final vanLeafPosition = eventIntFromTxEventsJson(
+      eventsJson,
       'delegate_vote',
       roundId,
       'leaf_index',
@@ -4526,9 +4525,12 @@ class FakeVotingRustApi implements VotingRustApi {
     required int bundleIndex,
     required int proposalId,
     required String txHash,
-    required List<rust_voting.TxEvent> events,
+    required String eventsJson,
   }) async {
-    final leafPositions = _castVoteLeafPositions(events, roundId);
+    final leafPositions = castVoteLeafPositionsFromTxEventsJson(
+      eventsJson,
+      roundId,
+    );
     _recordVoteConfirmed(
       bundleIndex: bundleIndex,
       proposalId: proposalId,
@@ -4592,66 +4594,6 @@ void _addUnique<T>(List<T> values, T value) {
   if (!values.contains(value)) {
     values.add(value);
   }
-}
-
-int _eventInt(
-  List<rust_voting.TxEvent> events,
-  String eventType,
-  String roundId,
-  String key,
-) {
-  final value = _eventAttribute(events, eventType, roundId, key);
-  final parsed = int.tryParse(value ?? '');
-  if (parsed == null) {
-    throw StateError('Missing $eventType $key.');
-  }
-  return parsed;
-}
-
-({int vanPosition, BigInt vcTreePosition}) _castVoteLeafPositions(
-  List<rust_voting.TxEvent> events,
-  String roundId,
-) {
-  final raw = _eventAttribute(events, 'cast_vote', roundId, 'leaf_index');
-  if (raw == null) {
-    throw StateError('Missing cast_vote leaf_index.');
-  }
-  final parts = raw.split(',');
-  if (parts.length != 2) {
-    throw StateError('Malformed cast_vote leaf_index: $raw');
-  }
-  final vanPosition = int.tryParse(parts[0].trim());
-  final vcTreePosition = BigInt.tryParse(parts[1].trim());
-  if (vanPosition == null || vcTreePosition == null) {
-    throw StateError('Malformed cast_vote leaf_index: $raw');
-  }
-  return (vanPosition: vanPosition, vcTreePosition: vcTreePosition);
-}
-
-String? _eventAttribute(
-  List<rust_voting.TxEvent> events,
-  String eventType,
-  String roundId,
-  String key,
-) {
-  for (final event in events) {
-    if (event.eventType != eventType) continue;
-    final eventRoundId = _eventRoundId(event);
-    if (eventRoundId != roundId) continue;
-    for (final attribute in event.attributes) {
-      if (attribute.key == key) return attribute.value;
-    }
-  }
-  return null;
-}
-
-String? _eventRoundId(rust_voting.TxEvent event) {
-  for (final attribute in event.attributes) {
-    if (attribute.key == 'vote_round_id' || attribute.key == 'round_id') {
-      return attribute.value;
-    }
-  }
-  return null;
 }
 
 class _RecordedShare {

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -497,7 +497,10 @@ void main() {
     final confirmation = await client.getTxConfirmation('delegation-tx');
 
     expect(confirmation?.height, 12);
-    expect(confirmation?.event('delegate_vote')?.attribute('leaf_index'), '3');
+    expect(
+      confirmation?.events.single['attributes'].single['value'],
+      '3',
+    );
   });
 
   test('rejects malformed transaction confirmation bodies', () async {


### PR DESCRIPTION
## Summary
- switch vote/delegation confirmation APIs from structured `TxEvent` lists to `eventsJson` payloads
- parse tx events in Rust from canonical wire JSON and thread that through FRB bindings
- update provider/session call sites and tests to cover JSON-based tx-event confirmation flows

## Test plan
- [ ] fvm flutter test test/services/voting/voting_api_client_test.dart
- [ ] fvm flutter test test/providers/voting/voting_providers_test.dart