### PR TITLE
fix Keystone multi-bundle skipped bundle showing wrong amount

### DIFF
--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -9,6 +9,7 @@ import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/privacy/sensitive_privacy_overlay.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
+import '../../../providers/voting/voting_session_provider.dart';
 import '../../../providers/voting/voting_submission_job_provider.dart';
 import '../../../providers/voting/voting_state.dart';
 import '../../../rust/third_party/zcash_voting/delegate.dart' as rust_delegate;
@@ -438,13 +439,28 @@ class _VotingStatusScreenState extends ConsumerState<VotingStatusScreen> {
         }
         return;
       }
-      context.go(
-        votingSubmissionConfirmedRoute(
-          key.roundId,
-          accountUuid: key.accountUuid,
-        ),
-      );
+      unawaited(_navigateToConfirmation(key));
     });
+  }
+
+  Future<void> _navigateToConfirmation(VotingSessionKey key) async {
+    try {
+      await ref
+          .read(votingSubmissionSessionProvider(key).notifier)
+          .refreshEligibleWeight();
+    } catch (error) {
+      debugPrint(
+        '[zcash] Voting: pre-confirmation voting power refresh failed '
+        'round=${key.roundId} account=${key.accountUuid} error=$error',
+      );
+    }
+    if (!mounted || _selectedJobKey() != key) return;
+    context.go(
+      votingSubmissionConfirmedRoute(
+        key.roundId,
+        accountUuid: key.accountUuid,
+      ),
+    );
   }
 }
 

--- a/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
+++ b/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
@@ -14,6 +14,7 @@ import '../../../providers/voting/voting_config_provider.dart';
 import '../../../providers/voting/voting_rounds_provider.dart';
 import '../../../providers/voting/voting_session_provider.dart';
 import '../../../providers/voting/voting_submission_job_provider.dart';
+import '../../../providers/voting/voting_state.dart';
 import '../voting_flow_models.dart';
 import '../voting_formatters.dart';
 import '../voting_resume_plan.dart';
@@ -36,6 +37,9 @@ class VotingSubmissionConfirmationScreen extends ConsumerStatefulWidget {
 class _VotingSubmissionConfirmationScreenState
     extends ConsumerState<VotingSubmissionConfirmationScreen> {
   bool _isReturningToPolls = false;
+  bool _refreshingVotingPower = false;
+  String? _votingPowerRefreshKey;
+  BigInt? _refreshedVotingPowerZatoshi;
 
   @override
   Widget build(BuildContext context) {
@@ -70,6 +74,12 @@ class _VotingSubmissionConfirmationScreenState
                 final pollTitle = state.round?.title.isNotEmpty == true
                     ? state.round!.title
                     : 'Coinholder poll';
+                final confirmed = hasCompletedVoteForDisplay(state.roundPlan);
+                _maybeRefreshVotingPower(
+                  confirmed: confirmed,
+                  state: state,
+                  jobKey: jobKey,
+                );
                 if (!hasCompletedVoteForDisplay(state.roundPlan)) {
                   return _ConfirmationScaffold(
                     confirmed: false,
@@ -86,9 +96,9 @@ class _VotingSubmissionConfirmationScreenState
                   pollTitle: pollTitle,
                   message:
                       'Your vote was successfully published and cannot be changed.',
-                  votingPower: state.eligibleWeightZatoshi == null
-                      ? 'Not available'
-                      : formatVotingPower(state.eligibleWeightZatoshi!),
+                  votingPower: _formatVotingPower(
+                    _refreshedVotingPowerZatoshi ?? state.eligibleWeightZatoshi,
+                  ),
                   doneEnabled: !_isReturningToPolls,
                   onDone: () => unawaited(_returnToPolls(jobKey)),
                 );
@@ -123,6 +133,61 @@ class _VotingSubmissionConfirmationScreenState
       );
       setState(() {
         _isReturningToPolls = false;
+      });
+    }
+  }
+
+  String _formatVotingPower(BigInt? zatoshi) {
+    if (zatoshi == null) return 'Not available';
+    return formatVotingPower(zatoshi);
+  }
+
+  void _maybeRefreshVotingPower({
+    required bool confirmed,
+    required VotingSessionState state,
+    required VotingSessionKey? jobKey,
+  }) {
+    final refreshKey =
+        '${widget.roundId}|${jobKey?.accountUuid ?? state.accountUuid ?? ''}';
+    if (_votingPowerRefreshKey != refreshKey) {
+      _votingPowerRefreshKey = refreshKey;
+      _refreshingVotingPower = false;
+      _refreshedVotingPowerZatoshi = null;
+    }
+    if (!confirmed || _refreshingVotingPower || _refreshedVotingPowerZatoshi != null) {
+      return;
+    }
+
+    _refreshingVotingPower = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_refreshVotingPower(state: state, jobKey: jobKey, key: refreshKey));
+    });
+  }
+
+  Future<void> _refreshVotingPower({
+    required VotingSessionState state,
+    required VotingSessionKey? jobKey,
+    required String key,
+  }) async {
+    try {
+      final notifier = jobKey == null
+          ? ref.read(votingSessionProvider(widget.roundId).notifier)
+          : ref.read(votingSubmissionSessionProvider(jobKey).notifier);
+      final refreshed = await notifier.refreshEligibleWeight();
+      if (!mounted || _votingPowerRefreshKey != key) return;
+      setState(() {
+        _refreshedVotingPowerZatoshi = refreshed;
+      });
+    } catch (error) {
+      debugPrint(
+        '[zcash] Voting: confirmation voting power refresh failed '
+        'round=${widget.roundId} account=${state.accountUuid} error=$error',
+      );
+    } finally {
+      if (!mounted || _votingPowerRefreshKey != key) return;
+      setState(() {
+        _refreshingVotingPower = false;
       });
     }
   }

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -234,6 +234,12 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     return _enqueue(_prepareDelegationUnlocked);
   }
 
+  Future<BigInt?> refreshEligibleWeight() {
+    return _enqueue(_refreshEligibleWeightUnlocked).then((_) {
+      return state.value?.eligibleWeightZatoshi;
+    });
+  }
+
   Future<void> ensureWalletReadyForVoting() {
     return _enqueue(() async {
       final context = await _loadContext(_roundId);
@@ -597,6 +603,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             roundId: context.round.roundId,
             keepCount: signedPrefixCount,
           );
+      final bundleSetup = await ref
+          .read(votingRustApiProvider)
+          .setupDelegationBundles(ctx: _apiRoundContext(context));
       final refreshedPlan = await _loadResumePlan(context);
       final refreshedRoundPlan = await _loadRoundPlan(context);
       final retainedSignatures = {
@@ -609,6 +618,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           phase: VotingSessionPhase.readyToDelegate,
           resumePlan: refreshedPlan,
           roundPlan: refreshedRoundPlan,
+          eligibleWeightZatoshi: bundleSetup.eligibleWeight,
           keystoneSignatures: retainedSignatures,
           clearKeystoneSigningRequest: true,
           clearKeystoneScanError: true,
@@ -2487,6 +2497,26 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         resumePlan: refreshedPlan,
         roundPlan: refreshedRoundPlan,
         eligibleWeightZatoshi: bundleSetup.eligibleWeight,
+        isHardwareAccount: context.isHardwareAccount,
+      ),
+    );
+  }
+
+  Future<void> _refreshEligibleWeightUnlocked() async {
+    final current = await future;
+    final context = await _loadContext(_roundId);
+    final bundleSetup = await ref
+        .read(votingRustApiProvider)
+        .setupDelegationBundles(ctx: _apiRoundContext(context));
+    final refreshedPlan = await _loadResumePlan(context);
+    final refreshedRoundPlan = await _loadRoundPlan(context);
+    final eligibleWeight = bundleSetup.eligibleWeight;
+    _setStateForContext(
+      context,
+      (state.value ?? current).copyWith(
+        resumePlan: refreshedPlan,
+        roundPlan: refreshedRoundPlan,
+        eligibleWeightZatoshi: eligibleWeight,
         isHardwareAccount: context.isHardwareAccount,
       ),
     );

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1644,10 +1644,13 @@ void main() {
     'hardware voting can skip unsigned Keystone bundles after prefix signed',
     () async {
       late FakeVotingRecoveryApi recoveryApi;
-      final rust = FakeVotingRustApi(
+      late FakeVotingRustApi rust;
+      rust = FakeVotingRustApi(
         bundleCount: 2,
+        setupEligibleWeight: 4900000000,
         onDeleteSkippedBundles: (keepCount) {
           recoveryApi.state = recoveryState(bundleCount: keepCount);
+          rust.setupEligibleWeight = 3712500000;
         },
       );
       recoveryApi = FakeVotingRecoveryApi(state: recoveryState(bundleCount: 2));
@@ -1678,6 +1681,7 @@ void main() {
 
       expect(state.phase, VotingSessionPhase.readyToDelegate);
       expect(state.resumePlan?.bundleCount, 1);
+      expect(state.eligibleWeightZatoshi, BigInt.from(3712500000));
       expect(state.keystoneSigningRequest, isNull);
       expect(rust.deleteSkippedBundleKeepCounts, [1]);
       expect(rust.storedKeystoneSignatures.keys, [0]);
@@ -5702,6 +5706,7 @@ class FakeVotingRustApi implements VotingRustApi {
     this.precomputeGate,
     this.failPrecompute = false,
     this.bundleCount = 1,
+    this.setupEligibleWeight = 100,
     this.commitmentShareCount = 1,
     this.mismatchKeystoneSubmission = false,
     this.delegationStreamError,
@@ -5720,6 +5725,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final Completer<void>? precomputeGate;
   final bool failPrecompute;
   final int bundleCount;
+  int setupEligibleWeight;
   final int commitmentShareCount;
   final bool mismatchKeystoneSubmission;
   final Object? delegationStreamError;
@@ -5815,7 +5821,7 @@ class FakeVotingRustApi implements VotingRustApi {
     _activeSetups--;
     return rust_round.BundleLayout(
       bundleCount: bundleCount,
-      eligibleWeight: BigInt.from(100),
+      eligibleWeight: BigInt.from(setupEligibleWeight),
       droppedCount: 0,
     );
   }


### PR DESCRIPTION
The voting power did not update when the bundle was skipped. This fixes.