### PR TITLE
pr6-recovery-surface: isolated voting-ui slice

### DIFF
--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -5,9 +5,7 @@ import '../../features/voting/voting_flow_models.dart';
 import '../../features/voting/voting_resume_plan.dart';
 import '../../rust/third_party/zcash_voting/wire.dart' as rust_voting;
 import '../../services/voting/voting_api_client.dart';
-import '../../services/voting/resolved_voting_config_extensions.dart';
 import '../../services/voting/voting_models.dart';
-import '../../services/voting/voting_retry.dart';
 import 'voting_config_provider.dart';
 import 'voting_service_providers.dart';
 import 'voting_state.dart';
@@ -28,11 +26,6 @@ Future<void> refreshVotingPollList({
 
 /// Provides poll-list rows with explicit, route-driven reloads.
 class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
-  static const _roundsRetryDelays = <Duration>[
-    Duration(milliseconds: 300),
-    Duration(seconds: 1),
-  ];
-
   Future<void>? _reloadFuture;
   bool _reloadQueued = false;
 
@@ -55,7 +48,7 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
       do {
         _reloadQueued = false;
         state = const AsyncLoading<List<VotingRoundView>>();
-        state = await AsyncValue.guard(() => _withRoundsRetry(_load));
+        state = await AsyncValue.guard(_load);
       } while (_reloadQueued);
     }();
     _reloadFuture = run;
@@ -94,6 +87,7 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
           round,
           voted: recoveryStates[round.roundId]?.voted ?? false,
           inProgress: recoveryStates[round.roundId]?.inProgress ?? false,
+          recoveryError: recoveryStates[round.roundId]?.recoveryError ?? false,
         ),
     ];
   }
@@ -124,14 +118,21 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
           accountUuid: accountUuid,
           round: round,
         );
-        if (recoveryState.voted || recoveryState.inProgress) {
+        if (recoveryState.voted ||
+            recoveryState.inProgress ||
+            recoveryState.recoveryError) {
           states[round.roundId] = recoveryState;
         }
       } catch (error) {
         debugPrint(
-          '[zcash] Voting: skipped poll-state lookup for round '
+          '[zcash] Voting: recovery lookup failed for round '
           '${round.roundId}: '
           '$error',
+        );
+        states[round.roundId] = const _RoundListRecoveryState(
+          voted: false,
+          inProgress: true,
+          recoveryError: true,
         );
       }
     }
@@ -148,30 +149,32 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
     final proposalIds = await _proposalIdsForRound(api, round);
     rust_voting.RoundPlanView? roundPlan;
     if (proposalIds.isNotEmpty) {
-      try {
-        roundPlan = await recovery.loadRoundPlan(
-          dbPath: dbPath,
-          accountUuid: accountUuid,
-          roundId: round.roundId,
-          proposalIds: proposalIds,
-        );
-      } catch (error) {
-        debugPrint(
-          '[zcash] Voting: skipped in-progress lookup for round '
-          '${round.roundId}: $error',
-        );
-      }
+      roundPlan = await recovery.loadRoundPlan(
+        dbPath: dbPath,
+        accountUuid: accountUuid,
+        roundId: round.roundId,
+        proposalIds: proposalIds,
+      );
     }
     if (hasBlockingRoundRecoveryWork(roundPlan)) {
-      return const _RoundListRecoveryState(voted: false, inProgress: true);
+      return const _RoundListRecoveryState(
+        voted: false,
+        inProgress: true,
+        recoveryError: false,
+      );
     }
     if (hasCompletedVoteForDisplay(roundPlan)) {
-      return const _RoundListRecoveryState(voted: true, inProgress: false);
+      return const _RoundListRecoveryState(
+        voted: true,
+        inProgress: false,
+        recoveryError: false,
+      );
     }
 
     return _RoundListRecoveryState(
       voted: false,
       inProgress: roundPlan?.pendingRecovery ?? false,
+      recoveryError: false,
     );
   }
 
@@ -204,14 +207,6 @@ class VotingRoundsNotifier extends AsyncNotifier<List<VotingRoundView>> {
       return const [];
     }
   }
-
-  Future<T> _withRoundsRetry<T>(Future<T> Function() operation) async {
-    return retryVotingOperation(
-      operation: operation,
-      delays: _roundsRetryDelays,
-      label: 'round reload',
-    );
-  }
 }
 
 final votingRoundsProvider =
@@ -223,8 +218,10 @@ class _RoundListRecoveryState {
   const _RoundListRecoveryState({
     required this.voted,
     required this.inProgress,
+    required this.recoveryError,
   });
 
   final bool voted;
   final bool inProgress;
+  final bool recoveryError;
 }

--- a/lib/src/providers/voting/voting_state.dart
+++ b/lib/src/providers/voting/voting_state.dart
@@ -17,6 +17,7 @@ class VotingRoundView {
   final String status;
   final bool voted;
   final bool inProgress;
+  final bool recoveryError;
   final Map<String, dynamic> rawJson;
 
   const VotingRoundView({
@@ -25,6 +26,7 @@ class VotingRoundView {
     required this.status,
     this.voted = false,
     this.inProgress = false,
+    this.recoveryError = false,
     this.rawJson = const {},
   });
 
@@ -32,6 +34,7 @@ class VotingRoundView {
     VotingRoundSummary summary, {
     bool voted = false,
     bool inProgress = false,
+    bool recoveryError = false,
   }) {
     return VotingRoundView(
       roundId: summary.roundId,
@@ -39,6 +42,7 @@ class VotingRoundView {
       status: summary.status,
       voted: voted,
       inProgress: inProgress,
+      recoveryError: recoveryError,
       rawJson: summary.rawJson,
     );
   }
@@ -46,6 +50,7 @@ class VotingRoundView {
   VotingRoundView copyWith({
     bool? voted,
     bool? inProgress,
+    bool? recoveryError,
   }) {
     return VotingRoundView(
       roundId: roundId,
@@ -53,6 +58,7 @@ class VotingRoundView {
       status: status,
       voted: voted ?? this.voted,
       inProgress: inProgress ?? this.inProgress,
+      recoveryError: recoveryError ?? this.recoveryError,
       rawJson: rawJson,
     );
   }


### PR DESCRIPTION
## Summary
- Surface per-round recovery lookup failures as a degraded-state signal in the rounds list payload (`recoveryError`) so UI can distinguish round-level recovery issues from fully healthy rounds.
- Keep this slice focused on recovery-state surfacing for PR6.

## Out of scope
- Reload retry/failover behavior is handled in #165 (merged): https://github.com/chainapsis/vizor-wallet/pull/165
- Vote-tree sync failover handling is tracked in #173: https://github.com/chainapsis/vizor-wallet/pull/173

## Test plan
- [ ] Trigger a round-level recovery lookup failure (e.g. transient round/proposal fetch error) and verify the affected round is marked degraded via `recoveryError` in provider output.
- [ ] Verify normal rounds still report expected `voted`/`inProgress` values.
- [ ] Return to voting menu and confirm rounds list refresh path remains stable with current upstream retry/failover behavior from #165.