### PR TITLE
Retry vote-tree sync across failover servers

### DIFF
--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1083,14 +1083,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             'proposal=${draftVote.proposalId}',
           );
           final syncTimer = Stopwatch()..start();
-          final anchorHeight = await ref
-              .read(votingRustApiProvider)
-              .syncVoteTree(
-                dbPath: context.dbPath,
-                accountUuid: context.accountUuid,
-                roundId: context.round.roundId,
-                nodeUrl: context.config.apiBaseUrl.toString(),
-              );
+          final anchorHeight = await _syncVoteTreeWithFailover(
+            context: context,
+            bundleIndex: bundleIndex,
+            proposalId: draftVote.proposalId,
+          );
           debugPrint(
             '[zcash] Voting: vote tree sync completed '
             'round=${context.round.roundId} bundle=$bundleIndex '
@@ -1514,6 +1511,39 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
       }
     }
+  }
+
+  Future<int> _syncVoteTreeWithFailover({
+    required _VotingSessionContext context,
+    required int bundleIndex,
+    required int proposalId,
+  }) async {
+    final nodeUrls = context.config.apiServers.all;
+    Object? lastError;
+    for (var attempt = 0; attempt < nodeUrls.length; attempt++) {
+      final nodeUrl = nodeUrls[attempt];
+      try {
+        return await ref
+            .read(votingRustApiProvider)
+            .syncVoteTree(
+              dbPath: context.dbPath,
+              accountUuid: context.accountUuid,
+              roundId: context.round.roundId,
+              nodeUrl: nodeUrl.toString(),
+            );
+      } catch (error) {
+        lastError = error;
+        if (attempt == nodeUrls.length - 1) {
+          rethrow;
+        }
+        debugPrint(
+          '[zcash] Voting: vote tree sync retrying failover '
+          'round=${context.round.roundId} bundle=$bundleIndex '
+          'proposal=$proposalId from=$nodeUrl error=$error',
+        );
+      }
+    }
+    throw StateError('vote tree sync failover exited unexpectedly: $lastError');
   }
 
   String? _bundleProgressMessage({

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -1519,23 +1519,26 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required int proposalId,
   }) async {
     final nodeUrls = context.config.apiServers.all;
+    final rust = ref.read(votingRustApiProvider);
     Object? lastError;
     for (var attempt = 0; attempt < nodeUrls.length; attempt++) {
       final nodeUrl = nodeUrls[attempt];
       try {
-        return await ref
-            .read(votingRustApiProvider)
-            .syncVoteTree(
-              dbPath: context.dbPath,
-              accountUuid: context.accountUuid,
-              roundId: context.round.roundId,
-              nodeUrl: nodeUrl.toString(),
-            );
+        return await rust.syncVoteTree(
+          dbPath: context.dbPath,
+          accountUuid: context.accountUuid,
+          roundId: context.round.roundId,
+          nodeUrl: nodeUrl.toString(),
+        );
       } catch (error) {
         lastError = error;
         if (attempt == nodeUrls.length - 1) {
           rethrow;
         }
+        await rust.resetVotingSessionState(
+          dbPath: context.dbPath,
+          accountUuid: context.accountUuid,
+        );
         debugPrint(
           '[zcash] Voting: vote tree sync retrying failover '
           'round=${context.round.roundId} bundle=$bundleIndex '

--- a/lib/src/providers/voting/voting_tree_sync_provider.dart
+++ b/lib/src/providers/voting/voting_tree_sync_provider.dart
@@ -46,8 +46,8 @@ class VotingTreePreSyncService {
         return;
       }
       final dbPath = await _ref.read(votingWalletDbPathProvider).call();
-      final primaryApiServer = config.apiServers.primary;
-      final key = '$dbPath|$accountUuid|$primaryApiServer|$roundId';
+      final apiServers = config.apiServers.all;
+      final key = '$dbPath|$accountUuid|${apiServers.join(',')}|$roundId';
       if (_completed.contains(key)) return;
       final existing = _inFlight[key];
       if (existing != null) {
@@ -60,7 +60,7 @@ class VotingTreePreSyncService {
         dbPath: dbPath,
         accountUuid: accountUuid,
         roundId: roundId,
-        nodeUrl: primaryApiServer.toString(),
+        nodeUrls: apiServers,
       );
       _inFlight[key] = future;
       await future;
@@ -77,28 +77,47 @@ class VotingTreePreSyncService {
     required String dbPath,
     required String accountUuid,
     required String roundId,
-    required String nodeUrl,
+    required List<Uri> nodeUrls,
   }) async {
     final timer = Stopwatch()..start();
     debugPrint('[zcash] Voting: vote tree pre-sync start round=$roundId');
+    Object? lastError;
     try {
-      final height = await _ref
-          .read(votingRustApiProvider)
-          .syncVoteTree(
-            dbPath: dbPath,
-            accountUuid: accountUuid,
-            roundId: roundId,
-            nodeUrl: nodeUrl,
+      for (var attempt = 0; attempt < nodeUrls.length; attempt++) {
+        final nodeUrl = nodeUrls[attempt];
+        try {
+          final height = await _ref
+              .read(votingRustApiProvider)
+              .syncVoteTree(
+                dbPath: dbPath,
+                accountUuid: accountUuid,
+                roundId: roundId,
+                nodeUrl: nodeUrl.toString(),
+              );
+          _completed.add(key);
+          debugPrint(
+            '[zcash] Voting: vote tree pre-sync completed '
+            'round=$roundId height=$height nodeUrl=$nodeUrl '
+            'elapsed=${formatElapsedSeconds(timer.elapsed)}',
           );
-      _completed.add(key);
-      debugPrint(
-        '[zcash] Voting: vote tree pre-sync completed '
-        'round=$roundId height=$height elapsed=${formatElapsedSeconds(timer.elapsed)}',
-      );
+          return;
+        } catch (e) {
+          lastError = e;
+          if (attempt < nodeUrls.length - 1) {
+            debugPrint(
+              '[zcash] Voting: vote tree pre-sync retrying failover '
+              'round=$roundId from=$nodeUrl error=$e',
+            );
+            continue;
+          }
+          rethrow;
+        }
+      }
     } catch (e) {
       debugPrint(
         '[zcash] Voting: vote tree pre-sync failed '
-        'round=$roundId elapsed=${formatElapsedSeconds(timer.elapsed)} error=$e',
+        'round=$roundId elapsed=${formatElapsedSeconds(timer.elapsed)} '
+        'error=${lastError ?? e}',
       );
     } finally {
       _inFlight.remove(key);

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3686,6 +3686,7 @@ void main() {
       'https://voting.example',
       'https://voting-failover.example',
     ]);
+    expect(rust.resetVotingSessionStateCalls, ['account-1:*']);
   });
 
   test('vote commitments submit shares and record recovery rows', () async {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3593,6 +3593,32 @@ void main() {
     expect(rust.syncedVoteTrees, [kRoundId]);
   });
 
+  test('vote tree pre-sync retries failover servers', () async {
+    final rust = FakeVotingRustApi(
+      failingVoteTreeNodeUrls: const {'https://voting.example'},
+    );
+    final http = FakeVotingHttpClient(
+      responses: votingHttpResponses(
+        dynamicConfig: dynamicConfigJson(
+          voteServers: const [
+            {'url': 'https://voting.example', 'label': 'primary'},
+            {'url': 'https://voting-failover.example', 'label': 'failover'},
+          ],
+        ),
+      ),
+    );
+    final container = _sessionContainer(http: http, rust: rust);
+    addTearDown(container.dispose);
+
+    final service = container.read(votingTreePreSyncProvider);
+    await service.preSyncRound(kRoundId);
+
+    expect(rust.syncedVoteTreeNodeUrls, [
+      'https://voting.example',
+      'https://voting-failover.example',
+    ]);
+  });
+
   test('vote tree sync runs before each proposal', () async {
     final rust = FakeVotingRustApi();
     final container = _sessionContainer(rust: rust);
@@ -3622,6 +3648,44 @@ void main() {
 
     expect(rust.syncedVoteTrees, [kRoundId, kRoundId]);
     expect(rust.voteCommitBundleCalls, [0, 0]);
+  });
+
+  test('cast-time vote tree sync retries failover servers', () async {
+    final rust = FakeVotingRustApi(
+      failingVoteTreeNodeUrls: const {'https://voting.example'},
+    );
+    final http = FakeVotingHttpClient(
+      responses: votingHttpResponses(
+        dynamicConfig: dynamicConfigJson(
+          voteServers: const [
+            {'url': 'https://voting.example', 'label': 'primary'},
+            {'url': 'https://voting-failover.example', 'label': 'failover'},
+          ],
+        ),
+      ),
+    );
+    final container = _sessionContainer(http: http, rust: rust);
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .castVotes(
+          draftVotes: [
+            rust_wire.DraftVote(
+              proposalId: 7,
+              choice: 1,
+              numOptions: 2,
+              vcTreePosition: BigInt.zero,
+              singleShare: false,
+            ),
+          ],
+        );
+
+    expect(rust.syncedVoteTreeNodeUrls, [
+      'https://voting.example',
+      'https://voting-failover.example',
+    ]);
   });
 
   test('vote commitments submit shares and record recovery rows', () async {
@@ -5671,6 +5735,7 @@ class FakeVotingRustApi implements VotingRustApi {
     this.keystoneDelegationProofGate,
     this.voteCommitmentGate,
     this.onDeleteSkippedBundles,
+    this.failingVoteTreeNodeUrls = const {},
   });
 
   final Duration setupDelay;
@@ -5688,6 +5753,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final Completer<void>? keystoneDelegationProofGate;
   final Completer<void>? voteCommitmentGate;
   final void Function(int keepCount)? onDeleteSkippedBundles;
+  final Set<String> failingVoteTreeNodeUrls;
   int setupCalls = 0;
   int _activeSetups = 0;
   int maxConcurrentSetups = 0;
@@ -5702,6 +5768,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final operationLog = <String>[];
   final recordedShares = <_RecordedShare>[];
   final syncedVoteTrees = <String>[];
+  final syncedVoteTreeNodeUrls = <String>[];
   final precomputedDelegationPir = <int>[];
   final precomputeStoredHotkeySecrets = <List<int>>[];
   final delegationStoredHotkeySecrets = <List<int>>[];
@@ -6069,6 +6136,10 @@ class FakeVotingRustApi implements VotingRustApi {
     required String nodeUrl,
   }) async {
     syncedVoteTrees.add(roundId);
+    syncedVoteTreeNodeUrls.add(nodeUrl);
+    if (failingVoteTreeNodeUrls.contains(nodeUrl)) {
+      throw StateError('syncVoteTree failed for $nodeUrl');
+    }
     return 10;
   }
 


### PR DESCRIPTION
## Summary
- make vote-tree pre-sync try `config.apiServers.all` (primary then failovers) instead of only primary
- make cast-time vote-tree sync use the same failover server order before failing submission
- add focused provider tests for both pre-sync and cast-time failover behavior

## Test plan
- [x] `flutter test test/providers/voting/voting_providers_test.dart --plain-name "vote tree pre-sync dedupes warmup for the same round"`
- [x] `flutter test test/providers/voting/voting_providers_test.dart --plain-name "vote tree pre-sync retries failover servers"`
- [x] `flutter test test/providers/voting/voting_providers_test.dart --plain-name "vote tree sync runs before each proposal"`
- [x] `flutter test test/providers/voting/voting_providers_test.dart --plain-name "cast-time vote tree sync retries failover servers"`