### PR TITLE
Clear voting drafts on account removal

### DIFF
--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -342,6 +342,25 @@ class AppSecureStore {
     );
   }
 
+  /// Deletes plain storage entries whose keys start with [prefix].
+  ///
+  /// Secret values that use the mnemonic or voting hotkey storage helpers should
+  /// keep using their dedicated deletion paths.
+  Future<void> deletePlainKeysWithPrefix(String prefix) async {
+    if (prefix.isEmpty) return;
+    final storedValues = await _runStorageOperation(
+      'read keys with prefix "$prefix"',
+      _storage.readAll,
+    );
+    for (final key in storedValues.keys.toList(growable: false)) {
+      if (!key.startsWith(prefix)) continue;
+      await _runStorageOperation(
+        'delete "$key"',
+        () => _storage.delete(key: key),
+      );
+    }
+  }
+
   Future<bool> isPasswordConfigured() async {
     final verifier = await readPlain(_passwordVerifierKey);
     final salt = await readPlain(_passwordVerifierSaltKey);

--- a/lib/src/features/voting/voting_flow_models.dart
+++ b/lib/src/features/voting/voting_flow_models.dart
@@ -189,6 +189,10 @@ abstract interface class VotingDraftPersistence {
   Future<VotingDraftState> load(VotingSessionKey key);
 
   Future<void> save(VotingSessionKey key, VotingDraftState draft);
+
+  /// Deletes drafts for an account and rejects later saves for that account in
+  /// this process.
+  Future<void> deleteForAccount(String accountUuid);
 }
 
 final votingDraftPersistenceProvider = Provider<VotingDraftPersistence>(
@@ -199,6 +203,8 @@ class SecureVotingDraftPersistence implements VotingDraftPersistence {
   const SecureVotingDraftPersistence();
 
   static const _keyPrefix = 'zcash_voting_draft_votes_';
+  static final _deletedAccountUuids = <String>{};
+  static Future<void> _mutationChain = Future.value();
 
   @override
   Future<VotingDraftState> load(VotingSessionKey key) async {
@@ -219,19 +225,39 @@ class SecureVotingDraftPersistence implements VotingDraftPersistence {
 
   @override
   Future<void> save(VotingSessionKey key, VotingDraftState draft) async {
-    final storageKey = _storageKey(key);
-    if (draft.choices.isEmpty) {
-      await AppSecureStore.instance.delete(storageKey);
-      return;
-    }
-    final encoded = <String, int>{
-      for (final entry in draft.choices.entries) '${entry.key}': entry.value,
-    };
-    await AppSecureStore.instance.writePlain(storageKey, jsonEncode(encoded));
+    await _runMutation(() async {
+      if (_deletedAccountUuids.contains(key.accountUuid)) return;
+      final storageKey = _storageKey(key);
+      if (draft.choices.isEmpty) {
+        await AppSecureStore.instance.delete(storageKey);
+        return;
+      }
+      final encoded = <String, int>{
+        for (final entry in draft.choices.entries) '${entry.key}': entry.value,
+      };
+      await AppSecureStore.instance.writePlain(storageKey, jsonEncode(encoded));
+    });
+  }
+
+  @override
+  Future<void> deleteForAccount(String accountUuid) {
+    return _runMutation(() async {
+      if (accountUuid.isEmpty) return;
+      _deletedAccountUuids.add(accountUuid);
+      await AppSecureStore.instance.deletePlainKeysWithPrefix(
+        '$_keyPrefix$accountUuid|',
+      );
+    });
   }
 
   static String _storageKey(VotingSessionKey key) =>
       '$_keyPrefix${key.accountUuid}|${key.roundId}';
+
+  static Future<void> _runMutation(Future<void> Function() operation) {
+    final next = _mutationChain.then((_) => operation());
+    _mutationChain = next.catchError((_) {});
+    return next;
+  }
 }
 
 List<VotingProposalView> proposalsFromRound(VotingRoundDetails round) {

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -14,6 +14,7 @@ import '../core/profile_pictures.dart';
 import '../core/storage/app_secure_store.dart';
 import '../core/storage/wallet_paths.dart';
 import '../features/swap/providers/swap_activity_store.dart';
+import '../features/voting/voting_flow_models.dart';
 import '../rust/api/voting.dart' as rust_voting;
 import '../rust/api/wallet.dart' as rust_wallet;
 import 'account_models.dart';
@@ -404,6 +405,11 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       await _storage.deleteVotingHotkeysForAccount(uuid);
     } catch (e, st) {
       log('removeAccount: failed to delete voting hotkeys for $uuid: $e\n$st');
+    }
+    try {
+      await ref.read(votingDraftPersistenceProvider).deleteForAccount(uuid);
+    } catch (e, st) {
+      log('removeAccount: failed to delete voting drafts for $uuid: $e\n$st');
     }
 
     final updated = [

--- a/test/features/voting/voting_flow_models_test.dart
+++ b/test/features/voting/voting_flow_models_test.dart
@@ -1,10 +1,17 @@
 import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    FlutterSecureStorage.setMockInitialValues({});
+  });
+
   test('proposal parser preserves explicit service proposal ids', () {
     final proposals = proposalsFromJson({
       'proposals': [
@@ -97,6 +104,45 @@ void main() {
     expect(draft.clearChoice(2).isEmpty, true);
   });
 
+  test('secure draft persistence deletes matching account drafts', () async {
+    const persistence = SecureVotingDraftPersistence();
+    const removedAccountRoundOne = VotingSessionKey(
+      accountUuid: 'account-1',
+      roundId: 'round-1',
+    );
+    const removedAccountRoundTwo = VotingSessionKey(
+      accountUuid: 'account-1',
+      roundId: 'round-2',
+    );
+    const retainedAccountRound = VotingSessionKey(
+      accountUuid: 'account-2',
+      roundId: 'round-1',
+    );
+
+    await persistence.save(
+      removedAccountRoundOne,
+      const VotingDraftState(choices: {1: 0}),
+    );
+    await persistence.save(
+      removedAccountRoundTwo,
+      const VotingDraftState(choices: {2: 1}),
+    );
+    await persistence.save(
+      retainedAccountRound,
+      const VotingDraftState(choices: {3: 0}),
+    );
+
+    await persistence.deleteForAccount('account-1');
+    await persistence.save(
+      removedAccountRoundOne,
+      const VotingDraftState(choices: {4: 1}),
+    );
+
+    expect((await persistence.load(removedAccountRoundOne)).isEmpty, true);
+    expect((await persistence.load(removedAccountRoundTwo)).isEmpty, true);
+    expect((await persistence.load(retainedAccountRound)).choices, {3: 0});
+  });
+
   test('draft notifier merges early edits with persisted choices', () async {
     final key = const VotingSessionKey(
       roundId: 'round-1',
@@ -172,6 +218,9 @@ class _DelayedDraftPersistence implements VotingDraftPersistence {
       }
     }
   }
+
+  @override
+  Future<void> deleteForAccount(String accountUuid) async {}
 
   void completeLoad(VotingDraftState draft) {
     _load.complete(draft);

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -3145,6 +3145,7 @@ class _FakeVotingConfigSourceStore implements VotingConfigSourceStore {
 
 class _MemoryVotingDraftPersistence implements VotingDraftPersistence {
   final _drafts = <VotingSessionKey, VotingDraftState>{};
+  final _deletedAccountUuids = <String>{};
 
   @override
   Future<VotingDraftState> load(VotingSessionKey key) async {
@@ -3153,7 +3154,14 @@ class _MemoryVotingDraftPersistence implements VotingDraftPersistence {
 
   @override
   Future<void> save(VotingSessionKey key, VotingDraftState draft) async {
+    if (_deletedAccountUuids.contains(key.accountUuid)) return;
     _drafts[key] = draft;
+  }
+
+  @override
+  Future<void> deleteForAccount(String accountUuid) async {
+    _deletedAccountUuids.add(accountUuid);
+    _drafts.removeWhere((key, _) => key.accountUuid == accountUuid);
   }
 }
 

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -5417,6 +5417,7 @@ class FakeVotingRecoveryApi implements VotingRecoveryApi {
 
 class FakeVotingDraftPersistence implements VotingDraftPersistence {
   final _stored = <VotingSessionKey, VotingDraftState>{};
+  final _deletedAccountUuids = <String>{};
 
   @override
   Future<VotingDraftState> load(VotingSessionKey key) async {
@@ -5425,11 +5426,18 @@ class FakeVotingDraftPersistence implements VotingDraftPersistence {
 
   @override
   Future<void> save(VotingSessionKey key, VotingDraftState draft) async {
+    if (_deletedAccountUuids.contains(key.accountUuid)) return;
     if (draft.choices.isEmpty) {
       _stored.remove(key);
     } else {
       _stored[key] = VotingDraftState(choices: Map.of(draft.choices));
     }
+  }
+
+  @override
+  Future<void> deleteForAccount(String accountUuid) async {
+    _deletedAccountUuids.add(accountUuid);
+    _stored.removeWhere((key, _) => key.accountUuid == accountUuid);
   }
 }
 


### PR DESCRIPTION
Clear account-scoped voting draft choices when an account is removed, alongside the existing mnemonic, swap activity, and voting hotkey cleanup.

Draft persistence now rejects later saves for a removed account in the current process, so queued draft writes cannot recreate the deleted keys after the cleanup sweep.

Validation:
- fvm flutter test test/features/voting/voting_flow_models_test.dart
- fvm flutter analyze lib/src/core/storage/app_secure_store.dart lib/src/features/voting/voting_flow_models.dart lib/src/providers/account_provider.dart test/features/voting/voting_flow_models_test.dart test/features/voting/voting_status_screen_test.dart test/providers/voting/voting_providers_test.dart
- git diff --check