### PR TITLE
Prewarm voting power before poll detail

### DIFF
--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -15,12 +15,15 @@ import '../../../core/widgets/app_pane_modal_overlay.dart';
 import '../../../core/widgets/app_tooltip.dart';
 import '../../../providers/voting/voting_config_provider.dart';
 import '../../../providers/voting/voting_rounds_provider.dart';
+import '../../../providers/voting/voting_session_provider.dart';
 import '../../../providers/voting/voting_state.dart';
 import '../../../providers/voting/voting_tree_sync_provider.dart';
 import '../voting_poll_ordering.dart';
 import '../voting_routes.dart';
 import '../widgets/voting_config_settings_panel.dart';
 import '../widgets/voting_pane_scroll_area.dart';
+
+const _votingPowerRouteWait = Duration(seconds: 3);
 
 class VotingPollsScreen extends ConsumerStatefulWidget {
   const VotingPollsScreen({super.key});
@@ -33,6 +36,7 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
   bool _showSettings = false;
   bool _entryRefreshInFlight = true;
   bool _pollListRefreshInFlight = false;
+  String? _openingRoundId;
 
   @override
   void initState() {
@@ -101,7 +105,7 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
       );
     }
     final sortedItems = sortVotingRoundsForPollList(items);
-    _preSyncVisibleRoundTrees(sortedItems);
+    _warmVisibleActiveRound(sortedItems);
     return VotingPaneListView.separated(
       maxWidth: 560,
       padding: const EdgeInsets.fromLTRB(
@@ -114,18 +118,30 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
       separatorBuilder: (_, _) => const SizedBox(height: AppSpacing.base),
       itemBuilder: (context, index) {
         final round = sortedItems[index];
-        return _PollCard(round: round, onAction: () => _openRoundAction(round));
+        return _PollCard(
+          round: round,
+          checkingVotingPower: _openingRoundId == round.roundId,
+          onAction: () => _openRoundAction(round),
+        );
       },
     );
   }
 
-  void _preSyncVisibleRoundTrees(Iterable<VotingRoundView> rounds) {
+  void _warmVisibleActiveRound(Iterable<VotingRoundView> rounds) {
+    var warmedTree = false;
+    var warmedPower = false;
     for (final round in rounds) {
-      if (!shouldPreSyncVotingTree(round.status)) continue;
-      unawaited(
-        ref.read(votingTreePreSyncProvider).preSyncRound(round.roundId),
-      );
-      return;
+      if (!warmedTree && shouldPreSyncVotingTree(round.status)) {
+        warmedTree = true;
+        unawaited(
+          ref.read(votingTreePreSyncProvider).preSyncRound(round.roundId),
+        );
+      }
+      if (!warmedPower && _shouldWarmVotingPower(round)) {
+        warmedPower = true;
+        unawaited(_warmVotingPower(round.roundId));
+      }
+      if (warmedTree && warmedPower) return;
     }
   }
 
@@ -135,11 +151,11 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
           .read(votingRoundsProvider.future)
           .then((rounds) {
             if (!mounted) return;
-            _preSyncVisibleRoundTrees(rounds);
+            _warmVisibleActiveRound(rounds);
           })
           .catchError((Object error) {
             debugPrint(
-              '[zcash] Voting: vote tree pre-sync skipped '
+              '[zcash] Voting: active round warm-up skipped '
               'reason=rounds-load-failed error=$error',
             );
           }),
@@ -148,11 +164,15 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
 
   void _openRoundAction(VotingRoundView round) {
     final state = _pollCardState(round);
-    final route =
-        state == _PollCardState.tallying || state == _PollCardState.closed
-        ? votingResultsRoute(round.roundId)
-        : votingPollRoute(round.roundId);
-    _pushRoundRoute(route);
+    if (state == _PollCardState.tallying || state == _PollCardState.closed) {
+      _pushRoundRoute(votingResultsRoute(round.roundId));
+      return;
+    }
+    if (state == _PollCardState.active || state == _PollCardState.voted) {
+      unawaited(_openRoundAfterVotingPower(round.roundId));
+      return;
+    }
+    _pushRoundRoute(votingPollRoute(round.roundId));
   }
 
   void _pushRoundRoute(String route) {
@@ -162,6 +182,48 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
         _reloadRoundsWithFreshConfig();
       }),
     );
+  }
+
+  Future<void> _openRoundAfterVotingPower(String roundId) async {
+    if (_openingRoundId != null) return;
+    setState(() {
+      _openingRoundId = roundId;
+    });
+    await _warmVotingPowerForRoute(roundId);
+    if (!mounted) return;
+    setState(() {
+      _openingRoundId = null;
+    });
+    _pushRoundRoute(votingPollRoute(roundId));
+  }
+
+  Future<void> _warmVotingPower(String roundId) async {
+    try {
+      await ref.read(votingPowerProvider(roundId).future);
+    } catch (e) {
+      debugPrint(
+        '[zcash] Voting: voting power warm-up skipped '
+        'round=$roundId error=$e',
+      );
+    }
+  }
+
+  Future<void> _warmVotingPowerForRoute(String roundId) async {
+    try {
+      await ref
+          .read(votingPowerProvider(roundId).future)
+          .timeout(_votingPowerRouteWait);
+    } on TimeoutException {
+      debugPrint(
+        '[zcash] Voting: voting power warm-up still pending; '
+        'opening poll round=$roundId',
+      );
+    } catch (e) {
+      debugPrint(
+        '[zcash] Voting: voting power warm-up skipped '
+        'round=$roundId error=$e',
+      );
+    }
   }
 
   void _reloadRoundsWithFreshConfig({bool entryRefresh = false}) {
@@ -314,9 +376,14 @@ class _VotingTopBarIconButtonState extends State<_VotingTopBarIconButton> {
 }
 
 class _PollCard extends StatelessWidget {
-  const _PollCard({required this.round, required this.onAction});
+  const _PollCard({
+    required this.round,
+    required this.checkingVotingPower,
+    required this.onAction,
+  });
 
   final VotingRoundView round;
+  final bool checkingVotingPower;
   final VoidCallback onAction;
 
   @override
@@ -392,10 +459,20 @@ class _PollCard extends StatelessWidget {
             Align(
               alignment: Alignment.centerRight,
               child: AppButton(
-                onPressed: onAction,
+                onPressed: checkingVotingPower ? null : onAction,
                 variant: _actionButtonVariant(state),
                 size: AppButtonSize.medium,
-                child: Text(_actionLabel(state)),
+                minWidth: 96,
+                leading: checkingVotingPower
+                    ? const SizedBox(
+                        width: 14,
+                        height: 14,
+                        child: CircularProgressIndicator(strokeWidth: 1.5),
+                      )
+                    : null,
+                child: Text(
+                  checkingVotingPower ? 'Checking' : _actionLabel(state),
+                ),
               ),
             ),
           ],
@@ -583,6 +660,11 @@ AppButtonVariant _actionButtonVariant(_PollCardState state) {
 }
 
 enum _PollCardState { inProgress, active, voted, tallying, closed }
+
+bool _shouldWarmVotingPower(VotingRoundView round) {
+  final state = _pollCardState(round);
+  return state == _PollCardState.active || state == _PollCardState.voted;
+}
 
 _PollCardState _pollCardState(VotingRoundView round) {
   return switch (votingPollListStatus(round.status)) {

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -35,18 +35,12 @@ class VotingProposalDetailScreen extends ConsumerStatefulWidget {
 
 class _VotingProposalDetailScreenState
     extends ConsumerState<VotingProposalDetailScreen> {
-  bool _votingPowerPreparationStarted = false;
-  bool _votingPowerPreparationInFlight = false;
-  String? _votingPowerPreparationKey;
   String? _delegationPirPrecomputeKey;
 
   @override
   void didUpdateWidget(covariant VotingProposalDetailScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.roundId != widget.roundId) {
-      _votingPowerPreparationStarted = false;
-      _votingPowerPreparationInFlight = false;
-      _votingPowerPreparationKey = null;
       _delegationPirPrecomputeKey = null;
     }
   }
@@ -86,7 +80,6 @@ class _VotingProposalDetailScreenState
                 : ref.watch(votingDraftProvider(draftKey));
             final proposals = proposalsFromRound(round);
             final completedVote = _CompletedVote.fromPlan(state.roundPlan);
-            _maybePrepareVotingPower(state);
             // Foreground recovery takes precedence over the read-only voted view.
             // Accepted helper shares may still be tracked after submission, but
             // that background work should not keep this screen resumable.
@@ -105,6 +98,7 @@ class _VotingProposalDetailScreenState
               );
             }
             if (completedVote != null) {
+              final votingPower = _votingPowerFor(state);
               return Padding(
                 padding: const EdgeInsets.all(AppSpacing.md),
                 child: _VotedPollContent(
@@ -113,8 +107,8 @@ class _VotingProposalDetailScreenState
                       : round.title,
                   snapshotHeight: round.snapshotHeight,
                   description: _roundDescription(round.rawJson),
-                  votingPowerZatoshi: state.eligibleWeightZatoshi,
-                  votingPowerPreparing: _votingPowerPreparationInFlight,
+                  votingPowerZatoshi: votingPower.zatoshi,
+                  votingPowerPreparing: votingPower.preparing,
                   votedAt: completedVote.votedAt,
                   proposals: proposals,
                   choicesByProposalId: completedVote.choicesByProposalId,
@@ -136,15 +130,18 @@ class _VotingProposalDetailScreenState
                 ),
               );
             }
-            _maybePrecomputeDelegationPir(state);
+            final votingPower = _votingPowerFor(state);
+            if (votingPower.zatoshi != null) {
+              _maybePrecomputeDelegationPir(state);
+            }
             return _ActivePollContent(
               roundId: roundId,
               title: round.title.isEmpty ? 'Coinholder poll' : round.title,
               snapshotHeight: round.snapshotHeight,
               description: _roundDescription(round.rawJson),
               endDate: _roundEndDate(round.rawJson),
-              votingPowerZatoshi: state.eligibleWeightZatoshi,
-              votingPowerPreparing: _votingPowerPreparationInFlight,
+              votingPowerZatoshi: votingPower.zatoshi,
+              votingPowerPreparing: votingPower.preparing,
               proposals: proposals,
               draft: draft,
               onChoice: draftKey == null
@@ -166,36 +163,19 @@ class _VotingProposalDetailScreenState
     );
   }
 
-  void _maybePrepareVotingPower(VotingSessionState state) {
-    final preparationKey = '${widget.roundId}|${state.accountUuid ?? ''}';
-    if (_votingPowerPreparationKey != preparationKey) {
-      _votingPowerPreparationKey = preparationKey;
-      _votingPowerPreparationStarted = false;
-      _votingPowerPreparationInFlight = false;
+  _VotingPowerView _votingPowerFor(VotingSessionState state) {
+    final sessionPower = state.eligibleWeightZatoshi;
+    if (sessionPower != null) {
+      return _VotingPowerView(zatoshi: sessionPower, preparing: false);
     }
-
-    if (_votingPowerPreparationStarted ||
-        state.eligibleWeightZatoshi != null ||
-        !_shouldPrepareVotingPower(state)) {
-      return;
+    if (!_shouldPrepareVotingPower(state)) {
+      return const _VotingPowerView(zatoshi: null, preparing: false);
     }
-
-    _votingPowerPreparationStarted = true;
-    _votingPowerPreparationInFlight = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      unawaited(
-        ref
-            .read(votingSessionProvider(widget.roundId).notifier)
-            .prepareDelegation()
-            .whenComplete(() {
-              if (!mounted) return;
-              setState(() {
-                _votingPowerPreparationInFlight = false;
-              });
-            }),
-      );
-    });
+    final votingPower = ref.watch(votingPowerProvider(widget.roundId));
+    return _VotingPowerView(
+      zatoshi: votingPower.asData?.value.eligibleWeightZatoshi,
+      preparing: votingPower.isLoading,
+    );
   }
 
   // Warm the delegation PIR / padded-note secrets as soon as the round page
@@ -237,6 +217,13 @@ bool _shouldPrepareVotingPower(VotingSessionState state) {
     VotingSessionPhase.done => true,
     _ => false,
   };
+}
+
+class _VotingPowerView {
+  const _VotingPowerView({required this.zatoshi, required this.preparing});
+
+  final BigInt? zatoshi;
+  final bool preparing;
 }
 
 class _ActivePollContent extends StatefulWidget {

--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -7,7 +7,6 @@ import '../../rust/third_party/zcash_voting/wire.dart' as rust_voting;
 import '../../services/voting/voting_api_client.dart';
 import '../../services/voting/resolved_voting_config_extensions.dart';
 import '../../services/voting/voting_models.dart';
-import '../../services/voting/resolved_voting_config_extensions.dart';
 import 'voting_config_provider.dart';
 import 'voting_service_providers.dart';
 import 'voting_state.dart';

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -53,15 +53,13 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   rust_api.ApiVotingRoundContext _apiRoundContext(
     _VotingSessionContext context,
   ) {
-    return rust_api.ApiVotingRoundContext(
+    return _apiVotingRoundContext(
       dbPath: context.dbPath,
       lightwalletdUrl: context.lightwalletdUrl,
       network: context.network,
       roundParams: context.roundParams,
-      roundName: context.round.title,
-      sessionJson: context.round.sessionJson,
+      round: context.round,
       accountUuid: context.accountUuid,
-      maxRealNotesPerBundle: null,
     );
   }
 
@@ -3130,8 +3128,30 @@ class _VotingSessionContext {
   });
 }
 
+class _VotingPowerContext {
+  const _VotingPowerContext({
+    required this.dbPath,
+    required this.accountUuid,
+    required this.network,
+    required this.lightwalletdUrl,
+    required this.round,
+    required this.roundParams,
+  });
+
+  final String dbPath;
+  final String accountUuid;
+  final String network;
+  final String lightwalletdUrl;
+  final VotingRoundDetails round;
+  final rust_wire.VotingRoundParams roundParams;
+}
+
 class _StaleVotingSessionAction implements Exception {
   const _StaleVotingSessionAction();
+}
+
+class _StaleVotingPowerRequest implements Exception {
+  const _StaleVotingPowerRequest();
 }
 
 class VotingSubmissionSessionNotifier extends VotingSessionNotifier {
@@ -3157,12 +3177,158 @@ final votingSessionProvider =
       String
     >(VotingSessionNotifier.new);
 
+final votingPowerProvider = FutureProvider.family<VotingPowerState, String>((
+  ref,
+  roundId,
+) async {
+  final disposed = Completer<void>();
+  ref.onDispose(() {
+    if (!disposed.isCompleted) disposed.complete();
+  });
+
+  void throwIfDisposed() {
+    if (disposed.isCompleted) throw const _StaleVotingPowerRequest();
+  }
+
+  final activeAccountUuidLoader = ref.watch(votingActiveAccountUuidProvider);
+  final dbPathLoader = ref.watch(votingWalletDbPathProvider);
+  final endpoint = ref.watch(votingRpcEndpointConfigProvider);
+  final readinessChecker = ref.watch(votingWalletSyncReadinessCheckerProvider);
+  final syncStarter = ref.watch(votingWalletSyncStarterProvider);
+  final pollInterval = ref.watch(votingWalletSyncPollIntervalProvider);
+  final rust = ref.watch(votingRustApiProvider);
+  final config = await ref.watch(votingConfigProvider.future);
+  throwIfDisposed();
+
+  config.assertRoundAuthenticated(roundId);
+  final api = ref.read(votingApiClientProvider(config.apiServers));
+  final round = VotingRoundDetails.fromStatus(
+    await api.getRoundStatus(roundId),
+  );
+  throwIfDisposed();
+  final roundParams = await rust.trustedVotingRoundParamsFromConfig(
+    config: config,
+    roundId: round.roundId,
+    snapshotHeight: BigInt.from(round.snapshotHeight),
+    ncRoot: round.ncRoot,
+    nullifierImtRoot: round.nullifierImtRoot,
+  );
+  throwIfDisposed();
+  final accountUuid = await activeAccountUuidLoader.call();
+  if (accountUuid == null) {
+    throw StateError('No active account for voting power.');
+  }
+  final dbPath = await dbPathLoader.call();
+  throwIfDisposed();
+  final context = _VotingPowerContext(
+    dbPath: dbPath,
+    accountUuid: accountUuid,
+    network: endpoint.networkName,
+    lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+    round: round,
+    roundParams: roundParams,
+  );
+  await _waitUntilWalletReadyForVotingPower(
+    context: context,
+    readinessChecker: readinessChecker,
+    syncStarter: syncStarter,
+    pollInterval: pollInterval,
+    disposed: disposed,
+  );
+  throwIfDisposed();
+  final timer = Stopwatch()..start();
+  final bundleSetup = await rust.setupDelegationBundles(
+    ctx: _apiVotingRoundContext(
+      dbPath: context.dbPath,
+      lightwalletdUrl: context.lightwalletdUrl,
+      network: context.network,
+      roundParams: context.roundParams,
+      round: context.round,
+      accountUuid: context.accountUuid,
+    ),
+  );
+  throwIfDisposed();
+  debugPrint(
+    '[zcash] Voting: voting power ready '
+    'round=${context.round.roundId} account=${context.accountUuid} '
+    'bundles=${bundleSetup.bundleCount} '
+    'elapsed=${formatElapsedSeconds(timer.elapsed)}',
+  );
+  return VotingPowerState(
+    roundId: context.round.roundId,
+    accountUuid: context.accountUuid,
+    snapshotHeight: context.round.snapshotHeight,
+    eligibleWeightZatoshi: bundleSetup.eligibleWeight,
+    bundleCount: bundleSetup.bundleCount,
+    droppedCount: bundleSetup.droppedCount,
+  );
+});
+
 final votingSubmissionSessionProvider = AsyncNotifierProvider.autoDispose
     .family<
       VotingSubmissionSessionNotifier,
       VotingSessionState,
       VotingSessionKey
     >(VotingSubmissionSessionNotifier.new);
+
+rust_api.ApiVotingRoundContext _apiVotingRoundContext({
+  required String dbPath,
+  required String lightwalletdUrl,
+  required String network,
+  required rust_wire.VotingRoundParams roundParams,
+  required VotingRoundDetails round,
+  required String accountUuid,
+}) {
+  return rust_api.ApiVotingRoundContext(
+    dbPath: dbPath,
+    lightwalletdUrl: lightwalletdUrl,
+    network: network,
+    roundParams: roundParams,
+    roundName: round.title,
+    sessionJson: round.sessionJson,
+    accountUuid: accountUuid,
+    maxRealNotesPerBundle: null,
+  );
+}
+
+Future<void> _waitUntilWalletReadyForVotingPower({
+  required _VotingPowerContext context,
+  required VotingWalletSyncReadinessChecker readinessChecker,
+  required void Function() syncStarter,
+  required Duration pollInterval,
+  required Completer<void> disposed,
+}) async {
+  var loggedWait = false;
+  while (true) {
+    if (disposed.isCompleted) throw const _StaleVotingPowerRequest();
+    final readiness = await readinessChecker.check(
+      dbPath: context.dbPath,
+      network: context.network,
+      snapshotHeight: context.round.snapshotHeight,
+    );
+    if (disposed.isCompleted) throw const _StaleVotingPowerRequest();
+    if (readiness.isReady) return;
+
+    if (!loggedWait) {
+      loggedWait = true;
+      debugPrint(
+        '[zcash] Voting: waiting for wallet scan before voting power '
+        'round=${context.round.roundId} '
+        'scanned=${readiness.scannedHeight} '
+        'snapshot=${readiness.snapshotHeight}',
+      );
+    }
+    try {
+      syncStarter();
+    } catch (e) {
+      debugPrint('[zcash] Voting: wallet sync start skipped: $e');
+    }
+    await Future.any<void>([
+      Future<void>.delayed(pollInterval),
+      disposed.future,
+    ]);
+  }
+}
 
 @visibleForTesting
 final votingTxConfirmationPollingProvider =

--- a/lib/src/providers/voting/voting_state.dart
+++ b/lib/src/providers/voting/voting_state.dart
@@ -167,6 +167,26 @@ class VotingRoundDetails {
   DateTime? get ceremonyStart => _dateFromJson(rawJson, 'ceremony_phase_start');
 }
 
+/// Cached light eligibility result used to render voting power before the full
+/// delegation flow resolves PIR or builds proofs.
+class VotingPowerState {
+  final String roundId;
+  final String accountUuid;
+  final int snapshotHeight;
+  final BigInt eligibleWeightZatoshi;
+  final int bundleCount;
+  final int droppedCount;
+
+  const VotingPowerState({
+    required this.roundId,
+    required this.accountUuid,
+    required this.snapshotHeight,
+    required this.eligibleWeightZatoshi,
+    required this.bundleCount,
+    required this.droppedCount,
+  });
+}
+
 /// Immutable state for a single `votingSessionProvider(roundId)` instance.
 ///
 /// State keeps bundle-indexed delegation progress and bundle/proposal-indexed

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1189,6 +1189,112 @@ void main() {
     expect(rust.delegationBundleCalls, isEmpty);
   });
 
+  test(
+    'voting power provider prepares bundles without resolving PIR',
+    () async {
+      final rust = FakeVotingRustApi();
+      final container = _sessionContainer(
+        rust: rust,
+        pirResolver: FakePirResolver(error: StateError('PIR was touched')),
+      );
+      addTearDown(container.dispose);
+
+      final votingPower = await container.read(
+        votingPowerProvider(kRoundId).future,
+      );
+
+      expect(votingPower.roundId, kRoundId);
+      expect(votingPower.accountUuid, 'account-1');
+      expect(votingPower.snapshotHeight, 123);
+      expect(votingPower.eligibleWeightZatoshi, BigInt.from(100));
+      expect(votingPower.bundleCount, 1);
+      expect(rust.setupCalls, 1);
+      expect(rust.generateVotingHotkeyCalls, 0);
+      expect(rust.precomputedDelegationPir, isEmpty);
+    },
+  );
+
+  test('voting power provider deduplicates concurrent reads', () async {
+    final setupGate = Completer<void>();
+    final rust = FakeVotingRustApi(setupGate: setupGate);
+    final container = _sessionContainer(rust: rust);
+    addTearDown(container.dispose);
+
+    final first = container.read(votingPowerProvider(kRoundId).future);
+    await rust.setupStarted.future;
+    final second = container.read(votingPowerProvider(kRoundId).future);
+
+    setupGate.complete();
+    final results = await Future.wait([first, second]);
+
+    expect(results.first.eligibleWeightZatoshi, BigInt.from(100));
+    expect(results.last.eligibleWeightZatoshi, BigInt.from(100));
+    expect(rust.setupCalls, 1);
+    expect(rust.maxConcurrentSetups, 1);
+  });
+
+  test('voting power provider waits for wallet sync before setup', () async {
+    final rust = FakeVotingRustApi();
+    final readiness = FakeVotingWalletSyncReadinessChecker(
+      responses: const [
+        VotingWalletSyncReadiness(
+          scannedHeight: 122,
+          snapshotHeight: 123,
+          chainTipHeight: 130,
+        ),
+        VotingWalletSyncReadiness(
+          scannedHeight: 123,
+          snapshotHeight: 123,
+          chainTipHeight: 130,
+        ),
+      ],
+    );
+    var syncStartCalls = 0;
+    final container = _sessionContainer(
+      rust: rust,
+      walletSyncReadinessChecker: readiness,
+      walletSyncStarter: () {
+        syncStartCalls++;
+      },
+      walletSyncPollInterval: Duration.zero,
+    );
+    addTearDown(container.dispose);
+
+    final votingPower = await container.read(
+      votingPowerProvider(kRoundId).future,
+    );
+
+    expect(votingPower.eligibleWeightZatoshi, BigInt.from(100));
+    expect(readiness.calls, 2);
+    expect(syncStartCalls, 1);
+    expect(rust.setupCalls, 1);
+  });
+
+  test('cached voting power does not satisfy delegation preparation', () async {
+    final rust = FakeVotingRustApi();
+    final container = _sessionContainer(rust: rust);
+    addTearDown(container.dispose);
+
+    await container.read(votingPowerProvider(kRoundId).future);
+    final initialSession = await container.read(
+      votingSessionProvider(kRoundId).future,
+    );
+
+    expect(initialSession.eligibleWeightZatoshi, isNull);
+    expect(rust.setupCalls, 1);
+
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .prepareDelegation();
+    final preparedSession = container
+        .read(votingSessionProvider(kRoundId))
+        .value!;
+
+    expect(preparedSession.pirEndpoint, Uri.parse('https://pir.example'));
+    expect(preparedSession.eligibleWeightZatoshi, BigInt.from(100));
+    expect(rust.setupCalls, 2);
+  });
+
   test('wallet sync guard waits before delegation setup', () async {
     final rust = FakeVotingRustApi();
     final readiness = FakeVotingWalletSyncReadinessChecker(


### PR DESCRIPTION
Adds a display-only voting power provider that runs the light eligibility bundle setup without resolving PIR or marking delegation preparation complete.

The polls list now warms voting power for the first actionable active/voted round and gives tap navigation a bounded wait, so proposal detail usually opens with the round power already available while still routing if sync is slow.

Tests: fvm flutter analyze --no-pub; fvm flutter test --no-pub; git diff --check origin/voting-ui...HEAD.