### PR TITLE
Apply voting domain review fixes

### DIFF
--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -85,16 +85,13 @@ class _VotingProposalDetailScreenState
                 : ref.watch(votingDraftProvider(draftKey));
             final proposals = proposalsFromRound(round);
             final completedVote = draft.isEmpty
-                ? _CompletedVote.fromPlan(state.resumePlan, state.roundPlan)
+                ? _CompletedVote.fromPlan(state.roundPlan)
                 : null;
             _maybePrepareVotingPower(state);
             // Foreground recovery takes precedence over the read-only voted view.
             // Accepted helper shares may still be tracked after submission, but
             // that background work should not keep this screen resumable.
-            if (hasBlockingRoundRecoveryWork(
-              roundPlan: state.roundPlan,
-              resumePlan: state.resumePlan,
-            )) {
+            if (hasBlockingRoundRecoveryWork(state.roundPlan)) {
               return Padding(
                 padding: const EdgeInsets.all(AppSpacing.md),
                 child: _PendingVoteContent(
@@ -1185,13 +1182,9 @@ class _CompletedVote {
   final Map<int, int?> choicesByProposalId;
   final DateTime? votedAt;
 
-  static _CompletedVote? fromPlan(
-    VotingResumePlan? plan,
-    rust_wire.RoundPlanView? roundPlan,
-  ) {
+  static _CompletedVote? fromPlan(rust_wire.RoundPlanView? roundPlan) {
     final display = roundPlan?.completedVoteDisplay;
-    if (display == null ||
-        !hasCompletedVoteForDisplay(roundPlan: roundPlan, resumePlan: plan)) {
+    if (display == null || !hasCompletedVoteForDisplay(roundPlan)) {
       return null;
     }
     final choices = {

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -135,10 +135,7 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
 
   bool _hasCompletedSubmission(VotingSessionState? session) {
     if (session == null) return false;
-    return hasCompletedVoteForDisplay(
-      roundPlan: session.roundPlan,
-      resumePlan: session.resumePlan,
-    );
+    return hasCompletedVoteForDisplay(session.roundPlan);
   }
 
   String _messageFromError(Object error) {

--- a/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
+++ b/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
@@ -54,10 +54,7 @@ class VotingSubmissionConfirmationScreen extends ConsumerWidget {
                 final pollTitle = state.round?.title.isNotEmpty == true
                     ? state.round!.title
                     : 'Coinholder poll';
-                if (!hasCompletedVoteForDisplay(
-                  roundPlan: state.roundPlan,
-                  resumePlan: state.resumePlan,
-                )) {
+                if (!hasCompletedVoteForDisplay(state.roundPlan)) {
                   return _ConfirmationScaffold(
                     confirmed: false,
                     title: 'Submission not complete',

--- a/lib/src/features/voting/voting_flow_models.dart
+++ b/lib/src/features/voting/voting_flow_models.dart
@@ -75,7 +75,7 @@ class VotingDraftNotifier extends Notifier<VotingDraftState> {
   final VotingSessionKey key;
   Future<VotingDraftState>? _loadFuture;
   bool _loaded = false;
-  bool _mutatedBeforeLoad = false;
+  final Map<int, int?> _pendingBeforeLoad = {};
 
   @override
   VotingDraftState build() {
@@ -89,31 +89,55 @@ class VotingDraftNotifier extends Notifier<VotingDraftState> {
   }
 
   void setChoice(int proposalId, int choice) {
-    _mutatedBeforeLoad = !_loaded;
     final next = state.setChoice(proposalId, choice);
     state = next;
-    unawaited(_persist(next));
+    if (_loaded) {
+      unawaited(_persist(next));
+    } else {
+      _pendingBeforeLoad[proposalId] = choice;
+    }
   }
 
   void clearChoice(int proposalId) {
-    _mutatedBeforeLoad = !_loaded;
     final next = state.clearChoice(proposalId);
     state = next;
-    unawaited(_persist(next));
+    if (_loaded) {
+      unawaited(_persist(next));
+    } else {
+      _pendingBeforeLoad[proposalId] = null;
+    }
   }
 
   Future<VotingDraftState> _loadPersisted() async {
     final persisted = await ref.read(votingDraftPersistenceProvider).load(key);
     _loaded = true;
-    if (!_mutatedBeforeLoad && ref.mounted) {
-      state = persisted;
-      return persisted;
+    final hadPendingBeforeLoad = _pendingBeforeLoad.isNotEmpty;
+    final next = hadPendingBeforeLoad
+        ? _applyPendingBeforeLoad(persisted)
+        : persisted;
+    _pendingBeforeLoad.clear();
+    if (ref.mounted) {
+      state = next;
+      if (hadPendingBeforeLoad) {
+        unawaited(_persist(next));
+      }
     }
-    return state;
+    return next;
   }
 
   Future<void> _persist(VotingDraftState draft) {
     return ref.read(votingDraftPersistenceProvider).save(key, draft);
+  }
+
+  VotingDraftState _applyPendingBeforeLoad(VotingDraftState base) {
+    var next = base;
+    for (final entry in _pendingBeforeLoad.entries) {
+      final choice = entry.value;
+      next = choice == null
+          ? next.clearChoice(entry.key)
+          : next.setChoice(entry.key, choice);
+    }
+    return next;
   }
 }
 

--- a/lib/src/features/voting/voting_flow_models.dart
+++ b/lib/src/features/voting/voting_flow_models.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/storage/app_secure_store.dart';
 import '../../providers/voting/voting_state.dart';
+import '../../rust/third_party/zcash_voting/wire.dart' as rust_voting;
 
 const int _minProposalId = 1;
 const int _maxProposalId = 15;
@@ -65,6 +66,23 @@ class VotingDraftState {
   VotingDraftState clearChoice(int proposalId) {
     final nextChoices = Map<int, int>.from(choices)..remove(proposalId);
     return VotingDraftState(choices: nextChoices);
+  }
+
+  List<rust_voting.DraftVote> toDraftVotes(
+    List<VotingProposalView> proposals, {
+    bool singleShare = false,
+  }) {
+    return [
+      for (final proposal in proposals)
+        if (choices[proposal.id] != null)
+          rust_voting.DraftVote(
+            proposalId: proposal.id,
+            choice: choices[proposal.id]!,
+            numOptions: proposal.options.length,
+            vcTreePosition: BigInt.zero,
+            singleShare: singleShare,
+          ),
+    ];
   }
 }
 

--- a/lib/src/features/voting/voting_flow_models.dart
+++ b/lib/src/features/voting/voting_flow_models.dart
@@ -202,8 +202,7 @@ List<VotingProposalView> proposalsFromRound(VotingRoundDetails round) {
 }
 
 List<VotingProposalView> proposalsFromJson(Map<String, dynamic> json) {
-  final value =
-      json['proposals'] ?? json['questions'] ?? json['ballot'] ?? const [];
+  final value = json['proposals'];
   final values = value is List ? value : const [];
   return [
     for (var i = 0; i < values.length; i++)
@@ -216,7 +215,7 @@ VotingProposalView _proposalFromJson(
   required int fallbackId,
 }) {
   final id = _proposalIdFromJson(json);
-  final optionsJson = json['options'] ?? json['choices'] ?? const [];
+  final optionsJson = json['options'] ?? const [];
   final options = optionsJson is List
       ? [
           for (var i = 0; i < optionsJson.length; i++)
@@ -226,10 +225,8 @@ VotingProposalView _proposalFromJson(
   return VotingProposalView(
     id: id,
     title:
-        _stringFromJson(json, const ['title', 'name', 'question']) ??
-        'Proposal ${fallbackId + 1}',
-    description:
-        _stringFromJson(json, const ['description', 'body', 'summary']) ?? '',
+        _stringFromJson(json, const ['title']) ?? 'Proposal ${fallbackId + 1}',
+    description: _stringFromJson(json, const ['description']) ?? '',
     options: options.isEmpty
         ? const [
             VotingOptionView(index: 0, label: 'Yes'),
@@ -240,28 +237,24 @@ VotingProposalView _proposalFromJson(
 }
 
 int _proposalIdFromJson(Map<String, dynamic> json) {
-  final id = _intFromJson(json, const ['proposal_id', 'proposalId', 'id']);
+  final id = _intFromJson(json, const ['id']);
   if (id == null) {
-    throw const FormatException('Missing required int: proposal_id');
+    throw const FormatException('Missing required int: id');
   }
   if (id < _minProposalId || id > _maxProposalId) {
     throw FormatException(
-      'proposal_id must be $_minProposalId..$_maxProposalId, got $id',
+      'id must be $_minProposalId..$_maxProposalId, got $id',
     );
   }
   return id;
 }
 
 VotingOptionView _optionFromJson(Object? value, {required int fallbackIndex}) {
-  if (value is String) {
-    return VotingOptionView(index: fallbackIndex, label: value);
-  }
   final json = _objectFromValue(value);
   return VotingOptionView(
-    index: _intFromJson(json, const ['index', 'choice', 'id']) ?? fallbackIndex,
+    index: _intFromJson(json, const ['index']) ?? fallbackIndex,
     label:
-        _stringFromJson(json, const ['label', 'title', 'name']) ??
-        'Option ${fallbackIndex + 1}',
+        _stringFromJson(json, const ['label']) ?? 'Option ${fallbackIndex + 1}',
   );
 }
 

--- a/lib/src/features/voting/voting_flow_models.dart
+++ b/lib/src/features/voting/voting_flow_models.dart
@@ -4,7 +4,6 @@ import 'dart:convert';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/storage/app_secure_store.dart';
-import '../../rust/third_party/zcash_voting/wire.dart' as rust_voting;
 import '../../providers/voting/voting_state.dart';
 
 const int _minProposalId = 1;
@@ -66,23 +65,6 @@ class VotingDraftState {
   VotingDraftState clearChoice(int proposalId) {
     final nextChoices = Map<int, int>.from(choices)..remove(proposalId);
     return VotingDraftState(choices: nextChoices);
-  }
-
-  List<rust_voting.DraftVote> toDraftVotes(
-    List<VotingProposalView> proposals, {
-    bool singleShare = false,
-  }) {
-    return [
-      for (final proposal in proposals)
-        if (choices[proposal.id] != null)
-          rust_voting.DraftVote(
-            proposalId: proposal.id,
-            choice: choices[proposal.id]!,
-            numOptions: proposal.options.length,
-            vcTreePosition: BigInt.zero,
-            singleShare: singleShare,
-          ),
-    ];
   }
 }
 
@@ -281,8 +263,13 @@ int? _intFromJson(Map<String, dynamic> json, List<String> keys) {
     final value = json[key];
     if (value == null) continue;
     if (value is int) return value;
-    if (value is num) return value.toInt();
-    return int.tryParse(value.toString());
+    if (value is num) {
+      if (value.isFinite && value == value.truncateToDouble()) {
+        return value.toInt();
+      }
+      throw FormatException('$key must be an integer');
+    }
+    return int.parse(value.toString());
   }
   return null;
 }

--- a/lib/src/features/voting/voting_recovery_service.dart
+++ b/lib/src/features/voting/voting_recovery_service.dart
@@ -5,8 +5,9 @@ import 'voting_resume_plan.dart';
 /// Converts persisted Rust recovery records into Dart actions for resuming UI.
 ///
 /// Rust owns the durable voting database. This service keeps the Dart side
-/// focused on orchestration: deciding which bundle/proposal/share steps still
-/// need network work and clearing recovery records only at explicit boundaries.
+/// focused on orchestration: loading the crate planner, keying raw recovery
+/// records by bundle/proposal/share, and clearing recovery records only at
+/// explicit boundaries.
 class VotingRecoveryService {
   final VotingRecoveryApi _api;
 
@@ -53,7 +54,7 @@ class VotingRecoveryService {
     );
   }
 
-  /// Loads the raw round recovery state and derives the next resume actions.
+  /// Loads the raw round recovery state and indexes records for exact retries.
   Future<VotingResumePlan> loadResumePlan({
     required String dbPath,
     required String accountUuid,
@@ -68,7 +69,7 @@ class VotingRecoveryService {
     return buildResumePlan(state);
   }
 
-  /// Builds a deterministic view of incomplete delegation, vote, and share work.
+  /// Builds a deterministic keyed view of delegation, vote, and share records.
   ///
   /// Bundle/proposal pairs are keyed together because voting is bundle-indexed:
   /// one proposal can have independent state for each note bundle.

--- a/lib/src/features/voting/voting_resume_plan.dart
+++ b/lib/src/features/voting/voting_resume_plan.dart
@@ -15,20 +15,12 @@ abstract final class VotingWorkflowPhase {
   static const confirmed = 'confirmed';
 }
 
-bool hasBlockingRoundRecoveryWork({
-  required rust_wire.RoundPlanView? roundPlan,
-  required VotingResumePlan? resumePlan,
-}) {
-  return roundPlan?.blockingRecovery ??
-      (resumePlan?.hasBlockingCompletedVoteDisplay ?? false);
+bool hasBlockingRoundRecoveryWork(rust_wire.RoundPlanView? roundPlan) {
+  return roundPlan?.blockingRecovery ?? false;
 }
 
-bool hasCompletedVoteForDisplay({
-  required rust_wire.RoundPlanView? roundPlan,
-  required VotingResumePlan? resumePlan,
-}) {
-  return roundPlan?.completedForDisplay ??
-      (resumePlan?.hasCompletedVoteForDisplay ?? false);
+bool hasCompletedVoteForDisplay(rust_wire.RoundPlanView? roundPlan) {
+  return roundPlan?.completedForDisplay ?? false;
 }
 
 bool roundPlanNeedsDraftSetup(rust_wire.RoundPlanView? roundPlan) {
@@ -61,11 +53,11 @@ class VotingVoteKey {
       'VotingVoteKey(bundleIndex: $bundleIndex, proposalId: $proposalId)';
 }
 
-/// Immutable summary of what the app should resume for a voting round.
+/// Immutable keyed view of persisted recovery records for a voting round.
 ///
-/// The plan preserves the raw recovery state for details, but exposes sorted
-/// indexes and maps for the UI/state machine so resume work happens in a stable
-/// order after app restarts.
+/// The crate `RoundPlanView` decides high-level recovery and display state. This
+/// object preserves raw records in stable order so Dart can retry the exact
+/// bundle/proposal/share work selected by that plan.
 class VotingResumePlan {
   final rust_wire.RoundRecoveryStateView recoveryState;
   final UnmodifiableListView<int> pendingDelegationBundleIndexes;
@@ -133,37 +125,12 @@ class VotingResumePlan {
 
   int get bundleCount => recoveryState.bundleCount;
 
-  /// Shares already accepted by at least one helper are tracked for later
-  /// confirmation, but they should not keep the foreground submission screen
-  /// blocked.
+  /// Shares with no accepted helper server still need foreground retry work.
+  ///
+  /// High-level recovery and completed-vote display decisions come from
+  /// [rust_wire.RoundPlanView]. This value is only the local share retry shape.
   bool get hasBlockingShareWork =>
       unconfirmedShareDelegations.any((record) => record.sentToUrls.isEmpty);
-
-  /// True once the local DB contains any artifact from a completed vote path.
-  bool get hasCompletedVoteArtifact =>
-      votesByKey.isNotEmpty ||
-      voteTxHashesByKey.isNotEmpty ||
-      commitmentBundlesByKey.isNotEmpty ||
-      shareDelegations.isNotEmpty;
-
-  /// Blocking work that should suppress the read-only "voted" view.
-  bool get hasBlockingCompletedVoteDisplay =>
-      pendingDelegationBundleIndexes.isNotEmpty ||
-      pendingVoteSubmissionKeys.isNotEmpty ||
-      incompleteVoteRecoveryKeys.isNotEmpty ||
-      hasBlockingShareWork;
-
-  /// Mirrors the proposal-detail screen's completed-vote predicate.
-  bool get hasCompletedVoteForDisplay =>
-      hasCompletedVoteArtifact && !hasBlockingCompletedVoteDisplay;
-
-  /// True when there is still user-visible network or confirmation work.
-  bool get hasPendingWork =>
-      pendingDelegationBundleIndexes.isNotEmpty ||
-      pendingVoteSubmissionKeys.isNotEmpty ||
-      submittedDelegationBundleIndexes.isNotEmpty ||
-      submittedVoteConfirmationKeys.isNotEmpty ||
-      hasBlockingShareWork;
 
   rust_wire.RecoverableCommitmentBundle? commitmentBundleFor(
     VotingVoteKey key,

--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -129,13 +129,7 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
     required String accountUuid,
   }) async {
     final recovery = ref.read(votingRecoveryServiceProvider);
-    final resumePlan = await recovery.loadResumePlan(
-      dbPath: dbPath,
-      accountUuid: accountUuid,
-      roundId: round.roundId,
-    );
     final proposalIds = await _proposalIdsForRound(api, round);
-    var hasBlockingRecovery = false;
     rust_voting.RoundPlanView? roundPlan;
     if (proposalIds.isNotEmpty) {
       try {
@@ -145,10 +139,6 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
           roundId: round.roundId,
           proposalIds: proposalIds,
         );
-        hasBlockingRecovery = hasBlockingRoundRecoveryWork(
-          roundPlan: roundPlan,
-          resumePlan: resumePlan,
-        );
       } catch (error) {
         debugPrint(
           '[zcash] Voting: skipped in-progress lookup for round '
@@ -156,24 +146,16 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
         );
       }
     }
-    if (hasBlockingRecovery) {
+    if (hasBlockingRoundRecoveryWork(roundPlan)) {
       return const _RoundListRecoveryState(voted: false, inProgress: true);
     }
-    if (hasCompletedVoteForDisplay(
-      roundPlan: roundPlan,
-      resumePlan: resumePlan,
-    )) {
+    if (hasCompletedVoteForDisplay(roundPlan)) {
       return const _RoundListRecoveryState(voted: true, inProgress: false);
     }
 
     return _RoundListRecoveryState(
       voted: false,
-      inProgress: roundPlan != null
-          ? roundPlan.blockingRecovery ||
-                (roundPlanNeedsDraftSetup(roundPlan) &&
-                    resumePlan.hasPendingWork)
-          : resumePlan.hasPendingWork ||
-                resumePlan.hasBlockingCompletedVoteDisplay,
+      inProgress: roundPlan?.pendingRecovery ?? false,
     );
   }
 

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -80,7 +80,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       round: context.round,
       resumePlan: context.resumePlan,
       roundPlan: context.roundPlan,
-      phase: _phaseForPlans(context.resumePlan, context.roundPlan),
+      phase: _phaseForPlans(context.roundPlan),
     );
     _shareTrackingTimer?.cancel();
     unawaited(_scheduleShareTracking(context, context.resumePlan));
@@ -213,7 +213,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           round: context.round,
           resumePlan: context.resumePlan,
           roundPlan: context.roundPlan,
-          phase: _phaseForPlans(context.resumePlan, context.roundPlan),
+          phase: _phaseForPlans(context.roundPlan),
         ),
       );
       unawaited(_scheduleShareTracking(context, context.resumePlan));
@@ -1844,17 +1844,14 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
 
       final refreshedPlan = await _loadResumePlan(context);
       final refreshedRoundPlan = await _loadRoundPlan(context);
-      final hasBlockingWork = hasBlockingRoundRecoveryWork(
-        roundPlan: refreshedRoundPlan,
-        resumePlan: refreshedPlan,
-      );
+      final hasBlockingWork = hasBlockingRoundRecoveryWork(refreshedRoundPlan);
       if (!hasBlockingWork) {
         await _clearPersistedDraftChoices(context);
       }
       _setStateForContext(
         context,
         (state.value ?? current).copyWith(
-          phase: _phaseForPlans(refreshedPlan, refreshedRoundPlan),
+          phase: _phaseForPlans(refreshedRoundPlan),
           resumePlan: refreshedPlan,
           roundPlan: refreshedRoundPlan,
         ),
@@ -2720,40 +2717,16 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     }
   }
 
-  static VotingSessionPhase _phaseForPlans(
-    VotingResumePlan plan,
-    rust_wire.RoundPlanView? roundPlan,
-  ) {
-    if (roundPlan != null) {
-      switch (roundPlan.primaryAction) {
-        case 'done':
-          return VotingSessionPhase.done;
-        case 'delegate':
-          return VotingSessionPhase.readyToDelegate;
-        case 'vote':
-          return VotingSessionPhase.readyToVote;
-        case 'submit_shares':
-          return VotingSessionPhase.submittingShares;
-      }
-    }
-    return _phaseForResumePlan(plan);
-  }
-
-  static VotingSessionPhase _phaseForResumePlan(VotingResumePlan plan) {
-    if (plan.pendingDelegationBundleIndexes.isNotEmpty ||
-        plan.submittedDelegationBundleIndexes.isNotEmpty) {
-      return VotingSessionPhase.readyToDelegate;
-    }
-    if (plan.pendingVoteSubmissionKeys.isNotEmpty ||
-        plan.submittedVoteConfirmationKeys.isNotEmpty ||
-        plan.incompleteVoteRecoveryKeys.isNotEmpty) {
-      return VotingSessionPhase.readyToVote;
-    }
-    if (plan.hasBlockingShareWork) {
-      return VotingSessionPhase.submittingShares;
-    }
-    if (plan.hasCompletedVoteArtifact) {
-      return VotingSessionPhase.done;
+  static VotingSessionPhase _phaseForPlans(rust_wire.RoundPlanView? roundPlan) {
+    switch (roundPlan?.primaryAction) {
+      case 'done':
+        return VotingSessionPhase.done;
+      case 'delegate':
+        return VotingSessionPhase.readyToDelegate;
+      case 'vote':
+        return VotingSessionPhase.readyToVote;
+      case 'submit_shares':
+        return VotingSessionPhase.submittingShares;
     }
     return VotingSessionPhase.idle;
   }

--- a/lib/src/providers/voting/voting_state.dart
+++ b/lib/src/providers/voting/voting_state.dart
@@ -449,7 +449,12 @@ int _intFromJson(Map<String, dynamic> json, List<String> keys) {
     final value = json[key];
     if (value == null) continue;
     if (value is int) return value;
-    if (value is num) return value.toInt();
+    if (value is num) {
+      if (value.isFinite && value == value.truncateToDouble()) {
+        return value.toInt();
+      }
+      throw FormatException('$key must be an integer');
+    }
     return int.parse(value.toString());
   }
   throw FormatException('Missing required int: ${keys.first}');

--- a/lib/src/providers/voting/voting_state.dart
+++ b/lib/src/providers/voting/voting_state.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import '../../core/formatting/date_format.dart';
-import '../../core/formatting/hex_codec.dart';
 import '../../features/voting/voting_resume_plan.dart';
 import '../../rust/third_party/zcash_voting/delegate.dart' as rust_delegate;
 import '../../rust/third_party/zcash_voting/wire.dart' as rust_wire;
@@ -159,16 +158,14 @@ class VotingRoundDetails {
     final json = status.rawJson;
     return VotingRoundDetails(
       roundId: status.roundId,
-      title: _optionalStringFromJson(json, const ['title', 'name']) ?? '',
+      title: _optionalStringFromJson(json, const ['title']) ?? '',
       status: status.status,
       snapshotHeight: _intFromJson(json, const ['snapshot_height']),
-      eaPk: _bytesFromJson(json, const ['ea_pk', 'eaPk']),
-      ncRoot: _bytesFromJson(json, const ['nc_root', 'ncRoot']),
-      nullifierImtRoot: _bytesFromJson(json, const [
+      eaPk: _fixedBytesFromJson(json, const ['ea_pk'], 32),
+      ncRoot: _fixedBytesFromJson(json, const ['nc_root'], 32),
+      nullifierImtRoot: _fixedBytesFromJson(json, const [
         'nullifier_imt_root',
-        'nullifierIMTRoot',
-        'nullifierImtRoot',
-      ]),
+      ], 32),
       rawJson: json,
     );
   }
@@ -462,11 +459,23 @@ int _intFromJson(Map<String, dynamic> json, List<String> keys) {
 
 Uint8List _bytesFromJson(Map<String, dynamic> json, List<String> keys) {
   final value = _stringFromJson(json, keys);
-  final hex = value.startsWith('0x') ? value.substring(2) : value;
-  if (hex.length.isEven && RegExp(r'^[0-9a-fA-F]+$').hasMatch(hex)) {
-    return hexToBytes(hex);
+  try {
+    return Uint8List.fromList(base64Decode(value));
+  } on FormatException catch (error) {
+    throw FormatException('${keys.first} must be base64: ${error.message}');
   }
-  return Uint8List.fromList(base64Decode(value));
+}
+
+Uint8List _fixedBytesFromJson(
+  Map<String, dynamic> json,
+  List<String> keys,
+  int expectedLength,
+) {
+  final bytes = _bytesFromJson(json, keys);
+  if (bytes.length != expectedLength) {
+    throw FormatException('${keys.first} must decode to $expectedLength bytes');
+  }
+  return bytes;
 }
 
 DateTime? _dateFromJson(Map<String, dynamic> json, String key) {

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -838,10 +838,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
 
   bool _hasCompletedSubmission(VotingSessionState? session) {
     if (session == null) return false;
-    return hasCompletedVoteForDisplay(
-      roundPlan: session.roundPlan,
-      resumePlan: session.resumePlan,
-    );
+    return hasCompletedVoteForDisplay(session.roundPlan);
   }
 
   String _messageFromError(Object error) => friendlyVotingErrorMessage(error);

--- a/lib/src/services/voting/voting_models.dart
+++ b/lib/src/services/voting/voting_models.dart
@@ -504,8 +504,8 @@ class VotingRoundSummary {
   factory VotingRoundSummary.fromJson(Map<String, dynamic> json) {
     return VotingRoundSummary(
       roundId: _roundIdFromJson(json),
-      title: _optionalStringFromJson(json, const ['title', 'name']) ?? '',
-      status: _optionalStringFromJson(json, const ['status', 'phase']) ?? '',
+      title: _optionalStringFromJson(json, const ['title']) ?? '',
+      status: _optionalStringFromJson(json, const ['status']) ?? '',
       rawJson: Map.unmodifiable(json),
     );
   }
@@ -526,7 +526,7 @@ class VotingRoundStatus {
   factory VotingRoundStatus.fromJson(Map<String, dynamic> json) {
     return VotingRoundStatus(
       roundId: _roundIdFromJson(json),
-      status: _stringFromJson(json, const ['status', 'phase']),
+      status: _stringFromJson(json, const ['status']),
       rawJson: Map.unmodifiable(json),
     );
   }

--- a/test/features/voting/voting_flow_models_test.dart
+++ b/test/features/voting/voting_flow_models_test.dart
@@ -63,6 +63,23 @@ void main() {
     );
   });
 
+  test('proposal parser rejects fractional proposal ids', () {
+    expect(
+      () => proposalsFromJson({
+        'proposals': [
+          {'proposal_id': 1.9, 'title': 'Fractional'},
+        ],
+      }),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          'proposal_id must be an integer',
+        ),
+      ),
+    );
+  });
+
   test('draft choices can be cleared by proposal id', () {
     final draft = const VotingDraftState()
         .setChoice(1, 0)

--- a/test/features/voting/voting_flow_models_test.dart
+++ b/test/features/voting/voting_flow_models_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
 
@@ -90,4 +93,75 @@ void main() {
     expect(draft.isEmpty, false);
     expect(draft.clearChoice(2).isEmpty, true);
   });
+
+  test('draft notifier merges early edits with persisted choices', () async {
+    final key = const VotingSessionKey(
+      roundId: 'round-1',
+      accountUuid: 'account-1',
+    );
+    final persistence = _DelayedDraftPersistence();
+    final container = ProviderContainer(
+      overrides: [
+        votingDraftPersistenceProvider.overrideWithValue(persistence),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(votingDraftProvider(key));
+    final notifier = container.read(votingDraftProvider(key).notifier);
+    notifier.setChoice(3, 0);
+
+    expect(container.read(votingDraftProvider(key)).choices, {3: 0});
+
+    persistence.completeLoad(const VotingDraftState(choices: {1: 0, 2: 1}));
+    await notifier.ensureLoaded();
+
+    expect(container.read(votingDraftProvider(key)).choices, {
+      1: 0,
+      2: 1,
+      3: 0,
+    });
+    expect(persistence.saved.single.choices, {1: 0, 2: 1, 3: 0});
+  });
+
+  test('draft notifier applies early clears to persisted choices', () async {
+    final key = const VotingSessionKey(
+      roundId: 'round-1',
+      accountUuid: 'account-1',
+    );
+    final persistence = _DelayedDraftPersistence();
+    final container = ProviderContainer(
+      overrides: [
+        votingDraftPersistenceProvider.overrideWithValue(persistence),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(votingDraftProvider(key));
+    final notifier = container.read(votingDraftProvider(key).notifier);
+    notifier.clearChoice(1);
+
+    persistence.completeLoad(const VotingDraftState(choices: {1: 0, 2: 1}));
+    await notifier.ensureLoaded();
+
+    expect(container.read(votingDraftProvider(key)).choices, {2: 1});
+    expect(persistence.saved.single.choices, {2: 1});
+  });
+}
+
+class _DelayedDraftPersistence implements VotingDraftPersistence {
+  final _load = Completer<VotingDraftState>();
+  final saved = <VotingDraftState>[];
+
+  @override
+  Future<VotingDraftState> load(VotingSessionKey key) => _load.future;
+
+  @override
+  Future<void> save(VotingSessionKey key, VotingDraftState draft) async {
+    saved.add(draft);
+  }
+
+  void completeLoad(VotingDraftState draft) {
+    _load.complete(draft);
+  }
 }

--- a/test/features/voting/voting_flow_models_test.dart
+++ b/test/features/voting/voting_flow_models_test.dart
@@ -9,16 +9,19 @@ void main() {
     final proposals = proposalsFromJson({
       'proposals': [
         {
-          'proposal_id': 1,
+          'id': 1,
           'title': 'First',
-          'options': ['Yes', 'No'],
+          'options': [
+            {'index': 0, 'label': 'Yes'},
+            {'index': 1, 'label': 'No'},
+          ],
         },
         {
-          'proposalId': 2,
+          'id': 2,
           'title': 'Second',
-          'choices': [
-            {'id': 0, 'label': 'Abstain'},
-            {'id': 1, 'label': 'Support'},
+          'options': [
+            {'index': 0, 'label': 'Abstain'},
+            {'index': 1, 'label': 'Support'},
           ],
         },
       ],
@@ -43,7 +46,7 @@ void main() {
         isA<FormatException>().having(
           (error) => error.message,
           'message',
-          'Missing required int: proposal_id',
+          'Missing required int: id',
         ),
       ),
     );
@@ -53,14 +56,14 @@ void main() {
     expect(
       () => proposalsFromJson({
         'proposals': [
-          {'proposal_id': 0, 'title': 'Zero'},
+          {'id': 0, 'title': 'Zero'},
         ],
       }),
       throwsA(
         isA<FormatException>().having(
           (error) => error.message,
           'message',
-          'proposal_id must be 1..15, got 0',
+          'id must be 1..15, got 0',
         ),
       ),
     );
@@ -70,14 +73,14 @@ void main() {
     expect(
       () => proposalsFromJson({
         'proposals': [
-          {'proposal_id': 1.9, 'title': 'Fractional'},
+          {'id': 1.9, 'title': 'Fractional'},
         ],
       }),
       throwsA(
         isA<FormatException>().having(
           (error) => error.message,
           'message',
-          'proposal_id must be an integer',
+          'id must be an integer',
         ),
       ),
     );

--- a/test/features/voting/voting_recovery_service_test.dart
+++ b/test/features/voting/voting_recovery_service_test.dart
@@ -22,7 +22,6 @@ void main() {
 
     expect(plan.pendingDelegationBundleIndexes, [0, 1, 2]);
     expect(plan.pendingVoteSubmissionKeys, isEmpty);
-    expect(plan.hasPendingWork, isTrue);
     expect(api.clearCalls, isEmpty);
   });
 
@@ -78,7 +77,6 @@ void main() {
 
       expect(plan.pendingDelegationBundleIndexes, [2]);
       expect(plan.submittedDelegationBundleIndexes, [1]);
-      expect(plan.hasPendingWork, isTrue);
     },
   );
 
@@ -281,20 +279,12 @@ void main() {
 
       expect(plan.unconfirmedShareDelegations, [accepted]);
       expect(plan.hasBlockingShareWork, isFalse);
-      expect(plan.hasPendingWork, isFalse);
     },
   );
 
   test(
     'share-only round planner work does not block accepted share completion',
     () async {
-      final accepted = share(shareIndex: 0, confirmed: false);
-      final plan = VotingRecoveryService().buildResumePlan(
-        recoveryState(
-          shareDelegations: [accepted],
-          unconfirmedShareDelegations: [accepted],
-        ),
-      );
       final roundPlan = apiRoundPlan(
         roundId: 'round-1',
         pendingRecovery: true,
@@ -311,10 +301,7 @@ void main() {
         allDecided: true,
       );
 
-      expect(
-        hasBlockingRoundRecoveryWork(roundPlan: roundPlan, resumePlan: plan),
-        isFalse,
-      );
+      expect(hasBlockingRoundRecoveryWork(roundPlan), isFalse);
     },
   );
 
@@ -335,10 +322,7 @@ void main() {
       allDecided: false,
     );
 
-    expect(
-      hasBlockingRoundRecoveryWork(roundPlan: roundPlan, resumePlan: null),
-      isTrue,
-    );
+    expect(hasBlockingRoundRecoveryWork(roundPlan), isTrue);
   });
 
   test(
@@ -366,7 +350,6 @@ void main() {
 
       expect(plan.unconfirmedShareDelegations, [unaccepted]);
       expect(plan.hasBlockingShareWork, isTrue);
-      expect(plan.hasPendingWork, isTrue);
     },
   );
 

--- a/test/features/voting/voting_state_test.dart
+++ b/test/features/voting/voting_state_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_state.dart';
+import 'package:zcash_wallet/src/services/voting/voting_models.dart';
+
+void main() {
+  test('round details reject fractional snapshot heights', () {
+    final status = VotingRoundStatus(
+      roundId: 'round-1',
+      status: 'active',
+      rawJson: const {'snapshot_height': 100.5},
+    );
+
+    expect(
+      () => VotingRoundDetails.fromStatus(status),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          'message',
+          'snapshot_height must be an integer',
+        ),
+      ),
+    );
+  });
+}

--- a/test/features/voting/voting_state_test.dart
+++ b/test/features/voting/voting_state_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_state.dart';
 import 'package:zcash_wallet/src/services/voting/voting_models.dart';
@@ -7,7 +9,7 @@ void main() {
     final status = VotingRoundStatus(
       roundId: 'round-1',
       status: 'active',
-      rawJson: const {'snapshot_height': 100.5},
+      rawJson: _roundJson(snapshotHeight: 100.5),
     );
 
     expect(
@@ -21,4 +23,49 @@ void main() {
       ),
     );
   });
+
+  test('round details require 32-byte round parameter fields', () {
+    for (final entry in const {
+      'ea_pk': 31,
+      'nc_root': 33,
+      'nullifier_imt_root': 1,
+    }.entries) {
+      final status = VotingRoundStatus(
+        roundId: 'round-1',
+        status: 'active',
+        rawJson: _roundJsonWithField(entry.key, _b64(entry.value)),
+      );
+
+      expect(
+        () => VotingRoundDetails.fromStatus(status),
+        throwsA(
+          isA<FormatException>().having(
+            (error) => error.message,
+            'message',
+            '${entry.key} must decode to 32 bytes',
+          ),
+        ),
+      );
+    }
+  });
 }
+
+Map<String, dynamic> _roundJsonWithField(String key, String value) {
+  return _roundJson()..[key] = value;
+}
+
+Map<String, dynamic> _roundJson({
+  Object snapshotHeight = 100,
+  String? eaPk,
+  String? ncRoot,
+  String? nullifierImtRoot,
+}) {
+  return {
+    'snapshot_height': snapshotHeight,
+    'ea_pk': eaPk ?? _b64(32),
+    'nc_root': ncRoot ?? _b64(32),
+    'nullifier_imt_root': nullifierImtRoot ?? _b64(32),
+  };
+}
+
+String _b64(int byteLength) => base64Encode(List.filled(byteLength, 1));

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -715,16 +715,8 @@ void main() {
 
     final round = _roundStatusJson()
       ..['proposals'] = [
-        {
-          'proposal_id': 1,
-          'title': 'First proposal',
-          'options': ['Yes', 'No'],
-        },
-        {
-          'proposal_id': 2,
-          'title': 'Second proposal',
-          'options': ['Aye', 'Nay', 'Abstain'],
-        },
+        _proposalJson(1, 'First proposal', ['Yes', 'No']),
+        _proposalJson(2, 'Second proposal', ['Aye', 'Nay', 'Abstain']),
       ];
     final http = FakeVotingHttpClient(
       responses: _votingHttpResponses()
@@ -1023,16 +1015,8 @@ void main() {
       ..['status'] = 'closed'
       ..['summary'] = 'Completed poll'
       ..['proposals'] = [
-        {
-          'proposal_id': 1,
-          'title': 'First proposal',
-          'options': ['Yes', 'No'],
-        },
-        {
-          'proposal_id': 2,
-          'title': 'Second proposal',
-          'options': ['Mint', 'Burn'],
-        },
+        _proposalJson(1, 'First proposal', ['Yes', 'No']),
+        _proposalJson(2, 'Second proposal', ['Mint', 'Burn']),
       ];
     final http = FakeVotingHttpClient(
       responses: _votingHttpResponses()
@@ -1133,16 +1117,8 @@ void main() {
 
     final round = _roundStatusJson()
       ..['proposals'] = [
-        {
-          'proposal_id': 1,
-          'title': 'First proposal',
-          'options': ['Yes', 'No'],
-        },
-        {
-          'proposal_id': 2,
-          'title': 'Second proposal',
-          'options': ['Aye', 'Nay'],
-        },
+        _proposalJson(1, 'First proposal', ['Yes', 'No']),
+        _proposalJson(2, 'Second proposal', ['Aye', 'Nay']),
       ];
     final http = FakeVotingHttpClient(
       responses: _votingHttpResponses()
@@ -1196,16 +1172,8 @@ void main() {
 
     final round = _roundStatusJson()
       ..['proposals'] = [
-        {
-          'proposal_id': 1,
-          'title': 'First proposal',
-          'options': ['Yes', 'No'],
-        },
-        {
-          'proposal_id': 2,
-          'title': 'Second proposal',
-          'options': ['Aye', 'Nay', 'Abstain'],
-        },
+        _proposalJson(1, 'First proposal', ['Yes', 'No']),
+        _proposalJson(2, 'Second proposal', ['Aye', 'Nay', 'Abstain']),
       ];
     final http = FakeVotingHttpClient(
       responses: _votingHttpResponses()
@@ -1288,16 +1256,8 @@ void main() {
 
     final round = _roundStatusJson()
       ..['proposals'] = [
-        {
-          'proposal_id': 1,
-          'title': 'First proposal',
-          'options': ['Yes', 'No'],
-        },
-        {
-          'proposal_id': 2,
-          'title': 'Second proposal',
-          'options': ['Aye', 'Nay', 'Abstain'],
-        },
+        _proposalJson(1, 'First proposal', ['Yes', 'No']),
+        _proposalJson(2, 'Second proposal', ['Aye', 'Nay', 'Abstain']),
       ];
     final http = FakeVotingHttpClient(
       responses: _votingHttpResponses()
@@ -1412,16 +1372,8 @@ void main() {
 
     final round = _roundStatusJson()
       ..['proposals'] = [
-        {
-          'proposal_id': 1,
-          'title': 'First proposal',
-          'options': ['Yes', 'No'],
-        },
-        {
-          'proposal_id': 2,
-          'title': 'Second proposal',
-          'options': ['Aye', 'Nay', 'Abstain'],
-        },
+        _proposalJson(1, 'First proposal', ['Yes', 'No']),
+        _proposalJson(2, 'Second proposal', ['Aye', 'Nay', 'Abstain']),
       ];
     final http = FakeVotingHttpClient(
       responses: _votingHttpResponses()
@@ -1943,11 +1895,20 @@ Map<String, dynamic> _roundStatusJson() => {
   'nc_root': _bytes2x32Base64,
   'nullifier_imt_root': _bytes3x32Base64,
   'proposals': [
-    {
-      'proposal_id': 1,
-      'title': 'First proposal',
-      'options': ['Yes', 'No'],
-    },
+    _proposalJson(1, 'First proposal', ['Yes', 'No']),
+  ],
+};
+
+Map<String, dynamic> _proposalJson(
+  int id,
+  String title,
+  List<String> options,
+) => {
+  'id': id,
+  'title': title,
+  'options': [
+    for (var index = 0; index < options.length; index++)
+      {'index': index, 'label': options[index]},
   ],
 };
 

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -194,7 +194,21 @@ void main() {
               dynamicConfigJson(),
           '/shielded-vote/v1/rounds': {
             'rounds': [
-              {'vote_round_id': kRoundId, 'title': 'Poll', 'status': 'active'},
+              {
+                'vote_round_id': kRoundId,
+                'title': 'Poll',
+                'status': 'active',
+                'proposals': [
+                  {
+                    'id': 7,
+                    'title': 'Question',
+                    'options': [
+                      {'index': 0, 'label': 'Yes'},
+                      {'index': 1, 'label': 'No'},
+                    ],
+                  },
+                ],
+              },
             ],
           },
           '/shielded-vote/v1/endorsed-rounds/zodl': {
@@ -280,9 +294,12 @@ void main() {
       final roundStatusWithProposals = roundStatusJson(roundId: kRoundId)
         ..['proposals'] = [
           {
-            'proposal_id': 7,
+            'id': 7,
             'title': 'Question',
-            'options': ['Yes', 'No'],
+            'options': [
+              {'index': 0, 'label': 'Yes'},
+              {'index': 1, 'label': 'No'},
+            ],
           },
         ];
       final http = FakeVotingHttpClient(
@@ -458,7 +475,7 @@ void main() {
     final state = await container.read(votingSessionProvider(kRoundId).future);
 
     expect(state.phase, VotingSessionPhase.idle);
-    expect(state.resumePlan?.hasCompletedVoteArtifact, isFalse);
+    expect(state.roundPlan?.completedVoteArtifact, isFalse);
   });
 
   test('PIR mismatch fails before Rust delegation work is called', () async {


### PR DESCRIPTION
Applies the voting domain and recovery fixes from the downstream review onto the voting UI branch.

The changes make the Rust round plan the source of truth for recovery display, tighten voting domain parsing to the current vote-sdk shape, preserve draft edits made while persisted choices are still loading, and validate round fields before passing them to Rust. This also keeps the target branch-specific provider and UI call sites compiling against those stricter helpers.

Test plan:
- fvm flutter test test/features/voting/voting_flow_models_test.dart test/features/voting/voting_state_test.dart test/services/voting/voting_api_client_test.dart test/services/voting/voting_config_loader_test.dart test/providers/voting/voting_providers_test.dart test/features/voting/voting_status_screen_test.dart
- fvm flutter analyze lib/src/features/voting lib/src/providers/voting lib/src/services/voting test/features/voting test/providers/voting test/services/voting
