### PR TITLE
Fix voting-ui test regressions after resync

### DIFF
--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -5,6 +5,7 @@ import '../../features/voting/voting_flow_models.dart';
 import '../../features/voting/voting_resume_plan.dart';
 import '../../rust/third_party/zcash_voting/wire.dart' as rust_voting;
 import '../../services/voting/voting_api_client.dart';
+import '../../services/voting/resolved_voting_config_extensions.dart';
 import '../../services/voting/voting_models.dart';
 import 'voting_config_provider.dart';
 import 'voting_service_providers.dart';

--- a/test/features/voting/voting_flow_models_test.dart
+++ b/test/features/voting/voting_flow_models_test.dart
@@ -118,6 +118,7 @@ void main() {
 
     persistence.completeLoad(const VotingDraftState(choices: {1: 0, 2: 1}));
     await notifier.ensureLoaded();
+    await persistence.waitForSaveCount(1);
 
     expect(container.read(votingDraftProvider(key)).choices, {
       1: 0,
@@ -146,6 +147,7 @@ void main() {
 
     persistence.completeLoad(const VotingDraftState(choices: {1: 0, 2: 1}));
     await notifier.ensureLoaded();
+    await persistence.waitForSaveCount(1);
 
     expect(container.read(votingDraftProvider(key)).choices, {2: 1});
     expect(persistence.saved.single.choices, {2: 1});
@@ -155,6 +157,7 @@ void main() {
 class _DelayedDraftPersistence implements VotingDraftPersistence {
   final _load = Completer<VotingDraftState>();
   final saved = <VotingDraftState>[];
+  final _saveWaiters = <({int count, Completer<void> waiter})>[];
 
   @override
   Future<VotingDraftState> load(VotingSessionKey key) => _load.future;
@@ -162,9 +165,22 @@ class _DelayedDraftPersistence implements VotingDraftPersistence {
   @override
   Future<void> save(VotingSessionKey key, VotingDraftState draft) async {
     saved.add(draft);
+    for (final entry in _saveWaiters.toList()) {
+      if (saved.length >= entry.count && !entry.waiter.isCompleted) {
+        entry.waiter.complete();
+        _saveWaiters.remove(entry);
+      }
+    }
   }
 
   void completeLoad(VotingDraftState draft) {
     _load.complete(draft);
+  }
+
+  Future<void> waitForSaveCount(int count) {
+    if (saved.length >= count) return Future.value();
+    final waiter = Completer<void>();
+    _saveWaiters.add((count: count, waiter: waiter));
+    return waiter.future;
   }
 }


### PR DESCRIPTION
## Summary
- restore the missing `resolved_voting_config_extensions` import in `voting_rounds_provider` so voting providers compile after syncing with latest `voting-ui`
- make `voting_flow_models_test` deterministic by waiting for async draft persistence writes before asserting saved state
- keep scope limited to non-E2E test/build stability in the isolated worktree sync

## Test plan
- [x] `fvm flutter analyze`
- [x] `fvm flutter test`
- [x] `cargo test` (from `rust/`)
- [ ] E2E tests intentionally not part of this PR