### PR TITLE
Address voting recovery review feedback

### DIFF
--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -19,6 +19,7 @@ import '../../../rust/third_party/zcash_voting/wire.dart' as rust_wire;
 import '../voting_choice_style.dart';
 import '../voting_flow_models.dart';
 import '../voting_formatters.dart';
+import '../voting_poll_ordering.dart';
 import '../voting_resume_plan.dart';
 import '../voting_routes.dart';
 import '../widgets/voting_metadata_widgets.dart';
@@ -40,6 +41,7 @@ class _VotingProposalDetailScreenState
   bool _votingPowerPreparationInFlight = false;
   String? _votingPowerPreparationKey;
   String? _delegationPirPrecomputeKey;
+  String? _resultsRedirectRoundId;
 
   @override
   void didUpdateWidget(covariant VotingProposalDetailScreen oldWidget) {
@@ -49,6 +51,7 @@ class _VotingProposalDetailScreenState
       _votingPowerPreparationInFlight = false;
       _votingPowerPreparationKey = null;
       _delegationPirPrecomputeKey = null;
+      _resultsRedirectRoundId = null;
     }
   }
 
@@ -72,6 +75,11 @@ class _VotingProposalDetailScreenState
                 title: 'Poll unavailable',
                 message: 'The selected poll could not be loaded.',
               );
+            }
+            if (votingPollListStatus(round.status) !=
+                VotingPollListStatus.active) {
+              _redirectToResults(round.roundId);
+              return const Center(child: CircularProgressIndicator());
             }
             if (shouldPreSyncVotingTree(round.status)) {
               unawaited(
@@ -170,6 +178,15 @@ class _VotingProposalDetailScreenState
         ),
       ),
     );
+  }
+
+  void _redirectToResults(String roundId) {
+    if (_resultsRedirectRoundId == roundId) return;
+    _resultsRedirectRoundId = roundId;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.go(votingResultsRoute(roundId));
+    });
   }
 
   void _maybePrepareVotingPower(VotingSessionState state) {

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -76,27 +76,16 @@ class _VotingProposalDetailScreenState
                 message: 'The selected poll could not be loaded.',
               );
             }
-            if (votingPollListStatus(round.status) !=
-                VotingPollListStatus.active) {
-              _redirectToResults(round.roundId);
-              return const Center(child: CircularProgressIndicator());
-            }
             if (shouldPreSyncVotingTree(round.status)) {
               unawaited(
                 ref.read(votingTreePreSyncProvider).preSyncRound(round.roundId),
               );
             }
             final accountUuid = state.accountUuid;
-            final draftKey = accountUuid == null
-                ? null
-                : VotingSessionKey(roundId: roundId, accountUuid: accountUuid);
-            final draft = draftKey == null
-                ? const VotingDraftState()
-                : ref.watch(votingDraftProvider(draftKey));
             final proposals = proposalsFromRound(round);
             final forumUri = votingRoundForumUriFromJson(round.rawJson);
             final completedVote = _CompletedVote.fromPlan(state.roundPlan);
-            _maybePrepareVotingPower(state);
+            final pendingVote = _PendingVoteRecovery.fromPlan(state.roundPlan);
             // Foreground recovery takes precedence over the read-only voted view.
             // Accepted helper shares may still be tracked after submission, but
             // that background work should not keep this screen resumable.
@@ -116,6 +105,7 @@ class _VotingProposalDetailScreenState
               );
             }
             if (completedVote != null) {
+              _maybePrepareVotingPower(state);
               return Padding(
                 padding: const EdgeInsets.all(AppSpacing.md),
                 child: _VotedPollContent(
@@ -133,7 +123,6 @@ class _VotingProposalDetailScreenState
                 ),
               );
             }
-            final pendingVote = _PendingVoteRecovery.fromPlan(state.roundPlan);
             if (pendingVote != null) {
               return Padding(
                 padding: const EdgeInsets.all(AppSpacing.md),
@@ -149,6 +138,18 @@ class _VotingProposalDetailScreenState
                 ),
               );
             }
+            if (votingPollListStatus(round.status) !=
+                VotingPollListStatus.active) {
+              _redirectToResults(round.roundId);
+              return const Center(child: CircularProgressIndicator());
+            }
+            final draftKey = accountUuid == null
+                ? null
+                : VotingSessionKey(roundId: roundId, accountUuid: accountUuid);
+            final draft = draftKey == null
+                ? const VotingDraftState()
+                : ref.watch(votingDraftProvider(draftKey));
+            _maybePrepareVotingPower(state);
             _maybePrecomputeDelegationPir(state);
             return _ActivePollContent(
               roundId: roundId,

--- a/lib/src/providers/voting/voting_config_provider.dart
+++ b/lib/src/providers/voting/voting_config_provider.dart
@@ -138,7 +138,10 @@ class VotingConfigNotifier extends AsyncNotifier<ResolvedVotingConfig> {
     VotingConfigResolution resolution, {
     required String sourceUrl,
   }) {
-    _applySwitch(resolution.switchKind);
+    final sourceChanged =
+        _previousResolvedSourceUrl != null &&
+        _previousResolvedSourceUrl != sourceUrl;
+    _applySwitch(resolution.switchKind, sourceChanged: sourceChanged);
     _previousResolvedConfig = resolution.config;
     _previousResolvedSourceUrl = sourceUrl;
     _clearRefreshFailure();
@@ -160,10 +163,11 @@ class VotingConfigNotifier extends AsyncNotifier<ResolvedVotingConfig> {
 
   /// Applies the Rust-computed switch plan to dependent voting state.
   ///
-  /// `unchanged`/`initialLoad` keep all caches. The remaining kinds all imply
-  /// the vote/PIR endpoints, signing keys, rounds, or protocol moved, so
-  /// endpoint-dependent caches are rebuilt to force re-resolution against the new
-  /// config:
+  /// `unchanged`/`initialLoad` keep all caches unless the configured source URL
+  /// changed. A source change or any of the remaining kinds imply the vote/PIR
+  /// endpoints, signing keys, rounds, or protocol may have moved, so
+  /// endpoint-dependent caches are rebuilt to force re-resolution against the
+  /// new config:
   ///
   /// - shared transport/client + PIR resolver caches via [_invalidateEndpointState];
   /// - the poll list ([votingRoundsProvider]) and the interactive session
@@ -171,7 +175,11 @@ class VotingConfigNotifier extends AsyncNotifier<ResolvedVotingConfig> {
   /// - the submission-session family ([votingSubmissionSessionProvider]) so a
   ///   subsequent submission re-resolves its endpoints. Active submission guards
   ///   keep existing sessions alive until their jobs release process-local state.
-  void _applySwitch(ConfigSwitchKind kind) {
+  void _applySwitch(ConfigSwitchKind kind, {required bool sourceChanged}) {
+    if (sourceChanged) {
+      _invalidateConfigDependentState();
+      return;
+    }
     switch (kind) {
       case ConfigSwitchKind.unchanged:
       case ConfigSwitchKind.initialLoad:
@@ -179,13 +187,17 @@ class VotingConfigNotifier extends AsyncNotifier<ResolvedVotingConfig> {
       case ConfigSwitchKind.sameChainServiceUpdate:
       case ConfigSwitchKind.newChainOrRound:
       case ConfigSwitchKind.protocolChanged:
-        _invalidateEndpointState();
-        ref.invalidate(votingRoundsProvider);
-        if (ref.read(votingSubmissionGuardProvider).isEmpty) {
-          ref.invalidate(votingSessionProvider);
-          ref.invalidate(votingSubmissionSessionProvider);
-        }
+        _invalidateConfigDependentState();
         return;
+    }
+  }
+
+  void _invalidateConfigDependentState() {
+    _invalidateEndpointState();
+    ref.invalidate(votingRoundsProvider);
+    if (ref.read(votingSubmissionGuardProvider).isEmpty) {
+      ref.invalidate(votingSessionProvider);
+      ref.invalidate(votingSubmissionSessionProvider);
     }
   }
 

--- a/lib/src/providers/voting/voting_service_providers.dart
+++ b/lib/src/providers/voting/voting_service_providers.dart
@@ -446,11 +446,21 @@ abstract interface class VotingRustApi {
     required int anchorHeight,
   });
 
+  /// Clear only the process-local vote-tree sync cache for a round or account.
+  ///
+  /// A non-null, non-empty `roundId` clears that round's tree sync cache.
+  /// `null` (or empty) performs account-wide vote-tree cleanup for `accountUuid`.
+  Future<void> resetVoteTree({
+    required String dbPath,
+    required String accountUuid,
+    String? roundId,
+  });
+
   /// Clear process-local Rust voting caches for a round or account.
   ///
-  /// A non-null, non-empty `roundId` clears vote-tree sync cache for that
-  /// round. `null` (or empty) performs account-wide cleanup of vote-tree sync
-  /// state for `accountUuid`.
+  /// A non-null, non-empty `roundId` clears round-scoped vote-tree sync cache
+  /// and unsigned delegation setup fields. `null` (or empty) performs
+  /// account-wide cleanup for `accountUuid`.
   Future<void> resetVotingSessionState({
     required String dbPath,
     required String accountUuid,
@@ -808,6 +818,19 @@ class FrbVotingRustApi implements VotingRustApi {
     String? roundId,
   }) {
     return rust_api.resetVotingSessionState(
+      dbPath: dbPath,
+      accountUuid: accountUuid,
+      roundId: roundId,
+    );
+  }
+
+  @override
+  Future<void> resetVoteTree({
+    required String dbPath,
+    required String accountUuid,
+    String? roundId,
+  }) {
+    return rust_api.resetVoteTree(
       dbPath: dbPath,
       accountUuid: accountUuid,
       roundId: roundId,

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -840,17 +840,18 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       final api = ref.read(votingApiClientProvider(context.config.apiServers));
       final rust = ref.read(votingRustApiProvider);
       final effectiveDraftVotes = draftVotes;
-      if (effectiveDraftVotes.isNotEmpty) {
+      final draftVotesByProposal = {
+        for (final draftVote in effectiveDraftVotes)
+          draftVote.proposalId: draftVote,
+      };
+      final intentProposalIds = {
+        ...?allProposalIds,
+        ...draftVotesByProposal.keys,
+      }.toList()..sort();
+      Future<bool> writeBallotIntents() async {
+        if (effectiveDraftVotes.isEmpty) return true;
         // Write durable ballot intent before the cast loop so recovery can
         // resume from the correct choice if the user quits mid-vote.
-        final draftVotesByProposal = {
-          for (final draftVote in effectiveDraftVotes)
-            draftVote.proposalId: draftVote,
-        };
-        final intentProposalIds = {
-          ...?allProposalIds,
-          ...draftVotesByProposal.keys,
-        }.toList()..sort();
         for (final proposalId in intentProposalIds) {
           final draftVote = draftVotesByProposal[proposalId];
           final numOptions =
@@ -862,7 +863,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
                 'missing numOptions for proposal_id $proposalId',
               ),
             );
-            return;
+            return false;
           }
           await ref
               .read(votingRecoveryServiceProvider)
@@ -876,7 +877,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
                 choice: draftVote?.choice,
               );
         }
+        return true;
       }
+
       var confirmedSubmittedVotes = false;
       for (final work in _pendingVotePollingWork(roundPlan)) {
         final key = VotingVoteKey(
@@ -971,6 +974,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
           );
           return;
         }
+      }
+      if (!await writeBallotIntents()) {
+        return;
       }
       final totalQuestions = recoveredVoteWork.length + voteWork.length;
       final totalBundleTasks =
@@ -1579,6 +1585,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         await rust.resetVotingSessionState(
           dbPath: context.dbPath,
           accountUuid: context.accountUuid,
+          roundId: context.round.roundId,
         );
         debugPrint(
           '[zcash] Voting: vote tree sync retrying failover '

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -327,16 +327,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   Future<void> delegatePendingBundles({String? mnemonic}) {
     return _enqueue(() async {
       var current = await future;
-      if (_needsDelegationPreparation(current)) {
-        await _prepareDelegationUnlocked();
-        current = await future;
-        if (current.phase == VotingSessionPhase.error ||
-            current.phase == VotingSessionPhase.waitingForWalletSync) {
-          return;
-        }
-      }
-
-      final context = await _loadContext(_roundId);
+      var context = await _loadContext(_roundId);
       if (context.isHardwareAccount) {
         _setError(
           'Sign delegation bundles with Keystone before submitting.',
@@ -344,14 +335,28 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
         return;
       }
-      final plan = current.resumePlan ?? context.resumePlan;
-      final roundPlan = current.roundPlan ?? context.roundPlan;
-      final pirEndpoint = current.pirEndpoint;
-      if (pirEndpoint == null) {
-        _setError('PIR endpoint has not been resolved.', context: context);
-        return;
+      var plan = current.resumePlan ?? context.resumePlan;
+      var roundPlan = current.roundPlan ?? context.roundPlan;
+      if (_needsFreshDelegationWork(plan, roundPlan) &&
+          _needsDelegationPreparation(current)) {
+        await _prepareDelegationUnlocked();
+        current = await future;
+        if (current.phase == VotingSessionPhase.error ||
+            current.phase == VotingSessionPhase.waitingForWalletSync) {
+          return;
+        }
+        context = await _loadContext(_roundId);
+        plan = current.resumePlan ?? context.resumePlan;
+        roundPlan = current.roundPlan ?? context.roundPlan;
       }
-      if (plan.pendingDelegationBundleIndexes.isNotEmpty) {
+
+      final hasPendingBundles = plan.pendingDelegationBundleIndexes.isNotEmpty;
+      final pirEndpoint = current.pirEndpoint;
+      if (hasPendingBundles) {
+        if (pirEndpoint == null) {
+          _setError('PIR endpoint has not been resolved.', context: context);
+          return;
+        }
         // Software delegation proving still needs the account mnemonic in the
         // current Rust API. Keystone signing uses a separate flow
         // (`delegatePendingBundlesWithKeystoneSignatures`) and never reaches
@@ -372,7 +377,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         _setStateForContext(context, nextState);
         current = nextState;
       }
-      final storedHotkeySecret = await _ensureHotkey(context);
+      final storedHotkeySecret = hasPendingBundles
+          ? await _ensureHotkey(context)
+          : null;
 
       final progress = Map<int, VotingSessionProgress>.from(
         current.delegationProgress,
@@ -403,9 +410,9 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         await for (final event
             in rust.buildProveAndSignDelegationPayloadWithProgress(
               ctx: _apiRoundContext(context),
-              pirServerUrl: pirEndpoint.toString(),
+              pirServerUrl: pirEndpoint!.toString(),
               mnemonic: mnemonic!,
-              storedHotkeySecret: storedHotkeySecret,
+              storedHotkeySecret: storedHotkeySecret!,
               bundleIndex: bundleIndex,
             )) {
           signedDelegationPayload =
@@ -644,16 +651,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
   Future<void> delegatePendingBundlesWithKeystoneSignatures() {
     return _enqueue(() async {
       var current = await future;
-      if (_needsDelegationPreparation(current)) {
-        await _prepareDelegationUnlocked();
-        current = await future;
-        if (current.phase == VotingSessionPhase.error ||
-            current.phase == VotingSessionPhase.waitingForWalletSync) {
-          return;
-        }
-      }
-
-      final context = await _loadContext(_roundId);
+      var context = await _loadContext(_roundId);
       if (!context.isHardwareAccount) {
         _setError(
           'Keystone voting is only available for hardware accounts.',
@@ -661,19 +659,20 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         );
         return;
       }
-      final plan = current.resumePlan ?? context.resumePlan;
-      final roundPlan = current.roundPlan ?? context.roundPlan;
-      final pirEndpoint = current.pirEndpoint;
-      if (pirEndpoint == null) {
-        _setError('PIR endpoint has not been resolved.', context: context);
-        return;
+      var plan = current.resumePlan ?? context.resumePlan;
+      var roundPlan = current.roundPlan ?? context.roundPlan;
+      if (_needsFreshDelegationWork(plan, roundPlan) &&
+          _needsDelegationPreparation(current)) {
+        await _prepareDelegationUnlocked();
+        current = await future;
+        if (current.phase == VotingSessionPhase.error ||
+            current.phase == VotingSessionPhase.waitingForWalletSync) {
+          return;
+        }
+        context = await _loadContext(_roundId);
+        plan = current.resumePlan ?? context.resumePlan;
+        roundPlan = current.roundPlan ?? context.roundPlan;
       }
-
-      final signatures = await _loadKeystoneSignatures(context);
-      final storedHotkeySecret = await _ensureHotkey(
-        context,
-        alreadyBound: signatures.isNotEmpty,
-      );
       final progress = Map<int, VotingSessionProgress>.from(
         current.delegationProgress,
       );
@@ -684,6 +683,25 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         progress: progress,
       );
       if (completedBundleIndexes == null) return;
+
+      final hasPendingBundles = plan.pendingDelegationBundleIndexes.isNotEmpty;
+      final signatures = hasPendingBundles
+          ? await _loadKeystoneSignatures(context)
+          : current.keystoneSignatures;
+      final List<int>? storedHotkeySecret;
+      if (hasPendingBundles) {
+        storedHotkeySecret = await _ensureHotkey(
+          context,
+          alreadyBound: signatures.isNotEmpty,
+        );
+      } else {
+        storedHotkeySecret = null;
+      }
+      final pirEndpoint = current.pirEndpoint;
+      if (hasPendingBundles && pirEndpoint == null) {
+        _setError('PIR endpoint has not been resolved.', context: context);
+        return;
+      }
 
       final rust = ref.read(votingRustApiProvider);
       for (final bundleIndex in plan.pendingDelegationBundleIndexes) {
@@ -718,8 +736,8 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             in rust
                 .buildProveDelegationPayloadWithKeystoneSignatureWithProgress(
                   ctx: _apiRoundContext(context),
-                  pirServerUrl: pirEndpoint.toString(),
-                  storedHotkeySecret: storedHotkeySecret,
+                  pirServerUrl: pirEndpoint!.toString(),
+                  storedHotkeySecret: storedHotkeySecret!,
                   bundleIndex: bundleIndex,
                   keystoneSig: signature.sig,
                   keystoneSighash: signature.sighash,
@@ -2356,6 +2374,16 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
 
   static bool _needsDelegationPreparation(VotingSessionState state) {
     return state.pirEndpoint == null || state.eligibleWeightZatoshi == null;
+  }
+
+  static bool _needsFreshDelegationWork(
+    VotingResumePlan plan,
+    rust_wire.RoundPlanView? roundPlan,
+  ) {
+    if (plan.pendingDelegationBundleIndexes.isNotEmpty) return true;
+    if (roundPlan == null) return false;
+    return roundPlan.nextSteps.any((step) => step.kind == 'delegate') ||
+        roundPlanNeedsDraftSetup(roundPlan);
   }
 
   Future<void> _prepareKeystoneSigningUnlocked() async {

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -813,15 +813,6 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
       final current = await future;
       final context = await _loadContext(_roundId);
       await _waitUntilWalletReadyForVoting(context);
-      final storedHotkeySecret = await _hotkeyForVoteCasting(context);
-      if (storedHotkeySecret == null) {
-        _setError(
-          'Voting hotkey is missing. Delegate this round before casting votes.',
-          cause: const VotingHotkeyUnavailable('missing stored hotkey'),
-          context: context,
-        );
-        return;
-      }
 
       final progress = Map<VotingVoteKey, VotingSessionProgress>.from(
         current.voteProgress,
@@ -949,6 +940,20 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
             bundleIndexes: bundleIndexesByProposal[draftVote.proposalId]!,
           ),
       ].where((work) => work.bundleIndexes.isNotEmpty).toList();
+      final List<int>? storedHotkeySecret;
+      if (voteWork.isEmpty) {
+        storedHotkeySecret = null;
+      } else {
+        storedHotkeySecret = await _hotkeyForVoteCasting(context);
+        if (storedHotkeySecret == null) {
+          _setError(
+            'Voting hotkey is missing. Delegate this round before casting votes.',
+            cause: const VotingHotkeyUnavailable('missing stored hotkey'),
+            context: context,
+          );
+          return;
+        }
+      }
       final totalQuestions = recoveredVoteWork.length + voteWork.length;
       final totalBundleTasks =
           recoveredVoteWork.length +
@@ -1169,7 +1174,7 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
                     network: context.network,
                     roundId: context.round.roundId,
                     bundleIndex: bundleIndex,
-                    storedHotkeySecret: storedHotkeySecret,
+                    storedHotkeySecret: storedHotkeySecret!,
                     vanWitness: witness,
                     draftVotes: [timedDraftVote],
                   )) {

--- a/lib/src/providers/voting/voting_tree_sync_provider.dart
+++ b/lib/src/providers/voting/voting_tree_sync_provider.dart
@@ -104,6 +104,12 @@ class VotingTreePreSyncService {
         } catch (e) {
           lastError = e;
           if (attempt < nodeUrls.length - 1) {
+            await _ref
+                .read(votingRustApiProvider)
+                .resetVotingSessionState(
+                  dbPath: dbPath,
+                  accountUuid: accountUuid,
+                );
             debugPrint(
               '[zcash] Voting: vote tree pre-sync retrying failover '
               'round=$roundId from=$nodeUrl error=$e',

--- a/lib/src/providers/voting/voting_tree_sync_provider.dart
+++ b/lib/src/providers/voting/voting_tree_sync_provider.dart
@@ -109,6 +109,7 @@ class VotingTreePreSyncService {
                 .resetVotingSessionState(
                   dbPath: dbPath,
                   accountUuid: accountUuid,
+                  roundId: roundId,
                 );
             debugPrint(
               '[zcash] Voting: vote tree pre-sync retrying failover '

--- a/lib/src/providers/voting/voting_tree_sync_provider.dart
+++ b/lib/src/providers/voting/voting_tree_sync_provider.dart
@@ -106,7 +106,7 @@ class VotingTreePreSyncService {
           if (attempt < nodeUrls.length - 1) {
             await _ref
                 .read(votingRustApiProvider)
-                .resetVotingSessionState(
+                .resetVoteTree(
                   dbPath: dbPath,
                   accountUuid: accountUuid,
                   roundId: roundId,

--- a/lib/src/rust/api/voting.dart
+++ b/lib/src/rust/api/voting.dart
@@ -442,6 +442,25 @@ Future<VanWitness> generateVanWitness({
 /// Clear process-local vote-tree sync state for a wallet or round.
 ///
 /// Passing a non-empty round ID clears only that round's cached vote-tree sync
+/// state by calling `zcash_voting::precompute::reset_vote_tree(db, round_id)`.
+/// Passing `None` or an empty round ID performs account-wide vote-tree cleanup
+/// with `zcash_voting::precompute::reset_vote_tree(db, "")`.
+///
+/// This does not clear unsigned delegation setup fields, delete durable recovery
+/// rows, or abort in-flight proof/vote work already running on worker threads.
+Future<void> resetVoteTree({
+  required String dbPath,
+  required String accountUuid,
+  String? roundId,
+}) => RustLib.instance.api.crateApiVotingResetVoteTree(
+  dbPath: dbPath,
+  accountUuid: accountUuid,
+  roundId: roundId,
+);
+
+/// Clear process-local voting session state for a wallet or round.
+///
+/// Passing a non-empty round ID clears only that round's cached vote-tree sync
 /// state and unsigned delegation setup fields by calling
 /// `zcash_voting::precompute::reset_voting_session_state(db, round_id)`.
 /// Passing `None` or an empty round ID performs account-wide vote-tree cleanup

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 518494237;
+  int get rustContentHash => 1430873601;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -594,6 +594,12 @@ abstract class RustLibApi extends BaseApi {
   });
 
   void crateApiKeystoneResetUrSession();
+
+  Future<void> crateApiVotingResetVoteTree({
+    required String dbPath,
+    required String accountUuid,
+    String? roundId,
+  });
 
   Future<void> crateApiVotingResetVotingSessionState({
     required String dbPath,
@@ -4088,7 +4094,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "reset_ur_session", argNames: []);
 
   @override
-  Future<void> crateApiVotingResetVotingSessionState({
+  Future<void> crateApiVotingResetVoteTree({
     required String dbPath,
     required String accountUuid,
     String? roundId,
@@ -4104,6 +4110,43 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             generalizedFrbRustBinding,
             serializer,
             funcId: 84,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiVotingResetVoteTreeConstMeta,
+        argValues: [dbPath, accountUuid, roundId],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiVotingResetVoteTreeConstMeta =>
+      const TaskConstMeta(
+        debugName: "reset_vote_tree",
+        argNames: ["dbPath", "accountUuid", "roundId"],
+      );
+
+  @override
+  Future<void> crateApiVotingResetVotingSessionState({
+    required String dbPath,
+    required String accountUuid,
+    String? roundId,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(accountUuid, serializer);
+          sse_encode_opt_String(roundId, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 85,
             port: port_,
           );
         },
@@ -4138,7 +4181,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 86,
             port: port_,
           );
         },
@@ -4180,7 +4223,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 87,
             port: port_,
           );
         },
@@ -4217,7 +4260,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 88,
             port: port_,
           );
         },
@@ -4255,7 +4298,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 89,
             port: port_,
           );
         },
@@ -4308,7 +4351,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 90,
             port: port_,
           );
         },
@@ -4376,7 +4419,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4420,7 +4463,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4454,7 +4497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -4487,7 +4530,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 94,
             port: port_,
           );
         },
@@ -4527,7 +4570,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 95,
             port: port_,
           );
         },
@@ -4568,7 +4611,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 96,
             port: port_,
           );
         },
@@ -4622,7 +4665,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -4672,7 +4715,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 97,
+              funcId: 98,
               port: port_,
             );
           },
@@ -4713,7 +4756,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 98,
+              funcId: 99,
               port: port_,
             );
           },
@@ -4742,7 +4785,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
+          return pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 100,
+          )!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4782,7 +4829,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 101,
             port: port_,
           );
         },
@@ -4833,7 +4880,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 102,
             port: port_,
           );
         },
@@ -4872,7 +4919,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 103,
             port: port_,
           );
         },
@@ -4915,7 +4962,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 104,
             port: port_,
           );
         },
@@ -4965,7 +5012,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 105,
             port: port_,
           );
         },
@@ -4997,7 +5044,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 106,
             port: port_,
           );
         },
@@ -5025,7 +5072,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 107,
           )!;
         },
         codec: SseCodec(
@@ -5057,7 +5104,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 108,
             port: port_,
           );
         },
@@ -5094,7 +5141,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 109,
             port: port_,
           );
         },
@@ -5125,7 +5172,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
           )!;
         },
         codec: SseCodec(
@@ -5156,7 +5203,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },

--- a/rust/src/api/voting.rs
+++ b/rust/src/api/voting.rs
@@ -1034,6 +1034,45 @@ pub fn generate_van_witness(
 /// Clear process-local vote-tree sync state for a wallet or round.
 ///
 /// Passing a non-empty round ID clears only that round's cached vote-tree sync
+/// state by calling `zcash_voting::precompute::reset_vote_tree(db, round_id)`.
+/// Passing `None` or an empty round ID performs account-wide vote-tree cleanup
+/// with `zcash_voting::precompute::reset_vote_tree(db, "")`.
+///
+/// This does not clear unsigned delegation setup fields, delete durable recovery
+/// rows, or abort in-flight proof/vote work already running on worker threads.
+pub fn reset_vote_tree(
+    db_path: String,
+    account_uuid: String,
+    round_id: Option<String>,
+) -> Result<(), String> {
+    catch(|| {
+        let db = db::open_voting_db(&db_path, &account_uuid)?;
+
+        let scoped_round_id = round_id
+            .as_deref()
+            .filter(|id| !id.is_empty())
+            .unwrap_or("");
+        let reset_scope = if scoped_round_id.is_empty() {
+            "account"
+        } else {
+            "round"
+        };
+        zcash_voting::precompute::reset_vote_tree(&db, scoped_round_id)
+            .map_err(|e| format!("reset vote tree failed: {e}"))?;
+        log::info!(
+            "voting: reset vote-tree state \
+             (account_uuid={}, scope={}, round_id={:?})",
+            account_uuid,
+            reset_scope,
+            round_id
+        );
+        Ok(())
+    })
+}
+
+/// Clear process-local voting session state for a wallet or round.
+///
+/// Passing a non-empty round ID clears only that round's cached vote-tree sync
 /// state and unsigned delegation setup fields by calling
 /// `zcash_voting::precompute::reset_voting_session_state(db, round_id)`.
 /// Passing `None` or an empty round ID performs account-wide vote-tree cleanup

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 518494237;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1430873601;
 
 // Section: executor
 
@@ -3220,6 +3220,45 @@ fn wire__crate__api__keystone__reset_ur_session_impl(
                 })?;
                 Ok(output_ok)
             })())
+        },
+    )
+}
+fn wire__crate__api__voting__reset_vote_tree_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "reset_vote_tree",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_round_id = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::voting::reset_vote_tree(
+                        api_db_path,
+                        api_account_uuid,
+                        api_round_id,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
         },
     )
 }
@@ -6530,29 +6569,30 @@ fn pde_ffi_dispatcher_primary_impl(
 80 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
 81 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
 82 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-86 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-90 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-92 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-93 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-94 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-95 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-97 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-100 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-103 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-104 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-105 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-107 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-108 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
+88 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+96 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+99 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+101 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+102 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+104 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+105 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+106 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+108 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+109 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -6580,10 +6620,10 @@ fn pde_ffi_dispatcher_sync_impl(
         }
         72 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
         83 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        91 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        99 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        106 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        109 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        100 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        107 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        110 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/wallet/voting/README.md
+++ b/rust/src/wallet/voting/README.md
@@ -75,15 +75,20 @@ wallet DB path plus the session account UUID where applicable.
 
 ### Reset Semantics
 
-`reset_voting_session_state(db_path, account_uuid, round_id)` clears only
-process-local vote-tree sync state. It does not delete durable recovery rows,
-signed artifacts, transaction hashes, or share history, and it does not abort
-in-flight proof or vote jobs already running on worker threads.
+`reset_vote_tree(db_path, account_uuid, round_id)` clears only process-local
+vote-tree sync state. It does not delete durable recovery rows, signed
+artifacts, transaction hashes, or share history, and it does not abort in-flight
+proof or vote jobs already running on worker threads.
 
 - A non-empty `round_id` performs round-scoped cleanup via
   `zcash_voting::precompute::reset_vote_tree(db, round_id)`.
 - `None` or an empty `round_id` is an account-wide reset via
   `zcash_voting::precompute::reset_vote_tree(db, "")`.
+
+`reset_voting_session_state(db_path, account_uuid, round_id)` is broader. It
+clears the same vote-tree sync state and also clears unsigned delegation setup
+fields for abandoned round work. Do not use it for best-effort vote-tree warmup
+failover while the user may still be signing or submitting.
 
 Vote-tree sync and reset are owned by the crate
 (`zcash_voting::precompute::{sync_vote_tree, reset_vote_tree}`); Vizor does not

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1247,6 +1247,33 @@ void main() {
     expect(find.text('Review answers'), findsNothing);
   });
 
+  testWidgets('proposal detail routes non-active rounds to results', (
+    tester,
+  ) async {
+    final round = _roundStatusJson()..['status'] = 'pending';
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
+    );
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: _MutableVotingRecoveryApi(),
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('results route'), findsOneWidget);
+    expect(find.text('Review answers'), findsNothing);
+  });
+
   testWidgets('poll stops preparing voting power when setup fails', (
     tester,
   ) async {
@@ -2563,6 +2590,10 @@ Widget _proposalHarness({String? initialLocation}) {
         builder: (_, state) => Text(
           'status account: ${state.uri.queryParameters['account'] ?? ''}',
         ),
+      ),
+      GoRoute(
+        path: '/voting/poll/:roundId/results',
+        builder: (_, _) => const Text('results route'),
       ),
       GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
       GoRoute(path: '/send', builder: (_, _) => const Text('send route')),

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -1274,6 +1274,52 @@ void main() {
     expect(find.text('Review answers'), findsNothing);
   });
 
+  testWidgets('proposal detail shows recovery before non-active redirect', (
+    tester,
+  ) async {
+    final round = _roundStatusJson()..['status'] = 'pending';
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
+    );
+    final recoveryApi = _MutableVotingRecoveryApi()
+      ..roundPlan = apiRoundPlan(
+        roundId: _roundId,
+        pendingRecovery: true,
+        nextSteps: const [
+          rust_wire.NextStepView(
+            kind: 'cast_vote',
+            bundleIndex: 0,
+            proposalId: 1,
+            choice: 0,
+            shareIndex: 0,
+          ),
+        ],
+        openProposals: Uint32List(0),
+        allDecided: false,
+      );
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _MnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final sessionState = container.read(votingSessionProvider(_roundId)).value!;
+    expect(sessionState.roundPlan?.blockingRecovery, isTrue);
+    expect(find.text('Vote in progress'), findsOneWidget);
+    expect(find.text('Continue voting'), findsOneWidget);
+    expect(find.text('results route'), findsNothing);
+  });
+
   testWidgets('poll stops preparing voting power when setup fails', (
     tester,
   ) async {
@@ -2155,10 +2201,7 @@ void main() {
 
     expect(find.text('Sign bundle 1 of 1'), findsOneWidget);
     expect(find.text('Memo'), findsOneWidget);
-    expect(
-      find.textContaining('Amount: 0.00000100 ZEC'),
-      findsOneWidget,
-    );
+    expect(find.textContaining('Amount: 0.00000100 ZEC'), findsOneWidget);
     expect(find.text('Scan signature'), findsOneWidget);
     expect(find.text('Software account required'), findsNothing);
     await tester.tap(find.text('Scan signature'));

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -3247,6 +3247,13 @@ class _NoopVotingRustApi implements VotingRustApi {
   }) async {}
 
   @override
+  Future<void> resetVoteTree({
+    required String dbPath,
+    required String accountUuid,
+    String? roundId,
+  }) async {}
+
+  @override
   Future<List<int>> generateVotingHotkey({required String network}) async {
     return [9, 9, 9];
   }

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3853,7 +3853,7 @@ void main() {
       'https://voting.example',
       'https://voting-failover.example',
     ]);
-    expect(rust.resetVotingSessionStateCalls, ['account-1:*']);
+    expect(rust.resetVotingSessionStateCalls, ['account-1:$kRoundId']);
   });
 
   test('vote tree sync runs before each proposal', () async {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3774,6 +3774,7 @@ void main() {
       'https://voting.example',
       'https://voting-failover.example',
     ]);
+    expect(rust.resetVotingSessionStateCalls, ['account-1:*']);
   });
 
   test('vote tree sync runs before each proposal', () async {

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -1556,10 +1556,7 @@ void main() {
     expect(state.keystoneSigningRequest?.bundleIndex, 0);
     expect(state.error, isNull);
     expect(rust.deleteSkippedBundleKeepCounts, isEmpty);
-    expect(
-      rust.resetVotingSessionStateCalls,
-      contains('account-1:$kRoundId'),
-    );
+    expect(rust.resetVotingSessionStateCalls, contains('account-1:$kRoundId'));
     expect(rust.keystoneDelegationRequestCalls, [0, 0]);
     expect(rust.setupCalls, 2);
   });
@@ -1662,31 +1659,34 @@ void main() {
     },
   );
 
-  test('hardware voting surfaces non-recoverable Keystone request failures', () async {
-    final rust = FakeVotingRustApi(
-      keystoneDelegationRequestFailuresByCall: {
-        0: StateError(
-          'delegate::keystone_request failed: invalid branch id from lightwalletd',
-        ),
-      },
-    );
-    final container = _sessionContainer(rust: rust, accountIsHardware: true);
-    addTearDown(container.dispose);
+  test(
+    'hardware voting surfaces non-recoverable Keystone request failures',
+    () async {
+      final rust = FakeVotingRustApi(
+        keystoneDelegationRequestFailuresByCall: {
+          0: StateError(
+            'delegate::keystone_request failed: invalid branch id from lightwalletd',
+          ),
+        },
+      );
+      final container = _sessionContainer(rust: rust, accountIsHardware: true);
+      addTearDown(container.dispose);
 
-    await container.read(votingSessionProvider(kRoundId).future);
-    await container
-        .read(votingSessionProvider(kRoundId).notifier)
-        .prepareKeystoneSigning();
-    final state = container.read(votingSessionProvider(kRoundId)).value!;
+      await container.read(votingSessionProvider(kRoundId).future);
+      await container
+          .read(votingSessionProvider(kRoundId).notifier)
+          .prepareKeystoneSigning();
+      final state = container.read(votingSessionProvider(kRoundId)).value!;
 
-    expect(state.phase, VotingSessionPhase.error);
-    expect(
-      state.error?.message,
-      contains('invalid branch id from lightwalletd'),
-    );
-    expect(rust.keystoneDelegationRequestCalls, [0]);
-    expect(rust.deleteSkippedBundleKeepCounts, isEmpty);
-  });
+      expect(state.phase, VotingSessionPhase.error);
+      expect(
+        state.error?.message,
+        contains('invalid branch id from lightwalletd'),
+      );
+      expect(rust.keystoneDelegationRequestCalls, [0]);
+      expect(rust.deleteSkippedBundleKeepCounts, isEmpty);
+    },
+  );
 
   test(
     'hardware voting permits prepared-only recovery without stored hotkey',
@@ -3923,7 +3923,7 @@ void main() {
       'https://voting.example',
       'https://voting-failover.example',
     ]);
-    expect(rust.resetVotingSessionStateCalls, ['account-1:*']);
+    expect(rust.resetVotingSessionStateCalls, ['account-1:$kRoundId']);
   });
 
   test('vote commitments submit shares and record recovery rows', () async {
@@ -4687,23 +4687,24 @@ void main() {
 
   test('hotkey failure moves session into error phase', () async {
     final rust = FakeVotingRustApi();
+    final recoveryApi = FakeVotingRecoveryApi(
+      state: recoveryState(
+        bundleCount: 1,
+        delegationTxHashes: [
+          rust_frb_types.DelegationRecoveryView(
+            bundleIndex: 0,
+            phase: VotingWorkflowPhase.submittedDelegation,
+            txHash: 'delegation-0',
+            vanLeafPosition: null,
+          ),
+        ],
+        votes: [vote(bundleIndex: 0, proposalId: 7)],
+      ),
+    );
     final container = _sessionContainer(
       rust: rust,
       hotkeyStore: const FailingVotingHotkeyStore(),
-      recoveryApi: FakeVotingRecoveryApi(
-        state: recoveryState(
-          bundleCount: 1,
-          delegationTxHashes: [
-            rust_frb_types.DelegationRecoveryView(
-              bundleIndex: 0,
-              phase: VotingWorkflowPhase.submittedDelegation,
-              txHash: 'delegation-0',
-              vanLeafPosition: null,
-            ),
-          ],
-          votes: [vote(bundleIndex: 0, proposalId: 7)],
-        ),
-      ),
+      recoveryApi: recoveryApi,
     );
     addTearDown(container.dispose);
 
@@ -4725,6 +4726,7 @@ void main() {
 
     expect(state.phase, VotingSessionPhase.error);
     expect(state.error?.cause, isA<VotingHotkeyUnavailable>());
+    expect(recoveryApi.ballotIntents, isEmpty);
     expect(rust.resetVotingSessionStateCalls, contains('account-1:$kRoundId'));
   });
 }

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -2511,6 +2511,8 @@ void main() {
         rust: rust,
         recoveryApi: _submittedDelegationOnlyRecoveryApi(),
         accountMnemonic: null,
+        hotkeyStore: const FailingVotingHotkeyStore(),
+        pirResolver: FakePirResolver(error: StateError('unexpected PIR')),
         txConfirmationPolling: _fastTxConfirmationPolling,
       );
       addTearDown(container.dispose);
@@ -2530,6 +2532,7 @@ void main() {
       );
 
       expect(completed.errorMessage, isNull);
+      expect(rust.setupCalls, 0);
       expect(rust.delegationBundleCalls, isEmpty);
       expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 0);
       expect(_postRequestCount(http, '/shielded-vote/v1/cast-vote'), 0);
@@ -2551,6 +2554,8 @@ void main() {
         rust: rust,
         recoveryApi: _submittedDelegationOnlyRecoveryApi(),
         accountIsHardware: true,
+        hotkeyStore: const FailingVotingHotkeyStore(),
+        pirResolver: FakePirResolver(error: StateError('unexpected PIR')),
         txConfirmationPolling: _fastTxConfirmationPolling,
       );
       addTearDown(container.dispose);
@@ -2570,6 +2575,7 @@ void main() {
       );
 
       expect(completed.errorMessage, isNull);
+      expect(rust.setupCalls, 0);
       expect(rust.keystoneDelegationRequestCalls, isEmpty);
       expect(rust.keystoneProofBundleCalls, isEmpty);
       expect(_postRequestCount(http, '/shielded-vote/v1/delegate-vote'), 0);

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3716,6 +3716,7 @@ void main() {
       http: FakeVotingHttpClient(responses: httpResponses),
       rust: rust,
       recoveryApi: recoveryApi,
+      hotkeyStore: const FailingVotingHotkeyStore(),
       txConfirmationPolling: _fastTxConfirmationPolling,
     );
     addTearDown(container.dispose);

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -427,6 +427,78 @@ void main() {
     expect(roundsCallsAfter, greaterThan(roundsCallsBefore));
   });
 
+  test(
+    'config source change invalidates rounds provider on initial load',
+    () async {
+      const firstSource = 'https://voting-a.example/static-voting-config.json';
+      const secondSource = 'https://voting-b.example/static-voting-config.json';
+      final http = FakeVotingHttpClient(
+        responses: {
+          firstSource: staticConfigJson(),
+          secondSource: staticConfigJson(),
+          'https://voting.example/dynamic-voting-config.json':
+              dynamicConfigJson(),
+          '/shielded-vote/v1/rounds': {
+            'rounds': [
+              {'vote_round_id': kRoundId, 'title': 'Poll', 'status': 'active'},
+            ],
+          },
+        },
+      );
+      final container = ProviderContainer(
+        overrides: [
+          votingConfigSourceStoreProvider.overrideWithValue(
+            FakeVotingConfigSourceStore(sourceUrl: firstSource),
+          ),
+          votingHttpClientProvider.overrideWithValue(http),
+          votingConfigLoaderProvider.overrideWith((ref) {
+            final source =
+                ref.watch(votingConfigSourceProvider).value?.sourceUrl ??
+                kDefaultStaticVotingConfigSource;
+            return VotingConfigLoader(
+              httpClient: http,
+              sourceUrl: source,
+              resolveStaticVotingConfig: fakeResolveStaticVotingConfig,
+              resolveVotingConfig:
+                  ({
+                    required source,
+                    required staticBytes,
+                    required dynamicBytes,
+                    previous,
+                  }) => fakeResolveVotingConfig(
+                    dynamicBytes: dynamicBytes,
+                    previous: previous,
+                    authenticatedRoundIds: const [kRoundId],
+                  ),
+            );
+          }),
+          votingActiveAccountUuidProvider.overrideWithValue(() async => null),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(votingRoundsProvider.future);
+      final roundsCallsBefore = http.requests
+          .where(
+            (request) => request.uri.path.endsWith('/shielded-vote/v1/rounds'),
+          )
+          .length;
+
+      await container
+          .read(votingConfigSourceProvider.notifier)
+          .setCustom(secondSource);
+      await container.read(votingConfigProvider.notifier).refresh();
+      await container.read(votingRoundsProvider.future);
+      final roundsCallsAfter = http.requests
+          .where(
+            (request) => request.uri.path.endsWith('/shielded-vote/v1/rounds'),
+          )
+          .length;
+
+      expect(roundsCallsAfter, greaterThan(roundsCallsBefore));
+    },
+  );
+
   test('config switch preserves sessions during active submission', () async {
     var refreshCount = 0;
     final roundProvider = votingSessionProvider(kRoundId);

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -3853,7 +3853,8 @@ void main() {
       'https://voting.example',
       'https://voting-failover.example',
     ]);
-    expect(rust.resetVotingSessionStateCalls, ['account-1:$kRoundId']);
+    expect(rust.resetVoteTreeCalls, ['account-1:$kRoundId']);
+    expect(rust.resetVotingSessionStateCalls, isEmpty);
   });
 
   test('vote tree sync runs before each proposal', () async {
@@ -6036,6 +6037,7 @@ class FakeVotingRustApi implements VotingRustApi {
   final hotkeyGenerationStarted = Completer<void>();
   final precomputeStarted = Completer<void>();
   final precomputeFinished = Completer<void>();
+  final resetVoteTreeCalls = <String>[];
   final resetVotingSessionStateCalls = <String>[];
   final draftSingleShareValues = <bool>[];
   final planLastMomentBufferSeconds = <BigInt?>[];
@@ -6429,6 +6431,15 @@ class FakeVotingRustApi implements VotingRustApi {
     String? roundId,
   }) async {
     resetVotingSessionStateCalls.add('$accountUuid:${roundId ?? '*'}');
+  }
+
+  @override
+  Future<void> resetVoteTree({
+    required String dbPath,
+    required String accountUuid,
+    String? roundId,
+  }) async {
+    resetVoteTreeCalls.add('$accountUuid:${roundId ?? '*'}');
   }
 
   @override


### PR DESCRIPTION
Addresses remaining voting recovery review feedback by tightening cache invalidation, vote-tree failover reset behavior, poll status routing, and recovery-only secret access.

Validation:
- git diff --check origin/voting-ui..HEAD
- fvm flutter analyze on touched voting files
- focused voting provider and status screen tests for the changed paths