### PR TITLE
Narrow completion-poll timeout fix (clean replacement for #170)

### DIFF
--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -866,11 +866,35 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     required int generation,
   }) {
     _completionPollTimer?.cancel();
-    _completionPollTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+    final timeout = ref.read(votingSubmissionCompletionPollTimeoutProvider);
+    if (timeout <= Duration.zero) {
+      _failJob(
+        key: key,
+        generation: generation,
+        message: _completionPollTimeoutMessage,
+      );
+      return;
+    }
+    final configuredInterval = ref.read(
+      votingSubmissionCompletionPollIntervalProvider,
+    );
+    final pollInterval = configuredInterval > Duration.zero
+        ? configuredInterval
+        : const Duration(milliseconds: 10);
+    final startedAt = DateTime.now();
+    _completionPollTimer = Timer.periodic(pollInterval, (timer) {
       if (!_isCurrentJob(key: key, generation: generation) ||
           !state.isInFlight) {
         timer.cancel();
         if (identical(_completionPollTimer, timer)) _completionPollTimer = null;
+        return;
+      }
+      if (DateTime.now().difference(startedAt) >= timeout) {
+        _failJob(
+          key: key,
+          generation: generation,
+          message: _completionPollTimeoutMessage,
+        );
         return;
       }
       final session = _sessionForJob(key);
@@ -971,6 +995,9 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
   static const _genericVotingStatusErrorMessage =
       'Voting could not continue for this account. Retry, or switch to an '
       'eligible account if this account cannot vote in this poll.';
+  static const _completionPollTimeoutMessage =
+      'Submission confirmation is taking longer than expected. Retry to '
+      'resume confirmation, or dismiss this job and try again later.';
 
   bool _canRecoverWithoutDraft(VotingSessionState session) {
     final roundPlan = session.roundPlan;
@@ -1127,3 +1154,13 @@ final votingSubmissionJobSessionProvider = Provider.autoDispose
     .family<AsyncValue<VotingSessionState>, VotingSessionKey>((ref, key) {
       return ref.watch(votingSubmissionSessionProvider(key));
     });
+
+@visibleForTesting
+final votingSubmissionCompletionPollIntervalProvider = Provider<Duration>(
+  (ref) => const Duration(seconds: 1),
+);
+
+@visibleForTesting
+final votingSubmissionCompletionPollTimeoutProvider = Provider<Duration>(
+  (ref) => const Duration(minutes: 3),
+);

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -2312,6 +2312,67 @@ void main() {
     },
   );
 
+  test('submission completion poll timeout marks job as error', () async {
+    final beforeConfirmation = apiRoundPlan(
+      roundId: kRoundId,
+      pendingRecovery: true,
+      nextSteps: const [
+        rust_wire.NextStepView(
+          kind: 'submit_shares',
+          bundleIndex: 0,
+          proposalId: 7,
+          shareIndex: 0,
+          choice: 0,
+        ),
+      ],
+      openProposals: Uint32List(0),
+      allDecided: false,
+      recoveredDelegationWork: const [],
+    );
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 1,
+        delegationWorkflows: [
+          rust_frb_types.DelegationRecoveryView(
+            bundleIndex: 0,
+            phase: VotingWorkflowPhase.submittedDelegation,
+            txHash: 'delegation-tx',
+            vanLeafPosition: null,
+          ),
+        ],
+      ),
+      roundPlanSequence: [beforeConfirmation],
+    );
+    final container = _sessionContainer(
+      recoveryApi: recoveryApi,
+      txConfirmationPolling: _fastTxConfirmationPolling,
+      submissionCompletionPollTimeout: Duration.zero,
+    );
+    addTearDown(container.dispose);
+
+    final key = await container
+        .read(votingSubmissionJobsProvider.notifier)
+        .start(kRoundId);
+    expect(key, isNotNull);
+
+    final failed = await _waitForJobStatus(
+      container,
+      key!,
+      VotingSubmissionJobStatus.error,
+    );
+
+    expect(
+      failed.errorMessage,
+      contains('Submission confirmation is taking longer than expected'),
+    );
+    expect(
+      container
+          .read(votingSubmissionGuardProvider.notifier)
+          .guardForAccount(key.accountUuid),
+      isNull,
+    );
+  });
+
   test(
     'hardware submission resumes submitted delegation without draft',
     () async {
@@ -4561,6 +4622,8 @@ ProviderContainer _sessionContainer({
   VotingWalletSyncReadinessChecker? walletSyncReadinessChecker,
   void Function()? walletSyncStarter,
   Duration? walletSyncPollInterval,
+  Duration? submissionCompletionPollInterval,
+  Duration? submissionCompletionPollTimeout,
   List<String> authenticatedRoundIds = const [kRoundId, kOtherRoundId],
   Map<String, Uint8List>? authenticatedRoundEaPks,
   List<String> skippedRoundIds = const [],
@@ -4658,6 +4721,14 @@ ProviderContainer _sessionContainer({
       votingWalletSyncPollIntervalProvider.overrideWithValue(
         walletSyncPollInterval ?? Duration.zero,
       ),
+      if (submissionCompletionPollInterval != null)
+        votingSubmissionCompletionPollIntervalProvider.overrideWithValue(
+          submissionCompletionPollInterval,
+        ),
+      if (submissionCompletionPollTimeout != null)
+        votingSubmissionCompletionPollTimeoutProvider.overrideWithValue(
+          submissionCompletionPollTimeout,
+        ),
       if (txConfirmationPolling != null)
         votingTxConfirmationPollingProvider.overrideWithValue(
           txConfirmationPolling,


### PR DESCRIPTION
## Summary
- Re-cuts a minimal, reviewable slice from #170 focused only on submission completion polling reliability.
- Adds bounded completion polling (configurable interval and timeout) to avoid indefinite in-flight jobs.
- Adds focused provider tests for timeout failure behavior and guard release; keeps `dismiss()` semantics unchanged.

## Why this replaces #170
- #170 mixed broader/ambiguous behavior and noisy churn.
- This PR intentionally keeps only the completion-poll timeout/interval behavior with targeted tests.

## Test plan
- [x] `flutter test test/providers/voting/voting_providers_test.dart --plain-name "submission completion poll timeout marks job as error"`
- [x] `flutter test test/providers/voting/voting_providers_test.dart --plain-name "software submission resumes submitted delegation without draft"`