### PR TITLE
fix(voting): treat pending poll status as tallying in list

### DIFF
--- a/lib/src/features/voting/voting_poll_ordering.dart
+++ b/lib/src/features/voting/voting_poll_ordering.dart
@@ -45,6 +45,7 @@ VotingPollListStatus votingPollListStatus(String value) {
   if (status == '1') return VotingPollListStatus.active;
   if (status == '2') return VotingPollListStatus.tallying;
   if (status == '3') return VotingPollListStatus.closed;
+  if (status == 'pending') return VotingPollListStatus.tallying;
   if (status.contains('tally')) return VotingPollListStatus.tallying;
   if (status.contains('closed') ||
       status.contains('complete') ||

--- a/test/features/voting/voting_poll_ordering_test.dart
+++ b/test/features/voting/voting_poll_ordering_test.dart
@@ -3,6 +3,32 @@ import 'package:zcash_wallet/src/features/voting/voting_poll_ordering.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_state.dart';
 
 void main() {
+  test('treats pending status as tallying for poll list classification', () {
+    expect(votingPollListStatus('pending'), VotingPollListStatus.tallying);
+    expect(
+      votingPollOrderingState(_round('pending', status: 'pending', end: '')),
+      VotingPollOrderingState.closed,
+    );
+  });
+
+  test('sorts pending polls with tallying and closed rounds', () {
+    final rounds = [
+      _round('active', status: 'active', end: '2026-02-01T00:00:00Z'),
+      _round('pending', status: 'pending', end: '2026-03-01T00:00:00Z'),
+      _round('tallying', status: 'tallying', end: '2026-03-15T00:00:00Z'),
+      _round('closed', status: 'closed', end: '2026-04-01T00:00:00Z'),
+    ];
+
+    final sorted = sortVotingRoundsForPollList(rounds);
+
+    expect(sorted.map((round) => round.roundId), [
+      'active',
+      'closed',
+      'tallying',
+      'pending',
+    ]);
+  });
+
   test('prioritizes in-progress polls before normal active polls', () {
     final rounds = [
       _round('closed-old', status: 'finalized', end: '2026-01-01T00:00:00Z'),


### PR DESCRIPTION
## Summary
- Classify round status `pending` as `VotingPollListStatus.tallying` in `votingPollListStatus()`
- Align poll list ordering and card tap routing with the results screen, which already treats `pending` as tallying/pending results

## Problem
When the round list returns status `pending`, `votingPollListStatus()` fell through to `active`. `_openRoundAction` then routed the card to the poll/voting flow instead of the results/pending screen, so users could still enter vote preparation from the list even though tally was in progress.

## Test plan
- [x] `flutter test test/features/voting/voting_poll_ordering_test.dart`