### PR TITLE
pr3-retry-failover: isolated voting-ui slice

### DIFF
--- a/lib/src/features/voting/screens/voting_results_screen.dart
+++ b/lib/src/features/voting/screens/voting_results_screen.dart
@@ -31,7 +31,7 @@ final _roundTallyProvider = FutureProvider.autoDispose.family((
   final config = await ref.watch(votingConfigProvider.future);
   config.assertRoundAuthenticated(roundId);
   return ref
-      .read(votingApiClientProvider(config.apiBaseUrl))
+      .read(votingApiClientProvider(config.apiServers))
       .getRoundTally(roundId);
 });
 

--- a/lib/src/providers/voting/voting_config_provider.dart
+++ b/lib/src/providers/voting/voting_config_provider.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../rust/api/voting_config.dart';
 import '../../rust/third_party/zcash_voting/config.dart';
-import '../../services/voting/voting_models.dart';
 import '../../services/voting/voting_retry.dart';
 import 'voting_config_source_provider.dart';
 import 'voting_rounds_provider.dart';
@@ -52,6 +51,7 @@ final votingConfigRefreshFailureProvider =
 class VotingConfigNotifier extends AsyncNotifier<ResolvedVotingConfig> {
   int _loadGeneration = 0;
   ResolvedVotingConfig? _previousResolvedConfig;
+  String? _previousResolvedSourceUrl;
 
   @override
   Future<ResolvedVotingConfig> build() async {
@@ -98,8 +98,13 @@ class VotingConfigNotifier extends AsyncNotifier<ResolvedVotingConfig> {
     } catch (error, stackTrace) {
       if (!_isCurrentLoad(generation)) return;
       _recordRefreshFailure(error: error, stackTrace: stackTrace);
+      final sourceUrl = (await ref.read(
+        votingConfigSourceProvider.future,
+      )).sourceUrl;
       final lastGoodConfig = _previousResolvedConfig;
-      if (_isRetryableRefreshError(error) && lastGoodConfig != null) {
+      final canReuseLastGood =
+          lastGoodConfig != null && _previousResolvedSourceUrl == sourceUrl;
+      if (_isRetryableRefreshError(error) && canReuseLastGood) {
         state = AsyncData(lastGoodConfig);
         return;
       }
@@ -115,19 +120,27 @@ class VotingConfigNotifier extends AsyncNotifier<ResolvedVotingConfig> {
   ///
   /// Returning `null` signals this generation became stale while resolving.
   Future<ResolvedVotingConfig?> _loadAndCommit(int generation) async {
-    await ref.read(votingConfigSourceProvider.future);
+    final sourceState = await ref.read(votingConfigSourceProvider.future);
+    final sourceUrl = sourceState.sourceUrl;
+    final previousForSource = _previousResolvedSourceUrl == sourceUrl
+        ? _previousResolvedConfig
+        : null;
     final resolution = await _loadWithConfigRetry(
       () => ref
           .read(votingConfigLoaderProvider)
-          .load(previous: _previousResolvedConfig),
+          .load(previous: previousForSource),
     );
     if (!_isCurrentLoad(generation)) return null;
-    return _commitResolution(resolution);
+    return _commitResolution(resolution, sourceUrl: sourceUrl);
   }
 
-  ResolvedVotingConfig _commitResolution(VotingConfigResolution resolution) {
+  ResolvedVotingConfig _commitResolution(
+    VotingConfigResolution resolution, {
+    required String sourceUrl,
+  }) {
     _applySwitch(resolution.switchKind);
     _previousResolvedConfig = resolution.config;
+    _previousResolvedSourceUrl = sourceUrl;
     _clearRefreshFailure();
     return resolution.config;
   }

--- a/lib/src/providers/voting/voting_config_provider.dart
+++ b/lib/src/providers/voting/voting_config_provider.dart
@@ -1,11 +1,10 @@
 import 'dart:async';
-import 'dart:io';
-
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../rust/api/voting_config.dart';
 import '../../rust/third_party/zcash_voting/config.dart';
 import '../../services/voting/voting_models.dart';
+import '../../services/voting/voting_retry.dart';
 import 'voting_config_source_provider.dart';
 import 'voting_rounds_provider.dart';
 import 'voting_service_providers.dart';
@@ -205,15 +204,7 @@ class VotingConfigNotifier extends AsyncNotifier<ResolvedVotingConfig> {
   }
 
   bool _isRetryableRefreshError(Object error) {
-    if (error is TimeoutException ||
-        error is SocketException ||
-        error is HttpException) {
-      return true;
-    }
-    if (error is VotingHttpException) {
-      return error.statusCode == 502 || error.statusCode == 503;
-    }
-    return false;
+    return isRetryableVotingError(error);
   }
 }
 

--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -68,7 +68,7 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
 
   Future<List<VotingRoundView>> _load() async {
     final config = await ref.read(votingConfigProvider.future);
-    final api = ref.read(votingApiClientProvider(config.apiBaseUrl));
+    final api = ref.read(votingApiClientProvider(config.apiServers));
 
     final rounds = await api.listRounds();
     final authenticatedRoundIds = config.authenticatedRounds

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -19,10 +19,12 @@ import '../../rust/third_party/zcash_voting/share_policy.dart'
 import '../../rust/third_party/zcash_voting/vote.dart' as rust_vote;
 import '../../rust/third_party/zcash_voting/wire.dart' as rust_voting;
 import '../../services/voting/pir_snapshot_resolver.dart';
+import '../../services/voting/resolved_voting_config_extensions.dart';
 import '../../services/voting/voting_api_client.dart';
 import '../../services/voting/voting_config_loader.dart';
 import '../../services/voting/voting_helper_health_tracker.dart';
 import '../../services/voting/voting_http.dart';
+import '../../services/voting/voting_retry.dart';
 import 'voting_config_source_provider.dart';
 
 /// Transport shared by the voting service clients.
@@ -38,19 +40,91 @@ final votingConfigLoaderProvider = Provider<VotingConfigLoader>((ref) {
   return VotingConfigLoader(
     httpClient: ref.watch(votingHttpClientProvider),
     sourceUrl: source?.sourceUrl,
+    timeout: ref.watch(votingConfigLoaderTimeoutProvider),
   );
 });
 
-/// REST client for chain-facing vote server endpoints.
-final votingApiClientProvider = Provider.family<VotingApiClient, Uri>((
-  ref,
-  baseUrl,
-) {
-  return VotingApiClient(
-    baseUrl: baseUrl,
-    httpClient: ref.watch(votingHttpClientProvider),
+/// Static/dynamic config fetch timeout.
+final votingConfigLoaderTimeoutProvider = Provider<Duration>((ref) {
+  return const Duration(seconds: 10);
+});
+
+/// Timeout for chain-facing vote server endpoints.
+final votingApiRequestTimeoutProvider = Provider<Duration>((ref) {
+  return const Duration(seconds: 10);
+});
+
+/// Timeout for helper share endpoints.
+final votingHelperRequestTimeoutProvider = Provider<Duration>((ref) {
+  return const Duration(seconds: 5);
+});
+
+/// Timeout for PIR `/root` probe requests.
+final votingPirProbeTimeoutProvider = Provider<Duration>((ref) {
+  return const Duration(seconds: 10);
+});
+
+/// Baseline policy for transient voting transport errors.
+final votingTransportRetryPolicyProvider = Provider<VotingRetryPolicy>((ref) {
+  return VotingRetryPolicy.transientHttp(
+    name: 'voting-transport',
+    delays: const [Duration(milliseconds: 300), Duration(seconds: 1)],
   );
 });
+
+/// Retry policy for chain broadcasts (`cast-vote`, `delegate-vote`).
+final votingBroadcastRetryPolicyProvider = Provider<VotingRetryPolicy>((ref) {
+  return VotingRetryPolicy.transientHttp(
+    name: 'voting-broadcast',
+    delays: const [Duration(seconds: 2), Duration(seconds: 4)],
+  );
+});
+
+/// Retry policy for helper share and share-status calls.
+final votingHelperRetryPolicyProvider = Provider<VotingRetryPolicy>((ref) {
+  return VotingRetryPolicy.transientHttp(
+    name: 'voting-helper',
+    delays: const [Duration(milliseconds: 200), Duration(milliseconds: 600)],
+  );
+});
+
+/// Retry policy for PIR endpoint probes.
+final votingPirProbeRetryPolicyProvider = Provider<VotingRetryPolicy>((ref) {
+  return VotingRetryPolicy.transientHttp(
+    name: 'voting-pir-probe',
+    delays: const [Duration.zero],
+  );
+});
+
+/// Retry policy used by voting config refresh/load.
+final votingConfigRetryPolicyProvider = Provider<VotingRetryPolicy>((ref) {
+  return ref.watch(votingTransportRetryPolicyProvider);
+});
+
+/// Retry policy used by rounds list reload.
+final votingRoundsRetryPolicyProvider = Provider<VotingRetryPolicy>((ref) {
+  return ref.watch(votingTransportRetryPolicyProvider);
+});
+
+/// Retry policy for chain reads (rounds/status/tally/tx).
+final votingApiReadRetryPolicyProvider = Provider<VotingRetryPolicy>((ref) {
+  return ref.watch(votingTransportRetryPolicyProvider);
+});
+
+/// REST client for chain-facing vote server endpoints.
+final votingApiClientProvider =
+    Provider.family<VotingApiClient, VotingApiServerSet>((ref, servers) {
+      return VotingApiClient(
+        baseUrl: servers.primary,
+        fallbackBaseUrls: servers.failovers,
+        httpClient: ref.watch(votingHttpClientProvider),
+        timeout: ref.watch(votingApiRequestTimeoutProvider),
+        helperTimeout: ref.watch(votingHelperRequestTimeoutProvider),
+        readRetryPolicy: ref.watch(votingApiReadRetryPolicyProvider),
+        helperRetryPolicy: ref.watch(votingHelperRetryPolicyProvider),
+        broadcastRetryPolicy: ref.watch(votingBroadcastRetryPolicyProvider),
+      );
+    });
 
 /// Tracks helper servers that repeatedly fail so recovery can prefer healthier
 /// endpoints without blocking voting when every helper is degraded.
@@ -62,7 +136,11 @@ final votingHelperHealthTrackerProvider = Provider<VotingHelperHealthTracker>((
 
 /// Resolves PIR endpoints before proof generation.
 final votingPirResolverProvider = Provider<PirSnapshotResolver>((ref) {
-  return PirSnapshotResolver(httpClient: ref.watch(votingHttpClientProvider));
+  return PirSnapshotResolver(
+    httpClient: ref.watch(votingHttpClientProvider),
+    timeout: ref.watch(votingPirProbeTimeoutProvider),
+    retryPolicy: ref.watch(votingPirProbeRetryPolicyProvider),
+  );
 });
 
 /// Adapter over durable Rust recovery/share-tracking state.
@@ -124,6 +202,12 @@ final votingWalletSyncStarterProvider = Provider<void Function()>((ref) {
 /// Delay between contiguous scan readiness checks while waiting to vote.
 final votingWalletSyncPollIntervalProvider = Provider<Duration>((ref) {
   return const Duration(seconds: 2);
+});
+
+/// Upper bound for waiting on wallet scan readiness before surfacing retryable
+/// session error state.
+final votingWalletSyncMaxWaitProvider = Provider<Duration>((ref) {
+  return const Duration(minutes: 3);
 });
 
 /// Checks whether wallet scan progress has reached a voting snapshot height.
@@ -364,8 +448,8 @@ abstract interface class VotingRustApi {
 
   /// Clear process-local Rust voting caches for a round or account.
   ///
-  /// A non-null, non-empty `roundId` clears only prepared delegation PCZTs for
-  /// that round. `null` performs account-wide cleanup, including vote-tree sync
+  /// A non-null, non-empty `roundId` clears vote-tree sync cache for that
+  /// round. `null` (or empty) performs account-wide cleanup of vote-tree sync
   /// state for `accountUuid`.
   Future<void> resetVotingSessionState({
     required String dbPath,

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -806,7 +806,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       );
       var plan = context.resumePlan;
       var roundPlan = context.roundPlan;
-      final api = ref.read(votingApiClientProvider(context.config.apiBaseUrl));
+      final api = ref.read(votingApiClientProvider(context.config.apiServers));
       final rust = ref.read(votingRustApiProvider);
       final effectiveDraftVotes = VotingShareTimingPolicy.applyLastMomentMode(
         draftVotes,
@@ -1383,7 +1383,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required int totalQuestions,
     required double? voteSubmissionProgress,
   }) async {
-    final api = ref.read(votingApiClientProvider(context.config.apiBaseUrl));
+    final api = ref.read(votingApiClientProvider(context.config.apiServers));
     final rust = ref.read(votingRustApiProvider);
     final helperHealth = ref.read(votingHelperHealthTrackerProvider);
     final serverUrls = context.config.voteServers
@@ -1596,7 +1596,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     _VotingSessionContext context,
     rust_wire.SignedVoteCommitmentsView commitments,
   ) async {
-    final api = ref.read(votingApiClientProvider(context.config.apiBaseUrl));
+    final api = ref.read(votingApiClientProvider(context.config.apiServers));
     final rust = ref.read(votingRustApiProvider);
     final vcTreePositions = <int, BigInt>{};
     for (final commitment in commitments.commitments) {
@@ -1686,7 +1686,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required rust_wire.RoundPlanView? roundPlan,
     required Map<int, VotingSessionProgress> progress,
   }) async {
-    final api = ref.read(votingApiClientProvider(context.config.apiBaseUrl));
+    final api = ref.read(votingApiClientProvider(context.config.apiServers));
     final rust = ref.read(votingRustApiProvider);
     final completedBundleIndexes = <int>{};
     final submittedDelegationsByBundle = <int, String>{};
@@ -1749,7 +1749,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required int bundleIndex,
     required rust_wire.SignedDelegationPayloadView submission,
   }) async {
-    final api = ref.read(votingApiClientProvider(context.config.apiBaseUrl));
+    final api = ref.read(votingApiClientProvider(context.config.apiServers));
     final rust = ref.read(votingRustApiProvider);
     final submitTimer = Stopwatch()..start();
     debugPrint(
@@ -1867,7 +1867,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         ),
       );
 
-      final api = ref.read(votingApiClientProvider(context.config.apiBaseUrl));
+      final api = ref.read(votingApiClientProvider(context.config.apiServers));
       final rust = ref.read(votingRustApiProvider);
       final helperHealth = ref.read(votingHelperHealthTrackerProvider);
       final configuredServerUrls = context.config.voteServers
@@ -2475,7 +2475,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     checkAction();
     final config = await ref.read(votingConfigProvider.future);
     config.assertRoundAuthenticated(roundId);
-    final api = ref.read(votingApiClientProvider(config.apiBaseUrl));
+    final api = ref.read(votingApiClientProvider(config.apiServers));
     final round = VotingRoundDetails.fromStatus(
       await api.getRoundStatus(roundId),
     );

--- a/lib/src/providers/voting/voting_tree_sync_provider.dart
+++ b/lib/src/providers/voting/voting_tree_sync_provider.dart
@@ -1,8 +1,8 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/formatting/duration_format.dart';
 import '../../services/voting/resolved_voting_config_extensions.dart';
+import 'voting_debug_print.dart';
 import 'voting_config_provider.dart';
 import 'voting_service_providers.dart';
 
@@ -46,7 +46,8 @@ class VotingTreePreSyncService {
         return;
       }
       final dbPath = await _ref.read(votingWalletDbPathProvider).call();
-      final key = '$dbPath|$accountUuid|${config.apiBaseUrl}|$roundId';
+      final primaryApiServer = config.apiServers.primary;
+      final key = '$dbPath|$accountUuid|$primaryApiServer|$roundId';
       if (_completed.contains(key)) return;
       final existing = _inFlight[key];
       if (existing != null) {
@@ -59,7 +60,7 @@ class VotingTreePreSyncService {
         dbPath: dbPath,
         accountUuid: accountUuid,
         roundId: roundId,
-        nodeUrl: config.apiBaseUrl.toString(),
+        nodeUrl: primaryApiServer.toString(),
       );
       _inFlight[key] = future;
       await future;

--- a/lib/src/providers/voting/voting_tree_sync_provider.dart
+++ b/lib/src/providers/voting/voting_tree_sync_provider.dart
@@ -1,8 +1,8 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/formatting/duration_format.dart';
 import '../../services/voting/resolved_voting_config_extensions.dart';
-import 'voting_debug_print.dart';
 import 'voting_config_provider.dart';
 import 'voting_service_providers.dart';
 

--- a/lib/src/services/voting/pir_snapshot_resolver.dart
+++ b/lib/src/services/voting/pir_snapshot_resolver.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:math' as math;
 
 import 'voting_http.dart';
+import 'voting_models.dart';
 import 'voting_retry.dart';
 
 /// Probe outcome for one configured PIR endpoint.
@@ -142,10 +143,24 @@ class PirSnapshotResolver {
     required int expectedSnapshotHeight,
   }) async {
     try {
+      final rootUri = _rootUri(endpoint);
       final response = await withVotingRetry(
         policy: _retryPolicy,
         delay: _delay,
-        operation: () => _httpClient.get(_rootUri(endpoint), timeout: _timeout),
+        operation: () async {
+          final response = await _httpClient.get(rootUri, timeout: _timeout);
+          if (response.statusCode != 200) {
+            final error = VotingHttpException(
+              uri: rootUri,
+              statusCode: response.statusCode,
+              body: response.bodyText,
+            );
+            if (isRetryableVotingError(error)) {
+              throw error;
+            }
+          }
+          return response;
+        },
       );
       if (response.statusCode != 200) {
         return PirSnapshotEndpointDiagnostic(
@@ -189,6 +204,13 @@ class PirSnapshotResolver {
         endpoint: endpoint,
         status: PirSnapshotEndpointStatus.matched,
         reportedHeight: height,
+      );
+    } on VotingHttpException catch (e) {
+      return PirSnapshotEndpointDiagnostic(
+        endpoint: endpoint,
+        status: PirSnapshotEndpointStatus.nonSuccessStatus,
+        httpStatusCode: e.statusCode,
+        message: e.body,
       );
     } on FormatException catch (e) {
       return PirSnapshotEndpointDiagnostic(

--- a/lib/src/services/voting/pir_snapshot_resolver.dart
+++ b/lib/src/services/voting/pir_snapshot_resolver.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:math' as math;
 
 import 'voting_http.dart';
+import 'voting_retry.dart';
 
 /// Probe outcome for one configured PIR endpoint.
 ///
@@ -80,13 +81,24 @@ class PirSnapshotResolver {
     required VotingHttpClient httpClient,
     math.Random? random,
     Duration timeout = const Duration(seconds: 10),
+    VotingRetryPolicy? retryPolicy,
+    Future<void> Function(Duration delay)? delay,
   }) : _httpClient = httpClient,
        _random = random ?? math.Random.secure(),
-       _timeout = timeout;
+       _timeout = timeout,
+       _retryPolicy =
+           retryPolicy ??
+           VotingRetryPolicy.transientHttp(
+             name: 'voting-pir-probe',
+             delays: const [Duration.zero],
+           ),
+       _delay = delay ?? Future<void>.delayed;
 
   final VotingHttpClient _httpClient;
   final math.Random _random;
   final Duration _timeout;
+  final VotingRetryPolicy _retryPolicy;
+  final Future<void> Function(Duration delay) _delay;
 
   /// Probes all endpoints and randomly selects among exact-height matches.
   ///
@@ -130,9 +142,10 @@ class PirSnapshotResolver {
     required int expectedSnapshotHeight,
   }) async {
     try {
-      final response = await _httpClient.get(
-        _rootUri(endpoint),
-        timeout: _timeout,
+      final response = await withVotingRetry(
+        policy: _retryPolicy,
+        delay: _delay,
+        operation: () => _httpClient.get(_rootUri(endpoint), timeout: _timeout),
       );
       if (response.statusCode != 200) {
         return PirSnapshotEndpointDiagnostic(

--- a/lib/src/services/voting/resolved_voting_config_extensions.dart
+++ b/lib/src/services/voting/resolved_voting_config_extensions.dart
@@ -1,7 +1,53 @@
+import 'package:flutter/foundation.dart';
+
 import '../../rust/third_party/zcash_voting/config.dart';
 
+@immutable
+class VotingApiServerSet {
+  const VotingApiServerSet({required this.primary, required this.failovers});
+
+  final Uri primary;
+  final List<Uri> failovers;
+
+  List<Uri> get all => [primary, ...failovers];
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is VotingApiServerSet &&
+        other.primary == primary &&
+        listEquals(other.failovers, failovers);
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(primary, Object.hashAll(failovers));
+  }
+}
+
 extension ResolvedVotingConfigX on ResolvedVotingConfig {
-  Uri get apiBaseUrl => Uri.parse(voteServers.first.url);
+  VotingApiServerSet get apiServers {
+    if (voteServers.isEmpty) {
+      throw StateError('Resolved voting config has no vote servers.');
+    }
+    final all = <Uri>[];
+    final seen = <String>{};
+    for (final endpoint in voteServers) {
+      final uri = Uri.parse(endpoint.url);
+      final key = uri.toString();
+      if (seen.add(key)) {
+        all.add(uri);
+      }
+    }
+    return VotingApiServerSet(
+      primary: all.first,
+      failovers: all.skip(1).toList(growable: false),
+    );
+  }
+
+  Uri get apiBaseUrl => apiServers.primary;
+
+  List<Uri> get apiFailoverBaseUrls => apiServers.failovers;
 
   Set<String> get authenticatedRoundIdSet =>
       authenticatedRounds.map((round) => round.roundId).toSet();

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -91,11 +91,10 @@ class VotingApiClient {
 
   /// Fetches the currently active round, returning null when the chain has none.
   Future<VotingRoundStatus?> getActiveRoundStatus() async {
-    late final Uri requestUri;
     final response = await _withVoteServerFailover(
       policy: _readRetryPolicy,
       operation: (baseUrl) {
-        requestUri = _endpoint(['rounds', 'active'], baseUrl: baseUrl);
+        final requestUri = _endpoint(['rounds', 'active'], baseUrl: baseUrl);
         return _runRequestWithRetry(
           retryPolicy: _readRetryPolicy,
           operation: () async {
@@ -226,11 +225,10 @@ class VotingApiClient {
   }
 
   Future<VotingTxConfirmation?> getTxConfirmation(String txHash) async {
-    late final Uri requestUri;
     final response = await _withVoteServerFailover(
       policy: _readRetryPolicy,
       operation: (baseUrl) {
-        requestUri = _endpoint(['tx', txHash], baseUrl: baseUrl);
+        final requestUri = _endpoint(['tx', txHash], baseUrl: baseUrl);
         return _runRequestWithRetry(
           retryPolicy: _readRetryPolicy,
           operation: () async {
@@ -244,7 +242,6 @@ class VotingApiClient {
       },
     );
     if (response.statusCode == 404) return null;
-    _throwIfNotSuccess(requestUri, response, allowStatusCodes: const {422});
     return VotingTxConfirmation.fromJson(
       _objectFromValue(jsonDecode(response.bodyText)),
     );

--- a/lib/src/services/voting/voting_api_client.dart
+++ b/lib/src/services/voting/voting_api_client.dart
@@ -7,32 +7,57 @@ import 'voting_models.dart';
 
 /// Minimal REST client for vote-sdk's `/shielded-vote/v1` API surface.
 ///
-/// Chain-facing calls use the configured vote server base URL. Helper-server
-/// share calls take an explicit [serverUrl] because foreground submission and
-/// recovery may target different helper subsets over time.
+/// Chain-facing calls use the configured vote server base URL with optional
+/// failover endpoints. Helper-server share calls take an explicit [serverUrl]
+/// because foreground submission and recovery may target different helper
+/// subsets over time.
 class VotingApiClient {
   VotingApiClient({
     required Uri baseUrl,
     required VotingHttpClient httpClient,
+    List<Uri> fallbackBaseUrls = const [],
     Duration timeout = const Duration(seconds: 10),
     Duration helperTimeout = const Duration(seconds: 5),
-    List<Duration> broadcastRetryDelays = const [
-      Duration(seconds: 2),
-      Duration(seconds: 4),
-    ],
+    VotingRetryPolicy? readRetryPolicy,
+    VotingRetryPolicy? helperRetryPolicy,
+    VotingRetryPolicy? broadcastRetryPolicy,
     Future<void> Function(Duration delay)? delay,
   }) : _baseUrl = baseUrl,
        _httpClient = httpClient,
+       _fallbackBaseUrls = _dedupeBaseUrls(fallbackBaseUrls, baseUrl: baseUrl),
        _timeout = timeout,
        _helperTimeout = helperTimeout,
-       _broadcastRetryDelays = List.unmodifiable(broadcastRetryDelays),
+       _readRetryPolicy =
+           readRetryPolicy ??
+           VotingRetryPolicy.transientHttp(
+             name: 'voting-api-read',
+             delays: const [Duration(milliseconds: 300), Duration(seconds: 1)],
+           ),
+       _helperRetryPolicy =
+           helperRetryPolicy ??
+           VotingRetryPolicy.transientHttp(
+             name: 'voting-api-helper',
+             delays: const [
+               Duration(milliseconds: 200),
+               Duration(milliseconds: 600),
+             ],
+           ),
+       _broadcastRetryPolicy =
+           broadcastRetryPolicy ??
+           VotingRetryPolicy.transientHttp(
+             name: 'voting-api-broadcast',
+             delays: const [Duration(seconds: 2), Duration(seconds: 4)],
+           ),
        _delay = delay ?? Future<void>.delayed;
 
   final Uri _baseUrl;
+  final List<Uri> _fallbackBaseUrls;
   final VotingHttpClient _httpClient;
   final Duration _timeout;
   final Duration _helperTimeout;
-  final List<Duration> _broadcastRetryDelays;
+  final VotingRetryPolicy _readRetryPolicy;
+  final VotingRetryPolicy _helperRetryPolicy;
+  final VotingRetryPolicy _broadcastRetryPolicy;
   final Future<void> Function(Duration delay) _delay;
 
   /// Lists rounds from the vote server.
@@ -40,7 +65,13 @@ class VotingApiClient {
   /// Current vote-sdk returns `{ "rounds": [...] }`. An empty `{}` is accepted
   /// because proto3 JSON omits empty repeated fields.
   Future<List<VotingRoundSummary>> listRounds() async {
-    final decoded = await _getJson(_endpoint(['rounds']));
+    final decoded = await _withVoteServerFailover(
+      policy: _readRetryPolicy,
+      operation: (baseUrl) => _getJson(
+        _endpoint(['rounds'], baseUrl: baseUrl),
+        retryPolicy: _readRetryPolicy,
+      ),
+    );
     final object = _objectFromValue(decoded);
     final values = object['rounds'];
     if (values == null) {
@@ -60,10 +91,24 @@ class VotingApiClient {
 
   /// Fetches the currently active round, returning null when the chain has none.
   Future<VotingRoundStatus?> getActiveRoundStatus() async {
-    final uri = _endpoint(['rounds', 'active']);
-    final response = await _httpClient.get(uri, timeout: _timeout);
+    late final Uri requestUri;
+    final response = await _withVoteServerFailover(
+      policy: _readRetryPolicy,
+      operation: (baseUrl) {
+        requestUri = _endpoint(['rounds', 'active'], baseUrl: baseUrl);
+        return _runRequestWithRetry(
+          retryPolicy: _readRetryPolicy,
+          operation: () async {
+            final response = await _get(requestUri, timeout: _timeout);
+            if (response.statusCode != 404) {
+              _throwIfNotSuccess(requestUri, response);
+            }
+            return response;
+          },
+        );
+      },
+    );
     if (response.statusCode == 404) return null;
-    _throwIfNotSuccess(uri, response);
     final decoded = jsonDecode(response.bodyText);
     final object = _objectFromValue(decoded);
     if (!object.containsKey('round')) {
@@ -77,7 +122,13 @@ class VotingApiClient {
   /// Fetches one round and unwraps the ZODL-style `{ "round": ... }` envelope.
   Future<VotingRoundStatus> getRoundStatus(String roundId) async {
     final normalizedRoundId = normalizeVotingRoundId(roundId);
-    final decoded = await _getJson(_endpoint(['round', normalizedRoundId]));
+    final decoded = await _withVoteServerFailover(
+      policy: _readRetryPolicy,
+      operation: (baseUrl) => _getJson(
+        _endpoint(['round', normalizedRoundId], baseUrl: baseUrl),
+        retryPolicy: _readRetryPolicy,
+      ),
+    );
     final status = VotingRoundStatus.fromJson(
       _requiredNestedObject(decoded, 'round'),
     );
@@ -91,8 +142,12 @@ class VotingApiClient {
 
   Future<VotingRoundTally> getRoundTally(String roundId) async {
     final normalizedRoundId = normalizeVotingRoundId(roundId);
-    final decoded = await _getJson(
-      _endpoint(['tally-results', normalizedRoundId]),
+    final decoded = await _withVoteServerFailover(
+      policy: _readRetryPolicy,
+      operation: (baseUrl) => _getJson(
+        _endpoint(['tally-results', normalizedRoundId], baseUrl: baseUrl),
+        retryPolicy: _readRetryPolicy,
+      ),
     );
     final object = _objectFromValue(decoded);
     _validateTallyResultsEnvelope(object, expectedRoundId: normalizedRoundId);
@@ -107,8 +162,16 @@ class VotingApiClient {
     int proposalId,
   ) async {
     final normalizedRoundId = normalizeVotingRoundId(roundId);
-    final decoded = await _getJson(
-      _endpoint(['tally', normalizedRoundId, proposalId.toString()]),
+    final decoded = await _withVoteServerFailover(
+      policy: _readRetryPolicy,
+      operation: (baseUrl) => _getJson(
+        _endpoint([
+          'tally',
+          normalizedRoundId,
+          proposalId.toString(),
+        ], baseUrl: baseUrl),
+        retryPolicy: _readRetryPolicy,
+      ),
     );
     final tally = VotingRoundTally.fromJson(
       _objectFromValue(decoded),
@@ -126,15 +189,17 @@ class VotingApiClient {
   ///
   /// Deterministic vote-chain rejections are returned as [VotingTxResult] when
   /// the service responds with HTTP 422. Transient gateway or network failures
-  /// are retried according to [_broadcastRetryDelays].
+  /// are retried according to [_broadcastRetryPolicy].
   Future<VotingTxResult> submitDelegation({
     required Map<String, dynamic> submission,
   }) async {
-    final decoded = await _withBroadcastRetry(
-      () => _postJson(
-        _endpoint(['delegate-vote']),
+    final decoded = await _withVoteServerFailover(
+      policy: _broadcastRetryPolicy,
+      operation: (baseUrl) => _postJson(
+        _endpoint(['delegate-vote'], baseUrl: baseUrl),
         submission,
         allowStatusCodes: const {422},
+        retryPolicy: _broadcastRetryPolicy,
       ),
     );
     return VotingTxResult.fromJson(_objectFromValue(decoded));
@@ -144,25 +209,42 @@ class VotingApiClient {
   ///
   /// Deterministic vote-chain rejections are returned as [VotingTxResult] when
   /// the service responds with HTTP 422. Transient gateway or network failures
-  /// are retried according to [_broadcastRetryDelays].
+  /// are retried according to [_broadcastRetryPolicy].
   Future<VotingTxResult> submitVoteCommitment({
     required Map<String, dynamic> commitment,
   }) async {
-    final decoded = await _withBroadcastRetry(
-      () => _postJson(
-        _endpoint(['cast-vote']),
+    final decoded = await _withVoteServerFailover(
+      policy: _broadcastRetryPolicy,
+      operation: (baseUrl) => _postJson(
+        _endpoint(['cast-vote'], baseUrl: baseUrl),
         commitment,
         allowStatusCodes: const {422},
+        retryPolicy: _broadcastRetryPolicy,
       ),
     );
     return VotingTxResult.fromJson(_objectFromValue(decoded));
   }
 
   Future<VotingTxConfirmation?> getTxConfirmation(String txHash) async {
-    final uri = _endpoint(['tx', txHash]);
-    final response = await _httpClient.get(uri, timeout: _timeout);
+    late final Uri requestUri;
+    final response = await _withVoteServerFailover(
+      policy: _readRetryPolicy,
+      operation: (baseUrl) {
+        requestUri = _endpoint(['tx', txHash], baseUrl: baseUrl);
+        return _runRequestWithRetry(
+          retryPolicy: _readRetryPolicy,
+          operation: () async {
+            final response = await _get(requestUri, timeout: _timeout);
+            if (response.statusCode != 404 && response.statusCode != 422) {
+              _throwIfNotSuccess(requestUri, response);
+            }
+            return response;
+          },
+        );
+      },
+    );
     if (response.statusCode == 404) return null;
-    _throwIfNotSuccess(uri, response, allowStatusCodes: const {422});
+    _throwIfNotSuccess(requestUri, response, allowStatusCodes: const {422});
     return VotingTxConfirmation.fromJson(
       _objectFromValue(jsonDecode(response.bodyText)),
     );
@@ -183,6 +265,7 @@ class VotingApiClient {
       _endpoint(['shares'], baseUrl: serverUrl),
       body,
       timeout: _helperTimeout,
+      retryPolicy: _helperRetryPolicy,
     );
     return VotingShareSubmissionResult.fromJson(_objectFromValue(decoded));
   }
@@ -200,6 +283,7 @@ class VotingApiClient {
         shareId,
       ], baseUrl: serverUrl),
       timeout: _helperTimeout,
+      retryPolicy: _helperRetryPolicy,
     );
     return VotingShareStatus.fromJson(_objectFromValue(decoded));
   }
@@ -220,6 +304,7 @@ class VotingApiClient {
       _endpoint(['shares'], baseUrl: serverUrl),
       body,
       timeout: _helperTimeout,
+      retryPolicy: _helperRetryPolicy,
     );
     return VotingShareSubmissionResult.fromJson(_objectFromValue(decoded));
   }
@@ -239,9 +324,19 @@ class VotingApiClient {
     );
   }
 
-  Future<Object?> _getJson(Uri uri, {Duration? timeout}) async {
-    final response = await _httpClient.get(uri, timeout: timeout ?? _timeout);
-    _throwIfNotSuccess(uri, response);
+  Future<Object?> _getJson(
+    Uri uri, {
+    Duration? timeout,
+    VotingRetryPolicy? retryPolicy,
+  }) async {
+    final response = await _runRequestWithRetry(
+      retryPolicy: retryPolicy,
+      operation: () async {
+        final response = await _get(uri, timeout: timeout ?? _timeout);
+        _throwIfNotSuccess(uri, response);
+        return response;
+      },
+    );
     return jsonDecode(response.bodyText);
   }
 
@@ -250,23 +345,63 @@ class VotingApiClient {
     Map<String, dynamic> body, {
     Set<int> allowStatusCodes = const {},
     Duration? timeout,
+    VotingRetryPolicy? retryPolicy,
   }) async {
-    final response = await _httpClient.postJson(
-      uri,
-      body,
-      timeout: timeout ?? _timeout,
+    final response = await _runRequestWithRetry(
+      retryPolicy: retryPolicy,
+      operation: () async {
+        final response = await _post(uri, body, timeout: timeout ?? _timeout);
+        _throwIfNotSuccess(uri, response, allowStatusCodes: allowStatusCodes);
+        return response;
+      },
     );
-    _throwIfNotSuccess(uri, response, allowStatusCodes: allowStatusCodes);
     return jsonDecode(response.bodyText);
   }
 
-  Future<T> _withBroadcastRetry<T>(Future<T> Function() operation) async {
-    return retryVotingOperation(
+  Future<VotingHttpResponse> _get(Uri uri, {required Duration timeout}) {
+    return _httpClient.get(uri, timeout: timeout);
+  }
+
+  Future<VotingHttpResponse> _post(
+    Uri uri,
+    Map<String, dynamic> body, {
+    required Duration timeout,
+  }) {
+    return _httpClient.postJson(uri, body, timeout: timeout);
+  }
+
+  Future<T> _runRequestWithRetry<T>({
+    required Future<T> Function() operation,
+    VotingRetryPolicy? retryPolicy,
+  }) {
+    if (retryPolicy == null) {
+      return operation();
+    }
+    return withVotingRetry(
+      policy: retryPolicy,
       operation: operation,
-      delays: _broadcastRetryDelays,
-      label: 'broadcast',
       delay: _delay,
     );
+  }
+
+  Future<T> _withVoteServerFailover<T>({
+    required VotingRetryPolicy policy,
+    required Future<T> Function(Uri baseUrl) operation,
+  }) async {
+    final candidates = [_baseUrl, ..._fallbackBaseUrls];
+    Object? lastError;
+    for (var attempt = 0; attempt < candidates.length; attempt++) {
+      final baseUrl = candidates[attempt];
+      try {
+        return await operation(baseUrl);
+      } catch (error) {
+        lastError = error;
+        if (attempt == candidates.length - 1 || !policy.shouldRetry(error)) {
+          rethrow;
+        }
+      }
+    }
+    throw StateError('vote-server failover exited unexpectedly: $lastError');
   }
 
   static void _throwIfNotSuccess(
@@ -282,6 +417,20 @@ class VotingApiClient {
         body: response.bodyText,
       );
     }
+  }
+
+  static List<Uri> _dedupeBaseUrls(
+    List<Uri> fallbackBaseUrls, {
+    required Uri baseUrl,
+  }) {
+    final keys = <String>{baseUrl.toString()};
+    final deduped = <Uri>[];
+    for (final uri in fallbackBaseUrls) {
+      if (keys.add(uri.toString())) {
+        deduped.add(uri);
+      }
+    }
+    return List<Uri>.unmodifiable(deduped);
   }
 }
 

--- a/lib/src/services/voting/voting_retry.dart
+++ b/lib/src/services/voting/voting_retry.dart
@@ -3,26 +3,63 @@ import 'dart:io';
 
 import 'voting_models.dart';
 
+class VotingRetryPolicy {
+  const VotingRetryPolicy({
+    required this.name,
+    required this.delays,
+    required bool Function(Object error) shouldRetry,
+  }) : _shouldRetry = shouldRetry;
+
+  factory VotingRetryPolicy.transientHttp({
+    required String name,
+    required List<Duration> delays,
+  }) {
+    return VotingRetryPolicy(
+      name: name,
+      delays: delays,
+      shouldRetry: isRetryableVotingError,
+    );
+  }
+
+  final String name;
+  final List<Duration> delays;
+  final bool Function(Object error) _shouldRetry;
+
+  bool shouldRetry(Object error) => _shouldRetry(error);
+}
+
+Future<T> withVotingRetry<T>({
+  required VotingRetryPolicy policy,
+  required Future<T> Function() operation,
+  Future<void> Function(Duration delay)? delay,
+}) async {
+  final wait = delay ?? Future<void>.delayed;
+  Object? lastError;
+  for (var attempt = 0; attempt <= policy.delays.length; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      if (attempt == policy.delays.length || !policy.shouldRetry(error)) {
+        rethrow;
+      }
+      await wait(policy.delays[attempt]);
+    }
+  }
+  throw StateError('${policy.name} retry exited unexpectedly: $lastError');
+}
+
 Future<T> retryVotingOperation<T>({
   required Future<T> Function() operation,
   required List<Duration> delays,
   required String label,
   Future<void> Function(Duration delay)? delay,
 }) async {
-  final wait = delay ?? Future<void>.delayed;
-  Object? lastError;
-  for (var attempt = 0; attempt <= delays.length; attempt++) {
-    try {
-      return await operation();
-    } catch (error) {
-      lastError = error;
-      if (attempt == delays.length || !isRetryableVotingError(error)) {
-        rethrow;
-      }
-      await wait(delays[attempt]);
-    }
-  }
-  throw StateError('$label retry exited unexpectedly: $lastError');
+  return withVotingRetry(
+    policy: VotingRetryPolicy.transientHttp(name: label, delays: delays),
+    operation: operation,
+    delay: delay,
+  );
 }
 
 bool isRetryableVotingError(Object error) {
@@ -32,7 +69,11 @@ bool isRetryableVotingError(Object error) {
     return true;
   }
   if (error is VotingHttpException) {
-    return error.statusCode == 502 || error.statusCode == 503;
+    return error.statusCode == 429 ||
+        error.statusCode == 500 ||
+        error.statusCode == 502 ||
+        error.statusCode == 503 ||
+        error.statusCode == 504;
   }
   return false;
 }

--- a/test/services/voting/resolved_voting_config_extensions_test.dart
+++ b/test/services/voting/resolved_voting_config_extensions_test.dart
@@ -6,6 +6,35 @@ import 'package:zcash_wallet/src/rust/third_party/zcash_voting/config.dart'
 import 'package:zcash_wallet/src/services/voting/resolved_voting_config_extensions.dart';
 
 void main() {
+  test('apiServers exposes primary and failover vote servers', () {
+    final config = _resolvedConfig(
+      authenticatedRoundIds: const [],
+      voteServerUrls: const [
+        'https://vote-primary.example',
+        'https://vote-secondary.example',
+        'https://vote-secondary.example',
+      ],
+    );
+
+    expect(config.apiBaseUrl, Uri.parse('https://vote-primary.example'));
+    expect(config.apiFailoverBaseUrls, [
+      Uri.parse('https://vote-secondary.example'),
+    ]);
+    expect(config.apiServers.all, [
+      Uri.parse('https://vote-primary.example'),
+      Uri.parse('https://vote-secondary.example'),
+    ]);
+  });
+
+  test('apiServers throws when vote server list is empty', () {
+    final config = _resolvedConfig(
+      authenticatedRoundIds: const [],
+      voteServerUrls: const [],
+    );
+
+    expect(() => config.apiServers, throwsA(isA<StateError>()));
+  });
+
   test('assertRoundAuthenticated accepts authenticated round ids', () {
     final config = _resolvedConfig(
       authenticatedRoundIds: const [
@@ -67,14 +96,20 @@ void main() {
 rust_config.ResolvedVotingConfig _resolvedConfig({
   required List<String> authenticatedRoundIds,
   List<String> skippedRoundIds = const [],
+  List<String> voteServerUrls = const ['https://voting.example'],
 }) {
   return rust_config.ResolvedVotingConfig(
     sourceFingerprint: 'source-fp',
     trustedKeyFingerprint: 'key-fp',
     dynamicConfigFingerprint: 'dynamic-fp',
-    voteServers: const [
-      rust_config.ServiceEndpoint(url: 'https://voting.example', label: 'vote'),
-    ],
+    voteServers: voteServerUrls
+        .map(
+          (url) => rust_config.ServiceEndpoint(
+            url: url,
+            label: 'vote-${Uri.parse(url).host}',
+          ),
+        )
+        .toList(growable: false),
     pirEndpoints: const [
       rust_config.ServiceEndpoint(url: 'https://pir.example', label: 'pir'),
     ],

--- a/test/services/voting/voting_api_client_test.dart
+++ b/test/services/voting/voting_api_client_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/services/voting/voting_api_client.dart';
+import 'package:zcash_wallet/src/services/voting/voting_retry.dart';
 
 import 'fake_voting_http.dart';
 
@@ -497,10 +498,7 @@ void main() {
     final confirmation = await client.getTxConfirmation('delegation-tx');
 
     expect(confirmation?.height, 12);
-    expect(
-      confirmation?.events.single['attributes'].single['value'],
-      '3',
-    );
+    expect(confirmation?.events.single['attributes'].single['value'], '3');
   });
 
   test('rejects malformed transaction confirmation bodies', () async {
@@ -538,7 +536,10 @@ void main() {
     final client = VotingApiClient(
       baseUrl: Uri.parse('https://voting.valargroup.org'),
       httpClient: http,
-      broadcastRetryDelays: const [Duration(milliseconds: 1)],
+      broadcastRetryPolicy: VotingRetryPolicy.transientHttp(
+        name: 'test-broadcast-retry',
+        delays: const [Duration(milliseconds: 1)],
+      ),
       delay: (delay) async => delays.add(delay),
     );
 
@@ -552,6 +553,65 @@ void main() {
       '/shielded-vote/v1/cast-vote',
     ]);
     expect(delays, const [Duration(milliseconds: 1)]);
+  });
+
+  test('retries transient round reads for 500 responses', () async {
+    final delays = <Duration>[];
+    final http = FakeVotingHttpClient(
+      responses: {
+        '/shielded-vote/v1/rounds': SequentialVotingHttpResponses([
+          jsonResponse({'error': 'upstream'}, statusCode: 500),
+          {'rounds': const []},
+        ]),
+      },
+    );
+    final client = VotingApiClient(
+      baseUrl: Uri.parse('https://voting.valargroup.org'),
+      httpClient: http,
+      readRetryPolicy: VotingRetryPolicy.transientHttp(
+        name: 'test-read-retry',
+        delays: const [Duration(milliseconds: 2)],
+      ),
+      delay: (delay) async => delays.add(delay),
+    );
+
+    final rounds = await client.listRounds();
+
+    expect(rounds, isEmpty);
+    expect(http.requests.length, 2);
+    expect(delays, const [Duration(milliseconds: 2)]);
+  });
+
+  test('fails over chain reads to secondary vote server', () async {
+    final primary = Uri.parse('https://vote-primary.example');
+    final secondary = Uri.parse('https://vote-secondary.example');
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://vote-primary.example/shielded-vote/v1/round/$hexRoundId':
+            timeoutResponse(),
+        'https://vote-secondary.example/shielded-vote/v1/round/$hexRoundId': {
+          'round': {'vote_round_id': encodedRoundId, 'status': 'active'},
+        },
+      },
+    );
+    final client = VotingApiClient(
+      baseUrl: primary,
+      fallbackBaseUrls: [secondary],
+      httpClient: http,
+      readRetryPolicy: VotingRetryPolicy.transientHttp(
+        name: 'test-failover-read',
+        delays: const [],
+      ),
+      delay: (_) async {},
+    );
+
+    final status = await client.getRoundStatus(hexRoundId);
+
+    expect(status.roundId, hexRoundId);
+    expect(http.requests.map((request) => request.uri.host), [
+      'vote-primary.example',
+      'vote-secondary.example',
+    ]);
   });
 
   test('rejects malformed successful broadcast responses', () async {
@@ -606,7 +666,10 @@ void main() {
       final client = VotingApiClient(
         baseUrl: Uri.parse('https://voting.valargroup.org'),
         httpClient: http,
-        broadcastRetryDelays: const [Duration.zero],
+        broadcastRetryPolicy: VotingRetryPolicy.transientHttp(
+          name: 'test-delegate-retry',
+          delays: const [Duration.zero],
+        ),
         delay: (_) async {},
       );
 
@@ -646,6 +709,38 @@ void main() {
       'vote_round_id': hexRoundId,
     });
     expect(http.requests.single.timeout, const Duration(seconds: 5));
+  });
+
+  test('retries helper share submission on transient timeout', () async {
+    final delays = <Duration>[];
+    final http = FakeVotingHttpClient(
+      responses: {
+        'https://helper.example/shielded-vote/v1/shares':
+            SequentialVotingHttpResponses([
+              timeoutResponse(),
+              {'status': 'queued'},
+            ]),
+      },
+    );
+    final client = VotingApiClient(
+      baseUrl: Uri.parse('https://voting.valargroup.org'),
+      httpClient: http,
+      helperRetryPolicy: VotingRetryPolicy.transientHttp(
+        name: 'test-helper-retry',
+        delays: const [Duration(milliseconds: 2)],
+      ),
+      delay: (delay) async => delays.add(delay),
+    );
+
+    final result = await client.submitShare(
+      roundId: encodedRoundId,
+      serverUrl: Uri.parse('https://helper.example'),
+      share: {'share_index': 0},
+    );
+
+    expect(result.status, 'queued');
+    expect(http.requests.length, 2);
+    expect(delays, const [Duration(milliseconds: 2)]);
   });
 
   test('helper responses require known status values', () async {

--- a/test/services/voting/voting_retry_test.dart
+++ b/test/services/voting/voting_retry_test.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/services/voting/voting_models.dart';
+import 'package:zcash_wallet/src/services/voting/voting_retry.dart';
+
+void main() {
+  test('retries transient timeout errors and returns success', () async {
+    var attempts = 0;
+    final delays = <Duration>[];
+
+    final result = await withVotingRetry<int>(
+      policy: VotingRetryPolicy.transientHttp(
+        name: 'test-timeout',
+        delays: const [Duration(milliseconds: 1)],
+      ),
+      delay: (delay) async => delays.add(delay),
+      operation: () async {
+        attempts += 1;
+        if (attempts == 1) throw TimeoutException('timed out');
+        return 7;
+      },
+    );
+
+    expect(result, 7);
+    expect(attempts, 2);
+    expect(delays, const [Duration(milliseconds: 1)]);
+  });
+
+  test('retries retryable HTTP status codes', () async {
+    var attempts = 0;
+    final delays = <Duration>[];
+
+    final result = await withVotingRetry<String>(
+      policy: VotingRetryPolicy.transientHttp(
+        name: 'test-http-500',
+        delays: const [Duration(milliseconds: 1)],
+      ),
+      delay: (delay) async => delays.add(delay),
+      operation: () async {
+        attempts += 1;
+        if (attempts == 1) {
+          throw VotingHttpException(
+            uri: Uri.parse('https://vote.example/rounds'),
+            statusCode: 500,
+            body: 'gateway failure',
+          );
+        }
+        return 'ok';
+      },
+    );
+
+    expect(result, 'ok');
+    expect(attempts, 2);
+    expect(delays, const [Duration(milliseconds: 1)]);
+  });
+
+  test('does not retry non-retryable HTTP status codes', () async {
+    var attempts = 0;
+
+    await expectLater(
+      withVotingRetry<void>(
+        policy: VotingRetryPolicy.transientHttp(
+          name: 'test-http-422',
+          delays: const [Duration(milliseconds: 1)],
+        ),
+        operation: () async {
+          attempts += 1;
+          throw VotingHttpException(
+            uri: Uri.parse('https://vote.example/cast'),
+            statusCode: 422,
+            body: 'deterministic rejection',
+          );
+        },
+      ),
+      throwsA(
+        isA<VotingHttpException>().having(
+          (error) => error.statusCode,
+          'statusCode',
+          422,
+        ),
+      ),
+    );
+    expect(attempts, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- Add shared voting retry primitives and centralized transient-error classification used across voting config/service layers.
- Harden vote-server failover by propagating full server sets through voting API call paths instead of single-endpoint wiring.
- Align config refresh retry behavior with the shared policy so transient statuses (including 429/500/502/503/504) retry consistently.
- Fix failover edge cases by removing unsafe `late final` URI reassignment in fallback closures and ensuring PIR transient non-200 responses are retried inside the retry wrapper.

## Test plan
- [x] `flutter test test/services/voting/voting_retry_test.dart`
- [x] `flutter test test/services/voting/voting_api_client_test.dart test/services/voting/pir_snapshot_resolver_test.dart`
- [x] `flutter test test/providers/voting/voting_config_provider_test.dart test/providers/voting/voting_providers_test.dart`
- [x] `flutter analyze lib/src/providers/voting lib/src/services/voting lib/src/features/voting/screens/voting_results_screen.dart`