### PR TITLE
Use additive whale protection threshold

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree"
 version = "0.3.2"
-source = "git+https://github.com/valargroup/zcash_voting?rev=5703b44197ca61b93cabc05c4cec422937f4c11f#5703b44197ca61b93cabc05c4cec422937f4c11f"
+source = "git+https://github.com/valargroup/zcash_voting?rev=5b164d03cb12b1635deea589e575d461481fed72#5b164d03cb12b1635deea589e575d461481fed72"
 dependencies = [
  "anyhow",
  "ff",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.5.2"
-source = "git+https://github.com/valargroup/zcash_voting?rev=5703b44197ca61b93cabc05c4cec422937f4c11f#5703b44197ca61b93cabc05c4cec422937f4c11f"
+source = "git+https://github.com/valargroup/zcash_voting?rev=5b164d03cb12b1635deea589e575d461481fed72#5b164d03cb12b1635deea589e575d461481fed72"
 dependencies = [
  "base64",
  "ff",
@@ -4695,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "0.11.0"
-source = "git+https://github.com/valargroup/zcash_voting?rev=5703b44197ca61b93cabc05c4cec422937f4c11f#5703b44197ca61b93cabc05c4cec422937f4c11f"
+source = "git+https://github.com/valargroup/zcash_voting?rev=5b164d03cb12b1635deea589e575d461481fed72#5b164d03cb12b1635deea589e575d461481fed72"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree"
 version = "0.3.2"
-source = "git+https://github.com/valargroup/zcash_voting?rev=0a030e2d98968799fc8d9a8943a2b89dfd7e9df2#0a030e2d98968799fc8d9a8943a2b89dfd7e9df2"
+source = "git+https://github.com/valargroup/zcash_voting?rev=5703b44197ca61b93cabc05c4cec422937f4c11f#5703b44197ca61b93cabc05c4cec422937f4c11f"
 dependencies = [
  "anyhow",
  "ff",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.5.2"
-source = "git+https://github.com/valargroup/zcash_voting?rev=0a030e2d98968799fc8d9a8943a2b89dfd7e9df2#0a030e2d98968799fc8d9a8943a2b89dfd7e9df2"
+source = "git+https://github.com/valargroup/zcash_voting?rev=5703b44197ca61b93cabc05c4cec422937f4c11f#5703b44197ca61b93cabc05c4cec422937f4c11f"
 dependencies = [
  "base64",
  "ff",
@@ -4695,7 +4695,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "0.11.0"
-source = "git+https://github.com/valargroup/zcash_voting?rev=0a030e2d98968799fc8d9a8943a2b89dfd7e9df2#0a030e2d98968799fc8d9a8943a2b89dfd7e9df2"
+source = "git+https://github.com/valargroup/zcash_voting?rev=5703b44197ca61b93cabc05c4cec422937f4c11f#5703b44197ca61b93cabc05c4cec422937f4c11f"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ zcash_client_backend = { version = "0.23", features = [
 ] }
 zcash_client_sqlite = { version = "0.21", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 # Voting clients need PIR lookup support and vote-commitment-tree sync.
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "5703b44197ca61b93cabc05c4cec422937f4c11f", package = "zcash_voting" }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "5b164d03cb12b1635deea589e575d461481fed72", package = "zcash_voting" }
 # Must match versions used by zcash_client_sqlite to avoid type conflicts
 orchard = "0.14"
 sapling-crypto = { version = "0.7", default-features = false, features = ["circuit"] }
@@ -96,7 +96,7 @@ security-framework = { version = "3.7", features = ["OSX_10_15"] }
 [dev-dependencies]
 tempfile = "3"
 hex = "0.4"
-vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting", rev = "5703b44197ca61b93cabc05c4cec422937f4c11f", package = "vote-commitment-tree" }
+vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting", rev = "5b164d03cb12b1635deea589e575d461481fed72", package = "vote-commitment-tree" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ zcash_client_backend = { version = "0.23", features = [
 ] }
 zcash_client_sqlite = { version = "0.21", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 # Voting clients need PIR lookup support and vote-commitment-tree sync.
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "0a030e2d98968799fc8d9a8943a2b89dfd7e9df2", package = "zcash_voting" }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "5703b44197ca61b93cabc05c4cec422937f4c11f", package = "zcash_voting" }
 # Must match versions used by zcash_client_sqlite to avoid type conflicts
 orchard = "0.14"
 sapling-crypto = { version = "0.7", default-features = false, features = ["circuit"] }
@@ -96,7 +96,7 @@ security-framework = { version = "3.7", features = ["OSX_10_15"] }
 [dev-dependencies]
 tempfile = "3"
 hex = "0.4"
-vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting", rev = "0a030e2d98968799fc8d9a8943a2b89dfd7e9df2", package = "vote-commitment-tree" }
+vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting", rev = "5703b44197ca61b93cabc05c4cec422937f4c11f", package = "vote-commitment-tree" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -24,22 +24,24 @@ use zcash_voting::storage::VotingDb;
 use zcash_voting::BundlePolicy;
 
 const ZATOSHI_PER_ZEC: u64 = 100_000_000;
-const WHALE_PROTECTION_NOTE_VALUE_ZATOSHI: u64 = 500 * ZATOSHI_PER_ZEC;
+const WHALE_PROTECTION_SNAPSHOT_BALANCE_ZATOSHI: u64 = 500 * ZATOSHI_PER_ZEC;
 const WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE: usize = 1;
 
-/// Lower the bundle cap when the selected snapshot contains a large note.
+/// Lower the bundle cap when the selected snapshot balance is large.
 ///
 /// The current `zcash_voting` policy applies to the whole round, so this
-/// guarantees any note at or above the whale threshold is never bundled with
-/// another real note in Vizor's delegation flow.
+/// treats whale protection as an all-or-nothing rule for Vizor's delegation
+/// flow.
 fn whale_protected_bundle_policy(
     notes: &[zcash_voting::NoteInfo],
     bundle_policy: BundlePolicy,
 ) -> Result<BundlePolicy, String> {
-    let has_whale_note = notes
-        .iter()
-        .any(|note| note.value >= WHALE_PROTECTION_NOTE_VALUE_ZATOSHI);
-    if has_whale_note
+    let snapshot_balance = notes.iter().try_fold(0u64, |total, note| {
+        total
+            .checked_add(note.value)
+            .ok_or_else(|| "snapshot balance overflow during whale protection".to_string())
+    })?;
+    if snapshot_balance >= WHALE_PROTECTION_SNAPSHOT_BALANCE_ZATOSHI
         && bundle_policy.max_real_notes_per_bundle() > WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE
     {
         return BundlePolicy::new(WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE)
@@ -496,7 +498,10 @@ mod tests {
     #[test]
     fn whale_protected_bundle_policy_leaves_non_whale_policy_unchanged() {
         let requested = BundlePolicy::new(3).unwrap();
-        let notes = vec![note_with_value(1, WHALE_PROTECTION_NOTE_VALUE_ZATOSHI - 1)];
+        let notes = vec![note_with_value(
+            1,
+            WHALE_PROTECTION_SNAPSHOT_BALANCE_ZATOSHI - 1,
+        )];
 
         let policy = whale_protected_bundle_policy(&notes, requested).unwrap();
 
@@ -506,7 +511,10 @@ mod tests {
     #[test]
     fn whale_protected_bundle_policy_uses_single_note_policy_at_threshold() {
         let requested = BundlePolicy::default();
-        let notes = vec![note_with_value(1, WHALE_PROTECTION_NOTE_VALUE_ZATOSHI)];
+        let notes = vec![
+            note_with_value(1, WHALE_PROTECTION_SNAPSHOT_BALANCE_ZATOSHI - 1),
+            note_with_value(2, 1),
+        ];
 
         let policy = whale_protected_bundle_policy(&notes, requested).unwrap();
 
@@ -519,7 +527,10 @@ mod tests {
     #[test]
     fn whale_protected_bundle_policy_keeps_requested_single_note_policy() {
         let requested = BundlePolicy::new(1).unwrap();
-        let notes = vec![note_with_value(1, WHALE_PROTECTION_NOTE_VALUE_ZATOSHI)];
+        let notes = vec![note_with_value(
+            1,
+            WHALE_PROTECTION_SNAPSHOT_BALANCE_ZATOSHI,
+        )];
 
         let policy = whale_protected_bundle_policy(&notes, requested).unwrap();
 
@@ -527,9 +538,9 @@ mod tests {
     }
 
     #[test]
-    fn whale_protection_plans_singleton_bundles_for_whale_sets() {
+    fn whale_protection_plans_singleton_bundles_for_large_snapshot_balances() {
         let notes = vec![
-            note_with_value(1, WHALE_PROTECTION_NOTE_VALUE_ZATOSHI),
+            note_with_value(1, WHALE_PROTECTION_SNAPSHOT_BALANCE_ZATOSHI - 2),
             note_with_value(2, zcash_voting::governance::BALLOT_DIVISOR),
             note_with_value(3, zcash_voting::governance::BALLOT_DIVISOR),
         ];

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -24,7 +24,7 @@ use zcash_voting::storage::VotingDb;
 use zcash_voting::BundlePolicy;
 
 const ZATOSHI_PER_ZEC: u64 = 100_000_000;
-const WHALE_PROTECTION_NOTE_VALUE_ZATOSHI: u64 = 1_000 * ZATOSHI_PER_ZEC;
+const WHALE_PROTECTION_NOTE_VALUE_ZATOSHI: u64 = 500 * ZATOSHI_PER_ZEC;
 const WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE: usize = 1;
 
 /// Lower the bundle cap when the selected snapshot contains a large note.

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -1,8 +1,12 @@
-use std::sync::Arc;
+use std::{borrow::Borrow, sync::Arc};
 
 use ff::PrimeField;
+use prost::Message;
 use secrecy::{ExposeSecret, SecretVec};
+use zcash_client_backend::proto::service::TreeState;
+use zcash_client_sqlite::WalletDb;
 use zcash_keys::keys::UnifiedSpendingKey;
+use zcash_protocol::consensus::Parameters;
 use zeroize::Zeroizing;
 use zip32::{fingerprint::SeedFingerprint, AccountId};
 
@@ -15,9 +19,62 @@ pub use zcash_voting::delegate::DelegationProgress;
 use zcash_voting::delegate::{
     DelegationSigningRequest, PrepareDelegationBundleParams, PreparedDelegationBundle,
 };
-use zcash_voting::selection::select_notes_with_lwd;
+use zcash_voting::selection::{select_notes_with_lwd, select_notes_with_wallet_db};
 use zcash_voting::storage::VotingDb;
 use zcash_voting::BundlePolicy;
+
+const ZATOSHI_PER_ZEC: u64 = 100_000_000;
+const WHALE_PROTECTION_NOTE_VALUE_ZATOSHI: u64 = 1_000 * ZATOSHI_PER_ZEC;
+const WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE: usize = 1;
+
+/// Lower the bundle cap when the selected snapshot contains a large note.
+///
+/// The current `zcash_voting` policy applies to the whole round, so this
+/// guarantees any note at or above the whale threshold is never bundled with
+/// another real note in Vizor's delegation flow.
+fn whale_protected_bundle_policy(
+    notes: &[zcash_voting::NoteInfo],
+    bundle_policy: BundlePolicy,
+) -> Result<BundlePolicy, String> {
+    let has_whale_note = notes
+        .iter()
+        .any(|note| note.value >= WHALE_PROTECTION_NOTE_VALUE_ZATOSHI);
+    if has_whale_note
+        && bundle_policy.max_real_notes_per_bundle() > WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE
+    {
+        return BundlePolicy::new(WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE)
+            .map_err(|e| e.to_string());
+    }
+    Ok(bundle_policy)
+}
+
+fn prepare_params_with_whale_protection<'a, C, P, CL, R>(
+    wallet_db: &WalletDb<C, P, CL, R>,
+    mut prepare_params: PrepareDelegationBundleParams<'a>,
+) -> Result<PrepareDelegationBundleParams<'a>, String>
+where
+    C: Borrow<rusqlite::Connection>,
+    P: Parameters,
+{
+    // The shared crate expects a final policy before it prepares the bundle, so
+    // inspect the same snapshot note set here and then call into the crate.
+    let anchor_tree_state =
+        TreeState::decode(prepare_params.lwd.anchor_tree_state_bytes.as_slice()).map_err(|e| {
+            format!("decode delegation anchor tree state for whale protection failed: {e}")
+        })?;
+    let selected = select_notes_with_wallet_db(
+        wallet_db,
+        prepare_params.voting_hotkey.network(),
+        prepare_params.account_uuid,
+        prepare_params.lwd.round_params.snapshot_height,
+        anchor_tree_state,
+    )
+    .map_err(|e| e.to_string())?;
+    let note_infos = selected.voting_note_infos();
+    prepare_params.bundle_policy =
+        whale_protected_bundle_policy(&note_infos, prepare_params.bundle_policy)?;
+    Ok(prepare_params)
+}
 
 /// Completes the proof phase for a previously prepared delegation bundle.
 ///
@@ -104,6 +161,7 @@ pub async fn setup_delegation_bundles(
     .await
     .map_err(|e| e.to_string())?;
     let note_infos = selected.voting_note_infos();
+    let bundle_policy = whale_protected_bundle_policy(&note_infos, bundle_policy)?;
     voting_db
         .ensure_bundles_with_skipped_suffix_with_policy(
             round_params.vote_round_id.as_str(),
@@ -141,6 +199,7 @@ pub async fn check_voting_eligibility(
     .await
     .map_err(|e| e.to_string())?;
     let note_infos = selected.voting_note_infos();
+    let bundle_policy = whale_protected_bundle_policy(&note_infos, bundle_policy)?;
     zcash_voting::minimum_voting_eligibility_for_notes(&note_infos, bundle_policy)
         .map_err(|e| e.to_string())
 }
@@ -185,17 +244,19 @@ pub async fn precompute_delegation_pir(
         .map_err(|e| format!("Voting hotkey reconstruction failed: {e}"))?;
         let voting_db = open_voting_db(&db_path, &account_uuid)?;
         let wallet_db = open_wallet_db_for_read(&db_path, wallet_network(voting_hotkey.network()))?;
+        let prepare_params = PrepareDelegationBundleParams {
+            lwd,
+            session_json: session_json.as_deref(),
+            account_uuid: &account_uuid,
+            voting_hotkey: &voting_hotkey,
+            bundle_index,
+            bundle_policy,
+        };
+        let prepare_params = prepare_params_with_whale_protection(&wallet_db, prepare_params)?;
         let prepared = zcash_voting::delegate::prepare_delegation_bundle(
             &voting_db,
             &wallet_db,
-            PrepareDelegationBundleParams {
-                lwd,
-                session_json: session_json.as_deref(),
-                account_uuid: &account_uuid,
-                voting_hotkey: &voting_hotkey,
-                bundle_index,
-                bundle_policy,
-            },
+            prepare_params,
         )
         .map_err(|e| e.to_string())?;
         let pir_client = zcash_voting::PirClientBlocking::with_transport(
@@ -242,6 +303,7 @@ where
         db_path,
         wallet_network(prepare_params.voting_hotkey.network()),
     )?;
+    let prepare_params = prepare_params_with_whale_protection(&wallet_db, prepare_params)?;
 
     let prepared_bundle =
         zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
@@ -336,6 +398,7 @@ pub async fn build_keystone_delegation_request(
         db_path,
         wallet_network(prepare_params.voting_hotkey.network()),
     )?;
+    let prepare_params = prepare_params_with_whale_protection(&wallet_db, prepare_params)?;
     let prepared =
         zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
             .map_err(|e| e.to_string())?;
@@ -375,6 +438,7 @@ where
         db_path,
         wallet_network(prepare_params.voting_hotkey.network()),
     )?;
+    let prepare_params = prepare_params_with_whale_protection(&wallet_db, prepare_params)?;
     let prepared_bundle =
         zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
             .map_err(|e| e.to_string())?;
@@ -413,6 +477,74 @@ mod tests {
     use secrecy::ExposeSecret;
     use std::sync::{Arc, Mutex};
     use zip32::{fingerprint::SeedFingerprint, AccountId};
+
+    fn note_with_value(position: u64, value: u64) -> zcash_voting::NoteInfo {
+        let tag = position as u8;
+        zcash_voting::NoteInfo {
+            commitment: vec![tag; 32],
+            nullifier: vec![tag.wrapping_add(1); 32],
+            value,
+            position,
+            diversifier: vec![tag; 11],
+            rho: vec![tag; 32],
+            rseed: vec![tag; 32],
+            scope: 0,
+            ufvk_str: "uviewtest".to_string(),
+        }
+    }
+
+    #[test]
+    fn whale_protected_bundle_policy_leaves_non_whale_policy_unchanged() {
+        let requested = BundlePolicy::new(3).unwrap();
+        let notes = vec![note_with_value(1, WHALE_PROTECTION_NOTE_VALUE_ZATOSHI - 1)];
+
+        let policy = whale_protected_bundle_policy(&notes, requested).unwrap();
+
+        assert_eq!(policy.max_real_notes_per_bundle(), 3);
+    }
+
+    #[test]
+    fn whale_protected_bundle_policy_uses_single_note_policy_at_threshold() {
+        let requested = BundlePolicy::default();
+        let notes = vec![note_with_value(1, WHALE_PROTECTION_NOTE_VALUE_ZATOSHI)];
+
+        let policy = whale_protected_bundle_policy(&notes, requested).unwrap();
+
+        assert_eq!(
+            policy.max_real_notes_per_bundle(),
+            WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE
+        );
+    }
+
+    #[test]
+    fn whale_protected_bundle_policy_keeps_requested_single_note_policy() {
+        let requested = BundlePolicy::new(1).unwrap();
+        let notes = vec![note_with_value(1, WHALE_PROTECTION_NOTE_VALUE_ZATOSHI)];
+
+        let policy = whale_protected_bundle_policy(&notes, requested).unwrap();
+
+        assert_eq!(policy, requested);
+    }
+
+    #[test]
+    fn whale_protection_plans_singleton_bundles_for_whale_sets() {
+        let notes = vec![
+            note_with_value(1, WHALE_PROTECTION_NOTE_VALUE_ZATOSHI),
+            note_with_value(2, zcash_voting::governance::BALLOT_DIVISOR),
+            note_with_value(3, zcash_voting::governance::BALLOT_DIVISOR),
+        ];
+        let default_plan =
+            zcash_voting::round::note_bundles_with_policy(&notes, BundlePolicy::default()).unwrap();
+        assert_eq!(default_plan[0].len(), 3);
+
+        let policy = whale_protected_bundle_policy(&notes, BundlePolicy::default()).unwrap();
+        let protected_plan = zcash_voting::round::note_bundles_with_policy(&notes, policy).unwrap();
+
+        assert_eq!(protected_plan.len(), 3);
+        assert!(protected_plan
+            .iter()
+            .all(|bundle| bundle.len() == WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE));
+    }
 
     #[test]
     fn build_prove_and_sign_delegation_payload_rejects_invalid_round_params_before_progress() {

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -1,12 +1,8 @@
-use std::{borrow::Borrow, sync::Arc};
+use std::sync::Arc;
 
 use ff::PrimeField;
-use prost::Message;
 use secrecy::{ExposeSecret, SecretVec};
-use zcash_client_backend::proto::service::TreeState;
-use zcash_client_sqlite::WalletDb;
 use zcash_keys::keys::UnifiedSpendingKey;
-use zcash_protocol::consensus::Parameters;
 use zeroize::Zeroizing;
 use zip32::{fingerprint::SeedFingerprint, AccountId};
 
@@ -19,63 +15,26 @@ pub use zcash_voting::delegate::DelegationProgress;
 use zcash_voting::delegate::{
     DelegationSigningRequest, PrepareDelegationBundleParams, PreparedDelegationBundle,
 };
-use zcash_voting::selection::{select_notes_with_lwd, select_notes_with_wallet_db};
+use zcash_voting::selection::select_notes_with_lwd;
 use zcash_voting::storage::VotingDb;
 use zcash_voting::BundlePolicy;
 
 const ZATOSHI_PER_ZEC: u64 = 100_000_000;
-const WHALE_PROTECTION_SNAPSHOT_BALANCE_ZATOSHI: u64 = 500 * ZATOSHI_PER_ZEC;
-const WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE: usize = 1;
+const WHALE_PROTECTION_NOTE_VALUE_ZATOSHI: u64 = 500 * ZATOSHI_PER_ZEC;
 
-/// Lower the bundle cap when the selected snapshot balance is large.
+/// Isolate large notes while preserving normal packing for smaller notes.
 ///
-/// The current `zcash_voting` policy applies to the whole round, so this
-/// treats whale protection as an all-or-nothing rule for Vizor's delegation
-/// flow.
-fn whale_protected_bundle_policy(
-    notes: &[zcash_voting::NoteInfo],
-    bundle_policy: BundlePolicy,
-) -> Result<BundlePolicy, String> {
-    let snapshot_balance = notes.iter().try_fold(0u64, |total, note| {
-        total
-            .checked_add(note.value)
-            .ok_or_else(|| "snapshot balance overflow during whale protection".to_string())
-    })?;
-    if snapshot_balance >= WHALE_PROTECTION_SNAPSHOT_BALANCE_ZATOSHI
-        && bundle_policy.max_real_notes_per_bundle() > WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE
-    {
-        return BundlePolicy::new(WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE)
-            .map_err(|e| e.to_string());
-    }
-    Ok(bundle_policy)
+/// `zcash_voting` owns the final bundle planning. Vizor only supplies the
+/// threshold that marks a note as large enough to receive its own bundle.
+fn whale_protected_bundle_policy(bundle_policy: BundlePolicy) -> BundlePolicy {
+    bundle_policy.with_isolated_note_threshold(WHALE_PROTECTION_NOTE_VALUE_ZATOSHI)
 }
 
-fn prepare_params_with_whale_protection<'a, C, P, CL, R>(
-    wallet_db: &WalletDb<C, P, CL, R>,
+fn prepare_params_with_whale_protection<'a>(
     mut prepare_params: PrepareDelegationBundleParams<'a>,
-) -> Result<PrepareDelegationBundleParams<'a>, String>
-where
-    C: Borrow<rusqlite::Connection>,
-    P: Parameters,
-{
-    // The shared crate expects a final policy before it prepares the bundle, so
-    // inspect the same snapshot note set here and then call into the crate.
-    let anchor_tree_state =
-        TreeState::decode(prepare_params.lwd.anchor_tree_state_bytes.as_slice()).map_err(|e| {
-            format!("decode delegation anchor tree state for whale protection failed: {e}")
-        })?;
-    let selected = select_notes_with_wallet_db(
-        wallet_db,
-        prepare_params.voting_hotkey.network(),
-        prepare_params.account_uuid,
-        prepare_params.lwd.round_params.snapshot_height,
-        anchor_tree_state,
-    )
-    .map_err(|e| e.to_string())?;
-    let note_infos = selected.voting_note_infos();
-    prepare_params.bundle_policy =
-        whale_protected_bundle_policy(&note_infos, prepare_params.bundle_policy)?;
-    Ok(prepare_params)
+) -> PrepareDelegationBundleParams<'a> {
+    prepare_params.bundle_policy = whale_protected_bundle_policy(prepare_params.bundle_policy);
+    prepare_params
 }
 
 /// Completes the proof phase for a previously prepared delegation bundle.
@@ -163,7 +122,7 @@ pub async fn setup_delegation_bundles(
     .await
     .map_err(|e| e.to_string())?;
     let note_infos = selected.voting_note_infos();
-    let bundle_policy = whale_protected_bundle_policy(&note_infos, bundle_policy)?;
+    let bundle_policy = whale_protected_bundle_policy(bundle_policy);
     voting_db
         .ensure_bundles_with_skipped_suffix_with_policy(
             round_params.vote_round_id.as_str(),
@@ -201,7 +160,7 @@ pub async fn check_voting_eligibility(
     .await
     .map_err(|e| e.to_string())?;
     let note_infos = selected.voting_note_infos();
-    let bundle_policy = whale_protected_bundle_policy(&note_infos, bundle_policy)?;
+    let bundle_policy = whale_protected_bundle_policy(bundle_policy);
     zcash_voting::minimum_voting_eligibility_for_notes(&note_infos, bundle_policy)
         .map_err(|e| e.to_string())
 }
@@ -254,7 +213,7 @@ pub async fn precompute_delegation_pir(
             bundle_index,
             bundle_policy,
         };
-        let prepare_params = prepare_params_with_whale_protection(&wallet_db, prepare_params)?;
+        let prepare_params = prepare_params_with_whale_protection(prepare_params);
         let prepared = zcash_voting::delegate::prepare_delegation_bundle(
             &voting_db,
             &wallet_db,
@@ -305,7 +264,7 @@ where
         db_path,
         wallet_network(prepare_params.voting_hotkey.network()),
     )?;
-    let prepare_params = prepare_params_with_whale_protection(&wallet_db, prepare_params)?;
+    let prepare_params = prepare_params_with_whale_protection(prepare_params);
 
     let prepared_bundle =
         zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
@@ -400,7 +359,7 @@ pub async fn build_keystone_delegation_request(
         db_path,
         wallet_network(prepare_params.voting_hotkey.network()),
     )?;
-    let prepare_params = prepare_params_with_whale_protection(&wallet_db, prepare_params)?;
+    let prepare_params = prepare_params_with_whale_protection(prepare_params);
     let prepared =
         zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
             .map_err(|e| e.to_string())?;
@@ -440,7 +399,7 @@ where
         db_path,
         wallet_network(prepare_params.voting_hotkey.network()),
     )?;
-    let prepare_params = prepare_params_with_whale_protection(&wallet_db, prepare_params)?;
+    let prepare_params = prepare_params_with_whale_protection(prepare_params);
     let prepared_bundle =
         zcash_voting::delegate::prepare_delegation_bundle(&voting_db, &wallet_db, prepare_params)
             .map_err(|e| e.to_string())?;
@@ -496,65 +455,26 @@ mod tests {
     }
 
     #[test]
-    fn whale_protected_bundle_policy_leaves_non_whale_policy_unchanged() {
-        let requested = BundlePolicy::new(3).unwrap();
-        let notes = vec![note_with_value(
-            1,
-            WHALE_PROTECTION_SNAPSHOT_BALANCE_ZATOSHI - 1,
-        )];
-
-        let policy = whale_protected_bundle_policy(&notes, requested).unwrap();
-
-        assert_eq!(policy.max_real_notes_per_bundle(), 3);
-    }
-
-    #[test]
-    fn whale_protected_bundle_policy_uses_single_note_policy_at_threshold() {
-        let requested = BundlePolicy::default();
+    fn whale_protection_isolates_large_notes_and_packs_smaller_notes() {
         let notes = vec![
-            note_with_value(1, WHALE_PROTECTION_SNAPSHOT_BALANCE_ZATOSHI - 1),
-            note_with_value(2, 1),
-        ];
-
-        let policy = whale_protected_bundle_policy(&notes, requested).unwrap();
-
-        assert_eq!(
-            policy.max_real_notes_per_bundle(),
-            WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE
-        );
-    }
-
-    #[test]
-    fn whale_protected_bundle_policy_keeps_requested_single_note_policy() {
-        let requested = BundlePolicy::new(1).unwrap();
-        let notes = vec![note_with_value(
-            1,
-            WHALE_PROTECTION_SNAPSHOT_BALANCE_ZATOSHI,
-        )];
-
-        let policy = whale_protected_bundle_policy(&notes, requested).unwrap();
-
-        assert_eq!(policy, requested);
-    }
-
-    #[test]
-    fn whale_protection_plans_singleton_bundles_for_large_snapshot_balances() {
-        let notes = vec![
-            note_with_value(1, WHALE_PROTECTION_SNAPSHOT_BALANCE_ZATOSHI - 2),
-            note_with_value(2, zcash_voting::governance::BALLOT_DIVISOR),
-            note_with_value(3, zcash_voting::governance::BALLOT_DIVISOR),
+            note_with_value(1, WHALE_PROTECTION_NOTE_VALUE_ZATOSHI),
+            note_with_value(2, 400 * ZATOSHI_PER_ZEC),
+            note_with_value(3, 200 * ZATOSHI_PER_ZEC),
         ];
         let default_plan =
             zcash_voting::round::note_bundles_with_policy(&notes, BundlePolicy::default()).unwrap();
         assert_eq!(default_plan[0].len(), 3);
 
-        let policy = whale_protected_bundle_policy(&notes, BundlePolicy::default()).unwrap();
+        let policy = whale_protected_bundle_policy(BundlePolicy::default());
         let protected_plan = zcash_voting::round::note_bundles_with_policy(&notes, policy).unwrap();
-
-        assert_eq!(protected_plan.len(), 3);
-        assert!(protected_plan
+        let protected_positions: Vec<Vec<u64>> = protected_plan
             .iter()
-            .all(|bundle| bundle.len() == WHALE_PROTECTION_MAX_REAL_NOTES_PER_BUNDLE));
+            .map(|bundle| bundle.iter().map(|note| note.position).collect())
+            .collect();
+
+        assert_eq!(protected_plan.len(), 2);
+        assert!(protected_positions.contains(&vec![1]));
+        assert!(protected_positions.contains(&vec![2, 3]));
     }
 
     #[test]

--- a/rust/src/wallet/voting/delegation.rs
+++ b/rust/src/wallet/voting/delegation.rs
@@ -20,14 +20,14 @@ use zcash_voting::storage::VotingDb;
 use zcash_voting::BundlePolicy;
 
 const ZATOSHI_PER_ZEC: u64 = 100_000_000;
-const WHALE_PROTECTION_NOTE_VALUE_ZATOSHI: u64 = 500 * ZATOSHI_PER_ZEC;
+const WHALE_PROTECTION_BUNDLE_ADDITION_THRESHOLD_ZATOSHI: u64 = 500 * ZATOSHI_PER_ZEC;
 
-/// Isolate large notes while preserving normal packing for smaller notes.
+/// Start a new bundle before adding a note would cross the whale threshold.
 ///
 /// `zcash_voting` owns the final bundle planning. Vizor only supplies the
-/// threshold that marks a note as large enough to receive its own bundle.
+/// threshold used when deciding whether another note can join a bundle.
 fn whale_protected_bundle_policy(bundle_policy: BundlePolicy) -> BundlePolicy {
-    bundle_policy.with_isolated_note_threshold(WHALE_PROTECTION_NOTE_VALUE_ZATOSHI)
+    bundle_policy.with_bundle_addition_threshold(WHALE_PROTECTION_BUNDLE_ADDITION_THRESHOLD_ZATOSHI)
 }
 
 fn prepare_params_with_whale_protection<'a>(
@@ -455,9 +455,9 @@ mod tests {
     }
 
     #[test]
-    fn whale_protection_isolates_large_notes_and_packs_smaller_notes() {
+    fn whale_protection_starts_new_bundle_when_addition_would_cross_threshold() {
         let notes = vec![
-            note_with_value(1, WHALE_PROTECTION_NOTE_VALUE_ZATOSHI),
+            note_with_value(1, WHALE_PROTECTION_BUNDLE_ADDITION_THRESHOLD_ZATOSHI),
             note_with_value(2, 400 * ZATOSHI_PER_ZEC),
             note_with_value(3, 200 * ZATOSHI_PER_ZEC),
         ];
@@ -472,9 +472,10 @@ mod tests {
             .map(|bundle| bundle.iter().map(|note| note.position).collect())
             .collect();
 
-        assert_eq!(protected_plan.len(), 2);
+        assert_eq!(protected_plan.len(), 3);
         assert!(protected_positions.contains(&vec![1]));
-        assert!(protected_positions.contains(&vec![2, 3]));
+        assert!(protected_positions.contains(&vec![2]));
+        assert!(protected_positions.contains(&vec![3]));
     }
 
     #[test]


### PR DESCRIPTION
Adds Vizor whale protection by passing a 500 ZEC bundle addition threshold into the shared bundle policy. The planner starts a new bundle before adding a note would push the current bundle over 500 ZEC, while a single note above 500 ZEC still forms its own bundle.

Validation: cargo test --locked --lib.