### PR TITLE
fix(voting): reset vote-tree cache before pre-sync failover

### DIFF
--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -23,6 +23,7 @@ import 'voting_config_provider.dart';
 import 'voting_service_providers.dart';
 import 'voting_state.dart';
 import 'voting_submission_guard_provider.dart';
+import 'voting_vote_tree_round_guard.dart';
 
 /// Orchestrates one round's voting lifecycle for the UI.
 ///
@@ -1089,40 +1090,45 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             'round=${context.round.roundId} bundle=$bundleIndex '
             'proposal=${draftVote.proposalId}',
           );
-          final syncTimer = Stopwatch()..start();
-          final anchorHeight = await _syncVoteTreeWithFailover(
-            context: context,
-            bundleIndex: bundleIndex,
-            proposalId: draftVote.proposalId,
-          );
-          debugPrint(
-            '[zcash] Voting: vote tree sync completed '
-            'round=${context.round.roundId} bundle=$bundleIndex '
-            'proposal=${draftVote.proposalId} anchorHeight=$anchorHeight '
-            'elapsed=${formatElapsedSeconds(syncTimer.elapsed)}',
-          );
-
-          final witnessTimer = Stopwatch()..start();
-          debugPrint(
-            '[zcash] Voting: VAN witness generation start '
-            'round=${context.round.roundId} bundle=$bundleIndex '
-            'proposal=${draftVote.proposalId} anchorHeight=$anchorHeight',
-          );
           final witness = await ref
-              .read(votingRustApiProvider)
-              .generateVanWitness(
-                dbPath: context.dbPath,
-                accountUuid: context.accountUuid,
-                roundId: context.round.roundId,
-                bundleIndex: bundleIndex,
-                anchorHeight: anchorHeight,
-              );
-          debugPrint(
-            '[zcash] Voting: VAN witness generation completed '
-            'round=${context.round.roundId} bundle=$bundleIndex '
-            'proposal=${draftVote.proposalId} position=${witness.position} '
-            'elapsed=${formatElapsedSeconds(witnessTimer.elapsed)}',
-          );
+              .read(votingVoteTreeRoundGuardProvider)
+              .runHeld(context.round.roundId, () async {
+            final syncTimer = Stopwatch()..start();
+            final anchorHeight = await _syncVoteTreeWithFailover(
+              context: context,
+              bundleIndex: bundleIndex,
+              proposalId: draftVote.proposalId,
+            );
+            debugPrint(
+              '[zcash] Voting: vote tree sync completed '
+              'round=${context.round.roundId} bundle=$bundleIndex '
+              'proposal=${draftVote.proposalId} anchorHeight=$anchorHeight '
+              'elapsed=${formatElapsedSeconds(syncTimer.elapsed)}',
+            );
+
+            final witnessTimer = Stopwatch()..start();
+            debugPrint(
+              '[zcash] Voting: VAN witness generation start '
+              'round=${context.round.roundId} bundle=$bundleIndex '
+              'proposal=${draftVote.proposalId} anchorHeight=$anchorHeight',
+            );
+            final witness = await ref
+                .read(votingRustApiProvider)
+                .generateVanWitness(
+                  dbPath: context.dbPath,
+                  accountUuid: context.accountUuid,
+                  roundId: context.round.roundId,
+                  bundleIndex: bundleIndex,
+                  anchorHeight: anchorHeight,
+                );
+            debugPrint(
+              '[zcash] Voting: VAN witness generation completed '
+              'round=${context.round.roundId} bundle=$bundleIndex '
+              'proposal=${draftVote.proposalId} position=${witness.position} '
+              'elapsed=${formatElapsedSeconds(witnessTimer.elapsed)}',
+            );
+            return witness;
+          });
           _setStateForContext(
             context,
             (state.value ?? current).copyWith(

--- a/lib/src/providers/voting/voting_tree_sync_provider.dart
+++ b/lib/src/providers/voting/voting_tree_sync_provider.dart
@@ -64,7 +64,11 @@ class VotingTreePreSyncService {
         nodeUrls: apiServers,
       );
       _inFlight[key] = future;
-      await future;
+      try {
+        await future;
+      } finally {
+        _inFlight.remove(key);
+      }
     } catch (e) {
       debugPrint(
         '[zcash] Voting: vote tree pre-sync setup failed '
@@ -81,17 +85,18 @@ class VotingTreePreSyncService {
     required List<Uri> nodeUrls,
   }) async {
     final guard = _ref.read(votingVoteTreeRoundGuardProvider);
-    if (guard.isHeld(roundId)) {
-      debugPrint(
-        '[zcash] Voting: vote tree pre-sync skipped round=$roundId '
-        'reason=interactive-sync-active',
-      );
-      return;
-    }
-    final timer = Stopwatch()..start();
-    debugPrint('[zcash] Voting: vote tree pre-sync start round=$roundId');
     Object? lastError;
+    Stopwatch? timer;
     try {
+      if (guard.isHeld(roundId)) {
+        debugPrint(
+          '[zcash] Voting: vote tree pre-sync skipped round=$roundId '
+          'reason=interactive-sync-active',
+        );
+        return;
+      }
+      timer = Stopwatch()..start();
+      debugPrint('[zcash] Voting: vote tree pre-sync start round=$roundId');
       for (var attempt = 0; attempt < nodeUrls.length; attempt++) {
         if (guard.isHeld(roundId)) {
           debugPrint(
@@ -144,11 +149,9 @@ class VotingTreePreSyncService {
     } catch (e) {
       debugPrint(
         '[zcash] Voting: vote tree pre-sync failed '
-        'round=$roundId elapsed=${formatElapsedSeconds(timer.elapsed)} '
+        'round=$roundId elapsed=${formatElapsedSeconds(timer?.elapsed ?? Duration.zero)} '
         'error=${lastError ?? e}',
       );
-    } finally {
-      _inFlight.remove(key);
     }
   }
 }

--- a/lib/src/providers/voting/voting_tree_sync_provider.dart
+++ b/lib/src/providers/voting/voting_tree_sync_provider.dart
@@ -5,6 +5,7 @@ import '../../core/formatting/duration_format.dart';
 import '../../services/voting/resolved_voting_config_extensions.dart';
 import 'voting_config_provider.dart';
 import 'voting_service_providers.dart';
+import 'voting_vote_tree_round_guard.dart';
 
 final votingTreePreSyncProvider = Provider<VotingTreePreSyncService>((ref) {
   return VotingTreePreSyncService(ref);
@@ -79,11 +80,26 @@ class VotingTreePreSyncService {
     required String roundId,
     required List<Uri> nodeUrls,
   }) async {
+    final guard = _ref.read(votingVoteTreeRoundGuardProvider);
+    if (guard.isHeld(roundId)) {
+      debugPrint(
+        '[zcash] Voting: vote tree pre-sync skipped round=$roundId '
+        'reason=interactive-sync-active',
+      );
+      return;
+    }
     final timer = Stopwatch()..start();
     debugPrint('[zcash] Voting: vote tree pre-sync start round=$roundId');
     Object? lastError;
     try {
       for (var attempt = 0; attempt < nodeUrls.length; attempt++) {
+        if (guard.isHeld(roundId)) {
+          debugPrint(
+            '[zcash] Voting: vote tree pre-sync aborted round=$roundId '
+            'reason=interactive-sync-active',
+          );
+          return;
+        }
         final nodeUrl = nodeUrls[attempt];
         try {
           final height = await _ref
@@ -104,6 +120,13 @@ class VotingTreePreSyncService {
         } catch (e) {
           lastError = e;
           if (attempt < nodeUrls.length - 1) {
+            if (guard.isHeld(roundId)) {
+              debugPrint(
+                '[zcash] Voting: vote tree pre-sync failover reset skipped '
+                'round=$roundId reason=interactive-sync-active',
+              );
+              return;
+            }
             await _ref.read(votingRustApiProvider).resetVotingSessionState(
                   dbPath: dbPath,
                   accountUuid: accountUuid,

--- a/lib/src/providers/voting/voting_tree_sync_provider.dart
+++ b/lib/src/providers/voting/voting_tree_sync_provider.dart
@@ -107,6 +107,7 @@ class VotingTreePreSyncService {
             await _ref.read(votingRustApiProvider).resetVotingSessionState(
                   dbPath: dbPath,
                   accountUuid: accountUuid,
+                  roundId: roundId,
                 );
             debugPrint(
               '[zcash] Voting: vote tree pre-sync retrying failover '

--- a/lib/src/providers/voting/voting_tree_sync_provider.dart
+++ b/lib/src/providers/voting/voting_tree_sync_provider.dart
@@ -104,6 +104,10 @@ class VotingTreePreSyncService {
         } catch (e) {
           lastError = e;
           if (attempt < nodeUrls.length - 1) {
+            await _ref.read(votingRustApiProvider).resetVotingSessionState(
+                  dbPath: dbPath,
+                  accountUuid: accountUuid,
+                );
             debugPrint(
               '[zcash] Voting: vote tree pre-sync retrying failover '
               'round=$roundId from=$nodeUrl error=$e',

--- a/lib/src/providers/voting/voting_vote_tree_round_guard.dart
+++ b/lib/src/providers/voting/voting_vote_tree_round_guard.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Serializes interactive vote-tree sync/witness work per round.
+///
+/// Fire-and-forget pre-sync must not reset or advance vote-tree cache for a
+/// round while [runHeld] is active for that round.
+final votingVoteTreeRoundGuardProvider = Provider<VotingVoteTreeRoundGuard>(
+  (ref) => VotingVoteTreeRoundGuard(),
+);
+
+class VotingVoteTreeRoundGuard {
+  final Map<String, int> _holdersByRound = {};
+
+  bool isHeld(String roundId) => (_holdersByRound[roundId] ?? 0) > 0;
+
+  Future<T> runHeld<T>(String roundId, Future<T> Function() action) async {
+    _acquire(roundId);
+    try {
+      return await action();
+    } finally {
+      _release(roundId);
+    }
+  }
+
+  void _acquire(String roundId) {
+    _holdersByRound[roundId] = (_holdersByRound[roundId] ?? 0) + 1;
+  }
+
+  void _release(String roundId) {
+    final remaining = (_holdersByRound[roundId] ?? 0) - 1;
+    if (remaining <= 0) {
+      _holdersByRound.remove(roundId);
+    } else {
+      _holdersByRound[roundId] = remaining;
+    }
+  }
+}

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3616,6 +3616,27 @@ void main() {
   );
 
   test(
+    'vote tree pre-sync warms tree after skipping during interactive sync',
+    () async {
+      final rust = FakeVotingRustApi();
+      final container = _sessionContainer(rust: rust);
+      addTearDown(container.dispose);
+
+      final guard = container.read(votingVoteTreeRoundGuardProvider);
+      final service = container.read(votingTreePreSyncProvider);
+      final releaseGuard = Completer<void>();
+      final held = guard.runHeld(kRoundId, () => releaseGuard.future);
+      await service.preSyncRound(kRoundId);
+      expect(rust.syncedVoteTrees, isEmpty);
+      releaseGuard.complete();
+      await held;
+      await service.preSyncRound(kRoundId);
+
+      expect(rust.syncedVoteTrees, [kRoundId]);
+    },
+  );
+
+  test(
     'vote tree pre-sync does not reset cache during castVotes witness wait',
     () async {
       final witnessGate = Completer<void>();

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3582,6 +3582,7 @@ void main() {
       'https://voting.example',
       'https://voting-failover.example',
     ]);
+    expect(rust.resetVotingSessionStateCalls, ['account-1:*']);
   });
 
   test('vote tree sync runs before each proposal', () async {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -20,6 +20,7 @@ import 'package:zcash_wallet/src/providers/voting/voting_service_providers.dart'
 import 'package:zcash_wallet/src/providers/voting/voting_session_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_state.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_tree_sync_provider.dart';
+import 'package:zcash_wallet/src/providers/voting/voting_vote_tree_round_guard.dart';
 import 'package:zcash_wallet/src/rust/api/voting.dart' as rust_api;
 import 'package:zcash_wallet/src/rust/api/voting_config.dart'
     as rust_config_api;
@@ -3585,6 +3586,103 @@ void main() {
     expect(rust.resetVotingSessionStateCalls, ['account-1:$kRoundId']);
   });
 
+  test(
+    'vote tree pre-sync skips while interactive vote-tree sync is active',
+    () async {
+      final rust = FakeVotingRustApi(
+        failingVoteTreeNodeUrls: const {'https://voting.example'},
+      );
+      final http = FakeVotingHttpClient(
+        responses: votingHttpResponses(
+          dynamicConfig: dynamicConfigJson(
+            voteServers: const [
+              {'url': 'https://voting.example', 'label': 'primary'},
+              {'url': 'https://voting-failover.example', 'label': 'failover'},
+            ],
+          ),
+        ),
+      );
+      final container = _sessionContainer(http: http, rust: rust);
+      addTearDown(container.dispose);
+
+      final guard = container.read(votingVoteTreeRoundGuardProvider);
+      await guard.runHeld(kRoundId, () async {
+        await container.read(votingTreePreSyncProvider).preSyncRound(kRoundId);
+      });
+
+      expect(rust.syncedVoteTreeNodeUrls, isEmpty);
+      expect(rust.resetVotingSessionStateCalls, isEmpty);
+    },
+  );
+
+  test(
+    'vote tree pre-sync does not reset cache during castVotes witness wait',
+    () async {
+      final witnessGate = Completer<void>();
+      final rust = FakeVotingRustApi(
+        emitCommitments: true,
+        vanWitnessGate: witnessGate,
+        failingVoteTreeNodeUrls: const {'https://voting.example'},
+      );
+      final http = FakeVotingHttpClient(
+        responses: votingHttpResponses(
+          dynamicConfig: dynamicConfigJson(
+            voteServers: const [
+              {'url': 'https://voting.example', 'label': 'primary'},
+              {'url': 'https://voting-failover.example', 'label': 'failover'},
+            ],
+          ),
+        ),
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(
+          bundleCount: 1,
+          delegationTxHashes: [
+            rust_frb_types.DelegationRecoveryView(
+              bundleIndex: 0,
+              phase: VotingWorkflowPhase.submittedDelegation,
+              txHash: 'delegation-0',
+              vanLeafPosition: null,
+            ),
+          ],
+        ),
+      );
+      final container = _sessionContainer(
+        http: http,
+        rust: rust,
+        recoveryApi: recoveryApi,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      final castVotes = container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .castVotes(
+            draftVotes: [
+              rust_wire.DraftVote(
+                proposalId: 7,
+                choice: 1,
+                numOptions: 2,
+                vcTreePosition: BigInt.zero,
+                singleShare: false,
+              ),
+            ],
+          );
+      await rust.vanWitnessStarted.future;
+      await container.read(votingTreePreSyncProvider).preSyncRound(kRoundId);
+      witnessGate.complete();
+      await castVotes;
+
+      expect(
+        rust.resetVotingSessionStateCalls.where(
+          (call) => call == 'account-1:$kRoundId',
+        ),
+        isEmpty,
+      );
+      expect(rust.voteCommitBundleCalls, [0]);
+    },
+  );
+
   test('vote tree sync runs before each proposal', () async {
     final rust = FakeVotingRustApi();
     final container = _sessionContainer(rust: rust);
@@ -5714,6 +5812,7 @@ class FakeVotingRustApi implements VotingRustApi {
     this.delegationProofGate,
     this.keystoneDelegationProofGate,
     this.voteCommitmentGate,
+    this.vanWitnessGate,
     this.onDeleteSkippedBundles,
     this.failingVoteTreeNodeUrls = const {},
   });
@@ -5733,6 +5832,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final Completer<void>? delegationProofGate;
   final Completer<void>? keystoneDelegationProofGate;
   final Completer<void>? voteCommitmentGate;
+  final Completer<void>? vanWitnessGate;
   final void Function(int keepCount)? onDeleteSkippedBundles;
   final Set<String> failingVoteTreeNodeUrls;
   int setupCalls = 0;
@@ -5757,6 +5857,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final delegationProofStarted = Completer<void>();
   final keystoneDelegationProofStarted = Completer<void>();
   final voteCommitmentStarted = Completer<void>();
+  final vanWitnessStarted = Completer<void>();
   final hotkeyGenerationStarted = Completer<void>();
   final precomputeStarted = Completer<void>();
   final precomputeFinished = Completer<void>();
@@ -6134,6 +6235,10 @@ class FakeVotingRustApi implements VotingRustApi {
     required int bundleIndex,
     required int anchorHeight,
   }) async {
+    if (!vanWitnessStarted.isCompleted) {
+      vanWitnessStarted.complete();
+    }
+    await vanWitnessGate?.future;
     return rust_vote.VanWitness(
       authPath: const [],
       position: bundleIndex,

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3582,7 +3582,7 @@ void main() {
       'https://voting.example',
       'https://voting-failover.example',
     ]);
-    expect(rust.resetVotingSessionStateCalls, ['account-1:*']);
+    expect(rust.resetVotingSessionStateCalls, ['account-1:$kRoundId']);
   });
 
   test('vote tree sync runs before each proposal', () async {


### PR DESCRIPTION
## Summary

When the first pre-sync vote server fails after `syncVoteTree` has created or advanced the cached vote-tree client, the pre-sync failover path now calls `resetVotingSessionState` before retrying the next server. This matches the interactive `_syncVoteTreeWithFailover` behavior and avoids later VAN witness / vote-casting work reusing partial process-local state from the failed node.

## Test plan

- [x] `fvm flutter test test/providers/voting/voting_providers_test.dart --plain-name "vote tree pre-sync retries failover servers"`
- [x] `fvm flutter test test/providers/voting/voting_providers_test.dart`