### PR TITLE
Apply voting provider review fixes

### DIFF
--- a/lib/src/providers/voting/voting_config_provider.dart
+++ b/lib/src/providers/voting/voting_config_provider.dart
@@ -14,19 +14,33 @@ import 'voting_service_providers.dart';
 /// must fail closed when service discovery is unavailable or malformed.
 class VotingConfigNotifier extends AsyncNotifier<VotingConfig> {
   AppLifecycleListener? _lifecycleListener;
+  int _loadGeneration = 0;
 
   @override
   Future<VotingConfig> build() async {
+    final generation = ++_loadGeneration;
     _lifecycleListener = AppLifecycleListener(onResume: refresh);
     ref.onDispose(() {
+      _loadGeneration++;
       _lifecycleListener?.dispose();
     });
-    return _load();
+    final config = await _load();
+    if (!_isCurrentLoad(generation)) {
+      return state.value ?? config;
+    }
+    return config;
   }
 
   Future<void> refresh() async {
+    final generation = ++_loadGeneration;
     state = const AsyncLoading<VotingConfig>();
-    state = await AsyncValue.guard(_load);
+    final config = await AsyncValue.guard(_load);
+    if (!_isCurrentLoad(generation)) return;
+    state = config;
+  }
+
+  bool _isCurrentLoad(int generation) {
+    return ref.mounted && generation == _loadGeneration;
   }
 
   Future<VotingConfig> _load() async {

--- a/lib/src/providers/voting/voting_config_provider.dart
+++ b/lib/src/providers/voting/voting_config_provider.dart
@@ -24,11 +24,19 @@ class VotingConfigNotifier extends AsyncNotifier<VotingConfig> {
       _loadGeneration++;
       _lifecycleListener?.dispose();
     });
-    final config = await _load();
-    if (!_isCurrentLoad(generation)) {
-      return state.value ?? config;
+    try {
+      final config = await _load();
+      if (!_isCurrentLoad(generation)) {
+        return state.value ?? config;
+      }
+      return config;
+    } catch (_) {
+      if (!_isCurrentLoad(generation)) {
+        final previous = state.value;
+        if (previous != null) return previous;
+      }
+      rethrow;
     }
-    return config;
   }
 
   Future<void> refresh() async {

--- a/lib/src/providers/voting/voting_config_provider.dart
+++ b/lib/src/providers/voting/voting_config_provider.dart
@@ -27,13 +27,12 @@ class VotingConfigNotifier extends AsyncNotifier<VotingConfig> {
     try {
       final config = await _load();
       if (!_isCurrentLoad(generation)) {
-        return state.value ?? config;
+        return _staleLoadResult();
       }
       return config;
     } catch (_) {
       if (!_isCurrentLoad(generation)) {
-        final previous = state.value;
-        if (previous != null) return previous;
+        return _staleLoadResult();
       }
       rethrow;
     }
@@ -49,6 +48,16 @@ class VotingConfigNotifier extends AsyncNotifier<VotingConfig> {
 
   bool _isCurrentLoad(int generation) {
     return ref.mounted && generation == _loadGeneration;
+  }
+
+  VotingConfig _staleLoadResult() {
+    final previous = state.value;
+    if (previous != null) return previous;
+    final error = state.error;
+    if (error != null) {
+      Error.throwWithStackTrace(error, state.stackTrace ?? StackTrace.current);
+    }
+    throw StateError('Ignored stale voting config load.');
   }
 
   Future<VotingConfig> _load() async {

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -739,17 +739,16 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required List<rust_wire.DraftVote> draftVotes,
     List<int>? allProposalIds,
     Map<int, int>? proposalOptionCounts,
+    String? mnemonic,
   }) {
     return _enqueue(() async {
       final current = await future;
       final context = await _loadContext(_roundId);
       await _waitUntilWalletReadyForVoting(context);
-      final hotkeySeed = await ref
-          .read(votingHotkeyStoreProvider)
-          .readHotkey(
-            accountUuid: context.accountUuid,
-            roundId: context.round.roundId,
-          );
+      final hotkeySeed = await _hotkeyForVoteCasting(
+        context,
+        mnemonic: mnemonic,
+      );
       if (hotkeySeed == null) {
         _setError(
           'Voting hotkey is missing. Delegate this round before casting votes.',
@@ -1243,6 +1242,18 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       );
       await _scheduleShareTracking(context, refreshedPlan);
     });
+  }
+
+  Future<List<int>?> _hotkeyForVoteCasting(
+    _VotingSessionContext context, {
+    String? mnemonic,
+  }) async {
+    final existing = await _readStoredHotkey(context);
+    if (existing != null) return existing;
+    if (context.isHardwareAccount || mnemonic == null || mnemonic.isEmpty) {
+      return null;
+    }
+    return _ensureHotkey(context, mnemonic: mnemonic);
   }
 
   Future<List<int>> _ensureHotkey(

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1141,6 +1141,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             }
             final commitments = event.commitments;
             if (commitments != null) {
+              _throwIfContextStale(context, 'vote-commitment-submit');
               final vcTreePositions = await _submitVoteCommitments(
                 context,
                 commitments,

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -320,6 +320,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       final rust = ref.read(votingRustApiProvider);
       final completedBundleIndexes = await _confirmSubmittedDelegations(
         context: context,
+        plan: plan,
         roundPlan: roundPlan,
         progress: progress,
       );
@@ -610,6 +611,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       );
       final completedBundleIndexes = await _confirmSubmittedDelegations(
         context: context,
+        plan: plan,
         roundPlan: roundPlan,
         progress: progress,
       );
@@ -1597,19 +1599,30 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
 
   Future<Set<int>?> _confirmSubmittedDelegations({
     required _VotingSessionContext context,
+    required VotingResumePlan plan,
     required rust_wire.RoundPlanView? roundPlan,
     required Map<int, VotingSessionProgress> progress,
   }) async {
     final api = ref.read(votingApiClientProvider(context.config.apiBaseUrl));
     final rust = ref.read(votingRustApiProvider);
     final completedBundleIndexes = <int>{};
-    final submittedDelegationsByBundle = {
-      for (final work
-          in roundPlan?.recoveredDelegationWork ??
-              const <rust_wire.DelegationRecoveryWorkView>[])
-        if (work.kind == 'poll_delegation' && work.txHash != null)
-          work.bundleIndex: work.txHash!,
-    };
+    final submittedDelegationsByBundle = <int, String>{};
+    for (final work
+        in roundPlan?.recoveredDelegationWork ??
+            const <rust_wire.DelegationRecoveryWorkView>[]) {
+      if (work.kind == 'poll_delegation' && work.txHash != null) {
+        submittedDelegationsByBundle[work.bundleIndex] = work.txHash!;
+      }
+    }
+    for (final record in plan.recoveryState.delegation) {
+      if (record.phase == VotingWorkflowPhase.submittedDelegation &&
+          record.txHash != null) {
+        submittedDelegationsByBundle.putIfAbsent(
+          record.bundleIndex,
+          () => record.txHash!,
+        );
+      }
+    }
     for (final entry in submittedDelegationsByBundle.entries) {
       final bundleIndex = entry.key;
       final txHash = entry.value;

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -374,6 +374,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             'Delegation proof completed without submission payload.',
           );
         }
+        _throwIfContextStale(context, 'delegation-submit');
         final result = await _submitAndConfirmDelegation(
           context: context,
           bundleIndex: bundleIndex,
@@ -685,6 +686,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           signature: signature,
           bundleIndex: bundleIndex,
         );
+        _throwIfContextStale(context, 'keystone-delegation-submit');
         final result = await _submitAndConfirmDelegation(
           context: context,
           bundleIndex: bundleIndex,

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -881,7 +881,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
         if (step.kind == 'delegate') return false;
         if (step.kind == 'poll_delegation') hasSubmittedDelegation = true;
       }
-      return hasSubmittedDelegation;
+      if (hasSubmittedDelegation) return true;
     }
     final resumePlan = session.resumePlan;
     return resumePlan != null &&
@@ -899,8 +899,9 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
   bool _sessionNeedsDelegation(VotingSessionState? session) {
     if (session == null) return false;
     if (_planNeedsDelegation(session.roundPlan)) return true;
-    return session.resumePlan?.pendingDelegationBundleIndexes.isNotEmpty ??
-        false;
+    final plan = session.resumePlan;
+    return (plan?.pendingDelegationBundleIndexes.isNotEmpty ?? false) ||
+        (plan?.submittedDelegationBundleIndexes.isNotEmpty ?? false);
   }
 
   bool _sessionNeedsDelegationSubmission(VotingSessionState? session) {

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -445,36 +445,37 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
         return;
       }
 
-      if (draftVotes.isNotEmpty || needsDelegation) {
-        if (activeSession.isHardwareAccount) {
-          if (needsDelegation) {
-            _storePendingKeystoneState(
-              key: key,
-              generation: generation,
-              draftVotes: draftVotes,
-              intentProposalIds: intentProposalIds,
-              proposalOptionCounts: proposalOptionCounts,
-              pendingRecoveryWithoutDraft:
-                  canRecoverWithoutDraft || canPollDelegationWithoutDraft,
-            );
-            await _submitAfterKeystoneSignatures(
-              sessionNotifier,
-              key: key,
-              generation: generation,
-            );
-          } else {
-            await _submitVotesAndShares(
-              sessionNotifier,
-              key: key,
-              generation: generation,
-              draftVotes: draftVotes,
-              intentProposalIds: intentProposalIds,
-              proposalOptionCounts: proposalOptionCounts,
-              initialSession: activeSession,
-            );
-          }
-          return;
+      if (activeSession.isHardwareAccount &&
+          (draftVotes.isNotEmpty || needsDelegation)) {
+        if (needsDelegation) {
+          _storePendingKeystoneState(
+            key: key,
+            generation: generation,
+            draftVotes: draftVotes,
+            intentProposalIds: intentProposalIds,
+            proposalOptionCounts: proposalOptionCounts,
+            pendingRecoveryWithoutDraft:
+                canRecoverWithoutDraft || canPollDelegationWithoutDraft,
+          );
+          await _submitAfterKeystoneSignatures(
+            sessionNotifier,
+            key: key,
+            generation: generation,
+          );
+        } else {
+          await _submitVotesAndShares(
+            sessionNotifier,
+            key: key,
+            generation: generation,
+            draftVotes: draftVotes,
+            intentProposalIds: intentProposalIds,
+            proposalOptionCounts: proposalOptionCounts,
+            initialSession: activeSession,
+          );
         }
+        return;
+      }
+      if (needsDelegation) {
         final mnemonic = await ref
             .read(accountProvider.notifier)
             .getMnemonicForAccount(key.accountUuid);
@@ -897,12 +898,8 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
 
   bool _sessionNeedsDelegation(VotingSessionState? session) {
     if (session == null) return false;
-    final roundPlan = session.roundPlan;
-    if (_planNeedsDelegation(roundPlan)) return true;
-    if (roundPlan != null && !roundPlanNeedsDraftSetup(roundPlan)) {
-      return false;
-    }
-    return session.resumePlan?.submittedDelegationBundleIndexes.isNotEmpty ??
+    if (_planNeedsDelegation(session.roundPlan)) return true;
+    return session.resumePlan?.pendingDelegationBundleIndexes.isNotEmpty ??
         false;
   }
 

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -692,7 +692,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       _failFromSession(key: key, generation: generation, session: done!);
       return;
     }
-    if (!_hasCompletedSubmission(done)) {
+    if (!_canCompleteSubmission(done)) {
       _scheduleCompletionPoll(key: key, generation: generation);
       return;
     }
@@ -840,7 +840,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
         _failFromSession(key: key, generation: generation, session: session!);
         return;
       }
-      if (_hasCompletedSubmission(session)) {
+      if (_canCompleteSubmission(session)) {
         _completeJob(key: key, generation: generation);
       }
     });
@@ -851,9 +851,10 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     _completionPollTimer = null;
   }
 
-  bool _hasCompletedSubmission(VotingSessionState? session) {
+  bool _canCompleteSubmission(VotingSessionState? session) {
     if (session == null) return false;
-    return hasCompletedVoteForDisplay(session.roundPlan);
+    return hasCompletedVoteForDisplay(session.roundPlan) &&
+        !_hasRemainingVoteOrShareWork(session);
   }
 
   bool _completeJobIfSubmissionDone({
@@ -861,7 +862,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     required int generation,
     required VotingSessionState? session,
   }) {
-    if (!_hasCompletedSubmission(session)) return false;
+    if (!_canCompleteSubmission(session)) return false;
     _completeJob(key: key, generation: generation);
     return true;
   }
@@ -897,6 +898,20 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     return roundPlan != null && roundPlan.openProposals.isEmpty;
   }
 
+  bool _hasRemainingVoteOrShareWork(VotingSessionState session) {
+    final roundPlan = session.roundPlan;
+    if (roundPlan != null) {
+      for (final step in roundPlan.nextSteps) {
+        if (_stepCanRecoverWithoutDraft(step)) return true;
+      }
+    }
+    final resumePlan = session.resumePlan;
+    return resumePlan != null &&
+        (resumePlan.pendingVoteSubmissionKeys.isNotEmpty ||
+            resumePlan.submittedVoteConfirmationKeys.isNotEmpty ||
+            resumePlan.unconfirmedShareDelegations.isNotEmpty);
+  }
+
   bool _canPollDelegationWithoutDraft(VotingSessionState session) {
     final roundPlan = session.roundPlan;
     if (roundPlan != null) {
@@ -923,9 +938,11 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
   bool _sessionNeedsDelegation(VotingSessionState? session) {
     if (session == null) return false;
     if (_planNeedsDelegation(session.roundPlan)) return true;
-    final plan = session.resumePlan;
-    return (plan?.pendingDelegationBundleIndexes.isNotEmpty ?? false) ||
-        (plan?.submittedDelegationBundleIndexes.isNotEmpty ?? false);
+    if (session.roundPlan != null) {
+      return _canPollDelegationWithoutDraft(session);
+    }
+    return session.resumePlan?.submittedDelegationBundleIndexes.isNotEmpty ??
+        false;
   }
 
   bool _sessionNeedsDelegationSubmission(VotingSessionState? session) {

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -502,6 +502,13 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
           );
           return;
         }
+        if (_completeJobIfSubmissionDone(
+          key: key,
+          generation: generation,
+          session: afterDelegation,
+        )) {
+          return;
+        }
       }
       final afterDelegation = _sessionForJob(key);
       await _submitVotesAndShares(
@@ -613,6 +620,13 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
           generation: generation,
           session: afterDelegation!,
         );
+        return;
+      }
+      if (_completeJobIfSubmissionDone(
+        key: key,
+        generation: generation,
+        session: afterDelegation,
+      )) {
         return;
       }
       await _submitVotesAndShares(
@@ -842,6 +856,16 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     return hasCompletedVoteForDisplay(session.roundPlan);
   }
 
+  bool _completeJobIfSubmissionDone({
+    required VotingSessionKey key,
+    required int generation,
+    required VotingSessionState? session,
+  }) {
+    if (!_hasCompletedSubmission(session)) return false;
+    _completeJob(key: key, generation: generation);
+    return true;
+  }
+
   String _messageFromError(Object error) => friendlyVotingErrorMessage(error);
 
   String? _statusErrorMessage(VotingSessionState state) {
@@ -908,12 +932,8 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     if (session == null) return false;
     final roundPlan = session.roundPlan;
     if (_planNeedsDelegation(roundPlan)) return true;
-    if (roundPlan != null && !roundPlanNeedsDraftSetup(roundPlan)) {
-      return false;
-    }
-    final plan = session.resumePlan;
-    return (plan?.pendingDelegationBundleIndexes.isNotEmpty ?? false) ||
-        (plan?.submittedDelegationBundleIndexes.isNotEmpty ?? false);
+    if (_canPollDelegationWithoutDraft(session)) return true;
+    return roundPlan != null && roundPlanNeedsDraftSetup(roundPlan);
   }
 
   bool _sessionNeedsKeystoneSigning(VotingSessionState session) {

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -506,6 +506,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
           key: key,
           generation: generation,
           session: afterDelegation,
+          requireNoUnconfirmedShares: true,
         )) {
           return;
         }
@@ -626,6 +627,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
         key: key,
         generation: generation,
         session: afterDelegation,
+        requireNoUnconfirmedShares: true,
       )) {
         return;
       }
@@ -861,7 +863,13 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     required VotingSessionKey key,
     required int generation,
     required VotingSessionState? session,
+    bool requireNoUnconfirmedShares = false,
   }) {
+    if (requireNoUnconfirmedShares &&
+        (session?.resumePlan?.unconfirmedShareDelegations.isNotEmpty ??
+            false)) {
+      return false;
+    }
     if (!_canCompleteSubmission(session)) return false;
     _completeJob(key: key, generation: generation);
     return true;
@@ -902,6 +910,10 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     final roundPlan = session.roundPlan;
     if (roundPlan != null) {
       for (final step in roundPlan.nextSteps) {
+        if (step.kind == 'confirm_share') {
+          if (session.resumePlan?.hasBlockingShareWork ?? true) return true;
+          continue;
+        }
         if (_stepCanRecoverWithoutDraft(step)) return true;
       }
     }
@@ -909,7 +921,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     return resumePlan != null &&
         (resumePlan.pendingVoteSubmissionKeys.isNotEmpty ||
             resumePlan.submittedVoteConfirmationKeys.isNotEmpty ||
-            resumePlan.unconfirmedShareDelegations.isNotEmpty);
+            resumePlan.hasBlockingShareWork);
   }
 
   bool _canPollDelegationWithoutDraft(VotingSessionState session) {

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -475,12 +475,14 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
         }
         return;
       }
-      if (needsDelegation) {
-        final mnemonic = await ref
+      String? softwareMnemonic;
+      if (!activeSession.isHardwareAccount &&
+          (draftVotes.isNotEmpty || needsDelegation)) {
+        softwareMnemonic = await ref
             .read(accountProvider.notifier)
             .getMnemonicForAccount(key.accountUuid);
         if (!_isCurrentJob(key: key, generation: generation)) return;
-        if (mnemonic == null || mnemonic.isEmpty) {
+        if (softwareMnemonic == null || softwareMnemonic.isEmpty) {
           _failJob(
             key: key,
             generation: generation,
@@ -490,8 +492,12 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
           );
           return;
         }
+      }
+      if (needsDelegation) {
         if (!_isCurrentJob(key: key, generation: generation)) return;
-        await sessionNotifier.delegatePendingBundles(mnemonic: mnemonic);
+        await sessionNotifier.delegatePendingBundles(
+          mnemonic: softwareMnemonic!,
+        );
         if (!_isCurrentJob(key: key, generation: generation)) return;
         final afterDelegation = _sessionForJob(key);
         if (afterDelegation?.phase == VotingSessionPhase.error) {
@@ -520,6 +526,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
         intentProposalIds: intentProposalIds,
         proposalOptionCounts: proposalOptionCounts,
         initialSession: afterDelegation ?? activeSession,
+        mnemonic: softwareMnemonic,
       );
     } catch (error) {
       if (!_isCurrentJob(key: key, generation: generation)) return;
@@ -661,6 +668,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     required List<int> intentProposalIds,
     required Map<int, int> proposalOptionCounts,
     VotingSessionState? initialSession,
+    String? mnemonic,
   }) async {
     if (!_isCurrentJob(key: key, generation: generation)) return;
     final votePollingSession = _sessionForJob(key) ?? initialSession;
@@ -679,6 +687,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
         draftVotes: draftVotes,
         allProposalIds: intentProposalIds,
         proposalOptionCounts: proposalOptionCounts,
+        mnemonic: mnemonic,
       );
     }
     if (!_isCurrentJob(key: key, generation: generation)) return;

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1509,47 +1509,54 @@ void main() {
     );
   });
 
-  test('software vote-only submission skips delegation preparation', () async {
-    final rust = FakeVotingRustApi(emitCommitments: true);
-    final roundStatus = roundStatusJson(roundId: kRoundId)
-      ..['proposals'] = [
-        {
-          'id': 7,
-          'title': 'Question',
-          'options': [
-            {'index': 0, 'label': 'No'},
-            {'index': 1, 'label': 'Yes'},
-          ],
-        },
-      ];
-    final http = FakeVotingHttpClient(
-      responses: votingHttpResponses(roundStatus: roundStatus),
-    );
-    final draftPersistence = FakeVotingDraftPersistence();
-    const key = VotingSessionKey(roundId: kRoundId, accountUuid: 'account-1');
-    await draftPersistence.save(key, const VotingDraftState(choices: {7: 1}));
-    final recoveryApi = FakeVotingRecoveryApi(
-      state: recoveryState(bundleCount: 1),
-    );
-    final container = _sessionContainer(
-      http: http,
-      rust: rust,
-      recoveryApi: recoveryApi,
-      draftPersistence: draftPersistence,
-    );
-    addTearDown(container.dispose);
+  test(
+    'software vote-only submission seeds hotkey without delegation',
+    () async {
+      final rust = FakeVotingRustApi(emitCommitments: true);
+      final hotkeyStore = FakeVotingHotkeyStore(null);
+      final roundStatus = roundStatusJson(roundId: kRoundId)
+        ..['proposals'] = [
+          {
+            'id': 7,
+            'title': 'Question',
+            'options': [
+              {'index': 0, 'label': 'No'},
+              {'index': 1, 'label': 'Yes'},
+            ],
+          },
+        ];
+      final http = FakeVotingHttpClient(
+        responses: votingHttpResponses(roundStatus: roundStatus),
+      );
+      final draftPersistence = FakeVotingDraftPersistence();
+      const key = VotingSessionKey(roundId: kRoundId, accountUuid: 'account-1');
+      await draftPersistence.save(key, const VotingDraftState(choices: {7: 1}));
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(bundleCount: 1),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+        draftPersistence: draftPersistence,
+        hotkeyStore: hotkeyStore,
+      );
+      addTearDown(container.dispose);
 
-    final startedKey = await container
-        .read(votingSubmissionJobsProvider.notifier)
-        .start(kRoundId);
-    expect(startedKey, key);
-    await _waitForVoteCommitmentKey(rust, '0:7');
+      final startedKey = await container
+          .read(votingSubmissionJobsProvider.notifier)
+          .start(kRoundId);
+      expect(startedKey, key);
+      await _waitForVoteCommitmentKey(rust, '0:7');
 
-    expect(rust.setupCalls, 0);
-    expect(rust.delegationBundleCalls, isEmpty);
-    expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 0);
-    expect(_postRequestCount(http, '/shielded-vote/v1/cast-vote'), 1);
-  });
+      expect(rust.setupCalls, 0);
+      expect(rust.delegationBundleCalls, isEmpty);
+      expect(rust.deriveHotkeyCalls, 1);
+      expect(hotkeyStore.hotkey, isNotNull);
+      expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 0);
+      expect(_postRequestCount(http, '/shielded-vote/v1/cast-vote'), 1);
+    },
+  );
 
   test(
     'software submission resumes submitted delegation without draft',
@@ -4693,6 +4700,8 @@ class FakeVotingRustApi implements VotingRustApi {
   final storedKeystoneSignatures = <int, rust_wire.KeystoneSignatureRecord>{};
   int generateVotingHotkeyCalls = 0;
   int parseSignedVotingPcztCalls = 0;
+  int deriveHotkeyCalls = 0;
+  int extractSpendAuthSignatureCalls = 0;
 
   @override
   Future<rust_round.BundleLayout> setupDelegationBundles({
@@ -5359,6 +5368,7 @@ class FakeVotingRustApi implements VotingRustApi {
     required String roundId,
     required String network,
   }) async {
+    deriveHotkeyCalls++;
     return [roundId.length, network.length, ...mnemonic.codeUnits.take(2)];
   }
 }

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1689,6 +1689,65 @@ void main() {
     },
   );
 
+  test(
+    'accepted share tracking does not keep submission job running',
+    () async {
+      final shareNullifier = Uint8List.fromList(List.filled(32, 1));
+      final acceptedShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        nullifier: shareNullifier,
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.zero,
+        createdAt: BigInt.one,
+      );
+      final rust = FakeVotingRustApi();
+      final http = FakeVotingHttpClient(
+        responses: votingHttpResponses(
+          dynamicConfig: dynamicConfigJson(
+            voteServers: const [
+              {'url': 'https://helper-a.example', 'label': 'helper-a'},
+            ],
+          ),
+        ),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: _submittedDelegationWithShareRecoveryApi(acceptedShare),
+        txConfirmationPolling: _fastTxConfirmationPolling,
+      );
+      addTearDown(container.dispose);
+
+      final startedKey = await container
+          .read(votingSubmissionJobsProvider.notifier)
+          .start(kRoundId);
+      expect(
+        startedKey,
+        const VotingSessionKey(roundId: kRoundId, accountUuid: 'account-1'),
+      );
+      await _waitForStoredVanPosition(rust, '0:0');
+      final completed = await _waitForJobStatus(
+        container,
+        startedKey!,
+        VotingSubmissionJobStatus.complete,
+      );
+
+      expect(completed.errorMessage, isNull);
+      expect(
+        container
+            .read(votingSubmissionGuardProvider.notifier)
+            .guardForAccount('account-1'),
+        isNull,
+      );
+      expect(rust.confirmedShares, isEmpty);
+    },
+  );
+
   test('Keystone signing starts after active account reload', () async {
     final rust = FakeVotingRustApi();
     final activeAccountProvider =

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1370,6 +1370,58 @@ void main() {
     );
   });
 
+  test('software vote-only submission skips delegation preparation', () async {
+    final rust = FakeVotingRustApi(emitCommitments: true);
+    final roundStatus = roundStatusJson(roundId: kRoundId)
+      ..['proposals'] = [
+        {
+          'id': 7,
+          'title': 'Question',
+          'options': [
+            {'index': 0, 'label': 'No'},
+            {'index': 1, 'label': 'Yes'},
+          ],
+        },
+      ];
+    final http = FakeVotingHttpClient(
+      responses: votingHttpResponses(roundStatus: roundStatus),
+    );
+    final draftPersistence = FakeVotingDraftPersistence();
+    const key = VotingSessionKey(roundId: kRoundId, accountUuid: 'account-1');
+    await draftPersistence.save(key, const VotingDraftState(choices: {7: 1}));
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 1,
+        delegationWorkflows: [
+          rust_frb_types.DelegationRecoveryView(
+            bundleIndex: 0,
+            phase: VotingWorkflowPhase.confirmed,
+            txHash: 'delegation-0',
+            vanLeafPosition: 0,
+          ),
+        ],
+      ),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      recoveryApi: recoveryApi,
+      draftPersistence: draftPersistence,
+    );
+    addTearDown(container.dispose);
+
+    final startedKey = await container
+        .read(votingSubmissionJobsProvider.notifier)
+        .start(kRoundId);
+    expect(startedKey, key);
+    await _waitForVoteCommitmentKey(rust, '0:7');
+
+    expect(rust.setupCalls, 0);
+    expect(rust.delegationBundleCalls, isEmpty);
+    expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 0);
+    expect(_postRequestCount(http, '/shielded-vote/v1/cast-vote'), 1);
+  });
+
   test('Keystone signing starts after active account reload', () async {
     final rust = FakeVotingRustApi();
     final activeAccountProvider =
@@ -3426,6 +3478,81 @@ Future<VotingSessionState> _waitForJobSessionPhase(
     'Last phase: '
     '${container.read(votingSubmissionJobSessionProvider(key)).value?.phase}',
   );
+}
+
+Future<void> _waitForVoteCommitmentKey(
+  FakeVotingRustApi rust,
+  String expectedKey,
+) async {
+  for (var i = 0; i < 100; i++) {
+    if (rust.voteCommitmentKeys.contains(expectedKey)) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail(
+    'Timed out waiting for vote commitment $expectedKey. '
+    'Saw ${rust.voteCommitmentKeys}.',
+  );
+}
+
+class _GatedVotingConfigLoads {
+  _GatedVotingConfigLoads(this._configs);
+
+  final Map<String, VotingConfig> _configs;
+  final Map<String, int> _loadCounts = {};
+  final Map<String, List<Completer<void>>> _gates = {};
+
+  Completer<void> gateNext(String sourceUrl) {
+    final gate = Completer<void>();
+    (_gates[sourceUrl] ??= []).add(gate);
+    return gate;
+  }
+
+  Future<VotingConfig> load(String sourceUrl) async {
+    _loadCounts[sourceUrl] = (_loadCounts[sourceUrl] ?? 0) + 1;
+    final gates = _gates[sourceUrl];
+    if (gates != null && gates.isNotEmpty) {
+      await gates.removeAt(0).future;
+    }
+    final config = _configs[sourceUrl];
+    if (config == null) {
+      throw StateError('No fake voting config for $sourceUrl');
+    }
+    return config;
+  }
+
+  Future<void> waitForLoadCount(String sourceUrl, int expected) async {
+    for (var i = 0; i < 100; i++) {
+      if ((_loadCounts[sourceUrl] ?? 0) >= expected) return;
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    fail(
+      'Timed out waiting for config load $sourceUrl count $expected. '
+      'Saw ${_loadCounts[sourceUrl] ?? 0}.',
+    );
+  }
+}
+
+class _GatedVotingConfigLoader extends VotingConfigLoader {
+  _GatedVotingConfigLoader(this._loads, this._sourceUrl)
+    : super(httpClient: FakeVotingHttpClient());
+
+  final _GatedVotingConfigLoads _loads;
+  final String _sourceUrl;
+
+  @override
+  Future<VotingConfig> load() {
+    return _loads.load(_sourceUrl);
+  }
+}
+
+VotingConfig _configForVoteServer(String url) {
+  return VotingConfig.fromJson(
+    dynamicConfigJson(
+      voteServers: [
+        {'url': url, 'label': 'primary'},
+      ],
+    ),
+  )..validate();
 }
 
 Map<String, dynamic> _postBody(FakeVotingHttpClient http, String path) {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -75,6 +75,54 @@ void main() {
     );
   });
 
+  test('config provider ignores stale refresh after source changes', () async {
+    const firstSource = 'https://voting-a.example/static-voting-config.json';
+    const secondSource = 'https://voting-b.example/static-voting-config.json';
+    final store = FakeVotingConfigSourceStore(sourceUrl: firstSource);
+    final loads = _GatedVotingConfigLoads({
+      firstSource: _configForVoteServer('https://voting-a.example'),
+      secondSource: _configForVoteServer('https://voting-b.example'),
+    });
+    final container = ProviderContainer(
+      overrides: [
+        votingConfigSourceStoreProvider.overrideWithValue(store),
+        votingConfigLoaderProvider.overrideWith((ref) {
+          final source =
+              ref.watch(votingConfigSourceProvider).value?.sourceUrl ??
+              kDefaultStaticVotingConfigSource;
+          return _GatedVotingConfigLoader(loads, source);
+        }),
+        votingActiveAccountUuidProvider.overrideWithValue(() async => null),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final first = await container.read(votingConfigProvider.future);
+    expect(first.apiBaseUrl, Uri.parse('https://voting-a.example'));
+
+    final staleGate = loads.gateNext(firstSource);
+    final staleRefresh = container
+        .read(votingConfigProvider.notifier)
+        .refresh();
+    await loads.waitForLoadCount(firstSource, 2);
+
+    await container
+        .read(votingConfigSourceProvider.notifier)
+        .setCustom(secondSource);
+    await container.read(votingConfigProvider.notifier).refresh();
+    expect(
+      container.read(votingConfigProvider).value?.apiBaseUrl,
+      Uri.parse('https://voting-b.example'),
+    );
+
+    staleGate.complete();
+    await staleRefresh;
+    expect(
+      container.read(votingConfigProvider).value?.apiBaseUrl,
+      Uri.parse('https://voting-b.example'),
+    );
+  });
+
   test('config source provider persists named saved sources', () async {
     final store = FakeVotingConfigSourceStore();
     final container = _container(

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -171,6 +171,49 @@ void main() {
     },
   );
 
+  test(
+    'config provider keeps failed refresh over stale load success',
+    () async {
+      const firstSource = 'https://voting-a.example/static-voting-config.json';
+      const secondSource = 'https://voting-b.example/static-voting-config.json';
+      final store = FakeVotingConfigSourceStore(sourceUrl: firstSource);
+      final newerFailure = StateError('replacement source failed');
+      final loads = _GatedVotingConfigLoads({
+        firstSource: _configForVoteServer('https://voting-a.example'),
+      });
+      final container = ProviderContainer(
+        overrides: [
+          votingConfigSourceStoreProvider.overrideWithValue(store),
+          votingConfigLoaderProvider.overrideWith((ref) {
+            final source =
+                ref.watch(votingConfigSourceProvider).value?.sourceUrl ??
+                kDefaultStaticVotingConfigSource;
+            return _GatedVotingConfigLoader(loads, source);
+          }),
+          votingActiveAccountUuidProvider.overrideWithValue(() async => null),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final staleGate = loads.gateNext(firstSource);
+      final staleLoad = container.read(votingConfigProvider.future);
+      await loads.waitForLoadCount(firstSource, 1);
+
+      loads.failNext(secondSource, newerFailure);
+      await container
+          .read(votingConfigSourceProvider.notifier)
+          .setCustom(secondSource);
+      await container.read(votingConfigProvider.notifier).refresh();
+      expect(container.read(votingConfigProvider).hasError, isTrue);
+      expect(container.read(votingConfigProvider).error, newerFailure);
+
+      staleGate.complete();
+      await expectLater(staleLoad, throwsA(same(newerFailure)));
+      expect(container.read(votingConfigProvider).hasError, isTrue);
+      expect(container.read(votingConfigProvider).error, newerFailure);
+    },
+  );
+
   test('config source provider persists named saved sources', () async {
     final store = FakeVotingConfigSourceStore();
     final container = _container(

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1476,31 +1476,10 @@ void main() {
     () async {
       final rust = FakeVotingRustApi();
       final http = FakeVotingHttpClient(responses: votingHttpResponses());
-      final recoveryApi = FakeVotingRecoveryApi(
-        state: recoveryState(
-          bundleCount: 1,
-          delegationWorkflows: [
-            rust_frb_types.DelegationRecoveryView(
-              bundleIndex: 0,
-              phase: VotingWorkflowPhase.submittedDelegation,
-              txHash: 'delegation-tx',
-              vanLeafPosition: null,
-            ),
-          ],
-        ),
-        roundPlan: apiRoundPlan(
-          roundId: kRoundId,
-          pendingRecovery: false,
-          nextSteps: const [],
-          openProposals: Uint32List(0),
-          allDecided: false,
-          recoveredDelegationWork: const [],
-        ),
-      );
       final container = _sessionContainer(
         http: http,
         rust: rust,
-        recoveryApi: recoveryApi,
+        recoveryApi: _submittedDelegationOnlyRecoveryApi(),
         txConfirmationPolling: _fastTxConfirmationPolling,
       );
       addTearDown(container.dispose);
@@ -1513,11 +1492,62 @@ void main() {
         const VotingSessionKey(roundId: kRoundId, accountUuid: 'account-1'),
       );
       await _waitForStoredVanPosition(rust, '0:0');
+      final completed = await _waitForJobStatus(
+        container,
+        startedKey!,
+        VotingSubmissionJobStatus.complete,
+      );
 
+      expect(completed.errorMessage, isNull);
       expect(rust.delegationBundleCalls, isEmpty);
       expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 0);
+      expect(_postRequestCount(http, '/shielded-vote/v1/cast-vote'), 0);
+      expect(_postRequestCount(http, '/shielded-vote/v1/shares'), 0);
       expect(rust.storedDelegationTxHashes, ['0:delegation-tx']);
       expect(rust.storedVanPositions, ['0:0']);
+      expect(rust.voteCommitmentKeys, isEmpty);
+      expect(rust.recordedShares, isEmpty);
+    },
+  );
+
+  test(
+    'hardware submission resumes submitted delegation without draft',
+    () async {
+      final rust = FakeVotingRustApi();
+      final http = FakeVotingHttpClient(responses: votingHttpResponses());
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: _submittedDelegationOnlyRecoveryApi(),
+        accountIsHardware: true,
+        txConfirmationPolling: _fastTxConfirmationPolling,
+      );
+      addTearDown(container.dispose);
+
+      final startedKey = await container
+          .read(votingSubmissionJobsProvider.notifier)
+          .start(kRoundId);
+      expect(
+        startedKey,
+        const VotingSessionKey(roundId: kRoundId, accountUuid: 'account-1'),
+      );
+      await _waitForStoredVanPosition(rust, '0:0');
+      final completed = await _waitForJobStatus(
+        container,
+        startedKey!,
+        VotingSubmissionJobStatus.complete,
+      );
+
+      expect(completed.errorMessage, isNull);
+      expect(rust.keystoneDelegationRequestCalls, isEmpty);
+      expect(rust.keystoneProofBundleCalls, isEmpty);
+      expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 0);
+      expect(_postRequestCount(http, '/shielded-vote/v1/cast-vote'), 0);
+      expect(_postRequestCount(http, '/shielded-vote/v1/shares'), 0);
+      expect(rust.storedDelegationTxHashes, ['0:delegation-tx']);
+      expect(rust.storedVanPositions, ['0:0']);
+      expect(rust.voteCommitmentKeys, isEmpty);
+      expect(rust.recordedShares, isEmpty);
     },
   );
 
@@ -3545,6 +3575,45 @@ ProviderContainer _sessionContainer({
         votingTxConfirmationPollingProvider.overrideWithValue(
           txConfirmationPolling,
         ),
+    ],
+  );
+}
+
+FakeVotingRecoveryApi _submittedDelegationOnlyRecoveryApi() {
+  final beforeConfirmation = apiRoundPlan(
+    roundId: kRoundId,
+    pendingRecovery: false,
+    nextSteps: const [],
+    openProposals: Uint32List(0),
+    allDecided: false,
+    recoveredDelegationWork: const [],
+  );
+  final afterConfirmation = apiRoundPlan(
+    roundId: kRoundId,
+    pendingRecovery: false,
+    nextSteps: const [],
+    openProposals: Uint32List(0),
+    allDecided: true,
+    completedVoteArtifact: true,
+    completedForDisplay: true,
+    recoveredDelegationWork: const [],
+  );
+  return FakeVotingRecoveryApi(
+    state: recoveryState(
+      bundleCount: 1,
+      delegationWorkflows: [
+        rust_frb_types.DelegationRecoveryView(
+          bundleIndex: 0,
+          phase: VotingWorkflowPhase.submittedDelegation,
+          txHash: 'delegation-tx',
+          vanLeafPosition: null,
+        ),
+      ],
+    ),
+    roundPlanSequence: [
+      beforeConfirmation,
+      beforeConfirmation,
+      afterConfirmation,
     ],
   );
 }

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -124,6 +124,53 @@ void main() {
     );
   });
 
+  test(
+    'config provider ignores stale load failure after source changes',
+    () async {
+      const firstSource = 'https://voting-a.example/static-voting-config.json';
+      const secondSource = 'https://voting-b.example/static-voting-config.json';
+      final store = FakeVotingConfigSourceStore(sourceUrl: firstSource);
+      final loads = _GatedVotingConfigLoads({
+        secondSource: _configForVoteServer('https://voting-b.example'),
+      });
+      final container = ProviderContainer(
+        overrides: [
+          votingConfigSourceStoreProvider.overrideWithValue(store),
+          votingConfigLoaderProvider.overrideWith((ref) {
+            final source =
+                ref.watch(votingConfigSourceProvider).value?.sourceUrl ??
+                kDefaultStaticVotingConfigSource;
+            return _GatedVotingConfigLoader(loads, source);
+          }),
+          votingActiveAccountUuidProvider.overrideWithValue(() async => null),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final staleGate = loads.gateNext(firstSource);
+      loads.failNext(firstSource, StateError('stale source failed'));
+      final staleLoad = container.read(votingConfigProvider.future);
+      await loads.waitForLoadCount(firstSource, 1);
+
+      await container
+          .read(votingConfigSourceProvider.notifier)
+          .setCustom(secondSource);
+      await container.read(votingConfigProvider.notifier).refresh();
+      expect(
+        container.read(votingConfigProvider).value?.apiBaseUrl,
+        Uri.parse('https://voting-b.example'),
+      );
+
+      staleGate.complete();
+      final staleResult = await staleLoad;
+      expect(staleResult.apiBaseUrl, Uri.parse('https://voting-b.example'));
+      expect(
+        container.read(votingConfigProvider).value?.apiBaseUrl,
+        Uri.parse('https://voting-b.example'),
+      );
+    },
+  );
+
   test('config source provider persists named saved sources', () async {
     final store = FakeVotingConfigSourceStore();
     final container = _container(
@@ -1439,17 +1486,7 @@ void main() {
     const key = VotingSessionKey(roundId: kRoundId, accountUuid: 'account-1');
     await draftPersistence.save(key, const VotingDraftState(choices: {7: 1}));
     final recoveryApi = FakeVotingRecoveryApi(
-      state: recoveryState(
-        bundleCount: 1,
-        delegationWorkflows: [
-          rust_frb_types.DelegationRecoveryView(
-            bundleIndex: 0,
-            phase: VotingWorkflowPhase.confirmed,
-            txHash: 'delegation-0',
-            vanLeafPosition: 0,
-          ),
-        ],
-      ),
+      state: recoveryState(bundleCount: 1),
     );
     final container = _sessionContainer(
       http: http,
@@ -1548,6 +1585,64 @@ void main() {
       expect(rust.storedVanPositions, ['0:0']);
       expect(rust.voteCommitmentKeys, isEmpty);
       expect(rust.recordedShares, isEmpty);
+    },
+  );
+
+  test(
+    'submitted delegation recovery continues pending share recovery',
+    () async {
+      final shareNullifier = Uint8List.fromList(List.filled(32, 1));
+      final shareId = _hexFromBytes(shareNullifier);
+      final acceptedShare = rust_frb_types.ShareDelegationRecordView(
+        roundId: kRoundId,
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        sentToUrls: const ['https://helper-a.example'],
+        nullifier: shareNullifier,
+        phase: VotingWorkflowPhase.submittedShare,
+        confirmed: false,
+        submitAt: BigInt.zero,
+        createdAt: BigInt.one,
+      );
+      final rust = FakeVotingRustApi();
+      final http = FakeVotingHttpClient(
+        responses:
+            votingHttpResponses(
+              dynamicConfig: dynamicConfigJson(
+                voteServers: const [
+                  {'url': 'https://helper-a.example', 'label': 'helper-a'},
+                ],
+              ),
+            )..addAll({
+              'https://helper-a.example/shielded-vote/v1/share-status/$kRoundId/$shareId':
+                  {'status': 'confirmed'},
+            }),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: _submittedDelegationWithShareRecoveryApi(acceptedShare),
+        txConfirmationPolling: _fastTxConfirmationPolling,
+      );
+      addTearDown(container.dispose);
+
+      final startedKey = await container
+          .read(votingSubmissionJobsProvider.notifier)
+          .start(kRoundId);
+      expect(
+        startedKey,
+        const VotingSessionKey(roundId: kRoundId, accountUuid: 'account-1'),
+      );
+      await _waitForStoredVanPosition(rust, '0:0');
+      await _waitForConfirmedShare(rust, '0:7:0');
+
+      expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 0);
+      expect(_postRequestCount(http, '/shielded-vote/v1/cast-vote'), 0);
+      expect(_postRequestCount(http, '/shielded-vote/v1/shares'), 0);
+      expect(rust.storedDelegationTxHashes, ['0:delegation-tx']);
+      expect(rust.confirmedShares, ['0:7:0']);
+      expect(rust.voteCommitmentKeys, isEmpty);
     },
   );
 
@@ -3618,6 +3713,62 @@ FakeVotingRecoveryApi _submittedDelegationOnlyRecoveryApi() {
   );
 }
 
+FakeVotingRecoveryApi _submittedDelegationWithShareRecoveryApi(
+  rust_frb_types.ShareDelegationRecordView share,
+) {
+  final beforeConfirmation = apiRoundPlan(
+    roundId: kRoundId,
+    pendingRecovery: false,
+    nextSteps: const [],
+    openProposals: Uint32List(0),
+    allDecided: false,
+    recoveredDelegationWork: const [],
+  );
+  final afterConfirmation = apiRoundPlan(
+    roundId: kRoundId,
+    pendingRecovery: true,
+    blockingRecovery: false,
+    completedVoteArtifact: true,
+    completedForDisplay: true,
+    completedVoteDisplay: const rust_wire.CompletedVoteDisplayView(
+      choices: [rust_wire.CompletedVoteChoiceView(proposalId: 7, choice: null)],
+      votedAt: null,
+    ),
+    nextSteps: const [
+      rust_wire.NextStepView(
+        kind: 'confirm_share',
+        bundleIndex: 0,
+        proposalId: 7,
+        shareIndex: 0,
+        choice: 0,
+      ),
+    ],
+    openProposals: Uint32List(0),
+    allDecided: true,
+    recoveredDelegationWork: const [],
+  );
+  return FakeVotingRecoveryApi(
+    state: recoveryState(
+      bundleCount: 1,
+      delegationWorkflows: [
+        rust_frb_types.DelegationRecoveryView(
+          bundleIndex: 0,
+          phase: VotingWorkflowPhase.submittedDelegation,
+          txHash: 'delegation-tx',
+          vanLeafPosition: null,
+        ),
+      ],
+      shareDelegations: [share],
+      unconfirmedShareDelegations: [share],
+    ),
+    roundPlanSequence: [
+      beforeConfirmation,
+      beforeConfirmation,
+      afterConfirmation,
+    ],
+  );
+}
+
 Future<VotingSubmissionJobState> _waitForJobStatus(
   ProviderContainer container,
   VotingSessionKey key,
@@ -3679,10 +3830,25 @@ Future<void> _waitForStoredVanPosition(
   );
 }
 
+Future<void> _waitForConfirmedShare(
+  FakeVotingRustApi rust,
+  String expectedShare,
+) async {
+  for (var i = 0; i < 100; i++) {
+    if (rust.confirmedShares.contains(expectedShare)) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail(
+    'Timed out waiting for confirmed share $expectedShare. '
+    'Saw ${rust.confirmedShares}.',
+  );
+}
+
 class _GatedVotingConfigLoads {
   _GatedVotingConfigLoads(this._configs);
 
   final Map<String, VotingConfig> _configs;
+  final Map<String, List<Object>> _failures = {};
   final Map<String, int> _loadCounts = {};
   final Map<String, List<Completer<void>>> _gates = {};
 
@@ -3692,11 +3858,19 @@ class _GatedVotingConfigLoads {
     return gate;
   }
 
+  void failNext(String sourceUrl, Object error) {
+    (_failures[sourceUrl] ??= []).add(error);
+  }
+
   Future<VotingConfig> load(String sourceUrl) async {
     _loadCounts[sourceUrl] = (_loadCounts[sourceUrl] ?? 0) + 1;
     final gates = _gates[sourceUrl];
     if (gates != null && gates.isNotEmpty) {
       await gates.removeAt(0).future;
+    }
+    final failures = _failures[sourceUrl];
+    if (failures != null && failures.isNotEmpty) {
+      throw failures.removeAt(0);
     }
     final config = _configs[sourceUrl];
     if (config == null) {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1487,6 +1487,49 @@ void main() {
     },
   );
 
+  test(
+    'delegation does not submit after active account changes during proof',
+    () async {
+      final proofGate = Completer<void>();
+      final rust = FakeVotingRustApi(delegationProofGate: proofGate);
+      final http = FakeVotingHttpClient(responses: votingHttpResponses());
+      final activeAccountProvider =
+          NotifierProvider<_ActiveVotingAccountNotifier, String?>(
+            _ActiveVotingAccountNotifier.new,
+          );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        activeAccountUuidListenable: activeAccountProvider,
+      );
+      final subscription = container.listen(
+        votingSessionProvider(kRoundId),
+        (_, _) {},
+      );
+      addTearDown(subscription.close);
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      final delegation = container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .delegatePendingBundles(mnemonic: kTestMnemonic);
+      await rust.delegationProofStarted.future;
+
+      container.read(activeAccountProvider.notifier).set('account-2');
+      final switched = await container.read(
+        votingSessionProvider(kRoundId).future,
+      );
+      expect(switched.accountUuid, 'account-2');
+
+      proofGate.complete();
+      await delegation;
+
+      expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 0);
+      expect(rust.storedDelegationTxHashes, isEmpty);
+      expect(container.read(votingSessionProvider(kRoundId)).hasError, isFalse);
+    },
+  );
+
   test('draft choices are isolated by pinned voting account', () async {
     final activeAccount = _MutableActiveAccount('account-1');
     final container = _sessionContainer(activeAccountUuid: activeAccount.call);
@@ -3320,6 +3363,12 @@ Map<String, dynamic> _postBody(FakeVotingHttpClient http, String path) {
   return request.body!;
 }
 
+int _postRequestCount(FakeVotingHttpClient http, String path) {
+  return http.requests
+      .where((request) => request.method == 'POST' && request.uri.path == path)
+      .length;
+}
+
 String _postBodyJson(FakeVotingHttpClient http, String path) =>
     jsonEncode(_postBody(http, path));
 
@@ -3907,6 +3956,8 @@ class FakeVotingRustApi implements VotingRustApi {
     this.commitmentShareCount = 1,
     this.mismatchKeystoneSubmission = false,
     this.delegationStreamError,
+    this.delegationProofGate,
+    this.keystoneDelegationProofGate,
     this.onDeleteSkippedBundles,
   });
 
@@ -3919,6 +3970,8 @@ class FakeVotingRustApi implements VotingRustApi {
   final int commitmentShareCount;
   final bool mismatchKeystoneSubmission;
   final Object? delegationStreamError;
+  final Completer<void>? delegationProofGate;
+  final Completer<void>? keystoneDelegationProofGate;
   final void Function(int keepCount)? onDeleteSkippedBundles;
   int setupCalls = 0;
   int _activeSetups = 0;
@@ -3937,6 +3990,8 @@ class FakeVotingRustApi implements VotingRustApi {
   final precomputedDelegationPir = <int>[];
   final precomputeMnemonics = <String>[];
   final setupStarted = Completer<void>();
+  final delegationProofStarted = Completer<void>();
+  final keystoneDelegationProofStarted = Completer<void>();
   final precomputeStarted = Completer<void>();
   final precomputeFinished = Completer<void>();
   final resetVotingSessionStateCalls = <String>[];
@@ -3987,6 +4042,10 @@ class FakeVotingRustApi implements VotingRustApi {
     delegationBundleCalls.add(bundleIndex);
     final error = delegationStreamError;
     if (error != null) throw error;
+    if (!delegationProofStarted.isCompleted) {
+      delegationProofStarted.complete();
+    }
+    await delegationProofGate?.future;
     yield rust_api.ApiDelegationProofEvent(
       phase: 'result',
       proofProgress: null,
@@ -4115,6 +4174,10 @@ class FakeVotingRustApi implements VotingRustApi {
   }) async* {
     accountUuids.add(ctx.accountUuid);
     keystoneProofBundleCalls.add(bundleIndex);
+    if (!keystoneDelegationProofStarted.isCompleted) {
+      keystoneDelegationProofStarted.complete();
+    }
+    await keystoneDelegationProofGate?.future;
     final signature = storedKeystoneSignatures[bundleIndex];
     final rk = mismatchKeystoneSubmission
         ? const [99]

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1530,6 +1530,78 @@ void main() {
     },
   );
 
+  test(
+    'vote commitments do not submit after active account changes during proof',
+    () async {
+      final proofGate = Completer<void>();
+      final rust = FakeVotingRustApi(
+        emitCommitments: true,
+        voteCommitmentGate: proofGate,
+      );
+      final http = FakeVotingHttpClient(responses: votingHttpResponses());
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 1,
+          delegationTxHashes: [
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: 0,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-0',
+              vanLeafPosition: null,
+            ),
+          ],
+        ),
+      );
+      final activeAccountProvider =
+          NotifierProvider<_ActiveVotingAccountNotifier, String?>(
+            _ActiveVotingAccountNotifier.new,
+          );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+        activeAccountUuidListenable: activeAccountProvider,
+      );
+      final subscription = container.listen(
+        votingSessionProvider(kRoundId),
+        (_, _) {},
+      );
+      addTearDown(subscription.close);
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      final voting = container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: [
+              rust_wire.DraftVote(
+                proposalId: 7,
+                choice: 1,
+                numOptions: 2,
+                vcTreePosition: BigInt.zero,
+                singleShare: false,
+              ),
+            ],
+          );
+      await rust.voteCommitmentStarted.future;
+
+      container.read(activeAccountProvider.notifier).set('account-2');
+      final switched = await container.read(
+        votingSessionProvider(kRoundId).future,
+      );
+      expect(switched.accountUuid, 'account-2');
+
+      proofGate.complete();
+      await voting;
+
+      expect(_postRequestCount(http, '/shielded-vote/v1/cast-vote'), 0);
+      expect(_postRequestCount(http, '/shielded-vote/v1/shares'), 0);
+      expect(rust.storedVoteTxHashes, isEmpty);
+      expect(rust.recordedShares, isEmpty);
+      expect(container.read(votingSessionProvider(kRoundId)).hasError, isFalse);
+    },
+  );
+
   test('draft choices are isolated by pinned voting account', () async {
     final activeAccount = _MutableActiveAccount('account-1');
     final container = _sessionContainer(activeAccountUuid: activeAccount.call);
@@ -3958,6 +4030,7 @@ class FakeVotingRustApi implements VotingRustApi {
     this.delegationStreamError,
     this.delegationProofGate,
     this.keystoneDelegationProofGate,
+    this.voteCommitmentGate,
     this.onDeleteSkippedBundles,
   });
 
@@ -3972,6 +4045,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final Object? delegationStreamError;
   final Completer<void>? delegationProofGate;
   final Completer<void>? keystoneDelegationProofGate;
+  final Completer<void>? voteCommitmentGate;
   final void Function(int keepCount)? onDeleteSkippedBundles;
   int setupCalls = 0;
   int _activeSetups = 0;
@@ -3992,6 +4066,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final setupStarted = Completer<void>();
   final delegationProofStarted = Completer<void>();
   final keystoneDelegationProofStarted = Completer<void>();
+  final voteCommitmentStarted = Completer<void>();
   final precomputeStarted = Completer<void>();
   final precomputeFinished = Completer<void>();
   final resetVotingSessionStateCalls = <String>[];
@@ -4352,6 +4427,10 @@ class FakeVotingRustApi implements VotingRustApi {
     required List<rust_wire.DraftVote> draftVotes,
   }) async* {
     voteCommitBundleCalls.add(bundleIndex);
+    if (!voteCommitmentStarted.isCompleted) {
+      voteCommitmentStarted.complete();
+    }
+    await voteCommitmentGate?.future;
     for (final draft in draftVotes) {
       voteCommitmentKeys.add('$bundleIndex:${draft.proposalId}');
       operationLog.add('build_vote:$bundleIndex:${draft.proposalId}');

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart' show ProviderListenable;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_submission_guard_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_submission_job_provider.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
@@ -1469,6 +1470,56 @@ void main() {
     expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 0);
     expect(_postRequestCount(http, '/shielded-vote/v1/cast-vote'), 1);
   });
+
+  test(
+    'software submission resumes submitted delegation without draft',
+    () async {
+      final rust = FakeVotingRustApi();
+      final http = FakeVotingHttpClient(responses: votingHttpResponses());
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 1,
+          delegationWorkflows: [
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: 0,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-tx',
+              vanLeafPosition: null,
+            ),
+          ],
+        ),
+        roundPlan: apiRoundPlan(
+          roundId: kRoundId,
+          pendingRecovery: false,
+          nextSteps: const [],
+          openProposals: Uint32List(0),
+          allDecided: false,
+          recoveredDelegationWork: const [],
+        ),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+        txConfirmationPolling: _fastTxConfirmationPolling,
+      );
+      addTearDown(container.dispose);
+
+      final startedKey = await container
+          .read(votingSubmissionJobsProvider.notifier)
+          .start(kRoundId);
+      expect(
+        startedKey,
+        const VotingSessionKey(roundId: kRoundId, accountUuid: 'account-1'),
+      );
+      await _waitForStoredVanPosition(rust, '0:0');
+
+      expect(rust.delegationBundleCalls, isEmpty);
+      expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 0);
+      expect(rust.storedDelegationTxHashes, ['0:delegation-tx']);
+      expect(rust.storedVanPositions, ['0:0']);
+    },
+  );
 
   test('Keystone signing starts after active account reload', () async {
     final rust = FakeVotingRustApi();
@@ -3456,6 +3507,9 @@ ProviderContainer _sessionContainer({
           api: recoveryApi ?? FakeVotingRecoveryApi(state: recoveryState()),
         ),
       ),
+      accountProvider.overrideWith(
+        () => _FakeVotingAccountNotifier(mnemonic: kTestMnemonic),
+      ),
       votingDraftPersistenceProvider.overrideWithValue(
         draftPersistence ?? FakeVotingDraftPersistence(),
       ),
@@ -3539,6 +3593,20 @@ Future<void> _waitForVoteCommitmentKey(
   fail(
     'Timed out waiting for vote commitment $expectedKey. '
     'Saw ${rust.voteCommitmentKeys}.',
+  );
+}
+
+Future<void> _waitForStoredVanPosition(
+  FakeVotingRustApi rust,
+  String expectedPosition,
+) async {
+  for (var i = 0; i < 100; i++) {
+    if (rust.storedVanPositions.contains(expectedPosition)) return;
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  fail(
+    'Timed out waiting for stored VAN position $expectedPosition. '
+    'Saw ${rust.storedVanPositions}.',
   );
 }
 
@@ -4040,6 +4108,32 @@ class _ActiveVotingAccountNotifier extends Notifier<String?> {
 
   void set(String? accountUuid) {
     state = accountUuid;
+  }
+}
+
+class _FakeVotingAccountNotifier extends AccountNotifier {
+  _FakeVotingAccountNotifier({required this.mnemonic});
+
+  final String? mnemonic;
+
+  @override
+  FutureOr<AccountState> build() {
+    return const AccountState(
+      accounts: [
+        AccountInfo(
+          uuid: 'account-1',
+          name: 'Account 1',
+          order: 0,
+          isSeedAnchor: true,
+        ),
+      ],
+      activeAccountUuid: 'account-1',
+    );
+  }
+
+  @override
+  Future<String?> getMnemonicForAccount(String uuid) async {
+    return mnemonic;
   }
 }
 


### PR DESCRIPTION
Applies the downstream voting provider review fixes onto the voting UI branch.

The changes fence stale delegation and vote commitment submissions after account switches, skip unnecessary delegation/PIR setup for software vote-only submissions, and prevent stale voting config refreshes from overwriting a newer source selection.

Test plan:
- fvm dart format --set-exit-if-changed lib/src/providers/voting/voting_config_provider.dart lib/src/providers/voting/voting_session_provider.dart lib/src/providers/voting/voting_submission_job_provider.dart test/providers/voting/voting_providers_test.dart
- fvm flutter analyze lib/src/providers/voting test/providers/voting/voting_providers_test.dart
- fvm flutter test test/providers/voting/voting_providers_test.dart
