### PR TITLE
Show voting ZIP and forum metadata

### DIFF
--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -18,8 +18,10 @@ import '../../../providers/voting/voting_rounds_provider.dart';
 import '../../../providers/voting/voting_state.dart';
 import '../../../providers/voting/voting_tree_sync_provider.dart';
 import '../voting_poll_ordering.dart';
+import '../voting_flow_models.dart';
 import '../voting_routes.dart';
 import '../widgets/voting_config_settings_panel.dart';
+import '../widgets/voting_metadata_widgets.dart';
 import '../widgets/voting_pane_scroll_area.dart';
 
 class VotingPollsScreen extends ConsumerStatefulWidget {
@@ -335,6 +337,7 @@ class _PollCard extends StatelessWidget {
     final colors = context.colors;
     final title = round.title.isEmpty ? round.roundId : round.title;
     final description = _roundDescription(round.rawJson);
+    final forumUri = votingRoundForumUriFromJson(round.rawJson);
     final state = _pollCardState(round);
     final dateLabel = _roundDateLabel(round.rawJson, state);
 
@@ -399,6 +402,13 @@ class _PollCard extends StatelessWidget {
                 letterSpacing: 0,
               ),
             ),
+            if (forumUri != null) ...[
+              const SizedBox(height: AppSpacing.xs),
+              Align(
+                alignment: Alignment.centerRight,
+                child: VotingForumLinkButton(uri: forumUri),
+              ),
+            ],
             const SizedBox(height: AppSpacing.md),
             Align(
               alignment: Alignment.centerRight,

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -21,6 +21,7 @@ import '../voting_flow_models.dart';
 import '../voting_formatters.dart';
 import '../voting_resume_plan.dart';
 import '../voting_routes.dart';
+import '../widgets/voting_metadata_widgets.dart';
 import '../widgets/voting_pane_scroll_area.dart';
 
 class VotingProposalDetailScreen extends ConsumerStatefulWidget {
@@ -85,6 +86,7 @@ class _VotingProposalDetailScreenState
                 ? const VotingDraftState()
                 : ref.watch(votingDraftProvider(draftKey));
             final proposals = proposalsFromRound(round);
+            final forumUri = votingRoundForumUriFromJson(round.rawJson);
             final completedVote = _CompletedVote.fromPlan(state.roundPlan);
             _maybePrepareVotingPower(state);
             // Foreground recovery takes precedence over the read-only voted view.
@@ -99,6 +101,7 @@ class _VotingProposalDetailScreenState
                       : round.title,
                   snapshotHeight: round.snapshotHeight,
                   description: _roundDescription(round.rawJson),
+                  forumUri: forumUri,
                   roundId: roundId,
                   accountUuid: accountUuid,
                 ),
@@ -113,6 +116,7 @@ class _VotingProposalDetailScreenState
                       : round.title,
                   snapshotHeight: round.snapshotHeight,
                   description: _roundDescription(round.rawJson),
+                  forumUri: forumUri,
                   votingPowerZatoshi: state.eligibleWeightZatoshi,
                   votingPowerPreparing: _votingPowerPreparationInFlight,
                   votedAt: completedVote.votedAt,
@@ -131,6 +135,7 @@ class _VotingProposalDetailScreenState
                       : round.title,
                   snapshotHeight: round.snapshotHeight,
                   description: _roundDescription(round.rawJson),
+                  forumUri: forumUri,
                   roundId: roundId,
                   accountUuid: accountUuid,
                 ),
@@ -142,6 +147,7 @@ class _VotingProposalDetailScreenState
               title: round.title.isEmpty ? 'Coinholder poll' : round.title,
               snapshotHeight: round.snapshotHeight,
               description: _roundDescription(round.rawJson),
+              forumUri: forumUri,
               endDate: _roundEndDate(round.rawJson),
               votingPowerZatoshi: state.eligibleWeightZatoshi,
               votingPowerPreparing: _votingPowerPreparationInFlight,
@@ -245,6 +251,7 @@ class _ActivePollContent extends StatefulWidget {
     required this.title,
     required this.snapshotHeight,
     required this.description,
+    required this.forumUri,
     required this.endDate,
     required this.votingPowerZatoshi,
     required this.votingPowerPreparing,
@@ -257,6 +264,7 @@ class _ActivePollContent extends StatefulWidget {
   final String title;
   final int snapshotHeight;
   final String description;
+  final Uri? forumUri;
   final DateTime? endDate;
   final BigInt? votingPowerZatoshi;
   final bool votingPowerPreparing;
@@ -339,6 +347,7 @@ class _ActivePollContentState extends State<_ActivePollContent> {
                         title: widget.title,
                         snapshotHeight: widget.snapshotHeight,
                         description: widget.description,
+                        forumUri: widget.forumUri,
                         endDate: widget.endDate,
                         votingPowerZatoshi: widget.votingPowerZatoshi,
                         votingPowerPreparing: widget.votingPowerPreparing,
@@ -458,6 +467,7 @@ class _PollSummary extends StatelessWidget {
     required this.title,
     required this.snapshotHeight,
     required this.description,
+    required this.forumUri,
     required this.endDate,
     required this.votingPowerZatoshi,
     required this.votingPowerPreparing,
@@ -468,6 +478,7 @@ class _PollSummary extends StatelessWidget {
   final String title;
   final int snapshotHeight;
   final String description;
+  final Uri? forumUri;
   final DateTime? endDate;
   final BigInt? votingPowerZatoshi;
   final bool votingPowerPreparing;
@@ -577,6 +588,13 @@ class _PollSummary extends StatelessWidget {
             },
           ),
         ],
+        if (forumUri != null) ...[
+          const SizedBox(height: AppSpacing.xs),
+          Align(
+            alignment: Alignment.centerRight,
+            child: VotingForumLinkButton(uri: forumUri!),
+          ),
+        ],
       ],
     );
   }
@@ -666,6 +684,7 @@ class _VotedPollContent extends StatelessWidget {
     required this.roundTitle,
     required this.snapshotHeight,
     required this.description,
+    required this.forumUri,
     required this.votingPowerZatoshi,
     required this.votingPowerPreparing,
     required this.votedAt,
@@ -676,6 +695,7 @@ class _VotedPollContent extends StatelessWidget {
   final String roundTitle;
   final int snapshotHeight;
   final String description;
+  final Uri? forumUri;
   final BigInt? votingPowerZatoshi;
   final bool votingPowerPreparing;
   final DateTime? votedAt;
@@ -706,6 +726,7 @@ class _VotedPollContent extends StatelessWidget {
             title: roundTitle,
             snapshotHeight: snapshotHeight,
             description: description,
+            forumUri: forumUri,
             votingPowerZatoshi: votingPowerZatoshi,
             votingPowerPreparing: votingPowerPreparing,
             votedAt: votedAt,
@@ -748,6 +769,7 @@ class _PendingVoteContent extends StatelessWidget {
     required this.roundTitle,
     required this.snapshotHeight,
     required this.description,
+    required this.forumUri,
     required this.roundId,
     required this.accountUuid,
   });
@@ -755,6 +777,7 @@ class _PendingVoteContent extends StatelessWidget {
   final String roundTitle;
   final int snapshotHeight;
   final String description;
+  final Uri? forumUri;
   final String roundId;
   final String? accountUuid;
 
@@ -810,6 +833,13 @@ class _PendingVoteContent extends StatelessWidget {
                       ),
                     ),
                   ],
+                  if (forumUri != null) ...[
+                    const SizedBox(height: AppSpacing.xs),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: VotingForumLinkButton(uri: forumUri!),
+                    ),
+                  ],
                   const SizedBox(height: AppSpacing.md),
                   Text(
                     'Vote in progress',
@@ -849,6 +879,7 @@ class _VotedPollHeader extends StatelessWidget {
     required this.title,
     required this.snapshotHeight,
     required this.description,
+    required this.forumUri,
     required this.votingPowerZatoshi,
     required this.votingPowerPreparing,
     required this.votedAt,
@@ -857,6 +888,7 @@ class _VotedPollHeader extends StatelessWidget {
   final String title;
   final int snapshotHeight;
   final String description;
+  final Uri? forumUri;
   final BigInt? votingPowerZatoshi;
   final bool votingPowerPreparing;
   final DateTime? votedAt;
@@ -915,6 +947,13 @@ class _VotedPollHeader extends StatelessWidget {
             style: AppTypography.bodyMedium.copyWith(
               color: colors.text.secondary,
             ),
+          ),
+        ],
+        if (forumUri != null) ...[
+          const SizedBox(height: AppSpacing.xs),
+          Align(
+            alignment: Alignment.centerRight,
+            child: VotingForumLinkButton(uri: forumUri!),
           ),
         ],
       ],
@@ -984,6 +1023,8 @@ class _VotedProposalCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final choiceLabel = _choiceLabel(proposal, choice);
+    final zipBadges = proposal.zipBadges;
+    final forumUri = proposal.forumUri;
     return Container(
       padding: const EdgeInsets.all(AppSpacing.sm),
       decoration: BoxDecoration(
@@ -1004,7 +1045,7 @@ class _VotedProposalCard extends StatelessWidget {
         children: [
           Row(
             children: [
-              _ProposalBadge('Proposal ${proposal.id}'),
+              VotingMetadataBadge('Proposal ${proposal.id}'),
               const SizedBox(width: AppSpacing.xs),
               Expanded(
                 child: Align(
@@ -1014,6 +1055,10 @@ class _VotedProposalCard extends StatelessWidget {
               ),
             ],
           ),
+          if (zipBadges.isNotEmpty || forumUri != null) ...[
+            const SizedBox(height: AppSpacing.s),
+            VotingProposalMetadataRow(zipBadges: zipBadges, forumUri: forumUri),
+          ],
           const SizedBox(height: AppSpacing.s),
           Text(
             proposal.title,
@@ -1033,36 +1078,6 @@ class _VotedProposalCard extends StatelessWidget {
             ),
           ],
         ],
-      ),
-    );
-  }
-}
-
-class _ProposalBadge extends StatelessWidget {
-  const _ProposalBadge(this.label);
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.xs,
-        vertical: 2,
-      ),
-      decoration: BoxDecoration(
-        color: colors.background.neutralSubtleOpacity,
-        borderRadius: BorderRadius.circular(AppRadii.full),
-        border: Border.all(color: colors.border.regular),
-      ),
-      child: Text(
-        label,
-        style: AppTypography.labelMedium.copyWith(
-          color: colors.text.secondary,
-          height: 16 / 12,
-          letterSpacing: 0,
-        ),
       ),
     );
   }
@@ -1110,7 +1125,8 @@ class _ProposalCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final badge = _proposalBadge(proposal);
+    final zipBadges = proposal.zipBadges;
+    final forumUri = proposal.forumUri;
     return Container(
       padding: const EdgeInsets.all(AppSpacing.sm),
       decoration: BoxDecoration(
@@ -1141,8 +1157,8 @@ class _ProposalCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (badge != null) ...[
-            _ProposalBadge(badge),
+          if (zipBadges.isNotEmpty || forumUri != null) ...[
+            VotingProposalMetadataRow(zipBadges: zipBadges, forumUri: forumUri),
             const SizedBox(height: AppSpacing.s),
           ],
           Text(
@@ -1276,15 +1292,6 @@ String _daysLeftLabel(DateTime endDate) {
   if (days <= 0) return 'Ends today';
   if (days == 1) return '1 day left';
   return '$days days left';
-}
-
-String? _proposalBadge(VotingProposalView proposal) {
-  final match = RegExp(
-    r'\bZIP[-\s]?\d+\b',
-    caseSensitive: false,
-  ).firstMatch('${proposal.title} ${proposal.description}');
-  if (match == null) return null;
-  return match.group(0)!.toUpperCase().replaceAll(RegExp(r'\s+'), '-');
 }
 
 class _OptionRow extends StatelessWidget {

--- a/lib/src/features/voting/screens/voting_results_screen.dart
+++ b/lib/src/features/voting/screens/voting_results_screen.dart
@@ -19,6 +19,7 @@ import '../../../services/voting/resolved_voting_config_extensions.dart';
 import '../voting_choice_style.dart';
 import '../voting_flow_models.dart';
 import '../voting_poll_ordering.dart';
+import '../widgets/voting_metadata_widgets.dart';
 import '../widgets/voting_pane_scroll_area.dart';
 
 const int _ballotDivisorZatoshi = 12500000;
@@ -127,6 +128,7 @@ class _VotingResultsScreenState extends ConsumerState<VotingResultsScreen> {
                           title: _roundTitle(round),
                           snapshotHeight: round.snapshotHeight,
                           description: _roundDescription(round) ?? '',
+                          forumUri: votingRoundForumUriFromJson(round.rawJson),
                         ),
                         const SizedBox(height: AppSpacing.md),
                         Text(
@@ -195,11 +197,13 @@ class _ResultsHeader extends StatefulWidget {
     required this.title,
     required this.snapshotHeight,
     required this.description,
+    required this.forumUri,
   });
 
   final String title;
   final int snapshotHeight;
   final String description;
+  final Uri? forumUri;
 
   @override
   State<_ResultsHeader> createState() => _ResultsHeaderState();
@@ -211,7 +215,8 @@ class _ResultsHeaderState extends State<_ResultsHeader> {
   @override
   void didUpdateWidget(covariant _ResultsHeader oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.description != widget.description) {
+    if (oldWidget.description != widget.description ||
+        oldWidget.forumUri != widget.forumUri) {
       _descriptionExpanded = false;
     }
   }
@@ -293,6 +298,13 @@ class _ResultsHeaderState extends State<_ResultsHeader> {
             },
           ),
         ],
+        if (widget.forumUri != null) ...[
+          const SizedBox(height: AppSpacing.xs),
+          Align(
+            alignment: Alignment.centerRight,
+            child: VotingForumLinkButton(uri: widget.forumUri!),
+          ),
+        ],
       ],
     );
   }
@@ -314,6 +326,8 @@ class _ResultCard extends StatelessWidget {
     final total = tally.values.fold<num>(0, (sum, value) => sum + value);
     final winningOption = _singleWinningOption(proposal.options, tally, total);
     final selectedLabel = _optionLabel(proposal.options, selectedChoice);
+    final zipBadges = proposal.zipBadges;
+    final forumUri = proposal.forumUri;
 
     return Container(
       padding: const EdgeInsets.all(AppSpacing.sm),
@@ -325,6 +339,10 @@ class _ResultCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
+          if (zipBadges.isNotEmpty || forumUri != null) ...[
+            VotingProposalMetadataRow(zipBadges: zipBadges, forumUri: forumUri),
+            const SizedBox(height: AppSpacing.s),
+          ],
           Text(
             proposal.title,
             style: AppTypography.headlineSmall.copyWith(

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -13,6 +13,7 @@ import '../../../providers/voting/voting_session_provider.dart';
 import '../voting_choice_style.dart';
 import '../voting_flow_models.dart';
 import '../voting_routes.dart';
+import '../widgets/voting_metadata_widgets.dart';
 
 class VotingReviewScreen extends ConsumerStatefulWidget {
   const VotingReviewScreen({super.key, required this.roundId});
@@ -69,6 +70,9 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
             final proposals = round == null
                 ? <VotingProposalView>[]
                 : proposalsFromRound(round);
+            final roundForumUri = round == null
+                ? null
+                : votingRoundForumUriFromJson(round.rawJson);
             final accountUuid = state.accountUuid;
             final draft = accountUuid == null
                 ? const VotingDraftState()
@@ -125,10 +129,19 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                                               color: context.colors.text.accent,
                                             ),
                                       ),
+                                      if (roundForumUri != null) ...[
+                                        const SizedBox(height: AppSpacing.xs),
+                                        Align(
+                                          alignment: Alignment.centerRight,
+                                          child: VotingForumLinkButton(
+                                            uri: roundForumUri,
+                                          ),
+                                        ),
+                                      ],
                                       const SizedBox(height: AppSpacing.md),
                                       for (final proposal in proposals)
                                         _ReviewRow(
-                                          title: proposal.title,
+                                          proposal: proposal,
                                           value: _reviewValue(proposal, draft),
                                           skipped:
                                               draft.choices[proposal.id] ==
@@ -188,12 +201,12 @@ String _reviewValue(VotingProposalView proposal, VotingDraftState draft) {
 
 class _ReviewRow extends StatelessWidget {
   const _ReviewRow({
-    required this.title,
+    required this.proposal,
     required this.value,
     this.skipped = false,
   });
 
-  final String title;
+  final VotingProposalView proposal;
   final String value;
   final bool skipped;
 
@@ -206,8 +219,10 @@ class _ReviewRow extends StatelessWidget {
     final valueColor = skipped
         ? colors.text.secondary.withValues(alpha: 0.72)
         : votingChoicePalette(context, value).text;
+    final zipBadges = proposal.zipBadges;
+    final forumUri = proposal.forumUri;
     final titleText = Text(
-      title,
+      proposal.title,
       style: AppTypography.bodyMedium.copyWith(color: titleColor),
     );
     final valueText = Text(
@@ -230,6 +245,10 @@ class _ReviewRow extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
+          if (zipBadges.isNotEmpty || forumUri != null) ...[
+            VotingProposalMetadataRow(zipBadges: zipBadges, forumUri: forumUri),
+            const SizedBox(height: AppSpacing.xs),
+          ],
           titleText,
           const SizedBox(height: AppSpacing.xxs),
           valueText,

--- a/lib/src/features/voting/voting_flow_models.dart
+++ b/lib/src/features/voting/voting_flow_models.dart
@@ -9,6 +9,35 @@ import '../../rust/third_party/zcash_voting/wire.dart' as rust_voting;
 
 const int _minProposalId = 1;
 const int _maxProposalId = 15;
+const List<String> _forumUrlKeys = [
+  'discussion_url',
+  'discussionUrl',
+  'discussionURL',
+  'discussion_link',
+  'discussionLink',
+  'discussion',
+  'forum_url',
+  'forumUrl',
+  'forumURL',
+  'forum_link',
+  'forumLink',
+  'forum',
+  'thread_url',
+  'threadUrl',
+  'thread_link',
+  'threadLink',
+  'topic_url',
+  'topicUrl',
+  'topic_link',
+  'topicLink',
+];
+const List<String> _proposalForumUrlKeys = [..._forumUrlKeys, 'url', 'link'];
+const List<String> _forumMetadataContainerKeys = [
+  'metadata',
+  'meta',
+  'links',
+  'resources',
+];
 
 class VotingProposalView {
   const VotingProposalView({
@@ -16,12 +45,26 @@ class VotingProposalView {
     required this.title,
     required this.description,
     required this.options,
+    this.zipNumber = '',
+    this.forumUrl = '',
   });
 
   final int id;
   final String title;
   final String description;
   final List<VotingOptionView> options;
+  final String zipNumber;
+  final String forumUrl;
+
+  List<String> get zipBadges {
+    final explicitBadges = votingZipBadgesFromZipNumber(zipNumber);
+    if (explicitBadges.isNotEmpty) return explicitBadges;
+    return votingZipBadgesFromText('$title $description');
+  }
+
+  Uri? get forumUri => votingForumUriFromString(forumUrl);
+
+  bool get hasDisplayMetadata => zipBadges.isNotEmpty || forumUri != null;
 }
 
 class VotingOptionView {
@@ -295,6 +338,21 @@ VotingProposalView _proposalFromJson(
     title:
         _stringFromJson(json, const ['title']) ?? 'Proposal ${fallbackId + 1}',
     description: _stringFromJson(json, const ['description']) ?? '',
+    zipNumber:
+        _stringFromJson(json, const [
+          'zip_number',
+          'zipNumber',
+          'zip_number_string',
+          'zipNumberString',
+        ])?.trim() ??
+        '',
+    forumUrl:
+        _forumUrlStringFromJson(
+          json,
+          keys: _proposalForumUrlKeys,
+          allowGenericRootLinkKeys: true,
+        ) ??
+        '',
     options: options.isEmpty
         ? const [
             VotingOptionView(index: 0, label: 'Yes'),
@@ -302,6 +360,152 @@ VotingProposalView _proposalFromJson(
           ]
         : options,
   );
+}
+
+Uri? votingRoundForumUriFromJson(Map<String, dynamic> json) {
+  return _forumUriFromJson(
+    json,
+    keys: _forumUrlKeys,
+    allowGenericRootLinkKeys: true,
+  );
+}
+
+Uri? votingForumUriFromString(String? value) {
+  final trimmed = value?.trim();
+  if (trimmed == null || trimmed.isEmpty) return null;
+  final uri = _externalWebUriFromCandidate(trimmed);
+  if (uri != null) return uri;
+  final match = RegExp(
+    r'''https?://[^\s<>()"']+''',
+    caseSensitive: false,
+  ).firstMatch(trimmed);
+  if (match == null) return null;
+  return _externalWebUriFromCandidate(match.group(0)!);
+}
+
+String? _forumUrlStringFromJson(
+  Map<String, dynamic> json, {
+  required List<String> keys,
+  required bool allowGenericRootLinkKeys,
+}) {
+  return _forumUriFromJson(
+    json,
+    keys: keys,
+    allowGenericRootLinkKeys: allowGenericRootLinkKeys,
+  )?.toString();
+}
+
+Uri? _forumUriFromJson(
+  Map<String, dynamic> json, {
+  required List<String> keys,
+  required bool allowGenericRootLinkKeys,
+}) {
+  final direct = votingForumUriFromString(_stringFromJson(json, keys));
+  if (direct != null) return direct;
+
+  for (final key in _forumMetadataContainerKeys) {
+    final uri = _forumUriFromValue(json[key]);
+    if (uri != null) return uri;
+  }
+
+  for (final entry in json.entries) {
+    if (!_isForumLinkKey(
+      entry.key,
+      allowGenericLinkKeys: allowGenericRootLinkKeys,
+    )) {
+      continue;
+    }
+    final uri = _forumUriFromValue(entry.value);
+    if (uri != null) return uri;
+  }
+
+  return null;
+}
+
+Uri? _forumUriFromValue(Object? value) {
+  if (value == null) return null;
+  if (value is String) return votingForumUriFromString(value);
+  if (value is Map) {
+    for (final entry in value.entries) {
+      final uri = _forumUriFromValue(entry.value);
+      if (uri != null) return uri;
+    }
+    return null;
+  }
+  if (value is Iterable) {
+    for (final item in value) {
+      final uri = _forumUriFromValue(item);
+      if (uri != null) return uri;
+    }
+  }
+  return null;
+}
+
+Uri? _externalWebUriFromCandidate(String value) {
+  final uri = Uri.tryParse(value);
+  if (uri == null || uri.host.trim().isEmpty) return null;
+  final scheme = uri.scheme.toLowerCase();
+  return scheme == 'https' || scheme == 'http' ? uri : null;
+}
+
+bool _isForumLinkKey(String key, {required bool allowGenericLinkKeys}) {
+  final normalized = key.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '');
+  if (normalized.contains('forum') ||
+      normalized.contains('discussion') ||
+      normalized.contains('thread') ||
+      normalized.contains('topic')) {
+    return true;
+  }
+  return allowGenericLinkKeys &&
+      (normalized == 'url' || normalized == 'link' || normalized == 'href');
+}
+
+List<String> votingZipBadgesFromZipNumber(String value) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty) return const [];
+
+  final parts = trimmed
+      .split(RegExp(r'\s*(?:,|;|/|&|\band\b)\s*', caseSensitive: false))
+      .map((part) => part.trim())
+      .where((part) => part.isNotEmpty)
+      .toList(growable: false);
+  final normalizedParts = [
+    for (final part in parts) _normalizeExplicitZipLabel(part),
+  ].whereType<String>().toList(growable: false);
+  if (normalizedParts.isNotEmpty) return _dedupe(normalizedParts);
+
+  return votingZipBadgesFromText(trimmed);
+}
+
+List<String> votingZipBadgesFromText(String value) {
+  final matches = RegExp(
+    r'\bZIP[-\s]?\d+\b',
+    caseSensitive: false,
+  ).allMatches(value);
+  return _dedupe([
+    for (final match in matches)
+      match.group(0)!.toUpperCase().replaceAll(RegExp(r'\s+'), '-'),
+  ]);
+}
+
+String? _normalizeExplicitZipLabel(String value) {
+  final trimmed = value.trim();
+  if (trimmed.isEmpty) return null;
+  final prefixed = RegExp(
+    r'^ZIP[-\s]?([A-Z0-9]+)$',
+    caseSensitive: false,
+  ).firstMatch(trimmed);
+  if (prefixed != null) return 'ZIP-${prefixed.group(1)!.toUpperCase()}';
+  if (RegExp(r'^\d+$').hasMatch(trimmed)) return 'ZIP-$trimmed';
+  return null;
+}
+
+List<String> _dedupe(Iterable<String> values) {
+  final seen = <String>{};
+  return [
+    for (final value in values)
+      if (seen.add(value)) value,
+  ];
 }
 
 int _proposalIdFromJson(Map<String, dynamic> json) {

--- a/lib/src/features/voting/widgets/voting_metadata_widgets.dart
+++ b/lib/src/features/voting/widgets/voting_metadata_widgets.dart
@@ -1,0 +1,115 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+
+class VotingMetadataBadge extends StatelessWidget {
+  const VotingMetadataBadge(this.label, {super.key});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: 2,
+      ),
+      decoration: BoxDecoration(
+        color: colors.background.neutralSubtleOpacity,
+        borderRadius: BorderRadius.circular(AppRadii.full),
+        border: Border.all(color: colors.border.regular),
+      ),
+      child: Text(
+        label,
+        style: AppTypography.labelMedium.copyWith(
+          color: colors.text.secondary,
+          height: 16 / 12,
+          letterSpacing: 0,
+        ),
+      ),
+    );
+  }
+}
+
+class VotingForumLinkButton extends StatelessWidget {
+  const VotingForumLinkButton({
+    required this.uri,
+    this.label = 'Forum discussion',
+    this.size = AppButtonSize.small,
+    super.key,
+  });
+
+  final Uri uri;
+  final String label;
+  final AppButtonSize size;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppButton(
+      onPressed: () {
+        unawaited(launchUrl(uri, mode: LaunchMode.externalApplication));
+      },
+      variant: AppButtonVariant.ghost,
+      size: size,
+      leading: const AppIcon(AppIcons.link),
+      child: Text(label),
+    );
+  }
+}
+
+class VotingProposalMetadataRow extends StatelessWidget {
+  const VotingProposalMetadataRow({
+    required this.zipBadges,
+    required this.forumUri,
+    this.forumLabel = 'Forum discussion',
+    super.key,
+  });
+
+  final List<String> zipBadges;
+  final Uri? forumUri;
+  final String forumLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    if (zipBadges.isEmpty && forumUri == null) {
+      return const SizedBox.shrink();
+    }
+    if (forumUri == null) {
+      return Wrap(
+        spacing: AppSpacing.xs,
+        runSpacing: AppSpacing.xxs,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [for (final badge in zipBadges) VotingMetadataBadge(badge)],
+      );
+    }
+    if (zipBadges.isEmpty) {
+      return Align(
+        alignment: Alignment.centerRight,
+        child: VotingForumLinkButton(uri: forumUri!, label: forumLabel),
+      );
+    }
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Expanded(
+          child: Wrap(
+            spacing: AppSpacing.xs,
+            runSpacing: AppSpacing.xxs,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              for (final badge in zipBadges) VotingMetadataBadge(badge),
+            ],
+          ),
+        ),
+        const SizedBox(width: AppSpacing.xs),
+        VotingForumLinkButton(uri: forumUri!, label: forumLabel),
+      ],
+    );
+  }
+}

--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -21,6 +21,11 @@ bool wasVotingPollListRecentlyRefreshed() {
       kVotingPollListRecentRefreshWindow;
 }
 
+@visibleForTesting
+void resetVotingPollListRecentRefreshForTests() {
+  _lastVotingPollListRefreshAt = null;
+}
+
 /// Refreshes the dynamic voting config and then reloads the poll list.
 ///
 /// Call this before returning to the poll menu after completing voting work so

--- a/test/features/voting/voting_flow_models_test.dart
+++ b/test/features/voting/voting_flow_models_test.dart
@@ -42,6 +42,125 @@ void main() {
     ]);
   });
 
+  test('proposal parser preserves structured ZIP and forum metadata', () {
+    final proposals = proposalsFromJson({
+      'proposals': [
+        {
+          'id': 1,
+          'title': 'First',
+          'zip_number': 'ZIP 233, 234',
+          'forum_url': 'https://forum.zcashcommunity.com/t/zip-233',
+        },
+        {
+          'id': 2,
+          'title': 'Second',
+          'zipNumber': 'ZIP 231',
+          'forumURL': 'https://forum.zcashcommunity.com/t/zip-231',
+        },
+        {
+          'id': 3,
+          'title': 'Third',
+          'zipNumberString': '232',
+          'forum_link': 'Discussion: https://example.com/voting/zip-232',
+        },
+        {
+          'id': 4,
+          'title': 'Fourth',
+          'metadata': {
+            'links': [
+              {'url': 'http://example.net/voting/zip-230'},
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(proposals.first.zipNumber, 'ZIP 233, 234');
+    expect(proposals.first.zipBadges, ['ZIP-233', 'ZIP-234']);
+    expect(
+      proposals.first.forumUri,
+      Uri.parse('https://forum.zcashcommunity.com/t/zip-233'),
+    );
+    expect(proposals[1].zipBadges, ['ZIP-231']);
+    expect(
+      proposals[1].forumUri,
+      Uri.parse('https://forum.zcashcommunity.com/t/zip-231'),
+    );
+    expect(proposals[2].zipBadges, ['ZIP-232']);
+    expect(
+      proposals[2].forumUri,
+      Uri.parse('https://example.com/voting/zip-232'),
+    );
+    expect(
+      proposals[3].forumUri,
+      Uri.parse('http://example.net/voting/zip-230'),
+    );
+  });
+
+  test('proposal ZIP badges fall back to title and description text', () {
+    final proposals = proposalsFromJson({
+      'proposals': [
+        {'id': 1, 'title': 'NU7 ZIP 233', 'description': 'Related to ZIP 234.'},
+      ],
+    });
+
+    expect(proposals.single.zipBadges, ['ZIP-233', 'ZIP-234']);
+  });
+
+  test('round forum URL parser accepts discussion and forum aliases', () {
+    expect(
+      votingRoundForumUriFromJson({
+        'discussion_url': 'https://forum.zcashcommunity.com/t/nu7',
+      }),
+      Uri.parse('https://forum.zcashcommunity.com/t/nu7'),
+    );
+    expect(
+      votingRoundForumUriFromJson({
+        'forumURL': 'https://forum.zcashcommunity.com/t/proposal',
+      }),
+      Uri.parse('https://forum.zcashcommunity.com/t/proposal'),
+    );
+    expect(
+      votingRoundForumUriFromJson({
+        'forum_link': 'https://example.com/proposal-link',
+      }),
+      Uri.parse('https://example.com/proposal-link'),
+    );
+    expect(
+      votingRoundForumUriFromJson({'url': 'http://example.org/root-url'}),
+      Uri.parse('http://example.org/root-url'),
+    );
+    expect(
+      votingRoundForumUriFromJson({
+        'metadata': {
+          'links': [
+            {'label': 'Forum', 'url': 'https://example.net/nested'},
+          ],
+        },
+      }),
+      Uri.parse('https://example.net/nested'),
+    );
+    expect(
+      votingRoundForumUriFromJson({
+        'proposals': [
+          {'forum_url': 'https://forum.zcashcommunity.com/t/proposal-only'},
+        ],
+      }),
+      null,
+    );
+    expect(votingRoundForumUriFromJson({'forum_url': 'javascript:bad'}), null);
+    expect(
+      votingRoundForumUriFromJson({
+        'forum_url': 'http://forum.zcashcommunity.com/t/nu7',
+      }),
+      Uri.parse('http://forum.zcashcommunity.com/t/nu7'),
+    );
+    expect(
+      votingRoundForumUriFromJson({'forum_url': 'https://example.com/t/nu7'}),
+      Uri.parse('https://example.com/t/nu7'),
+    );
+  });
+
   test(
     'proposal parser preserves option descriptions separately from labels',
     () {

--- a/test/features/voting/voting_polls_screen_test.dart
+++ b/test/features/voting/voting_polls_screen_test.dart
@@ -16,6 +16,8 @@ import 'package:zcash_wallet/src/providers/voting/voting_state.dart';
 import 'package:zcash_wallet/src/rust/third_party/zcash_voting/config.dart';
 
 void main() {
+  setUp(resetVotingPollListRecentRefreshForTests);
+
   testWidgets('poll list reloads when screen opens and route returns', (
     tester,
   ) async {
@@ -168,6 +170,49 @@ void main() {
 
     expect(find.text('Account 2 poll'), findsOneWidget);
     expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('poll cards show round forum discussion links', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final router = GoRouter(
+      initialLocation: '/voting',
+      routes: [
+        GoRoute(path: '/voting', builder: (_, _) => const VotingPollsScreen()),
+        GoRoute(path: '/accounts', builder: (_, _) => const Text('accounts')),
+        GoRoute(path: '/home', builder: (_, _) => const Text('home')),
+        GoRoute(
+          path: '/address-book',
+          builder: (_, _) => const Text('address book'),
+        ),
+        GoRoute(path: '/activity', builder: (_, _) => const Text('activity')),
+        GoRoute(path: '/settings', builder: (_, _) => const Text('settings')),
+        GoRoute(path: '/about', builder: (_, _) => const Text('about')),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          accountProvider.overrideWith(_SoftwareAccountNotifier.new),
+          syncProvider.overrideWith(_NoopSyncNotifier.new),
+          swapFeatureEnabledProvider.overrideWithValue(false),
+          votingConfigProvider.overrideWith(_TrackingVotingConfigNotifier.new),
+          votingRoundsProvider.overrideWith(_ForumLinkVotingRoundsNotifier.new),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, child) =>
+              AppTheme(data: AppThemeData.light, child: child!),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Forum discussion'), findsOneWidget);
   });
 
   testWidgets(
@@ -334,6 +379,26 @@ class _InitiallyFailingVotingRoundsNotifier extends VotingRoundsNotifier {
       ),
     ]);
   }
+}
+
+class _ForumLinkVotingRoundsNotifier extends VotingRoundsNotifier {
+  @override
+  Future<List<VotingRoundView>> build() async => const [_round];
+
+  @override
+  Future<void> reload() async {
+    state = const AsyncData([_round]);
+  }
+
+  static const _round = VotingRoundView(
+    roundId: 'round-1',
+    title: 'Active poll',
+    status: 'active',
+    rawJson: {
+      'description': 'Active poll description',
+      'discussion_url': 'https://forum.zcashcommunity.com/t/active-poll',
+    },
+  );
 }
 
 class _AccountReloadVotingRoundsNotifier extends VotingRoundsNotifier {

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1119,7 +1119,12 @@ void main() {
       await tester.binding.setSurfaceSize(null);
     });
 
-    final round = _roundStatusJson()..['summary'] = '[TEST] Max Proposals';
+    final proposal = _proposalJson(1, 'First proposal', ['Yes', 'No'])
+      ..['zip_number'] = 'ZIP 233'
+      ..['forum_url'] = 'https://forum.zcashcommunity.com/t/zip-233';
+    final round = _roundStatusJson()
+      ..['summary'] = '[TEST] Max Proposals'
+      ..['proposals'] = [proposal];
     final http = FakeVotingHttpClient(
       responses: _votingHttpResponses()
         ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
@@ -1143,6 +1148,8 @@ void main() {
 
     expect(find.text('[TEST] Max Proposals'), findsOneWidget);
     expect(find.text('Voting power 0.000001 ZEC'), findsOneWidget);
+    expect(find.text('ZIP-233'), findsOneWidget);
+    expect(find.text('Forum discussion'), findsOneWidget);
     expect(find.text('Yes'), findsOneWidget);
     expect(find.text('Review answers'), findsOneWidget);
     expect(find.text('Start Voting'), findsNothing);
@@ -1286,6 +1293,8 @@ void main() {
         {
           'id': 2,
           'title': 'Second proposal',
+          'zip_number': 'ZIP 231',
+          'forum_url': 'https://forum.zcashcommunity.com/t/zip-231',
           'options': [
             {'index': 0, 'label': 'Mint', 'description': optionDescription},
             {'index': 1, 'label': 'Burn'},
@@ -1339,6 +1348,8 @@ void main() {
     expect(find.text('Total: 0.75 ZEC'), findsOneWidget);
     expect(find.text('Voted: Yes'), findsOneWidget);
     expect(find.text('Second proposal'), findsOneWidget);
+    expect(find.text('ZIP-231'), findsOneWidget);
+    expect(find.text('Forum discussion'), findsOneWidget);
     expect(find.text('Mint'), findsOneWidget);
     expect(find.text(optionDescription), findsNothing);
     expect(find.text('0.13 ZEC'), findsOneWidget);
@@ -1535,9 +1546,12 @@ void main() {
       await tester.binding.setSurfaceSize(null);
     });
 
+    final firstProposal = _proposalJson(1, 'First proposal', ['Yes', 'No'])
+      ..['zip_number'] = 'ZIP 233';
     final round = _roundStatusJson()
+      ..['forum_link'] = 'https://forum.zcashcommunity.com/t/zip-233'
       ..['proposals'] = [
-        _proposalJson(1, 'First proposal', ['Yes', 'No']),
+        firstProposal,
         _proposalJson(2, 'Second proposal', ['Aye', 'Nay']),
       ];
     final http = FakeVotingHttpClient(
@@ -1576,6 +1590,8 @@ void main() {
 
     expect(find.text('Review your answers'), findsOneWidget);
     expect(find.text('Confirm & submit'), findsOneWidget);
+    expect(find.text('ZIP-233'), findsOneWidget);
+    expect(find.text('Forum discussion'), findsOneWidget);
     expect(find.text('First proposal'), findsOneWidget);
     expect(find.text('Yes'), findsOneWidget);
     expect(find.text('Second proposal'), findsOneWidget);


### PR DESCRIPTION
Summary:
- Parse structured voting ZIP numbers and forum URLs from round/proposal payloads, with title/description ZIP inference kept as fallback.
- Render ZIP badges and forum links across poll list, proposal detail, review, completed-vote, and results surfaces.
- Restrict rendered forum URLs to HTTPS links on forum.zcashcommunity.com and add parser/widget coverage.

Tests:
- fvm dart analyze lib/src/features/voting/voting_flow_models.dart lib/src/features/voting/widgets/voting_metadata_widgets.dart lib/src/features/voting/screens/voting_polls_screen.dart lib/src/features/voting/screens/voting_proposal_detail_screen.dart lib/src/features/voting/screens/voting_results_screen.dart lib/src/features/voting/screens/voting_review_screen.dart lib/src/providers/voting/voting_rounds_provider.dart test/features/voting/voting_flow_models_test.dart test/features/voting/voting_polls_screen_test.dart test/features/voting/voting_status_screen_test.dart
- fvm flutter test test/features/voting/voting_flow_models_test.dart test/features/voting/voting_polls_screen_test.dart
- fvm flutter test test/features/voting/voting_status_screen_test.dart --plain-name "proposal detail"
- fvm flutter test test/features/voting/voting_status_screen_test.dart --plain-name "results screen"
- fvm flutter test test/features/voting/voting_status_screen_test.dart --plain-name "reviewing partial votes warns and marks skipped rows"
- fvm flutter analyze (fails on pre-existing control_flow_in_finally info in lib/src/features/voting/screens/voting_submission_confirmation_screen.dart)
