### PR TITLE
Apply voting UI review fixes

### DIFF
--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -222,15 +222,6 @@ class _VotingTopBar extends StatelessWidget {
                 onTap: onSettings,
               ),
             ),
-            Text(
-              'Coinholder polling',
-              textAlign: TextAlign.center,
-              style: AppTypography.headlineSmall.copyWith(
-                color: context.colors.text.accent,
-                fontWeight: FontWeight.w600,
-                letterSpacing: -0.18,
-              ),
-            ),
           ],
         ),
       ),
@@ -371,15 +362,6 @@ class _PollCard extends StatelessWidget {
               ),
             ),
             const SizedBox(height: AppSpacing.md),
-            Text(
-              'Poll description',
-              style: AppTypography.bodyMediumStrong.copyWith(
-                color: colors.text.secondary,
-                height: 20 / 14,
-                letterSpacing: -0.22,
-              ),
-            ),
-            const SizedBox(height: 2),
             Text(
               description.isEmpty ? round.roundId : description,
               maxLines: 4,

--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -153,11 +153,28 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
 
   void _openRoundAction(VotingRoundView round) {
     final state = _pollCardState(round);
-    if (state == _PollCardState.tallying || state == _PollCardState.closed) {
-      context.push(votingResultsRoute(round.roundId));
-      return;
-    }
-    context.push(votingPollRoute(round.roundId));
+    final route =
+        state == _PollCardState.tallying || state == _PollCardState.closed
+        ? votingResultsRoute(round.roundId)
+        : votingPollRoute(round.roundId);
+    _pushRoundRoute(route);
+  }
+
+  void _pushRoundRoute(String route) {
+    final VotingRoundsNotifier notifier =
+        _roundsNotifier ?? ref.read(votingRoundsProvider.notifier);
+    _roundsNotifier = notifier;
+    notifier.stopPolling();
+    unawaited(
+      context.push(route).whenComplete(() {
+        if (!mounted) return;
+        final VotingRoundsNotifier notifier =
+            _roundsNotifier ?? ref.read(votingRoundsProvider.notifier);
+        _roundsNotifier = notifier;
+        notifier.startPolling();
+        _preSyncLoadedRounds();
+      }),
+    );
   }
 
   void _openSettings() {
@@ -203,6 +220,15 @@ class _VotingTopBar extends StatelessWidget {
                 tooltip: 'Voting config',
                 semanticLabel: 'Voting config settings',
                 onTap: onSettings,
+              ),
+            ),
+            Text(
+              'Coinholder polling',
+              textAlign: TextAlign.center,
+              style: AppTypography.headlineSmall.copyWith(
+                color: context.colors.text.accent,
+                fontWeight: FontWeight.w600,
+                letterSpacing: -0.18,
               ),
             ),
           ],
@@ -345,6 +371,15 @@ class _PollCard extends StatelessWidget {
               ),
             ),
             const SizedBox(height: AppSpacing.md),
+            Text(
+              'Poll description',
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: colors.text.secondary,
+                height: 20 / 14,
+                letterSpacing: -0.22,
+              ),
+            ),
+            const SizedBox(height: 2),
             Text(
               description.isEmpty ? round.roundId : description,
               maxLines: 4,

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -38,6 +38,7 @@ class _VotingProposalDetailScreenState
     extends ConsumerState<VotingProposalDetailScreen> {
   bool _votingPowerPreparationStarted = false;
   bool _votingPowerPreparationInFlight = false;
+  String? _votingPowerPreparationKey;
   String? _delegationPirPrecomputeKey;
 
   @override
@@ -46,6 +47,7 @@ class _VotingProposalDetailScreenState
     if (oldWidget.roundId != widget.roundId) {
       _votingPowerPreparationStarted = false;
       _votingPowerPreparationInFlight = false;
+      _votingPowerPreparationKey = null;
       _delegationPirPrecomputeKey = null;
     }
   }
@@ -101,6 +103,7 @@ class _VotingProposalDetailScreenState
                   snapshotHeight: round.snapshotHeight,
                   description: _roundDescription(round.rawJson),
                   roundId: roundId,
+                  accountUuid: accountUuid,
                 ),
               );
             }
@@ -129,6 +132,7 @@ class _VotingProposalDetailScreenState
                   snapshotHeight: round.snapshotHeight,
                   description: _roundDescription(round.rawJson),
                   roundId: roundId,
+                  accountUuid: accountUuid,
                 ),
               );
             }
@@ -163,6 +167,13 @@ class _VotingProposalDetailScreenState
   }
 
   void _maybePrepareVotingPower(VotingSessionState state) {
+    final preparationKey = '${widget.roundId}|${state.accountUuid ?? ''}';
+    if (_votingPowerPreparationKey != preparationKey) {
+      _votingPowerPreparationKey = preparationKey;
+      _votingPowerPreparationStarted = false;
+      _votingPowerPreparationInFlight = false;
+    }
+
     if (_votingPowerPreparationStarted ||
         state.eligibleWeightZatoshi != null ||
         !_shouldPrepareVotingPower(state)) {
@@ -748,12 +759,14 @@ class _PendingVoteContent extends StatelessWidget {
     required this.snapshotHeight,
     required this.description,
     required this.roundId,
+    required this.accountUuid,
   });
 
   final String roundTitle;
   final int snapshotHeight;
   final String description;
   final String roundId;
+  final String? accountUuid;
 
   @override
   Widget build(BuildContext context) {
@@ -824,7 +837,9 @@ class _PendingVoteContent extends StatelessWidget {
                   ),
                   const SizedBox(height: AppSpacing.md),
                   AppButton(
-                    onPressed: () => context.go(votingStatusRoute(roundId)),
+                    onPressed: () => context.go(
+                      votingStatusRoute(roundId, accountUuid: accountUuid),
+                    ),
                     variant: AppButtonVariant.primary,
                     child: const Text('Continue voting'),
                   ),

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -108,17 +108,20 @@ class _VotingProposalDetailScreenState
               );
             }
             if (completedVote != null) {
-              return _VotedPollContent(
-                roundTitle: round.title.isEmpty
-                    ? 'Coinholder poll'
-                    : round.title,
-                snapshotHeight: round.snapshotHeight,
-                description: _roundDescription(round.rawJson),
-                votingPowerZatoshi: state.eligibleWeightZatoshi,
-                votingPowerPreparing: _votingPowerPreparationInFlight,
-                votedAt: completedVote.votedAt,
-                proposals: proposals,
-                choicesByProposalId: completedVote.choicesByProposalId,
+              return Padding(
+                padding: const EdgeInsets.all(AppSpacing.md),
+                child: _VotedPollContent(
+                  roundTitle: round.title.isEmpty
+                      ? 'Coinholder poll'
+                      : round.title,
+                  snapshotHeight: round.snapshotHeight,
+                  description: _roundDescription(round.rawJson),
+                  votingPowerZatoshi: state.eligibleWeightZatoshi,
+                  votingPowerPreparing: _votingPowerPreparationInFlight,
+                  votedAt: completedVote.votedAt,
+                  proposals: proposals,
+                  choicesByProposalId: completedVote.choicesByProposalId,
+                ),
               );
             }
             final pendingVote = _PendingVoteRecovery.fromPlan(state.roundPlan);

--- a/lib/src/features/voting/screens/voting_results_screen.dart
+++ b/lib/src/features/voting/screens/voting_results_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -14,26 +16,53 @@ import '../../../providers/voting/voting_session_provider.dart';
 import '../../../providers/voting/voting_state.dart';
 import '../voting_choice_style.dart';
 import '../voting_flow_models.dart';
+import '../voting_poll_ordering.dart';
 import '../widgets/voting_pane_scroll_area.dart';
 
 const int _ballotDivisorZatoshi = 12500000;
+const _pendingTallyRefreshInterval = Duration(seconds: 10);
 
-final _roundTallyProvider = FutureProvider.family((ref, String roundId) async {
+final _roundTallyProvider = FutureProvider.autoDispose.family((
+  ref,
+  String roundId,
+) async {
   final config = await ref.watch(votingConfigProvider.future);
   return ref
       .read(votingApiClientProvider(config.apiBaseUrl))
       .getRoundTally(roundId);
 });
 
-class VotingResultsScreen extends ConsumerWidget {
+class VotingResultsScreen extends ConsumerStatefulWidget {
   const VotingResultsScreen({super.key, required this.roundId});
 
   final String roundId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final session = ref.watch(votingSessionProvider(roundId));
-    final tally = ref.watch(_roundTallyProvider(roundId));
+  ConsumerState<VotingResultsScreen> createState() =>
+      _VotingResultsScreenState();
+}
+
+class _VotingResultsScreenState extends ConsumerState<VotingResultsScreen> {
+  Timer? _pendingTallyRefreshTimer;
+
+  @override
+  void didUpdateWidget(covariant VotingResultsScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.roundId != widget.roundId) {
+      _clearPendingTallyRefresh();
+    }
+  }
+
+  @override
+  void dispose() {
+    _clearPendingTallyRefresh();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final session = ref.watch(votingSessionProvider(widget.roundId));
+    final tally = ref.watch(_roundTallyProvider(widget.roundId));
 
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
@@ -59,10 +88,18 @@ class VotingResultsScreen extends ConsumerWidget {
               child: tally.when(
                 skipLoadingOnRefresh: false,
                 loading: () => const Center(child: CircularProgressIndicator()),
-                error: (error, _) => _Message("Couldn't load results: $error"),
+                error: (error, _) {
+                  final round = session.value?.round;
+                  if (round != null && _roundIsTallying(round)) {
+                    return _pendingResults();
+                  }
+                  _clearPendingTallyRefresh();
+                  return _Message("Couldn't load results: $error");
+                },
                 data: (result) {
                   final round = session.value?.round;
                   if (round == null) {
+                    _clearPendingTallyRefresh();
                     if (session.hasError) {
                       return _Message(
                         "Couldn't load poll details: ${session.error}",
@@ -72,8 +109,9 @@ class VotingResultsScreen extends ConsumerWidget {
                   }
                   final proposals = proposalsFromRound(round);
                   if (_isTallying(result.rawJson)) {
-                    return const _Message('Results pending...');
+                    return _pendingResults();
                   }
+                  _clearPendingTallyRefresh();
                   return VotingPaneScrollView(
                     maxWidth: 720,
                     scrollPadding: const EdgeInsets.only(bottom: AppSpacing.md),
@@ -125,6 +163,25 @@ class VotingResultsScreen extends ConsumerWidget {
         ),
       ),
     );
+  }
+
+  Widget _pendingResults() {
+    _schedulePendingTallyRefresh();
+    return const _Message('Results pending...');
+  }
+
+  void _schedulePendingTallyRefresh() {
+    if (_pendingTallyRefreshTimer != null) return;
+    _pendingTallyRefreshTimer = Timer(_pendingTallyRefreshInterval, () {
+      _pendingTallyRefreshTimer = null;
+      if (!mounted) return;
+      ref.invalidate(_roundTallyProvider(widget.roundId));
+    });
+  }
+
+  void _clearPendingTallyRefresh() {
+    _pendingTallyRefreshTimer?.cancel();
+    _pendingTallyRefreshTimer = null;
   }
 }
 
@@ -466,8 +523,14 @@ class _Message extends StatelessWidget {
 bool _isTallying(Map<String, dynamic> json) {
   final status = (json['status'] ?? json['phase'] ?? '')
       .toString()
+      .trim()
       .toLowerCase();
-  return status == 'tallying' || status == 'pending';
+  return status == '2' || status == 'tallying' || status == 'pending';
+}
+
+bool _roundIsTallying(VotingRoundDetails round) {
+  return votingPollListStatus(round.status) == VotingPollListStatus.tallying ||
+      _isTallying(round.rawJson);
 }
 
 String _roundTitle(VotingRoundDetails round) {

--- a/lib/src/features/voting/screens/voting_results_screen.dart
+++ b/lib/src/features/voting/screens/voting_results_screen.dart
@@ -14,6 +14,7 @@ import '../../../providers/voting/voting_config_provider.dart';
 import '../../../providers/voting/voting_service_providers.dart';
 import '../../../providers/voting/voting_session_provider.dart';
 import '../../../providers/voting/voting_state.dart';
+import '../../../services/voting/voting_models.dart';
 import '../voting_choice_style.dart';
 import '../voting_flow_models.dart';
 import '../voting_poll_ordering.dart';
@@ -90,7 +91,9 @@ class _VotingResultsScreenState extends ConsumerState<VotingResultsScreen> {
                 loading: () => const Center(child: CircularProgressIndicator()),
                 error: (error, _) {
                   final round = session.value?.round;
-                  if (round != null && _roundIsTallying(round)) {
+                  if (round != null &&
+                      _roundIsTallying(round) &&
+                      _isTallyNotReadyError(error)) {
                     return _pendingResults();
                   }
                   _clearPendingTallyRefresh();
@@ -531,6 +534,10 @@ bool _isTallying(Map<String, dynamic> json) {
 bool _roundIsTallying(VotingRoundDetails round) {
   return votingPollListStatus(round.status) == VotingPollListStatus.tallying ||
       _isTallying(round.rawJson);
+}
+
+bool _isTallyNotReadyError(Object error) {
+  return error is VotingHttpException && error.statusCode == 404;
 }
 
 String _roundTitle(VotingRoundDetails round) {

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -90,57 +90,74 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                       ),
                     ),
                   );
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                const Align(
-                  alignment: Alignment.centerLeft,
-                  child: AppRouteBackLink(),
-                ),
-                const Spacer(),
-                Text(
-                  'Review your answers',
-                  textAlign: TextAlign.center,
-                  style: AppTypography.displaySmall.copyWith(
-                    color: context.colors.text.accent,
-                  ),
-                ),
-                const SizedBox(height: AppSpacing.md),
-                ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 620),
-                  child: Column(
-                    children: [
-                      for (final proposal in proposals)
-                        _ReviewRow(
-                          title: proposal.title,
-                          value: _reviewValue(proposal, draft),
-                          skipped: draft.choices[proposal.id] == null,
+            return LayoutBuilder(
+              builder: (context, constraints) {
+                return SingleChildScrollView(
+                  child: ConstrainedBox(
+                    constraints: BoxConstraints(
+                      minHeight: constraints.maxHeight,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        const Align(
+                          alignment: Alignment.centerLeft,
+                          child: AppRouteBackLink(),
                         ),
-                    ],
-                  ),
-                ),
-                if (draft.isEmpty)
-                  const _Message(
-                    'Choose at least one option before submitting.',
-                  ),
-                const SizedBox(height: AppSpacing.md),
-                Center(
-                  child: AppButton(
-                    onPressed: draft.isEmpty
-                        ? null
-                        : () => context.go(
-                            votingStatusRoute(
-                              widget.roundId,
-                              accountUuid: accountUuid,
+                        const SizedBox(height: AppSpacing.xl),
+                        Center(
+                          child: ConstrainedBox(
+                            constraints: const BoxConstraints(maxWidth: 620),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  'Review your answers',
+                                  textAlign: TextAlign.center,
+                                  style: AppTypography.displaySmall.copyWith(
+                                    color: context.colors.text.accent,
+                                  ),
+                                ),
+                                const SizedBox(height: AppSpacing.md),
+                                for (final proposal in proposals)
+                                  _ReviewRow(
+                                    title: proposal.title,
+                                    value: _reviewValue(proposal, draft),
+                                    skipped: draft.choices[proposal.id] == null,
+                                  ),
+                                if (draft.isEmpty) ...[
+                                  const SizedBox(height: AppSpacing.xs),
+                                  const _Message(
+                                    'Choose at least one option before submitting.',
+                                  ),
+                                ],
+                                const SizedBox(height: AppSpacing.md),
+                                Center(
+                                  child: AppButton(
+                                    onPressed: draft.isEmpty
+                                        ? null
+                                        : () => context.go(
+                                            votingStatusRoute(
+                                              widget.roundId,
+                                              accountUuid: accountUuid,
+                                            ),
+                                          ),
+                                    variant: AppButtonVariant.primary,
+                                    minWidth: 240,
+                                    child: const Text('Confirm and submit'),
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
-                    variant: AppButtonVariant.primary,
-                    minWidth: 240,
-                    child: const Text('Confirm and submit'),
+                        ),
+                        const SizedBox(height: AppSpacing.xl),
+                      ],
+                    ),
                   ),
-                ),
-                const Spacer(),
-              ],
+                );
+              },
             );
           },
         ),
@@ -191,6 +208,7 @@ class _ReviewRow extends StatelessWidget {
         border: Border.all(color: colors.border.subtle),
       ),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Expanded(
             child: Text(
@@ -198,9 +216,15 @@ class _ReviewRow extends StatelessWidget {
               style: AppTypography.bodyMedium.copyWith(color: titleColor),
             ),
           ),
-          Text(
-            value,
-            style: AppTypography.bodyMediumStrong.copyWith(color: valueColor),
+          const SizedBox(width: AppSpacing.sm),
+          Flexible(
+            child: Text(
+              value,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.right,
+              style: AppTypography.bodyMediumStrong.copyWith(color: valueColor),
+            ),
           ),
         ],
       ),

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -128,7 +128,12 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                   child: AppButton(
                     onPressed: draft.isEmpty
                         ? null
-                        : () => context.go(votingStatusRoute(widget.roundId)),
+                        : () => context.go(
+                            votingStatusRoute(
+                              widget.roundId,
+                              accountUuid: accountUuid,
+                            ),
+                          ),
                     variant: AppButtonVariant.primary,
                     minWidth: 240,
                     child: const Text('Confirm and submit'),

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -145,7 +145,7 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                                           ),
                                     variant: AppButtonVariant.primary,
                                     minWidth: 240,
-                                    child: const Text('Confirm and submit'),
+                                    child: const Text('Confirm & submit'),
                                   ),
                                 ),
                               ],

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -37,6 +37,7 @@ class VotingStatusScreen extends ConsumerStatefulWidget {
 
 class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
   bool _startScheduled = false;
+  int _startGeneration = 0;
   VotingSessionKey? _jobKey;
   VotingSessionKey? _confirmationNavigationScheduledFor;
 
@@ -67,20 +68,40 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
   void _scheduleStart() {
     if (_startScheduled) return;
     _startScheduled = true;
+    final generation = ++_startGeneration;
+    final roundId = widget.roundId;
+    final accountUuid = widget.accountUuid;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
+      if (!_isCurrentStart(generation, roundId, accountUuid)) return;
       unawaited(
         ref
             .read(votingSubmissionJobsProvider.notifier)
-            .start(widget.roundId, accountUuid: widget.accountUuid)
+            .start(roundId, accountUuid: accountUuid)
             .then((key) {
-              if (!mounted || key == null) return;
+              if (!_isCurrentStart(generation, roundId, accountUuid) ||
+                  key == null ||
+                  !_isCurrentRouteKey(key)) {
+                return;
+              }
               setState(() {
                 _jobKey = key;
               });
             }),
       );
     });
+  }
+
+  bool _isCurrentStart(int generation, String roundId, String? accountUuid) {
+    return mounted &&
+        generation == _startGeneration &&
+        widget.roundId == roundId &&
+        widget.accountUuid == accountUuid;
+  }
+
+  bool _isCurrentRouteKey(VotingSessionKey key) {
+    if (!mounted || key.roundId != widget.roundId) return false;
+    final accountUuid = widget.accountUuid;
+    return accountUuid == null || key.accountUuid == accountUuid;
   }
 
   VotingSessionKey? _selectedJobKey() {
@@ -97,7 +118,7 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
     final key = _selectedJobKey();
     if (key == null) return;
     final signedPczt = await context.push<List<int>>('/voting/keystone/scan');
-    if (!mounted) return;
+    if (!mounted || _selectedJobKey() != key) return;
     if (signedPczt == null || signedPczt.isEmpty) return;
     await ref
         .read(votingSubmissionJobsProvider.notifier)
@@ -128,7 +149,7 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
         );
       },
     );
-    if (!mounted) return;
+    if (!mounted || _selectedJobKey() != key) return;
     if (confirmed != true) return;
     await ref
         .read(votingSubmissionJobsProvider.notifier)
@@ -417,7 +438,7 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
       }
       context.go(
         votingSubmissionConfirmedRoute(
-          widget.roundId,
+          key.roundId,
           accountUuid: key.accountUuid,
         ),
       );

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -97,6 +97,7 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
     final key = _selectedJobKey();
     if (key == null) return;
     final signedPczt = await context.push<List<int>>('/voting/keystone/scan');
+    if (!mounted) return;
     if (signedPczt == null || signedPczt.isEmpty) return;
     await ref
         .read(votingSubmissionJobsProvider.notifier)
@@ -127,6 +128,7 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
         );
       },
     );
+    if (!mounted) return;
     if (confirmed != true) return;
     await ref
         .read(votingSubmissionJobsProvider.notifier)

--- a/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
+++ b/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
@@ -66,7 +66,7 @@ class VotingSubmissionConfirmationScreen extends ConsumerWidget {
                 }
                 return _ConfirmationScaffold(
                   confirmed: true,
-                  title: 'Submission confirmed',
+                  title: 'Submission confirmed!',
                   pollTitle: pollTitle,
                   message:
                       'Your vote was successfully published and cannot be changed.',

--- a/lib/src/features/voting/voting_routes.dart
+++ b/lib/src/features/voting/voting_routes.dart
@@ -9,13 +9,15 @@ String votingReviewRoute(String roundId) =>
 String votingStatusRoute(String roundId, {String? accountUuid}) {
   final base = '${votingPollRoute(roundId)}/status';
   if (accountUuid == null || accountUuid.isEmpty) return base;
-  return Uri(path: base, queryParameters: {'account': accountUuid}).toString();
+  final query = Uri(queryParameters: {'account': accountUuid}).query;
+  return '$base?$query';
 }
 
 String votingSubmissionConfirmedRoute(String roundId, {String? accountUuid}) {
   final base = '${votingPollRoute(roundId)}/submitted';
   if (accountUuid == null || accountUuid.isEmpty) return base;
-  return Uri(path: base, queryParameters: {'account': accountUuid}).toString();
+  final query = Uri(queryParameters: {'account': accountUuid}).query;
+  return '$base?$query';
 }
 
 String votingResultsRoute(String roundId) =>

--- a/lib/src/features/voting/widgets/voting_config_settings_panel.dart
+++ b/lib/src/features/voting/widgets/voting_config_settings_panel.dart
@@ -11,6 +11,7 @@ import '../../../providers/voting/voting_config_provider.dart';
 import '../../../providers/voting/voting_config_source_provider.dart';
 import '../../../providers/voting/voting_rounds_provider.dart';
 import '../../../providers/voting/voting_service_providers.dart';
+import '../../../providers/voting/voting_submission_guard_provider.dart';
 import '../../../services/voting/voting_config_loader.dart';
 import '../../../services/voting/voting_models.dart';
 
@@ -119,6 +120,7 @@ class _VotingConfigSettingsPanelState
 
   bool _canSaveEditor(VotingConfigSourceState source) {
     if (_isSubmitting || !_showEditor) return false;
+    if (ref.read(votingSubmissionGuardProvider).isNotEmpty) return false;
     final name = _nameController.text.trim();
     final url = _urlController.text.trim();
     if (name.length > _maxSourceNameLength || url.isEmpty) return false;
@@ -134,6 +136,7 @@ class _VotingConfigSettingsPanelState
   Future<void> _saveEditor() async {
     final source = ref.read(votingConfigSourceProvider).value;
     if (source == null || !_canSaveEditor(source)) return;
+    if (_blockIfVotingSubmissionInProgress()) return;
     final name = _nameController.text.trim();
     final url = _urlController.text.trim();
 
@@ -144,11 +147,11 @@ class _VotingConfigSettingsPanelState
     });
 
     try {
-      await _validateSource(url);
+      final config = await _validateSource(url);
       await ref
           .read(votingConfigSourceProvider.notifier)
           .saveSource(id: _editingSourceId, name: name, sourceUrl: url);
-      await _refreshAndClose();
+      await _refreshAndClose(config: config);
     } catch (error) {
       if (!mounted) return;
       setState(() {
@@ -161,6 +164,7 @@ class _VotingConfigSettingsPanelState
 
   Future<void> _useDefault(VotingConfigSourceState source) async {
     if (_isSubmitting || source.isDefault) return;
+    if (_blockIfVotingSubmissionInProgress()) return;
     setState(() {
       _isSubmitting = true;
       _submitError = null;
@@ -182,6 +186,7 @@ class _VotingConfigSettingsPanelState
 
   Future<void> _useSaved(SavedVotingConfigSource saved) async {
     if (_isSubmitting) return;
+    if (_blockIfVotingSubmissionInProgress()) return;
     setState(() {
       _isSubmitting = true;
       _submitError = null;
@@ -189,11 +194,11 @@ class _VotingConfigSettingsPanelState
     });
 
     try {
-      await _validateSource(saved.sourceUrl);
+      final config = await _validateSource(saved.sourceUrl);
       await ref
           .read(votingConfigSourceProvider.notifier)
           .setCustom(saved.sourceUrl);
-      await _refreshAndClose();
+      await _refreshAndClose(config: config);
     } catch (error) {
       if (!mounted) return;
       setState(() {
@@ -206,6 +211,7 @@ class _VotingConfigSettingsPanelState
 
   Future<void> _deleteSaved(SavedVotingConfigSource saved) async {
     if (_isSubmitting) return;
+    if (_blockIfVotingSubmissionInProgress()) return;
     setState(() {
       _isSubmitting = true;
       _submitError = null;
@@ -246,16 +252,31 @@ class _VotingConfigSettingsPanelState
     }
   }
 
-  Future<void> _validateSource(String input) async {
+  bool _blockIfVotingSubmissionInProgress() {
+    final guards = ref.read(votingSubmissionGuardProvider);
+    if (guards.isEmpty) return false;
+    setState(() {
+      _submitError = guards.first.message;
+      _validationField = null;
+      _isSubmitting = false;
+    });
+    return true;
+  }
+
+  Future<VotingConfig> _validateSource(String input) async {
     final parsed = StaticVotingConfigSource.parse(input);
-    await VotingConfigLoader(
+    return VotingConfigLoader(
       httpClient: ref.read(votingHttpClientProvider),
       staticConfigSource: parsed,
     ).load();
   }
 
-  Future<void> _refreshAndClose() async {
-    await ref.read(votingConfigProvider.notifier).refresh();
+  Future<void> _refreshAndClose({VotingConfig? config}) async {
+    if (config == null) {
+      await ref.read(votingConfigProvider.notifier).refresh();
+    } else {
+      ref.read(votingConfigProvider.notifier).setLoadedConfig(config);
+    }
     await ref.read(votingRoundsProvider.notifier).refresh();
     if (!mounted) return;
     setState(() {
@@ -297,6 +318,9 @@ class _VotingConfigSettingsPanelState
   Widget build(BuildContext context) {
     final colors = context.colors;
     final sourceState = ref.watch(votingConfigSourceProvider);
+    final submissionInProgress = ref
+        .watch(votingSubmissionGuardProvider)
+        .isNotEmpty;
 
     return DecoratedBox(
       decoration: BoxDecoration(
@@ -348,7 +372,7 @@ class _VotingConfigSettingsPanelState
                             sourceUrl: kDefaultStaticVotingConfigSource,
                             isDefault: true,
                             selected: source.isDefault,
-                            onUse: source.isDefault
+                            onUse: source.isDefault || submissionInProgress
                                 ? null
                                 : () => _useDefault(source),
                           ),
@@ -364,15 +388,20 @@ class _VotingConfigSettingsPanelState
                                     saved.sourceUrl,
                                   ),
                               onUse:
-                                  !source.isDefault &&
-                                      _sameSourceUrl(
-                                        source.sourceUrl,
-                                        saved.sourceUrl,
-                                      )
+                                  submissionInProgress ||
+                                      (!source.isDefault &&
+                                          _sameSourceUrl(
+                                            source.sourceUrl,
+                                            saved.sourceUrl,
+                                          ))
                                   ? null
                                   : () => _useSaved(saved),
-                              onEdit: () => _startEdit(saved),
-                              onDelete: () => _deleteSaved(saved),
+                              onEdit: submissionInProgress
+                                  ? null
+                                  : () => _startEdit(saved),
+                              onDelete: submissionInProgress
+                                  ? null
+                                  : () => _deleteSaved(saved),
                             ),
                           ],
                           const SizedBox(height: AppSpacing.sm),
@@ -394,7 +423,9 @@ class _VotingConfigSettingsPanelState
                             )
                           else
                             AppButton(
-                              onPressed: _isSubmitting ? null : _startAdd,
+                              onPressed: _isSubmitting || submissionInProgress
+                                  ? null
+                                  : _startAdd,
                               variant: AppButtonVariant.secondary,
                               minWidth: 220,
                               leading: const AppIcon(AppIcons.addNew),

--- a/lib/src/providers/voting/voting_config_provider.dart
+++ b/lib/src/providers/voting/voting_config_provider.dart
@@ -46,6 +46,12 @@ class VotingConfigNotifier extends AsyncNotifier<VotingConfig> {
     state = config;
   }
 
+  /// Replaces state with a config that was already loaded and validated.
+  void setLoadedConfig(VotingConfig config) {
+    _loadGeneration++;
+    state = AsyncData(config);
+  }
+
   bool _isCurrentLoad(int generation) {
     return ref.mounted && generation == _loadGeneration;
   }

--- a/test/features/voting/voting_config_settings_panel_test.dart
+++ b/test/features/voting/voting_config_settings_panel_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/features/voting/widgets/voting_config_settings_panel.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_config_source_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_submission_guard_provider.dart';
+
+void main() {
+  testWidgets('config source actions are disabled during submission', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(800, 720));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          votingConfigSourceStoreProvider.overrideWithValue(
+            _FakeVotingConfigSourceStore(),
+          ),
+          votingSubmissionGuardProvider.overrideWith(
+            _GuardedVotingSubmissionGuardNotifier.new,
+          ),
+        ],
+        child: WidgetsApp(
+          color: const Color(0xFFFFFFFF),
+          builder: (context, _) {
+            return AppTheme(
+              data: AppThemeData.light,
+              child: const Center(child: VotingConfigSettingsPanel()),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final addButton = tester.widget<AppButton>(
+      find.ancestor(
+        of: find.text('Add custom source'),
+        matching: find.byType(AppButton),
+      ),
+    );
+    expect(addButton.onPressed, isNull);
+
+    await tester.tap(find.text('Add custom source'));
+    await tester.pump();
+
+    expect(find.text('Add Custom Source'), findsNothing);
+  });
+}
+
+class _GuardedVotingSubmissionGuardNotifier
+    extends VotingSubmissionGuardNotifier {
+  @override
+  List<VotingSubmissionGuard> build() {
+    return const [
+      VotingSubmissionGuard(
+        token: 1,
+        accountUuid: 'account-1',
+        roundId: 'round-1',
+      ),
+    ];
+  }
+}
+
+class _FakeVotingConfigSourceStore implements VotingConfigSourceStore {
+  String? sourceUrl;
+  String? savedSourcesJson;
+
+  @override
+  Future<String?> readSourceUrl() async => sourceUrl;
+
+  @override
+  Future<void> writeSourceUrl(String sourceUrl) async {
+    this.sourceUrl = sourceUrl;
+  }
+
+  @override
+  Future<void> resetSourceUrl() async {
+    sourceUrl = null;
+  }
+
+  @override
+  Future<String?> readSavedSourcesJson() async => savedSourcesJson;
+
+  @override
+  Future<void> writeSavedSourcesJson(String savedSourcesJson) async {
+    this.savedSourcesJson = savedSourcesJson;
+  }
+}

--- a/test/features/voting/voting_config_settings_panel_test.dart
+++ b/test/features/voting/voting_config_settings_panel_test.dart
@@ -50,7 +50,7 @@ void main() {
     await tester.tap(find.text('Add custom source'));
     await tester.pump();
 
-    expect(find.text('Add Custom Source'), findsNothing);
+    expect(find.text('Static config URL'), findsNothing);
   });
 }
 

--- a/test/features/voting/voting_polls_screen_test.dart
+++ b/test/features/voting/voting_polls_screen_test.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/config/swap_feature_config.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/voting/screens/voting_polls_screen.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_rounds_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_state.dart';
+
+void main() {
+  testWidgets('poll list pauses polling while a pushed poll route is open', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    late _TrackingVotingRoundsNotifier roundsNotifier;
+    late final GoRouter router;
+    router = GoRouter(
+      initialLocation: '/voting',
+      routes: [
+        GoRoute(path: '/voting', builder: (_, _) => const VotingPollsScreen()),
+        GoRoute(
+          path: '/voting/poll/:roundId/results',
+          builder: (_, _) => const Text('results route'),
+        ),
+        GoRoute(path: '/accounts', builder: (_, _) => const Text('accounts')),
+        GoRoute(path: '/home', builder: (_, _) => const Text('home')),
+        GoRoute(
+          path: '/address-book',
+          builder: (_, _) => const Text('address book'),
+        ),
+        GoRoute(path: '/activity', builder: (_, _) => const Text('activity')),
+        GoRoute(path: '/settings', builder: (_, _) => const Text('settings')),
+        GoRoute(path: '/about', builder: (_, _) => const Text('about')),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          accountProvider.overrideWith(_SoftwareAccountNotifier.new),
+          syncProvider.overrideWith(_NoopSyncNotifier.new),
+          swapFeatureEnabledProvider.overrideWithValue(false),
+          votingRoundsProvider.overrideWith(() {
+            roundsNotifier = _TrackingVotingRoundsNotifier();
+            return roundsNotifier;
+          }),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, child) =>
+              AppTheme(data: AppThemeData.light, child: child!),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(roundsNotifier.startCount, 1);
+    expect(roundsNotifier.stopCount, 0);
+
+    await tester.tap(find.text('View results'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('results route'), findsOneWidget);
+    expect(roundsNotifier.stopCount, 1);
+
+    router.pop();
+    await tester.pumpAndSettle();
+
+    expect(find.text('View results'), findsOneWidget);
+    expect(roundsNotifier.startCount, 2);
+  });
+}
+
+class _TrackingVotingRoundsNotifier extends VotingRoundsNotifier {
+  int startCount = 0;
+  int stopCount = 0;
+  int refreshCount = 0;
+
+  @override
+  Future<List<VotingRoundView>> build() async {
+    return const [
+      VotingRoundView(
+        roundId: 'round-1',
+        title: 'Closed poll',
+        status: 'closed',
+        rawJson: {'description': 'Closed poll description'},
+      ),
+    ];
+  }
+
+  @override
+  void startPolling({
+    Duration interval = VotingRoundsNotifier.defaultPollInterval,
+  }) {
+    startCount++;
+  }
+
+  @override
+  void stopPolling() {
+    stopCount++;
+  }
+
+  @override
+  Future<void> refresh() async {
+    refreshCount++;
+  }
+}
+
+class _SoftwareAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() => const AccountState(
+    accounts: [AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0)],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1softwareaddress',
+  );
+}
+
+class _NoopSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncState> build() async => SyncState();
+}

--- a/test/features/voting/voting_routes_test.dart
+++ b/test/features/voting/voting_routes_test.dart
@@ -20,8 +20,16 @@ void main() {
       '/voting/poll/El5UdfZTsHTV9MNnMIUmlfNWQWwrbDBCUWqRLlv%2F3RE%3D/status',
     );
     expect(
+      votingStatusRoute(roundId, accountUuid: 'account/1'),
+      '/voting/poll/El5UdfZTsHTV9MNnMIUmlfNWQWwrbDBCUWqRLlv%2F3RE%3D/status?account=account%2F1',
+    );
+    expect(
       votingSubmissionConfirmedRoute(roundId),
       '/voting/poll/El5UdfZTsHTV9MNnMIUmlfNWQWwrbDBCUWqRLlv%2F3RE%3D/submitted',
+    );
+    expect(
+      votingSubmissionConfirmedRoute(roundId, accountUuid: 'account/1'),
+      '/voting/poll/El5UdfZTsHTV9MNnMIUmlfNWQWwrbDBCUWqRLlv%2F3RE%3D/submitted?account=account%2F1',
     );
     expect(
       votingResultsRoute(roundId),

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -279,7 +279,7 @@ void main() {
     await tester.pumpAndSettle();
     await _pumpUntilFound(tester, find.text('Submission not complete'));
 
-    expect(find.text('Submission confirmed'), findsNothing);
+    expect(find.text('Submission confirmed!'), findsNothing);
     expect(
       find.text('This account has not completed submission for this poll.'),
       findsOneWidget,
@@ -1156,13 +1156,13 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Review your answers'), findsOneWidget);
-    expect(find.text('Confirm and submit'), findsOneWidget);
+    expect(find.text('Confirm & submit'), findsOneWidget);
     expect(find.text('First proposal'), findsOneWidget);
     expect(find.text('Yes'), findsOneWidget);
     expect(find.text('Second proposal'), findsOneWidget);
     expect(find.text('Skipped'), findsOneWidget);
 
-    await tester.tap(find.text('Confirm & Submit'));
+    await tester.tap(find.text('Confirm & submit'));
     await tester.pumpAndSettle();
 
     expect(find.text('status account: account-1'), findsOneWidget);
@@ -1216,8 +1216,8 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(find.byType(SingleChildScrollView), findsWidgets);
 
-    await tester.scrollUntilVisible(find.text('Confirm & Submit'), 300);
-    expect(find.text('Confirm & Submit'), findsOneWidget);
+    await tester.scrollUntilVisible(find.text('Confirm & submit'), 300);
+    expect(find.text('Confirm & submit'), findsOneWidget);
   });
 
   testWidgets('pending vote continue keeps the session account', (
@@ -1369,7 +1369,7 @@ void main() {
 
     expect(starts, [staleKey, currentKey]);
     expect(find.text('stale key selected'), findsNothing);
-    expect(find.text('Submitting Votes'), findsOneWidget);
+    expect(find.text('Submitting votes'), findsOneWidget);
   });
 
   testWidgets('status screen navigates after successful submission', (
@@ -2398,7 +2398,6 @@ class _NoopVotingRustApi implements VotingRustApi {
   Future<List<int>> deriveHotkey({
     required String mnemonic,
     required String roundId,
-    required String accountUuid,
     required String network,
   }) async {
     return [9, 9, 9];

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1108,6 +1108,87 @@ void main() {
     expect(find.textContaining("Couldn't load results"), findsNothing);
   });
 
+  testWidgets('results screen refreshes pending tally responses', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final round = _roundStatusJson()..['status'] = 'tallying';
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round}
+        ..['/shielded-vote/v1/tally-results/$_roundId'] =
+            SequentialVotingHttpResponses([
+              {
+                'vote_round_id': _roundId,
+                'status': 'pending',
+                'results': const [],
+              },
+              {
+                'vote_round_id': _roundId,
+                'results': [
+                  {'proposal_id': 1, 'vote_decision': 0, 'total_value': 8},
+                ],
+              },
+            ]),
+    );
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _MnemonicAccountNotifier.new,
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: _resultsHarness()),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Results pending...'), findsOneWidget);
+    expect(_tallyRequestCount(http), 1);
+
+    await tester.pump(const Duration(seconds: 10));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Results pending...'), findsNothing);
+    expect(find.text('First proposal'), findsOneWidget);
+    expect(find.text('1.00 ZEC'), findsOneWidget);
+    expect(_tallyRequestCount(http), greaterThanOrEqualTo(2));
+  });
+
+  testWidgets('results screen treats not-ready tally errors as pending', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final round = _roundStatusJson()..['status'] = '2';
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round}
+        ..['/shielded-vote/v1/tally-results/$_roundId'] = jsonResponse({
+          'error': 'tally not ready',
+        }, statusCode: 404),
+    );
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _MnemonicAccountNotifier.new,
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: _resultsHarness()),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Results pending...'), findsOneWidget);
+    expect(find.textContaining("Couldn't load results"), findsNothing);
+  });
+
   testWidgets('reviewing partial votes warns and marks skipped rows', (
     tester,
   ) async {
@@ -2059,6 +2140,12 @@ Map<String, Object> _votingHttpResponses() => {
   'https://voting.example/dynamic-voting-config.json': _dynamicConfigJson(),
   '/shielded-vote/v1/round/$_roundId': {'round': _roundStatusJson()},
 };
+
+int _tallyRequestCount(FakeVotingHttpClient http) {
+  return http.requests
+      .where((request) => request.uri.path.endsWith('/tally-results/$_roundId'))
+      .length;
+}
 
 const _roundId =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1189,6 +1189,37 @@ void main() {
     expect(find.textContaining("Couldn't load results"), findsNothing);
   });
 
+  testWidgets('results screen surfaces non-pending tally errors', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final round = _roundStatusJson()..['status'] = 'tallying';
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round}
+        ..['/shielded-vote/v1/tally-results/$_roundId'] = jsonResponse({
+          'error': 'server unavailable',
+        }, statusCode: 500),
+    );
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _MnemonicAccountNotifier.new,
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: _resultsHarness()),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Results pending...'), findsNothing);
+    expect(find.textContaining("Couldn't load results"), findsOneWidget);
+  });
+
   testWidgets('reviewing partial votes warns and marks skipped rows', (
     tester,
   ) async {

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1168,6 +1168,58 @@ void main() {
     expect(find.text('status account: account-1'), findsOneWidget);
   });
 
+  testWidgets('review screen scrolls long ballots without overflowing', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 520));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final round = _roundStatusJson()
+      ..['proposals'] = [
+        for (var i = 1; i <= 15; i++)
+          _proposalJson(i, 'Long proposal title number $i', [
+            'A very long answer label that must not overflow the review row $i',
+            'No',
+          ]),
+      ];
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
+    );
+    final recoveryApi = _MutableVotingRecoveryApi();
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _NoMnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _VotingStatusRustApi(recoveryApi),
+    );
+    addTearDown(container.dispose);
+    final draftNotifier = container.read(
+      votingDraftProvider(_draftKey).notifier,
+    );
+    for (var i = 1; i <= 15; i++) {
+      draftNotifier.setChoice(i, 0);
+    }
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(
+          initialLocation: '/voting/poll/$_roundId/review',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(SingleChildScrollView), findsWidgets);
+
+    await tester.scrollUntilVisible(find.text('Confirm & Submit'), 300);
+    expect(find.text('Confirm & Submit'), findsOneWidget);
+  });
+
   testWidgets('pending vote continue keeps the session account', (
     tester,
   ) async {
@@ -1211,6 +1263,113 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('status account: account-1'), findsOneWidget);
+  });
+
+  testWidgets('status screen ignores stale start results after route change', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    const staleKey = VotingSessionKey(
+      roundId: 'round-a',
+      accountUuid: 'account-a',
+    );
+    const currentKey = VotingSessionKey(
+      roundId: 'round-b',
+      accountUuid: 'account-b',
+    );
+    final firstStart = Completer<VotingSessionKey?>();
+    final secondStart = Completer<VotingSessionKey?>();
+    final starts = <VotingSessionKey>[];
+    late final GoRouter router;
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      overrides: [
+        votingSubmissionJobsProvider.overrideWith(
+          () => _ControlledVotingSubmissionJobsNotifier(
+            starts: starts,
+            completions: [firstStart, secondStart],
+          ),
+        ),
+        votingSubmissionJobProvider(staleKey).overrideWith(
+          () => _StaticVotingSubmissionJobNotifier(
+            staleKey,
+            const VotingSubmissionJobState(
+              key: staleKey,
+              status: VotingSubmissionJobStatus.error,
+              generation: 1,
+              errorMessage: 'stale key selected',
+            ),
+          ),
+        ),
+        votingSubmissionJobProvider(currentKey).overrideWith(
+          () => _StaticVotingSubmissionJobNotifier(
+            currentKey,
+            const VotingSubmissionJobState(
+              key: currentKey,
+              status: VotingSubmissionJobStatus.running,
+              generation: 1,
+            ),
+          ),
+        ),
+        votingSubmissionJobSessionProvider(staleKey).overrideWithValue(
+          AsyncValue.data(
+            VotingSessionState(
+              roundId: 'round-a',
+              accountUuid: 'account-a',
+              phase: VotingSessionPhase.error,
+            ),
+          ),
+        ),
+        votingSubmissionJobSessionProvider(currentKey).overrideWithValue(
+          AsyncValue.data(
+            VotingSessionState(
+              roundId: 'round-b',
+              accountUuid: 'account-b',
+              phase: VotingSessionPhase.submittingShares,
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    router = GoRouter(
+      initialLocation: '/voting/poll/round-a/status?account=account-a',
+      routes: [
+        GoRoute(
+          path: '/voting/poll/:roundId/status',
+          builder: (_, state) => VotingStatusScreen(
+            roundId: state.pathParameters['roundId']!,
+            accountUuid: state.uri.queryParameters['account'],
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, child) =>
+              AppTheme(data: AppThemeData.light, child: child!),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    router.go('/voting/poll/round-b/status?account=account-b');
+    await tester.pump();
+    firstStart.complete(staleKey);
+    secondStart.complete(currentKey);
+    await tester.pump();
+
+    expect(starts, [staleKey, currentKey]);
+    expect(find.text('stale key selected'), findsNothing);
+    expect(find.text('Submitting Votes'), findsOneWidget);
   });
 
   testWidgets('status screen navigates after successful submission', (
@@ -1748,9 +1907,9 @@ Widget _statusHarness({
   );
 }
 
-Widget _proposalHarness() {
+Widget _proposalHarness({String? initialLocation}) {
   final router = GoRouter(
-    initialLocation: '/voting/poll/$_roundId',
+    initialLocation: initialLocation ?? '/voting/poll/$_roundId',
     routes: [
       GoRoute(
         path: '/voting/poll/:roundId',
@@ -2099,6 +2258,30 @@ class _StaticVotingSubmissionJobsNotifier extends VotingSubmissionJobsNotifier {
 
   @override
   VotingSubmissionJobsState build() => _initial;
+}
+
+class _ControlledVotingSubmissionJobsNotifier
+    extends VotingSubmissionJobsNotifier {
+  _ControlledVotingSubmissionJobsNotifier({
+    required this.starts,
+    required this.completions,
+  });
+
+  final List<VotingSessionKey> starts;
+  final List<Completer<VotingSessionKey?>> completions;
+
+  @override
+  VotingSubmissionJobsState build() => const VotingSubmissionJobsState();
+
+  @override
+  Future<VotingSessionKey?> start(String roundId, {String? accountUuid}) {
+    final key = VotingSessionKey(
+      roundId: roundId,
+      accountUuid: accountUuid ?? 'resolved-account',
+    );
+    starts.add(key);
+    return completions[starts.length - 1].future;
+  }
 }
 
 class _FakeVotingRecoveryApi implements VotingRecoveryApi {

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -202,6 +202,7 @@ void main() {
     final container = _statusContainer(
       accountOverride: _MnemonicAccountNotifier.new,
       rust: _IneligibleVotingRustApi(),
+      hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
     );
     addTearDown(container.dispose);
     container.read(votingDraftProvider(_draftKey).notifier).setChoice(1, 0);
@@ -233,6 +234,7 @@ void main() {
     final container = _statusContainer(
       accountOverride: _MnemonicAccountNotifier.new,
       rust: _IneligibleVotingRustApi(),
+      hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
     );
     addTearDown(container.dispose);
     container.read(votingDraftProvider(_draftKey).notifier).setChoice(1, 0);
@@ -570,12 +572,12 @@ void main() {
     );
     final recoveryApi = _MutableVotingRecoveryApi()
       ..state = _recoveryState(
-        delegationTxHashes: [
+        delegationWorkflows: const [
           rust_frb_types.DelegationRecoveryView(
             bundleIndex: 0,
-            phase: VotingWorkflowPhase.submittedDelegation,
+            phase: VotingWorkflowPhase.confirmed,
             txHash: 'delegation-0',
-            vanLeafPosition: null,
+            vanLeafPosition: 0,
           ),
         ],
         shareDelegations: [share],
@@ -647,12 +649,12 @@ void main() {
     );
     final recoveryApi = _MutableVotingRecoveryApi()
       ..state = _recoveryState(
-        delegationTxHashes: [
+        delegationWorkflows: const [
           rust_frb_types.DelegationRecoveryView(
             bundleIndex: 0,
-            phase: VotingWorkflowPhase.submittedDelegation,
+            phase: VotingWorkflowPhase.confirmed,
             txHash: 'delegation-0',
-            vanLeafPosition: null,
+            vanLeafPosition: 0,
           ),
         ],
         shareDelegations: [share],
@@ -745,12 +747,12 @@ void main() {
     );
     final recoveryApi = _MutableVotingRecoveryApi()
       ..state = _recoveryState(
-        delegationTxHashes: [
+        delegationWorkflows: const [
           rust_frb_types.DelegationRecoveryView(
             bundleIndex: 0,
-            phase: VotingWorkflowPhase.submittedDelegation,
+            phase: VotingWorkflowPhase.confirmed,
             txHash: 'delegation-0',
-            vanLeafPosition: null,
+            vanLeafPosition: 0,
           ),
         ],
       )
@@ -1159,6 +1161,56 @@ void main() {
     expect(find.text('Yes'), findsOneWidget);
     expect(find.text('Second proposal'), findsOneWidget);
     expect(find.text('Skipped'), findsOneWidget);
+
+    await tester.tap(find.text('Confirm & Submit'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('status account: account-1'), findsOneWidget);
+  });
+
+  testWidgets('pending vote continue keeps the session account', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final recoveryApi = _MutableVotingRecoveryApi()
+      ..roundPlan = apiRoundPlan(
+        roundId: _roundId,
+        pendingRecovery: true,
+        nextSteps: const [
+          rust_wire.NextStepView(
+            kind: 'cast_vote',
+            bundleIndex: 0,
+            proposalId: 1,
+            choice: 0,
+            shareIndex: 0,
+          ),
+        ],
+        openProposals: Uint32List(0),
+        allDecided: false,
+      );
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _VotingStatusRustApi(recoveryApi),
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Continue voting'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('status account: account-1'), findsOneWidget);
   });
 
   testWidgets('status screen navigates after successful submission', (
@@ -1577,6 +1629,7 @@ Future<void> _pumpUntilFound(
     await tester.pump(const Duration(milliseconds: 100));
     if (finder.evaluate().isNotEmpty) return;
   }
+  expect(finder, findsWidgets, reason: 'Timed out waiting for $finder.');
 }
 
 ProviderContainer _statusContainer({
@@ -1709,6 +1762,12 @@ Widget _proposalHarness() {
         path: '/voting/poll/:roundId/review',
         builder: (_, state) =>
             VotingReviewScreen(roundId: state.pathParameters['roundId']!),
+      ),
+      GoRoute(
+        path: '/voting/poll/:roundId/status',
+        builder: (_, state) => Text(
+          'status account: ${state.uri.queryParameters['account'] ?? ''}',
+        ),
       ),
       GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
       GoRoute(path: '/send', builder: (_, _) => const Text('send route')),
@@ -2153,6 +2212,16 @@ class _NoopVotingRustApi implements VotingRustApi {
   }) async {}
 
   @override
+  Future<List<int>> deriveHotkey({
+    required String mnemonic,
+    required String roundId,
+    required String accountUuid,
+    required String network,
+  }) async {
+    return [9, 9, 9];
+  }
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
@@ -2165,11 +2234,20 @@ class _FailingVotingPowerRustApi extends _NoopVotingRustApi {
   }
 }
 
-class _IneligibleVotingRustApi extends _NoopVotingRustApi {
+class _IneligibleVotingRustApi extends _VotingStatusRustApi {
+  _IneligibleVotingRustApi() : super(_MutableVotingRecoveryApi());
+
   @override
-  Future<rust_round.BundleLayout> setupDelegationBundles({
-    required rust_api.ApiVotingRoundContext ctx,
-  }) async {
+  Stream<rust_api.ApiVoteCommitEvent> buildVoteCommitmentsWithProgress({
+    required String dbPath,
+    required String accountUuid,
+    required String network,
+    required String roundId,
+    required int bundleIndex,
+    required List<int> hotkeySeed,
+    required rust_vote.VanWitness vanWitness,
+    required List<rust_wire.DraftVote> draftVotes,
+  }) async* {
     throw Exception(
       'Invalid input: no spendable voting notes at snapshot height 3359740',
     );


### PR DESCRIPTION
Applies the voting UI follow-up fixes from the stacked review branch onto the upstream voting UI branch. This keeps voting flows account scoped during navigation, hardens submission edge cases, normalizes voting UI copy, and refreshes pending tally results instead of caching not-ready responses.

Tests:
- fvm flutter analyze --no-pub
- fvm flutter test --no-pub test/features/voting