### PR TITLE
Improve voting config URL display and copy behavior

### DIFF
--- a/lib/src/features/voting/widgets/voting_config_settings_panel.dart
+++ b/lib/src/features/voting/widgets/voting_config_settings_panel.dart
@@ -5,8 +5,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_copy_feedback.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_text_field.dart';
+import '../../swap/models/swap_address_formatting.dart';
 import '../../../providers/voting/voting_config_provider.dart';
 import '../../../providers/voting/voting_config_source_provider.dart';
 import '../../../providers/voting/voting_rounds_provider.dart';
@@ -454,18 +456,33 @@ class _CurrentSourceText extends StatelessWidget {
     final label = source.isDefault
         ? 'Default'
         : _compactSourceUrl(source.sourceUrl);
-    return Text.rich(
-      TextSpan(
-        text: 'Current: ',
-        children: [
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text.rich(
           TextSpan(
-            text: label,
-            style: TextStyle(color: colors.text.brandCrimson),
+            text: 'Current: ',
+            children: [
+              TextSpan(
+                text: label,
+                style: TextStyle(color: colors.text.brandCrimson),
+              ),
+            ],
+          ),
+          textAlign: TextAlign.center,
+          style: AppTypography.bodyMedium.copyWith(color: colors.text.primary),
+        ),
+        if (source.isDefault) ...[
+          const SizedBox(height: AppSpacing.xxs),
+          Text(
+            source.sourceUrl,
+            textAlign: TextAlign.center,
+            style: AppTypography.labelMedium.copyWith(
+              color: colors.text.secondary,
+            ),
           ),
         ],
-      ),
-      textAlign: TextAlign.center,
-      style: AppTypography.bodyMedium.copyWith(color: colors.text.primary),
+      ],
     );
   }
 }
@@ -532,9 +549,9 @@ class _SourceCard extends StatelessWidget {
                   ),
                   const SizedBox(height: AppSpacing.xxs),
                   Text(
-                    _compactSourceUrl(sourceUrl),
+                    _middleTruncateSourceUrl(sourceUrl),
                     maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
+                    overflow: TextOverflow.clip,
                     style: AppTypography.labelMedium.copyWith(
                       color: colors.text.secondary,
                     ),
@@ -543,6 +560,17 @@ class _SourceCard extends StatelessWidget {
               ),
             ),
             const SizedBox(width: AppSpacing.sm),
+            _SmallIconButton(
+              icon: AppIcons.copy,
+              semanticLabel: 'Copy source URL',
+              onTap: () {
+                copyTextWithToast(
+                  context,
+                  text: sourceUrl,
+                  toastMessage: 'Source URL copied.',
+                );
+              },
+            ),
             if (onEdit != null)
               _SmallIconButton(
                 icon: AppIcons.options,
@@ -874,6 +902,17 @@ String _compactSourceUrl(String raw) {
   } on StaticVotingConfigSourceMalformed {
     return trimmed;
   }
+}
+
+String _middleTruncateSourceUrl(String raw) {
+  final compact = _compactSourceUrl(raw);
+  return compactSwapAddress(
+    compact,
+    maxLength: 56,
+    prefixLength: 28,
+    suffixLength: 25,
+    separator: '...',
+  );
 }
 
 bool _sameSourceUrl(String lhs, String rhs) {

--- a/test/features/voting/voting_config_settings_panel_test.dart
+++ b/test/features/voting/voting_config_settings_panel_test.dart
@@ -1,13 +1,102 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_toast.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/voting/widgets/voting_config_settings_panel.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_config_source_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_submission_guard_provider.dart';
+import 'package:zcash_wallet/src/services/voting/voting_config_loader.dart';
 
 void main() {
+  testWidgets('default source shows current URL', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 720));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await _pumpPanel(tester, store: _FakeVotingConfigSourceStore());
+
+    expect(find.text('Current: Default'), findsOneWidget);
+    expect(find.text(kDefaultStaticVotingConfigSource), findsOneWidget);
+  });
+
+  testWidgets('source entries middle-truncate long URLs', (tester) async {
+    const longUrl =
+        'https://example.com/path/for/voting/config/source/that/is/definitely/very/long/static-voting-config.json'
+        '?checksum=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    final expectedDisplay = _expectedMiddleTruncate(longUrl);
+
+    await tester.binding.setSurfaceSize(const Size(800, 720));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await _pumpPanel(
+      tester,
+      store: _FakeVotingConfigSourceStore(
+        savedSourcesJson: jsonEncode([
+          {'id': 'saved-1', 'name': 'Long Source', 'sourceUrl': longUrl},
+        ]),
+      ),
+    );
+
+    expect(find.text(expectedDisplay), findsOneWidget);
+  });
+
+  testWidgets('copy action copies full source URL', (tester) async {
+    const savedUrl =
+        'https://example.com/path/for/voting/config/source/that/is/definitely/very/long/static-voting-config.json'
+        '?checksum=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    await tester.binding.setSurfaceSize(const Size(800, 720));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    MethodCall? clipboardCall;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          clipboardCall = call;
+        }
+        return null;
+      },
+    );
+    addTearDown(() {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    });
+
+    await _pumpPanel(
+      tester,
+      store: _FakeVotingConfigSourceStore(
+        savedSourcesJson: jsonEncode([
+          {'id': 'saved-copy', 'name': 'Saved Copy', 'sourceUrl': savedUrl},
+        ]),
+      ),
+    );
+
+    await tester.tap(find.bySemanticsLabel('Copy source URL').first);
+    await tester.pump();
+
+    expect(clipboardCall, isNotNull);
+    final clipboardArgs = clipboardCall!.arguments as Map<dynamic, dynamic>;
+    expect(clipboardArgs['text'], kDefaultStaticVotingConfigSource);
+
+    await tester.tap(find.bySemanticsLabel('Copy source URL').at(1));
+    await tester.pump();
+
+    final secondClipboardArgs = clipboardCall!.arguments as Map<dynamic, dynamic>;
+    expect(secondClipboardArgs['text'], savedUrl);
+  });
+
   testWidgets('config source actions are disabled during submission', (
     tester,
   ) async {
@@ -16,26 +105,10 @@ void main() {
       await tester.binding.setSurfaceSize(null);
     });
 
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          votingConfigSourceStoreProvider.overrideWithValue(
-            _FakeVotingConfigSourceStore(),
-          ),
-          votingSubmissionGuardProvider.overrideWith(
-            _GuardedVotingSubmissionGuardNotifier.new,
-          ),
-        ],
-        child: WidgetsApp(
-          color: const Color(0xFFFFFFFF),
-          builder: (context, _) {
-            return AppTheme(
-              data: AppThemeData.light,
-              child: const Center(child: VotingConfigSettingsPanel()),
-            );
-          },
-        ),
-      ),
+    await _pumpPanel(
+      tester,
+      store: _FakeVotingConfigSourceStore(),
+      guarded: true,
     );
     await tester.pumpAndSettle();
 
@@ -54,6 +127,48 @@ void main() {
   });
 }
 
+Future<void> _pumpPanel(
+  WidgetTester tester, {
+  required _FakeVotingConfigSourceStore store,
+  bool guarded = false,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        votingConfigSourceStoreProvider.overrideWithValue(store),
+        if (guarded)
+          votingSubmissionGuardProvider.overrideWith(
+            _GuardedVotingSubmissionGuardNotifier.new,
+          ),
+      ],
+      child: WidgetsApp(
+        color: const Color(0xFFFFFFFF),
+        builder: (context, _) {
+          return AppTheme(
+            data: AppThemeData.light,
+            child: const AppToastHost(
+              child: Center(child: VotingConfigSettingsPanel()),
+            ),
+          );
+        },
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+String _expectedMiddleTruncate(String raw) {
+  final compact = _compactForExpectation(raw);
+  if (compact.length <= 56) return compact;
+  return '${compact.substring(0, 28)}...${compact.substring(compact.length - 25)}';
+}
+
+String _compactForExpectation(String raw) {
+  final uri = Uri.parse(raw);
+  final path = uri.path.replaceFirst(RegExp(r'^/'), '');
+  return path.isEmpty ? uri.host : '${uri.host}/$path';
+}
+
 class _GuardedVotingSubmissionGuardNotifier
     extends VotingSubmissionGuardNotifier {
   @override
@@ -69,7 +184,10 @@ class _GuardedVotingSubmissionGuardNotifier
 }
 
 class _FakeVotingConfigSourceStore implements VotingConfigSourceStore {
+  _FakeVotingConfigSourceStore({this.savedSourcesJson});
+
   String? sourceUrl;
+
   String? savedSourcesJson;
 
   @override


### PR DESCRIPTION
## Summary
- show the active default voting config source URL under `Current: Default`
- middle-truncate long source URLs in voting config entries while keeping full values copyable
- add widget tests for current default URL visibility, truncation behavior, and copy actions

## Test plan
- [x] `flutter test test/features/voting/voting_config_settings_panel_test.dart`
- [x] `flutter analyze lib/src/features/voting/widgets/voting_config_settings_panel.dart test/features/voting/voting_config_settings_panel_test.dart`