### PR TITLE
Show tooltips for truncated text field messages

### DIFF
--- a/lib/src/core/widgets/app_text_field.dart
+++ b/lib/src/core/widgets/app_text_field.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 
 import '../theme/app_theme.dart';
 import 'app_icon.dart';
+import 'app_tooltip.dart';
 
 enum AppTextFieldTone { neutral, destructive, success, brandCrimson }
 
@@ -684,29 +685,67 @@ class _AppTextFieldState extends State<AppTextField> {
             top: messageTop,
             left: 0,
             right: 0,
-            child: IgnorePointer(
-              child: Row(
-                children: [
-                  widget.messageIcon ?? defaultMessageIcon ?? const SizedBox(),
-                  if (widget.messageIcon != null || defaultMessageIcon != null)
-                    const SizedBox(width: AppSpacing.xxs),
-                  Expanded(
-                    child: Text(
-                      widget.messageText!,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style:
-                          widget.messageStyle ??
-                          AppTypography.labelMedium.copyWith(
-                            color: messageColor,
-                          ),
-                    ),
+            child: Row(
+              children: [
+                IgnorePointer(
+                  child:
+                      widget.messageIcon ??
+                      defaultMessageIcon ??
+                      const SizedBox(),
+                ),
+                if (widget.messageIcon != null || defaultMessageIcon != null)
+                  const IgnorePointer(child: SizedBox(width: AppSpacing.xxs)),
+                Expanded(
+                  child: _AppTextFieldMessageText(
+                    text: widget.messageText!,
+                    style:
+                        widget.messageStyle ??
+                        AppTypography.labelMedium.copyWith(color: messageColor),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
       ],
+    );
+  }
+}
+
+class _AppTextFieldMessageText extends StatelessWidget {
+  const _AppTextFieldMessageText({required this.text, required this.style});
+
+  final String text;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    final child = Text(
+      text,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: style,
+    );
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (!constraints.maxWidth.isFinite || constraints.maxWidth <= 0) {
+          return IgnorePointer(child: child);
+        }
+
+        final textPainter = TextPainter(
+          text: TextSpan(text: text, style: style),
+          textDirection: Directionality.of(context),
+          textScaler: MediaQuery.textScalerOf(context),
+          ellipsis: '...',
+          maxLines: 1,
+        )..layout(maxWidth: constraints.maxWidth);
+
+        if (!textPainter.didExceedMaxLines) {
+          return IgnorePointer(child: child);
+        }
+
+        return AppTooltip(message: text, preferBelow: true, child: child);
+      },
     );
   }
 }

--- a/lib/src/core/widgets/app_text_field.dart
+++ b/lib/src/core/widgets/app_text_field.dart
@@ -685,25 +685,12 @@ class _AppTextFieldState extends State<AppTextField> {
             top: messageTop,
             left: 0,
             right: 0,
-            child: Row(
-              children: [
-                IgnorePointer(
-                  child:
-                      widget.messageIcon ??
-                      defaultMessageIcon ??
-                      const SizedBox(),
-                ),
-                if (widget.messageIcon != null || defaultMessageIcon != null)
-                  const IgnorePointer(child: SizedBox(width: AppSpacing.xxs)),
-                Expanded(
-                  child: _AppTextFieldMessageText(
-                    text: widget.messageText!,
-                    style:
-                        widget.messageStyle ??
-                        AppTypography.labelMedium.copyWith(color: messageColor),
-                  ),
-                ),
-              ],
+            child: _AppTextFieldMessage(
+              text: widget.messageText!,
+              icon: widget.messageIcon ?? defaultMessageIcon,
+              style:
+                  widget.messageStyle ??
+                  AppTypography.labelMedium.copyWith(color: messageColor),
             ),
           ),
       ],
@@ -711,15 +698,29 @@ class _AppTextFieldState extends State<AppTextField> {
   }
 }
 
-class _AppTextFieldMessageText extends StatelessWidget {
-  const _AppTextFieldMessageText({required this.text, required this.style});
+class _AppTextFieldMessage extends StatelessWidget {
+  const _AppTextFieldMessage({
+    required this.text,
+    required this.style,
+    this.icon,
+  });
+
+  static const _rowKey = ValueKey('app-text-field-message-row');
+  static const _iconSlotKey = ValueKey('app-text-field-message-icon-slot');
+  static const _textKey = ValueKey('app-text-field-message-text');
+  static const _tooltipTargetKey = ValueKey(
+    'app-text-field-message-tooltip-target',
+  );
 
   final String text;
   final TextStyle style;
+  final Widget? icon;
 
   @override
   Widget build(BuildContext context) {
-    final child = Text(
+    final hasIcon = icon != null;
+    final textChild = Text(
+      key: _textKey,
       text,
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
@@ -728,8 +729,42 @@ class _AppTextFieldMessageText extends StatelessWidget {
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        if (!constraints.maxWidth.isFinite || constraints.maxWidth <= 0) {
-          return IgnorePointer(child: child);
+        const iconWidth = AppIconSize.medium;
+        final leadingWidth = hasIcon ? iconWidth + AppSpacing.xxs : 0.0;
+        final textMaxWidth = constraints.maxWidth - leadingWidth;
+        final textLayoutWidth = textMaxWidth <= 0 ? 0.0 : textMaxWidth;
+        final messageRow = Row(
+          key: _rowKey,
+          children: [
+            if (hasIcon) ...[
+              IgnorePointer(
+                child: SizedBox(
+                  key: _iconSlotKey,
+                  width: iconWidth,
+                  height: iconWidth,
+                  child: Center(child: icon),
+                ),
+              ),
+              const IgnorePointer(child: SizedBox(width: AppSpacing.xxs)),
+            ],
+            Expanded(child: textChild),
+          ],
+        );
+        final visibleMessage = IgnorePointer(child: messageRow);
+        Widget messageLine({Widget? overlay}) {
+          return SizedBox(
+            height: AppIconSize.medium,
+            child: Stack(
+              children: [
+                visibleMessage,
+                if (overlay != null) Positioned.fill(child: overlay),
+              ],
+            ),
+          );
+        }
+
+        if (!constraints.maxWidth.isFinite) {
+          return messageLine();
         }
 
         final textPainter = TextPainter(
@@ -738,13 +773,19 @@ class _AppTextFieldMessageText extends StatelessWidget {
           textScaler: MediaQuery.textScalerOf(context),
           ellipsis: '...',
           maxLines: 1,
-        )..layout(maxWidth: constraints.maxWidth);
+        )..layout(maxWidth: textLayoutWidth);
 
         if (!textPainter.didExceedMaxLines) {
-          return IgnorePointer(child: child);
+          return messageLine();
         }
 
-        return AppTooltip(message: text, preferBelow: true, child: child);
+        return messageLine(
+          overlay: AppTooltip(
+            message: text,
+            preferBelow: true,
+            child: const SizedBox.expand(key: _tooltipTargetKey),
+          ),
+        );
       },
     );
   }

--- a/lib/src/core/widgets/app_tooltip.dart
+++ b/lib/src/core/widgets/app_tooltip.dart
@@ -8,6 +8,7 @@ class AppTooltip extends StatelessWidget {
     required this.child,
     this.message,
     this.richMessage,
+    this.preferBelow = false,
     super.key,
   }) : assert(
          (message == null) != (richMessage == null),
@@ -16,6 +17,7 @@ class AppTooltip extends StatelessWidget {
 
   final String? message;
   final InlineSpan? richMessage;
+  final bool preferBelow;
   final Widget child;
 
   @override
@@ -35,7 +37,7 @@ class AppTooltip extends StatelessWidget {
       textStyle: textStyle,
       waitDuration: const Duration(milliseconds: 350),
       showDuration: const Duration(seconds: 8),
-      preferBelow: false,
+      preferBelow: preferBelow,
       constraints: const BoxConstraints(maxWidth: 340),
       padding: const EdgeInsets.symmetric(
         horizontal: AppSpacing.s,

--- a/test/core/widgets/app_text_field_test.dart
+++ b/test/core/widgets/app_text_field_test.dart
@@ -120,6 +120,85 @@ void main() {
     expect(tooltip.preferBelow, isTrue);
   });
 
+  testWidgets('truncated message tooltip anchors to icon and text row', (
+    tester,
+  ) async {
+    const message =
+        'Use only English letters, numbers, and symbols before continuing.';
+
+    await tester.pumpWidget(
+      const _ThemedHarness(
+        child: SizedBox(
+          width: 128,
+          height: 86,
+          child: AppTextField(
+            label: 'Password',
+            messageText: message,
+            tone: AppTextFieldTone.destructive,
+          ),
+        ),
+      ),
+    );
+
+    final tooltipTarget = find.descendant(
+      of: find.byType(Tooltip),
+      matching: find.byKey(
+        const ValueKey('app-text-field-message-tooltip-target'),
+      ),
+    );
+    final iconSlot = find.byKey(
+      const ValueKey('app-text-field-message-icon-slot'),
+    );
+
+    expect(tooltipTarget, findsOneWidget);
+    expect(iconSlot, findsOneWidget);
+
+    final fieldRect = tester.getRect(find.byType(AppTextField));
+    final targetRect = tester.getRect(tooltipTarget);
+    final textRect = tester.getRect(find.text(message));
+
+    expect(targetRect.left, moreOrLessEquals(fieldRect.left));
+    expect(targetRect.width, moreOrLessEquals(fieldRect.width));
+    expect(textRect.left, greaterThan(targetRect.left));
+  });
+
+  testWidgets('truncated message tooltip appears when hovering icon slot', (
+    tester,
+  ) async {
+    const message =
+        'Use only English letters, numbers, and symbols before continuing.';
+
+    await tester.pumpWidget(
+      const _ThemedHarness(
+        child: SizedBox(
+          width: 128,
+          height: 86,
+          child: AppTextField(
+            label: 'Password',
+            messageText: message,
+            tone: AppTextFieldTone.destructive,
+          ),
+        ),
+      ),
+    );
+
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.addPointer(location: Offset.zero);
+    addTearDown(mouse.removePointer);
+
+    await mouse.moveTo(
+      tester
+          .getRect(
+            find.byKey(const ValueKey('app-text-field-message-icon-slot')),
+          )
+          .center,
+    );
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pumpAndSettle();
+
+    expect(find.text(message), findsNWidgets(2));
+  });
+
   testWidgets('truncated message tooltip does not block root unfocus', (
     tester,
   ) async {
@@ -143,6 +222,7 @@ void main() {
             controller: controller,
             focusNode: focusNode,
             messageText: message,
+            tone: AppTextFieldTone.destructive,
           ),
         ),
       ),
@@ -156,6 +236,22 @@ void main() {
     await tester.pump();
 
     expect(rootTapCount, 1);
+    expect(focusNode.hasFocus, isFalse);
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+    expect(focusNode.hasFocus, isTrue);
+
+    await tester.tapAt(
+      tester
+          .getRect(
+            find.byKey(const ValueKey('app-text-field-message-icon-slot')),
+          )
+          .center,
+    );
+    await tester.pump();
+
+    expect(rootTapCount, 2);
     expect(focusNode.hasFocus, isFalse);
   });
 

--- a/test/core/widgets/app_text_field_test.dart
+++ b/test/core/widgets/app_text_field_test.dart
@@ -162,7 +162,7 @@ void main() {
     expect(textRect.left, greaterThan(targetRect.left));
   });
 
-  testWidgets('truncated message tooltip appears when hovering icon slot', (
+  testWidgets('truncated message tooltip can show full message overlay', (
     tester,
   ) async {
     const message =
@@ -182,18 +182,9 @@ void main() {
       ),
     );
 
-    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await mouse.addPointer(location: Offset.zero);
-    addTearDown(mouse.removePointer);
-
-    await mouse.moveTo(
-      tester
-          .getRect(
-            find.byKey(const ValueKey('app-text-field-message-icon-slot')),
-          )
-          .center,
-    );
-    await tester.pump(const Duration(milliseconds: 400));
+    final tooltipState = tester.state<TooltipState>(find.byType(Tooltip));
+    expect(tooltipState.ensureTooltipVisible(), isTrue);
+    await tester.pump();
     await tester.pumpAndSettle();
 
     expect(find.text(message), findsNWidgets(2));

--- a/test/core/widgets/app_text_field_test.dart
+++ b/test/core/widgets/app_text_field_test.dart
@@ -85,6 +85,80 @@ void main() {
     expect(focusNode.hasFocus, isFalse);
   });
 
+  testWidgets('message text does not use tooltip when it fits', (tester) async {
+    await tester.pumpWidget(
+      const _ThemedHarness(
+        child: SizedBox(
+          width: 352,
+          height: 86,
+          child: AppTextField(label: 'Send to', messageText: 'Valid address'),
+        ),
+      ),
+    );
+
+    expect(find.byType(Tooltip), findsNothing);
+  });
+
+  testWidgets('truncated message text uses below-preferred tooltip', (
+    tester,
+  ) async {
+    const message =
+        'Use only English letters, numbers, and symbols before continuing.';
+
+    await tester.pumpWidget(
+      const _ThemedHarness(
+        child: SizedBox(
+          width: 128,
+          height: 86,
+          child: AppTextField(label: 'Password', messageText: message),
+        ),
+      ),
+    );
+
+    final tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+    expect(tooltip.message, message);
+    expect(tooltip.preferBelow, isTrue);
+  });
+
+  testWidgets('truncated message tooltip does not block root unfocus', (
+    tester,
+  ) async {
+    const message =
+        'Use only English letters, numbers, and symbols before continuing.';
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    var rootTapCount = 0;
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      _ThemedHarness(
+        includeRootUnfocus: true,
+        onRootTap: () => rootTapCount += 1,
+        child: SizedBox(
+          width: 128,
+          height: 86,
+          child: AppTextField(
+            label: 'Password',
+            controller: controller,
+            focusNode: focusNode,
+            messageText: message,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+    expect(focusNode.hasFocus, isTrue);
+
+    await tester.tapAt(tester.getRect(find.text(message)).center);
+    await tester.pump();
+
+    expect(rootTapCount, 1);
+    expect(focusNode.hasFocus, isFalse);
+  });
+
   testWidgets('multiline clear button uses the Figma hit target', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
- Show the full text in a tooltip when an AppTextField bottom message is truncated.
- Prefer the tooltip below the message while preserving existing tooltip defaults elsewhere.
- Keep AppTextField message spacing owned by callers and avoid changing the field layout contract.

## Validation
- fvm flutter test test/core/widgets/app_text_field_test.dart
- fvm flutter analyze
- git diff --check