### PR TITLE
Add address book labels to transaction details

### DIFF
--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -458,14 +458,24 @@ class _ActivityTransactionStatusScreenState
     if (tx?.txKind == 'sent' &&
         primaryAddress != null &&
         primaryAddress.isNotEmpty) {
-      return _recipientBlock(
-        context,
+      final addressBookLabel = addressBookLabelFor(
+        contacts: addressBookContacts,
+        network: AddressBookNetwork.zcash,
         address: primaryAddress,
-        addressBookLabel: addressBookLabelFor(
-          contacts: addressBookContacts,
-          network: AddressBookNetwork.zcash,
+      );
+      if (addressBookLabel != null && addressBookLabel.trim().isNotEmpty) {
+        return _recipientBlock(
+          context,
           address: primaryAddress,
-        ),
+          addressBookLabel: addressBookLabel,
+        );
+      }
+      return _addressBlock(
+        context,
+        title: 'To',
+        address: primaryAddress,
+        useFailedReceiptLayout: useFailedReceiptLayout,
+        compactAddress: compactAddress,
       );
     }
     if ((tx?.txKind == 'received' || tx?.txKind == 'receiving') &&

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -419,14 +419,13 @@ class _ActivityTransactionStatusScreenState
             const SizedBox(height: AppSpacing.xxs),
           ],
           Row(
+            mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Expanded(
-                child: Text(
-                  displayAddress,
-                  style: AppTypography.codeSmall.copyWith(
-                    color: colors.text.muted,
-                  ),
+              Text(
+                displayAddress,
+                style: AppTypography.codeSmall.copyWith(
+                  color: colors.text.muted,
                 ),
               ),
               const SizedBox(width: AppSpacing.xs),

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -385,6 +385,7 @@ class _ActivityTransactionStatusScreenState
   }) {
     final colors = context.colors;
     final trimmedAddress = address.trim();
+    final displayAddress = compactActivityReceiptAddress(trimmedAddress);
     final nickname = addressBookLabel?.trim();
     final hasNickname = nickname != null && nickname.isNotEmpty;
     return TransactionReceiptBlockData(
@@ -420,11 +421,9 @@ class _ActivityTransactionStatusScreenState
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // Show the full address (wrapping across lines) rather than an
-              // aggressive prefix/suffix truncation.
               Expanded(
                 child: Text(
-                  trimmedAddress,
+                  displayAddress,
                   style: AppTypography.codeSmall.copyWith(
                     color: colors.text.muted,
                   ),
@@ -607,6 +606,20 @@ class _ActivityTransactionStatusScreenState
       ),
     );
   }
+}
+
+const _activityReceiptAddressEdgeLength = 16;
+const _activityReceiptAddressSeparator = ' ... ';
+
+String compactActivityReceiptAddress(String address) {
+  final trimmed = address.trim();
+  final compactLength =
+      _activityReceiptAddressEdgeLength * 2 +
+      _activityReceiptAddressSeparator.length;
+  if (trimmed.length <= compactLength) return trimmed;
+  return '${trimmed.substring(0, _activityReceiptAddressEdgeLength)}'
+      '$_activityReceiptAddressSeparator'
+      '${trimmed.substring(trimmed.length - _activityReceiptAddressEdgeLength)}';
 }
 
 /// Icon-only copy affordance placed at the end of the recipient address line.

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -14,7 +14,6 @@ import '../../../core/privacy/privacy_mask.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
-import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_toast.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/privacy_mode_provider.dart';
@@ -378,64 +377,18 @@ class _ActivityTransactionStatusScreenState
   /// Sent "To" block: a matched address-book contact shows its nickname +
   /// crimson saved mark above the (truncated) address; copy sits at the end of
   /// the address line and always copies the full address.
-  TransactionReceiptBlockData _recipientBlock(
-    BuildContext context, {
+  TransactionReceiptBlockData _recipientBlock({
     required String address,
     String? addressBookLabel,
   }) {
-    final colors = context.colors;
     final trimmedAddress = address.trim();
-    final displayAddress = compactActivityReceiptAddress(trimmedAddress);
     final nickname = addressBookLabel?.trim();
-    final hasNickname = nickname != null && nickname.isNotEmpty;
     return TransactionReceiptBlockData(
       title: 'To',
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (hasNickname) ...[
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                AppIcon(
-                  AppIcons.user,
-                  size: 14,
-                  color: colors.icon.brandCrimson,
-                ),
-                const SizedBox(width: AppSpacing.xxs),
-                Flexible(
-                  child: Text(
-                    nickname,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: AppTypography.bodyMediumStrong.copyWith(
-                      color: colors.text.accent,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-            const SizedBox(height: AppSpacing.xxs),
-          ],
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                displayAddress,
-                style: AppTypography.codeSmall.copyWith(
-                  color: colors.text.muted,
-                ),
-              ),
-              const SizedBox(width: AppSpacing.xs),
-              _InlineCopyButton(
-                onTap: () =>
-                    unawaited(_copyText(trimmedAddress, 'Address copied')),
-              ),
-            ],
-          ),
-        ],
+      child: TransactionReceiptSavedRecipientAddress(
+        address: trimmedAddress,
+        label: nickname ?? '',
+        onCopy: () => unawaited(_copyText(trimmedAddress, 'Address copied')),
       ),
     );
   }
@@ -463,7 +416,6 @@ class _ActivityTransactionStatusScreenState
       );
       if (addressBookLabel != null && addressBookLabel.trim().isNotEmpty) {
         return _recipientBlock(
-          context,
           address: primaryAddress,
           addressBookLabel: addressBookLabel,
         );
@@ -601,43 +553,6 @@ class _ActivityTransactionStatusScreenState
               ),
             ),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-const _activityReceiptAddressEdgeLength = 16;
-const _activityReceiptAddressSeparator = ' ... ';
-
-String compactActivityReceiptAddress(String address) {
-  final trimmed = address.trim();
-  final compactLength =
-      _activityReceiptAddressEdgeLength * 2 +
-      _activityReceiptAddressSeparator.length;
-  if (trimmed.length <= compactLength) return trimmed;
-  return '${trimmed.substring(0, _activityReceiptAddressEdgeLength)}'
-      '$_activityReceiptAddressSeparator'
-      '${trimmed.substring(trimmed.length - _activityReceiptAddressEdgeLength)}';
-}
-
-/// Icon-only copy affordance placed at the end of the recipient address line.
-class _InlineCopyButton extends StatelessWidget {
-  const _InlineCopyButton({required this.onTap});
-
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: AppIcon(
-          AppIcons.copy,
-          size: 16,
-          color: context.colors.icon.muted,
         ),
       ),
     );

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -14,12 +14,16 @@ import '../../../core/privacy/privacy_mask.dart';
 import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
+import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_toast.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/privacy_mode_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
+import '../../address_book/models/address_book_contact.dart';
+import '../../address_book/models/address_book_label_lookup.dart';
+import '../../address_book/providers/address_book_provider.dart';
 import '../../send/widgets/transaction_receipt_view.dart';
 
 class ActivityTransactionStatusArgs {
@@ -371,6 +375,73 @@ class _ActivityTransactionStatusScreenState
     );
   }
 
+  /// Sent "To" block: a matched address-book contact shows its nickname +
+  /// crimson saved mark above the (truncated) address; copy sits at the end of
+  /// the address line and always copies the full address.
+  TransactionReceiptBlockData _recipientBlock(
+    BuildContext context, {
+    required String address,
+    String? addressBookLabel,
+  }) {
+    final colors = context.colors;
+    final trimmedAddress = address.trim();
+    final nickname = addressBookLabel?.trim();
+    final hasNickname = nickname != null && nickname.isNotEmpty;
+    return TransactionReceiptBlockData(
+      title: 'To',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (hasNickname) ...[
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                AppIcon(
+                  AppIcons.user,
+                  size: 14,
+                  color: colors.icon.brandCrimson,
+                ),
+                const SizedBox(width: AppSpacing.xxs),
+                Flexible(
+                  child: Text(
+                    nickname,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.bodyMediumStrong.copyWith(
+                      color: colors.text.accent,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.xxs),
+          ],
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Show the full address (wrapping across lines) rather than an
+              // aggressive prefix/suffix truncation.
+              Expanded(
+                child: Text(
+                  trimmedAddress,
+                  style: AppTypography.codeSmall.copyWith(
+                    color: colors.text.muted,
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xs),
+              _InlineCopyButton(
+                onTap: () =>
+                    unawaited(_copyText(trimmedAddress, 'Address copied')),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
   bool _shouldHighlightAddressEdges(String address) {
     return address.startsWith('u1') || address.startsWith('zs');
   }
@@ -379,6 +450,7 @@ class _ActivityTransactionStatusScreenState
     BuildContext context,
     rust_sync.TransactionInfo? tx,
     rust_sync.TransactionDetail? detail,
+    List<AddressBookContact> addressBookContacts,
   ) {
     final primaryAddress = detail?.primaryAddress?.trim();
     final useFailedReceiptLayout = tx?.expiredUnmined == true;
@@ -386,12 +458,14 @@ class _ActivityTransactionStatusScreenState
     if (tx?.txKind == 'sent' &&
         primaryAddress != null &&
         primaryAddress.isNotEmpty) {
-      return _addressBlock(
+      return _recipientBlock(
         context,
-        title: 'To',
         address: primaryAddress,
-        useFailedReceiptLayout: useFailedReceiptLayout,
-        compactAddress: compactAddress,
+        addressBookLabel: addressBookLabelFor(
+          contacts: addressBookContacts,
+          network: AddressBookNetwork.zcash,
+          address: primaryAddress,
+        ),
       );
     }
     if ((tx?.txKind == 'received' || tx?.txKind == 'receiving') &&
@@ -446,6 +520,8 @@ class _ActivityTransactionStatusScreenState
 
     final tx = _transaction;
     final detail = _matchingDetailFor(tx);
+    final addressBookContacts =
+        ref.watch(addressBookProvider).value?.contacts ?? const [];
     final privacyModeEnabled = ref.watch(privacyModeProvider);
     final useFailedReceiptLayout = tx?.expiredUnmined == true;
     final error = useFailedReceiptLayout
@@ -491,7 +567,12 @@ class _ActivityTransactionStatusScreenState
                               tx,
                               privacyModeEnabled: privacyModeEnabled,
                             ),
-                            primaryBlock: _primaryBlockFor(context, tx, detail),
+                            primaryBlock: _primaryBlockFor(
+                              context,
+                              tx,
+                              detail,
+                              addressBookContacts,
+                            ),
                             extraBlocks: _extraBlocksFor(detail),
                             dateText: _dateText(tx),
                             feeText: _feeText(
@@ -512,6 +593,29 @@ class _ActivityTransactionStatusScreenState
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Icon-only copy affordance placed at the end of the recipient address line.
+class _InlineCopyButton extends StatelessWidget {
+  const _InlineCopyButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: AppIcon(
+          AppIcons.copy,
+          size: 16,
+          color: context.colors.icon.muted,
         ),
       ),
     );

--- a/lib/src/features/address_book/models/address_book_label_lookup.dart
+++ b/lib/src/features/address_book/models/address_book_label_lookup.dart
@@ -1,0 +1,51 @@
+import 'address_book_contact.dart';
+
+/// Resolves the address-book label/nickname for [address] on [network].
+///
+/// Returns the first matching contact's non-empty label, or `null` when no
+/// contact matches. Matching mirrors the swap activity details behavior: a
+/// trimmed exact match, case-insensitive for EVM/NEAR networks and
+/// case-sensitive otherwise (Zcash addresses are case-sensitive).
+String? addressBookLabelFor({
+  required Iterable<AddressBookContact> contacts,
+  required AddressBookNetwork network,
+  required String address,
+}) {
+  final target = _normalizedAddress(network, address);
+  if (target.isEmpty) return null;
+  for (final contact in contacts) {
+    if (contact.network != network) continue;
+    if (_normalizedAddress(network, contact.address) != target) continue;
+    final label = contact.label.trim();
+    if (label.isNotEmpty) return label;
+  }
+  return null;
+}
+
+String _normalizedAddress(AddressBookNetwork network, String address) {
+  final trimmed = address.trim();
+  return _addressBookNetworkIgnoresCase(network)
+      ? trimmed.toLowerCase()
+      : trimmed;
+}
+
+bool _addressBookNetworkIgnoresCase(AddressBookNetwork network) {
+  return switch (network) {
+    AddressBookNetwork.ethereum ||
+    AddressBookNetwork.base ||
+    AddressBookNetwork.arbitrum ||
+    AddressBookNetwork.binanceSmartChain ||
+    AddressBookNetwork.optimism ||
+    AddressBookNetwork.avalanche ||
+    AddressBookNetwork.gnosis ||
+    AddressBookNetwork.polygon ||
+    AddressBookNetwork.xLayer ||
+    AddressBookNetwork.plasma ||
+    AddressBookNetwork.abstractChain ||
+    AddressBookNetwork.bera ||
+    AddressBookNetwork.monad ||
+    AddressBookNetwork.scroll ||
+    AddressBookNetwork.near => true,
+    _ => false,
+  };
+}

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -22,9 +22,13 @@ import '../../../providers/account_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../rust/api/sync.dart' as rust_sync;
+import '../../address_book/models/address_book_contact.dart';
+import '../../address_book/models/address_book_label_lookup.dart';
+import '../../address_book/providers/address_book_provider.dart';
 import '../../keystone/widgets/keystone_signing_modal.dart';
 import '../services/sapling_params.dart';
 import '../widgets/sapling_params_prompt.dart';
+import '../widgets/transaction_receipt_view.dart';
 
 class SendReviewArgs {
   const SendReviewArgs({
@@ -394,6 +398,16 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
     showAppToast(context, 'Address copied');
   }
 
+  String? _recipientAddressBookLabel(
+    Iterable<AddressBookContact> addressBookContacts,
+  ) {
+    return addressBookLabelFor(
+      contacts: addressBookContacts,
+      network: AddressBookNetwork.zcash,
+      address: widget.args.address,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
@@ -401,6 +415,10 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
         .read(accountProvider.notifier)
         .isHardwareAccount(widget.args.proposalAccountUuid);
     final keystonePhase = _keystonePhase;
+    final addressBookContacts =
+        ref.watch(addressBookProvider).value?.contacts ??
+        const <AddressBookContact>[];
+    final addressBookLabel = _recipientAddressBookLabel(addressBookContacts);
 
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
@@ -429,6 +447,7 @@ class _SendReviewScreenState extends ConsumerState<SendReviewScreen> {
                             ),
                             feeText: _formatFee(widget.args.feeZatoshi),
                             addressSpans: _addressSpans(context),
+                            addressBookLabel: addressBookLabel,
                             messageExpanded: _messageExpanded,
                             onToggleMessageExpanded: _toggleMessageExpanded,
                             onCopyAddress: () =>
@@ -502,6 +521,7 @@ class _SendReviewReceiptCard extends StatelessWidget {
     required this.amountText,
     required this.feeText,
     required this.addressSpans,
+    required this.addressBookLabel,
     required this.messageExpanded,
     required this.onToggleMessageExpanded,
     required this.onCopyAddress,
@@ -511,6 +531,7 @@ class _SendReviewReceiptCard extends StatelessWidget {
   final String amountText;
   final String feeText;
   final List<TextSpan> addressSpans;
+  final String? addressBookLabel;
   final bool messageExpanded;
   final VoidCallback onToggleMessageExpanded;
   final VoidCallback onCopyAddress;
@@ -528,6 +549,9 @@ class _SendReviewReceiptCard extends StatelessWidget {
     final dividerTop = hasMemo ? 214.0 + messageBlockHeight + 16.0 : 214.0;
     final feeTop = dividerTop + 32.0;
     final receiptHeight = hasMemo && messageExpanded ? feeTop + 56.0 : 404.0;
+    final savedRecipientLabel = addressBookLabel?.trim();
+    final hasSavedRecipient =
+        savedRecipientLabel != null && savedRecipientLabel.isNotEmpty;
 
     return SizedBox(
       width: 352,
@@ -584,21 +608,30 @@ class _SendReviewReceiptCard extends StatelessWidget {
             left: AppSpacing.sm,
             top: 138,
             width: 320,
-            height: 60,
+            height: hasSavedRecipient ? 68 : 60,
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 _SendReviewFieldTitle(
                   label: 'To',
-                  rightLabel: _SendReviewCopyAction(onTap: onCopyAddress),
+                  rightLabel: hasSavedRecipient
+                      ? null
+                      : _SendReviewCopyAction(onTap: onCopyAddress),
                 ),
                 const SizedBox(height: AppSpacing.xs),
-                RichText(
-                  maxLines: 2,
-                  overflow: TextOverflow.clip,
-                  softWrap: false,
-                  text: TextSpan(children: addressSpans),
-                ),
+                if (hasSavedRecipient)
+                  _SendReviewSavedRecipientValue(
+                    address: args.address,
+                    label: savedRecipientLabel,
+                    onCopy: onCopyAddress,
+                  )
+                else
+                  RichText(
+                    maxLines: 2,
+                    overflow: TextOverflow.clip,
+                    softWrap: false,
+                    text: TextSpan(children: addressSpans),
+                  ),
               ],
             ),
           ),
@@ -665,6 +698,67 @@ class _SendReviewReceiptCard extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _SendReviewSavedRecipientValue extends StatelessWidget {
+  const _SendReviewSavedRecipientValue({
+    required this.address,
+    required this.label,
+    required this.onCopy,
+  });
+
+  final String address;
+  final String label;
+  final VoidCallback onCopy;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final compactAddress = compactTransactionReceiptSavedAddress(address);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            AppIcon(AppIcons.user, size: 14, color: colors.icon.brandCrimson),
+            const SizedBox(width: AppSpacing.xxs),
+            Flexible(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.xxs),
+        FittedBox(
+          fit: BoxFit.scaleDown,
+          alignment: Alignment.centerLeft,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                compactAddress,
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.accent,
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xs),
+              _SendReviewInlineCopyAction(onTap: onCopy),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }
@@ -754,6 +848,28 @@ class _SendReviewCopyAction extends StatelessWidget {
               color: colors.icon.muted,
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SendReviewInlineCopyAction extends StatelessWidget {
+  const _SendReviewInlineCopyAction({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: AppIcon(
+          AppIcons.copy,
+          size: 16,
+          color: context.colors.icon.muted,
         ),
       ),
     );

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -750,7 +750,7 @@ class _SendReviewSavedRecipientValue extends StatelessWidget {
               Text(
                 compactAddress,
                 style: AppTypography.labelLarge.copyWith(
-                  color: colors.text.accent,
+                  color: colors.text.muted,
                 ),
               ),
               const SizedBox(width: AppSpacing.xs),

--- a/lib/src/features/send/screens/send_status_screen.dart
+++ b/lib/src/features/send/screens/send_status_screen.dart
@@ -21,6 +21,9 @@ import '../../../providers/app_security_provider.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
+import '../../address_book/models/address_book_contact.dart';
+import '../../address_book/models/address_book_label_lookup.dart';
+import '../../address_book/providers/address_book_provider.dart';
 import '../../keystone/widgets/keystone_transaction_progress_panel.dart';
 import '../services/sapling_params.dart';
 import '../widgets/sapling_params_prompt.dart';
@@ -498,6 +501,50 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     );
   }
 
+  TransactionReceiptBlockData _primaryBlockFor(
+    BuildContext context, {
+    required bool useFailedReceiptLayout,
+    required String? addressBookLabel,
+  }) {
+    final trimmedAddress = widget.args.address.trim();
+    final trimmedLabel = addressBookLabel?.trim();
+    if (trimmedLabel != null && trimmedLabel.isNotEmpty) {
+      return TransactionReceiptBlockData(
+        title: 'To',
+        child: TransactionReceiptSavedRecipientAddress(
+          address: trimmedAddress,
+          label: trimmedLabel,
+          onCopy: () => unawaited(_copyRecipientAddress()),
+        ),
+      );
+    }
+
+    return TransactionReceiptBlockData(
+      title: 'To',
+      child: TransactionReceiptAddressText(
+        address: trimmedAddress,
+        highlightEdges: widget.args.isShielded,
+        compact: !useFailedReceiptLayout && widget.args.isShielded,
+        highlightColor: useFailedReceiptLayout
+            ? null
+            : context.colors.text.brandCrimson,
+      ),
+      onCopy: useFailedReceiptLayout
+          ? () => unawaited(_copyRecipientAddress())
+          : null,
+    );
+  }
+
+  String? _recipientAddressBookLabel(
+    Iterable<AddressBookContact> addressBookContacts,
+  ) {
+    return addressBookLabelFor(
+      contacts: addressBookContacts,
+      network: AddressBookNetwork.zcash,
+      address: widget.args.address,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final receiptPhase = switch (_phase) {
@@ -510,6 +557,10 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
     final statusMessage = _statusMessage;
     final isKeystoneSubmitting =
         widget.keystone != null && _phase == _SendStatusPhase.sending;
+    final addressBookContacts =
+        ref.watch(addressBookProvider).value?.contacts ??
+        const <AddressBookContact>[];
+    final addressBookLabel = _recipientAddressBookLabel(addressBookContacts);
 
     return PopScope<void>(
       canPop: false,
@@ -560,23 +611,11 @@ class _SendStatusScreenState extends ConsumerState<SendStatusScreen> {
                                     amountText: _formatReceiptAmount(
                                       widget.args.amountZatoshi,
                                     ),
-                                    primaryBlock: TransactionReceiptBlockData(
-                                      title: 'To',
-                                      child: TransactionReceiptAddressText(
-                                        address: widget.args.address,
-                                        highlightEdges: widget.args.isShielded,
-                                        compact:
-                                            !useFailedReceiptLayout &&
-                                            widget.args.isShielded,
-                                        highlightColor: useFailedReceiptLayout
-                                            ? null
-                                            : context.colors.text.brandCrimson,
-                                      ),
-                                      onCopy: useFailedReceiptLayout
-                                          ? () => unawaited(
-                                              _copyRecipientAddress(),
-                                            )
-                                          : null,
+                                    primaryBlock: _primaryBlockFor(
+                                      context,
+                                      useFailedReceiptLayout:
+                                          useFailedReceiptLayout,
+                                      addressBookLabel: addressBookLabel,
                                     ),
                                     feeText: _formatFee(widget.args.feeZatoshi),
                                     extraBlocks: [

--- a/lib/src/features/send/widgets/transaction_receipt_view.dart
+++ b/lib/src/features/send/widgets/transaction_receipt_view.dart
@@ -367,6 +367,88 @@ class TransactionReceiptAddressText extends StatelessWidget {
   }
 }
 
+class TransactionReceiptSavedRecipientAddress extends StatelessWidget {
+  const TransactionReceiptSavedRecipientAddress({
+    required this.address,
+    required this.label,
+    required this.onCopy,
+    super.key,
+  });
+
+  final String address;
+  final String label;
+  final VoidCallback onCopy;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final trimmedAddress = address.trim();
+    final trimmedLabel = label.trim();
+    final displayAddress = compactTransactionReceiptSavedAddress(
+      trimmedAddress,
+    );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (trimmedLabel.isNotEmpty) ...[
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AppIcon(AppIcons.user, size: 14, color: colors.icon.brandCrimson),
+              const SizedBox(width: AppSpacing.xxs),
+              Flexible(
+                child: Text(
+                  trimmedLabel,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTypography.bodyMediumStrong.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.xxs),
+        ],
+        FittedBox(
+          fit: BoxFit.scaleDown,
+          alignment: Alignment.centerLeft,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                displayAddress,
+                style: AppTypography.codeSmall.copyWith(
+                  color: colors.text.muted,
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xs),
+              _TransactionReceiptInlineCopyButton(onTap: onCopy),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+const _transactionReceiptSavedAddressEdgeLength = 16;
+const _transactionReceiptSavedAddressSeparator = ' ... ';
+
+String compactTransactionReceiptSavedAddress(String address) {
+  final trimmed = address.trim();
+  final compactLength =
+      _transactionReceiptSavedAddressEdgeLength * 2 +
+      _transactionReceiptSavedAddressSeparator.length;
+  if (trimmed.length <= compactLength) return trimmed;
+  return '${trimmed.substring(0, _transactionReceiptSavedAddressEdgeLength)}'
+      '$_transactionReceiptSavedAddressSeparator'
+      '${trimmed.substring(trimmed.length - _transactionReceiptSavedAddressEdgeLength)}';
+}
+
 class _TransactionReceiptActions extends StatelessWidget {
   const _TransactionReceiptActions({required this.view});
 
@@ -591,6 +673,28 @@ class _TransactionReceiptCopyAction extends StatelessWidget {
             const SizedBox(width: AppSpacing.xxs),
             AppIcon(AppIcons.copy, size: 16, color: colors.text.secondary),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TransactionReceiptInlineCopyButton extends StatelessWidget {
+  const _TransactionReceiptInlineCopyButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: AppIcon(
+          AppIcons.copy,
+          size: 16,
+          color: context.colors.icon.muted,
         ),
       ),
     );

--- a/lib/src/features/swap/models/swap_activity_status_mapper.dart
+++ b/lib/src/features/swap/models/swap_activity_status_mapper.dart
@@ -231,9 +231,7 @@ List<SwapStatusDetailRowData> _swapActivityStatusDetails(
         : const <SwapStatusDetailRowData>[];
     return [
       _accountDetailRow(accountDetail),
-      if (terminalRecipientRows.isNotEmpty &&
-          terminalRecipientRows.first.addressBookLabel != null)
-        ...terminalRecipientRows,
+      if (terminalRecipientRows.isNotEmpty) ...terminalRecipientRows,
       if (failed && refundAddress != null && refundAddress.isNotEmpty)
         ..._addressDetailRows(
           label: '$sourceSymbol refunded to',

--- a/lib/src/features/swap/models/swap_activity_status_mapper.dart
+++ b/lib/src/features/swap/models/swap_activity_status_mapper.dart
@@ -1,4 +1,5 @@
 import '../../../core/profile_pictures.dart';
+import '../../address_book/models/address_book_contact.dart';
 import 'swap_address_formatting.dart';
 import 'swap_detail_tooltips.dart';
 import 'swap_fiat_value_formatting.dart';
@@ -11,6 +12,29 @@ class SwapActivityAccountDetail {
 
   final String name;
   final String? profilePictureId;
+}
+
+class _SwapActivityAddressBookLabels {
+  _SwapActivityAddressBookLabels(Iterable<AddressBookContact> contacts)
+    : _contacts = contacts.toList(growable: false);
+
+  final List<AddressBookContact> _contacts;
+
+  String? labelFor({required SwapAsset? asset, required String address}) {
+    if (asset == null) return null;
+    final network = AddressBookNetwork.tryFromChainTicker(asset.chainTicker);
+    if (network == null) return null;
+
+    final target = _normalizedAddress(network, address);
+    if (target.isEmpty) return null;
+    for (final contact in _contacts) {
+      if (contact.network != network) continue;
+      if (_normalizedAddress(network, contact.address) != target) continue;
+      final label = contact.label.trim();
+      return label.isEmpty ? null : label;
+    }
+    return null;
+  }
 }
 
 class SwapActivityStatusPresentation {
@@ -47,6 +71,7 @@ SwapActivityStatusPresentation swapActivityStatusPresentationForIntent(
   SwapState state,
   SwapIntent intent, {
   SwapActivityAccountDetail? accountDetail,
+  Iterable<AddressBookContact> addressBookContacts = const [],
 }) {
   final sellAsset = swapActivitySellAsset(intent) ?? SwapAsset.zec;
   final receiveAsset = swapActivityReceiveAsset(intent) ?? SwapAsset.usdc;
@@ -69,7 +94,11 @@ SwapActivityStatusPresentation swapActivityStatusPresentationForIntent(
     badgeKind: _swapActivityStatusBadgeKind(intent.status),
     progressIndex: _swapActivityStatusProgressIndex(intent),
     steps: _swapActivityProgressSteps(intent),
-    details: _swapActivityStatusDetails(intent, accountDetail: accountDetail),
+    details: _swapActivityStatusDetails(
+      intent,
+      accountDetail: accountDetail,
+      addressBookContacts: addressBookContacts,
+    ),
     showTabs: !intent.status.isTerminal,
   );
 }
@@ -114,18 +143,15 @@ int _swapActivityStatusProgressIndex(SwapIntent intent) {
 List<SwapStatusStepData> _swapActivityProgressSteps(SwapIntent intent) {
   final sourceSymbol = swapActivityPairSymbol(intent.pair, 0);
   final receiveSymbol = swapActivityPairSymbol(intent.pair, 1);
-  final sourceVerb =
-      intent.direction == SwapDirection.zecToExternal
-          ? 'Sending'
-          : 'Depositing';
-  final sourceDone =
-      intent.direction == SwapDirection.zecToExternal
-          ? '$sourceSymbol sent'
-          : '$sourceSymbol Deposited';
-  final deliveryTitle =
-      intent.direction == SwapDirection.zecToExternal
-          ? 'Deliver $receiveSymbol'
-          : 'Send $receiveSymbol';
+  final sourceVerb = intent.direction == SwapDirection.zecToExternal
+      ? 'Sending'
+      : 'Depositing';
+  final sourceDone = intent.direction == SwapDirection.zecToExternal
+      ? '$sourceSymbol sent'
+      : '$sourceSymbol Deposited';
+  final deliveryTitle = intent.direction == SwapDirection.zecToExternal
+      ? 'Deliver $receiveSymbol'
+      : 'Send $receiveSymbol';
 
   final lastCheckedLabel =
       _swapActivityLastRelativeStatusCheckedLabel(intent.lastStatusCheckedAt) ??
@@ -137,10 +163,9 @@ List<SwapStatusStepData> _swapActivityProgressSteps(SwapIntent intent) {
       state: SwapStatusStepState.pending,
       completeTitle: sourceDone,
       activeTitle: '$sourceVerb $sourceSymbol...',
-      pendingTitle:
-          intent.direction == SwapDirection.zecToExternal
-              ? 'Send $sourceSymbol'
-              : 'Deposit $sourceSymbol',
+      pendingTitle: intent.direction == SwapDirection.zecToExternal
+          ? 'Send $sourceSymbol'
+          : 'Deposit $sourceSymbol',
       lastCheckedLabel: lastCheckedLabel,
       description:
           'Confirm waiting for the source chain and provider to recognise the deposit',
@@ -172,9 +197,13 @@ List<SwapStatusStepData> _swapActivityProgressSteps(SwapIntent intent) {
 List<SwapStatusDetailRowData> _swapActivityStatusDetails(
   SwapIntent intent, {
   SwapActivityAccountDetail? accountDetail,
+  required Iterable<AddressBookContact> addressBookContacts,
 }) {
   final sourceSymbol = swapActivityPairSymbol(intent.pair, 0);
   final receiveSymbol = swapActivityPairSymbol(intent.pair, 1);
+  final sourceAsset = swapActivitySellAsset(intent);
+  final receiveAsset = swapActivityReceiveAsset(intent);
+  final addressBookLabels = _SwapActivityAddressBookLabels(addressBookContacts);
   final refundAddress = intent.oneClickRefundTo?.trim();
   final recipientAddress = intent.oneClickRecipient?.trim();
   final depositAddress = intent.depositAddress?.trim();
@@ -191,21 +220,31 @@ List<SwapStatusDetailRowData> _swapActivityStatusDetails(
   final sendsZec = intent.direction != SwapDirection.externalToZec;
 
   if (terminal) {
+    final terminalRecipientRows =
+        !failed && recipientAddress != null && recipientAddress.isNotEmpty
+        ? _addressDetailRows(
+            label: '$receiveSymbol recipient',
+            address: recipientAddress,
+            asset: receiveAsset,
+            addressBookLabels: addressBookLabels,
+          )
+        : const <SwapStatusDetailRowData>[];
     return [
       _accountDetailRow(accountDetail),
+      if (terminalRecipientRows.length > 1) ...terminalRecipientRows,
       if (failed && refundAddress != null && refundAddress.isNotEmpty)
-        SwapStatusDetailRowData(
+        ..._addressDetailRows(
           label: '$sourceSymbol refunded to',
-          value: compactSwapAddress(refundAddress),
-          copyable: true,
-          copyText: refundAddress,
+          address: refundAddress,
+          asset: sourceAsset,
+          addressBookLabels: addressBookLabels,
         )
       else if (!failed && depositAddress != null && depositAddress.isNotEmpty)
-        SwapStatusDetailRowData(
+        ..._addressDetailRows(
           label: '$sourceSymbol deposit to',
-          value: compactSwapAddress(depositAddress),
-          copyable: true,
-          copyText: depositAddress,
+          address: depositAddress,
+          asset: sourceAsset,
+          addressBookLabels: addressBookLabels,
         ),
       SwapStatusDetailRowData(
         label: 'Total fees',
@@ -239,6 +278,7 @@ List<SwapStatusDetailRowData> _swapActivityStatusDetails(
       recipientAddress: recipientAddress,
       depositTxHash: depositTxHash,
       sendsZec: sendsZec,
+      addressBookLabels: addressBookLabels,
     );
   }
 
@@ -246,25 +286,25 @@ List<SwapStatusDetailRowData> _swapActivityStatusDetails(
   return [
     _accountDetailRow(accountDetail),
     if (sendsZec && recipientAddress != null && recipientAddress.isNotEmpty)
-      SwapStatusDetailRowData(
+      ..._addressDetailRows(
         label: '$receiveSymbol recipient',
-        value: compactSwapAddress(recipientAddress),
-        copyable: true,
-        copyText: recipientAddress,
+        address: recipientAddress,
+        asset: receiveAsset,
+        addressBookLabels: addressBookLabels,
       ),
     if (!sendsZec && refundAddress != null && refundAddress.isNotEmpty)
-      SwapStatusDetailRowData(
+      ..._addressDetailRows(
         label: '$sourceSymbol refund address',
-        value: compactSwapAddress(refundAddress),
-        copyable: true,
-        copyText: refundAddress,
+        address: refundAddress,
+        asset: sourceAsset,
+        addressBookLabels: addressBookLabels,
       ),
     if (depositAddress != null && depositAddress.isNotEmpty)
-      SwapStatusDetailRowData(
+      ..._addressDetailRows(
         label: 'Deposit $sourceSymbol to',
-        value: compactSwapAddress(depositAddress),
-        copyable: true,
-        copyText: depositAddress,
+        address: depositAddress,
+        asset: sourceAsset,
+        addressBookLabels: addressBookLabels,
       ),
     // externalToZec deposits the user sends manually: keep a required memo
     // reachable after the optimistic claim hides the deposit page (memo/tag
@@ -293,18 +333,18 @@ List<SwapStatusDetailRowData> _swapActivityStatusDetails(
       helpTooltip: swapMinimumReceiveTooltip(receiveSymbol),
     ),
     if (sendsZec && refundAddress != null && refundAddress.isNotEmpty)
-      SwapStatusDetailRowData(
+      ..._addressDetailRows(
         label: '$sourceSymbol refund address',
-        value: compactSwapAddress(refundAddress),
-        copyable: true,
-        copyText: refundAddress,
+        address: refundAddress,
+        asset: sourceAsset,
+        addressBookLabels: addressBookLabels,
       ),
     if (!sendsZec && recipientAddress != null && recipientAddress.isNotEmpty)
-      SwapStatusDetailRowData(
+      ..._addressDetailRows(
         label: '$receiveSymbol recipient',
-        value: compactSwapAddress(recipientAddress),
-        copyable: true,
-        copyText: recipientAddress,
+        address: recipientAddress,
+        asset: receiveAsset,
+        addressBookLabels: addressBookLabels,
       ),
     if (depositTxHash != null && depositTxHash.isNotEmpty)
       SwapStatusDetailRowData(
@@ -334,13 +374,14 @@ List<SwapStatusDetailRowData> _swapActivityIncompleteDepositDetails(
   required String? recipientAddress,
   required String? depositTxHash,
   required bool sendsZec,
+  required _SwapActivityAddressBookLabels addressBookLabels,
 }) {
   final sourceAsset = swapActivitySellAsset(intent);
+  final receiveAsset = swapActivityReceiveAsset(intent);
   final providerInfo = intent.providerRefundInfo;
-  final missingDepositText =
-      sourceAsset == null
-          ? null
-          : _swapActivityMissingDepositText(intent, sourceAsset);
+  final missingDepositText = sourceAsset == null
+      ? null
+      : _swapActivityMissingDepositText(intent, sourceAsset);
   final deadlineText = _swapActivityTimestampLabel(intent.depositDeadline);
 
   return [
@@ -358,11 +399,11 @@ List<SwapStatusDetailRowData> _swapActivityIncompleteDepositDetails(
         copyText: depositMemo,
       ),
     if (depositAddress != null && depositAddress.isNotEmpty)
-      SwapStatusDetailRowData(
+      ..._addressDetailRows(
         label: 'Deposit $sourceSymbol to',
-        value: compactSwapAddress(depositAddress),
-        copyable: true,
-        copyText: depositAddress,
+        address: depositAddress,
+        asset: sourceAsset,
+        addressBookLabels: addressBookLabels,
       ),
     SwapStatusDetailRowData(
       label: 'Required deposit',
@@ -381,18 +422,18 @@ List<SwapStatusDetailRowData> _swapActivityIncompleteDepositDetails(
         value: providerInfo!.refundFeeText!,
       ),
     if (refundAddress != null && refundAddress.isNotEmpty)
-      SwapStatusDetailRowData(
+      ..._addressDetailRows(
         label: '$sourceSymbol refund address',
-        value: compactSwapAddress(refundAddress),
-        copyable: true,
-        copyText: refundAddress,
+        address: refundAddress,
+        asset: sourceAsset,
+        addressBookLabels: addressBookLabels,
       ),
     if (!sendsZec && recipientAddress != null && recipientAddress.isNotEmpty)
-      SwapStatusDetailRowData(
+      ..._addressDetailRows(
         label: '$receiveSymbol recipient',
-        value: compactSwapAddress(recipientAddress),
-        copyable: true,
-        copyText: recipientAddress,
+        address: recipientAddress,
+        asset: receiveAsset,
+        addressBookLabels: addressBookLabels,
       ),
     if (depositTxHash != null && depositTxHash.isNotEmpty)
       SwapStatusDetailRowData(
@@ -401,6 +442,28 @@ List<SwapStatusDetailRowData> _swapActivityIncompleteDepositDetails(
         copyable: true,
         copyText: depositTxHash,
       ),
+  ];
+}
+
+List<SwapStatusDetailRowData> _addressDetailRows({
+  required String label,
+  required String address,
+  required SwapAsset? asset,
+  required _SwapActivityAddressBookLabels addressBookLabels,
+}) {
+  final addressBookLabel = addressBookLabels.labelFor(
+    asset: asset,
+    address: address,
+  );
+  return [
+    SwapStatusDetailRowData(
+      label: label,
+      value: compactSwapAddress(address),
+      copyable: true,
+      copyText: address,
+    ),
+    if (addressBookLabel != null)
+      SwapStatusDetailRowData(label: '', value: addressBookLabel),
   ];
 }
 
@@ -515,16 +578,14 @@ class SwapActivityDepositInstruction {
     }
 
     final depositSymbol = direction.fromSymbol(externalAsset);
-    final depositAddressLabel =
-        direction.sendsZec
-            ? '$depositSymbol deposit'
-            : '$depositSymbol source deposit';
+    final depositAddressLabel = direction.sendsZec
+        ? '$depositSymbol deposit'
+        : '$depositSymbol source deposit';
 
     return SwapActivityDepositInstruction(
-      sendLabel:
-          direction.sendsZec
-              ? 'Send $depositSymbol'
-              : 'Send $depositSymbol from source chain',
+      sendLabel: direction.sendsZec
+          ? 'Send $depositSymbol'
+          : 'Send $depositSymbol from source chain',
       depositSymbol: depositSymbol,
       depositAddressLabel: depositAddressLabel,
       address: depositAddress,
@@ -532,13 +593,12 @@ class SwapActivityDepositInstruction {
       txHashLabel: '$depositSymbol deposit tx hash',
       txHashHint: '$depositSymbol source-chain transaction hash',
       submitLabel: 'Submit $depositSymbol deposit',
-      qr:
-          direction.sendsZec
-              ? null
-              : SwapActivityDepositQrInstruction(
-                railLabel: externalAsset.railLabel,
-                reuseWarning: 'Do not reuse this address',
-              ),
+      qr: direction.sendsZec
+          ? null
+          : SwapActivityDepositQrInstruction(
+              railLabel: externalAsset.railLabel,
+              reuseWarning: 'Do not reuse this address',
+            ),
     );
   }
 
@@ -562,7 +622,6 @@ class SwapActivityDepositQrInstruction {
   final String railLabel;
   final String reuseWarning;
 }
-
 
 bool canRefreshSwapIntentStatus(SwapIntentStatus status) {
   return status != SwapIntentStatus.complete;
@@ -630,6 +689,34 @@ String? _firstNonEmpty(Iterable<String?> values) {
     if (trimmed != null && trimmed.isNotEmpty) return trimmed;
   }
   return null;
+}
+
+String _normalizedAddress(AddressBookNetwork network, String address) {
+  final trimmed = address.trim();
+  return _addressBookNetworkIgnoresCase(network)
+      ? trimmed.toLowerCase()
+      : trimmed;
+}
+
+bool _addressBookNetworkIgnoresCase(AddressBookNetwork network) {
+  return switch (network) {
+    AddressBookNetwork.ethereum ||
+    AddressBookNetwork.base ||
+    AddressBookNetwork.arbitrum ||
+    AddressBookNetwork.binanceSmartChain ||
+    AddressBookNetwork.optimism ||
+    AddressBookNetwork.avalanche ||
+    AddressBookNetwork.gnosis ||
+    AddressBookNetwork.polygon ||
+    AddressBookNetwork.xLayer ||
+    AddressBookNetwork.plasma ||
+    AddressBookNetwork.abstractChain ||
+    AddressBookNetwork.bera ||
+    AddressBookNetwork.monad ||
+    AddressBookNetwork.scroll ||
+    AddressBookNetwork.near => true,
+    _ => false,
+  };
 }
 
 double? _numericAmount(String amountText) {

--- a/lib/src/features/swap/models/swap_activity_status_mapper.dart
+++ b/lib/src/features/swap/models/swap_activity_status_mapper.dart
@@ -231,7 +231,9 @@ List<SwapStatusDetailRowData> _swapActivityStatusDetails(
         : const <SwapStatusDetailRowData>[];
     return [
       _accountDetailRow(accountDetail),
-      if (terminalRecipientRows.length > 1) ...terminalRecipientRows,
+      if (terminalRecipientRows.isNotEmpty &&
+          terminalRecipientRows.first.addressBookLabel != null)
+        ...terminalRecipientRows,
       if (failed && refundAddress != null && refundAddress.isNotEmpty)
         ..._addressDetailRows(
           label: '$sourceSymbol refunded to',
@@ -455,15 +457,28 @@ List<SwapStatusDetailRowData> _addressDetailRows({
     asset: asset,
     address: address,
   );
+  final addressNetwork = addressBookLabel == null || asset == null
+      ? null
+      : AddressBookNetwork.tryFromChainTicker(asset.chainTicker);
+  // Matched rows share the address line with the network chip, so use a tighter
+  // compaction (keeps the 0x prefix and the last 5 chars, no spaced ellipsis).
+  final value = addressBookLabel == null
+      ? compactSwapAddress(address)
+      : compactSwapAddress(
+          address,
+          prefixLength: 7,
+          suffixLength: 5,
+          separator: '…',
+        );
   return [
     SwapStatusDetailRowData(
       label: label,
-      value: compactSwapAddress(address),
+      value: value,
       copyable: true,
       copyText: address,
+      addressBookLabel: addressBookLabel,
+      addressNetwork: addressNetwork,
     ),
-    if (addressBookLabel != null)
-      SwapStatusDetailRowData(label: '', value: addressBookLabel),
   ];
 }
 

--- a/lib/src/features/swap/models/swap_status_presentation.dart
+++ b/lib/src/features/swap/models/swap_status_presentation.dart
@@ -1,3 +1,5 @@
+import '../../address_book/models/address_book_contact.dart';
+
 enum SwapStatusBadgeKind { liveQuote, completed, warning, failed }
 
 enum SwapStatusTab { progress, details }
@@ -53,6 +55,8 @@ class SwapStatusDetailRowData {
     this.help = false,
     this.helpTooltip,
     this.accountProfilePictureId,
+    this.addressBookLabel,
+    this.addressNetwork,
   });
 
   final String label;
@@ -62,4 +66,13 @@ class SwapStatusDetailRowData {
   final bool help;
   final String? helpTooltip;
   final String? accountProfilePictureId;
+
+  /// When this row is an address that matches a saved address-book contact,
+  /// the contact's nickname. Renders as a matched-contact identity cell
+  /// (nickname + saved mark above the network + address).
+  final String? addressBookLabel;
+
+  /// The contact's network, used to draw the chain chip on the address line.
+  /// Only set when [addressBookLabel] is non-null.
+  final AddressBookNetwork? addressNetwork;
 }

--- a/lib/src/features/swap/screens/swap_review_screen.dart
+++ b/lib/src/features/swap/screens/swap_review_screen.dart
@@ -13,6 +13,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/sync_provider.dart';
+import '../../address_book/providers/address_book_provider.dart';
 import '../models/swap_activity_navigation.dart';
 import '../models/swap_fiat_amount.dart';
 import '../models/swap_fiat_value_formatting.dart';
@@ -110,6 +111,8 @@ class _SwapReviewScreenState extends ConsumerState<SwapReviewScreen> {
     final swapState = ref.watch(swapStateProvider);
     final quote = swapState.reviewQuote;
     final addressPlan = swapState.reviewAddressPlan;
+    final addressBookContacts =
+        ref.watch(addressBookProvider).value?.contacts ?? const [];
     if (!swapState.reviewVisible || quote == null || addressPlan == null) {
       if (!_hadReviewState || !_startingIntent) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -180,6 +183,7 @@ class _SwapReviewScreenState extends ConsumerState<SwapReviewScreen> {
                                   SwapReviewPageContent(
                                     quote: quote,
                                     addressPlan: addressPlan,
+                                    addressBookContacts: addressBookContacts,
                                     accountLabel: accountLabel,
                                     accountProfilePictureId:
                                         accountProfilePictureId,

--- a/lib/src/features/swap/widgets/swap_activity_panel.dart
+++ b/lib/src/features/swap/widgets/swap_activity_panel.dart
@@ -8,6 +8,7 @@ import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_toast.dart';
 import '../../../providers/account_provider.dart';
+import '../../address_book/providers/address_book_provider.dart';
 import '../domain/near_intents_explorer.dart';
 import '../models/swap_activity_navigation.dart';
 import '../models/swap_activity_status_mapper.dart';
@@ -563,6 +564,8 @@ class _SwapStatusForIntentState extends ConsumerState<_SwapStatusForIntent> {
       ref.watch(accountProvider).value,
       intent,
     );
+    final addressBookContacts =
+        ref.watch(addressBookProvider).value?.contacts ?? const [];
     final presentation = swapActivityStatusPresentationForIntent(
       state,
       intent,
@@ -572,6 +575,7 @@ class _SwapStatusForIntentState extends ConsumerState<_SwapStatusForIntent> {
               name: accountInfo.name,
               profilePictureId: accountInfo.profilePictureId,
             ),
+      addressBookContacts: addressBookContacts,
     );
     return SwapStatusPageContent(
       title: presentation.title,

--- a/lib/src/features/swap/widgets/swap_review_page_content.dart
+++ b/lib/src/features/swap/widgets/swap_review_page_content.dart
@@ -556,81 +556,84 @@ class _ReviewMatchedAddressRow extends StatelessWidget {
     final colors = context.colors;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.only(top: 2),
-              child: Text(
-                label,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: AppTypography.labelLarge.copyWith(
-                  color: colors.text.secondary,
+          SizedBox(
+            height: 32,
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: colors.text.secondary,
+                    ),
+                  ),
                 ),
-              ),
+                const SizedBox(width: AppSpacing.s),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Flexible(
+                          child: Text(
+                            addressBookLabel,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            textAlign: TextAlign.end,
+                            style: AppTypography.bodyMediumStrong.copyWith(
+                              color: colors.text.accent,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: AppSpacing.xxs),
+                        AppIcon(
+                          AppIcons.user,
+                          size: 14,
+                          color: colors.icon.brandCrimson,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
-          const SizedBox(width: AppSpacing.s),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    Flexible(
-                      child: Text(
-                        addressBookLabel,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        textAlign: TextAlign.end,
-                        style: AppTypography.bodyMediumStrong.copyWith(
-                          color: colors.text.accent,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: AppSpacing.xxs),
-                    AppIcon(
-                      AppIcons.user,
-                      size: 14,
-                      color: colors.icon.brandCrimson,
-                    ),
-                  ],
-                ),
-                const SizedBox(height: AppSpacing.xxs),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
+          SizedBox(
+            height: 18,
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                alignment: Alignment.centerRight,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
                   children: [
                     AddressBookNetworkIcon(network: network, size: 14),
                     const SizedBox(width: AppSpacing.xxs),
-                    Flexible(
-                      child: Text(
-                        network.label,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: AppTypography.labelSmall.copyWith(
-                          color: colors.text.secondary,
-                        ),
+                    Text(
+                      network.label,
+                      maxLines: 1,
+                      style: AppTypography.labelSmall.copyWith(
+                        color: colors.text.secondary,
                       ),
                     ),
                     const SizedBox(width: AppSpacing.xs),
-                    Flexible(
-                      child: Text(
-                        value,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        textAlign: TextAlign.end,
-                        style: AppTypography.codeSmall.copyWith(
-                          color: colors.text.muted,
-                        ),
+                    Text(
+                      value,
+                      maxLines: 1,
+                      style: AppTypography.codeSmall.copyWith(
+                        color: colors.text.muted,
                       ),
                     ),
                   ],
                 ),
-              ],
+              ),
             ),
           ),
         ],

--- a/lib/src/features/swap/widgets/swap_review_page_content.dart
+++ b/lib/src/features/swap/widgets/swap_review_page_content.dart
@@ -6,6 +6,9 @@ import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_profile_picture.dart';
 import '../../../core/widgets/app_tooltip.dart';
+import '../../address_book/models/address_book_contact.dart';
+import '../../address_book/models/address_book_label_lookup.dart';
+import '../../address_book/widgets/address_book_network_icon.dart';
 import '../domain/swap_address_plan.dart';
 import '../domain/swap_contract.dart';
 import '../models/swap_address_formatting.dart';
@@ -21,6 +24,7 @@ class SwapReviewPageContent extends StatelessWidget {
   const SwapReviewPageContent({
     required this.quote,
     required this.addressPlan,
+    this.addressBookContacts = const [],
     required this.accountLabel,
     required this.expired,
     required this.amountWarning,
@@ -35,6 +39,7 @@ class SwapReviewPageContent extends StatelessWidget {
 
   final SwapQuote quote;
   final SwapAddressPlan addressPlan;
+  final Iterable<AddressBookContact> addressBookContacts;
   final String? accountLabel;
   final String accountProfilePictureId;
   final bool expired;
@@ -72,6 +77,7 @@ class SwapReviewPageContent extends StatelessWidget {
           _ReviewDetailsList(
             quote: quote,
             addressPlan: addressPlan,
+            addressBookContacts: addressBookContacts,
             accountLabel: accountLabel,
             accountProfilePictureId: accountProfilePictureId,
             slippageToleranceTextOverride: slippageToleranceTextOverride,
@@ -445,6 +451,7 @@ class _ReviewDetailsList extends StatelessWidget {
   const _ReviewDetailsList({
     required this.quote,
     required this.addressPlan,
+    required this.addressBookContacts,
     required this.accountLabel,
     required this.accountProfilePictureId,
     required this.slippageToleranceTextOverride,
@@ -452,6 +459,7 @@ class _ReviewDetailsList extends StatelessWidget {
 
   final SwapQuote quote;
   final SwapAddressPlan addressPlan;
+  final Iterable<AddressBookContact> addressBookContacts;
   final String? accountLabel;
   final String accountProfilePictureId;
   final String? slippageToleranceTextOverride;
@@ -459,15 +467,38 @@ class _ReviewDetailsList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final sendsZec = quote.direction.sendsZec;
+    final externalAddress = _refundOrRecipientValue(addressPlan);
+    final addressNetwork = AddressBookNetwork.tryFromChainTicker(
+      addressPlan.externalAsset.chainTicker,
+    );
+    final addressBookLabel = addressNetwork == null
+        ? null
+        : addressBookLabelFor(
+            contacts: addressBookContacts,
+            network: addressNetwork,
+            address: externalAddress,
+          );
     final accountRow = _ReviewDetailRow(
       label: sendsZec ? 'From' : 'To',
       value: accountLabel ?? 'Current account',
       leadingValue: _AccountAvatar(profilePictureId: accountProfilePictureId),
     );
-    final addressRow = _ReviewDetailRow(
-      label: sendsZec ? 'To' : 'From',
-      value: compactSwapAddress(_refundOrRecipientValue(addressPlan)),
-    );
+    final addressRow = addressBookLabel == null || addressNetwork == null
+        ? _ReviewDetailRow(
+            label: sendsZec ? 'To' : 'From',
+            value: compactSwapAddress(externalAddress),
+          )
+        : _ReviewMatchedAddressRow(
+            label: sendsZec ? 'To' : 'From',
+            addressBookLabel: addressBookLabel,
+            network: addressNetwork,
+            value: compactSwapAddress(
+              externalAddress,
+              prefixLength: 7,
+              suffixLength: 5,
+              separator: '…',
+            ),
+          );
     return SizedBox(
       key: const ValueKey('swap_review_details'),
       width: 400,
@@ -502,6 +533,107 @@ class _ReviewDetailsList extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+class _ReviewMatchedAddressRow extends StatelessWidget {
+  const _ReviewMatchedAddressRow({
+    required this.label,
+    required this.addressBookLabel,
+    required this.network,
+    required this.value,
+  });
+
+  final String label;
+  final String addressBookLabel;
+  final AddressBookNetwork network;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Flexible(
+                      child: Text(
+                        addressBookLabel,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        textAlign: TextAlign.end,
+                        style: AppTypography.bodyMediumStrong.copyWith(
+                          color: colors.text.accent,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.xxs),
+                    AppIcon(
+                      AppIcons.user,
+                      size: 14,
+                      color: colors.icon.brandCrimson,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: AppSpacing.xxs),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    AddressBookNetworkIcon(network: network, size: 14),
+                    const SizedBox(width: AppSpacing.xxs),
+                    Flexible(
+                      child: Text(
+                        network.label,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTypography.labelSmall.copyWith(
+                          color: colors.text.secondary,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: AppSpacing.xs),
+                    Flexible(
+                      child: Text(
+                        value,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        textAlign: TextAlign.end,
+                        style: AppTypography.codeSmall.copyWith(
+                          color: colors.text.muted,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/features/swap/widgets/swap_status_page_content.dart
+++ b/lib/src/features/swap/widgets/swap_status_page_content.dart
@@ -9,6 +9,7 @@ import '../../../core/widgets/app_copy_feedback.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_profile_picture.dart';
 import '../../../core/widgets/app_tooltip.dart';
+import '../../address_book/widgets/address_book_network_icon.dart';
 import '../domain/swap_contract.dart';
 import '../models/swap_detail_tooltips.dart';
 import '../models/swap_status_presentation.dart';
@@ -1135,86 +1136,190 @@ class _DetailRow extends StatelessWidget {
                     );
                   }
                 : null),
-        child: SizedBox(
-          height: 32,
-          child: row.value.isEmpty
-              ? Center(
+        child: row.addressBookLabel != null
+            ? _matchedAddressCell(context)
+            : SizedBox(
+                height: 32,
+                child: row.value.isEmpty
+                    ? Center(
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              row.label,
+                              style: AppTypography.labelLarge.copyWith(
+                                color: colors.text.secondary,
+                              ),
+                            ),
+                            const SizedBox(width: AppSpacing.xxs),
+                            AppIcon(
+                              chevronUp ? AppIcons.collapsed : AppIcons.expand,
+                              size: 16,
+                              color: colors.icon.regular.withValues(
+                                alpha: 0.72,
+                              ),
+                            ),
+                          ],
+                        ),
+                      )
+                    : Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              row.label,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: AppTypography.labelLarge.copyWith(
+                                color: colors.text.secondary,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: AppSpacing.s),
+                          Expanded(
+                            child: Align(
+                              alignment: Alignment.centerRight,
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  if (showAccountAvatar) ...[
+                                    AppProfilePicture(
+                                      profilePictureId:
+                                          row.accountProfilePictureId ??
+                                          kDefaultProfilePictureId,
+                                      size: AppProfilePictureSize.medium,
+                                    ),
+                                    const SizedBox(width: AppSpacing.xs),
+                                  ],
+                                  Flexible(
+                                    child: Text(
+                                      row.value,
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      textAlign: TextAlign.end,
+                                      style: AppTypography.labelLarge.copyWith(
+                                        color: colors.text.accent,
+                                      ),
+                                    ),
+                                  ),
+                                  if (row.copyable || row.help) ...[
+                                    const SizedBox(width: AppSpacing.xxs),
+                                    _StatusDetailActionIcon(
+                                      icon: row.copyable
+                                          ? AppIcons.copy
+                                          : AppIcons.help,
+                                      tooltipMessage: row.help
+                                          ? row.helpTooltip ??
+                                                _swapStatusHelpTooltip(
+                                                  row.label,
+                                                )
+                                          : null,
+                                    ),
+                                  ],
+                                ],
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+              ),
+      ),
+    );
+  }
+
+  /// Renders an address row that matches a saved address-book contact:
+  /// the nickname + crimson saved mark on top, and the network chip +
+  /// truncated address + copy icon (copy last) below.
+  Widget _matchedAddressCell(BuildContext context) {
+    final colors = context.colors;
+    final network = row.addressNetwork;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Intrinsic-width label so the identity column below can use the
+          // rest of the panel (more than half) without truncating.
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Text(
+              row.label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Align(
+                  alignment: Alignment.centerRight,
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      Text(
-                        row.label,
-                        style: AppTypography.labelLarge.copyWith(
-                          color: colors.text.secondary,
+                      Flexible(
+                        child: Text(
+                          row.addressBookLabel!,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          textAlign: TextAlign.end,
+                          style: AppTypography.bodyMediumStrong.copyWith(
+                            color: colors.text.accent,
+                          ),
                         ),
                       ),
                       const SizedBox(width: AppSpacing.xxs),
                       AppIcon(
-                        chevronUp ? AppIcons.collapsed : AppIcons.expand,
-                        size: 16,
-                        color: colors.icon.regular.withValues(alpha: 0.72),
+                        AppIcons.user,
+                        size: 14,
+                        color: colors.icon.brandCrimson,
                       ),
                     ],
                   ),
-                )
-              : Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        row.label,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: AppTypography.labelLarge.copyWith(
-                          color: colors.text.secondary,
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: AppSpacing.s),
-                    Expanded(
-                      child: Align(
-                        alignment: Alignment.centerRight,
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            if (showAccountAvatar) ...[
-                              AppProfilePicture(
-                                profilePictureId:
-                                    row.accountProfilePictureId ??
-                                    kDefaultProfilePictureId,
-                                size: AppProfilePictureSize.medium,
-                              ),
-                              const SizedBox(width: AppSpacing.xs),
-                            ],
-                            Flexible(
-                              child: Text(
-                                row.value,
-                                maxLines: 1,
-                                overflow: TextOverflow.ellipsis,
-                                textAlign: TextAlign.end,
-                                style: AppTypography.labelLarge.copyWith(
-                                  color: colors.text.accent,
-                                ),
-                              ),
-                            ),
-                            if (row.copyable || row.help) ...[
-                              const SizedBox(width: AppSpacing.xxs),
-                              _StatusDetailActionIcon(
-                                icon: row.copyable
-                                    ? AppIcons.copy
-                                    : AppIcons.help,
-                                tooltipMessage: row.help
-                                    ? row.helpTooltip ??
-                                          _swapStatusHelpTooltip(row.label)
-                                    : null,
-                              ),
-                            ],
-                          ],
-                        ),
-                      ),
-                    ),
-                  ],
                 ),
-        ),
+                const SizedBox(height: AppSpacing.xxs),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (network != null) ...[
+                        AddressBookNetworkIcon(network: network, size: 14),
+                        const SizedBox(width: AppSpacing.xxs),
+                        Text(
+                          network.label,
+                          maxLines: 1,
+                          style: AppTypography.labelSmall.copyWith(
+                            color: colors.text.secondary,
+                          ),
+                        ),
+                        const SizedBox(width: AppSpacing.xs),
+                      ],
+                      Text(
+                        row.value,
+                        maxLines: 1,
+                        style: AppTypography.codeSmall.copyWith(
+                          color: colors.text.muted,
+                        ),
+                      ),
+                      if (row.copyable) ...[
+                        const SizedBox(width: AppSpacing.xxs),
+                        const _StatusDetailActionIcon(
+                          icon: AppIcons.copy,
+                          tooltipMessage: null,
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/features/swap/widgets/swap_status_page_content.dart
+++ b/lib/src/features/swap/widgets/swap_status_page_content.dart
@@ -1226,97 +1226,102 @@ class _DetailRow extends StatelessWidget {
     );
   }
 
-  /// Renders an address row that matches a saved address-book contact:
-  /// the nickname + crimson saved mark on top, and the network chip +
-  /// truncated address + copy icon (copy last) below.
+  /// Renders an address row that matches a saved address-book contact. The
+  /// first line keeps the regular two-column detail-row geometry; the metadata
+  /// line below is right-aligned across the full row so the network and compact
+  /// address are not squeezed into the value column.
   Widget _matchedAddressCell(BuildContext context) {
     final colors = context.colors;
     final network = row.addressNetwork;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: AppSpacing.xs),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          // Intrinsic-width label so the identity column below can use the
-          // rest of the panel (more than half) without truncating.
-          Padding(
-            padding: const EdgeInsets.only(top: 2),
-            child: Text(
-              row.label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: AppTypography.labelLarge.copyWith(
-                color: colors.text.secondary,
-              ),
-            ),
-          ),
-          const SizedBox(width: AppSpacing.s),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              mainAxisSize: MainAxisSize.min,
+          SizedBox(
+            height: 32,
+            child: Row(
               children: [
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Flexible(
-                        child: Text(
-                          row.addressBookLabel!,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          textAlign: TextAlign.end,
-                          style: AppTypography.bodyMediumStrong.copyWith(
-                            color: colors.text.accent,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: AppSpacing.xxs),
-                      AppIcon(
-                        AppIcons.user,
-                        size: 14,
-                        color: colors.icon.brandCrimson,
-                      ),
-                    ],
+                Expanded(
+                  child: Text(
+                    row.label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: colors.text.secondary,
+                    ),
                   ),
                 ),
-                const SizedBox(height: AppSpacing.xxs),
-                Align(
-                  alignment: Alignment.centerRight,
-                  child: Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      if (network != null) ...[
-                        AddressBookNetworkIcon(network: network, size: 14),
-                        const SizedBox(width: AppSpacing.xxs),
-                        Text(
-                          network.label,
-                          maxLines: 1,
-                          style: AppTypography.labelSmall.copyWith(
-                            color: colors.text.secondary,
+                const SizedBox(width: AppSpacing.s),
+                Expanded(
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Flexible(
+                          child: Text(
+                            row.addressBookLabel!,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            textAlign: TextAlign.end,
+                            style: AppTypography.bodyMediumStrong.copyWith(
+                              color: colors.text.accent,
+                            ),
                           ),
                         ),
-                        const SizedBox(width: AppSpacing.xs),
-                      ],
-                      Text(
-                        row.value,
-                        maxLines: 1,
-                        style: AppTypography.codeSmall.copyWith(
-                          color: colors.text.muted,
-                        ),
-                      ),
-                      if (row.copyable) ...[
                         const SizedBox(width: AppSpacing.xxs),
-                        const _StatusDetailActionIcon(
-                          icon: AppIcons.copy,
-                          tooltipMessage: null,
+                        AppIcon(
+                          AppIcons.user,
+                          size: 14,
+                          color: colors.icon.brandCrimson,
                         ),
                       ],
-                    ],
+                    ),
                   ),
                 ),
               ],
+            ),
+          ),
+          SizedBox(
+            height: 18,
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                alignment: Alignment.centerRight,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (network != null) ...[
+                      AddressBookNetworkIcon(network: network, size: 14),
+                      const SizedBox(width: AppSpacing.xxs),
+                      Text(
+                        network.label,
+                        maxLines: 1,
+                        style: AppTypography.labelSmall.copyWith(
+                          color: colors.text.secondary,
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.xs),
+                    ],
+                    Text(
+                      row.value,
+                      maxLines: 1,
+                      style: AppTypography.codeSmall.copyWith(
+                        color: colors.text.muted,
+                      ),
+                    ),
+                    if (row.copyable) ...[
+                      const SizedBox(width: AppSpacing.xxs),
+                      const _StatusDetailActionIcon(
+                        icon: AppIcons.copy,
+                        tooltipMessage: null,
+                      ),
+                    ],
+                  ],
+                ),
+              ),
             ),
           ),
         ],

--- a/lib/src/features/swap/widgets/swap_status_page_content.dart
+++ b/lib/src/features/swap/widgets/swap_status_page_content.dart
@@ -235,14 +235,20 @@ class _SwapStatusPageContentState extends State<SwapStatusPageContent> {
                       onChanged: widget.onTabChanged,
                     ),
                     const SizedBox(height: AppSpacing.md),
-                    tabContent,
+                    if (widget.activeTab == SwapStatusTab.details)
+                      Flexible(fit: FlexFit.loose, child: tabContent)
+                    else
+                      tabContent,
                   ] else
-                    _SwapFinalDetails(rows: widget.details),
+                    Flexible(
+                      fit: FlexFit.loose,
+                      child: _SwapFinalDetails(rows: widget.details),
+                    ),
                 ],
               ),
             ),
           ),
-          const SizedBox(height: AppSpacing.sm),
+          const SizedBox(height: AppSpacing.xs),
           Align(
             alignment: Alignment.center,
             child: _NearIntentsLink(onPressed: widget.onOpenExplorer),
@@ -979,6 +985,7 @@ class _SwapTransactionDetailsState extends State<_SwapTransactionDetails> {
         ? const <SwapStatusDetailRowData>[]
         : widget.rows.skip(anchorIndex + 1).toList();
     final content = Column(
+      mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: widget.expanded
           ? [
@@ -1017,9 +1024,12 @@ class _SwapTransactionDetailsState extends State<_SwapTransactionDetails> {
     );
 
     if (!widget.expanded) {
-      return KeyedSubtree(
-        key: const ValueKey('swap_transaction_details_collapsed'),
-        child: content,
+      return _StatusDetailsScrollView(
+        key: const ValueKey('swap_transaction_details_collapsed_scroll_view'),
+        child: KeyedSubtree(
+          key: const ValueKey('swap_transaction_details_collapsed'),
+          child: content,
+        ),
       );
     }
 
@@ -1084,17 +1094,32 @@ class _SwapFinalDetails extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      key: const ValueKey('swap_final_details'),
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        for (var index = 0; index < rows.length; index++) ...[
-          _InsetDetailRow(row: rows[index]),
-          if (_finalDetailSectionGapAfter(rows, index))
-            const SizedBox(height: AppSpacing.sm),
+    return _StatusDetailsScrollView(
+      key: const ValueKey('swap_final_details_scroll_view'),
+      child: Column(
+        key: const ValueKey('swap_final_details'),
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          for (var index = 0; index < rows.length; index++) ...[
+            _InsetDetailRow(row: rows[index]),
+            if (_finalDetailSectionGapAfter(rows, index))
+              const SizedBox(height: AppSpacing.sm),
+          ],
         ],
-      ],
+      ),
     );
+  }
+}
+
+class _StatusDetailsScrollView extends StatelessWidget {
+  const _StatusDetailsScrollView({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(primary: false, child: child);
   }
 }
 

--- a/test/features/activity/activity_transaction_status_screen_test.dart
+++ b/test/features/activity/activity_transaction_status_screen_test.dart
@@ -1,23 +1,29 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:zcash_wallet/src/features/activity/screens/activity_transaction_status_screen.dart';
+import 'package:zcash_wallet/src/features/send/widgets/transaction_receipt_view.dart';
 
 void main() {
-  test('compactActivityReceiptAddress keeps sixteen characters at each edge', () {
-    const address =
-        'u1z76wfe98p8ue25zwrrdg7v4hv28grpcxtqwuwd1c12ttmcw0hcsr6ju6cdtnjxjc744qhmyyt5qxze6683576ujdvamp6tkh9076ee3ny5jqqtgnq6u8gh0h95y04yx97rz2hxrzz44ypk1yegx6mllga4hn7m4q3eatnj3jxdvggvdg2';
+  test(
+    'compactTransactionReceiptSavedAddress keeps sixteen characters at each edge',
+    () {
+      const address =
+          'u1z76wfe98p8ue25zwrrdg7v4hv28grpcxtqwuwd1c12ttmcw0hcsr6ju6cdtnjxjc744qhmyyt5qxze6683576ujdvamp6tkh9076ee3ny5jqqtgnq6u8gh0h95y04yx97rz2hxrzz44ypk1yegx6mllga4hn7m4q3eatnj3jxdvggvdg2';
 
-    final compact = compactActivityReceiptAddress(address);
+      final compact = compactTransactionReceiptSavedAddress(address);
 
-    expect(
-      compact,
-      '${address.substring(0, 16)} ... ${address.substring(address.length - 16)}',
-    );
-    expect(compact, isNot(address));
-  });
+      expect(
+        compact,
+        '${address.substring(0, 16)} ... ${address.substring(address.length - 16)}',
+      );
+      expect(compact, isNot(address));
+    },
+  );
 
-  test('compactActivityReceiptAddress keeps short addresses unchanged', () {
-    const address = 'u1shortaddress';
+  test(
+    'compactTransactionReceiptSavedAddress keeps short addresses unchanged',
+    () {
+      const address = 'u1shortaddress';
 
-    expect(compactActivityReceiptAddress(address), address);
-  });
+      expect(compactTransactionReceiptSavedAddress(address), address);
+    },
+  );
 }

--- a/test/features/activity/activity_transaction_status_screen_test.dart
+++ b/test/features/activity/activity_transaction_status_screen_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/activity/screens/activity_transaction_status_screen.dart';
+
+void main() {
+  test('compactActivityReceiptAddress keeps sixteen characters at each edge', () {
+    const address =
+        'u1z76wfe98p8ue25zwrrdg7v4hv28grpcxtqwuwd1c12ttmcw0hcsr6ju6cdtnjxjc744qhmyyt5qxze6683576ujdvamp6tkh9076ee3ny5jqqtgnq6u8gh0h95y04yx97rz2hxrzz44ypk1yegx6mllga4hn7m4q3eatnj3jxdvggvdg2';
+
+    final compact = compactActivityReceiptAddress(address);
+
+    expect(
+      compact,
+      '${address.substring(0, 16)} ... ${address.substring(address.length - 16)}',
+    );
+    expect(compact, isNot(address));
+  });
+
+  test('compactActivityReceiptAddress keeps short addresses unchanged', () {
+    const address = 'u1shortaddress';
+
+    expect(compactActivityReceiptAddress(address), address);
+  });
+}

--- a/test/features/address_book/address_book_label_lookup_test.dart
+++ b/test/features/address_book/address_book_label_lookup_test.dart
@@ -1,0 +1,173 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
+import 'package:zcash_wallet/src/features/address_book/models/address_book_label_lookup.dart';
+
+AddressBookContact _contact({
+  required String label,
+  required AddressBookNetwork network,
+  required String address,
+}) {
+  return AddressBookContact(
+    id: 'id_$label',
+    label: label,
+    network: network,
+    address: address,
+    profilePictureId: 'knight',
+    createdAtMs: 0,
+    updatedAtMs: 0,
+  );
+}
+
+void main() {
+  const zcashAddress = 'u1tvg4akwn3gk64hhq6dfe05psw8zr0x4tspgwhkgy8x9yhy6djx';
+
+  test('returns the label for an exact Zcash address match', () {
+    final contacts = [
+      _contact(
+        label: 'Alice',
+        network: AddressBookNetwork.zcash,
+        address: zcashAddress,
+      ),
+    ];
+
+    expect(
+      addressBookLabelFor(
+        contacts: contacts,
+        network: AddressBookNetwork.zcash,
+        address: zcashAddress,
+      ),
+      'Alice',
+    );
+  });
+
+  test('matches Zcash addresses after trimming surrounding whitespace', () {
+    final contacts = [
+      _contact(
+        label: 'Alice',
+        network: AddressBookNetwork.zcash,
+        address: '  $zcashAddress  ',
+      ),
+    ];
+
+    expect(
+      addressBookLabelFor(
+        contacts: contacts,
+        network: AddressBookNetwork.zcash,
+        address: '$zcashAddress\n',
+      ),
+      'Alice',
+    );
+  });
+
+  test('Zcash matching is case-sensitive', () {
+    final contacts = [
+      _contact(
+        label: 'Alice',
+        network: AddressBookNetwork.zcash,
+        address: zcashAddress.toUpperCase(),
+      ),
+    ];
+
+    expect(
+      addressBookLabelFor(
+        contacts: contacts,
+        network: AddressBookNetwork.zcash,
+        address: zcashAddress,
+      ),
+      isNull,
+    );
+  });
+
+  test('EVM matching ignores case', () {
+    const checksummed = '0xAbC0000000000000000000000000000000000123';
+    final contacts = [
+      _contact(
+        label: 'Bob',
+        network: AddressBookNetwork.ethereum,
+        address: checksummed,
+      ),
+    ];
+
+    expect(
+      addressBookLabelFor(
+        contacts: contacts,
+        network: AddressBookNetwork.ethereum,
+        address: checksummed.toLowerCase(),
+      ),
+      'Bob',
+    );
+  });
+
+  test('ignores contacts on a different network', () {
+    final contacts = [
+      _contact(
+        label: 'Eve',
+        network: AddressBookNetwork.ethereum,
+        address: zcashAddress,
+      ),
+    ];
+
+    expect(
+      addressBookLabelFor(
+        contacts: contacts,
+        network: AddressBookNetwork.zcash,
+        address: zcashAddress,
+      ),
+      isNull,
+    );
+  });
+
+  test('returns null when nothing matches or input is empty', () {
+    final contacts = [
+      _contact(
+        label: 'Alice',
+        network: AddressBookNetwork.zcash,
+        address: zcashAddress,
+      ),
+    ];
+
+    expect(
+      addressBookLabelFor(
+        contacts: contacts,
+        network: AddressBookNetwork.zcash,
+        address: 'u1someotheraddress',
+      ),
+      isNull,
+    );
+    expect(
+      addressBookLabelFor(
+        contacts: contacts,
+        network: AddressBookNetwork.zcash,
+        address: '   ',
+      ),
+      isNull,
+    );
+    expect(
+      addressBookLabelFor(
+        contacts: const [],
+        network: AddressBookNetwork.zcash,
+        address: zcashAddress,
+      ),
+      isNull,
+    );
+  });
+
+  test('skips matching contacts whose label is blank', () {
+    final contacts = [
+      _contact(
+        label: '   ',
+        network: AddressBookNetwork.zcash,
+        address: zcashAddress,
+      ),
+    ];
+
+    expect(
+      addressBookLabelFor(
+        contacts: contacts,
+        network: AddressBookNetwork.zcash,
+        address: zcashAddress,
+      ),
+      isNull,
+    );
+  });
+}

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -7,7 +7,10 @@ import 'package:zcash_wallet/src/core/config/network_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
+import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
 import 'package:zcash_wallet/src/features/send/screens/send_review_screen.dart';
+import 'package:zcash_wallet/src/features/send/widgets/transaction_receipt_view.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
 void main() {
@@ -166,6 +169,45 @@ void main() {
     );
   });
 
+  testWidgets('shows saved recipient label with inline copy action', (
+    tester,
+  ) async {
+    final compactAddress = compactTransactionReceiptSavedAddress(_longAddress);
+
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _sendReviewHarness(
+        _reviewArgs(addressType: 'unified', memo: _longMemo),
+        addressBookRepository: _FakeAddressBookRepository([
+          _contact(id: 'me', label: 'me', address: _longAddress),
+        ]),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('me'), findsOneWidget);
+    expect(find.text(compactAddress), findsOneWidget);
+    expect(
+      find.byWidgetPredicate(
+        (widget) => widget is Text && widget.data == 'Copy',
+      ),
+      findsNothing,
+    );
+
+    final addressRect = tester.getRect(find.text(compactAddress));
+    final copyRect = tester.getRect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is AppIcon &&
+            widget.name == AppIcons.copy &&
+            widget.size == 16,
+      ),
+    );
+    final copyGap = copyRect.left - addressRect.right;
+    expect(copyGap, greaterThan(0));
+    expect(copyGap, lessThanOrEqualTo(AppSpacing.xs));
+  });
+
   testWidgets('renders defensive short recipient address without range error', (
     tester,
   ) async {
@@ -258,6 +300,7 @@ Future<void> _setDesktopViewport(WidgetTester tester) async {
 Widget _sendReviewHarness(
   SendReviewArgs args, {
   AppThemeData theme = AppThemeData.light,
+  AddressBookRepository? addressBookRepository,
 }) {
   final router = GoRouter(
     initialLocation: '/send/review',
@@ -273,12 +316,44 @@ Widget _sendReviewHarness(
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+      addressBookRepositoryProvider.overrideWithValue(
+        addressBookRepository ?? _FakeAddressBookRepository(),
+      ),
     ],
     child: MaterialApp.router(
       routerConfig: router,
       builder: (_, child) => AppTheme(data: theme, child: child!),
     ),
   );
+}
+
+AddressBookContact _contact({
+  required String id,
+  required String label,
+  required String address,
+}) {
+  return AddressBookContact(
+    id: id,
+    label: label,
+    network: AddressBookNetwork.zcash,
+    address: address,
+    profilePictureId: 'knight',
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  );
+}
+
+class _FakeAddressBookRepository implements AddressBookRepository {
+  _FakeAddressBookRepository([List<AddressBookContact> contacts = const []])
+    : contacts = [...contacts];
+
+  final List<AddressBookContact> contacts;
+
+  @override
+  Future<List<AddressBookContact>> loadContacts() async => [...contacts];
+
+  @override
+  Future<void> saveContacts(List<AddressBookContact> contacts) async {}
 }
 
 SendReviewArgs _reviewArgs({

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -188,6 +188,10 @@ void main() {
     expect(find.text('me'), findsOneWidget);
     expect(find.text(compactAddress), findsOneWidget);
     expect(
+      tester.widget<Text>(find.text(compactAddress)).style?.color,
+      AppThemeData.light.colors.text.muted,
+    );
+    expect(
       find.byWidgetPredicate(
         (widget) => widget is Text && widget.data == 'Copy',
       ),

--- a/test/features/swap/swap_activity_status_mapper_test.dart
+++ b/test/features/swap/swap_activity_status_mapper_test.dart
@@ -99,27 +99,25 @@ void main() {
     final recipient = _detailRow(presentation.details, 'USDC recipient');
     expect(recipient.value, contains('0x'));
     expect(recipient.copyText, recipientAddress);
-    expect(_detailRowAfter(presentation.details, 'USDC recipient'), (
-      label: '',
-      value: 'Treasury',
-      copyable: false,
-    ));
+    expect(recipient.addressBookLabel, 'Treasury');
+    expect(recipient.addressNetwork, AddressBookNetwork.ethereum);
 
     final refund = _detailRow(presentation.details, 'ZEC refund address');
     expect(refund.value, contains('u1'));
     expect(refund.copyText, 'u1refund-address');
-    expect(_detailRowAfter(presentation.details, 'ZEC refund address'), (
-      label: '',
-      value: 'Refund safe',
-      copyable: false,
-    ));
+    expect(refund.addressBookLabel, 'Refund safe');
+    expect(refund.addressNetwork, AddressBookNetwork.zcash);
 
     final deposit = _detailRow(presentation.details, 'Deposit ZEC to');
     expect(deposit.value, contains('t1'));
     expect(deposit.copyText, 't1deposit-address');
+    expect(deposit.addressBookLabel, isNull);
+
+    // The nickname is folded into the address row, not emitted as a separate
+    // empty-label row.
     expect(
-      _detailRowAfter(presentation.details, 'Deposit ZEC to').label,
-      isNot(''),
+      presentation.details.where((row) => row.label.isEmpty),
+      isEmpty,
     );
   });
 
@@ -146,11 +144,8 @@ void main() {
     final recipient = _detailRow(presentation.details, 'USDC recipient');
     expect(recipient.value, contains('0x'));
     expect(recipient.copyText, recipientAddress);
-    expect(_detailRowAfter(presentation.details, 'USDC recipient'), (
-      label: '',
-      value: 'Treasury',
-      copyable: false,
-    ));
+    expect(recipient.addressBookLabel, 'Treasury');
+    expect(recipient.addressNetwork, AddressBookNetwork.ethereum);
     expect(
       _detailValue(presentation.details, 'ZEC deposit to'),
       contains('t1'),
@@ -556,15 +551,6 @@ SwapStatusDetailRowData _detailRow(
   String label,
 ) {
   return rows.singleWhere((row) => row.label == label);
-}
-
-({String label, String value, bool copyable}) _detailRowAfter(
-  List<SwapStatusDetailRowData> rows,
-  String label,
-) {
-  final index = rows.indexWhere((row) => row.label == label);
-  final row = rows[index + 1];
-  return (label: row.label, value: row.value, copyable: row.copyable);
 }
 
 AddressBookContact _contact({

--- a/test/features/swap/swap_activity_status_mapper_test.dart
+++ b/test/features/swap/swap_activity_status_mapper_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_activity_status_mapper.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_detail_tooltips.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
@@ -66,6 +67,93 @@ void main() {
     expect(
       _detailRow(presentation.details, 'ZEC refund address').copyText,
       'u1refund-address',
+    );
+  });
+
+  test('adds address book labels to matching address detail rows', () {
+    const recipientAddress = '0x52908400098527886E0F7030069857D2E4169EE7';
+    final presentation = swapActivityStatusPresentationForIntent(
+      _state(),
+      _intent(
+        status: SwapIntentStatus.processing,
+        direction: SwapDirection.zecToExternal,
+        externalAsset: SwapAsset.usdc,
+        depositAddress: 't1deposit-address',
+        oneClickRecipient: recipientAddress,
+        oneClickRefundTo: 'u1refund-address',
+      ),
+      addressBookContacts: [
+        _contact(
+          label: 'Treasury',
+          network: AddressBookNetwork.ethereum,
+          address: recipientAddress.toLowerCase(),
+        ),
+        _contact(
+          label: 'Refund safe',
+          network: AddressBookNetwork.zcash,
+          address: 'u1refund-address',
+        ),
+      ],
+    );
+
+    final recipient = _detailRow(presentation.details, 'USDC recipient');
+    expect(recipient.value, contains('0x'));
+    expect(recipient.copyText, recipientAddress);
+    expect(_detailRowAfter(presentation.details, 'USDC recipient'), (
+      label: '',
+      value: 'Treasury',
+      copyable: false,
+    ));
+
+    final refund = _detailRow(presentation.details, 'ZEC refund address');
+    expect(refund.value, contains('u1'));
+    expect(refund.copyText, 'u1refund-address');
+    expect(_detailRowAfter(presentation.details, 'ZEC refund address'), (
+      label: '',
+      value: 'Refund safe',
+      copyable: false,
+    ));
+
+    final deposit = _detailRow(presentation.details, 'Deposit ZEC to');
+    expect(deposit.value, contains('t1'));
+    expect(deposit.copyText, 't1deposit-address');
+    expect(
+      _detailRowAfter(presentation.details, 'Deposit ZEC to').label,
+      isNot(''),
+    );
+  });
+
+  test('adds a labeled recipient row to terminal swap details', () {
+    const recipientAddress = '0x52908400098527886e0f7030069857d2e4169ee7';
+    final presentation = swapActivityStatusPresentationForIntent(
+      _state(),
+      _intent(
+        status: SwapIntentStatus.complete,
+        direction: SwapDirection.zecToExternal,
+        externalAsset: SwapAsset.usdc,
+        depositAddress: 't1deposit-address',
+        oneClickRecipient: recipientAddress,
+      ),
+      addressBookContacts: [
+        _contact(
+          label: 'Treasury',
+          network: AddressBookNetwork.ethereum,
+          address: recipientAddress,
+        ),
+      ],
+    );
+
+    final recipient = _detailRow(presentation.details, 'USDC recipient');
+    expect(recipient.value, contains('0x'));
+    expect(recipient.copyText, recipientAddress);
+    expect(_detailRowAfter(presentation.details, 'USDC recipient'), (
+      label: '',
+      value: 'Treasury',
+      copyable: false,
+    ));
+    expect(
+      _detailValue(presentation.details, 'ZEC deposit to'),
+      contains('t1'),
     );
   });
 
@@ -332,41 +420,53 @@ void main() {
     expect(canRefreshSwapIntentStatus(SwapIntentStatus.failed), true);
   });
 
-  test('swapActivityShowsExternalDepositPage returns false once depositClaimedAt is set', () {
-    final base = _intent(
-      status: SwapIntentStatus.awaitingExternalDeposit,
-      direction: SwapDirection.externalToZec,
-      externalAsset: SwapAsset.usdc,
-      depositAddress: '0xdeposit-address',
-    );
-    expect(swapActivityShowsExternalDepositPage(base), isTrue);
+  test(
+    'swapActivityShowsExternalDepositPage returns false once depositClaimedAt is set',
+    () {
+      final base = _intent(
+        status: SwapIntentStatus.awaitingExternalDeposit,
+        direction: SwapDirection.externalToZec,
+        externalAsset: SwapAsset.usdc,
+        depositAddress: '0xdeposit-address',
+      );
+      expect(swapActivityShowsExternalDepositPage(base), isTrue);
 
-    final claimed = base.copyWith(
-      depositClaimedAt: DateTime.utc(2026, 5, 29, 12),
-    );
-    expect(swapActivityShowsExternalDepositPage(claimed), isFalse);
-  });
+      final claimed = base.copyWith(
+        depositClaimedAt: DateTime.utc(2026, 5, 29, 12),
+      );
+      expect(swapActivityShowsExternalDepositPage(claimed), isFalse);
+    },
+  );
 
-  test('claimed external deposit advances progress to the confirmation step', () {
-    final awaiting = _intent(
-      status: SwapIntentStatus.awaitingExternalDeposit,
-      direction: SwapDirection.externalToZec,
-      externalAsset: SwapAsset.usdc,
-      depositAddress: '0xdeposit-address',
-    );
-    expect(
-      swapActivityStatusPresentationForIntent(_state(), awaiting).progressIndex,
-      0,
-    );
+  test(
+    'claimed external deposit advances progress to the confirmation step',
+    () {
+      final awaiting = _intent(
+        status: SwapIntentStatus.awaitingExternalDeposit,
+        direction: SwapDirection.externalToZec,
+        externalAsset: SwapAsset.usdc,
+        depositAddress: '0xdeposit-address',
+      );
+      expect(
+        swapActivityStatusPresentationForIntent(
+          _state(),
+          awaiting,
+        ).progressIndex,
+        0,
+      );
 
-    final claimed = awaiting.copyWith(
-      depositClaimedAt: DateTime.utc(2026, 5, 29, 12),
-    );
-    expect(
-      swapActivityStatusPresentationForIntent(_state(), claimed).progressIndex,
-      1,
-    );
-  });
+      final claimed = awaiting.copyWith(
+        depositClaimedAt: DateTime.utc(2026, 5, 29, 12),
+      );
+      expect(
+        swapActivityStatusPresentationForIntent(
+          _state(),
+          claimed,
+        ).progressIndex,
+        1,
+      );
+    },
+  );
 
   test('status details keep the deposit memo reachable after a claim', () {
     final claimed = _intent(
@@ -456,4 +556,29 @@ SwapStatusDetailRowData _detailRow(
   String label,
 ) {
   return rows.singleWhere((row) => row.label == label);
+}
+
+({String label, String value, bool copyable}) _detailRowAfter(
+  List<SwapStatusDetailRowData> rows,
+  String label,
+) {
+  final index = rows.indexWhere((row) => row.label == label);
+  final row = rows[index + 1];
+  return (label: row.label, value: row.value, copyable: row.copyable);
+}
+
+AddressBookContact _contact({
+  required String label,
+  required AddressBookNetwork network,
+  required String address,
+}) {
+  return AddressBookContact(
+    id: 'contact_$label',
+    label: label,
+    network: network,
+    address: address,
+    profilePictureId: 'knight',
+    createdAtMs: 0,
+    updatedAtMs: 0,
+  );
 }

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -228,6 +228,78 @@ void main() {
     );
   });
 
+  testWidgets('review details show saved recipient identity', (tester) async {
+    await tester.pumpWidget(
+      _themeHarness(
+        _reviewTestPage(
+          direction: SwapDirection.zecToExternal,
+          sellAsset: SwapAsset.zec,
+          receiveAsset: SwapAsset.usdc,
+          sellAmountText: '0.251 ZEC',
+          receiveAmountText: '999.99 USDC',
+          addressBookContacts: [
+            _addressBookContact(
+              id: 'treasury',
+              label: 'Treasury',
+              network: AddressBookNetwork.ethereum,
+              address: '0x52908400098527886E0F7030069857D2E4169EE7',
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final details = find.byKey(const ValueKey('swap_review_details'));
+    expect(
+      find.descendant(of: details, matching: find.text('Treasury')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: details, matching: find.text('Ethereum')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: details, matching: find.text('0x52908…69ee7')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('review details show saved refund identity', (tester) async {
+    await tester.pumpWidget(
+      _themeHarness(
+        _reviewTestPage(
+          direction: SwapDirection.externalToZec,
+          sellAsset: SwapAsset.usdc,
+          receiveAsset: SwapAsset.zec,
+          sellAmountText: '999.99 USDC',
+          receiveAmountText: '0.251 ZEC',
+          addressBookContacts: [
+            _addressBookContact(
+              id: 'refund',
+              label: 'Refund wallet',
+              network: AddressBookNetwork.ethereum,
+              address: '0x52908400098527886e0f7030069857d2e4169ee7',
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final details = find.byKey(const ValueKey('swap_review_details'));
+    expect(
+      find.descendant(of: details, matching: find.text('Refund wallet')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: details, matching: find.text('Ethereum')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(of: details, matching: find.text('0x52908…69ee7')),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('deposit tokens countdown starts in the final fifteen minutes', (
     tester,
   ) async {
@@ -7016,8 +7088,9 @@ Widget _routerHarness(
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(bootstrap ?? _bootstrap),
-      if (addressBookRepository != null)
-        addressBookRepositoryProvider.overrideWithValue(addressBookRepository),
+      addressBookRepositoryProvider.overrideWithValue(
+        addressBookRepository ?? _FakeAddressBookRepository(),
+      ),
       if (accountNotifier != null)
         accountProvider.overrideWith(accountNotifier),
       syncProvider.overrideWith(
@@ -7200,6 +7273,7 @@ Widget _reviewTestPage({
   required SwapAsset receiveAsset,
   required String sellAmountText,
   required String receiveAmountText,
+  Iterable<AddressBookContact> addressBookContacts = const [],
 }) {
   final externalAsset = direction.sendsZec ? receiveAsset : sellAsset;
   return SwapReviewPageContent(
@@ -7230,6 +7304,7 @@ Widget _reviewTestPage({
       userExternalAddress: '0x52908400098527886e0f7030069857d2e4169ee7',
       walletZecAddress: 'u1wallet',
     ),
+    addressBookContacts: addressBookContacts,
     accountLabel: 'John',
     expired: false,
     amountWarning: null,

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -929,17 +929,15 @@ void main() {
         Overlay(
           initialEntries: [
             OverlayEntry(
-              builder:
-                  (_) => StatefulBuilder(
-                    builder: (context, setState) {
-                      return _statusTestPage(
-                        activeTab: SwapStatusTab.details,
-                        detailsExpanded: expanded,
-                        onToggleDetails:
-                            () => setState(() => expanded = !expanded),
-                      );
-                    },
-                  ),
+              builder: (_) => StatefulBuilder(
+                builder: (context, setState) {
+                  return _statusTestPage(
+                    activeTab: SwapStatusTab.details,
+                    detailsExpanded: expanded,
+                    onToggleDetails: () => setState(() => expanded = !expanded),
+                  );
+                },
+              ),
             ),
           ],
         ),
@@ -1064,6 +1062,37 @@ void main() {
     );
   });
 
+  testWidgets('status details render address book labels with addresses', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _themeHarness(
+        _statusTestPage(
+          activeTab: SwapStatusTab.details,
+          details: const [
+            SwapStatusDetailRowData(label: 'Account', value: 'John'),
+            SwapStatusDetailRowData(
+              label: 'USDC recipient',
+              value: '0x123kjhc ... 4x98g20',
+              copyable: true,
+            ),
+            SwapStatusDetailRowData(label: '', value: 'Treasury'),
+            SwapStatusDetailRowData(
+              label: 'Swap fee',
+              value: 'Included in shown rate',
+              help: true,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.text('USDC recipient'), findsOneWidget);
+    expect(find.text('Treasury'), findsOneWidget);
+    expect(find.text('0x123kjhc ... 4x98g20'), findsOneWidget);
+  });
+
   testWidgets(
     'status details expanded use case starts inside the scroll range',
     (tester) async {
@@ -1103,18 +1132,17 @@ void main() {
       routes: [
         GoRoute(
           path: '/home',
-          builder:
-              (_, _) => AppDesktopShell(
-                sidebar: const AppMainSidebar(),
-                pane: AppDesktopPane(
-                  child: Text(
-                    'home route',
-                    style: AppTypography.bodyMedium.copyWith(
-                      color: AppThemeData.light.colors.text.primary,
-                    ),
-                  ),
+          builder: (_, _) => AppDesktopShell(
+            sidebar: const AppMainSidebar(),
+            pane: AppDesktopPane(
+              child: Text(
+                'home route',
+                style: AppTypography.bodyMedium.copyWith(
+                  color: AppThemeData.light.colors.text.primary,
                 ),
               ),
+            ),
+          ),
         ),
         GoRoute(path: '/send', builder: (_, _) => const Text('send route')),
         _swapRoute(),
@@ -1173,14 +1201,12 @@ void main() {
       findsWidgets,
     );
     expect(find.byKey(const ValueKey('swap_address_summary')), findsOneWidget);
-    final addressFieldHeight =
-        tester
-            .getSize(find.byKey(const ValueKey('swap_address_summary')))
-            .height;
-    final addressFieldWidth =
-        tester
-            .getSize(find.byKey(const ValueKey('swap_address_summary')))
-            .width;
+    final addressFieldHeight = tester
+        .getSize(find.byKey(const ValueKey('swap_address_summary')))
+        .height;
+    final addressFieldWidth = tester
+        .getSize(find.byKey(const ValueKey('swap_address_summary')))
+        .width;
     expect(addressFieldHeight, 32);
     expect(addressFieldWidth, closeTo(196, 1));
     expect(find.text('Ethereum recipient'), findsNothing);
@@ -1555,10 +1581,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(
-      find.text("Invalid EVM address"),
-      findsOneWidget,
-    );
+    expect(find.text("Invalid EVM address"), findsOneWidget);
     final blockedButton = tester.widget<AppButton>(
       find.byKey(const ValueKey('swap_address_update_button')),
     );
@@ -1570,10 +1593,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(
-      find.text("Invalid EVM address"),
-      findsNothing,
-    );
+    expect(find.text("Invalid EVM address"), findsNothing);
     final allowedButton = tester.widget<AppButton>(
       find.byKey(const ValueKey('swap_address_update_button')),
     );
@@ -1949,7 +1969,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -2015,7 +2038,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await container.read(accountProvider.notifier).switchAccount('account-2');
@@ -2237,7 +2263,10 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '1',
       );
-      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+      await _enterDestinationText(
+        tester,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
       await tester.pumpAndSettle();
 
       expect(find.text('Max: 1 ZEC'), findsOneWidget);
@@ -2465,10 +2494,9 @@ void main() {
     final selectorCursor = tester.widget<MouseRegion>(
       find
           .ancestor(
-            of:
-                find
-                    .byKey(const ValueKey('swap_external_asset_selector'))
-                    .first,
+            of: find
+                .byKey(const ValueKey('swap_external_asset_selector'))
+                .first,
             matching: find.byType(MouseRegion),
           )
           .first,
@@ -2507,12 +2535,12 @@ void main() {
       assetListGutter.padding,
       const EdgeInsets.only(right: AppSpacing.sm),
     );
-    final assetMenuWidth =
-        tester
-            .getSize(find.byKey(const ValueKey('swap_external_asset_menu')))
-            .width;
-    final usdcRowWidth =
-        tester.getSize(find.byKey(const ValueKey('swap_asset_row_usdc'))).width;
+    final assetMenuWidth = tester
+        .getSize(find.byKey(const ValueKey('swap_external_asset_menu')))
+        .width;
+    final usdcRowWidth = tester
+        .getSize(find.byKey(const ValueKey('swap_asset_row_usdc')))
+        .width;
     expect(usdcRowWidth, assetMenuWidth - 48);
 
     await tester.tapAt(const Offset(1200, 64));
@@ -2564,7 +2592,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -2596,12 +2627,12 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('swap_settings_button')));
     await tester.pumpAndSettle();
 
-    final slippageModalTop =
-        tester.getTopLeft(find.byKey(const ValueKey('swap_slippage_modal'))).dy;
-    final customCardTop =
-        tester
-            .getTopLeft(find.byKey(const ValueKey('swap_slippage_custom_card')))
-            .dy;
+    final slippageModalTop = tester
+        .getTopLeft(find.byKey(const ValueKey('swap_slippage_modal')))
+        .dy;
+    final customCardTop = tester
+        .getTopLeft(find.byKey(const ValueKey('swap_slippage_custom_card')))
+        .dy;
     expect(customCardTop - slippageModalTop, 218);
     expect(
       tester.getSize(find.byKey(const ValueKey('swap_slippage_50bps'))).height,
@@ -2649,7 +2680,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -2746,7 +2780,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '0.01',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     expect(swapProvider.pricingRequests, 1);
@@ -2781,7 +2818,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     expect(_fieldText(tester, 'swap_receive_amount_field'), '100.00');
@@ -2819,7 +2859,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     expect(_fieldText(tester, 'swap_receive_amount_field'), '100.00');
@@ -2857,7 +2900,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4162,7 +4208,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
@@ -4188,26 +4237,26 @@ void main() {
   ) async {
     await _setViewport(tester, const Size(940, 720));
 
-    final longIntent = _persistedIntent(
-      id: 'swap-long-provider-data',
-      txHash:
-          '0xdeposit-transaction-hash-with-a-very-long-source-chain-suffix-9876543210',
-      depositAddress:
-          '0xone-time-usdc-deposit-address-with-a-long-provider-suffix-abcdef1234567890',
-      status: SwapIntentStatus.awaitingExternalDeposit,
-      nextAction:
-          'Send the external deposit, then submit the source-chain transaction hash after confirmation.',
-    ).copyWith(
-      pair: 'USDC -> ZEC',
-      sellAmount: '12345.678901 USDC',
-      receiveEstimate: '175.9421 ZEC',
-      direction: SwapDirection.externalToZec,
-      externalAsset: SwapAsset.usdc,
-      depositMemo:
-          'memo-with-a-long-routing-tag-and-provider-reference-9876543210',
-      oneClickRefundTo:
-          '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359',
-    );
+    final longIntent =
+        _persistedIntent(
+          id: 'swap-long-provider-data',
+          txHash:
+              '0xdeposit-transaction-hash-with-a-very-long-source-chain-suffix-9876543210',
+          depositAddress:
+              '0xone-time-usdc-deposit-address-with-a-long-provider-suffix-abcdef1234567890',
+          status: SwapIntentStatus.awaitingExternalDeposit,
+          nextAction:
+              'Send the external deposit, then submit the source-chain transaction hash after confirmation.',
+        ).copyWith(
+          pair: 'USDC -> ZEC',
+          sellAmount: '12345.678901 USDC',
+          receiveEstimate: '175.9421 ZEC',
+          direction: SwapDirection.externalToZec,
+          externalAsset: SwapAsset.usdc,
+          depositMemo:
+              'memo-with-a-long-routing-tag-and-provider-reference-9876543210',
+          oneClickRefundTo: '0xfb6916095ca1df60bb79ce92ce3ea74c37c5d359',
+        );
 
     await tester.pumpWidget(
       _routerHarness(
@@ -4309,7 +4358,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '0.002',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4359,7 +4411,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0xde709f2102306220921060314715629080e2fb77');
+    await _enterDestinationText(
+      tester,
+      '0xde709f2102306220921060314715629080e2fb77',
+    );
     await tester.pumpAndSettle();
 
     expect(_fieldText(tester, 'swap_receive_amount_field'), '105.26');
@@ -4429,12 +4484,12 @@ void main() {
           .height,
       greaterThanOrEqualTo(44),
     );
-    final startButtonWidth =
-        tester.getSize(find.byKey(const ValueKey('swap_start_button'))).width;
-    final cancelButtonWidth =
-        tester
-            .getSize(find.byKey(const ValueKey('swap_review_cancel_button')))
-            .width;
+    final startButtonWidth = tester
+        .getSize(find.byKey(const ValueKey('swap_start_button')))
+        .width;
+    final cancelButtonWidth = tester
+        .getSize(find.byKey(const ValueKey('swap_review_cancel_button')))
+        .width;
     expect(startButtonWidth, greaterThanOrEqualTo(148));
     expect(cancelButtonWidth, greaterThanOrEqualTo(148));
     expect(
@@ -4526,7 +4581,10 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '1.5',
       );
-      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+      await _enterDestinationText(
+        tester,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4568,7 +4626,10 @@ void main() {
       final reviewDetails = find.byKey(const ValueKey('swap_review_details'));
       final reviewDetailsRect = tester.getRect(reviewDetails);
       final recipientValueRect = tester.getRect(
-        find.descendant(of: reviewDetails, matching: find.text('0x5290840 ... 4169ee7')),
+        find.descendant(
+          of: reviewDetails,
+          matching: find.text('0x5290840 ... 4169ee7'),
+        ),
       );
       final feeValueRect = tester.getRect(
         find.descendant(
@@ -4622,7 +4683,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '105',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     expect(_fieldText(tester, 'swap_amount_field'), '105');
@@ -4639,7 +4703,10 @@ void main() {
     expect(liveRequest.amount, 1.5);
     expect(liveRequest.amountText, '1.5000');
     expect(liveRequest.amountAsset, SwapAsset.zec);
-    expect(liveRequest.destination, '0x52908400098527886e0f7030069857d2e4169ee7');
+    expect(
+      liveRequest.destination,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
   });
 
   testWidgets('token amount fields cap fractional digits by asset decimals', (
@@ -4713,7 +4780,10 @@ void main() {
       find.byKey(const ValueKey('swap_receive_amount_field')),
       '105.26',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     expect(_fieldText(tester, 'swap_receive_amount_field'), '105.26');
@@ -4744,7 +4814,10 @@ void main() {
         find.byKey(const ValueKey('swap_receive_amount_field')),
         '105.27',
       );
-      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+      await _enterDestinationText(
+        tester,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
       await tester.pumpAndSettle();
 
       expect(_fieldText(tester, 'swap_receive_amount_field'), '105.27');
@@ -4760,7 +4833,10 @@ void main() {
       expect(liveRequest.mode, SwapQuoteMode.exactOutput);
       expect(liveRequest.amount, 105.27);
       expect(liveRequest.amountText, '105.27');
-      expect(liveRequest.destination, '0x52908400098527886e0f7030069857d2e4169ee7');
+      expect(
+        liveRequest.destination,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
       expect(liveRequest.refundAddress, 'u1actualshieldedrecipient');
       expect(find.text('Review swap'), findsOneWidget);
       expect(find.text('Slippage tolerance'), findsOneWidget);
@@ -4790,7 +4866,10 @@ void main() {
         find.byKey(const ValueKey('swap_receive_amount_field')),
         '105.26',
       );
-      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+      await _enterDestinationText(
+        tester,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4847,7 +4926,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4893,7 +4975,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -4934,7 +5019,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     expect(find.byKey(const ValueKey('swap_rate_line')), findsOneWidget);
@@ -5006,7 +5094,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5195,7 +5286,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5236,7 +5330,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5284,7 +5381,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '140.35',
     );
-    await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
+    await _enterDestinationText(
+      tester,
+      '0x8617e340b3d01fa5f11f306f4090fd50e238070d',
+    );
     await tester.pumpAndSettle();
 
     expect(find.text('Ethereum refund'), findsNothing);
@@ -5362,7 +5462,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5401,7 +5504,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '140.35',
     );
-    await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
+    await _enterDestinationText(
+      tester,
+      '0x8617e340b3d01fa5f11f306f4090fd50e238070d',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5413,7 +5519,10 @@ void main() {
       swapProvider.requests.single.destination,
       'u1actualshieldedrecipient',
     );
-    expect(swapProvider.requests.single.refundAddress, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
+    expect(
+      swapProvider.requests.single.refundAddress,
+      '0x8617e340b3d01fa5f11f306f4090fd50e238070d',
+    );
     expect(find.text('Review swap'), findsOneWidget);
     expect(
       find.textContaining('ZEC arrives at your shielded address'),
@@ -5446,7 +5555,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '140.35',
     );
-    await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
+    await _enterDestinationText(
+      tester,
+      '0x8617e340b3d01fa5f11f306f4090fd50e238070d',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5462,7 +5574,10 @@ void main() {
       swapProvider.requests.single.destination,
       isNot(_hardwareBootstrap.initialAccountState.activeAddress),
     );
-    expect(swapProvider.requests.single.refundAddress, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
+    expect(
+      swapProvider.requests.single.refundAddress,
+      '0x8617e340b3d01fa5f11f306f4090fd50e238070d',
+    );
   });
 
   testWidgets('started swap can refresh status from provider', (tester) async {
@@ -5484,7 +5599,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5508,71 +5626,69 @@ void main() {
     );
   });
 
-  testWidgets(
-    'started swap routes to status page when deposit is claimed',
-    (tester) async {
-      await _setDesktopViewport(tester);
-      final swapProvider = _FakeSwapProvider();
+  testWidgets('started swap routes to status page when deposit is claimed', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final swapProvider = _FakeSwapProvider();
 
-      await tester.pumpWidget(
-        _routerHarness(
-          GoRouter(
-            initialLocation: '/swap',
-            routes: [_swapRoute(), _swapActivityRoute()],
-          ),
-          swapProvider: swapProvider,
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
         ),
-      );
-      await tester.pumpAndSettle();
+        swapProvider: swapProvider,
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      await tester.tap(
-        find.byKey(const ValueKey('swap_direction_externalToZec')),
-      );
-      await tester.enterText(
-        find.byKey(const ValueKey('swap_amount_field')),
-        '140.35',
-      );
-      await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
-      await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('swap_direction_externalToZec')),
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_amount_field')),
+      '140.35',
+    );
+    await _enterDestinationText(
+      tester,
+      '0x8617e340b3d01fa5f11f306f4090fd50e238070d',
+    );
+    await tester.pumpAndSettle();
 
-      await tester.tap(find.byKey(const ValueKey('swap_review_button')));
-      await tester.pumpAndSettle();
-      await tester.ensureVisible(
-        find.byKey(const ValueKey('swap_start_button')),
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('swap_start_button')));
-      await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_review_button')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('swap_start_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_start_button')));
+    await tester.pumpAndSettle();
 
-      expect(find.text('Deposit tokens'), findsOneWidget);
-      expect(find.text('0xlive-deposit'), findsOneWidget);
-      expect(
-        find.byKey(const ValueKey('swap_deposit_check_warning')),
-        findsNothing,
-      );
+    expect(find.text('Deposit tokens'), findsOneWidget);
+    expect(find.text('0xlive-deposit'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('swap_deposit_check_warning')),
+      findsNothing,
+    );
 
-      await tester.tap(
-        find.byKey(const ValueKey('swap_deposit_confirm_button')),
-      );
-      await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_deposit_confirm_button')));
+    await tester.pumpAndSettle();
 
-      // Tapping "I've deposited" immediately routes to the status page;
-      // no provider status request is triggered by this tap.
-      expect(swapProvider.submittedDeposits, isEmpty);
-      expect(
-        find.byKey(const ValueKey('swap_deposit_confirm_button')),
-        findsNothing,
-      );
-      expect(
-        find.byKey(const ValueKey('swap_status_page_content')),
-        findsOneWidget,
-      );
-      expect(
-        find.byKey(const ValueKey('swap_deposit_check_warning')),
-        findsNothing,
-      );
-    },
-  );
+    // Tapping "I've deposited" immediately routes to the status page;
+    // no provider status request is triggered by this tap.
+    expect(swapProvider.submittedDeposits, isEmpty);
+    expect(
+      find.byKey(const ValueKey('swap_deposit_confirm_button')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(const ValueKey('swap_status_page_content')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('swap_deposit_check_warning')),
+      findsNothing,
+    );
+  });
 
   testWidgets(
     'external deposit claim immediately routes to status page without warning',
@@ -5598,7 +5714,10 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '140.35',
       );
-      await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
+      await _enterDestinationText(
+        tester,
+        '0x8617e340b3d01fa5f11f306f4090fd50e238070d',
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5683,7 +5802,10 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '140.35',
       );
-      await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
+      await _enterDestinationText(
+        tester,
+        '0x8617e340b3d01fa5f11f306f4090fd50e238070d',
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5836,7 +5958,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5872,7 +5997,10 @@ void main() {
       sessionStore.savedIntents.single.direction,
       SwapDirection.zecToExternal,
     );
-    expect(sessionStore.savedIntents.single.oneClickRecipient, '0x52908400098527886e0f7030069857d2e4169ee7');
+    expect(
+      sessionStore.savedIntents.single.oneClickRecipient,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     expect(
       sessionStore.savedIntents.single.oneClickRefundTo,
       'u1actualshieldedrecipient',
@@ -5914,7 +6042,10 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '1.5',
       );
-      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+      await _enterDestinationText(
+        tester,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -5943,72 +6074,69 @@ void main() {
     },
   );
 
-  testWidgets(
-    'pending ZEC deposit broadcast switches to a fallback endpoint',
-    (tester) async {
-      await _setDesktopViewport(tester);
-      final swapProvider = _FakeSwapProvider();
-      final depositSender = _FakeSwapDepositSender(
-        broadcastStatus: SwapDepositBroadcastStatus.pendingBroadcast,
-        broadcastMessage: 'gRPC connect failed: connection refused',
-      );
-      final sessionStore = _FakeSwapPersistenceStore();
-      final primary = defaultRpcEndpointConfig('main');
-      final fallback = fallbackRpcEndpointCandidatesFor(primary).first;
+  testWidgets('pending ZEC deposit broadcast switches to a fallback endpoint', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final swapProvider = _FakeSwapProvider();
+    final depositSender = _FakeSwapDepositSender(
+      broadcastStatus: SwapDepositBroadcastStatus.pendingBroadcast,
+      broadcastMessage: 'gRPC connect failed: connection refused',
+    );
+    final sessionStore = _FakeSwapPersistenceStore();
+    final primary = defaultRpcEndpointConfig('main');
+    final fallback = fallbackRpcEndpointCandidatesFor(primary).first;
 
-      await tester.pumpWidget(
-        _routerHarness(
-          GoRouter(
-            initialLocation: '/swap',
-            routes: [_swapRoute(), _swapActivityRoute()],
-          ),
-          swapProvider: swapProvider,
-          depositSender: depositSender,
-          sessionStore: sessionStore,
-          failoverChainNameGetter: (url) async => 'main',
-          failoverHeightGetter: (url) async =>
-              url == fallback.normalizedLightwalletdUrl
-              ? BigInt.from(100)
-              : BigInt.from(100),
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
         ),
-      );
-      await tester.pumpAndSettle();
+        swapProvider: swapProvider,
+        depositSender: depositSender,
+        sessionStore: sessionStore,
+        failoverChainNameGetter: (url) async => 'main',
+        failoverHeightGetter: (url) async =>
+            url == fallback.normalizedLightwalletdUrl
+            ? BigInt.from(100)
+            : BigInt.from(100),
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      await tester.enterText(
-        find.byKey(const ValueKey('swap_amount_field')),
-        '1.5',
-      );
-      await _enterDestinationText(
-        tester,
-        '0x52908400098527886e0f7030069857d2e4169ee7',
-      );
-      await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_amount_field')),
+      '1.5',
+    );
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
+    await tester.pumpAndSettle();
 
-      final container = ProviderScope.containerOf(
-        tester.element(find.byType(SwapScreen)),
-      );
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(SwapScreen)),
+    );
 
-      await tester.tap(find.byKey(const ValueKey('swap_review_button')));
-      await tester.pumpAndSettle();
-      await tester.ensureVisible(
-        find.byKey(const ValueKey('swap_start_button')),
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(find.byKey(const ValueKey('swap_start_button')));
-      await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_review_button')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('swap_start_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_start_button')));
+    await tester.pumpAndSettle();
 
-      final failoverState = container.read(rpcEndpointFailoverProvider);
-      expect(depositSender.requests, hasLength(1));
-      expect(failoverState.isUsingFallback, isTrue);
-      expect(
-        failoverState.current.normalizedLightwalletdUrl,
-        fallback.normalizedLightwalletdUrl,
-      );
-      final syncNotifier =
-          container.read(syncProvider.notifier) as _FakeSwapSyncNotifier;
-      expect(syncNotifier.restartCount, 1);
-    },
-  );
+    final failoverState = container.read(rpcEndpointFailoverProvider);
+    expect(depositSender.requests, hasLength(1));
+    expect(failoverState.isUsingFallback, isTrue);
+    expect(
+      failoverState.current.normalizedLightwalletdUrl,
+      fallback.normalizedLightwalletdUrl,
+    );
+    final syncNotifier =
+        container.read(syncProvider.notifier) as _FakeSwapSyncNotifier;
+    expect(syncNotifier.restartCount, 1);
+  });
 
   testWidgets('ZEC swap opens activity before deposit broadcast finishes', (
     tester,
@@ -6035,7 +6163,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6092,7 +6223,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6141,7 +6275,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '0.002',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6192,7 +6329,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '0.003',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6287,7 +6427,10 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '0.003',
       );
-      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+      await _enterDestinationText(
+        tester,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6355,7 +6498,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '0.003',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6423,7 +6569,10 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '0.003',
       );
-      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+      await _enterDestinationText(
+        tester,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6525,7 +6674,10 @@ void main() {
         find.byKey(const ValueKey('swap_amount_field')),
         '0.003',
       );
-      await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+      await _enterDestinationText(
+        tester,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
       await tester.pumpAndSettle();
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6737,7 +6889,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '8.5',
     );
-    await _enterDestinationText(tester, '0x8617e340b3d01fa5f11f306f4090fd50e238070d');
+    await _enterDestinationText(
+      tester,
+      '0x8617e340b3d01fa5f11f306f4090fd50e238070d',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6801,7 +6956,10 @@ void main() {
       find.byKey(const ValueKey('swap_amount_field')),
       '1.5',
     );
-    await _enterDestinationText(tester, '0x52908400098527886e0f7030069857d2e4169ee7');
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('swap_review_button')));
@@ -6846,10 +7004,9 @@ Widget _routerHarness(
   RpcEndpointChainNameGetter? failoverChainNameGetter,
   RpcEndpointLatestBlockHeightGetter? failoverHeightGetter,
 }) {
-  final fixtureIntents =
-      seedSwapActivityFixtures
-          ? _accountScopedSwapActivityFixtureIntents()
-          : const <SwapIntent>[];
+  final fixtureIntents = seedSwapActivityFixtures
+      ? _accountScopedSwapActivityFixtureIntents()
+      : const <SwapIntent>[];
   final effectiveSessionStore =
       sessionStore ?? _FakeSwapPersistenceStore(initialIntents: fixtureIntents);
   return ProviderScope(
@@ -6953,16 +7110,15 @@ GoRoute _swapActivityRoute() {
     routes: [
       GoRoute(
         path: 'swap/:swapId',
-        builder:
-            (_, state) => SwapActivityDetailScreen(
-              swapIntentId: state.pathParameters['swapId'] ?? '',
-              returnTarget: SwapActivityReturnTarget.fromQueryValue(
-                state.uri.queryParameters[swapActivityReturnQueryKey],
-              ),
-              autoSignZecDeposit:
-                  state.uri.queryParameters[swapActivitySignQueryKey] ==
-                  swapActivitySignZecDepositValue,
-            ),
+        builder: (_, state) => SwapActivityDetailScreen(
+          swapIntentId: state.pathParameters['swapId'] ?? '',
+          returnTarget: SwapActivityReturnTarget.fromQueryValue(
+            state.uri.queryParameters[swapActivityReturnQueryKey],
+          ),
+          autoSignZecDeposit:
+              state.uri.queryParameters[swapActivitySignQueryKey] ==
+              swapActivitySignZecDepositValue,
+        ),
       ),
     ],
   );

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -4030,6 +4030,8 @@ void main() {
 
     expect(find.text('Swap completed'), findsOneWidget);
     expect(find.byKey(const ValueKey('swap_final_details')), findsOneWidget);
+    expect(find.text('USDC recipient'), findsOneWidget);
+    expect(find.text('0x5290840 ... 4169ee7'), findsOneWidget);
     expect(find.text('ZEC deposit to'), findsOneWidget);
     expect(find.text('Total fees'), findsOneWidget);
     expect(find.text('0.0000134 ZEC'), findsOneWidget);

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
+import 'package:zcash_wallet/src/features/address_book/widgets/address_book_network_icon.dart';
 import 'package:zcash_wallet/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_activity_navigation.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_detail_tooltips.dart';
@@ -1076,8 +1077,9 @@ void main() {
               label: 'USDC recipient',
               value: '0x123kjhc ... 4x98g20',
               copyable: true,
+              addressBookLabel: 'Treasury',
+              addressNetwork: AddressBookNetwork.ethereum,
             ),
-            SwapStatusDetailRowData(label: '', value: 'Treasury'),
             SwapStatusDetailRowData(
               label: 'Swap fee',
               value: 'Included in shown rate',
@@ -1091,6 +1093,8 @@ void main() {
     expect(find.text('USDC recipient'), findsOneWidget);
     expect(find.text('Treasury'), findsOneWidget);
     expect(find.text('0x123kjhc ... 4x98g20'), findsOneWidget);
+    // The matched-contact cell renders the network chip beside the address.
+    expect(find.byType(AddressBookNetworkIcon), findsOneWidget);
   });
 
   testWidgets(

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -1198,6 +1198,61 @@ void main() {
     expect(find.byType(AddressBookNetworkIcon), findsOneWidget);
   });
 
+  testWidgets('status details absorb saved address row overflow', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _themeHarness(
+        _statusTestPage(
+          activeTab: SwapStatusTab.details,
+          details: const [
+            SwapStatusDetailRowData(label: 'Account', value: 'John'),
+            SwapStatusDetailRowData(
+              label: 'USDC recipient',
+              value: '0x1234567…89abc',
+              copyable: true,
+              addressBookLabel: 'eth account',
+              addressNetwork: AddressBookNetwork.ethereum,
+            ),
+            SwapStatusDetailRowData(
+              label: 'Deposit ZEC to',
+              value: 't1V4tMBk8 ... hunXYpe',
+            ),
+            SwapStatusDetailRowData(
+              label: 'Swap fee',
+              value: 'Included in shown rate',
+              help: true,
+            ),
+            SwapStatusDetailRowData(
+              label: 'Slippage tolerance',
+              value: '0.01 USDC (1.0%)',
+            ),
+            SwapStatusDetailRowData(
+              label: 'Guaranteed minimum',
+              value: '52.00 USDC',
+              help: true,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(
+      find.byKey(const ValueKey('swap_transaction_details_collapsed')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(
+        const ValueKey('swap_transaction_details_collapsed_scroll_view'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('eth account'), findsOneWidget);
+    expect(find.text('More details'), findsOneWidget);
+  });
+
   testWidgets(
     'status details expanded use case starts inside the scroll range',
     (tester) async {

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -262,6 +262,15 @@ void main() {
       find.descendant(of: details, matching: find.text('0x52908…69ee7')),
       findsOneWidget,
     );
+    final addressText = find.descendant(
+      of: details,
+      matching: find.text('0x52908…69ee7'),
+    );
+    expect(tester.widget<Text>(addressText).overflow, isNull);
+    expect(
+      find.ancestor(of: addressText, matching: find.byType(FittedBox)),
+      findsOneWidget,
+    );
   });
 
   testWidgets('review details show saved refund identity', (tester) async {
@@ -296,6 +305,15 @@ void main() {
     );
     expect(
       find.descendant(of: details, matching: find.text('0x52908…69ee7')),
+      findsOneWidget,
+    );
+    final addressText = find.descendant(
+      of: details,
+      matching: find.text('0x52908…69ee7'),
+    );
+    expect(tester.widget<Text>(addressText).overflow, isNull);
+    expect(
+      find.ancestor(of: addressText, matching: find.byType(FittedBox)),
       findsOneWidget,
     );
   });
@@ -1165,6 +1183,17 @@ void main() {
     expect(find.text('USDC recipient'), findsOneWidget);
     expect(find.text('Treasury'), findsOneWidget);
     expect(find.text('0x123kjhc ... 4x98g20'), findsOneWidget);
+    expect(
+      tester.widget<Text>(find.text('0x123kjhc ... 4x98g20')).overflow,
+      isNull,
+    );
+    expect(
+      find.ancestor(
+        of: find.text('0x123kjhc ... 4x98g20'),
+        matching: find.byType(FittedBox),
+      ),
+      findsOneWidget,
+    );
     // The matched-contact cell renders the network chip beside the address.
     expect(find.byType(AddressBookNetworkIcon), findsOneWidget);
   });

--- a/test/transaction_receipt_view_test.dart
+++ b/test/transaction_receipt_view_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/send/widgets/transaction_receipt_view.dart';
 
 void main() {
@@ -168,6 +169,43 @@ void main() {
     expect(plainText, contains('\n... '));
     expect(plainText, endsWith('n8fh5'));
     expect(plainText, isNot(_longAddress));
+  });
+
+  testWidgets('saved recipient address keeps copy icon next to compact text', (
+    tester,
+  ) async {
+    final compactAddress = compactTransactionReceiptSavedAddress(_longAddress);
+
+    await tester.pumpWidget(
+      _receiptHarness(
+        SizedBox(
+          width: 328,
+          child: TransactionReceiptSavedRecipientAddress(
+            address: _longAddress,
+            label: 'me',
+            onCopy: _noop,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('me'), findsOneWidget);
+    expect(find.text(compactAddress), findsOneWidget);
+    expect(find.text(_longAddress), findsNothing);
+
+    final addressRect = tester.getRect(find.text(compactAddress));
+    final copyRect = tester.getRect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is AppIcon &&
+            widget.name == AppIcons.copy &&
+            widget.size == 16,
+      ),
+    );
+
+    final copyGap = copyRect.left - addressRect.right;
+    expect(copyGap, greaterThan(0));
+    expect(copyGap, lessThanOrEqualTo(AppSpacing.xs));
   });
 }
 


### PR DESCRIPTION
## Summary
- Show saved address book labels for matched recipients/refund addresses across swap review, swap activity details, send review, send status, and transaction activity details.
- Keep the existing address-only UI when no address book contact matches, while rendering saved-contact addresses with compact/muted address text and inline copy actions.
- Add address book label lookup coverage and layout regression tests for saved-contact rows.

## Screenshots

### Send review
![Send review saved recipient](https://github.com/chainapsis/vizor-wallet/raw/pr-157-screenshots/screenshots/send-review.png)

### Send status
![Send status saved recipient](https://github.com/chainapsis/vizor-wallet/raw/pr-157-screenshots/screenshots/send-status.png)

### Swap review
![Swap review saved address](https://github.com/chainapsis/vizor-wallet/raw/pr-157-screenshots/screenshots/swap-review.png)

## Validation
- `git diff --check c91790cf8673a74fedf3c02a811bee4f3f63e6f9`
- `fvm flutter test test/features/address_book/address_book_label_lookup_test.dart test/transaction_receipt_view_test.dart test/features/send/send_review_screen_test.dart test/features/swap/swap_activity_status_mapper_test.dart test/features/swap/swap_screen_test.dart test/features/activity/activity_transaction_status_screen_test.dart`
- `fvm flutter analyze`