### PR TITLE
Block voting below minimum eligibility

### DIFF
--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -325,14 +325,18 @@ class _ActivePollContent extends StatefulWidget {
 class _ActivePollContentState extends State<_ActivePollContent> {
   bool _descriptionExpanded = false;
 
+  Future<void> _showIneligibleDialog() async {
+    final message = widget.votingEligibilityErrorMessage;
+    if (message == null) return;
+    await showDialog<void>(
+      context: context,
+      builder: (_) => _IneligiblePollDialog(message: message),
+    );
+  }
+
   Future<void> _handleBottomActionPressed() async {
     if (!widget.votingEligibilityConfirmed) {
-      final message = widget.votingEligibilityErrorMessage;
-      if (message == null) return;
-      await showDialog<void>(
-        context: context,
-        builder: (_) => _IneligiblePollDialog(message: message),
-      );
+      await _showIneligibleDialog();
       return;
     }
     final skippedCount = widget.proposals
@@ -428,12 +432,18 @@ class _ActivePollContentState extends State<_ActivePollContent> {
                       );
                     }
                     final proposal = widget.proposals[index - 1];
+                    final isIneligible =
+                        !widget.votingEligibilityConfirmed &&
+                        widget.votingEligibilityErrorMessage != null;
                     return _ProposalCard(
                       proposal: proposal,
                       selectedChoice: widget.votingEligibilityConfirmed
                           ? widget.draft.choices[proposal.id]
                           : null,
                       enabled: widget.votingEligibilityConfirmed,
+                      onDisabledOptionTap: isIneligible
+                          ? _showIneligibleDialog
+                          : null,
                       onChoice: (choice) =>
                           widget.onChoice(proposal.id, choice),
                     );
@@ -1272,12 +1282,14 @@ class _ProposalCard extends StatelessWidget {
     required this.proposal,
     required this.selectedChoice,
     required this.enabled,
+    required this.onDisabledOptionTap,
     required this.onChoice,
   });
 
   final VotingProposalView proposal;
   final int? selectedChoice;
   final bool enabled;
+  final VoidCallback? onDisabledOptionTap;
   final ValueChanged<int?> onChoice;
 
   @override
@@ -1347,6 +1359,7 @@ class _ProposalCard extends StatelessWidget {
               option: option,
               selected: selectedChoice == option.index,
               enabled: enabled,
+              onDisabledTap: onDisabledOptionTap,
               onTap: () => onChoice(
                 selectedChoice == option.index ? null : option.index,
               ),
@@ -1458,12 +1471,14 @@ class _OptionRow extends StatelessWidget {
     required this.option,
     required this.selected,
     required this.enabled,
+    required this.onDisabledTap,
     required this.onTap,
   });
 
   final VotingOptionView option;
   final bool selected;
   final bool enabled;
+  final VoidCallback? onDisabledTap;
   final VoidCallback onTap;
 
   @override
@@ -1483,7 +1498,7 @@ class _OptionRow extends StatelessWidget {
         : colors.text.secondary.withValues(alpha: 0.48);
     return InkWell(
       borderRadius: BorderRadius.circular(AppRadii.small),
-      onTap: enabled ? onTap : null,
+      onTap: enabled ? onTap : onDisabledTap,
       child: Container(
         padding: const EdgeInsets.symmetric(
           horizontal: AppSpacing.sm,

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -111,7 +111,7 @@ class _VotingProposalDetailScreenState
                 ),
               );
             }
-            if (completedVote != null) {
+            if (completedVote != null && hasConfirmedVotingEligibility) {
               return Padding(
                 padding: const EdgeInsets.all(AppSpacing.md),
                 child: _VotedPollContent(

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -17,6 +17,7 @@ import '../../../providers/voting/voting_tree_sync_provider.dart';
 import '../../../providers/voting/voting_state.dart';
 import '../../../rust/third_party/zcash_voting/wire.dart' as rust_wire;
 import '../voting_choice_style.dart';
+import '../voting_error_messages.dart';
 import '../voting_flow_models.dart';
 import '../voting_formatters.dart';
 import '../voting_resume_plan.dart';
@@ -88,11 +89,14 @@ class _VotingProposalDetailScreenState
             final proposals = proposalsFromRound(round);
             final forumUri = votingRoundForumUriFromJson(round.rawJson);
             final completedVote = _CompletedVote.fromPlan(state.roundPlan);
+            final hasConfirmedVotingEligibility =
+                state.hasConfirmedVotingEligibility;
             _maybePrepareVotingPower(state);
             // Foreground recovery takes precedence over the read-only voted view.
             // Accepted helper shares may still be tracked after submission, but
             // that background work should not keep this screen resumable.
-            if (hasBlockingRoundRecoveryWork(state.roundPlan)) {
+            if (hasBlockingRoundRecoveryWork(state.roundPlan) &&
+                hasConfirmedVotingEligibility) {
               return Padding(
                 padding: const EdgeInsets.all(AppSpacing.md),
                 child: _PendingVoteContent(
@@ -107,7 +111,7 @@ class _VotingProposalDetailScreenState
                 ),
               );
             }
-            if (completedVote != null) {
+            if (completedVote != null && hasConfirmedVotingEligibility) {
               return Padding(
                 padding: const EdgeInsets.all(AppSpacing.md),
                 child: _VotedPollContent(
@@ -126,7 +130,7 @@ class _VotingProposalDetailScreenState
               );
             }
             final pendingVote = _PendingVoteRecovery.fromPlan(state.roundPlan);
-            if (pendingVote != null) {
+            if (pendingVote != null && hasConfirmedVotingEligibility) {
               return Padding(
                 padding: const EdgeInsets.all(AppSpacing.md),
                 child: _PendingVoteContent(
@@ -141,6 +145,15 @@ class _VotingProposalDetailScreenState
                 ),
               );
             }
+            final votingPowerPreparing =
+                _votingPowerPreparationInFlight ||
+                (state.eligibleWeightZatoshi == null &&
+                    state.error == null &&
+                    _shouldPrepareVotingPower(state));
+            final votingEligibilityMessage = _votingEligibilityMessage(
+              state,
+              preparing: votingPowerPreparing,
+            );
             _maybePrecomputeDelegationPir(state);
             return _ActivePollContent(
               roundId: roundId,
@@ -150,7 +163,9 @@ class _VotingProposalDetailScreenState
               forumUri: forumUri,
               endDate: _roundEndDate(round.rawJson),
               votingPowerZatoshi: state.eligibleWeightZatoshi,
-              votingPowerPreparing: _votingPowerPreparationInFlight,
+              votingPowerPreparing: votingPowerPreparing,
+              votingEligibilityConfirmed: hasConfirmedVotingEligibility,
+              votingEligibilityMessage: votingEligibilityMessage,
               proposals: proposals,
               draft: draft,
               onChoice: draftKey == null
@@ -209,7 +224,9 @@ class _VotingProposalDetailScreenState
   // from PCZT construction, so it only needs the stored voting hotkey secret.
   void _maybePrecomputeDelegationPir(VotingSessionState state) {
     final accountUuid = state.accountUuid;
-    if (accountUuid == null || !_shouldPrepareVotingPower(state)) {
+    if (accountUuid == null ||
+        !state.hasConfirmedVotingEligibility ||
+        !_shouldPrepareVotingPower(state)) {
       return;
     }
 
@@ -245,6 +262,17 @@ bool _shouldPrepareVotingPower(VotingSessionState state) {
   };
 }
 
+String? _votingEligibilityMessage(
+  VotingSessionState state, {
+  required bool preparing,
+}) {
+  if (state.hasConfirmedVotingEligibility) return null;
+  final error = state.error;
+  if (error != null) return friendlyVotingErrorText(error.message);
+  if (preparing) return null;
+  return 'Voting power unavailable.';
+}
+
 class _ActivePollContent extends StatefulWidget {
   const _ActivePollContent({
     required this.roundId,
@@ -255,6 +283,8 @@ class _ActivePollContent extends StatefulWidget {
     required this.endDate,
     required this.votingPowerZatoshi,
     required this.votingPowerPreparing,
+    required this.votingEligibilityConfirmed,
+    required this.votingEligibilityMessage,
     required this.proposals,
     required this.draft,
     required this.onChoice,
@@ -268,6 +298,8 @@ class _ActivePollContent extends StatefulWidget {
   final DateTime? endDate;
   final BigInt? votingPowerZatoshi;
   final bool votingPowerPreparing;
+  final bool votingEligibilityConfirmed;
+  final String? votingEligibilityMessage;
   final List<VotingProposalView> proposals;
   final VotingDraftState draft;
   final void Function(int proposalId, int? choice) onChoice;
@@ -280,6 +312,7 @@ class _ActivePollContentState extends State<_ActivePollContent> {
   bool _descriptionExpanded = false;
 
   Future<void> _handleBottomActionPressed() async {
+    if (!widget.votingEligibilityConfirmed) return;
     final skippedCount = widget.proposals
         .where((proposal) => widget.draft.choices[proposal.id] == null)
         .length;
@@ -351,6 +384,8 @@ class _ActivePollContentState extends State<_ActivePollContent> {
                         endDate: widget.endDate,
                         votingPowerZatoshi: widget.votingPowerZatoshi,
                         votingPowerPreparing: widget.votingPowerPreparing,
+                        votingEligibilityMessage:
+                            widget.votingEligibilityMessage,
                         expanded: _descriptionExpanded,
                         onToggleDescription: () => setState(() {
                           _descriptionExpanded = !_descriptionExpanded;
@@ -359,14 +394,19 @@ class _ActivePollContentState extends State<_ActivePollContent> {
                     }
                     if (index == widget.proposals.length + 1) {
                       return _ReviewAnswersButton(
-                        enabled: !widget.draft.isEmpty,
+                        enabled:
+                            widget.votingEligibilityConfirmed &&
+                            !widget.draft.isEmpty,
                         onPressed: _handleBottomActionPressed,
                       );
                     }
                     final proposal = widget.proposals[index - 1];
                     return _ProposalCard(
                       proposal: proposal,
-                      selectedChoice: widget.draft.choices[proposal.id],
+                      selectedChoice: widget.votingEligibilityConfirmed
+                          ? widget.draft.choices[proposal.id]
+                          : null,
+                      enabled: widget.votingEligibilityConfirmed,
                       onChoice: (choice) =>
                           widget.onChoice(proposal.id, choice),
                     );
@@ -471,6 +511,7 @@ class _PollSummary extends StatelessWidget {
     required this.endDate,
     required this.votingPowerZatoshi,
     required this.votingPowerPreparing,
+    required this.votingEligibilityMessage,
     required this.expanded,
     required this.onToggleDescription,
   });
@@ -482,6 +523,7 @@ class _PollSummary extends StatelessWidget {
   final DateTime? endDate;
   final BigInt? votingPowerZatoshi;
   final bool votingPowerPreparing;
+  final String? votingEligibilityMessage;
   final bool expanded;
   final VoidCallback onToggleDescription;
 
@@ -554,6 +596,17 @@ class _PollSummary extends StatelessWidget {
             ],
           ],
         ),
+        if (votingEligibilityMessage != null) ...[
+          const SizedBox(height: AppSpacing.xxs),
+          Text(
+            votingEligibilityMessage!,
+            style: AppTypography.bodySmall.copyWith(
+              color: colors.text.secondary,
+              height: 16 / 12,
+              letterSpacing: 0,
+            ),
+          ),
+        ],
         if (hasDescription) ...[
           const SizedBox(height: AppSpacing.xs),
           LayoutBuilder(
@@ -1115,11 +1168,13 @@ class _ProposalCard extends StatelessWidget {
   const _ProposalCard({
     required this.proposal,
     required this.selectedChoice,
+    required this.enabled,
     required this.onChoice,
   });
 
   final VotingProposalView proposal;
   final int? selectedChoice;
+  final bool enabled;
   final ValueChanged<int?> onChoice;
 
   @override
@@ -1183,17 +1238,20 @@ class _ProposalCard extends StatelessWidget {
               ),
             ),
           ],
-          const SizedBox(height: AppSpacing.s),
-          for (final option in proposal.options) ...[
-            _OptionRow(
-              option: option,
-              selected: selectedChoice == option.index,
-              onTap: () => onChoice(
-                selectedChoice == option.index ? null : option.index,
+          if (enabled) ...[
+            const SizedBox(height: AppSpacing.s),
+            for (final option in proposal.options) ...[
+              _OptionRow(
+                option: option,
+                selected: selectedChoice == option.index,
+                enabled: enabled,
+                onTap: () => onChoice(
+                  selectedChoice == option.index ? null : option.index,
+                ),
               ),
-            ),
-            if (option != proposal.options.last)
-              const SizedBox(height: AppSpacing.xs),
+              if (option != proposal.options.last)
+                const SizedBox(height: AppSpacing.xs),
+            ],
           ],
         ],
       ),
@@ -1298,11 +1356,13 @@ class _OptionRow extends StatelessWidget {
   const _OptionRow({
     required this.option,
     required this.selected,
+    required this.enabled,
     required this.onTap,
   });
 
   final VotingOptionView option;
   final bool selected;
+  final bool enabled;
   final VoidCallback onTap;
 
   @override
@@ -1310,21 +1370,31 @@ class _OptionRow extends StatelessWidget {
     final colors = context.colors;
     final description = option.description.trim();
     final palette = votingChoicePalette(context, option.label);
+    final primaryTextColor = enabled
+        ? selected
+              ? palette.text
+              : colors.text.accent
+        : colors.text.secondary.withValues(alpha: 0.56);
+    final secondaryTextColor = enabled
+        ? selected
+              ? palette.text.withValues(alpha: 0.82)
+              : colors.text.secondary
+        : colors.text.secondary.withValues(alpha: 0.48);
     return InkWell(
       borderRadius: BorderRadius.circular(AppRadii.small),
-      onTap: onTap,
+      onTap: enabled ? onTap : null,
       child: Container(
         padding: const EdgeInsets.symmetric(
           horizontal: AppSpacing.sm,
           vertical: AppSpacing.xs,
         ),
         decoration: BoxDecoration(
-          color: selected
+          color: enabled && selected
               ? palette.background
               : colors.background.neutralSubtleOpacity,
           borderRadius: BorderRadius.circular(AppRadii.small),
           border: Border.all(
-            color: selected ? palette.border : colors.border.subtle,
+            color: enabled && selected ? palette.border : colors.border.subtle,
           ),
         ),
         child: Row(
@@ -1339,7 +1409,7 @@ class _OptionRow extends StatelessWidget {
                   Text(
                     option.label,
                     style: AppTypography.labelLarge.copyWith(
-                      color: selected ? palette.text : colors.text.accent,
+                      color: primaryTextColor,
                     ),
                   ),
                   if (description.isNotEmpty) ...[
@@ -1347,9 +1417,7 @@ class _OptionRow extends StatelessWidget {
                     Text(
                       description,
                       style: AppTypography.bodySmall.copyWith(
-                        color: selected
-                            ? palette.text.withValues(alpha: 0.82)
-                            : colors.text.secondary,
+                        color: secondaryTextColor,
                         height: 16 / 12,
                         letterSpacing: 0,
                       ),
@@ -1362,7 +1430,7 @@ class _OptionRow extends StatelessWidget {
             Text(
               selected ? 'Selected' : 'Choose',
               style: AppTypography.bodySmall.copyWith(
-                color: selected ? palette.text : colors.text.secondary,
+                color: enabled && selected ? palette.text : secondaryTextColor,
               ),
             ),
           ],

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -111,7 +111,7 @@ class _VotingProposalDetailScreenState
                 ),
               );
             }
-            if (completedVote != null && hasConfirmedVotingEligibility) {
+            if (completedVote != null) {
               return Padding(
                 padding: const EdgeInsets.all(AppSpacing.md),
                 child: _VotedPollContent(
@@ -154,6 +154,10 @@ class _VotingProposalDetailScreenState
               state,
               preparing: votingPowerPreparing,
             );
+            final votingError = state.error;
+            final votingEligibilityError = votingError == null
+                ? false
+                : isVotingEligibilityErrorText(votingError.message);
             _maybePrecomputeDelegationPir(state);
             return _ActivePollContent(
               roundId: roundId,
@@ -162,15 +166,23 @@ class _VotingProposalDetailScreenState
               description: _roundDescription(round.rawJson),
               forumUri: forumUri,
               endDate: _roundEndDate(round.rawJson),
-              votingPowerZatoshi: state.eligibleWeightZatoshi,
+              votingPowerZatoshi: votingEligibilityError
+                  ? BigInt.zero
+                  : state.eligibleWeightZatoshi,
               votingPowerPreparing: votingPowerPreparing,
               votingEligibilityConfirmed: hasConfirmedVotingEligibility,
-              votingEligibilityMessage: votingEligibilityMessage,
+              votingEligibilityMessage: votingEligibilityError
+                  ? null
+                  : votingEligibilityMessage,
+              votingEligibilityErrorMessage: votingEligibilityError
+                  ? votingEligibilityMessage
+                  : null,
               proposals: proposals,
               draft: draft,
               onChoice: draftKey == null
                   ? (_, _) {}
                   : (proposalId, choice) {
+                      if (!hasConfirmedVotingEligibility) return;
                       final notifier = ref.read(
                         votingDraftProvider(draftKey).notifier,
                       );
@@ -285,6 +297,7 @@ class _ActivePollContent extends StatefulWidget {
     required this.votingPowerPreparing,
     required this.votingEligibilityConfirmed,
     required this.votingEligibilityMessage,
+    required this.votingEligibilityErrorMessage,
     required this.proposals,
     required this.draft,
     required this.onChoice,
@@ -300,6 +313,7 @@ class _ActivePollContent extends StatefulWidget {
   final bool votingPowerPreparing;
   final bool votingEligibilityConfirmed;
   final String? votingEligibilityMessage;
+  final String? votingEligibilityErrorMessage;
   final List<VotingProposalView> proposals;
   final VotingDraftState draft;
   final void Function(int proposalId, int? choice) onChoice;
@@ -312,7 +326,15 @@ class _ActivePollContentState extends State<_ActivePollContent> {
   bool _descriptionExpanded = false;
 
   Future<void> _handleBottomActionPressed() async {
-    if (!widget.votingEligibilityConfirmed) return;
+    if (!widget.votingEligibilityConfirmed) {
+      final message = widget.votingEligibilityErrorMessage;
+      if (message == null) return;
+      await showDialog<void>(
+        context: context,
+        builder: (_) => _IneligiblePollDialog(message: message),
+      );
+      return;
+    }
     final skippedCount = widget.proposals
         .where((proposal) => widget.draft.choices[proposal.id] == null)
         .length;
@@ -393,10 +415,15 @@ class _ActivePollContentState extends State<_ActivePollContent> {
                       );
                     }
                     if (index == widget.proposals.length + 1) {
+                      final isIneligible =
+                          !widget.votingEligibilityConfirmed &&
+                          widget.votingEligibilityErrorMessage != null;
                       return _ReviewAnswersButton(
                         enabled:
+                            isIneligible ||
                             widget.votingEligibilityConfirmed &&
-                            !widget.draft.isEmpty,
+                                !widget.draft.isEmpty,
+                        label: isIneligible ? 'Not eligible' : 'Review answers',
                         onPressed: _handleBottomActionPressed,
                       );
                     }
@@ -493,6 +520,77 @@ class _SkippedQuestionsDialog extends StatelessWidget {
                 variant: AppButtonVariant.ghost,
                 minWidth: 312,
                 child: const Text('Keep voting'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _IneligiblePollDialog extends StatelessWidget {
+  const _IneligiblePollDialog({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Dialog(
+      backgroundColor: colors.background.ground,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadii.large),
+      ),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 360),
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.md),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    width: 32,
+                    height: 32,
+                    decoration: BoxDecoration(
+                      color: colors.background.neutralSubtleOpacity,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Center(
+                      child: AppIcon(
+                        AppIcons.warning,
+                        size: AppIconSize.medium,
+                        color: colors.icon.regular,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: AppSpacing.xs),
+                  Expanded(
+                    child: Text(
+                      'Not eligible for this poll',
+                      style: AppTypography.bodyLarge.copyWith(
+                        color: colors.text.accent,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                message,
+                style: AppTypography.bodyMedium.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.md),
+              AppButton(
+                onPressed: () => Navigator.of(context).pop(),
+                minWidth: 312,
+                child: const Text('Done'),
               ),
             ],
           ),
@@ -711,9 +809,14 @@ class _ViewMoreButton extends StatelessWidget {
 }
 
 class _ReviewAnswersButton extends StatelessWidget {
-  const _ReviewAnswersButton({required this.enabled, required this.onPressed});
+  const _ReviewAnswersButton({
+    required this.enabled,
+    required this.label,
+    required this.onPressed,
+  });
 
   final bool enabled;
+  final String label;
   final VoidCallback onPressed;
 
   @override
@@ -725,7 +828,7 @@ class _ReviewAnswersButton extends StatelessWidget {
           variant: AppButtonVariant.primary,
           size: AppButtonSize.large,
           minWidth: constraints.maxWidth,
-          child: const Text('Review answers'),
+          child: Text(label),
         );
       },
     );
@@ -1238,20 +1341,18 @@ class _ProposalCard extends StatelessWidget {
               ),
             ),
           ],
-          if (enabled) ...[
-            const SizedBox(height: AppSpacing.s),
-            for (final option in proposal.options) ...[
-              _OptionRow(
-                option: option,
-                selected: selectedChoice == option.index,
-                enabled: enabled,
-                onTap: () => onChoice(
-                  selectedChoice == option.index ? null : option.index,
-                ),
+          const SizedBox(height: AppSpacing.s),
+          for (final option in proposal.options) ...[
+            _OptionRow(
+              option: option,
+              selected: selectedChoice == option.index,
+              enabled: enabled,
+              onTap: () => onChoice(
+                selectedChoice == option.index ? null : option.index,
               ),
-              if (option != proposal.options.last)
-                const SizedBox(height: AppSpacing.xs),
-            ],
+            ),
+            if (option != proposal.options.last)
+              const SizedBox(height: AppSpacing.xs),
           ],
         ],
       ),

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -146,11 +146,8 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
               state,
               preparing: votingPowerPreparing,
             );
-            final sessionError = state.error;
-            final votingEligibilityError = sessionError == null
-                ? false
-                : isVotingEligibilityErrorText(sessionError.message);
-            final onSubmit = draft.isEmpty || votingEligibilityError
+            final onSubmit =
+                draft.isEmpty || !state.hasConfirmedVotingEligibility
                 ? null
                 : () => context.go(
                     votingStatusRoute(widget.roundId, accountUuid: accountUuid),

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -10,7 +10,9 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../providers/voting/voting_session_provider.dart';
+import '../../../providers/voting/voting_state.dart';
 import '../voting_choice_style.dart';
+import '../voting_error_messages.dart';
 import '../voting_flow_models.dart';
 import '../voting_routes.dart';
 import '../widgets/voting_metadata_widgets.dart';
@@ -26,26 +28,75 @@ class VotingReviewScreen extends ConsumerStatefulWidget {
 
 class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
   bool _precomputeStarted = false;
+  bool _votingPowerPreparationStarted = false;
+  bool _votingPowerPreparationInFlight = false;
+  String? _votingPowerPreparationKey;
+  String? _delegationPirPrecomputeKey;
 
   @override
-  void initState() {
-    super.initState();
+  void didUpdateWidget(covariant VotingReviewScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.roundId != widget.roundId) {
+      _precomputeStarted = false;
+      _votingPowerPreparationStarted = false;
+      _votingPowerPreparationInFlight = false;
+      _votingPowerPreparationKey = null;
+      _delegationPirPrecomputeKey = null;
+    }
+  }
+
+  void _maybePrepareVotingPower(VotingSessionState state) {
+    final preparationKey = '${widget.roundId}|${state.accountUuid ?? ''}';
+    if (_votingPowerPreparationKey != preparationKey) {
+      _votingPowerPreparationKey = preparationKey;
+      _votingPowerPreparationStarted = false;
+      _votingPowerPreparationInFlight = false;
+    }
+
+    if (_votingPowerPreparationStarted ||
+        state.eligibleWeightZatoshi != null ||
+        !_shouldPrepareVotingPower(state)) {
+      return;
+    }
+
+    _votingPowerPreparationStarted = true;
+    _votingPowerPreparationInFlight = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      unawaited(_startPirPrecompute());
+      unawaited(
+        ref
+            .read(votingSessionProvider(widget.roundId).notifier)
+            .prepareDelegation()
+            .whenComplete(() {
+              if (!mounted) return;
+              setState(() {
+                _votingPowerPreparationInFlight = false;
+              });
+            }),
+      );
     });
   }
 
-  Future<void> _startPirPrecompute() async {
+  void _maybePrecomputeDelegationPir(VotingSessionState state) {
+    final accountUuid = state.accountUuid;
+    if (accountUuid == null || !state.hasConfirmedVotingEligibility) {
+      return;
+    }
+
+    final key = '${widget.roundId}|$accountUuid';
+    if (_delegationPirPrecomputeKey == key) return;
+    _precomputeStarted = false;
+    _delegationPirPrecomputeKey = key;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      unawaited(_startPirPrecompute(accountUuid));
+    });
+  }
+
+  Future<void> _startPirPrecompute(String accountUuid) async {
     if (_precomputeStarted) return;
     _precomputeStarted = true;
     try {
-      final session = await ref.read(
-        votingSessionProvider(widget.roundId).future,
-      );
-      if (!mounted) return;
-      final accountUuid = session.accountUuid;
-      if (accountUuid == null) return;
       await ref
           .read(votingSessionProvider(widget.roundId).notifier)
           .precomputeDelegationPir(accountUuid: accountUuid);
@@ -66,6 +117,8 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
           loading: () => const Center(child: CircularProgressIndicator()),
           error: (error, _) => _Message("Couldn't load review: $error"),
           data: (state) {
+            _maybePrepareVotingPower(state);
+            _maybePrecomputeDelegationPir(state);
             final round = state.round;
             final proposals = round == null
                 ? <VotingProposalView>[]
@@ -84,7 +137,17 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                       ),
                     ),
                   );
-            final onSubmit = draft.isEmpty
+            final votingPowerPreparing =
+                _votingPowerPreparationInFlight ||
+                (state.eligibleWeightZatoshi == null &&
+                    state.error == null &&
+                    _shouldPrepareVotingPower(state));
+            final eligibilityMessage = _votingEligibilityMessage(
+              state,
+              preparing: votingPowerPreparing,
+            );
+            final onSubmit =
+                draft.isEmpty || !state.hasConfirmedVotingEligibility
                 ? null
                 : () => context.go(
                     votingStatusRoute(widget.roundId, accountUuid: accountUuid),
@@ -139,19 +202,28 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
                                         ),
                                       ],
                                       const SizedBox(height: AppSpacing.md),
-                                      for (final proposal in proposals)
-                                        _ReviewRow(
-                                          proposal: proposal,
-                                          value: _reviewValue(proposal, draft),
-                                          skipped:
-                                              draft.choices[proposal.id] ==
-                                              null,
-                                        ),
-                                      if (draft.isEmpty) ...[
+                                      if (state.hasConfirmedVotingEligibility)
+                                        for (final proposal in proposals)
+                                          _ReviewRow(
+                                            proposal: proposal,
+                                            value: _reviewValue(
+                                              proposal,
+                                              draft,
+                                            ),
+                                            skipped:
+                                                draft.choices[proposal.id] ==
+                                                null,
+                                          ),
+                                      if (state.hasConfirmedVotingEligibility &&
+                                          draft.isEmpty) ...[
                                         const SizedBox(height: AppSpacing.xs),
                                         const _Message(
                                           'Choose at least one option before submitting.',
                                         ),
+                                      ],
+                                      if (eligibilityMessage != null) ...[
+                                        const SizedBox(height: AppSpacing.xs),
+                                        _Message(eligibilityMessage),
                                       ],
                                     ],
                                   ),
@@ -197,6 +269,29 @@ String _reviewValue(VotingProposalView proposal, VotingDraftState draft) {
         orElse: () => VotingOptionView(index: choice, label: 'Choice $choice'),
       )
       .label;
+}
+
+bool _shouldPrepareVotingPower(VotingSessionState state) {
+  return switch (state.phase) {
+    VotingSessionPhase.idle ||
+    VotingSessionPhase.delegated ||
+    VotingSessionPhase.readyToDelegate ||
+    VotingSessionPhase.readyToVote ||
+    VotingSessionPhase.submittingShares ||
+    VotingSessionPhase.done => true,
+    _ => false,
+  };
+}
+
+String? _votingEligibilityMessage(
+  VotingSessionState state, {
+  required bool preparing,
+}) {
+  if (state.hasConfirmedVotingEligibility) return null;
+  final error = state.error;
+  if (error != null) return friendlyVotingErrorText(error.message);
+  if (preparing) return 'Preparing voting power.';
+  return 'Voting power unavailable.';
 }
 
 class _ReviewRow extends StatelessWidget {

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -146,8 +146,7 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
               state,
               preparing: votingPowerPreparing,
             );
-            final onSubmit =
-                draft.isEmpty || !state.hasConfirmedVotingEligibility
+            final onSubmit = draft.isEmpty
                 ? null
                 : () => context.go(
                     votingStatusRoute(widget.roundId, accountUuid: accountUuid),

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -146,7 +146,11 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
               state,
               preparing: votingPowerPreparing,
             );
-            final onSubmit = draft.isEmpty
+            final sessionError = state.error;
+            final votingEligibilityError = sessionError == null
+                ? false
+                : isVotingEligibilityErrorText(sessionError.message);
+            final onSubmit = draft.isEmpty || votingEligibilityError
                 ? null
                 : () => context.go(
                     votingStatusRoute(widget.roundId, accountUuid: accountUuid),

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -832,6 +832,7 @@ class _KeystoneSigningPanelState extends State<_KeystoneSigningPanel> {
 
   bool _showTransitionCue = false;
   int _cueGeneration = 0;
+  Timer? _cueTimer;
 
   @override
   void didUpdateWidget(covariant _KeystoneSigningPanel oldWidget) {
@@ -842,17 +843,24 @@ class _KeystoneSigningPanelState extends State<_KeystoneSigningPanel> {
   }
 
   void _triggerTransitionCue() {
+    _cueTimer?.cancel();
     setState(() {
       _showTransitionCue = true;
     });
 
     final generation = ++_cueGeneration;
-    Future<void>.delayed(_transitionCueDuration, () {
+    _cueTimer = Timer(_transitionCueDuration, () {
       if (!mounted || generation != _cueGeneration) return;
       setState(() {
         _showTransitionCue = false;
       });
     });
+  }
+
+  @override
+  void dispose() {
+    _cueTimer?.cancel();
+    super.dispose();
   }
 
   @override

--- a/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
+++ b/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
@@ -45,9 +45,28 @@ class _VotingSubmissionConfirmationScreenState
   String? _votingPowerRefreshKey;
   BigInt? _refreshedVotingPowerZatoshi;
   String? _votingPowerRefreshErrorMessage;
+  VotingSessionState? _lastSubmissionState;
   String? _pollRefreshKey;
   Future<void>? _pollRefreshFuture;
   String? _returnErrorMessage;
+
+  @override
+  void didUpdateWidget(covariant VotingSubmissionConfirmationScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.roundId == widget.roundId &&
+        oldWidget.accountUuid == widget.accountUuid) {
+      return;
+    }
+    _refreshingVotingPower = false;
+    _votingPowerRefreshAttempted = false;
+    _votingPowerRefreshKey = null;
+    _refreshedVotingPowerZatoshi = null;
+    _votingPowerRefreshErrorMessage = null;
+    _lastSubmissionState = null;
+    _pollRefreshKey = null;
+    _pollRefreshFuture = null;
+    _returnErrorMessage = null;
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -71,86 +90,116 @@ class _VotingSubmissionConfirmationScreenState
             child: session.when(
               skipLoadingOnRefresh: false,
               loading: () => const Center(child: CircularProgressIndicator()),
-              error: (error, _) => _ConfirmationScaffold(
-                confirmed: false,
-                title: 'Submission not complete',
-                pollTitle: 'Coinholder poll',
-                message: "Couldn't load submission details: $error",
-                votingPower: 'Not available',
-              ),
-              data: (state) {
-                final pollTitle = state.round?.title.isNotEmpty == true
-                    ? state.round!.title
-                    : 'Coinholder poll';
-                final hasCompletedSubmission = hasCompletedVoteForDisplay(
-                  state.roundPlan,
-                );
-                final hasConfirmedVotingEligibility =
-                    state.hasConfirmedVotingEligibility ||
-                    _refreshedVotingPowerZatoshi != null;
-                final confirmed =
-                    hasCompletedSubmission && hasConfirmedVotingEligibility;
-                _maybeRefreshVotingPower(
-                  confirmed: hasCompletedSubmission,
-                  state: state,
-                  jobKey: jobKey,
-                );
-                _maybePrefetchPollRefresh(
-                  confirmed: confirmed,
-                  state: state,
-                  jobKey: jobKey,
-                );
-                if (!hasCompletedSubmission) {
-                  return _ConfirmationScaffold(
-                    confirmed: false,
-                    title: 'Submission not complete',
-                    pollTitle: pollTitle,
-                    message:
-                        'This account has not completed submission for this poll.',
-                    votingPower: 'Not available',
-                    doneLabel: 'Done',
-                  );
-                }
-                if (!hasConfirmedVotingEligibility) {
-                  final storedEligibilityError = state.error;
-                  final storedEligibilityErrorMessage =
-                      storedEligibilityError == null
-                      ? null
-                      : friendlyVotingErrorText(storedEligibilityError.message);
-                  return _ConfirmationScaffold(
-                    confirmed: false,
-                    title: 'Submission not complete',
-                    pollTitle: pollTitle,
-                    message:
-                        _votingPowerRefreshErrorMessage ??
-                        storedEligibilityErrorMessage ??
-                        (_refreshingVotingPower
-                            ? 'Checking voting eligibility for this account.'
-                            : 'Voting eligibility has not been confirmed for this account.'),
-                    votingPower: 'Not available',
-                    doneLabel: 'Done',
+              error: (error, _) {
+                final cachedState = _lastSubmissionState;
+                if (cachedState != null) {
+                  return _buildSubmissionContent(
+                    state: cachedState,
+                    jobKey: jobKey,
+                    loadError: error,
                   );
                 }
                 return _ConfirmationScaffold(
-                  confirmed: true,
-                  title: 'Submission confirmed!',
-                  pollTitle: pollTitle,
-                  message:
-                      'Your vote was successfully published and cannot be changed.',
-                  votingPower: _formatVotingPower(
-                    _refreshedVotingPowerZatoshi ?? state.eligibleWeightZatoshi,
-                  ),
-                  isReturningToPolls: _isReturningToPolls,
-                  doneEnabled: !_isReturningToPolls,
-                  doneLabel: _isReturningToPolls ? 'Updating...' : 'Done',
-                  returnErrorMessage: _returnErrorMessage,
-                  onDone: () => unawaited(_returnToPolls(jobKey)),
+                  confirmed: false,
+                  title: 'Submission not complete',
+                  pollTitle: 'Coinholder poll',
+                  message: "Couldn't load submission details: $error",
+                  votingPower: 'Not available',
                 );
+              },
+              data: (state) {
+                return _buildSubmissionContent(state: state, jobKey: jobKey);
               },
             ),
           ),
         ),
       ),
+    );
+  }
+
+  Widget _buildSubmissionContent({
+    required VotingSessionState state,
+    required VotingSessionKey? jobKey,
+    Object? loadError,
+  }) {
+    final pollTitle = state.round?.title.isNotEmpty == true
+        ? state.round!.title
+        : 'Coinholder poll';
+    final hasCompletedSubmission = hasCompletedVoteForDisplay(state.roundPlan);
+    if (hasCompletedSubmission) {
+      _lastSubmissionState = state;
+    }
+    final hasConfirmedVotingEligibility =
+        state.hasConfirmedVotingEligibility ||
+        _refreshedVotingPowerZatoshi != null;
+    final confirmed = hasCompletedSubmission && hasConfirmedVotingEligibility;
+    _maybeRefreshVotingPower(
+      confirmed: hasCompletedSubmission,
+      state: state,
+      jobKey: jobKey,
+    );
+    _maybePrefetchPollRefresh(
+      confirmed: confirmed,
+      state: state,
+      jobKey: jobKey,
+    );
+
+    if (!hasCompletedSubmission) {
+      return _ConfirmationScaffold(
+        confirmed: false,
+        title: 'Submission not complete',
+        pollTitle: pollTitle,
+        message: 'This account has not completed submission for this poll.',
+        votingPower: 'Not available',
+        doneLabel: 'Done',
+      );
+    }
+    if (!hasConfirmedVotingEligibility) {
+      final storedEligibilityError = state.error;
+      final storedEligibilityErrorMessage = storedEligibilityError == null
+          ? null
+          : friendlyVotingErrorText(storedEligibilityError.message);
+      final loadErrorMessage = loadError == null
+          ? null
+          : friendlyVotingErrorMessage(loadError);
+      final latestRefreshMessage =
+          _votingPowerRefreshErrorMessage ?? loadErrorMessage;
+      final retryMessage = _refreshingVotingPower ? null : latestRefreshMessage;
+      final canRetry =
+          latestRefreshMessage != null &&
+          !_refreshingVotingPower &&
+          !isVotingEligibilityErrorText(latestRefreshMessage);
+      return _ConfirmationScaffold(
+        confirmed: false,
+        title: 'Submission not complete',
+        pollTitle: pollTitle,
+        message:
+            retryMessage ??
+            storedEligibilityErrorMessage ??
+            (_refreshingVotingPower
+                ? 'Checking voting eligibility for this account.'
+                : 'Voting eligibility has not been confirmed for this account.'),
+        votingPower: 'Not available',
+        doneLabel: 'Done',
+        retryLabel: canRetry ? 'Retry' : null,
+        onRetry: canRetry
+            ? () => _retryVotingPowerRefresh(state, jobKey)
+            : null,
+      );
+    }
+    return _ConfirmationScaffold(
+      confirmed: true,
+      title: 'Submission confirmed!',
+      pollTitle: pollTitle,
+      message: 'Your vote was successfully published and cannot be changed.',
+      votingPower: _formatVotingPower(
+        _refreshedVotingPowerZatoshi ?? state.eligibleWeightZatoshi,
+      ),
+      isReturningToPolls: _isReturningToPolls,
+      doneEnabled: !_isReturningToPolls,
+      doneLabel: _isReturningToPolls ? 'Updating...' : 'Done',
+      returnErrorMessage: _returnErrorMessage,
+      onDone: () => unawaited(_returnToPolls(jobKey)),
     );
   }
 
@@ -184,13 +233,36 @@ class _VotingSubmissionConfirmationScreenState
     return formatVotingPower(zatoshi);
   }
 
+  void _retryVotingPowerRefresh(
+    VotingSessionState state,
+    VotingSessionKey? jobKey,
+  ) {
+    if (_refreshingVotingPower) return;
+    final refreshKey = _submissionRefreshKey(state: state, jobKey: jobKey);
+    setState(() {
+      _votingPowerRefreshKey = refreshKey;
+      _refreshingVotingPower = true;
+      _votingPowerRefreshAttempted = true;
+      _votingPowerRefreshErrorMessage = null;
+    });
+    unawaited(
+      _refreshVotingPower(state: state, jobKey: jobKey, key: refreshKey),
+    );
+  }
+
+  String _submissionRefreshKey({
+    required VotingSessionState state,
+    required VotingSessionKey? jobKey,
+  }) {
+    return '${widget.roundId}|${jobKey?.accountUuid ?? state.accountUuid ?? ''}';
+  }
+
   void _maybeRefreshVotingPower({
     required bool confirmed,
     required VotingSessionState state,
     required VotingSessionKey? jobKey,
   }) {
-    final refreshKey =
-        '${widget.roundId}|${jobKey?.accountUuid ?? state.accountUuid ?? ''}';
+    final refreshKey = _submissionRefreshKey(state: state, jobKey: jobKey);
     if (_votingPowerRefreshKey != refreshKey) {
       _votingPowerRefreshKey = refreshKey;
       _refreshingVotingPower = false;
@@ -217,8 +289,7 @@ class _VotingSubmissionConfirmationScreenState
     required VotingSessionState state,
     required VotingSessionKey? jobKey,
   }) {
-    final refreshKey =
-        '${widget.roundId}|${jobKey?.accountUuid ?? state.accountUuid ?? ''}';
+    final refreshKey = _submissionRefreshKey(state: state, jobKey: jobKey);
     if (_pollRefreshKey != refreshKey) {
       _pollRefreshKey = refreshKey;
       _pollRefreshFuture = null;
@@ -302,6 +373,8 @@ class _ConfirmationScaffold extends StatelessWidget {
     this.isReturningToPolls = false,
     this.doneEnabled = true,
     this.doneLabel = 'Done',
+    this.retryLabel,
+    this.onRetry,
     this.returnErrorMessage,
   });
 
@@ -314,6 +387,8 @@ class _ConfirmationScaffold extends StatelessWidget {
   final bool isReturningToPolls;
   final bool doneEnabled;
   final String doneLabel;
+  final String? retryLabel;
+  final VoidCallback? onRetry;
   final String? returnErrorMessage;
 
   @override
@@ -424,6 +499,17 @@ class _ConfirmationScaffold extends StatelessWidget {
                           child: Text(doneLabel),
                         ),
                       ),
+                      if (onRetry != null && retryLabel != null) ...[
+                        const SizedBox(height: AppSpacing.xs),
+                        SizedBox(
+                          width: double.infinity,
+                          child: AppButton(
+                            onPressed: onRetry,
+                            variant: AppButtonVariant.secondary,
+                            child: Text(retryLabel!),
+                          ),
+                        ),
+                      ],
                       if (returnErrorMessage != null) ...[
                         const SizedBox(height: AppSpacing.xs),
                         Text(

--- a/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
+++ b/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
@@ -17,6 +17,7 @@ import '../../../providers/voting/voting_rounds_provider.dart';
 import '../../../providers/voting/voting_session_provider.dart';
 import '../../../providers/voting/voting_submission_job_provider.dart';
 import '../../../providers/voting/voting_state.dart';
+import '../voting_error_messages.dart';
 import '../voting_flow_models.dart';
 import '../voting_formatters.dart';
 import '../voting_resume_plan.dart';
@@ -43,6 +44,7 @@ class _VotingSubmissionConfirmationScreenState
   bool _votingPowerRefreshAttempted = false;
   String? _votingPowerRefreshKey;
   BigInt? _refreshedVotingPowerZatoshi;
+  String? _votingPowerRefreshErrorMessage;
   String? _pollRefreshKey;
   Future<void>? _pollRefreshFuture;
   String? _returnErrorMessage;
@@ -80,9 +82,16 @@ class _VotingSubmissionConfirmationScreenState
                 final pollTitle = state.round?.title.isNotEmpty == true
                     ? state.round!.title
                     : 'Coinholder poll';
-                final confirmed = hasCompletedVoteForDisplay(state.roundPlan);
+                final hasCompletedSubmission = hasCompletedVoteForDisplay(
+                  state.roundPlan,
+                );
+                final hasConfirmedVotingEligibility =
+                    state.hasConfirmedVotingEligibility ||
+                    _refreshedVotingPowerZatoshi != null;
+                final confirmed =
+                    hasCompletedSubmission && hasConfirmedVotingEligibility;
                 _maybeRefreshVotingPower(
-                  confirmed: confirmed,
+                  confirmed: hasCompletedSubmission,
                   state: state,
                   jobKey: jobKey,
                 );
@@ -91,13 +100,27 @@ class _VotingSubmissionConfirmationScreenState
                   state: state,
                   jobKey: jobKey,
                 );
-                if (!hasCompletedVoteForDisplay(state.roundPlan)) {
+                if (!hasCompletedSubmission) {
                   return _ConfirmationScaffold(
                     confirmed: false,
                     title: 'Submission not complete',
                     pollTitle: pollTitle,
                     message:
                         'This account has not completed submission for this poll.',
+                    votingPower: 'Not available',
+                    doneLabel: 'Done',
+                  );
+                }
+                if (!hasConfirmedVotingEligibility) {
+                  return _ConfirmationScaffold(
+                    confirmed: false,
+                    title: 'Submission not complete',
+                    pollTitle: pollTitle,
+                    message:
+                        _votingPowerRefreshErrorMessage ??
+                        (_refreshingVotingPower
+                            ? 'Checking voting eligibility for this account.'
+                            : 'Voting eligibility has not been confirmed for this account.'),
                     votingPower: 'Not available',
                     doneLabel: 'Done',
                   );
@@ -167,6 +190,7 @@ class _VotingSubmissionConfirmationScreenState
       _refreshingVotingPower = false;
       _votingPowerRefreshAttempted = false;
       _refreshedVotingPowerZatoshi = null;
+      _votingPowerRefreshErrorMessage = null;
     }
     if (!confirmed || _refreshingVotingPower || _votingPowerRefreshAttempted) {
       return;
@@ -239,17 +263,24 @@ class _VotingSubmissionConfirmationScreenState
       if (!mounted || _votingPowerRefreshKey != key) return;
       setState(() {
         _refreshedVotingPowerZatoshi = refreshed;
+        _votingPowerRefreshErrorMessage = null;
       });
     } catch (error) {
       debugPrint(
         '[zcash] Voting: confirmation voting power refresh failed '
         'round=${widget.roundId} account=${state.accountUuid} error=$error',
       );
+      if (mounted && _votingPowerRefreshKey == key) {
+        setState(() {
+          _votingPowerRefreshErrorMessage = friendlyVotingErrorText('$error');
+        });
+      }
     } finally {
-      if (!mounted || _votingPowerRefreshKey != key) return;
-      setState(() {
-        _refreshingVotingPower = false;
-      });
+      if (mounted && _votingPowerRefreshKey == key) {
+        setState(() {
+          _refreshingVotingPower = false;
+        });
+      }
     }
   }
 }

--- a/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
+++ b/lib/src/features/voting/screens/voting_submission_confirmation_screen.dart
@@ -112,12 +112,18 @@ class _VotingSubmissionConfirmationScreenState
                   );
                 }
                 if (!hasConfirmedVotingEligibility) {
+                  final storedEligibilityError = state.error;
+                  final storedEligibilityErrorMessage =
+                      storedEligibilityError == null
+                      ? null
+                      : friendlyVotingErrorText(storedEligibilityError.message);
                   return _ConfirmationScaffold(
                     confirmed: false,
                     title: 'Submission not complete',
                     pollTitle: pollTitle,
                     message:
                         _votingPowerRefreshErrorMessage ??
+                        storedEligibilityErrorMessage ??
                         (_refreshingVotingPower
                             ? 'Checking voting eligibility for this account.'
                             : 'Voting eligibility has not been confirmed for this account.'),

--- a/lib/src/features/voting/voting_error_messages.dart
+++ b/lib/src/features/voting/voting_error_messages.dart
@@ -32,5 +32,18 @@ String friendlyVotingErrorText(String text) {
         'shielded funds at $snapshot. Switch to an eligible account to vote.';
   }
 
+  final minimumVotingEligibility = RegExp(
+    r'minimum voting eligibility requires at least 5 eligible notes and 12500000 zatoshi voting weight; selected \d+ distinct eligible notes with \d+ zatoshi voting weight(?: at snapshot height (\d+))?',
+    caseSensitive: false,
+  ).firstMatch(message);
+  if (minimumVotingEligibility != null) {
+    final heightText = minimumVotingEligibility.group(1);
+    final snapshot = heightText == null
+        ? 'the poll snapshot block'
+        : 'snapshot block ${formatBlockHeight(int.parse(heightText))}';
+    return 'Voting requires at least 5 eligible shielded notes totaling '
+        '0.125 ZEC at $snapshot. Switch to an eligible account to vote.';
+  }
+
   return message.isEmpty ? 'Voting session action failed.' : message;
 }

--- a/lib/src/features/voting/voting_error_messages.dart
+++ b/lib/src/features/voting/voting_error_messages.dart
@@ -4,7 +4,45 @@ String friendlyVotingErrorMessage(Object error) {
   return friendlyVotingErrorText(error.toString());
 }
 
+bool isVotingEligibilityErrorText(String text) {
+  final message = _normalizedVotingErrorText(text);
+  final lowerMessage = message.toLowerCase();
+  return _noSpendableNotesPattern.firstMatch(message) != null ||
+      _minimumVotingEligibilityPattern.firstMatch(message) != null ||
+      lowerMessage.startsWith('this account is not eligible for this poll.') ||
+      lowerMessage.startsWith(
+        'voting requires at least 5 eligible shielded notes totaling 0.125 zec',
+      );
+}
+
 String friendlyVotingErrorText(String text) {
+  final message = _normalizedVotingErrorText(text);
+  final noSpendableNotes = _noSpendableNotesPattern.firstMatch(message);
+  if (noSpendableNotes != null) {
+    final heightText = noSpendableNotes.group(1);
+    final snapshot = heightText == null
+        ? 'the poll snapshot block'
+        : 'snapshot block ${formatBlockHeight(int.parse(heightText))}';
+    return 'This account is not eligible for this poll. It had no eligible '
+        'shielded funds at $snapshot. Switch to an eligible account to vote.';
+  }
+
+  final minimumVotingEligibility = _minimumVotingEligibilityPattern.firstMatch(
+    message,
+  );
+  if (minimumVotingEligibility != null) {
+    final heightText = minimumVotingEligibility.group(1);
+    final snapshot = heightText == null
+        ? 'the poll snapshot block'
+        : 'snapshot block ${formatBlockHeight(int.parse(heightText))}';
+    return 'Voting requires at least 5 eligible shielded notes totaling '
+        '0.125 ZEC at $snapshot. Switch to an eligible account to vote.';
+  }
+
+  return message.isEmpty ? 'Voting session action failed.' : message;
+}
+
+String _normalizedVotingErrorText(String text) {
   var message = text.trim();
   for (final prefix in const [
     'Exception: ',
@@ -18,32 +56,15 @@ String friendlyVotingErrorText(String text) {
       break;
     }
   }
-
-  final noSpendableNotes = RegExp(
-    r'no spendable voting notes at snapshot height (\d+)',
-    caseSensitive: false,
-  ).firstMatch(message);
-  if (noSpendableNotes != null) {
-    final heightText = noSpendableNotes.group(1);
-    final snapshot = heightText == null
-        ? 'the poll snapshot block'
-        : 'snapshot block ${formatBlockHeight(int.parse(heightText))}';
-    return 'This account is not eligible for this poll. It had no eligible '
-        'shielded funds at $snapshot. Switch to an eligible account to vote.';
-  }
-
-  final minimumVotingEligibility = RegExp(
-    r'minimum voting eligibility requires at least 5 eligible notes and 12500000 zatoshi voting weight; selected \d+ distinct eligible notes with \d+ zatoshi voting weight(?: at snapshot height (\d+))?',
-    caseSensitive: false,
-  ).firstMatch(message);
-  if (minimumVotingEligibility != null) {
-    final heightText = minimumVotingEligibility.group(1);
-    final snapshot = heightText == null
-        ? 'the poll snapshot block'
-        : 'snapshot block ${formatBlockHeight(int.parse(heightText))}';
-    return 'Voting requires at least 5 eligible shielded notes totaling '
-        '0.125 ZEC at $snapshot. Switch to an eligible account to vote.';
-  }
-
-  return message.isEmpty ? 'Voting session action failed.' : message;
+  return message;
 }
+
+final _noSpendableNotesPattern = RegExp(
+  r'no spendable voting notes at snapshot height (\d+)',
+  caseSensitive: false,
+);
+
+final _minimumVotingEligibilityPattern = RegExp(
+  r'minimum voting eligibility requires at least 5 eligible notes and 12500000 zatoshi voting weight; selected \d+ distinct eligible notes with \d+ zatoshi voting weight(?: at snapshot height (\d+))?',
+  caseSensitive: false,
+);

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -248,6 +248,10 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     });
   }
 
+  Future<void> ensureVotingEligibility() {
+    return _enqueue(_ensureVotingEligibilityUnlocked);
+  }
+
   void clearVoteSubmissionProgressForJobStart() {
     final current = state.value;
     if (current == null) return;
@@ -1894,10 +1898,19 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     return _enqueue(() async {
       _shareTrackingTimer?.cancel();
       _shareTrackingTimer = null;
-      final current = await future;
-      final context = await _loadContext(_roundId);
-      final plan = await _loadResumePlan(context);
-      final roundPlan = await _loadRoundPlan(context);
+      var current = await future;
+      var context = await _loadContext(_roundId);
+      var plan = await _loadResumePlan(context);
+      var roundPlan = await _loadRoundPlan(context);
+      if (plan.unconfirmedShareDelegations.isNotEmpty &&
+          !current.hasConfirmedVotingEligibility) {
+        await _ensureVotingEligibilityUnlocked();
+        current = await future;
+        if (!current.hasConfirmedVotingEligibility) return;
+        context = await _loadContext(_roundId);
+        plan = await _loadResumePlan(context);
+        roundPlan = await _loadRoundPlan(context);
+      }
       _setStateForContext(
         context,
         current.copyWith(
@@ -2577,6 +2590,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   Future<void> _refreshEligibleWeightUnlocked() async {
     final current = await future;
     final context = await _loadContext(_roundId);
+
     final bundleSetup = await ref
         .read(votingRustApiProvider)
         .setupDelegationBundles(ctx: _apiRoundContext(context));
@@ -2590,6 +2604,32 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         roundPlan: refreshedRoundPlan,
         eligibleWeightZatoshi: eligibleWeight,
         isHardwareAccount: context.isHardwareAccount,
+      ),
+    );
+  }
+
+  Future<void> _ensureVotingEligibilityUnlocked() async {
+    final current = await future;
+    if (current.hasConfirmedVotingEligibility) return;
+    final context = await _loadContext(_roundId);
+    await _waitUntilWalletReadyForVoting(context);
+
+    final bundleSetup = await ref
+        .read(votingRustApiProvider)
+        .setupDelegationBundles(ctx: _apiRoundContext(context));
+    final refreshedPlan = await _loadResumePlan(context);
+    final refreshedRoundPlan = await _loadRoundPlan(context);
+    _setStateForContext(
+      context,
+      (state.value ?? current).copyWith(
+        phase: current.phase,
+        config: context.config,
+        round: context.round,
+        resumePlan: refreshedPlan,
+        roundPlan: refreshedRoundPlan,
+        eligibleWeightZatoshi: bundleSetup.eligibleWeight,
+        isHardwareAccount: context.isHardwareAccount,
+        clearError: true,
       ),
     );
   }

--- a/lib/src/providers/voting/voting_state.dart
+++ b/lib/src/providers/voting/voting_state.dart
@@ -245,6 +245,11 @@ class VotingSessionState {
 
   bool get hasError => phase == VotingSessionPhase.error;
 
+  bool get hasConfirmedVotingEligibility =>
+      eligibleWeightZatoshi != null &&
+      error == null &&
+      phase != VotingSessionPhase.error;
+
   int get keystoneResolvedBundlePrefixCount =>
       resolvedKeystoneBundlePrefixCount(
         plan: resumePlan,

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -391,7 +391,14 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
             .ensureLoaded();
       } catch (_) {
         if (!_isCurrentJob(key: key, generation: generation)) return;
-        if (_canCompleteSessionAfterDraftLoadFailure(loadedSession)) {
+        final activeSession = await _ensureEligibilityForCompletedSession(
+          key: key,
+          generation: generation,
+          sessionNotifier: sessionNotifier,
+          session: loadedSession,
+        );
+        if (activeSession == null) return;
+        if (_canCompleteSessionAfterDraftLoadFailure(activeSession)) {
           _completeJob(key: key, generation: generation);
           return;
         }
@@ -419,21 +426,15 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       }
 
       var activeSession = afterWalletSync ?? loadedSession;
-      if (!activeSession.hasConfirmedVotingEligibility &&
-          _hasCompletedSubmissionArtifacts(activeSession)) {
-        await sessionNotifier.ensureVotingEligibility();
-        if (!_isCurrentJob(key: key, generation: generation)) return;
-        final afterEligibilityCheck = _sessionForJob(key);
-        if (afterEligibilityCheck?.phase == VotingSessionPhase.error) {
-          _failFromSession(
+      final completedEligibilitySession =
+          await _ensureEligibilityForCompletedSession(
             key: key,
             generation: generation,
-            session: afterEligibilityCheck!,
+            sessionNotifier: sessionNotifier,
+            session: activeSession,
           );
-          return;
-        }
-        activeSession = afterEligibilityCheck ?? activeSession;
-      }
+      if (completedEligibilitySession == null) return;
+      activeSession = completedEligibilitySession;
       if (!draft.isEmpty && _sessionNeedsDelegation(activeSession)) {
         await sessionNotifier.prepareDelegation();
         if (!_isCurrentJob(key: key, generation: generation)) return;
@@ -958,6 +959,30 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     if (session == null) return false;
     return session.hasConfirmedVotingEligibility &&
         _hasCompletedSubmissionArtifacts(session);
+  }
+
+  Future<VotingSessionState?> _ensureEligibilityForCompletedSession({
+    required VotingSessionKey key,
+    required int generation,
+    required VotingSessionNotifier sessionNotifier,
+    required VotingSessionState session,
+  }) async {
+    if (session.hasConfirmedVotingEligibility ||
+        !_hasCompletedSubmissionArtifacts(session)) {
+      return session;
+    }
+    await sessionNotifier.ensureVotingEligibility();
+    if (!_isCurrentJob(key: key, generation: generation)) return null;
+    final afterEligibilityCheck = _sessionForJob(key);
+    if (afterEligibilityCheck?.phase == VotingSessionPhase.error) {
+      _failFromSession(
+        key: key,
+        generation: generation,
+        session: afterEligibilityCheck!,
+      );
+      return null;
+    }
+    return afterEligibilityCheck ?? session;
   }
 
   bool _hasCompletedSubmissionArtifacts(VotingSessionState? session) {

--- a/lib/src/providers/voting/voting_submission_job_provider.dart
+++ b/lib/src/providers/voting/voting_submission_job_provider.dart
@@ -418,7 +418,37 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
         return;
       }
 
-      final activeSession = afterWalletSync ?? loadedSession;
+      var activeSession = afterWalletSync ?? loadedSession;
+      if (!activeSession.hasConfirmedVotingEligibility &&
+          _hasCompletedSubmissionArtifacts(activeSession)) {
+        await sessionNotifier.ensureVotingEligibility();
+        if (!_isCurrentJob(key: key, generation: generation)) return;
+        final afterEligibilityCheck = _sessionForJob(key);
+        if (afterEligibilityCheck?.phase == VotingSessionPhase.error) {
+          _failFromSession(
+            key: key,
+            generation: generation,
+            session: afterEligibilityCheck!,
+          );
+          return;
+        }
+        activeSession = afterEligibilityCheck ?? activeSession;
+      }
+      if (!draft.isEmpty && _sessionNeedsDelegation(activeSession)) {
+        await sessionNotifier.prepareDelegation();
+        if (!_isCurrentJob(key: key, generation: generation)) return;
+        final afterEligibilityCheck = _sessionForJob(key);
+        if (afterEligibilityCheck?.phase == VotingSessionPhase.error) {
+          _failFromSession(
+            key: key,
+            generation: generation,
+            session: afterEligibilityCheck!,
+          );
+          return;
+        }
+        activeSession = afterEligibilityCheck ?? activeSession;
+      }
+
       if (_canCompleteSessionWithoutDraft(activeSession, draft)) {
         _completeJob(key: key, generation: generation);
         return;
@@ -441,6 +471,22 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
       final canPollDelegationWithoutDraft = _canPollDelegationWithoutDraft(
         activeSession,
       );
+      if ((draftVotes.isNotEmpty ||
+              _hasRemainingVoteOrShareWork(activeSession)) &&
+          !activeSession.hasConfirmedVotingEligibility) {
+        await sessionNotifier.ensureVotingEligibility();
+        if (!_isCurrentJob(key: key, generation: generation)) return;
+        final afterEligibilityCheck = _sessionForJob(key);
+        if (afterEligibilityCheck?.phase == VotingSessionPhase.error) {
+          _failFromSession(
+            key: key,
+            generation: generation,
+            session: afterEligibilityCheck!,
+          );
+          return;
+        }
+        activeSession = afterEligibilityCheck ?? activeSession;
+      }
       final needsDelegation = _sessionNeedsDelegation(activeSession);
       final needsDelegationSubmission = _sessionNeedsDelegationSubmission(
         activeSession,
@@ -698,7 +744,7 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
     VotingSessionState? initialSession,
   }) async {
     if (!_isCurrentJob(key: key, generation: generation)) return;
-    final votePollingSession = _sessionForJob(key) ?? initialSession;
+    var votePollingSession = _sessionForJob(key) ?? initialSession;
     if (draftVotes.isEmpty &&
         (votePollingSession == null ||
             !_canRecoverWithoutDraft(votePollingSession))) {
@@ -708,6 +754,25 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
         message: 'Choose at least one vote before submitting.',
       );
       return;
+    }
+    final hasVoteOrShareWork =
+        draftVotes.isNotEmpty ||
+        (votePollingSession != null &&
+            _hasRemainingVoteOrShareWork(votePollingSession));
+    if (hasVoteOrShareWork &&
+        !(votePollingSession?.hasConfirmedVotingEligibility ?? false)) {
+      await sessionNotifier.ensureVotingEligibility();
+      if (!_isCurrentJob(key: key, generation: generation)) return;
+      final afterEligibilityCheck = _sessionForJob(key);
+      if (afterEligibilityCheck?.phase == VotingSessionPhase.error) {
+        _failFromSession(
+          key: key,
+          generation: generation,
+          session: afterEligibilityCheck!,
+        );
+        return;
+      }
+      votePollingSession = afterEligibilityCheck ?? votePollingSession;
     }
     if (draftVotes.isNotEmpty || _sessionNeedsVotePolling(votePollingSession)) {
       await sessionNotifier.castVotes(
@@ -890,6 +955,12 @@ class VotingSubmissionJobNotifier extends Notifier<VotingSubmissionJobState> {
   }
 
   bool _canCompleteSubmission(VotingSessionState? session) {
+    if (session == null) return false;
+    return session.hasConfirmedVotingEligibility &&
+        _hasCompletedSubmissionArtifacts(session);
+  }
+
+  bool _hasCompletedSubmissionArtifacts(VotingSessionState? session) {
     if (session == null) return false;
     return hasCompletedVoteForDisplay(session.roundPlan) &&
         !_hasRemainingVoteOrShareWork(session);

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -442,7 +442,9 @@ Future<VanWitness> generateVanWitness({
 /// Clear process-local vote-tree sync state for a wallet or round.
 ///
 /// Passing a non-empty round ID clears only that round's cached vote-tree sync
-/// state. Passing `None` or an empty round ID performs account-wide cleanup.
+/// state by calling `zcash_voting::precompute::reset_vote_tree(db, round_id)`.
+/// Passing `None` or an empty round ID performs account-wide cleanup with
+/// `zcash_voting::precompute::reset_vote_tree(db, "")`.
 ///
 /// This does not delete durable recovery rows or abort in-flight proof/vote
 /// work already running on worker threads.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3954,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree"
 version = "0.3.1"
-source = "git+https://github.com/valargroup/zcash_voting?rev=c757274dda22851cec99a7453eb0f2aed91fbf5c#c757274dda22851cec99a7453eb0f2aed91fbf5c"
+source = "git+https://github.com/valargroup/zcash_voting?rev=abfc5cc0f09d5eeae3e4a0f93c45afc6c08ed3ec#abfc5cc0f09d5eeae3e4a0f93c45afc6c08ed3ec"
 dependencies = [
  "anyhow",
  "ff",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.5.1"
-source = "git+https://github.com/valargroup/zcash_voting?rev=c757274dda22851cec99a7453eb0f2aed91fbf5c#c757274dda22851cec99a7453eb0f2aed91fbf5c"
+source = "git+https://github.com/valargroup/zcash_voting?rev=abfc5cc0f09d5eeae3e4a0f93c45afc6c08ed3ec#abfc5cc0f09d5eeae3e4a0f93c45afc6c08ed3ec"
 dependencies = [
  "base64",
  "ff",
@@ -3979,7 +3979,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "vote-commitment-tree 0.3.1 (git+https://github.com/valargroup/zcash_voting?rev=c757274dda22851cec99a7453eb0f2aed91fbf5c)",
+ "vote-commitment-tree 0.3.1 (git+https://github.com/valargroup/zcash_voting?rev=abfc5cc0f09d5eeae3e4a0f93c45afc6c08ed3ec)",
 ]
 
 [[package]]
@@ -4691,7 +4691,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "0.10.1"
-source = "git+https://github.com/valargroup/zcash_voting?rev=c757274dda22851cec99a7453eb0f2aed91fbf5c#c757274dda22851cec99a7453eb0f2aed91fbf5c"
+source = "git+https://github.com/valargroup/zcash_voting?rev=abfc5cc0f09d5eeae3e4a0f93c45afc6c08ed3ec#abfc5cc0f09d5eeae3e4a0f93c45afc6c08ed3ec"
 dependencies = [
  "anyhow",
  "base64",
@@ -4731,7 +4731,7 @@ dependencies = [
  "uuid",
  "valar-spiral-rs",
  "valar-ypir",
- "vote-commitment-tree 0.3.1 (git+https://github.com/valargroup/zcash_voting?rev=c757274dda22851cec99a7453eb0f2aed91fbf5c)",
+ "vote-commitment-tree 0.3.1 (git+https://github.com/valargroup/zcash_voting?rev=abfc5cc0f09d5eeae3e4a0f93c45afc6c08ed3ec)",
  "vote-commitment-tree-client",
  "voting-circuits",
  "zcash_client_backend",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ zcash_client_backend = { version = "0.22", features = [
 ] }
 zcash_client_sqlite = { version = "0.20", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 # Voting clients need PIR lookup support and vote-commitment-tree sync.
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "c757274dda22851cec99a7453eb0f2aed91fbf5c", package = "zcash_voting" }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "abfc5cc0f09d5eeae3e4a0f93c45afc6c08ed3ec", package = "zcash_voting" }
 # Must match versions used by zcash_client_sqlite to avoid type conflicts
 orchard = { version = "=0.13.1", features = ["unstable-voting-circuits"] }
 sapling-crypto = { version = "0.7", default-features = false, features = ["circuit"] }
@@ -96,6 +96,7 @@ security-framework = { version = "3.7", features = ["OSX_10_15"] }
 tempfile = "3"
 hex = "0.4"
 vote-commitment-tree = "0.3"
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "abfc5cc0f09d5eeae3e4a0f93c45afc6c08ed3ec", package = "zcash_voting", features = ["test-helpers"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1479,6 +1479,21 @@ mod tests {
     use zcash_voting::prelude::{TxEvent, TxEventAttribute};
     use zcash_voting::BundlePolicy;
 
+    fn distinct_test_notes(count: usize) -> Vec<zcash_voting::NoteInfo> {
+        (0..count)
+            .map(|index| {
+                let mut note = test_note_info(index as u64);
+                note.commitment[0] = 0x10 + index as u8;
+                note.nullifier[0] = 0x20 + index as u8;
+                note
+            })
+            .collect()
+    }
+
+    fn minimum_eligible_test_notes() -> Vec<zcash_voting::NoteInfo> {
+        distinct_test_notes(zcash_voting::BUNDLE_NOTE_SLOTS)
+    }
+
     fn b64(bytes: impl AsRef<[u8]>) -> String {
         base64::engine::general_purpose::STANDARD.encode(bytes)
     }
@@ -2149,7 +2164,7 @@ mod tests {
         let db_path = temp_dir.path().join("voting.sqlite");
         let db = db::open_voting_db(db_path.to_str().unwrap(), "wallet-api-bundles").unwrap();
         db.init_round(&test_api_round_params(), None).unwrap();
-        let notes: Vec<_> = (0..6).map(test_note_info).collect();
+        let notes = distinct_test_notes(6);
         db.ensure_bundles(ROUND_ID, &notes).unwrap();
 
         assert_eq!(
@@ -2361,8 +2376,9 @@ mod tests {
         let db_path = temp_dir.path().join("voting.sqlite");
         let db = db::open_voting_db(db_path.to_str().unwrap(), TEST_ACCOUNT_UUID).unwrap();
         db.init_round(&test_api_round_params(), None).unwrap();
-        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
-        seed_recovery_vote(&db, TEST_ACCOUNT_UUID, 0, 7, 1, 88);
+        let notes = minimum_eligible_test_notes();
+        db.ensure_bundles(ROUND_ID, &notes).unwrap();
+        seed_recovery_vote(&db, 0, 7, 1, 88, &notes);
 
         let recovered = recover_vote_commitment(
             db_path.to_str().unwrap().to_string(),
@@ -2385,22 +2401,12 @@ mod tests {
         let account_uuid = "wallet-api-recovery";
         let db = db::open_voting_db(db_path.to_str().unwrap(), account_uuid).unwrap();
         db.init_round(&test_api_round_params(), None).unwrap();
-        let notes: Vec<_> = (0..6).map(test_note_info).collect();
+        let notes = distinct_test_notes(6);
         db.ensure_bundles(ROUND_ID, &notes).unwrap();
         db.store_delegation_tx_hash(ROUND_ID, 0, "delegation-tx-0")
             .unwrap();
-        let conn = db.conn();
-        zcash_voting::storage::queries::store_vote(
-            &conn,
-            ROUND_ID,
-            account_uuid,
-            1,
-            2,
-            1,
-            b"vote-1",
-        )
-        .unwrap();
-        drop(conn);
+        let recovery = test_vote_recovery_bundle(1, 2, 1, 99);
+        zcash_voting::vote::insert_recovery_fixture(&db, &recovery, &notes).unwrap();
         mark_vote_submitted(
             db_path.to_str().unwrap().to_string(),
             account_uuid.to_string(),
@@ -2410,23 +2416,6 @@ mod tests {
             "vote-tx-1-2".to_string(),
         )
         .unwrap();
-        {
-            let conn = db.conn();
-            conn.execute(
-                "UPDATE votes SET commitment_bundle_json = :json, vc_tree_position = :pos
-                 WHERE round_id = :round_id AND wallet_id = :wallet_id
-                   AND bundle_index = :bundle_index AND proposal_id = :proposal_id",
-                rusqlite::named_params! {
-                    ":json": test_vote_recovery_json(1, 2, 1, 99),
-                    ":pos": 99i64,
-                    ":round_id": ROUND_ID,
-                    ":wallet_id": account_uuid,
-                    ":bundle_index": 1i64,
-                    ":proposal_id": 2i64,
-                },
-            )
-            .unwrap();
-        }
         record_share_delegation(
             db_path.to_str().unwrap().to_string(),
             account_uuid.to_string(),
@@ -2627,8 +2616,9 @@ mod tests {
         let db_path = temp_dir.path().join("voting.sqlite");
         let db = db::open_voting_db(db_path.to_str().unwrap(), TEST_ACCOUNT_UUID).unwrap();
         db.init_round(&test_api_round_params(), None).unwrap();
-        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
-        seed_recovery_vote(&db, TEST_ACCOUNT_UUID, 0, 7, 1, 88);
+        let notes = minimum_eligible_test_notes();
+        db.ensure_bundles(ROUND_ID, &notes).unwrap();
+        seed_recovery_vote(&db, 0, 7, 1, 88, &notes);
 
         let delegation = confirm_delegation_submission(
             db_path.to_str().unwrap().to_string(),
@@ -2736,13 +2726,13 @@ mod tests {
         assert!(err.contains("Voting hotkey reconstruction failed"));
     }
 
-    fn test_vote_recovery_json(
+    fn test_vote_recovery_bundle(
         bundle_index: u32,
         proposal_id: u32,
         vote_decision: u32,
         vc_tree_position: u64,
-    ) -> String {
-        zcash_voting::vote::serialize_recovery(&zcash_voting::vote::VoteRecoveryBundle {
+    ) -> zcash_voting::vote::VoteRecoveryBundle {
+        zcash_voting::vote::VoteRecoveryBundle {
             vote_round_id: ROUND_ID.to_string(),
             bundle_index,
             proposal_id,
@@ -2768,52 +2758,20 @@ mod tests {
             }],
             share_blinds: vec![[12u8; 32]],
             share_comms: vec![[13u8; 32]],
-        })
-        .unwrap()
+        }
     }
 
     fn seed_recovery_vote(
         db: &zcash_voting::storage::VotingDb,
-        account_uuid: &str,
         bundle_index: u32,
         proposal_id: u32,
         vote_decision: u32,
         vc_tree_position: u64,
+        notes: &[zcash_voting::NoteInfo],
     ) {
-        let recovery_json =
-            test_vote_recovery_json(bundle_index, proposal_id, vote_decision, vc_tree_position);
-        let recovery = zcash_voting::vote::parse_recovery(&recovery_json).unwrap();
-        let commitment_bytes = serde_json::to_vec(&serde_json::json!({
-            "van_nullifier": hex::encode(recovery.van_nullifier),
-            "vote_authority_note_new": hex::encode(recovery.vote_authority_note_new),
-            "vote_commitment": hex::encode(recovery.vote_commitment),
-            "proof": hex::encode(recovery.proof),
-        }))
-        .unwrap();
-        zcash_voting::storage::queries::store_vote(
-            &db.conn(),
-            ROUND_ID,
-            account_uuid,
-            bundle_index,
-            proposal_id,
-            vote_decision,
-            &commitment_bytes,
-        )
-        .unwrap();
-        db.conn()
-            .execute(
-                "UPDATE votes SET commitment_bundle_json = :json
-                 WHERE round_id = :round_id AND wallet_id = :wallet_id
-                   AND bundle_index = :bundle_index AND proposal_id = :proposal_id",
-                rusqlite::named_params! {
-                    ":json": recovery_json,
-                    ":round_id": ROUND_ID,
-                    ":wallet_id": account_uuid,
-                    ":bundle_index": i64::from(bundle_index),
-                    ":proposal_id": i64::from(proposal_id),
-                },
-            )
-            .unwrap();
+        let recovery =
+            test_vote_recovery_bundle(bundle_index, proposal_id, vote_decision, vc_tree_position);
+        zcash_voting::vote::insert_recovery_fixture(db, &recovery, notes).unwrap();
     }
 
     fn test_tree_state(height: u64) -> TreeState {

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -2203,7 +2203,8 @@ mod tests {
         let db_path = temp_dir.path().join("voting.sqlite");
         let db = db::open_voting_db(db_path.to_str().unwrap(), "wallet-api-witness").unwrap();
         db.init_round(&test_api_round_params(), None).unwrap();
-        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        let notes = minimum_eligible_test_notes();
+        db.ensure_bundles(ROUND_ID, &notes).unwrap();
         db.store_van_position(ROUND_ID, 0, 0).unwrap();
         let server = start_tree_server(1, vec![fp_one_base64()], 3);
 
@@ -2239,7 +2240,8 @@ mod tests {
         let account_uuid = "wallet-api-round-reset";
         let db = db::open_voting_db(db_path.to_str().unwrap(), account_uuid).unwrap();
         db.init_round(&test_api_round_params(), None).unwrap();
-        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        let notes = minimum_eligible_test_notes();
+        db.ensure_bundles(ROUND_ID, &notes).unwrap();
         db.store_van_position(ROUND_ID, 0, 0).unwrap();
         let server = start_tree_server(1, vec![fp_one_base64()], 3);
 
@@ -2281,10 +2283,10 @@ mod tests {
         let mut other_round_params = test_api_round_params();
         other_round_params.vote_round_id = OTHER_ROUND_ID.to_string();
         db.init_round(&other_round_params, None).unwrap();
-        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        let notes = minimum_eligible_test_notes();
+        db.ensure_bundles(ROUND_ID, &notes).unwrap();
         db.store_van_position(ROUND_ID, 0, 0).unwrap();
-        db.ensure_bundles(OTHER_ROUND_ID, &[test_note_info(0)])
-            .unwrap();
+        db.ensure_bundles(OTHER_ROUND_ID, &notes).unwrap();
         db.store_van_position(OTHER_ROUND_ID, 0, 0).unwrap();
 
         let server_round_one = start_tree_server(1, vec![fp_one_base64()], 3);
@@ -2340,7 +2342,8 @@ mod tests {
         let account_uuid = "wallet-api-account-reset";
         let db = db::open_voting_db(db_path.to_str().unwrap(), account_uuid).unwrap();
         db.init_round(&test_api_round_params(), None).unwrap();
-        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        let notes = minimum_eligible_test_notes();
+        db.ensure_bundles(ROUND_ID, &notes).unwrap();
         db.store_van_position(ROUND_ID, 0, 0).unwrap();
         let server = start_tree_server(1, vec![fp_one_base64()], 3);
 
@@ -2484,7 +2487,8 @@ mod tests {
         let db_path = temp_dir.path().join("voting.sqlite");
         let db = db::open_voting_db(db_path.to_str().unwrap(), TEST_ACCOUNT_UUID).unwrap();
         db.init_round(&test_api_round_params(), None).unwrap();
-        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        let notes = minimum_eligible_test_notes();
+        db.ensure_bundles(ROUND_ID, &notes).unwrap();
 
         store_keystone_signature(
             db_path.to_str().unwrap().to_string(),
@@ -2586,7 +2590,8 @@ mod tests {
         let db_path = temp_dir.path().join("voting.sqlite");
         let db = db::open_voting_db(db_path.to_str().unwrap(), TEST_ACCOUNT_UUID).unwrap();
         db.init_round(&test_api_round_params(), None).unwrap();
-        db.ensure_bundles(ROUND_ID, &[test_note_info(0)]).unwrap();
+        let notes = minimum_eligible_test_notes();
+        db.ensure_bundles(ROUND_ID, &notes).unwrap();
 
         mark_delegation_submitted(
             db_path.to_str().unwrap().to_string(),

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use ff::PrimeField;
 use secrecy::{ExposeSecret, SecretVec};
-use zeroize::Zeroizing;
 use zcash_keys::keys::UnifiedSpendingKey;
+use zeroize::Zeroizing;
 use zip32::{fingerprint::SeedFingerprint, AccountId};
 
 use crate::wallet::sync::open_wallet_db_for_read;
@@ -104,6 +104,8 @@ pub async fn setup_delegation_bundles(
     .await
     .map_err(|e| e.to_string())?;
     let note_infos = selected.voting_note_infos();
+    zcash_voting::validate_minimum_voting_eligibility_for_notes(&note_infos, bundle_policy)
+        .map_err(|e| format!("{e} at snapshot height {}", round_context.snapshot_height))?;
     voting_db
         .ensure_bundles_with_skipped_suffix_with_policy(
             round_params.vote_round_id.as_str(),
@@ -152,8 +154,7 @@ pub async fn precompute_delegation_pir(
         )
         .map_err(|e| format!("Voting hotkey reconstruction failed: {e}"))?;
         let voting_db = open_voting_db(&db_path, &account_uuid)?;
-        let wallet_db =
-            open_wallet_db_for_read(&db_path, wallet_network(voting_hotkey.network()))?;
+        let wallet_db = open_wallet_db_for_read(&db_path, wallet_network(voting_hotkey.network()))?;
         let prepared = zcash_voting::delegate::prepare_delegation_bundle(
             &voting_db,
             &wallet_db,
@@ -207,8 +208,10 @@ where
         .map_err(|e| format!("Invalid voting round params: {e}"))?;
     on_progress(DelegationProgress::SelectingNotes);
     let voting_db = open_voting_db(db_path, account_uuid)?;
-    let wallet_db =
-        open_wallet_db_for_read(db_path, wallet_network(prepare_params.voting_hotkey.network()))?;
+    let wallet_db = open_wallet_db_for_read(
+        db_path,
+        wallet_network(prepare_params.voting_hotkey.network()),
+    )?;
 
     let prepared_bundle =
         zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
@@ -299,8 +302,10 @@ pub async fn build_keystone_delegation_request(
     prepare_params: PrepareDelegationBundleParams<'_>,
 ) -> Result<zcash_voting::delegate::KeystoneSigningRequest, String> {
     let voting_db = open_voting_db(db_path, account_uuid)?;
-    let wallet_db =
-        open_wallet_db_for_read(db_path, wallet_network(prepare_params.voting_hotkey.network()))?;
+    let wallet_db = open_wallet_db_for_read(
+        db_path,
+        wallet_network(prepare_params.voting_hotkey.network()),
+    )?;
     let prepared =
         zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
             .map_err(|e| e.to_string())?;
@@ -336,8 +341,10 @@ where
 
     on_progress(DelegationProgress::SelectingNotes);
     let voting_db = open_voting_db(db_path, account_uuid)?;
-    let wallet_db =
-        open_wallet_db_for_read(db_path, wallet_network(prepare_params.voting_hotkey.network()))?;
+    let wallet_db = open_wallet_db_for_read(
+        db_path,
+        wallet_network(prepare_params.voting_hotkey.network()),
+    )?;
     let prepared_bundle =
         zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
             .map_err(|e| e.to_string())?;

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -219,6 +219,138 @@ void main() {
     expect(find.text('Retry'), findsOneWidget);
   });
 
+  testWidgets('status screen explains minimum voting eligibility failure', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      rust: _MinimumVotingEligibilityRustApi(),
+      hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
+    );
+    addTearDown(container.dispose);
+    container.read(votingDraftProvider(_draftKey).notifier).setChoice(1, 0);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: _statusHarness()),
+    );
+    await tester.pumpAndSettle();
+
+    const message =
+        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'at snapshot block 3,359,740. Switch to an eligible account to vote.';
+    await _pumpUntilFound(tester, find.text(message));
+
+    expect(find.text(message), findsOneWidget);
+    expect(find.text('Voting failed.'), findsNothing);
+    expect(find.text('Retry'), findsOneWidget);
+  });
+
+  testWidgets('status screen revalidates eligibility before cast recovery', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final recoveryApi = _MutableVotingRecoveryApi()
+      ..state = _recoveryState(
+        delegationWorkflows: const [
+          rust_frb_types.DelegationRecoveryView(
+            bundleIndex: 0,
+            phase: VotingWorkflowPhase.confirmed,
+            txHash: 'delegation-0',
+            vanLeafPosition: 0,
+          ),
+        ],
+      )
+      ..roundPlan = apiRoundPlan(
+        roundId: _roundId,
+        pendingRecovery: true,
+        nextSteps: const [
+          rust_wire.NextStepView(
+            kind: 'cast_vote',
+            bundleIndex: 0,
+            proposalId: 1,
+            choice: 0,
+            shareIndex: 0,
+          ),
+        ],
+        openProposals: Uint32List.fromList([1]),
+        allDecided: false,
+      );
+    final rust = _MinimumVotingEligibilityRustApi(recoveryApi);
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: rust,
+      hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
+    );
+    addTearDown(container.dispose);
+    container.read(votingDraftProvider(_draftKey).notifier).setChoice(1, 0);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: _statusHarness()),
+    );
+    await tester.pumpAndSettle();
+
+    const message =
+        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'at snapshot block 3,359,740. Switch to an eligible account to vote.';
+    await _pumpUntilFound(tester, find.text(message));
+
+    expect(find.text(message), findsOneWidget);
+    expect(rust.setupDelegationBundleCalls, 1);
+    expect(rust.voteCommitmentCalls, 0);
+  });
+
+  testWidgets('status screen revalidates eligibility before completion', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final recoveryApi = _MutableVotingRecoveryApi()
+      ..roundPlan = apiRoundPlan(
+        roundId: _roundId,
+        pendingRecovery: false,
+        nextSteps: const [],
+        openProposals: Uint32List(0),
+        allDecided: true,
+        completedVoteArtifact: true,
+        completedForDisplay: true,
+      );
+    final rust = _MinimumVotingEligibilityRustApi(recoveryApi);
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: rust,
+      hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: _statusHarness()),
+    );
+    await tester.pumpAndSettle();
+
+    const message =
+        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'at snapshot block 3,359,740. Switch to an eligible account to vote.';
+    await _pumpUntilFound(tester, find.text(message));
+
+    expect(find.text(message), findsOneWidget);
+    expect(find.text('submission confirmed route'), findsNothing);
+    expect(rust.setupDelegationBundleCalls, 1);
+  });
+
   testWidgets('status screen retry keeps setup errors specific', (
     tester,
   ) async {
@@ -282,6 +414,57 @@ void main() {
     );
   });
 
+  testWidgets('submitted route does not confirm without eligibility', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final completedRoundPlan = apiRoundPlan(
+      roundId: _roundId,
+      pendingRecovery: false,
+      nextSteps: const [],
+      openProposals: Uint32List(0),
+      allDecided: true,
+      completedVoteArtifact: true,
+      completedForDisplay: true,
+    );
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      overrides: [
+        votingSessionProvider(_roundId).overrideWith(
+          () => _FailingEligibilityVotingSessionNotifier(
+            VotingSessionState(
+              roundId: _roundId,
+              accountUuid: 'account-1',
+              phase: VotingSessionPhase.done,
+              roundPlan: completedRoundPlan,
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _submissionHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    const message =
+        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'at snapshot block 3,359,740. Switch to an eligible account to vote.';
+    await _pumpUntilFound(tester, find.text(message));
+
+    expect(find.text(message), findsOneWidget);
+    expect(find.text('Submission confirmed!'), findsNothing);
+  });
+
   testWidgets(
     'submitted route refreshes poll rows before returning to vote menu',
     (tester) async {
@@ -316,6 +499,7 @@ void main() {
                 accountUuid: 'account-1',
                 phase: VotingSessionPhase.done,
                 roundPlan: completedRoundPlan,
+                eligibleWeightZatoshi: BigInt.from(100),
               ),
             ),
           ),
@@ -349,7 +533,6 @@ void main() {
           child: _submissionHarness(votingRoute: const VotingPollsScreen()),
         ),
       );
-      await tester.pumpAndSettle();
       await _pumpUntilFound(tester, find.text('Submission confirmed!'));
 
       await tester.tap(find.text('Done'));
@@ -791,7 +974,7 @@ void main() {
     expect(find.text('submission confirmed route'), findsOne);
     expect(find.text('Sign bundle 1 of 1'), findsNothing);
     expect(find.text('Scan signature'), findsNothing);
-    expect(rust.setupDelegationBundleCalls, 0);
+    expect(rust.setupDelegationBundleCalls, 2);
     expect(rust.keystoneDelegationRequestCalls, 0);
     expect(recoveryApi.ballotIntents, isEmpty);
   });
@@ -893,7 +1076,7 @@ void main() {
     expect(find.text('submission confirmed route'), findsOne);
     expect(find.text('Sign bundle 1 of 1'), findsNothing);
     expect(find.text('Scan signature'), findsNothing);
-    expect(rust.setupDelegationBundleCalls, 0);
+    expect(rust.setupDelegationBundleCalls, 2);
     expect(rust.keystoneDelegationRequestCalls, 0);
     expect(
       http.requests.any(
@@ -1273,6 +1456,184 @@ void main() {
 
     expect(find.text('Voting power unavailable'), findsOneWidget);
     expect(find.text('Preparing voting power'), findsNothing);
+  });
+
+  testWidgets('proposal detail hides option labels when eligibility fails', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final recoveryApi = _MutableVotingRecoveryApi();
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _MinimumVotingEligibilityRustApi(recoveryApi),
+      hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    const message =
+        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'at snapshot block 3,359,740. Switch to an eligible account to vote.';
+    await _pumpUntilFound(tester, find.text(message));
+
+    expect(find.text(message), findsOneWidget);
+    expect(find.text('First proposal'), findsOneWidget);
+    expect(find.text('Yes'), findsNothing);
+    expect(find.text('No'), findsNothing);
+    expect(find.text('Review answers'), findsOneWidget);
+  });
+
+  testWidgets('proposal detail hides completed vote when eligibility fails', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final recoveryApi = _MutableVotingRecoveryApi()
+      ..roundPlan = apiRoundPlan(
+        roundId: _roundId,
+        pendingRecovery: false,
+        nextSteps: const [],
+        openProposals: Uint32List.fromList(const [1]),
+        allDecided: true,
+        completedVoteArtifact: true,
+        completedForDisplay: true,
+        completedVoteDisplay: rust_wire.CompletedVoteDisplayView(
+          choices: const [
+            rust_wire.CompletedVoteChoiceView(proposalId: 1, choice: 0),
+          ],
+          votedAt: BigInt.from(1717260000),
+        ),
+      );
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _MinimumVotingEligibilityRustApi(recoveryApi),
+      hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    const message =
+        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'at snapshot block 3,359,740. Switch to an eligible account to vote.';
+    await _pumpUntilFound(tester, find.text(message));
+
+    expect(find.text(message), findsOneWidget);
+    expect(find.textContaining('Voted'), findsNothing);
+    expect(find.text('Yes'), findsNothing);
+    expect(find.text('No'), findsNothing);
+  });
+
+  testWidgets('proposal detail hides pending recovery when eligibility fails', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final recoveryApi = _MutableVotingRecoveryApi()
+      ..roundPlan = apiRoundPlan(
+        roundId: _roundId,
+        pendingRecovery: true,
+        nextSteps: const [
+          rust_wire.NextStepView(
+            kind: 'cast_vote',
+            bundleIndex: 0,
+            proposalId: 1,
+            choice: 0,
+            shareIndex: 0,
+          ),
+        ],
+        openProposals: Uint32List.fromList([1]),
+        allDecided: false,
+        completedVoteArtifact: true,
+      );
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _MinimumVotingEligibilityRustApi(recoveryApi),
+      hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    const message =
+        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'at snapshot block 3,359,740. Switch to an eligible account to vote.';
+    await _pumpUntilFound(tester, find.text(message));
+
+    expect(find.text(message), findsOneWidget);
+    expect(find.text('Vote in progress'), findsNothing);
+    expect(find.text('Continue voting'), findsNothing);
+    expect(find.text('Yes'), findsNothing);
+    expect(find.text('No'), findsNothing);
+  });
+
+  testWidgets('review hides stale choices when eligibility fails', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final recoveryApi = _MutableVotingRecoveryApi();
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _MinimumVotingEligibilityRustApi(recoveryApi),
+      hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
+    );
+    addTearDown(container.dispose);
+    container.read(votingDraftProvider(_draftKey).notifier).setChoice(1, 0);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(
+          initialLocation: '/voting/poll/$_roundId/review',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    const message =
+        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'at snapshot block 3,359,740. Switch to an eligible account to vote.';
+    await _pumpUntilFound(tester, find.text(message));
+
+    expect(find.text(message), findsOneWidget);
+    expect(find.text('Yes'), findsNothing);
   });
 
   testWidgets('results screen renders flat tally rows as ZEC totals', (
@@ -3085,6 +3446,23 @@ class _StaticVotingSessionNotifier extends VotingSessionNotifier {
 
   @override
   Future<VotingSessionState> build() async => _state;
+
+  @override
+  Future<BigInt?> refreshEligibleWeight() async => _state.eligibleWeightZatoshi;
+}
+
+class _FailingEligibilityVotingSessionNotifier
+    extends _StaticVotingSessionNotifier {
+  _FailingEligibilityVotingSessionNotifier(super.state);
+
+  @override
+  Future<BigInt?> refreshEligibleWeight() async {
+    throw Exception(
+      'Invalid input: minimum voting eligibility requires at least 5 eligible '
+      'notes and 12500000 zatoshi voting weight; selected 2 distinct eligible '
+      'notes with 25000000 zatoshi voting weight at snapshot height 3359740',
+    );
+  }
 }
 
 class _CountingVotingConfigNotifier extends VotingConfigNotifier {
@@ -3187,6 +3565,23 @@ class _FailingVotingPowerRustApi extends _NoopVotingRustApi {
     required rust_api.ApiVotingRoundContext ctx,
   }) async {
     throw StateError('snapshot setup unavailable');
+  }
+}
+
+class _MinimumVotingEligibilityRustApi extends _VotingStatusRustApi {
+  _MinimumVotingEligibilityRustApi([_MutableVotingRecoveryApi? recoveryApi])
+    : super(recoveryApi ?? _MutableVotingRecoveryApi());
+
+  @override
+  Future<rust_round.BundleLayout> setupDelegationBundles({
+    required rust_api.ApiVotingRoundContext ctx,
+  }) async {
+    setupDelegationBundleCalls++;
+    throw Exception(
+      'Invalid input: minimum voting eligibility requires at least 5 eligible '
+      'notes and 12500000 zatoshi voting weight; selected 2 distinct eligible '
+      'notes with 25000000 zatoshi voting weight at snapshot height 3359740',
+    );
   }
 }
 
@@ -3342,6 +3737,7 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
   final storedKeystoneSignatures = <int, rust_wire.KeystoneSignatureRecord>{};
   int setupDelegationBundleCalls = 0;
   int keystoneDelegationRequestCalls = 0;
+  int voteCommitmentCalls = 0;
 
   @override
   Future<rust_round.BundleLayout> setupDelegationBundles({
@@ -3637,6 +4033,7 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
     required rust_vote.VanWitness vanWitness,
     required List<rust_wire.DraftVote> draftVotes,
   }) async* {
+    voteCommitmentCalls++;
     for (final draft in draftVotes) {
       yield rust_api.ApiVoteCommitEvent(
         phase: 'result',

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1500,6 +1500,11 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(container.read(votingDraftProvider(_draftKey)).isEmpty, true);
+    expect(find.text('Not eligible for this poll'), findsOneWidget);
+    expect(find.text(message), findsOneWidget);
+
+    await tester.tap(find.text('Done'));
+    await tester.pumpAndSettle();
 
     await tester.tap(find.text('Not eligible'));
     await tester.pumpAndSettle();

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -465,6 +465,63 @@ void main() {
     expect(find.text('Submission confirmed!'), findsNothing);
   });
 
+  testWidgets('submitted route can retry eligibility refresh', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final completedRoundPlan = apiRoundPlan(
+      roundId: _roundId,
+      pendingRecovery: false,
+      nextSteps: const [],
+      openProposals: Uint32List(0),
+      allDecided: true,
+      completedVoteArtifact: true,
+      completedForDisplay: true,
+    );
+    late _RetryableEligibilityVotingSessionNotifier notifier;
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      overrides: [
+        votingSessionProvider(_roundId).overrideWith(() {
+          notifier = _RetryableEligibilityVotingSessionNotifier(
+            VotingSessionState(
+              roundId: _roundId,
+              accountUuid: 'account-1',
+              phase: VotingSessionPhase.done,
+              roundPlan: completedRoundPlan,
+            ),
+          );
+          return notifier;
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _submissionHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _pumpUntilFound(tester, find.text('Retry'));
+
+    expect(find.text('Submission not complete'), findsOneWidget);
+    expect(find.textContaining('temporary setup unavailable'), findsOneWidget);
+    expect(notifier.refreshCalls, 1);
+
+    await tester.tap(find.text('Retry'));
+    await tester.pumpAndSettle();
+    await _pumpUntilFound(tester, find.text('Submission confirmed!'));
+
+    expect(find.text('Submission confirmed!'), findsOneWidget);
+    expect(find.text('Voting power'), findsOneWidget);
+    expect(find.text('0.000001 ZEC'), findsOneWidget);
+    expect(notifier.refreshCalls, 2);
+  });
+
   testWidgets(
     'submitted route refreshes poll rows before returning to vote menu',
     (tester) async {
@@ -1513,7 +1570,7 @@ void main() {
     expect(find.text(message), findsOneWidget);
   });
 
-  testWidgets('proposal detail shows completed vote when eligibility fails', (
+  testWidgets('proposal detail hides completed vote when eligibility fails', (
     tester,
   ) async {
     await tester.binding.setSurfaceSize(const Size(1152, 768));
@@ -1556,12 +1613,14 @@ void main() {
     const message =
         'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
         'at snapshot block 3,359,740. Switch to an eligible account to vote.';
-    await _pumpUntilFound(tester, find.textContaining('Voted'));
+    await _pumpUntilFound(tester, find.text('Not eligible'));
 
     expect(find.text(message), findsNothing);
-    expect(find.textContaining('Voted'), findsOneWidget);
+    expect(find.textContaining('Voted'), findsNothing);
+    expect(find.text('Voting power 0 ZEC'), findsOneWidget);
     expect(find.text('Yes'), findsOneWidget);
-    expect(find.text('No'), findsNothing);
+    expect(find.text('No'), findsOneWidget);
+    expect(find.text('Review answers'), findsNothing);
   });
 
   testWidgets('proposal detail hides pending recovery when eligibility fails', (
@@ -1657,6 +1716,47 @@ void main() {
       find.widgetWithText(AppButton, 'Confirm & submit'),
     );
     expect(submitButton.onPressed, isNull);
+  });
+
+  testWidgets('review disables submit until eligibility is confirmed', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final recoveryApi = _MutableVotingRecoveryApi();
+    final container = _statusContainer(
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _FailingVotingPowerRustApi(),
+      hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
+    );
+    addTearDown(container.dispose);
+    container.read(votingDraftProvider(_draftKey).notifier).setChoice(1, 0);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(
+          initialLocation: '/voting/poll/$_roundId/review',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _pumpUntilFound(tester, find.text('Review your answers'));
+
+    final submitButton = tester.widget<AppButton>(
+      find.widgetWithText(AppButton, 'Confirm & submit'),
+    );
+    expect(submitButton.onPressed, isNull);
+
+    await tester.tap(find.text('Confirm & submit'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review your answers'), findsOneWidget);
+    expect(find.textContaining('status account:'), findsNothing);
   });
 
   testWidgets('results screen renders flat tally rows as ZEC totals', (
@@ -3482,6 +3582,22 @@ class _FailingEligibilityVotingSessionNotifier
       'notes and 12500000 zatoshi voting weight; selected 2 distinct eligible '
       'notes with 25000000 zatoshi voting weight at snapshot height 3359740',
     );
+  }
+}
+
+class _RetryableEligibilityVotingSessionNotifier
+    extends _StaticVotingSessionNotifier {
+  _RetryableEligibilityVotingSessionNotifier(super.state);
+
+  int refreshCalls = 0;
+
+  @override
+  Future<BigInt?> refreshEligibleWeight() async {
+    refreshCalls++;
+    if (refreshCalls == 1) {
+      throw StateError('temporary setup unavailable');
+    }
+    return BigInt.from(100);
   }
 }
 

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1458,7 +1458,7 @@ void main() {
     expect(find.text('Preparing voting power'), findsNothing);
   });
 
-  testWidgets('proposal detail hides option labels when eligibility fails', (
+  testWidgets('proposal detail shows read-only options when eligibility fails', (
     tester,
   ) async {
     await tester.binding.setSurfaceSize(const Size(1152, 768));
@@ -1486,16 +1486,29 @@ void main() {
     const message =
         'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
         'at snapshot block 3,359,740. Switch to an eligible account to vote.';
-    await _pumpUntilFound(tester, find.text(message));
+    await _pumpUntilFound(tester, find.text('Not eligible'));
 
-    expect(find.text(message), findsOneWidget);
+    expect(find.text(message), findsNothing);
     expect(find.text('First proposal'), findsOneWidget);
-    expect(find.text('Yes'), findsNothing);
-    expect(find.text('No'), findsNothing);
-    expect(find.text('Review answers'), findsOneWidget);
+    expect(find.text('Voting power 0 ZEC'), findsOneWidget);
+    expect(find.text('Yes'), findsOneWidget);
+    expect(find.text('No'), findsOneWidget);
+    expect(find.text('Review answers'), findsNothing);
+    expect(find.text('Not eligible'), findsOneWidget);
+
+    await tester.tap(find.text('Yes'));
+    await tester.pumpAndSettle();
+
+    expect(container.read(votingDraftProvider(_draftKey)).isEmpty, true);
+
+    await tester.tap(find.text('Not eligible'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Not eligible for this poll'), findsOneWidget);
+    expect(find.text(message), findsOneWidget);
   });
 
-  testWidgets('proposal detail hides completed vote when eligibility fails', (
+  testWidgets('proposal detail shows completed vote when eligibility fails', (
     tester,
   ) async {
     await tester.binding.setSurfaceSize(const Size(1152, 768));
@@ -1538,11 +1551,11 @@ void main() {
     const message =
         'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
         'at snapshot block 3,359,740. Switch to an eligible account to vote.';
-    await _pumpUntilFound(tester, find.text(message));
+    await _pumpUntilFound(tester, find.textContaining('Voted'));
 
-    expect(find.text(message), findsOneWidget);
-    expect(find.textContaining('Voted'), findsNothing);
-    expect(find.text('Yes'), findsNothing);
+    expect(find.text(message), findsNothing);
+    expect(find.textContaining('Voted'), findsOneWidget);
+    expect(find.text('Yes'), findsOneWidget);
     expect(find.text('No'), findsNothing);
   });
 
@@ -1590,13 +1603,14 @@ void main() {
     const message =
         'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
         'at snapshot block 3,359,740. Switch to an eligible account to vote.';
-    await _pumpUntilFound(tester, find.text(message));
+    await _pumpUntilFound(tester, find.text('Not eligible'));
 
-    expect(find.text(message), findsOneWidget);
+    expect(find.text(message), findsNothing);
     expect(find.text('Vote in progress'), findsNothing);
     expect(find.text('Continue voting'), findsNothing);
-    expect(find.text('Yes'), findsNothing);
-    expect(find.text('No'), findsNothing);
+    expect(find.text('Yes'), findsOneWidget);
+    expect(find.text('No'), findsOneWidget);
+    expect(find.text('Not eligible'), findsOneWidget);
   });
 
   testWidgets('review hides stale choices when eligibility fails', (
@@ -1634,6 +1648,7 @@ void main() {
 
     expect(find.text(message), findsOneWidget);
     expect(find.text('Yes'), findsNothing);
+    expect(find.text('Confirm & submit'), findsOneWidget);
   });
 
   testWidgets('results screen renders flat tally rows as ZEC totals', (
@@ -2489,10 +2504,7 @@ void main() {
 
     expect(find.text('Sign bundle 1 of 1'), findsOneWidget);
     expect(find.text('Memo'), findsOneWidget);
-    expect(
-      find.textContaining('Amount: 0.00000100 ZEC'),
-      findsOneWidget,
-    );
+    expect(find.textContaining('Amount: 0.00000100 ZEC'), findsOneWidget);
     expect(find.text('Scan signature'), findsOneWidget);
     expect(find.text('Software account required'), findsNothing);
     await tester.tap(find.text('Scan signature'));

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1653,7 +1653,10 @@ void main() {
 
     expect(find.text(message), findsOneWidget);
     expect(find.text('Yes'), findsNothing);
-    expect(find.text('Confirm & submit'), findsOneWidget);
+    final submitButton = tester.widget<AppButton>(
+      find.widgetWithText(AppButton, 'Confirm & submit'),
+    );
+    expect(submitButton.onPressed, isNull);
   });
 
   testWidgets('results screen renders flat tally rows as ZEC totals', (

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -2510,6 +2510,51 @@ void main() {
   );
 
   test(
+    'submission job revalidates completed session after draft load failure',
+    () async {
+      final rust = FakeVotingRustApi();
+      final completedPlan = apiRoundPlan(
+        roundId: kRoundId,
+        pendingRecovery: false,
+        nextSteps: const [],
+        openProposals: Uint32List(0),
+        allDecided: true,
+        completedVoteArtifact: true,
+        completedForDisplay: true,
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(bundleCount: 1),
+        roundPlanSequence: [completedPlan, completedPlan],
+      );
+      final draftPersistence = FakeVotingDraftPersistence()
+        ..loadError = StateError('draft load failed');
+      final container = _sessionContainer(
+        rust: rust,
+        recoveryApi: recoveryApi,
+        draftPersistence: draftPersistence,
+        txConfirmationPolling: _fastTxConfirmationPolling,
+      );
+      addTearDown(container.dispose);
+
+      final startedKey = await container
+          .read(votingSubmissionJobsProvider.notifier)
+          .start(kRoundId);
+      expect(
+        startedKey,
+        const VotingSessionKey(roundId: kRoundId, accountUuid: 'account-1'),
+      );
+      final completed = await _waitForJobStatus(
+        container,
+        startedKey!,
+        VotingSubmissionJobStatus.complete,
+      );
+
+      expect(completed.errorMessage, isNull);
+      expect(rust.setupCalls, 1);
+    },
+  );
+
+  test(
     'submitted delegation recovery continues pending share recovery',
     () async {
       final shareNullifier = Uint8List.fromList(List.filled(32, 1));
@@ -5613,9 +5658,12 @@ class FakeVotingRecoveryApi implements VotingRecoveryApi {
 class FakeVotingDraftPersistence implements VotingDraftPersistence {
   final _stored = <VotingSessionKey, VotingDraftState>{};
   final _deletedAccountUuids = <String>{};
+  Object? loadError;
 
   @override
   Future<VotingDraftState> load(VotingSessionKey key) async {
+    final error = loadError;
+    if (error != null) throw error;
     return _stored[key] ?? const VotingDraftState();
   }
 


### PR DESCRIPTION
Summary:
- Pins the voting crate update and validates minimum voting eligibility before delegation, recovery, and completion paths.
- Hides vote choices, pending recovery CTAs, completed vote views, and review choices until eligibility is confirmed.
- Makes submitted confirmation require eligibility instead of completed local artifacts alone, and cancels the Keystone transition cue timer on dispose.

Test plan:
- flutter_rust_bridge_codegen generate
- fvm flutter analyze
- fvm flutter test test/features/voting/voting_status_screen_test.dart
- cd rust && cargo test