### PR TITLE
Smooth vote menu refreshes

### DIFF
--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -31,14 +31,15 @@ class VotingPollsScreen extends ConsumerStatefulWidget {
 
 class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
   bool _showSettings = false;
+  bool _entryRefreshInFlight = true;
+  bool _pollListRefreshInFlight = false;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      _reloadRoundsWithFreshConfig();
-      _preSyncLoadedRounds();
+      _reloadRoundsWithFreshConfig(entryRefresh: true);
     });
   }
 
@@ -57,47 +58,24 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
                 _VotingTopBar(onSettings: _openSettings),
                 const SizedBox(height: AppSpacing.s),
                 Expanded(
-                  child: rounds.when(
-                    skipLoadingOnRefresh: false,
-                    loading: () =>
-                        const Center(child: CircularProgressIndicator()),
-                    error: (error, _) => _VotingMessage(
-                      title: "Couldn't load polls",
-                      message: error.toString(),
-                      actionLabel: 'Try again',
-                      onAction: () => _reloadRoundsWithFreshConfig(),
-                    ),
-                    data: (items) {
-                      if (items.isEmpty) {
-                        return const _VotingMessage(
-                          title: 'No polls available',
-                          message:
-                              'There are no coinholder polls to display yet.',
-                        );
-                      }
-                      final sortedItems = sortVotingRoundsForPollList(items);
-                      _preSyncVisibleRoundTrees(sortedItems);
-                      return VotingPaneListView.separated(
-                        maxWidth: 560,
-                        padding: const EdgeInsets.fromLTRB(
-                          AppSpacing.md,
-                          AppSpacing.sm,
-                          AppSpacing.md,
-                          40,
+                  child: _entryRefreshInFlight && !rounds.hasValue
+                      ? const Center(child: CircularProgressIndicator())
+                      : (_pollListRefreshInFlight || _entryRefreshInFlight) &&
+                            rounds.hasValue
+                      ? _buildRoundList(rounds.requireValue)
+                      : rounds.when(
+                          skipLoadingOnRefresh: false,
+                          skipLoadingOnReload: false,
+                          loading: () =>
+                              const Center(child: CircularProgressIndicator()),
+                          error: (error, _) => _VotingMessage(
+                            title: "Couldn't load polls",
+                            message: error.toString(),
+                            actionLabel: 'Try again',
+                            onAction: () => _reloadRoundsWithFreshConfig(),
+                          ),
+                          data: _buildRoundList,
                         ),
-                        itemCount: sortedItems.length,
-                        separatorBuilder: (_, _) =>
-                            const SizedBox(height: AppSpacing.base),
-                        itemBuilder: (context, index) {
-                          final round = sortedItems[index];
-                          return _PollCard(
-                            round: round,
-                            onAction: () => _openRoundAction(round),
-                          );
-                        },
-                      );
-                    },
-                  ),
                 ),
               ],
             ),
@@ -112,6 +90,32 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildRoundList(List<VotingRoundView> items) {
+    if (items.isEmpty) {
+      return const _VotingMessage(
+        title: 'No polls available',
+        message: 'There are no coinholder polls to display yet.',
+      );
+    }
+    final sortedItems = sortVotingRoundsForPollList(items);
+    _preSyncVisibleRoundTrees(sortedItems);
+    return VotingPaneListView.separated(
+      maxWidth: 560,
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.sm,
+        AppSpacing.md,
+        40,
+      ),
+      itemCount: sortedItems.length,
+      separatorBuilder: (_, _) => const SizedBox(height: AppSpacing.base),
+      itemBuilder: (context, index) {
+        final round = sortedItems[index];
+        return _PollCard(round: round, onAction: () => _openRoundAction(round));
+      },
     );
   }
 
@@ -156,19 +160,37 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
       context.push(route).whenComplete(() {
         if (!mounted) return;
         _reloadRoundsWithFreshConfig();
-        _preSyncLoadedRounds();
       }),
     );
   }
 
-  void _reloadRoundsWithFreshConfig() {
-    unawaited(_refreshConfigAndReloadRounds());
+  void _reloadRoundsWithFreshConfig({bool entryRefresh = false}) {
+    if (!entryRefresh && ref.read(votingRoundsProvider).hasValue) {
+      setState(() {
+        _pollListRefreshInFlight = true;
+      });
+    }
+    unawaited(
+      _refreshConfigAndReloadRounds().whenComplete(() {
+        if (!mounted) return;
+        setState(() {
+          if (entryRefresh) {
+            _entryRefreshInFlight = false;
+          }
+          _pollListRefreshInFlight = false;
+        });
+      }),
+    );
   }
 
   Future<void> _refreshConfigAndReloadRounds() async {
-    await ref.read(votingConfigProvider.notifier).refresh();
+    await refreshVotingPollList(
+      config: ref.read(votingConfigProvider.notifier),
+      readRounds: () => ref.read(votingRoundsProvider.notifier),
+      shouldReload: () => mounted,
+    );
     if (!mounted) return;
-    await ref.read(votingRoundsProvider.notifier).reload();
+    _preSyncLoadedRounds();
   }
 
   void _openSettings() {

--- a/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
+++ b/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -8,13 +10,15 @@ import '../../../core/privacy/sensitive_privacy_overlay.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
+import '../../../providers/voting/voting_config_provider.dart';
+import '../../../providers/voting/voting_rounds_provider.dart';
 import '../../../providers/voting/voting_session_provider.dart';
 import '../../../providers/voting/voting_submission_job_provider.dart';
 import '../voting_flow_models.dart';
 import '../voting_formatters.dart';
 import '../voting_resume_plan.dart';
 
-class VotingSubmissionConfirmationScreen extends ConsumerWidget {
+class VotingSubmissionConfirmationScreen extends ConsumerStatefulWidget {
   const VotingSubmissionConfirmationScreen({
     super.key,
     required this.roundId,
@@ -25,12 +29,24 @@ class VotingSubmissionConfirmationScreen extends ConsumerWidget {
   final String? accountUuid;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final jobKey = accountUuid == null || accountUuid!.isEmpty
+  ConsumerState<VotingSubmissionConfirmationScreen> createState() =>
+      _VotingSubmissionConfirmationScreenState();
+}
+
+class _VotingSubmissionConfirmationScreenState
+    extends ConsumerState<VotingSubmissionConfirmationScreen> {
+  bool _isReturningToPolls = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final jobKey = widget.accountUuid == null || widget.accountUuid!.isEmpty
         ? null
-        : VotingSessionKey(roundId: roundId, accountUuid: accountUuid!);
+        : VotingSessionKey(
+            roundId: widget.roundId,
+            accountUuid: widget.accountUuid!,
+          );
     final session = jobKey == null
-        ? ref.watch(votingSessionProvider(roundId))
+        ? ref.watch(votingSessionProvider(widget.roundId))
         : ref.watch(votingSubmissionJobSessionProvider(jobKey));
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
@@ -73,14 +89,8 @@ class VotingSubmissionConfirmationScreen extends ConsumerWidget {
                   votingPower: state.eligibleWeightZatoshi == null
                       ? 'Not available'
                       : formatVotingPower(state.eligibleWeightZatoshi!),
-                  onDone: () {
-                    if (jobKey != null) {
-                      ref
-                          .read(votingSubmissionJobsProvider.notifier)
-                          .dismiss(jobKey);
-                    }
-                    context.go('/voting');
-                  },
+                  doneEnabled: !_isReturningToPolls,
+                  onDone: () => unawaited(_returnToPolls(jobKey)),
                 );
               },
             ),
@@ -88,6 +98,33 @@ class VotingSubmissionConfirmationScreen extends ConsumerWidget {
         ),
       ),
     );
+  }
+
+  Future<void> _returnToPolls(VotingSessionKey? jobKey) async {
+    if (_isReturningToPolls) return;
+    setState(() {
+      _isReturningToPolls = true;
+    });
+    try {
+      await refreshVotingPollList(
+        config: ref.read(votingConfigProvider.notifier),
+        readRounds: () => ref.read(votingRoundsProvider.notifier),
+        shouldReload: () => mounted,
+      );
+      if (!mounted) return;
+      if (jobKey != null) {
+        ref.read(votingSubmissionJobsProvider.notifier).dismiss(jobKey);
+      }
+      context.go('/voting');
+    } catch (error) {
+      if (!mounted) return;
+      debugPrint(
+        '[zcash] Voting: poll list refresh before return failed: $error',
+      );
+      setState(() {
+        _isReturningToPolls = false;
+      });
+    }
   }
 }
 
@@ -99,6 +136,7 @@ class _ConfirmationScaffold extends StatelessWidget {
     required this.message,
     required this.votingPower,
     this.onDone,
+    this.doneEnabled = true,
   });
 
   final bool confirmed;
@@ -107,6 +145,7 @@ class _ConfirmationScaffold extends StatelessWidget {
   final String message;
   final String votingPower;
   final VoidCallback? onDone;
+  final bool doneEnabled;
 
   @override
   Widget build(BuildContext context) {
@@ -194,7 +233,9 @@ class _ConfirmationScaffold extends StatelessWidget {
                   SizedBox(
                     width: double.infinity,
                     child: AppButton(
-                      onPressed: onDone ?? () => context.go('/voting'),
+                      onPressed: doneEnabled
+                          ? onDone ?? () => context.go('/voting')
+                          : null,
                       variant: AppButtonVariant.primary,
                       child: const Text('Done'),
                     ),

--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -12,6 +12,20 @@ import 'voting_config_provider.dart';
 import 'voting_service_providers.dart';
 import 'voting_state.dart';
 
+/// Refreshes the dynamic voting config and then reloads the poll list.
+///
+/// Call this before returning to the poll menu after completing voting work so
+/// row statuses are current before `/voting` becomes visible.
+Future<void> refreshVotingPollList({
+  required VotingConfigNotifier config,
+  required VotingRoundsNotifier Function() readRounds,
+  bool Function()? shouldReload,
+}) async {
+  await config.refresh();
+  if (shouldReload != null && !shouldReload()) return;
+  await readRounds().reload();
+}
+
 /// Provides poll-list rows with explicit, route-driven reloads.
 class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
   static const _roundsRetryDelays = <Duration>[

--- a/test/features/voting/voting_polls_screen_test.dart
+++ b/test/features/voting/voting_polls_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_config_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_rounds_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_service_providers.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_state.dart';
 import 'package:zcash_wallet/src/rust/third_party/zcash_voting/config.dart';
 
@@ -73,6 +74,9 @@ void main() {
     expect(roundsNotifier.reloadCount, 1);
     expect(configNotifier.refreshCount, 1);
 
+    final returnReload = Completer<void>();
+    roundsNotifier.nextReload = returnReload.future;
+
     await tester.tap(find.text('View results'));
     await tester.pumpAndSettle();
 
@@ -80,12 +84,164 @@ void main() {
     expect(roundsNotifier.reloadCount, 1);
 
     router.pop();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(roundsNotifier.reloadCount, 2);
+    expect(configNotifier.refreshCount, 2);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('View results'), findsOneWidget);
+
+    returnReload.complete();
     await tester.pumpAndSettle();
 
     expect(find.text('View results'), findsOneWidget);
-    expect(roundsNotifier.reloadCount, 2);
-    expect(configNotifier.refreshCount, 2);
   });
+
+  testWidgets('account reload shows loading instead of previous account rows', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    late _SwitchingAccountNotifier accountNotifier;
+    late _AccountReloadVotingRoundsNotifier roundsNotifier;
+    final accountReloadGate = Completer<void>();
+    final router = GoRouter(
+      initialLocation: '/voting',
+      routes: [
+        GoRoute(path: '/voting', builder: (_, _) => const VotingPollsScreen()),
+        GoRoute(path: '/accounts', builder: (_, _) => const Text('accounts')),
+        GoRoute(path: '/home', builder: (_, _) => const Text('home')),
+        GoRoute(
+          path: '/address-book',
+          builder: (_, _) => const Text('address book'),
+        ),
+        GoRoute(path: '/activity', builder: (_, _) => const Text('activity')),
+        GoRoute(path: '/settings', builder: (_, _) => const Text('settings')),
+        GoRoute(path: '/about', builder: (_, _) => const Text('about')),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          accountProvider.overrideWith(() {
+            accountNotifier = _SwitchingAccountNotifier();
+            return accountNotifier;
+          }),
+          syncProvider.overrideWith(_NoopSyncNotifier.new),
+          swapFeatureEnabledProvider.overrideWithValue(false),
+          votingConfigProvider.overrideWith(_TrackingVotingConfigNotifier.new),
+          votingRoundsProvider.overrideWith(() {
+            roundsNotifier = _AccountReloadVotingRoundsNotifier(
+              accountReloadGate.future,
+            );
+            return roundsNotifier;
+          }),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, child) =>
+              AppTheme(data: AppThemeData.light, child: child!),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(roundsNotifier.reloadCount, 1);
+    expect(find.text('Account 1 poll'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+
+    accountNotifier.activate('account-2');
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('Account 1 poll'), findsNothing);
+    expect(find.text('Account 2 poll'), findsNothing);
+
+    accountReloadGate.complete();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Account 2 poll'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets(
+    'initial entry refresh hides stale load errors until rows arrive',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1512, 982));
+      addTearDown(() async {
+        await tester.binding.setSurfaceSize(null);
+      });
+
+      late _TrackingVotingConfigNotifier configNotifier;
+      late _InitiallyFailingVotingRoundsNotifier roundsNotifier;
+      final reloadGate = Completer<void>();
+      final router = GoRouter(
+        initialLocation: '/voting',
+        routes: [
+          GoRoute(
+            path: '/voting',
+            builder: (_, _) => const VotingPollsScreen(),
+          ),
+          GoRoute(path: '/accounts', builder: (_, _) => const Text('accounts')),
+          GoRoute(path: '/home', builder: (_, _) => const Text('home')),
+          GoRoute(
+            path: '/address-book',
+            builder: (_, _) => const Text('address book'),
+          ),
+          GoRoute(path: '/activity', builder: (_, _) => const Text('activity')),
+          GoRoute(path: '/settings', builder: (_, _) => const Text('settings')),
+          GoRoute(path: '/about', builder: (_, _) => const Text('about')),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            accountProvider.overrideWith(_SoftwareAccountNotifier.new),
+            syncProvider.overrideWith(_NoopSyncNotifier.new),
+            swapFeatureEnabledProvider.overrideWithValue(false),
+            votingConfigProvider.overrideWith(() {
+              configNotifier = _TrackingVotingConfigNotifier();
+              return configNotifier;
+            }),
+            votingRoundsProvider.overrideWith(() {
+              roundsNotifier = _InitiallyFailingVotingRoundsNotifier(
+                reloadGate.future,
+              );
+              return roundsNotifier;
+            }),
+          ],
+          child: MaterialApp.router(
+            routerConfig: router,
+            builder: (_, child) =>
+                AppTheme(data: AppThemeData.light, child: child!),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(configNotifier.refreshCount, 1);
+      expect(roundsNotifier.reloadCount, 1);
+      expect(
+        find.textContaining('Bad state: first load became stale'),
+        findsNothing,
+      );
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      reloadGate.complete();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Closed poll'), findsOneWidget);
+      expect(find.text('View results'), findsOneWidget);
+    },
+  );
 }
 
 class _TrackingVotingConfigNotifier extends VotingConfigNotifier {
@@ -119,6 +275,7 @@ class _TrackingVotingConfigNotifier extends VotingConfigNotifier {
 
 class _TrackingVotingRoundsNotifier extends VotingRoundsNotifier {
   int reloadCount = 0;
+  Future<void>? nextReload;
 
   @override
   Future<List<VotingRoundView>> build() async {
@@ -135,6 +292,84 @@ class _TrackingVotingRoundsNotifier extends VotingRoundsNotifier {
   @override
   Future<void> reload() async {
     reloadCount++;
+    state = const AsyncLoading<List<VotingRoundView>>();
+    final pendingReload = nextReload;
+    nextReload = null;
+    if (pendingReload != null) {
+      await pendingReload;
+    }
+    state = const AsyncData([
+      VotingRoundView(
+        roundId: 'round-1',
+        title: 'Closed poll',
+        status: 'closed',
+        rawJson: {'description': 'Closed poll description'},
+      ),
+    ]);
+  }
+}
+
+class _InitiallyFailingVotingRoundsNotifier extends VotingRoundsNotifier {
+  _InitiallyFailingVotingRoundsNotifier(this.reloadGate);
+
+  final Future<void> reloadGate;
+  int reloadCount = 0;
+
+  @override
+  Future<List<VotingRoundView>> build() async {
+    throw StateError('first load became stale');
+  }
+
+  @override
+  Future<void> reload() async {
+    reloadCount++;
+    state = const AsyncLoading<List<VotingRoundView>>();
+    await reloadGate;
+    state = const AsyncData([
+      VotingRoundView(
+        roundId: 'round-1',
+        title: 'Closed poll',
+        status: 'closed',
+        rawJson: {'description': 'Closed poll description'},
+      ),
+    ]);
+  }
+}
+
+class _AccountReloadVotingRoundsNotifier extends VotingRoundsNotifier {
+  _AccountReloadVotingRoundsNotifier(this.accountReloadGate);
+
+  final Future<void> accountReloadGate;
+  int reloadCount = 0;
+
+  @override
+  Future<List<VotingRoundView>> build() async {
+    final loadActiveAccount = ref.watch(votingActiveAccountUuidProvider);
+    final activeAccountUuid = await loadActiveAccount();
+    if (activeAccountUuid == 'account-2') {
+      await accountReloadGate;
+    }
+    return [_rowFor(activeAccountUuid)];
+  }
+
+  @override
+  Future<void> reload() async {
+    reloadCount++;
+    final activeAccountUuid = await ref
+        .read(votingActiveAccountUuidProvider)
+        .call();
+    state = AsyncData([_rowFor(activeAccountUuid)]);
+  }
+
+  VotingRoundView _rowFor(String? activeAccountUuid) {
+    final isSecondAccount = activeAccountUuid == 'account-2';
+    return VotingRoundView(
+      roundId: 'round-1',
+      title: isSecondAccount ? 'Account 2 poll' : 'Account 1 poll',
+      status: 'closed',
+      voted: !isSecondAccount,
+      rawJson: const {'description': 'Closed poll description'},
+    );
   }
 }
 
@@ -145,6 +380,26 @@ class _SoftwareAccountNotifier extends AccountNotifier {
     activeAccountUuid: 'account-1',
     activeAddress: 'u1softwareaddress',
   );
+}
+
+class _SwitchingAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() => _stateFor('account-1');
+
+  void activate(String accountUuid) {
+    state = AsyncData(_stateFor(accountUuid));
+  }
+
+  AccountState _stateFor(String activeAccountUuid) {
+    return AccountState(
+      accounts: const [
+        AccountInfo(uuid: 'account-1', name: 'Account 1', order: 0),
+        AccountInfo(uuid: 'account-2', name: 'Account 2', order: 1),
+      ],
+      activeAccountUuid: activeAccountUuid,
+      activeAddress: 'u1$activeAccountUuid',
+    );
+  }
 }
 
 class _NoopSyncNotifier extends SyncNotifier {

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/voting/screens/voting_proposal_detail_screen.dart';
+import 'package:zcash_wallet/src/features/voting/screens/voting_polls_screen.dart';
 import 'package:zcash_wallet/src/features/voting/screens/voting_review_screen.dart';
 import 'package:zcash_wallet/src/features/voting/screens/voting_results_screen.dart';
 import 'package:zcash_wallet/src/features/voting/screens/voting_status_screen.dart';
@@ -22,7 +23,9 @@ import 'package:zcash_wallet/src/features/voting/voting_resume_plan.dart';
 import 'package:zcash_wallet/src/features/voting/voting_routes.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_config_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_config_source_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_rounds_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_session_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_service_providers.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_submission_job_provider.dart';
@@ -276,6 +279,98 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets(
+    'submitted route refreshes poll rows before returning to vote menu',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1512, 982));
+      addTearDown(() async {
+        await tester.binding.setSurfaceSize(null);
+      });
+
+      late _CountingVotingConfigNotifier configNotifier;
+      late _BlockingVotingRoundsNotifier roundsNotifier;
+      final reloadGate = Completer<void>();
+      final completedRoundPlan = apiRoundPlan(
+        roundId: _roundId,
+        pendingRecovery: false,
+        nextSteps: const [],
+        openProposals: Uint32List(0),
+        allDecided: true,
+        completedVoteArtifact: true,
+        completedForDisplay: true,
+      );
+      final container = _statusContainer(
+        accountOverride: _MnemonicAccountNotifier.new,
+        overrides: [
+          votingConfigProvider.overrideWith(() {
+            configNotifier = _CountingVotingConfigNotifier();
+            return configNotifier;
+          }),
+          votingSessionProvider(_roundId).overrideWith(
+            () => _StaticVotingSessionNotifier(
+              VotingSessionState(
+                roundId: _roundId,
+                accountUuid: 'account-1',
+                phase: VotingSessionPhase.done,
+                roundPlan: completedRoundPlan,
+              ),
+            ),
+          ),
+          votingRoundsProvider.overrideWith(() {
+            roundsNotifier = _BlockingVotingRoundsNotifier(
+              reloadGate.future,
+              initialRows: const [
+                VotingRoundView(
+                  roundId: _roundId,
+                  title: 'Stale poll',
+                  status: 'active',
+                ),
+              ],
+              refreshedRows: const [
+                VotingRoundView(
+                  roundId: _roundId,
+                  title: 'Refreshed poll',
+                  status: 'closed',
+                ),
+              ],
+            );
+            return roundsNotifier;
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: _submissionHarness(votingRoute: const VotingPollsScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await _pumpUntilFound(tester, find.text('Submission confirmed!'));
+
+      await tester.tap(find.text('Done'));
+      await tester.pump();
+
+      expect(configNotifier.refreshCount, 1);
+      expect(roundsNotifier.reloadCount, 1);
+      expect(find.text('Refreshed poll'), findsNothing);
+
+      await tester.tap(find.text('Done'));
+      await tester.pump();
+
+      expect(configNotifier.refreshCount, 1);
+      expect(roundsNotifier.reloadCount, 1);
+
+      reloadGate.complete();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Refreshed poll'), findsOneWidget);
+      expect(find.text('View results'), findsOneWidget);
+      expect(find.text('Stale poll'), findsNothing);
+    },
+  );
 
   testWidgets('status screen does not complete all-decided empty account', (
     tester,
@@ -2129,7 +2224,7 @@ Widget _proposalHarness({String? initialLocation}) {
   );
 }
 
-Widget _submissionHarness() {
+Widget _submissionHarness({Widget votingRoute = const Text('voting route')}) {
   final router = GoRouter(
     initialLocation: '/voting/poll/$_roundId/submitted',
     routes: [
@@ -2139,7 +2234,7 @@ Widget _submissionHarness() {
           roundId: state.pathParameters['roundId']!,
         ),
       ),
-      GoRoute(path: '/voting', builder: (_, _) => const Text('voting route')),
+      GoRoute(path: '/voting', builder: (_, _) => votingRoute),
       GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
       GoRoute(path: '/send', builder: (_, _) => const Text('send route')),
       GoRoute(path: '/receive', builder: (_, _) => const Text('receive route')),
@@ -2619,6 +2714,68 @@ class _MutableVotingRecoveryApi extends _FakeVotingRecoveryApi {
     int? choice,
   }) async {
     ballotIntents.add('$proposalId:$numOptions:$skipped:${choice ?? 'null'}');
+  }
+}
+
+class _StaticVotingSessionNotifier extends VotingSessionNotifier {
+  _StaticVotingSessionNotifier(this._state) : super(_state.roundId);
+
+  final VotingSessionState _state;
+
+  @override
+  Future<VotingSessionState> build() async => _state;
+}
+
+class _CountingVotingConfigNotifier extends VotingConfigNotifier {
+  int refreshCount = 0;
+
+  @override
+  Future<rust_config.ResolvedVotingConfig> build() async {
+    return const rust_config.ResolvedVotingConfig(
+      sourceFingerprint: 'source-fingerprint',
+      trustedKeyFingerprint: 'trusted-key-fingerprint',
+      dynamicConfigFingerprint: 'dynamic-config-fingerprint',
+      voteServers: [],
+      pirEndpoints: [],
+      supportedVersions: rust_config.SupportedVersions(
+        pir: [],
+        voteProtocol: 'vote-protocol',
+        tally: 'tally',
+        voteServer: 'vote-server',
+      ),
+      authenticatedRounds: [],
+      skippedRoundIds: [],
+      conditions: [],
+    );
+  }
+
+  @override
+  Future<void> refresh() async {
+    refreshCount++;
+  }
+}
+
+class _BlockingVotingRoundsNotifier extends VotingRoundsNotifier {
+  _BlockingVotingRoundsNotifier(
+    this.reloadGate, {
+    this.initialRows = const [],
+    this.refreshedRows = const [],
+  });
+
+  final Future<void> reloadGate;
+  final List<VotingRoundView> initialRows;
+  final List<VotingRoundView> refreshedRows;
+  int reloadCount = 0;
+
+  @override
+  Future<List<VotingRoundView>> build() async => initialRows;
+
+  @override
+  Future<void> reload() async {
+    reloadCount++;
+    state = const AsyncLoading<List<VotingRoundView>>();
+    await reloadGate;
+    state = AsyncData(refreshedRows);
   }
 }
 

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1014,6 +1014,67 @@ void main() {
     },
   );
 
+  test(
+    'rounds reload keeps previous rows visible while refresh is pending',
+    () async {
+      final responses = <String, Object>{
+        'https://voting.example/static-voting-config.json': staticConfigJson(),
+        'https://voting.example/dynamic-voting-config.json':
+            dynamicConfigJson(),
+        '/shielded-vote/v1/rounds': {
+          'rounds': [
+            {'vote_round_id': kRoundId, 'title': 'Poll', 'status': 'active'},
+          ],
+        },
+      };
+      final http = _GatedVotingHttpClient(responses: responses);
+      final container = _sessionContainer(http: http);
+      addTearDown(container.dispose);
+
+      final initial = await container.read(votingRoundsProvider.future);
+      expect(initial.single.title, 'Poll');
+
+      final roundsGate = http.gateNextGet('/shielded-vote/v1/rounds');
+      final reload = container.read(votingRoundsProvider.notifier).reload();
+      await http.waitForGetCount('/shielded-vote/v1/rounds', 2);
+      final refreshing = container.read(votingRoundsProvider);
+
+      expect(refreshing.isLoading, isTrue);
+      expect(refreshing.hasValue, isTrue);
+      expect(refreshing.requireValue.single.title, 'Poll');
+
+      roundsGate.complete();
+      await reload;
+    },
+  );
+
+  test('poll refresh skips rounds reload when guard cancels', () async {
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://voting.example/static-voting-config.json': staticConfigJson(),
+        'https://voting.example/dynamic-voting-config.json':
+            dynamicConfigJson(),
+      },
+    );
+    final container = _container(http: http);
+    addTearDown(container.dispose);
+    await container.read(votingConfigProvider.future);
+
+    final roundsNotifier = _CountingVotingRoundsNotifier();
+    var readRoundsCalled = false;
+    await refreshVotingPollList(
+      config: container.read(votingConfigProvider.notifier),
+      shouldReload: () => false,
+      readRounds: () {
+        readRoundsCalled = true;
+        return roundsNotifier;
+      },
+    );
+
+    expect(readRoundsCalled, isFalse);
+    expect(roundsNotifier.reloadCount, 0);
+  });
+
   test('rounds reload fails closed when refresh fails', () async {
     final responses = <String, Object>{
       'https://voting.example/static-voting-config.json': staticConfigJson(),
@@ -4426,6 +4487,18 @@ final class _ProviderDisposalObserver extends ProviderObserver {
   }
 }
 
+class _CountingVotingRoundsNotifier extends VotingRoundsNotifier {
+  int reloadCount = 0;
+
+  @override
+  Future<List<VotingRoundView>> build() async => const [];
+
+  @override
+  Future<void> reload() async {
+    reloadCount++;
+  }
+}
+
 ProviderContainer _sessionContainer({
   FakeVotingHttpClient? http,
   FakeVotingRustApi? rust,
@@ -4777,6 +4850,58 @@ class _GatedVotingConfigLoader extends VotingConfigLoader {
   }) {
     return _loads.load(_sourceUrl);
   }
+}
+
+class _GatedVotingHttpClient extends FakeVotingHttpClient {
+  _GatedVotingHttpClient({super.responses});
+
+  final Map<String, List<Completer<void>>> _getGates = {};
+  final Map<String, int> _getCounts = {};
+  final Map<String, List<_GetCountWaiter>> _getCountWaiters = {};
+
+  Completer<void> gateNextGet(String path) {
+    final gate = Completer<void>();
+    (_getGates[path] ??= []).add(gate);
+    return gate;
+  }
+
+  Future<void> waitForGetCount(String path, int count) {
+    if ((_getCounts[path] ?? 0) >= count) {
+      return Future<void>.value();
+    }
+    final waiter = _GetCountWaiter(count);
+    (_getCountWaiters[path] ??= []).add(waiter);
+    return waiter.completer.future;
+  }
+
+  @override
+  Future<VotingHttpResponse> get(Uri uri, {Duration? timeout}) async {
+    _recordGet(uri.path);
+    final gates = _getGates[uri.path];
+    if (gates != null && gates.isNotEmpty) {
+      await gates.removeAt(0).future;
+    }
+    return super.get(uri, timeout: timeout);
+  }
+
+  void _recordGet(String path) {
+    final count = (_getCounts[path] ?? 0) + 1;
+    _getCounts[path] = count;
+    final waiters = _getCountWaiters[path];
+    if (waiters == null || waiters.isEmpty) return;
+    waiters.removeWhere((waiter) {
+      if (count < waiter.count) return false;
+      waiter.completer.complete();
+      return true;
+    });
+  }
+}
+
+class _GetCountWaiter {
+  _GetCountWaiter(this.count);
+
+  final int count;
+  final Completer<void> completer = Completer<void>();
 }
 
 rust_config_api.VotingConfigResolution _configForVoteServer(String url) {


### PR DESCRIPTION
## Summary
- keep existing vote-menu rows visible during background refreshes instead of flashing a loading state
- refresh poll row status before returning from submission confirmation, and suppress transient stale-load errors on first menu entry
- add regression coverage for stale-row refresh, pre-navigation refresh, and initial entry error masking

## Validation
- fvm flutter test --no-pub test/features/voting/voting_polls_screen_test.dart test/features/voting/voting_status_screen_test.dart test/providers/voting/voting_providers_test.dart
- fvm flutter analyze --no-pub
- xcodebuild -workspace macos/Runner.xcworkspace -scheme Runner -configuration Debug -destination 'platform=macOS' SYMROOT="$PWD/build/macos/Build/Products" CODE_SIGNING_ALLOWED=NO PRODUCT_BUNDLE_IDENTIFIER=com.adamtucker.vizor.local build
