### PR TITLE
Show voting finalization status

### DIFF
--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -161,6 +161,14 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
     return hasCompletedVoteForDisplay(session.roundPlan);
   }
 
+  bool _hasCompletedCurrentSubmissionProgress(VotingSessionState session) {
+    final total = session.voteSubmissionTotalCount;
+    if (total > 0 && session.voteSubmissionCompletedCount >= total) {
+      return true;
+    }
+    return (session.voteSubmissionProgress ?? 0) >= 1;
+  }
+
   String _messageFromError(Object error) {
     return friendlyVotingErrorMessage(error);
   }
@@ -233,9 +241,16 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
             ),
             data: (state) {
               final localError = job?.errorMessage;
+              final submissionJobComplete =
+                  job?.status == VotingSubmissionJobStatus.complete;
+              final submissionJobInFlight = job?.isInFlight ?? false;
+              final sessionCompleted = _hasCompletedSubmission(state);
               final completedSubmission =
-                  job?.status == VotingSubmissionJobStatus.complete ||
-                  _hasCompletedSubmission(state);
+                  submissionJobComplete ||
+                  (!submissionJobInFlight && sessionCompleted) ||
+                  (submissionJobInFlight &&
+                      sessionCompleted &&
+                      _hasCompletedCurrentSubmissionProgress(state));
               final phase = job?.status != VotingSubmissionJobStatus.error
                   ? _displayPhase(
                       state.phase,
@@ -251,6 +266,8 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
                 ),
                 delegationProgress: _delegationProgress(state),
                 completedSubmission: completedSubmission,
+                submissionJobComplete: submissionJobComplete,
+                submissionJobInFlight: submissionJobInFlight,
                 softwareAccountRequired: job?.softwareAccountRequired ?? false,
                 isHardwareAccount: state.isHardwareAccount,
                 keystoneSigningRequest: state.keystoneSigningRequest,
@@ -453,6 +470,8 @@ class _StatusContent extends StatelessWidget {
     this.voteSubmissionProgress,
     this.delegationProgress,
     this.completedSubmission = false,
+    this.submissionJobComplete = false,
+    this.submissionJobInFlight = false,
     this.softwareAccountRequired = false,
     this.isHardwareAccount = false,
     this.keystoneSigningRequest,
@@ -475,6 +494,8 @@ class _StatusContent extends StatelessWidget {
   final double? voteSubmissionProgress;
   final double? delegationProgress;
   final bool completedSubmission;
+  final bool submissionJobComplete;
+  final bool submissionJobInFlight;
   final bool softwareAccountRequired;
   final bool isHardwareAccount;
   final rust_delegate.KeystoneSigningRequest? keystoneSigningRequest;
@@ -498,6 +519,11 @@ class _StatusContent extends StatelessWidget {
     }
     final voteStepComplete =
         completedSubmission || (voteSubmissionProgress ?? 0) >= 1;
+    final finalizingSubmission =
+        submissionJobInFlight &&
+        voteStepComplete &&
+        !submissionJobComplete &&
+        phase != VotingSessionPhase.error;
 
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -571,6 +597,11 @@ class _StatusContent extends StatelessWidget {
                 complete: voteStepComplete,
                 detail: voteStepComplete ? null : voteSubmissionDetail,
                 progressValue: voteStepComplete ? null : voteSubmissionProgress,
+              ),
+              _StepRow(
+                label: 'Finalizing submission',
+                active: finalizingSubmission,
+                complete: submissionJobComplete,
               ),
               if (phase == VotingSessionPhase.error) ...[
                 const SizedBox(height: AppSpacing.sm),

--- a/lib/src/features/voting/voting_flow_models.dart
+++ b/lib/src/features/voting/voting_flow_models.dart
@@ -92,12 +92,13 @@ class VotingDraftNotifier extends Notifier<VotingDraftState> {
   /// Round/account owner for this in-memory draft.
   final VotingSessionKey key;
   Future<VotingDraftState>? _loadFuture;
+  Future<void> _saveChain = Future.value();
   bool _loaded = false;
   final Map<int, int?> _pendingBeforeLoad = {};
 
   @override
   VotingDraftState build() {
-    unawaited(ensureLoaded());
+    unawaited(ensureLoaded().catchError((Object _, StackTrace _) => state));
     return const VotingDraftState();
   }
 
@@ -126,6 +127,20 @@ class VotingDraftNotifier extends Notifier<VotingDraftState> {
     }
   }
 
+  Future<void> clearAll() async {
+    if (!_loaded) {
+      try {
+        await ensureLoaded();
+      } catch (_) {
+        // If persisted draft loading failed, still best-effort delete below.
+      }
+    }
+    _pendingBeforeLoad.clear();
+    const next = VotingDraftState();
+    state = next;
+    await _persist(next);
+  }
+
   Future<VotingDraftState> _loadPersisted() async {
     final persisted = await ref.read(votingDraftPersistenceProvider).load(key);
     _loaded = true;
@@ -144,7 +159,11 @@ class VotingDraftNotifier extends Notifier<VotingDraftState> {
   }
 
   Future<void> _persist(VotingDraftState draft) {
-    return ref.read(votingDraftPersistenceProvider).save(key, draft);
+    final save = _saveChain.then(
+      (_) => ref.read(votingDraftPersistenceProvider).save(key, draft),
+    );
+    _saveChain = save.catchError((_) {});
+    return save;
   }
 
   VotingDraftState _applyPendingBeforeLoad(VotingDraftState base) {

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -242,6 +242,18 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     });
   }
 
+  void clearVoteSubmissionProgressForJobStart() {
+    final current = state.value;
+    if (current == null) return;
+    state = AsyncData(
+      current.copyWith(
+        clearVoteSubmissionProgress: true,
+        clearCurrentVoteKey: true,
+        clearError: true,
+      ),
+    );
+  }
+
   Future<void> precomputeDelegationPir({required String accountUuid}) async {
     final context = await _loadContext(_roundId);
     if (!_isCurrentPrecomputeContext(context, accountUuid)) return;
@@ -1246,6 +1258,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       );
       final refreshedPlan = await _loadResumePlan(context);
       final refreshedRoundPlan = await _loadRoundPlan(context);
+      final hasBlockingWork = hasBlockingRoundRecoveryWork(refreshedRoundPlan);
+      if (!hasBlockingWork) {
+        await _clearPersistedDraftChoices(context);
+      }
       debugPrint(
         '[zcash] Voting: resume plan after vote flow loaded '
         'round=${context.round.roundId} '
@@ -1257,7 +1273,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       _setStateForContext(
         context,
         (state.value ?? current).copyWith(
-          phase: VotingSessionPhase.submittingShares,
+          phase: _phaseForPlans(refreshedRoundPlan),
           resumePlan: refreshedPlan,
           roundPlan: refreshedRoundPlan,
           voteProgress: progress,
@@ -2831,9 +2847,16 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       accountUuid: context.accountUuid,
     );
     final notifier = ref.read(votingDraftProvider(draftKey).notifier);
-    final draft = await notifier.ensureLoaded();
-    for (final proposalId in draft.choices.keys.toList(growable: false)) {
-      notifier.clearChoice(proposalId);
+    try {
+      final draft = await notifier.ensureLoaded();
+      if (draft.isEmpty) return;
+      await notifier.clearAll();
+    } catch (error) {
+      debugPrint(
+        '[zcash] Voting: draft cleanup skipped '
+        'round=${context.round.roundId} account=${context.accountUuid} '
+        'error=$error',
+      );
     }
   }
 
@@ -3035,8 +3058,8 @@ final votingSessionProvider =
       String
     >(VotingSessionNotifier.new);
 
-final votingSubmissionSessionProvider =
-    AsyncNotifierProvider.autoDispose.family<
+final votingSubmissionSessionProvider = AsyncNotifierProvider.autoDispose
+    .family<
       VotingSubmissionSessionNotifier,
       VotingSessionState,
       VotingSessionKey

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -274,6 +274,10 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     _cancelCompletionPoll();
     _replaceGuard(accountUuid: key.accountUuid, roundId: key.roundId);
     _retainSession(key);
+    final sessionNotifier = ref.read(
+      votingSubmissionSessionProvider(key).notifier,
+    );
+    sessionNotifier.clearVoteSubmissionProgressForJobStart();
     final generation = ++_nextGeneration;
     state = VotingSubmissionJobState(
       key: key,
@@ -380,12 +384,24 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       final proposalOptionCounts = {
         for (final proposal in proposals) proposal.id: proposal.options.length,
       };
-      final draft = await ref
-          .read(votingDraftProvider(key).notifier)
-          .ensureLoaded();
+      final VotingDraftState draft;
+      try {
+        draft = await ref
+            .read(votingDraftProvider(key).notifier)
+            .ensureLoaded();
+      } catch (_) {
+        if (!_isCurrentJob(key: key, generation: generation)) return;
+        if (_canCompleteSessionAfterDraftLoadFailure(loadedSession)) {
+          _completeJob(key: key, generation: generation);
+          return;
+        }
+        rethrow;
+      }
       if (!_isCurrentJob(key: key, generation: generation)) return;
-      final userDraftVotes = draft.toDraftVotes(proposals);
-      final proposalIds = proposals.map((proposal) => proposal.id).toList();
+      if (_canCompleteSessionWithoutDraft(loadedSession, draft)) {
+        _completeJob(key: key, generation: generation);
+        return;
+      }
 
       await sessionNotifier.ensureWalletReadyForVoting();
       if (!_isCurrentJob(key: key, generation: generation)) return;
@@ -403,6 +419,14 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       }
 
       final activeSession = afterWalletSync ?? loadedSession;
+      if (_canCompleteSessionWithoutDraft(activeSession, draft)) {
+        _completeJob(key: key, generation: generation);
+        return;
+      }
+      final userDraftVotes = _draftForSession(
+        draft,
+        activeSession,
+      ).toDraftVotes(proposals);
       final recoveredDraftVotes =
           userDraftVotes.isEmpty && _roundPlanHasNoOpenProposals(activeSession)
           ? _draftVotesFromRoundPlan(activeSession.roundPlan, proposals)
@@ -411,7 +435,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
           ? userDraftVotes
           : recoveredDraftVotes;
       final intentProposalIds = userDraftVotes.isNotEmpty
-          ? proposalIds
+          ? _proposalIdsForDraftIntents(activeSession, proposals)
           : const <int>[];
       final canRecoverWithoutDraft = _canRecoverWithoutDraft(activeSession);
       final canPollDelegationWithoutDraft = _canPollDelegationWithoutDraft(
@@ -885,6 +909,54 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     if (!_canCompleteSubmission(session)) return false;
     _completeJob(key: key, generation: generation);
     return true;
+  }
+
+  bool _canCompleteSessionWithoutDraft(
+    VotingSessionState session,
+    VotingDraftState draft,
+  ) {
+    if (!_canCompleteSubmission(session)) return false;
+    if (draft.isEmpty) return true;
+    final roundPlan = session.roundPlan;
+    if (roundPlan == null) return false;
+    final openProposalIds = roundPlan.openProposals.toSet();
+    return draft.choices.keys.every(
+      (proposalId) => !openProposalIds.contains(proposalId),
+    );
+  }
+
+  bool _canCompleteSessionAfterDraftLoadFailure(VotingSessionState session) {
+    return _canCompleteSubmission(session) &&
+        _roundPlanHasNoOpenProposals(session);
+  }
+
+  VotingDraftState _draftForSession(
+    VotingDraftState draft,
+    VotingSessionState session,
+  ) {
+    final roundPlan = session.roundPlan;
+    if (roundPlan == null) return draft;
+    final openProposalIds = roundPlan.openProposals.toSet();
+    return VotingDraftState(
+      choices: {
+        for (final entry in draft.choices.entries)
+          if (openProposalIds.contains(entry.key)) entry.key: entry.value,
+      },
+    );
+  }
+
+  List<int> _proposalIdsForDraftIntents(
+    VotingSessionState session,
+    List<VotingProposalView> proposals,
+  ) {
+    final proposalIds = proposals.map((proposal) => proposal.id).toList();
+    final roundPlan = session.roundPlan;
+    if (roundPlan == null) return proposalIds;
+    final openProposalIds = roundPlan.openProposals.toSet();
+    return [
+      for (final proposalId in proposalIds)
+        if (openProposalIds.contains(proposalId)) proposalId,
+    ];
   }
 
   String _messageFromError(Object error) => friendlyVotingErrorMessage(error);

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -52,6 +52,7 @@ import 'package:zcash_wallet/src/rust/third_party/zcash_voting/wire.dart'
 import 'package:zcash_wallet/src/rust/third_party/zcash_voting/wire.dart'
     as rust_wire;
 import 'package:zcash_wallet/src/services/voting/voting_config_loader.dart';
+import 'package:zcash_wallet/src/services/voting/voting_http.dart';
 import 'package:zcash_wallet/src/services/voting/pir_snapshot_resolver.dart';
 
 import 'round_plan_test_utils.dart';
@@ -977,6 +978,136 @@ void main() {
     },
   );
 
+  testWidgets('status screen shows finalizing step before job completion', (
+    tester,
+  ) async {
+    const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
+    final completedRoundPlan = apiRoundPlan(
+      roundId: _roundId,
+      pendingRecovery: false,
+      nextSteps: const [],
+      openProposals: Uint32List(0),
+      allDecided: true,
+      completedVoteArtifact: true,
+    );
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      overrides: [
+        votingSubmissionJobsProvider.overrideWith(
+          () => _StaticVotingSubmissionJobsNotifier(
+            const VotingSubmissionJobsState(jobKeys: [key]),
+          ),
+        ),
+        votingSubmissionJobProvider(key).overrideWith(
+          () => _StaticVotingSubmissionJobNotifier(
+            key,
+            const VotingSubmissionJobState(
+              key: key,
+              status: VotingSubmissionJobStatus.running,
+              generation: 1,
+            ),
+          ),
+        ),
+        votingSubmissionJobSessionProvider(key).overrideWithValue(
+          AsyncValue.data(
+            VotingSessionState(
+              roundId: _roundId,
+              accountUuid: 'account-1',
+              phase: VotingSessionPhase.done,
+              roundPlan: completedRoundPlan,
+              voteSubmissionCompletedCount: 3,
+              voteSubmissionTotalCount: 3,
+              voteSubmissionProgress: 1,
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _statusHarness(
+          initialLocation: votingStatusRoute(
+            _roundId,
+            accountUuid: 'account-1',
+          ),
+        ),
+      ),
+    );
+    await _pumpUntilFound(tester, find.text('Finalizing submission'));
+
+    expect(find.text('Casting votes and submitting shares'), findsOneWidget);
+    expect(find.text('Finalizing submission'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('submission confirmed route'), findsNothing);
+  });
+
+  testWidgets('status screen ignores stale completed plan for running draft', (
+    tester,
+  ) async {
+    const key = VotingSessionKey(roundId: _roundId, accountUuid: 'account-1');
+    final completedRoundPlan = apiRoundPlan(
+      roundId: _roundId,
+      pendingRecovery: false,
+      nextSteps: const [],
+      openProposals: Uint32List.fromList(const [1]),
+      allDecided: false,
+      completedVoteArtifact: true,
+      completedForDisplay: true,
+    );
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      overrides: [
+        votingSubmissionJobsProvider.overrideWith(
+          () => _StaticVotingSubmissionJobsNotifier(
+            const VotingSubmissionJobsState(jobKeys: [key]),
+          ),
+        ),
+        votingSubmissionJobProvider(key).overrideWith(
+          () => _StaticVotingSubmissionJobNotifier(
+            key,
+            const VotingSubmissionJobState(
+              key: key,
+              status: VotingSubmissionJobStatus.running,
+              generation: 1,
+            ),
+          ),
+        ),
+        votingSubmissionJobSessionProvider(key).overrideWithValue(
+          AsyncValue.data(
+            VotingSessionState(
+              roundId: _roundId,
+              accountUuid: 'account-1',
+              phase: VotingSessionPhase.done,
+              roundPlan: completedRoundPlan,
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _statusHarness(
+          initialLocation: votingStatusRoute(
+            _roundId,
+            accountUuid: 'account-1',
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Casting votes and submitting shares'), findsOneWidget);
+    expect(find.text('Finalizing submission'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+    expect(find.text('submission confirmed route'), findsNothing);
+  });
+
   testWidgets('proposal detail hides View more when description fits', (
     tester,
   ) async {
@@ -1616,7 +1747,8 @@ void main() {
         _proposalJson(1, 'First proposal', ['Yes', 'No']),
         _proposalJson(2, 'Second proposal', ['Aye', 'Nay', 'Abstain']),
       ];
-    final http = FakeVotingHttpClient(
+    final shareId = List.filled(32, '01').join();
+    final http = _GatedShareVotingHttpClient(
       responses: _votingHttpResponses()
         ..['/shielded-vote/v1/round/$_roundId'] = {'round': round}
         ..addAll({
@@ -1659,6 +1791,9 @@ void main() {
             ],
           },
           '/shielded-vote/v1/shares': {'status': 'queued'},
+          '/shielded-vote/v1/share-status/$_roundId/$shareId': {
+            'status': 'confirmed',
+          },
         }),
     );
     final recoveryApi = _MutableVotingRecoveryApi();
@@ -1666,7 +1801,10 @@ void main() {
       http: http,
       accountOverride: _MnemonicAccountNotifier.new,
       recoveryApi: recoveryApi,
-      rust: _VotingStatusRustApi(recoveryApi),
+      rust: _VotingStatusRustApi(
+        recoveryApi,
+        shareTrackingDelaySeconds: BigInt.one,
+      ),
       hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
     );
     addTearDown(container.dispose);
@@ -1677,6 +1815,29 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.text('Confirmed by helper'), findsNothing);
+    await _pumpUntilCondition(
+      tester,
+      () => http.shareRequestStarted.isCompleted,
+    );
+    expect(http.shareRequestStarted.isCompleted, isTrue);
+
+    expect(find.text('submission confirmed route'), findsNothing);
+    expect(
+      http.requests.any(
+        (request) =>
+            request.method == 'POST' &&
+            request.uri.path == '/shielded-vote/v1/shares',
+      ),
+      isTrue,
+    );
+    expect(
+      http.requests.any(
+        (request) => request.uri.path.contains('/share-status/'),
+      ),
+      isFalse,
+    );
+
+    http.allowShareResponse.complete();
     await _pumpUntilFound(tester, find.text('submission confirmed route'));
 
     expect(find.text('submission confirmed route'), findsOne);
@@ -1685,6 +1846,30 @@ void main() {
       findsNothing,
     );
     expect(recoveryApi.ballotIntents, ['1:2:false:0', '2:3:true:null']);
+    expect(
+      http.requests.any(
+        (request) => request.uri.path.contains('/share-status/'),
+      ),
+      isTrue,
+    );
+
+    await tester.pump(const Duration(seconds: 1));
+    for (var i = 0; i < 20; i++) {
+      if (http.requests.any(
+        (request) => request.uri.path.contains('/share-status/'),
+      )) {
+        break;
+      }
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+
+    expect(find.text('submission confirmed route'), findsOne);
+    expect(
+      http.requests.any(
+        (request) => request.uri.path.contains('/share-status/'),
+      ),
+      isTrue,
+    );
   });
 
   testWidgets('hardware status screen scans Keystone signature and submits', (
@@ -2022,6 +2207,17 @@ Future<void> _pumpUntilFound(
   expect(finder, findsWidgets, reason: 'Timed out waiting for $finder.');
 }
 
+Future<void> _pumpUntilCondition(
+  WidgetTester tester,
+  bool Function() condition, {
+  int attempts = 50,
+}) async {
+  for (var i = 0; i < attempts; i++) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (condition()) return;
+  }
+}
+
 ProviderContainer _statusContainer({
   FakeVotingHttpClient? http,
   AccountNotifier Function()? accountOverride,
@@ -2052,53 +2248,52 @@ ProviderContainer _statusContainer({
         VotingConfigLoader(
           httpClient: effectiveHttp,
           sourceUrl: 'https://voting.example/static-voting-config.json',
-          resolveStaticVotingConfig: ({
-            required String source,
-            required List<int> staticBytes,
-          }) async {
-            return 'https://voting.example/dynamic-voting-config.json';
-          },
-          resolveVotingConfig: ({
-            required String source,
-            required List<int> staticBytes,
-            required List<int> dynamicBytes,
-            rust_config.ResolvedVotingConfig? previous,
-          }) async {
-            return rust_config_api.VotingConfigResolution(
-              config: rust_config.ResolvedVotingConfig(
-                sourceFingerprint: 'test-source-fingerprint',
-                trustedKeyFingerprint: 'test-trusted-key-fingerprint',
-                dynamicConfigFingerprint: 'test-dynamic-config-fingerprint',
-                voteServers: [
-                  rust_config.ServiceEndpoint(
-                    url: 'https://voting.example',
-                    label: 'vote-primary',
+          resolveStaticVotingConfig:
+              ({required String source, required List<int> staticBytes}) async {
+                return 'https://voting.example/dynamic-voting-config.json';
+              },
+          resolveVotingConfig:
+              ({
+                required String source,
+                required List<int> staticBytes,
+                required List<int> dynamicBytes,
+                rust_config.ResolvedVotingConfig? previous,
+              }) async {
+                return rust_config_api.VotingConfigResolution(
+                  config: rust_config.ResolvedVotingConfig(
+                    sourceFingerprint: 'test-source-fingerprint',
+                    trustedKeyFingerprint: 'test-trusted-key-fingerprint',
+                    dynamicConfigFingerprint: 'test-dynamic-config-fingerprint',
+                    voteServers: [
+                      rust_config.ServiceEndpoint(
+                        url: 'https://voting.example',
+                        label: 'vote-primary',
+                      ),
+                    ],
+                    pirEndpoints: [
+                      rust_config.ServiceEndpoint(
+                        url: 'https://pir.example',
+                        label: 'pir-primary',
+                      ),
+                    ],
+                    supportedVersions: rust_config.SupportedVersions(
+                      pir: ['2.0'],
+                      voteProtocol: '2.0',
+                      tally: '2.0',
+                      voteServer: '2.0',
+                    ),
+                    authenticatedRounds: [
+                      rust_config.AuthenticatedRound(
+                        roundId: _roundId,
+                        eaPk: Uint8List.fromList([1, 2, 3]),
+                      ),
+                    ],
+                    skippedRoundIds: [],
+                    conditions: [],
                   ),
-                ],
-                pirEndpoints: [
-                  rust_config.ServiceEndpoint(
-                    url: 'https://pir.example',
-                    label: 'pir-primary',
-                  ),
-                ],
-                supportedVersions: rust_config.SupportedVersions(
-                  pir: ['2.0'],
-                  voteProtocol: '2.0',
-                  tally: '2.0',
-                  voteServer: '2.0',
-                ),
-                authenticatedRounds: [
-                  rust_config.AuthenticatedRound(
-                    roundId: _roundId,
-                    eaPk: Uint8List.fromList([1, 2, 3]),
-                  ),
-                ],
-                skippedRoundIds: [],
-                conditions: [],
-              ),
-              switchKind: rust_config.ConfigSwitchKind.initialLoad,
-            );
-          },
+                  switchKind: rust_config.ConfigSwitchKind.initialLoad,
+                );
+              },
         ),
       ),
       votingWalletDbPathProvider.overrideWithValue(() async => 'wallet.db'),
@@ -2353,11 +2548,7 @@ Map<String, Object> _votingHttpResponses() => {
       },
     ],
   },
-  '/shielded-vote/v1/cast-vote': {
-    'tx_hash': 'vote-tx',
-    'code': 0,
-    'log': '',
-  },
+  '/shielded-vote/v1/cast-vote': {'tx_hash': 'vote-tx', 'code': 0, 'log': ''},
   '/shielded-vote/v1/tx/vote-tx': {
     'height': 11,
     'code': 0,
@@ -2373,9 +2564,8 @@ Map<String, Object> _votingHttpResponses() => {
     ],
   },
   '/shielded-vote/v1/shares': {'status': 'queued'},
-  'https://voting.example/shielded-vote/v1/share-status/$_roundId/$_shareIdOne': {
-    'status': 'confirmed',
-  },
+  'https://voting.example/shielded-vote/v1/share-status/$_roundId/$_shareIdOne':
+      {'status': 'confirmed'},
 };
 
 int _tallyRequestCount(FakeVotingHttpClient http, [String? roundId]) {
@@ -2589,6 +2779,12 @@ class _StaticVotingSubmissionJobsNotifier extends VotingSubmissionJobsNotifier {
 
   @override
   VotingSubmissionJobsState build() => _initial;
+
+  @override
+  Future<VotingSessionKey?> start(String roundId, {String? accountUuid}) async {
+    if (_initial.jobKeys.isEmpty) return null;
+    return _initial.jobKeys.first;
+  }
 }
 
 class _ControlledVotingSubmissionJobsNotifier
@@ -2961,10 +3157,15 @@ class _FakeVotingHotkeyStore implements VotingHotkeyStore {
 }
 
 class _VotingStatusRustApi extends _NoopVotingRustApi {
-  _VotingStatusRustApi(this.recoveryApi, {this.bundleCount = 1});
+  _VotingStatusRustApi(
+    this.recoveryApi, {
+    this.bundleCount = 1,
+    this.shareTrackingDelaySeconds,
+  });
 
   final _MutableVotingRecoveryApi recoveryApi;
   final int bundleCount;
+  final BigInt? shareTrackingDelaySeconds;
   final storedKeystoneSignatures = <int, rust_wire.KeystoneSignatureRecord>{};
   int setupDelegationBundleCalls = 0;
   int keystoneDelegationRequestCalls = 0;
@@ -3377,7 +3578,7 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
   Future<BigInt?> nextShareTrackingDelaySeconds({
     required List<rust_frb_types.ShareDelegationRecordView> shares,
     required BigInt nowSeconds,
-  }) async => null;
+  }) async => shareTrackingDelaySeconds;
 
   @override
   Future<String> recoveredVoteShareWireJson({
@@ -3620,6 +3821,32 @@ rust_wire.SignedVoteCommitmentsView _commitments({
       ),
     ],
   );
+}
+
+class _GatedShareVotingHttpClient extends FakeVotingHttpClient {
+  _GatedShareVotingHttpClient({required super.responses});
+
+  final shareRequestStarted = Completer<void>();
+  final allowShareResponse = Completer<void>();
+
+  @override
+  Future<VotingHttpResponse> postJson(
+    Uri uri,
+    Map<String, dynamic> body, {
+    Duration? timeout,
+  }) async {
+    if (uri.path != '/shielded-vote/v1/shares') {
+      return super.postJson(uri, body, timeout: timeout);
+    }
+    requests.add(
+      FakeVotingHttpRequest('POST', uri, body: body, timeout: timeout),
+    );
+    if (!shareRequestStarted.isCompleted) {
+      shareRequestStarted.complete();
+    }
+    await allowShareResponse.future;
+    return jsonResponse({'status': 'queued', 'share_id': '0102'});
+  }
 }
 
 class _RustApiFake implements RustLibApi {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -2470,6 +2470,87 @@ void main() {
     },
   );
 
+  test('submission job clears stale vote progress at start', () async {
+    final rust = FakeVotingRustApi(emitCommitments: true);
+    final readiness = _MutableVotingWalletSyncReadinessChecker(ready: true);
+    final persistence = FakeVotingDraftPersistence();
+    const draftKey = VotingSessionKey(
+      roundId: kRoundId,
+      accountUuid: 'account-1',
+    );
+    final http = FakeVotingHttpClient(
+      responses: votingHttpResponses(
+        roundStatus: roundStatusJson(roundId: kRoundId)
+          ..['proposals'] = [
+            {
+              'id': 7,
+              'title': 'One',
+              'options': [
+                {'index': 0, 'label': 'No'},
+                {'index': 1, 'label': 'Yes'},
+              ],
+            },
+          ],
+      ),
+    );
+    final container = _sessionContainer(
+      http: http,
+      rust: rust,
+      draftPersistence: persistence,
+      walletSyncReadinessChecker: readiness,
+      walletSyncPollInterval: const Duration(milliseconds: 1),
+      txConfirmationPolling: _fastTxConfirmationPolling,
+    );
+    addTearDown(container.dispose);
+
+    final submissionSessionSubscription = container.listen(
+      votingSubmissionSessionProvider(draftKey),
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(submissionSessionSubscription.close);
+
+    await container.read(votingSubmissionSessionProvider(draftKey).future);
+    await container
+        .read(votingSubmissionSessionProvider(draftKey).notifier)
+        .castVotes(
+          draftVotes: [
+            rust_wire.DraftVote(
+              proposalId: 7,
+              choice: 1,
+              numOptions: 2,
+              vcTreePosition: BigInt.zero,
+              singleShare: false,
+            ),
+          ],
+        );
+    final staleSession = container
+        .read(votingSubmissionJobSessionProvider(draftKey))
+        .value!;
+    expect(staleSession.voteSubmissionProgress, 1);
+    expect(staleSession.voteSubmissionCompletedCount, 1);
+
+    readiness.ready = false;
+    container.read(votingDraftProvider(draftKey).notifier).setChoice(7, 1);
+    await Future<void>.delayed(Duration.zero);
+    final key = await container
+        .read(votingSubmissionJobsProvider.notifier)
+        .start(kRoundId, accountUuid: 'account-1');
+    expect(key, draftKey);
+    await _waitForJobSessionPhase(
+      container,
+      draftKey,
+      VotingSessionPhase.waitingForWalletSync,
+    );
+    final resetSession = container
+        .read(votingSubmissionJobSessionProvider(draftKey))
+        .value!;
+
+    expect(resetSession.voteSubmissionProgress, isNull);
+    expect(resetSession.voteSubmissionCompletedCount, 0);
+    expect(resetSession.voteSubmissionTotalCount, 0);
+  });
+
   test('Keystone signing starts after active account reload', () async {
     final rust = FakeVotingRustApi();
     final activeAccountProvider =
@@ -2794,7 +2875,7 @@ void main() {
         );
     final state = container.read(votingSessionProvider(kRoundId)).value!;
 
-    expect(state.phase, VotingSessionPhase.submittingShares);
+    expect(state.phase, VotingSessionPhase.done);
     expect(state.voteProgress.keys.toSet(), {
       const VotingVoteKey(bundleIndex: 0, proposalId: 7),
       const VotingVoteKey(bundleIndex: 1, proposalId: 7),
@@ -2806,6 +2887,21 @@ void main() {
     'vote submission progress displays questions while bundle work advances',
     () async {
       final rust = FakeVotingRustApi(emitCommitments: true, bundleCount: 2);
+      final initialRoundPlan = apiRoundPlan(
+        roundId: kRoundId,
+        pendingRecovery: false,
+        nextSteps: const [],
+        openProposals: Uint32List(0),
+        allDecided: false,
+      );
+      final completedRoundPlan = apiRoundPlan(
+        roundId: kRoundId,
+        pendingRecovery: false,
+        nextSteps: const [],
+        openProposals: Uint32List(0),
+        allDecided: true,
+        completedVoteArtifact: true,
+      );
       final recoveryApi = FakeVotingRecoveryApi(
         state: recoveryState(
           bundleCount: 2,
@@ -2824,6 +2920,11 @@ void main() {
             ),
           ],
         ),
+        roundPlanSequence: [
+          initialRoundPlan,
+          initialRoundPlan,
+          completedRoundPlan,
+        ],
       );
       final container = _sessionContainer(rust: rust, recoveryApi: recoveryApi);
       addTearDown(container.dispose);
@@ -2860,7 +2961,7 @@ void main() {
           );
       final state = container.read(votingSessionProvider(kRoundId)).value!;
 
-      expect(state.phase, VotingSessionPhase.submittingShares);
+      expect(state.phase, VotingSessionPhase.done);
       expect(state.voteSubmissionCompletedCount, 2);
       expect(state.voteSubmissionTotalCount, 2);
       expect(state.voteSubmissionProgress, 1);
@@ -2879,11 +2980,15 @@ void main() {
         containsAll(<double>[0, 0.25, 0.5, 0.75, 1]),
       );
 
-      final submittingShareStates = observed
-          .where((state) => state.phase == VotingSessionPhase.submittingShares)
-          .toList(growable: false);
-      expect(submittingShareStates, hasLength(1));
-      expect(submittingShareStates.single.voteSubmissionCompletedCount, 2);
+      expect(
+        observed.where(
+          (state) =>
+              state.phase == VotingSessionPhase.done &&
+              state.voteSubmissionCompletedCount == 2 &&
+              state.voteSubmissionProgress == 1,
+        ),
+        isNotEmpty,
+      );
     },
   );
 
@@ -2910,130 +3015,6 @@ void main() {
 
     expect((await persistence.load(key)).choices, {8: 0});
   });
-
-  test(
-    'partial vote resume submits persisted drafts not already on chain',
-    () async {
-      final rust = FakeVotingRustApi(emitCommitments: true, bundleCount: 2);
-      final recoveryApi = FakeVotingRecoveryApi(
-        state: recoveryState(
-          bundleCount: 2,
-          delegationTxHashes: [
-            rust_frb_types.DelegationRecoveryView(
-              bundleIndex: 0,
-              phase: VotingWorkflowPhase.submittedDelegation,
-              txHash: 'delegation-0',
-              vanLeafPosition: null,
-            ),
-            rust_frb_types.DelegationRecoveryView(
-              bundleIndex: 1,
-              phase: VotingWorkflowPhase.submittedDelegation,
-              txHash: 'delegation-1',
-              vanLeafPosition: null,
-            ),
-          ],
-          votes: [
-            vote(bundleIndex: 0, proposalId: 7),
-            vote(bundleIndex: 1, proposalId: 7),
-          ],
-          voteTxHashes: [
-            rust_frb_types.VoteRecoveryView(
-              bundleIndex: 0,
-              proposalId: 7,
-              choice: 0,
-              phase: VotingWorkflowPhase.submittedVote,
-              txHash: 'vote-tx-0-7',
-              vcTreePosition: null,
-              hasCommitmentBundle: false,
-            ),
-            rust_frb_types.VoteRecoveryView(
-              bundleIndex: 1,
-              proposalId: 7,
-              choice: 0,
-              phase: VotingWorkflowPhase.submittedVote,
-              txHash: 'vote-tx-1-7',
-              vcTreePosition: null,
-              hasCommitmentBundle: false,
-            ),
-          ],
-          commitmentBundles: [
-            rust_frb_types.RecoverableCommitmentBundle(
-              bundleIndex: 0,
-              proposalId: 7,
-              commitmentBundleJson: commitmentBundleRecoveryJson(proposalId: 7),
-              vcTreePosition: BigInt.from(2),
-            ),
-            rust_frb_types.RecoverableCommitmentBundle(
-              bundleIndex: 1,
-              proposalId: 7,
-              commitmentBundleJson: commitmentBundleRecoveryJson(proposalId: 7),
-              vcTreePosition: BigInt.from(3),
-            ),
-          ],
-        ),
-      );
-      final persistence = FakeVotingDraftPersistence();
-      const draftKey = VotingSessionKey(
-        roundId: kRoundId,
-        accountUuid: 'account-1',
-      );
-      await persistence.save(
-        draftKey,
-        const VotingDraftState(choices: {7: 1, 8: 0, 9: 1}),
-      );
-      final container = _sessionContainer(
-        rust: rust,
-        recoveryApi: recoveryApi,
-        draftPersistence: persistence,
-      );
-      addTearDown(container.dispose);
-
-      await container.read(votingSessionProvider(kRoundId).future);
-      final loadedDraft = await container
-          .read(votingDraftProvider(draftKey).notifier)
-          .ensureLoaded();
-      await container
-          .read(votingSessionProvider(kRoundId).notifier)
-          .castVotes(
-            draftVotes: loadedDraft.toDraftVotes([
-              VotingProposalView(
-                id: 7,
-                title: 'One',
-                description: '',
-                options: [
-                  VotingOptionView(index: 0, label: 'No'),
-                  VotingOptionView(index: 1, label: 'Yes'),
-                ],
-              ),
-              VotingProposalView(
-                id: 8,
-                title: 'Two',
-                description: '',
-                options: [
-                  VotingOptionView(index: 0, label: 'No'),
-                  VotingOptionView(index: 1, label: 'Yes'),
-                ],
-              ),
-              VotingProposalView(
-                id: 9,
-                title: 'Three',
-                description: '',
-                options: [
-                  VotingOptionView(index: 0, label: 'No'),
-                  VotingOptionView(index: 1, label: 'Yes'),
-                ],
-              ),
-            ]),
-          );
-
-      expect(rust.voteCommitmentKeys, ['0:8', '1:8', '0:9', '1:9']);
-      expect((await persistence.load(draftKey)).choices, {7: 1, 8: 0, 9: 1});
-      await container
-          .read(votingSessionProvider(kRoundId).notifier)
-          .submitPendingShares();
-      expect((await persistence.load(draftKey)).choices, isEmpty);
-    },
-  );
 
   test(
     'resume submits interrupted earlier bundle before later proposal casts',
@@ -4725,9 +4706,10 @@ Future<VotingSubmissionJobState> _waitForJobStatus(
     if (state.status == status) return state;
     await Future<void>.delayed(const Duration(milliseconds: 10));
   }
+  final last = container.read(votingSubmissionJobProvider(key));
   fail(
     'Timed out waiting for voting submission job status $status. '
-    'Last state: ${container.read(votingSubmissionJobProvider(key)).status}',
+    'Last status: ${last.status}, error: ${last.errorMessage}',
   );
 }
 
@@ -5644,6 +5626,26 @@ class _GatedVotingWalletSyncReadinessChecker
     if (!firstCheck.isCompleted) firstCheck.complete();
     return VotingWalletSyncReadiness(
       scannedHeight: _ready ? snapshotHeight : snapshotHeight - 1,
+      snapshotHeight: snapshotHeight,
+      chainTipHeight: snapshotHeight,
+    );
+  }
+}
+
+class _MutableVotingWalletSyncReadinessChecker
+    implements VotingWalletSyncReadinessChecker {
+  _MutableVotingWalletSyncReadinessChecker({required this.ready});
+
+  bool ready;
+
+  @override
+  Future<VotingWalletSyncReadiness> check({
+    required String dbPath,
+    required String network,
+    required int snapshotHeight,
+  }) async {
+    return VotingWalletSyncReadiness(
+      scannedHeight: ready ? snapshotHeight : snapshotHeight - 1,
       snapshotHeight: snapshotHeight,
       chainTipHeight: snapshotHeight,
     );


### PR DESCRIPTION
Shows a finalizing step after vote and share submission reaches display-complete state while the background job waits for refresh and recovery checks. The status flow now clears stale vote progress when a job starts, keeps draft choices in password-protected storage, and avoids completing a running job from stale recovery state.

Validation:
- fvm flutter test test/features/voting/voting_status_screen_test.dart test/providers/voting/voting_providers_test.dart --reporter expanded
- fvm flutter analyze
- git diff --check origin/voting-ui...HEAD