### PR TITLE
Preserve voting option descriptions

### DIFF
--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -1005,8 +1005,13 @@ class _VotedProposalCard extends StatelessWidget {
           Row(
             children: [
               _ProposalBadge('Proposal ${proposal.id}'),
-              const Spacer(),
-              _ChoiceBadge(choiceLabel),
+              const SizedBox(width: AppSpacing.xs),
+              Expanded(
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  child: _ChoiceBadge(choiceLabel),
+                ),
+              ),
             ],
           ),
           const SizedBox(height: AppSpacing.s),
@@ -1083,6 +1088,8 @@ class _ChoiceBadge extends StatelessWidget {
       ),
       child: Text(
         label,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
         style: AppTypography.labelMedium.copyWith(color: palette.text),
       ),
     );
@@ -1294,6 +1301,7 @@ class _OptionRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final description = option.description.trim();
     final palette = votingChoicePalette(context, option.label);
     return InkWell(
       borderRadius: BorderRadius.circular(AppRadii.small),
@@ -1313,15 +1321,37 @@ class _OptionRow extends StatelessWidget {
           ),
         ),
         child: Row(
+          crossAxisAlignment: description.isEmpty
+              ? CrossAxisAlignment.center
+              : CrossAxisAlignment.start,
           children: [
             Expanded(
-              child: Text(
-                option.label,
-                style: AppTypography.labelLarge.copyWith(
-                  color: selected ? palette.text : colors.text.accent,
-                ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    option.label,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: selected ? palette.text : colors.text.accent,
+                    ),
+                  ),
+                  if (description.isNotEmpty) ...[
+                    const SizedBox(height: AppSpacing.xxs),
+                    Text(
+                      description,
+                      style: AppTypography.bodySmall.copyWith(
+                        color: selected
+                            ? palette.text.withValues(alpha: 0.82)
+                            : colors.text.secondary,
+                        height: 16 / 12,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ],
+                ],
               ),
             ),
+            const SizedBox(width: AppSpacing.sm),
             Text(
               selected ? 'Selected' : 'Choose',
               style: AppTypography.bodySmall.copyWith(

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -82,73 +82,98 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                   );
             return LayoutBuilder(
               builder: (context, constraints) {
-                return SingleChildScrollView(
-                  child: ConstrainedBox(
-                    constraints: BoxConstraints(
-                      minHeight: constraints.maxHeight,
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        const SizedBox(
-                          height: AppBackLink.height,
-                          child: Align(
-                            alignment: Alignment.centerLeft,
-                            child: AppRouteBackLink(minWidth: 60),
-                          ),
+                final onSubmit = draft.isEmpty
+                    ? null
+                    : () => context.go(
+                        votingStatusRoute(
+                          widget.roundId,
+                          accountUuid: accountUuid,
                         ),
-                        const SizedBox(height: AppSpacing.s),
-                        Center(
+                      );
+                return Stack(
+                  children: [
+                    Positioned.fill(
+                      child: SingleChildScrollView(
+                        child: Padding(
+                          padding: const EdgeInsets.only(
+                            bottom: AppSpacing.xl2,
+                          ),
                           child: ConstrainedBox(
-                            constraints: const BoxConstraints(maxWidth: 620),
+                            constraints: BoxConstraints(
+                              minHeight: constraints.maxHeight,
+                            ),
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.stretch,
-                              mainAxisSize: MainAxisSize.min,
                               children: [
-                                Text(
-                                  'Review your answers',
-                                  textAlign: TextAlign.center,
-                                  style: AppTypography.displaySmall.copyWith(
-                                    color: context.colors.text.accent,
+                                const SizedBox(
+                                  height: AppBackLink.height,
+                                  child: Align(
+                                    alignment: Alignment.centerLeft,
+                                    child: AppRouteBackLink(minWidth: 60),
                                   ),
                                 ),
-                                const SizedBox(height: AppSpacing.md),
-                                for (final proposal in proposals)
-                                  _ReviewRow(
-                                    title: proposal.title,
-                                    value: _reviewValue(proposal, draft),
-                                    skipped: draft.choices[proposal.id] == null,
-                                  ),
-                                if (draft.isEmpty) ...[
-                                  const SizedBox(height: AppSpacing.xs),
-                                  const _Message(
-                                    'Choose at least one option before submitting.',
-                                  ),
-                                ],
-                                const SizedBox(height: AppSpacing.md),
+                                const SizedBox(height: AppSpacing.s),
                                 Center(
-                                  child: AppButton(
-                                    onPressed: draft.isEmpty
-                                        ? null
-                                        : () => context.go(
-                                            votingStatusRoute(
-                                              widget.roundId,
-                                              accountUuid: accountUuid,
+                                  child: ConstrainedBox(
+                                    constraints: const BoxConstraints(
+                                      maxWidth: 620,
+                                    ),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.stretch,
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        Text(
+                                          'Review your answers',
+                                          textAlign: TextAlign.center,
+                                          style: AppTypography.displaySmall
+                                              .copyWith(
+                                                color:
+                                                    context.colors.text.accent,
+                                              ),
+                                        ),
+                                        const SizedBox(height: AppSpacing.md),
+                                        for (final proposal in proposals)
+                                          _ReviewRow(
+                                            title: proposal.title,
+                                            value: _reviewValue(
+                                              proposal,
+                                              draft,
                                             ),
+                                            skipped:
+                                                draft.choices[proposal.id] ==
+                                                null,
                                           ),
-                                    variant: AppButtonVariant.primary,
-                                    minWidth: 240,
-                                    child: const Text('Confirm & submit'),
+                                        if (draft.isEmpty) ...[
+                                          const SizedBox(height: AppSpacing.xs),
+                                          const _Message(
+                                            'Choose at least one option before submitting.',
+                                          ),
+                                        ],
+                                      ],
+                                    ),
                                   ),
                                 ),
+                                const SizedBox(height: AppSpacing.xl),
                               ],
                             ),
                           ),
                         ),
-                        const SizedBox(height: AppSpacing.xl),
-                      ],
+                      ),
                     ),
-                  ),
+                    Align(
+                      alignment: Alignment.bottomCenter,
+                      child: Padding(
+                        padding: const EdgeInsets.only(bottom: AppSpacing.md),
+                        child: AppButton(
+                          onPressed: onSubmit,
+                          variant: AppButtonVariant.primary,
+                          minWidth: 240,
+                          child: const Text('Confirm & submit'),
+                        ),
+                      ),
+                    ),
+                  ],
                 );
               },
             );

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -90,11 +90,6 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
-                        const Align(
-                          alignment: Alignment.centerLeft,
-                          child: AppRouteBackLink(),
-                        ),
-                        const SizedBox(height: AppSpacing.xl),
                         Center(
                           child: ConstrainedBox(
                             constraints: const BoxConstraints(maxWidth: 620),
@@ -102,6 +97,11 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                               crossAxisAlignment: CrossAxisAlignment.stretch,
                               mainAxisSize: MainAxisSize.min,
                               children: [
+                                const Align(
+                                  alignment: Alignment.centerLeft,
+                                  child: AppRouteBackLink(),
+                                ),
+                                const SizedBox(height: AppSpacing.xl),
                                 Text(
                                   'Review your answers',
                                   textAlign: TextAlign.left,

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -181,12 +181,25 @@ class _ReviewRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final valueTone = votingChoiceTone(value);
+    final stackValue = !skipped && valueTone == VotingChoiceTone.multi;
     final titleColor = skipped
         ? colors.text.secondary.withValues(alpha: 0.64)
         : colors.text.secondary;
     final valueColor = skipped
         ? colors.text.secondary.withValues(alpha: 0.72)
         : votingChoicePalette(context, value).text;
+    final titleText = Text(
+      title,
+      style: AppTypography.bodyMedium.copyWith(color: titleColor),
+    );
+    final valueText = Text(
+      value,
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+      textAlign: stackValue ? TextAlign.left : TextAlign.right,
+      style: AppTypography.bodyMediumStrong.copyWith(color: valueColor),
+    );
     return Container(
       margin: const EdgeInsets.only(bottom: AppSpacing.xs),
       padding: const EdgeInsets.all(AppSpacing.sm),
@@ -197,27 +210,23 @@ class _ReviewRow extends StatelessWidget {
         borderRadius: BorderRadius.circular(AppRadii.medium),
         border: Border.all(color: colors.border.subtle),
       ),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Expanded(
-            child: Text(
-              title,
-              style: AppTypography.bodyMedium.copyWith(color: titleColor),
+      child: stackValue
+          ? Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                titleText,
+                const SizedBox(height: AppSpacing.xxs),
+                valueText,
+              ],
+            )
+          : Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(child: titleText),
+                const SizedBox(width: AppSpacing.sm),
+                Flexible(child: valueText),
+              ],
             ),
-          ),
-          const SizedBox(width: AppSpacing.sm),
-          Flexible(
-            child: Text(
-              value,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.right,
-              style: AppTypography.bodyMediumStrong.copyWith(color: valueColor),
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -181,8 +181,6 @@ class _ReviewRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final valueTone = votingChoiceTone(value);
-    final stackValue = !skipped && valueTone == VotingChoiceTone.multi;
     final titleColor = skipped
         ? colors.text.secondary.withValues(alpha: 0.64)
         : colors.text.secondary;
@@ -197,7 +195,7 @@ class _ReviewRow extends StatelessWidget {
       value,
       maxLines: 2,
       overflow: TextOverflow.ellipsis,
-      textAlign: stackValue ? TextAlign.left : TextAlign.right,
+      textAlign: TextAlign.left,
       style: AppTypography.bodyMediumStrong.copyWith(color: valueColor),
     );
     return Container(
@@ -210,23 +208,14 @@ class _ReviewRow extends StatelessWidget {
         borderRadius: BorderRadius.circular(AppRadii.medium),
         border: Border.all(color: colors.border.subtle),
       ),
-      child: stackValue
-          ? Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                titleText,
-                const SizedBox(height: AppSpacing.xxs),
-                valueText,
-              ],
-            )
-          : Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Expanded(child: titleText),
-                const SizedBox(width: AppSpacing.sm),
-                Flexible(child: valueText),
-              ],
-            ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          titleText,
+          const SizedBox(height: AppSpacing.xxs),
+          valueText,
+        ],
+      ),
     );
   }
 }

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -107,7 +107,7 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                               children: [
                                 Text(
                                   'Review your answers',
-                                  textAlign: TextAlign.left,
+                                  textAlign: TextAlign.center,
                                   style: AppTypography.displaySmall.copyWith(
                                     color: context.colors.text.accent,
                                   ),

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -104,7 +104,7 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                               children: [
                                 Text(
                                   'Review your answers',
-                                  textAlign: TextAlign.center,
+                                  textAlign: TextAlign.left,
                                   style: AppTypography.displaySmall.copyWith(
                                     color: context.colors.text.accent,
                                   ),

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -90,6 +90,14 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
+                        const SizedBox(
+                          height: AppBackLink.height,
+                          child: Align(
+                            alignment: Alignment.centerLeft,
+                            child: AppRouteBackLink(minWidth: 60),
+                          ),
+                        ),
+                        const SizedBox(height: AppSpacing.s),
                         Center(
                           child: ConstrainedBox(
                             constraints: const BoxConstraints(maxWidth: 620),
@@ -97,11 +105,6 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                               crossAxisAlignment: CrossAxisAlignment.stretch,
                               mainAxisSize: MainAxisSize.min,
                               children: [
-                                const Align(
-                                  alignment: Alignment.centerLeft,
-                                  child: AppRouteBackLink(),
-                                ),
-                                const SizedBox(height: AppSpacing.xl),
                                 Text(
                                   'Review your answers',
                                   textAlign: TextAlign.left,

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -80,102 +80,93 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                       ),
                     ),
                   );
-            return LayoutBuilder(
-              builder: (context, constraints) {
-                final onSubmit = draft.isEmpty
-                    ? null
-                    : () => context.go(
-                        votingStatusRoute(
-                          widget.roundId,
-                          accountUuid: accountUuid,
+            final onSubmit = draft.isEmpty
+                ? null
+                : () => context.go(
+                    votingStatusRoute(widget.roundId, accountUuid: accountUuid),
+                  );
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Expanded(
+                  child: LayoutBuilder(
+                    builder: (context, scrollConstraints) {
+                      return SingleChildScrollView(
+                        child: ConstrainedBox(
+                          constraints: BoxConstraints(
+                            minHeight: scrollConstraints.maxHeight,
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              const SizedBox(
+                                height: AppBackLink.height,
+                                child: Align(
+                                  alignment: Alignment.centerLeft,
+                                  child: AppRouteBackLink(minWidth: 60),
+                                ),
+                              ),
+                              const SizedBox(height: AppSpacing.s),
+                              Center(
+                                child: ConstrainedBox(
+                                  constraints: const BoxConstraints(
+                                    maxWidth: 620,
+                                  ),
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.stretch,
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Text(
+                                        'Review your answers',
+                                        textAlign: TextAlign.center,
+                                        style: AppTypography.displaySmall
+                                            .copyWith(
+                                              color: context.colors.text.accent,
+                                            ),
+                                      ),
+                                      const SizedBox(height: AppSpacing.md),
+                                      for (final proposal in proposals)
+                                        _ReviewRow(
+                                          title: proposal.title,
+                                          value: _reviewValue(proposal, draft),
+                                          skipped:
+                                              draft.choices[proposal.id] ==
+                                              null,
+                                        ),
+                                      if (draft.isEmpty) ...[
+                                        const SizedBox(height: AppSpacing.xs),
+                                        const _Message(
+                                          'Choose at least one option before submitting.',
+                                        ),
+                                      ],
+                                    ],
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(height: AppSpacing.md),
+                            ],
+                          ),
                         ),
                       );
-                return Stack(
-                  children: [
-                    Positioned.fill(
-                      child: SingleChildScrollView(
-                        child: Padding(
-                          padding: const EdgeInsets.only(
-                            bottom: AppSpacing.xl2,
-                          ),
-                          child: ConstrainedBox(
-                            constraints: BoxConstraints(
-                              minHeight: constraints.maxHeight,
-                            ),
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.stretch,
-                              children: [
-                                const SizedBox(
-                                  height: AppBackLink.height,
-                                  child: Align(
-                                    alignment: Alignment.centerLeft,
-                                    child: AppRouteBackLink(minWidth: 60),
-                                  ),
-                                ),
-                                const SizedBox(height: AppSpacing.s),
-                                Center(
-                                  child: ConstrainedBox(
-                                    constraints: const BoxConstraints(
-                                      maxWidth: 620,
-                                    ),
-                                    child: Column(
-                                      crossAxisAlignment:
-                                          CrossAxisAlignment.stretch,
-                                      mainAxisSize: MainAxisSize.min,
-                                      children: [
-                                        Text(
-                                          'Review your answers',
-                                          textAlign: TextAlign.center,
-                                          style: AppTypography.displaySmall
-                                              .copyWith(
-                                                color:
-                                                    context.colors.text.accent,
-                                              ),
-                                        ),
-                                        const SizedBox(height: AppSpacing.md),
-                                        for (final proposal in proposals)
-                                          _ReviewRow(
-                                            title: proposal.title,
-                                            value: _reviewValue(
-                                              proposal,
-                                              draft,
-                                            ),
-                                            skipped:
-                                                draft.choices[proposal.id] ==
-                                                null,
-                                          ),
-                                        if (draft.isEmpty) ...[
-                                          const SizedBox(height: AppSpacing.xs),
-                                          const _Message(
-                                            'Choose at least one option before submitting.',
-                                          ),
-                                        ],
-                                      ],
-                                    ),
-                                  ),
-                                ),
-                                const SizedBox(height: AppSpacing.xl),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ),
+                    },
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(
+                    top: AppSpacing.xs,
+                    bottom: AppSpacing.md,
+                  ),
+                  child: Center(
+                    child: AppButton(
+                      onPressed: onSubmit,
+                      variant: AppButtonVariant.primary,
+                      minWidth: 240,
+                      child: const Text('Confirm & submit'),
                     ),
-                    Align(
-                      alignment: Alignment.bottomCenter,
-                      child: Padding(
-                        padding: const EdgeInsets.only(bottom: AppSpacing.md),
-                        child: AppButton(
-                          onPressed: onSubmit,
-                          variant: AppButtonVariant.primary,
-                          minWidth: 240,
-                          child: const Text('Confirm & submit'),
-                        ),
-                      ),
-                    ),
-                  ],
-                );
-              },
+                  ),
+                ),
+              ],
             );
           },
         ),

--- a/lib/src/features/voting/voting_flow_models.dart
+++ b/lib/src/features/voting/voting_flow_models.dart
@@ -25,10 +25,15 @@ class VotingProposalView {
 }
 
 class VotingOptionView {
-  const VotingOptionView({required this.index, required this.label});
+  const VotingOptionView({
+    required this.index,
+    required this.label,
+    this.description = '',
+  });
 
   final int index;
   final String label;
+  final String description;
 }
 
 /// Stable owner key for voting UI state that must not cross accounts.
@@ -317,7 +322,14 @@ VotingOptionView _optionFromJson(Object? value, {required int fallbackIndex}) {
   return VotingOptionView(
     index: _intFromJson(json, const ['index']) ?? fallbackIndex,
     label:
-        _stringFromJson(json, const ['label']) ?? 'Option ${fallbackIndex + 1}',
+        _stringFromJson(json, const [
+          'label',
+          'short_title',
+          'shortTitle',
+          'title',
+        ]) ??
+        'Option ${fallbackIndex + 1}',
+    description: _stringFromJson(json, const ['description']) ?? '',
   );
 }
 

--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -7,7 +7,6 @@ import '../../rust/third_party/zcash_voting/wire.dart' as rust_voting;
 import '../../services/voting/voting_api_client.dart';
 import '../../services/voting/resolved_voting_config_extensions.dart';
 import '../../services/voting/voting_models.dart';
-import '../../services/voting/resolved_voting_config_extensions.dart';
 import 'voting_config_provider.dart';
 import 'voting_service_providers.dart';
 import 'voting_state.dart';

--- a/test/features/voting/voting_flow_models_test.dart
+++ b/test/features/voting/voting_flow_models_test.dart
@@ -42,6 +42,53 @@ void main() {
     ]);
   });
 
+  test(
+    'proposal parser preserves option descriptions separately from labels',
+    () {
+      final proposals = proposalsFromJson({
+        'proposals': [
+          {
+            'id': 1,
+            'title': 'Issuance smoothing',
+            'options': [
+              {
+                'index': 0,
+                'label': 'Preserve halvings',
+                'description':
+                    'Keep the existing halving schedule for new ZEC.',
+              },
+              {
+                'index': 1,
+                'short_title': 'Smooth issuance curve',
+                'description':
+                    'Replace halvings with a gradual issuance curve.',
+              },
+              {'index': 2, 'shortTitle': 'Delay reissuance'},
+              {'index': 3, 'title': 'Do not smooth issuance'},
+            ],
+          },
+        ],
+      });
+
+      expect(proposals.single.options.map((option) => option.label), [
+        'Preserve halvings',
+        'Smooth issuance curve',
+        'Delay reissuance',
+        'Do not smooth issuance',
+      ]);
+      expect(
+        proposals.single.options.first.description,
+        'Keep the existing halving schedule for new ZEC.',
+      );
+      expect(
+        proposals.single.options[1].description,
+        'Replace halvings with a gradual issuance curve.',
+      );
+      expect(proposals.single.options[2].description, isEmpty);
+      expect(proposals.single.options[3].description, isEmpty);
+    },
+  );
+
   test('proposal parser rejects missing proposal ids', () {
     expect(
       () => proposalsFromJson({

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1697,8 +1697,23 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(find.byType(SingleChildScrollView), findsWidgets);
 
-    await tester.scrollUntilVisible(find.text('Confirm & submit'), 300);
-    expect(find.text('Confirm & submit'), findsOneWidget);
+    final submitButton = find.text('Confirm & submit');
+    expect(submitButton, findsOneWidget);
+    expect(tester.getBottomLeft(submitButton).dy, lessThanOrEqualTo(520));
+
+    await tester.drag(
+      find
+          .descendant(
+            of: find.byType(VotingReviewScreen),
+            matching: find.byType(SingleChildScrollView),
+          )
+          .first,
+      const Offset(0, -400),
+    );
+    await tester.pumpAndSettle();
+
+    expect(submitButton, findsOneWidget);
+    expect(tester.getBottomLeft(submitButton).dy, lessThanOrEqualTo(520));
   });
 
   testWidgets('pending vote continue keeps the session account', (

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/voting/screens/voting_proposal_detail_screen.dart';
 import 'package:zcash_wallet/src/features/voting/screens/voting_polls_screen.dart';
 import 'package:zcash_wallet/src/features/voting/screens/voting_review_screen.dart';
@@ -1697,23 +1698,35 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(find.byType(SingleChildScrollView), findsWidgets);
 
-    final submitButton = find.text('Confirm & submit');
+    final submitButtonLabel = find.text('Confirm & submit');
+    final submitButton = find.ancestor(
+      of: submitButtonLabel,
+      matching: find.byType(AppButton),
+    );
+    final reviewScrollView = find
+        .descendant(
+          of: find.byType(VotingReviewScreen),
+          matching: find.byType(SingleChildScrollView),
+        )
+        .first;
+    expect(submitButtonLabel, findsOneWidget);
     expect(submitButton, findsOneWidget);
     expect(tester.getBottomLeft(submitButton).dy, lessThanOrEqualTo(520));
-
-    await tester.drag(
-      find
-          .descendant(
-            of: find.byType(VotingReviewScreen),
-            matching: find.byType(SingleChildScrollView),
-          )
-          .first,
-      const Offset(0, -400),
+    expect(
+      tester.getBottomLeft(reviewScrollView).dy,
+      lessThanOrEqualTo(tester.getTopLeft(submitButton).dy),
     );
+
+    await tester.drag(reviewScrollView, const Offset(0, -400));
     await tester.pumpAndSettle();
 
+    expect(submitButtonLabel, findsOneWidget);
     expect(submitButton, findsOneWidget);
     expect(tester.getBottomLeft(submitButton).dy, lessThanOrEqualTo(520));
+    expect(
+      tester.getBottomLeft(reviewScrollView).dy,
+      lessThanOrEqualTo(tester.getTopLeft(submitButton).dy),
+    );
   });
 
   testWidgets('pending vote continue keeps the session account', (

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1273,12 +1273,21 @@ void main() {
       await tester.binding.setSurfaceSize(null);
     });
 
+    const optionDescription =
+        'Mint option explanation for detail screens only.';
     final round = _roundStatusJson()
       ..['status'] = 'closed'
       ..['summary'] = 'Completed poll'
       ..['proposals'] = [
         _proposalJson(1, 'First proposal', ['Yes', 'No']),
-        _proposalJson(2, 'Second proposal', ['Mint', 'Burn']),
+        {
+          'id': 2,
+          'title': 'Second proposal',
+          'options': [
+            {'index': 0, 'label': 'Mint', 'description': optionDescription},
+            {'index': 1, 'label': 'Burn'},
+          ],
+        },
       ];
     final http = FakeVotingHttpClient(
       responses: _votingHttpResponses()
@@ -1328,6 +1337,7 @@ void main() {
     expect(find.text('Voted: Yes'), findsOneWidget);
     expect(find.text('Second proposal'), findsOneWidget);
     expect(find.text('Mint'), findsOneWidget);
+    expect(find.text(optionDescription), findsNothing);
     expect(find.text('0.13 ZEC'), findsOneWidget);
     expect(find.text('Burn'), findsOneWidget);
     expect(find.text('0.00 ZEC'), findsOneWidget);
@@ -1572,6 +1582,71 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('status account: account-1'), findsOneWidget);
+  });
+
+  testWidgets('review uses short option label without option description', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final longDescription =
+        'Keep the existing halving schedule for new ZEC. Only fees and '
+        'donated funds are smoothed and reissued.';
+    final round = _roundStatusJson()
+      ..['proposals'] = [
+        {
+          'id': 1,
+          'title': 'NSM issuance smoothing',
+          'description': 'Question about the NSM issuance smoothing policy.',
+          'options': [
+            {
+              'index': 0,
+              'label': 'Preserve halvings',
+              'description': longDescription,
+            },
+            {
+              'index': 1,
+              'label': 'Smooth issuance curve',
+              'description': 'Replace halvings with a gradual issuance curve.',
+            },
+          ],
+        },
+      ];
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
+    );
+    final recoveryApi = _MutableVotingRecoveryApi();
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _NoMnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _VotingStatusRustApi(recoveryApi),
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Preserve halvings'), findsOneWidget);
+    expect(find.text(longDescription), findsOneWidget);
+
+    await tester.tap(find.text('Preserve halvings'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Review answers'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review your answers'), findsOneWidget);
+    expect(find.text('Preserve halvings'), findsOneWidget);
+    expect(find.text(longDescription), findsNothing);
   });
 
   testWidgets('review screen scrolls long ballots without overflowing', (


### PR DESCRIPTION
Summary
- Preserve voting option descriptions separately from short labels.
- Show descriptions only in proposal choices while review, results, and badges stay compact.
- Constrain long selected choice labels and remove a duplicate import so analyze stays clean.

Tests
- fvm flutter test --no-pub test/features/voting/voting_flow_models_test.dart
- fvm flutter test --no-pub test/features/voting/voting_status_screen_test.dart
- fvm flutter analyze --no-pub
- git diff --check