### PR TITLE
Restore strict checksum validation for static config sources.

### DIFF
--- a/lib/src/services/voting/voting_config_loader.dart
+++ b/lib/src/services/voting/voting_config_loader.dart
@@ -51,9 +51,19 @@ class StaticVotingConfigSourceMalformed implements Exception {
   String? sha256Hex;
   if (checksum != null) {
     const prefix = 'sha256:';
-    if (checksum.startsWith(prefix)) {
-      sha256Hex = checksum.substring(prefix.length);
+    if (!checksum.startsWith(prefix)) {
+      throw StaticVotingConfigSourceMalformed(
+        'checksum must use sha256: prefix: $raw',
+      );
     }
+    final checksumHex = checksum.substring(prefix.length);
+    final isLowerHex = RegExp(r'^[0-9a-f]+$').hasMatch(checksumHex);
+    if (checksumHex.length != 64 || !isLowerHex) {
+      throw StaticVotingConfigSourceMalformed(
+        'checksum must be 64 lowercase hex chars: $raw',
+      );
+    }
+    sha256Hex = checksumHex;
   }
 
   final strippedQuery = Map<String, String>.from(parsed.queryParameters)

--- a/test/services/voting/voting_config_loader_test.dart
+++ b/test/services/voting/voting_config_loader_test.dart
@@ -49,10 +49,20 @@ void main() {
   test('rejects malformed static config sources', () {
     const validHex =
         '0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a';
+    const shortHex =
+        '0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a';
+    const uppercaseHex =
+        'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
     for (final source in [
       'http://example.com/static.json?checksum=sha256:$validHex',
       'https:///static.json?checksum=sha256:$validHex',
       'not-a-url',
+      'https://example.com/static.json?checksum=sha512:$validHex',
+      'https://example.com/static.json?checksum=sha256:',
+      'https://example.com/static.json?checksum=sha256:$shortHex',
+      'https://example.com/static.json?checksum=sha256:$uppercaseHex',
+      'https://example.com/static.json?checksum=sha256:'
+          'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz',
     ]) {
       expect(
         () => parseStaticVotingConfigSource(source),


### PR DESCRIPTION
Reject non-sha256 checksum schemes and malformed sha256 values in the source parser so invalid custom sources cannot persist. Expand malformed-source tests to cover invalid checksum formats.