### PR TITLE
pr4-round-reset-ffi: isolated voting-ui slice

### DIFF
--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -6,6 +6,7 @@ import '../../features/voting/voting_resume_plan.dart';
 import '../../rust/third_party/zcash_voting/wire.dart' as rust_voting;
 import '../../services/voting/voting_api_client.dart';
 import '../../services/voting/voting_models.dart';
+import '../../services/voting/resolved_voting_config_extensions.dart';
 import 'voting_config_provider.dart';
 import 'voting_service_providers.dart';
 import 'voting_state.dart';

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -422,12 +422,13 @@ Future<VanWitness> generateVanWitness({
   anchorHeight: anchorHeight,
 );
 
-/// Clear process-local voting state for a wallet or round.
+/// Clear process-local vote-tree sync state for a wallet or round.
 ///
-/// Passing a non-empty round ID clears round-scoped caches only. Passing `None`
-/// or an empty round ID also drops the cached vote-tree client for the wallet.
-/// This does not abort in-flight proof or vote work already running on worker
-/// threads.
+/// Passing a non-empty round ID clears only that round's cached vote-tree sync
+/// state. Passing `None` or an empty round ID performs account-wide cleanup.
+///
+/// This does not delete durable recovery rows or abort in-flight proof/vote
+/// work already running on worker threads.
 Future<void> resetVotingSessionState({
   required String dbPath,
   required String accountUuid,

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1005,34 +1005,39 @@ pub fn generate_van_witness(
     })
 }
 
-/// Clear process-local voting state for a wallet or round.
+/// Clear process-local vote-tree sync state for a wallet or round.
 ///
-/// Passing a non-empty round ID clears round-scoped caches only. Passing `None`
-/// or an empty round ID also drops the cached vote-tree client for the wallet.
-/// This does not abort in-flight proof or vote work already running on worker
-/// threads.
+/// Passing a non-empty round ID clears only that round's cached vote-tree sync
+/// state by calling `zcash_voting::precompute::reset_vote_tree(db, round_id)`.
+/// Passing `None` or an empty round ID performs account-wide cleanup with
+/// `zcash_voting::precompute::reset_vote_tree(db, "")`.
+///
+/// This does not delete durable recovery rows or abort in-flight proof/vote
+/// work already running on worker threads.
 pub fn reset_voting_session_state(
     db_path: String,
     account_uuid: String,
     round_id: Option<String>,
 ) -> Result<(), String> {
     catch(|| {
-        // Empty/None round_id means clear account-wide cached vote tree state.
-        let account_wide = round_id.as_deref().map(str::is_empty).unwrap_or(true);
-        let tree_count = if account_wide {
-            let db = db::open_voting_db(&db_path, &account_uuid)?;
-            zcash_voting::precompute::reset_vote_tree(&db, "")
-                .map_err(|e| format!("clear_tree_sync_session failed: {e}"))?;
-            1
+        let scoped_round_id = round_id
+            .as_deref()
+            .filter(|id| !id.is_empty())
+            .unwrap_or("");
+        let reset_scope = if scoped_round_id.is_empty() {
+            "account"
         } else {
-            0
+            "round"
         };
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+        zcash_voting::precompute::reset_vote_tree(&db, scoped_round_id)
+            .map_err(|e| format!("reset_vote_tree failed: {e}"))?;
         log::info!(
             "voting: reset process-local session state \
-             (account_uuid={}, round_id={:?}, tree_entries={})",
+             (account_uuid={}, scope={}, round_id={:?})",
             account_uuid,
-            round_id,
-            tree_count
+            reset_scope,
+            round_id
         );
         Ok(())
     })
@@ -1409,8 +1414,8 @@ pub fn resolve_voting_config(
     dynamic_bytes: Vec<u8>,
     previous: Option<ResolvedVotingConfig>,
 ) -> Result<VotingConfigResolution, String> {
-    let resolved_static =
-        config::resolve_static_voting_config(&source, &static_bytes).map_err(|error| error.to_string())?;
+    let resolved_static = config::resolve_static_voting_config(&source, &static_bytes)
+        .map_err(|error| error.to_string())?;
     let next = config::resolve_dynamic_voting_config(
         resolved_static,
         &dynamic_bytes,
@@ -2185,7 +2190,7 @@ mod tests {
     }
 
     #[test]
-    fn reset_voting_session_state_with_round_preserves_tree_sync() {
+    fn reset_voting_session_state_with_round_drops_target_tree_sync() {
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join("voting.sqlite");
         let account_uuid = "wallet-api-round-reset";
@@ -2210,15 +2215,79 @@ mod tests {
         )
         .unwrap();
 
-        let witness = generate_van_witness(
+        let err = generate_van_witness(
             db_path.to_str().unwrap().to_string(),
             account_uuid.to_string(),
             ROUND_ID.to_string(),
             0,
             height,
         )
+        .unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn reset_voting_session_state_with_round_keeps_other_round_tree_sync() {
+        const OTHER_ROUND_ID: &str =
+            "0000000000000000000000000000000000000000000000000000000000000002";
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("voting.sqlite");
+        let account_uuid = "wallet-api-round-scope-reset";
+        let db = db::open_voting_db(db_path.to_str().unwrap(), account_uuid).unwrap();
+        db.init_round(&test_api_round_params(), None).unwrap();
+        let mut other_round_params = test_api_round_params();
+        other_round_params.vote_round_id = OTHER_ROUND_ID.to_string();
+        db.init_round(&other_round_params, None).unwrap();
+        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        db.store_van_position(ROUND_ID, 0, 0).unwrap();
+        db.ensure_bundles(OTHER_ROUND_ID, &[test_note_info(0)])
+            .unwrap();
+        db.store_van_position(OTHER_ROUND_ID, 0, 0).unwrap();
+
+        let server_round_one = start_tree_server(1, vec![fp_one_base64()], 3);
+        let round_one_height = sync_vote_tree(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+            server_round_one,
+        )
         .unwrap();
-        assert_eq!(witness.position, 0);
+
+        let server_round_two = start_tree_server(1, vec![fp_one_base64()], 3);
+        let round_two_height = sync_vote_tree(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            OTHER_ROUND_ID.to_string(),
+            server_round_two,
+        )
+        .unwrap();
+
+        reset_voting_session_state(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            Some(ROUND_ID.to_string()),
+        )
+        .unwrap();
+
+        let round_one_err = generate_van_witness(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            ROUND_ID.to_string(),
+            0,
+            round_one_height,
+        )
+        .unwrap_err();
+        assert!(!round_one_err.is_empty());
+
+        let round_two_witness = generate_van_witness(
+            db_path.to_str().unwrap().to_string(),
+            account_uuid.to_string(),
+            OTHER_ROUND_ID.to_string(),
+            0,
+            round_two_height,
+        )
+        .unwrap();
+        assert_eq!(round_two_witness.position, 0);
     }
 
     #[test]

--- a/rust/src/wallet/voting/README.md
+++ b/rust/src/wallet/voting/README.md
@@ -76,19 +76,18 @@ wallet DB path plus the session account UUID where applicable.
 ### Reset Semantics
 
 `reset_voting_session_state(db_path, account_uuid, round_id)` clears only
-process-local state. It does not delete durable recovery rows, signed artifacts,
-transaction hashes, or share history, and it does not abort in-flight proof or
-vote jobs already running on worker threads.
+process-local vote-tree sync state. It does not delete durable recovery rows,
+signed artifacts, transaction hashes, or share history, and it does not abort
+in-flight proof or vote jobs already running on worker threads.
 
-- A non-empty `round_id` clears round-scoped caches only.
-- `None` or an empty `round_id` is an account-wide reset and additionally drops
-  the cached vote-tree client by calling
-  `zcash_voting::precompute::reset_vote_tree`.
+- A non-empty `round_id` performs round-scoped cleanup via
+  `zcash_voting::precompute::reset_vote_tree(db, round_id)`.
+- `None` or an empty `round_id` is an account-wide reset via
+  `zcash_voting::precompute::reset_vote_tree(db, "")`.
 
 Vote-tree sync and reset are owned by the crate
 (`zcash_voting::precompute::{sync_vote_tree, reset_vote_tree}`); Vizor does not
-maintain its own tree-sync registry. The tree client is account/DB scoped, not
-round scoped, so a round-scoped reset must not drop it.
+maintain its own tree-sync registry.
 
 Account-wide reset runs when switching away from the active account, removing an
 account, resetting the wallet, or locking/signing out. These lifecycle


### PR DESCRIPTION
## Summary
This PR tightens voting session reset semantics so a round-scoped reset only clears round-specific runtime state while preserving wallet/session data needed across rounds.

## Scope
- Align Rust FFI voting reset behavior and docs with round-scoped cache clearing semantics.
- Keep Dart API bindings and provider logic consistent with the updated Rust behavior.
- Add/adjust provider coverage for round-reset session state handling and tree-sync interactions.

## Out of scope
- No new voting flow UX.
- No protocol/config policy changes.
- No broad refactor outside reset-related provider and FFI surfaces.

## Test plan
- [x] Run focused Rust tests for voting reset behavior touched by this PR.
- [x] Run focused Dart/Flutter provider/API tests touched by this PR.
- [x] Verify voting session round reset preserves cross-round state while clearing round-local artifacts.