### PR TITLE
fix: keystone recovery mid-signing

### DIFF
--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -13,6 +13,7 @@ import '../../features/voting/voting_formatters.dart';
 import '../../features/voting/voting_resume_plan.dart';
 import '../../rust/api/voting.dart' as rust_api;
 import '../../rust/third_party/zcash_voting/config.dart' as rust_config;
+import '../../rust/third_party/zcash_voting/delegate.dart' as rust_delegate;
 import '../../rust/third_party/zcash_voting/wire.dart' as rust_wire;
 import '../../services/voting/pir_snapshot_resolver.dart';
 import '../../services/voting/resolved_voting_config_extensions.dart';
@@ -675,15 +676,16 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
 
       final rust = ref.read(votingRustApiProvider);
       for (final bundleIndex in plan.pendingDelegationBundleIndexes) {
-        final signature = signatures[bundleIndex];
-        if (signature == null) {
+        if (!signatures.containsKey(bundleIndex)) {
           _setError(
             'Sign delegation bundle ${bundleIndex + 1} with Keystone before submitting.',
             context: context,
           );
           return;
         }
-
+      }
+      for (final bundleIndex in plan.pendingDelegationBundleIndexes) {
+        final signature = signatures[bundleIndex]!;
         final bundleTimer = Stopwatch()..start();
         debugPrint(
           '[zcash] Voting: Keystone delegation bundle start '
@@ -2359,9 +2361,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       context = await _loadContext(_roundId);
     }
 
-    final plan = current.resumePlan ?? context.resumePlan;
-    final roundPlan = current.roundPlan ?? context.roundPlan;
-    final signatures = await _loadKeystoneSignatures(context);
+    var plan = current.resumePlan ?? context.resumePlan;
+    var roundPlan = current.roundPlan ?? context.roundPlan;
+    var signatures = await _loadKeystoneSignatures(context);
     int? nextUnsignedBundle;
     for (final bundleIndex in plan.pendingDelegationBundleIndexes) {
       if (!signatures.containsKey(bundleIndex)) {
@@ -2410,19 +2412,89 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       ),
     );
 
-    final request = await ref
-        .read(votingRustApiProvider)
-        .buildKeystoneDelegationRequest(
-          ctx: _apiRoundContext(context),
-          storedHotkeySecret: storedHotkeySecret,
-          bundleIndex: nextUnsignedBundle,
+    final rust = ref.read(votingRustApiProvider);
+    late final rust_delegate.KeystoneSigningRequest request;
+    try {
+      request = await rust.buildKeystoneDelegationRequest(
+        ctx: _apiRoundContext(context),
+        storedHotkeySecret: storedHotkeySecret,
+        bundleIndex: nextUnsignedBundle,
+      );
+    } catch (error) {
+      if (!_isKeystoneSetupOverwriteError(error)) rethrow;
+      debugPrint(
+        '[zcash] Voting: Keystone request detected stale bundle setup '
+        'round=${context.round.roundId} bundle=$nextUnsignedBundle',
+      );
+      await _resetVotingSessionState(
+        rust: rust,
+        context: context,
+        reason: 'keystone-stale-setup',
+      );
+      await rust.setupDelegationBundles(ctx: _apiRoundContext(context));
+      plan = await _loadResumePlan(context);
+      roundPlan = await _loadRoundPlan(context);
+      signatures = await _loadKeystoneSignatures(context);
+      final maxBundleIndex = plan.bundleCount;
+      if (maxBundleIndex >= 0) {
+        signatures = {
+          for (final entry in signatures.entries)
+            if (entry.key >= 0 && entry.key < maxBundleIndex)
+              entry.key: entry.value,
+        };
+      }
+      nextUnsignedBundle = null;
+      for (final bundleIndex in plan.pendingDelegationBundleIndexes) {
+        if (!signatures.containsKey(bundleIndex)) {
+          nextUnsignedBundle = bundleIndex;
+          break;
+        }
+      }
+      if (nextUnsignedBundle == null) {
+        _setStateForContext(
+          context,
+          (state.value ?? current).copyWith(
+            phase: VotingSessionPhase.readyToDelegate,
+            isHardwareAccount: true,
+            resumePlan: plan,
+            roundPlan: roundPlan,
+            keystoneSignatures: signatures,
+            clearKeystoneSigningRequest: true,
+            clearKeystoneScanError: true,
+            clearCurrentBundleIndex: true,
+            clearError: true,
+          ),
         );
+        return;
+      }
+      _setStateForContext(
+        context,
+        (state.value ?? current).copyWith(
+          phase: VotingSessionPhase.keystoneSigning,
+          isHardwareAccount: true,
+          resumePlan: plan,
+          roundPlan: roundPlan,
+          keystoneSignatures: signatures,
+          currentBundleIndex: nextUnsignedBundle,
+          clearKeystoneSigningRequest: true,
+          clearKeystoneScanError: true,
+          clearError: true,
+        ),
+      );
+      request = await rust.buildKeystoneDelegationRequest(
+        ctx: _apiRoundContext(context),
+        storedHotkeySecret: storedHotkeySecret,
+        bundleIndex: nextUnsignedBundle,
+      );
+    }
 
     _setStateForContext(
       context,
       (state.value ?? current).copyWith(
         phase: VotingSessionPhase.keystoneSigning,
         isHardwareAccount: true,
+        resumePlan: plan,
+        roundPlan: roundPlan,
         eligibleWeightZatoshi: request.eligibleWeightZatoshi,
         keystoneSigningRequest: request,
         keystoneSignatures: signatures,
@@ -3083,6 +3155,17 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       if (left[i] != right[i]) return false;
     }
     return true;
+  }
+
+  static bool _isKeystoneSetupOverwriteError(Object error) {
+    final normalized = error
+        .toString()
+        .toLowerCase()
+        .replaceAll('_', ' ')
+        .replaceAll('-', ' ');
+    return normalized.contains('refusing to overwrite pczt sighash') ||
+        normalized.contains('refusing to overwrite pczt hash') ||
+        normalized.contains('refusing to overwrite padded note secrets');
   }
 }
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2098,12 +2098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
 name = "no_std_io2"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2636,7 +2630,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "log",
- "multimap 0.8.3",
+ "multimap",
  "petgraph 0.6.5",
  "prettyplease 0.1.25",
  "prost 0.11.9",
@@ -2656,7 +2650,7 @@ dependencies = [
  "heck 0.5.0",
  "itertools 0.14.0",
  "log",
- "multimap 0.10.1",
+ "multimap",
  "petgraph 0.8.3",
  "prettyplease 0.2.37",
  "prost 0.14.3",
@@ -3960,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree"
 version = "0.3.1"
-source = "git+https://github.com/valargroup/zcash_voting?rev=05791d2b8bb1c93e287f0cb3d86dd73072fde9e2#05791d2b8bb1c93e287f0cb3d86dd73072fde9e2"
+source = "git+https://github.com/valargroup/zcash_voting?rev=c757274dda22851cec99a7453eb0f2aed91fbf5c#c757274dda22851cec99a7453eb0f2aed91fbf5c"
 dependencies = [
  "anyhow",
  "ff",
@@ -3976,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.5.1"
-source = "git+https://github.com/valargroup/zcash_voting?rev=05791d2b8bb1c93e287f0cb3d86dd73072fde9e2#05791d2b8bb1c93e287f0cb3d86dd73072fde9e2"
+source = "git+https://github.com/valargroup/zcash_voting?rev=c757274dda22851cec99a7453eb0f2aed91fbf5c#c757274dda22851cec99a7453eb0f2aed91fbf5c"
 dependencies = [
  "base64",
  "ff",
@@ -3985,7 +3979,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "vote-commitment-tree 0.3.1 (git+https://github.com/valargroup/zcash_voting?rev=05791d2b8bb1c93e287f0cb3d86dd73072fde9e2)",
+ "vote-commitment-tree 0.3.1 (git+https://github.com/valargroup/zcash_voting?rev=c757274dda22851cec99a7453eb0f2aed91fbf5c)",
 ]
 
 [[package]]
@@ -4697,7 +4691,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "0.10.1"
-source = "git+https://github.com/valargroup/zcash_voting?rev=05791d2b8bb1c93e287f0cb3d86dd73072fde9e2#05791d2b8bb1c93e287f0cb3d86dd73072fde9e2"
+source = "git+https://github.com/valargroup/zcash_voting?rev=c757274dda22851cec99a7453eb0f2aed91fbf5c#c757274dda22851cec99a7453eb0f2aed91fbf5c"
 dependencies = [
  "anyhow",
  "base64",
@@ -4737,7 +4731,7 @@ dependencies = [
  "uuid",
  "valar-spiral-rs",
  "valar-ypir",
- "vote-commitment-tree 0.3.1 (git+https://github.com/valargroup/zcash_voting?rev=05791d2b8bb1c93e287f0cb3d86dd73072fde9e2)",
+ "vote-commitment-tree 0.3.1 (git+https://github.com/valargroup/zcash_voting?rev=c757274dda22851cec99a7453eb0f2aed91fbf5c)",
  "vote-commitment-tree-client",
  "voting-circuits",
  "zcash_client_backend",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ zcash_client_backend = { version = "0.22", features = [
 ] }
 zcash_client_sqlite = { version = "0.20", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 # Voting clients need PIR lookup support and vote-commitment-tree sync.
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "05791d2b8bb1c93e287f0cb3d86dd73072fde9e2", package = "zcash_voting" }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "c757274dda22851cec99a7453eb0f2aed91fbf5c", package = "zcash_voting" }
 # Must match versions used by zcash_client_sqlite to avoid type conflicts
 orchard = { version = "=0.13.1", features = ["unstable-voting-circuits"] }
 sapling-crypto = { version = "0.7", default-features = false, features = ["circuit"] }

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1034,9 +1034,10 @@ pub fn generate_van_witness(
 /// Clear process-local vote-tree sync state for a wallet or round.
 ///
 /// Passing a non-empty round ID clears only that round's cached vote-tree sync
-/// state by calling `zcash_voting::precompute::reset_vote_tree(db, round_id)`.
-/// Passing `None` or an empty round ID performs account-wide cleanup with
-/// `zcash_voting::precompute::reset_vote_tree(db, "")`.
+/// state and unsigned delegation setup fields by calling
+/// `zcash_voting::precompute::reset_voting_session_state(db, round_id)`.
+/// Passing `None` or an empty round ID performs account-wide vote-tree cleanup
+/// with `zcash_voting::precompute::reset_voting_session_state(db, "")`.
 ///
 /// This does not delete durable recovery rows or abort in-flight proof/vote
 /// work already running on worker threads.
@@ -1046,6 +1047,8 @@ pub fn reset_voting_session_state(
     round_id: Option<String>,
 ) -> Result<(), String> {
     catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+
         let scoped_round_id = round_id
             .as_deref()
             .filter(|id| !id.is_empty())
@@ -1055,9 +1058,8 @@ pub fn reset_voting_session_state(
         } else {
             "round"
         };
-        let db = db::open_voting_db(&db_path, &account_uuid)?;
-        zcash_voting::precompute::reset_vote_tree(&db, scoped_round_id)
-            .map_err(|e| format!("reset_vote_tree failed: {e}"))?;
+        zcash_voting::precompute::reset_voting_session_state(&db, scoped_round_id)
+            .map_err(|e| format!("reset voting session state failed: {e}"))?;
         log::info!(
             "voting: reset process-local session state \
              (account_uuid={}, scope={}, round_id={:?})",

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1462,6 +1462,160 @@ void main() {
     expect(rust.keystoneDelegationRequestCalls, [0, 0]);
   });
 
+  test('hardware voting retries stale Keystone setup overwrite once', () async {
+    final rust = FakeVotingRustApi(
+      keystoneDelegationRequestFailuresByCall: {
+        0: StateError(
+          'delegate::keystone_request failed: Invalid input: '
+          'refusing to overwrite pczt_sighash for round=round-id, bundle=0',
+        ),
+      },
+    );
+    final container = _sessionContainer(rust: rust, accountIsHardware: true);
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .prepareKeystoneSigning();
+    final state = container.read(votingSessionProvider(kRoundId)).value!;
+
+    expect(state.phase, VotingSessionPhase.keystoneSigning);
+    expect(state.keystoneSigningRequest?.bundleIndex, 0);
+    expect(state.error, isNull);
+    expect(rust.deleteSkippedBundleKeepCounts, isEmpty);
+    expect(
+      rust.resetVotingSessionStateCalls,
+      contains('account-1:$kRoundId'),
+    );
+    expect(rust.keystoneDelegationRequestCalls, [0, 0]);
+    expect(rust.setupCalls, 2);
+  });
+
+  test(
+    'hardware voting stale-setup recovery preserves unsigned Keystone bundles',
+    () async {
+      final rust = FakeVotingRustApi(
+        bundleCount: 2,
+        keystoneDelegationRequestFailuresByCall: {
+          0: StateError(
+            'delegate::keystone_request failed: Invalid input: '
+            'refusing to overwrite padded_note_secrets for round=round-id, bundle=1',
+          ),
+        },
+      );
+      rust.storedKeystoneSignatures[0] = rust_wire.KeystoneSignatureRecord(
+        bundleIndex: 0,
+        sig: Uint8List.fromList(const [3, 0]),
+        sighash: Uint8List.fromList(const [10, 0]),
+        rk: Uint8List.fromList(const [2, 0]),
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(bundleCount: 2),
+      );
+      final container = _sessionContainer(
+        rust: rust,
+        recoveryApi: recoveryApi,
+        accountIsHardware: true,
+        hotkeyStore: FakeVotingHotkeyStore(const [42, 43, 44]),
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      await container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .prepareKeystoneSigning();
+      final state = container.read(votingSessionProvider(kRoundId)).value!;
+
+      expect(state.phase, VotingSessionPhase.keystoneSigning);
+      expect(state.keystoneSigningRequest?.bundleIndex, 1);
+      expect(state.keystoneSignatures.keys, [0]);
+      expect(state.resumePlan?.bundleCount, 2);
+      expect(rust.deleteSkippedBundleKeepCounts, isEmpty);
+      expect(
+        rust.resetVotingSessionStateCalls,
+        contains('account-1:$kRoundId'),
+      );
+      expect(rust.keystoneDelegationRequestCalls, [1, 1]);
+      expect(rust.setupCalls, 2);
+    },
+  );
+
+  test(
+    'hardware restart after first keystone signature requests next unsigned bundle',
+    () async {
+      final rust = FakeVotingRustApi(bundleCount: 2);
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(bundleCount: 2),
+      );
+      final hotkeyStore = FakeVotingHotkeyStore(const [42, 43, 44]);
+      var container = _sessionContainer(
+        rust: rust,
+        recoveryApi: recoveryApi,
+        accountIsHardware: true,
+        hotkeyStore: hotkeyStore,
+      );
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      await container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .prepareKeystoneSigning();
+      await container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .handleKeystoneSignedPczt([10, 0]);
+
+      container.dispose();
+      await Future<void>.delayed(Duration.zero);
+
+      container = _sessionContainer(
+        rust: rust,
+        recoveryApi: recoveryApi,
+        accountIsHardware: true,
+        hotkeyStore: hotkeyStore,
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      await container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .prepareKeystoneSigning();
+      final state = container.read(votingSessionProvider(kRoundId)).value!;
+
+      expect(state.phase, VotingSessionPhase.keystoneSigning);
+      expect(state.keystoneSigningRequest?.bundleIndex, 1);
+      expect(state.keystoneSignatures.keys, [0]);
+      expect(state.resumePlan?.bundleCount, 2);
+      expect(rust.deleteSkippedBundleKeepCounts, isEmpty);
+      expect(rust.keystoneDelegationRequestCalls, [0, 1, 1]);
+    },
+  );
+
+  test('hardware voting surfaces non-recoverable Keystone request failures', () async {
+    final rust = FakeVotingRustApi(
+      keystoneDelegationRequestFailuresByCall: {
+        0: StateError(
+          'delegate::keystone_request failed: invalid branch id from lightwalletd',
+        ),
+      },
+    );
+    final container = _sessionContainer(rust: rust, accountIsHardware: true);
+    addTearDown(container.dispose);
+
+    await container.read(votingSessionProvider(kRoundId).future);
+    await container
+        .read(votingSessionProvider(kRoundId).notifier)
+        .prepareKeystoneSigning();
+    final state = container.read(votingSessionProvider(kRoundId)).value!;
+
+    expect(state.phase, VotingSessionPhase.error);
+    expect(
+      state.error?.message,
+      contains('invalid branch id from lightwalletd'),
+    );
+    expect(rust.keystoneDelegationRequestCalls, [0]);
+    expect(rust.deleteSkippedBundleKeepCounts, isEmpty);
+  });
+
   test(
     'hardware voting permits prepared-only recovery without stored hotkey',
     () async {
@@ -1794,6 +1948,43 @@ void main() {
       expect(rust.keystoneProofBundleCalls, [0]);
       expect(rust.storedDelegationTxHashes, ['0:delegation-tx']);
       expect(rust.storedVanPositions, ['0:0']);
+    },
+  );
+
+  test(
+    'hardware voting blocks delegation when later Keystone bundle is unsigned',
+    () async {
+      final rust = FakeVotingRustApi(bundleCount: 2);
+      rust.storedKeystoneSignatures[0] = rust_wire.KeystoneSignatureRecord(
+        bundleIndex: 0,
+        sig: Uint8List.fromList(const [3, 0]),
+        sighash: Uint8List.fromList(const [10, 0]),
+        rk: Uint8List.fromList(const [2, 0]),
+      );
+      final recoveryApi = FakeVotingRecoveryApi(
+        state: recoveryState(bundleCount: 2),
+      );
+      final container = _sessionContainer(
+        rust: rust,
+        recoveryApi: recoveryApi,
+        accountIsHardware: true,
+        hotkeyStore: FakeVotingHotkeyStore(const [42, 43, 44]),
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingSessionProvider(kRoundId).future);
+      await container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .delegatePendingBundlesWithKeystoneSignatures();
+      final state = container.read(votingSessionProvider(kRoundId)).value!;
+
+      expect(state.phase, VotingSessionPhase.error);
+      expect(
+        state.error?.message,
+        contains('Sign delegation bundle 2 with Keystone before submitting'),
+      );
+      expect(rust.keystoneProofBundleCalls, isEmpty);
+      expect(rust.storedDelegationTxHashes, isEmpty);
     },
   );
 
@@ -5714,6 +5905,7 @@ class FakeVotingRustApi implements VotingRustApi {
     this.keystoneDelegationProofGate,
     this.voteCommitmentGate,
     this.onDeleteSkippedBundles,
+    this.keystoneDelegationRequestFailuresByCall = const {},
     this.failingVoteTreeNodeUrls = const {},
   });
 
@@ -5733,6 +5925,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final Completer<void>? keystoneDelegationProofGate;
   final Completer<void>? voteCommitmentGate;
   final void Function(int keepCount)? onDeleteSkippedBundles;
+  final Map<int, Object> keystoneDelegationRequestFailuresByCall;
   final Set<String> failingVoteTreeNodeUrls;
   int setupCalls = 0;
   int _activeSetups = 0;
@@ -5891,8 +6084,13 @@ class FakeVotingRustApi implements VotingRustApi {
     required List<int> storedHotkeySecret,
     required int bundleIndex,
   }) async {
+    final callIndex = keystoneDelegationRequestCalls.length;
     accountUuids.add(ctx.accountUuid);
     keystoneDelegationRequestCalls.add(bundleIndex);
+    final forcedFailure = keystoneDelegationRequestFailuresByCall[callIndex];
+    if (forcedFailure != null) {
+      throw forcedFailure;
+    }
     return rust_delegate.KeystoneSigningRequest(
       pcztBytes: Uint8List.fromList([20, bundleIndex]),
       redactedPcztBytes: Uint8List.fromList([21, bundleIndex]),


### PR DESCRIPTION
This fixes a bug where crashing mid-signing would not allow recovery due to stale unsigned pczt metadata in the db.

We cleared half-finished delegation setup artifacts on unsigned bundles because restart always rebuilds the Keystone request from scratch, and the storage layer refuses to clobber an in-progress setup that may no longer match what the app is trying to produce.

## What actually gets cleared

`reset_voting_session_state` (round-scoped) does two things:

- Drops process-local vote-tree cache (in-memory only).
- NULLs transient setup columns on bundles that are still unsigned: pczt_sighash, padded_note_secrets, and related PCZT setu

It explicitly does not touch:

- keystone_signatures rows (bundle 0 stays “signed”)
- delegation_tx_hash (submitted bundles)
- Ballot intent, recovery rows, bundle plan, etc.

So this is not “clear the database and start over.” It is “forget the interrupted PCZT setup for bundles that still need signing.”


## Why “continue from the same spot” would need different code

True resume would mean one of:

- Persist the full Keystone request at setup time and, on restart, if pczt_sighash exists and there is no signature yet, reload that exact request and show it again — no regeneration.
- Add a read-only resume API in zcash_voting: “given stored setup columns, reconstruct KeystoneSigningRequest without calling setup() again.”

Neither existed. The wallet only had the regenerate path, so stale DB setup blocked forward progress.

Clearing unsigned setup is the minimal safe fix: treat interrupted setup as never started, rerun setup cleanly for the next unsigned bundle, while signed/submitted bundles keep their durable state.