### PR TITLE
Show completed vote UI despite stale local draft

### DIFF
--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -85,9 +85,7 @@ class _VotingProposalDetailScreenState
                 ? const VotingDraftState()
                 : ref.watch(votingDraftProvider(draftKey));
             final proposals = proposalsFromRound(round);
-            final completedVote = draft.isEmpty
-                ? _CompletedVote.fromPlan(state.roundPlan)
-                : null;
+            final completedVote = _CompletedVote.fromPlan(state.roundPlan);
             _maybePrepareVotingPower(state);
             // Foreground recovery takes precedence over the read-only voted view.
             // Accepted helper shares may still be tracked after submission, but

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1193,6 +1193,50 @@ void main() {
     expect(find.text('View more'), findsOneWidget);
   });
 
+  testWidgets('proposal detail shows completed vote with stale local draft', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final recoveryApi = _MutableVotingRecoveryApi()
+      ..roundPlan = apiRoundPlan(
+        roundId: _roundId,
+        pendingRecovery: false,
+        nextSteps: const [],
+        openProposals: Uint32List.fromList(const [1]),
+        allDecided: true,
+        completedVoteArtifact: true,
+        completedForDisplay: true,
+        completedVoteDisplay: rust_wire.CompletedVoteDisplayView(
+          choices: const [
+            rust_wire.CompletedVoteChoiceView(proposalId: 1, choice: 0),
+          ],
+          votedAt: BigInt.from(1717260000),
+        ),
+      );
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _VotingStatusRustApi(recoveryApi),
+    );
+    addTearDown(container.dispose);
+    container.read(votingDraftProvider(_draftKey).notifier).setChoice(1, 0);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Voted'), findsOneWidget);
+    expect(find.text('Review answers'), findsNothing);
+  });
+
   testWidgets('poll stops preparing voting power when setup fails', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
- derive proposal-detail completed vote rendering directly from `roundPlan` completion display data
- remove the `draft.isEmpty` gate that could hide completed receipt UI after stale draft persistence
- add a widget regression test covering completed round plan plus stale local draft

## Test plan
- [x] Ran lints on touched files (`ReadLints`): no errors