### PR TITLE
Improve swap refund/recipient address modal

### DIFF
--- a/lib/src/features/address_book/models/address_book_contact.dart
+++ b/lib/src/features/address_book/models/address_book_contact.dart
@@ -40,6 +40,28 @@ enum AddressBookNetwork {
 
   bool get canSendFromWallet => this == AddressBookNetwork.zcash;
 
+  /// Whether this network uses the shared EVM address format (0x + 40 hex).
+  /// EVM addresses are interchangeable across EVM chains — the same account
+  /// works on every one — so a destination on any EVM chain can accept an
+  /// address saved for any other EVM chain.
+  bool get isEvm => switch (this) {
+    AddressBookNetwork.ethereum ||
+    AddressBookNetwork.base ||
+    AddressBookNetwork.arbitrum ||
+    AddressBookNetwork.optimism ||
+    AddressBookNetwork.polygon ||
+    AddressBookNetwork.binanceSmartChain ||
+    AddressBookNetwork.avalanche ||
+    AddressBookNetwork.gnosis ||
+    AddressBookNetwork.scroll ||
+    AddressBookNetwork.xLayer ||
+    AddressBookNetwork.plasma ||
+    AddressBookNetwork.abstractChain ||
+    AddressBookNetwork.monad ||
+    AddressBookNetwork.bera => true,
+    _ => false,
+  };
+
   static AddressBookNetwork? tryFromId(String id) {
     final normalized = id.trim().toLowerCase();
     final alias = switch (normalized) {

--- a/lib/src/features/address_book/models/address_format_validator.dart
+++ b/lib/src/features/address_book/models/address_format_validator.dart
@@ -31,21 +31,13 @@ String? addressFormatIssue(
   final trimmed = address.trim();
   if (trimmed.isEmpty) return null;
 
+  // Every EVM chain shares the same 0x address family, so one check covers all
+  // of them (see AddressBookNetwork.isEvm — the single source of truth).
+  if (network.isEvm) {
+    return _isEvmAddress(trimmed) ? null : 'Invalid EVM address';
+  }
+
   final (ok, kind) = switch (network) {
-    AddressBookNetwork.ethereum ||
-    AddressBookNetwork.base ||
-    AddressBookNetwork.arbitrum ||
-    AddressBookNetwork.optimism ||
-    AddressBookNetwork.polygon ||
-    AddressBookNetwork.binanceSmartChain ||
-    AddressBookNetwork.avalanche ||
-    AddressBookNetwork.gnosis ||
-    AddressBookNetwork.scroll ||
-    AddressBookNetwork.xLayer ||
-    AddressBookNetwork.plasma ||
-    AddressBookNetwork.abstractChain ||
-    AddressBookNetwork.monad ||
-    AddressBookNetwork.bera => (_isEvmAddress(trimmed), 'EVM'),
     AddressBookNetwork.bitcoin => (_isBitcoinAddress(trimmed), 'Bitcoin'),
     AddressBookNetwork.solana => (_isSolanaAddress(trimmed), 'Solana'),
     AddressBookNetwork.near => (_isNearAddress(trimmed), 'NEAR'),

--- a/lib/src/features/swap/models/swap_state.dart
+++ b/lib/src/features/swap/models/swap_state.dart
@@ -170,10 +170,14 @@ class SwapState {
           ? 'Destination'
           : '${externalAsset.symbol} refund address';
 
+  // The address belongs to a chain, not the token (you don't have a "USDC
+  // address" — you have an Ethereum address that holds USDC), so name the
+  // chain. Leading with it also keeps the relevant part visible in the narrow
+  // modal field (the old "Refund address on the ET…" cut off the chain).
   String get destinationFieldHint =>
       direction.sendsZec
-          ? 'External ${externalAsset.symbol} address or account'
-          : 'Refund address on the ${externalAsset.symbol} source chain';
+          ? '${externalAsset.chainLabel} address or account'
+          : '${externalAsset.chainLabel} address';
 
   /// Best-effort format check of [destinationText] against the external asset's
   /// chain. Returns null when empty, when the chain has no validator, or when

--- a/lib/src/features/swap/providers/swap_state_provider.dart
+++ b/lib/src/features/swap/providers/swap_state_provider.dart
@@ -223,11 +223,22 @@ class SwapNotifier extends Notifier<SwapState> {
       state.supportedExternalAssets,
     );
     if (supportedAsset == null) return;
+    // The destination is an address on the external asset's chain. When the
+    // chain changes (e.g. USDC-on-Ethereum -> SOL-on-Solana) the old address is
+    // no longer valid, so clear it; keep it when only the token changes within
+    // the same chain (e.g. USDC -> DAI on Ethereum). copyWith treats null as
+    // "keep" and '' as "clear".
+    final chainChanged =
+        supportedAsset.chainTicker != state.externalAsset.chainTicker;
     _clearReviewState();
     state = swapStateWithDerivedFiatTexts(
       swapStateWithIndicativeCounterpart(
         swapStateWithTokenAmountsForFiatModes(
-          state.copyWith(externalAsset: supportedAsset, reviewVisible: false),
+          state.copyWith(
+            externalAsset: supportedAsset,
+            reviewVisible: false,
+            destinationText: chainChanged ? '' : null,
+          ),
         ),
       ),
       preserveAmountFiatInput:

--- a/lib/src/features/swap/screens/swap_screen.dart
+++ b/lib/src/features/swap/screens/swap_screen.dart
@@ -173,7 +173,15 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
             contact.network == network &&
             contact.address.trim().toLowerCase() == normalizedAddress,
       );
-      if (alreadySaved) return;
+      if (alreadySaved) {
+        // Don't create a duplicate, but tell the user why nothing was saved —
+        // otherwise the chosen label/avatar would vanish with no feedback.
+        final toastContext = _toastOverlayContextKey.currentContext;
+        if (toastContext != null && toastContext.mounted) {
+          showAppToast(toastContext, 'Already in your address book');
+        }
+        return;
+      }
 
       await ref
           .read(addressBookProvider.notifier)

--- a/lib/src/features/swap/screens/swap_screen.dart
+++ b/lib/src/features/swap/screens/swap_screen.dart
@@ -9,7 +9,6 @@ import 'package:go_router/go_router.dart';
 import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
-import '../../../core/profile_pictures.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
@@ -55,7 +54,18 @@ AddressBookNetwork? _addressBookNetworkForSwapDestination(SwapState state) {
 
 List<AddressBookNetwork> _swapContactPickerNetworks(SwapState state) {
   final network = _addressBookNetworkForSwapDestination(state);
-  return network == null ? const [] : [network];
+  if (network == null) return const [];
+  // EVM addresses are interchangeable across EVM chains (the same 0x account
+  // works on every one), so let the user pick any saved EVM contact — e.g. a
+  // Polygon address as the refund for a Base swap. Non-EVM chains keep the
+  // exact-network filter since those address formats are chain-specific.
+  if (network.isEvm) {
+    return [
+      for (final candidate in AddressBookNetwork.values)
+        if (candidate.isEvm) candidate,
+    ];
+  }
+  return [network];
 }
 
 String _swapContactPickerTitle(SwapState state) {
@@ -133,11 +143,24 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
     _closeSwapModal();
   }
 
-  Future<void> _rememberSwapAddress(String value, SwapState swapState) async {
+  Future<void> _rememberSwapAddress(
+    String value,
+    SwapState swapState,
+    String? nickname,
+    String profilePictureId,
+  ) async {
     final address = value.trim();
     if (address.isEmpty) return;
     final network = _addressBookNetworkForSwapDestination(swapState);
     if (network == null) return;
+
+    // The modal requires a nickname when "remember" is on; fall back to the
+    // auto-generated label only as a defensive default (e.g. an empty value
+    // slipping through from a future caller).
+    final trimmedNickname = nickname?.trim() ?? '';
+    final label = trimmedNickname.isEmpty
+        ? _swapAddressBookLabel(swapState)
+        : trimmedNickname;
 
     try {
       final current =
@@ -155,10 +178,10 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
       await ref
           .read(addressBookProvider.notifier)
           .addContact(
-            label: _swapAddressBookLabel(swapState),
+            label: label,
             network: network,
             address: address,
-            profilePictureId: kDefaultProfilePictureId,
+            profilePictureId: profilePictureId,
           );
     } catch (_) {
       // Saving a convenience contact must not block the swap form update.
@@ -326,13 +349,21 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                       ),
                       _SwapModalSurface.addressEditor => SwapAddressEditModal(
                         state: swapState,
-                        onSubmitted: (value, remember) {
-                          if (remember) {
-                            unawaited(_rememberSwapAddress(value, swapState));
-                          }
-                          swapNotifier.updateDestination(value);
-                          _closeSwapModal();
-                        },
+                        onSubmitted:
+                            (value, remember, nickname, profilePictureId) {
+                              if (remember) {
+                                unawaited(
+                                  _rememberSwapAddress(
+                                    value,
+                                    swapState,
+                                    nickname,
+                                    profilePictureId,
+                                  ),
+                                );
+                              }
+                              swapNotifier.updateDestination(value);
+                              _closeSwapModal();
+                            },
                         onScan: _openAddressScanner,
                         onOpenContacts: _openAddressContactPicker,
                         onCancel: _closeSwapModal,

--- a/lib/src/features/swap/widgets/swap_address_edit_modal.dart
+++ b/lib/src/features/swap/widgets/swap_address_edit_modal.dart
@@ -2,14 +2,22 @@ import 'package:flutter/material.dart' show InputDecoration, TextField;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
+import '../../../core/profile_pictures.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_profile_picture.dart';
 import '../../address_book/models/address_book_contact.dart';
 import '../../address_book/models/address_format_validator.dart';
 import '../models/swap_models.dart';
 import 'swap_modal_controls.dart';
 
-typedef SwapAddressSubmitCallback = void Function(String value, bool remember);
+typedef SwapAddressSubmitCallback =
+    void Function(
+      String value,
+      bool remember,
+      String? nickname,
+      String profilePictureId,
+    );
 
 class SwapAddressEditModal extends StatefulWidget {
   const SwapAddressEditModal({
@@ -33,14 +41,20 @@ class SwapAddressEditModal extends StatefulWidget {
 
 class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
   late final TextEditingController _controller;
+  late final TextEditingController _nicknameController;
   late final FocusNode _focusNode;
+  late final FocusNode _nicknameFocusNode;
   var _rememberAddress = false;
+  var _pickingAvatar = false;
+  var _selectedProfilePictureId = kDefaultProfilePictureId;
 
   @override
   void initState() {
     super.initState();
     _controller = TextEditingController(text: widget.state.destinationText);
+    _nicknameController = TextEditingController();
     _focusNode = FocusNode(debugLabel: 'SwapAddressModalField');
+    _nicknameFocusNode = FocusNode(debugLabel: 'SwapAddressModalNicknameField');
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _focusNode.requestFocus();
@@ -64,16 +78,41 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
   @override
   void dispose() {
     _controller.dispose();
+    _nicknameController.dispose();
     _focusNode.dispose();
+    _nicknameFocusNode.dispose();
     super.dispose();
   }
 
   void _submit() {
     // Guard the keyboard "done"/enter path the same way the primary button is
-    // gated, so a malformed address cannot be committed by pressing enter.
-    if (_formatError != null) return;
-    widget.onSubmitted(_controller.text.trim(), _rememberAddress);
+    // gated, so a malformed address (or a missing/invalid nickname when the
+    // user opted to remember it) cannot be committed by pressing enter.
+    if (!_canSubmit) return;
+    widget.onSubmitted(
+      _controller.text.trim(),
+      _rememberAddress,
+      _rememberAddress ? _nicknameController.text.trim() : null,
+      _selectedProfilePictureId,
+    );
   }
+
+  void _toggleRemember() {
+    setState(() {
+      _rememberAddress = !_rememberAddress;
+      if (!_rememberAddress) _pickingAvatar = false;
+    });
+    if (_rememberAddress) _nicknameFocusNode.requestFocus();
+  }
+
+  void _selectAvatar(String id) {
+    setState(() {
+      _selectedProfilePictureId = id;
+      _pickingAvatar = false;
+    });
+  }
+
+  bool get _canSubmit => _formatError == null && _nicknameError == null;
 
   String? get _formatError {
     final trimmed = _controller.text.trim();
@@ -83,6 +122,14 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
     );
     if (network == null) return null;
     return addressFormatIssue(network, trimmed);
+  }
+
+  // Only constrains submission when the user opted to remember the address; the
+  // saved entry becomes an address-book contact, so we reuse the same label
+  // rules (non-empty, 1-20 chars) the address-book add form enforces.
+  String? get _nicknameError {
+    if (!_rememberAddress) return null;
+    return validateAddressBookLabel(_nicknameController.text);
   }
 
   @override
@@ -96,17 +143,23 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
     final fieldLabel = sendsZec ? 'Recipient' : 'Refund to';
     final hint = widget.state.destinationFieldHint;
     final description = sendsZec
-        ? 'The external asset will be delivered to this address.'
-        : 'If swap fails, or market conditions change, your transaction may be refunded minus the fee. The refund currency is ${asset.symbol} on Near.';
+        ? 'Your ${asset.symbol} will be delivered to this address.'
+        : "If the swap fails or the rate moves, you'll be refunded in "
+              '${asset.symbol} on ${asset.chainLabel}, minus the fee.';
     final rememberLabel = sendsZec
         ? 'Remember this address for recipients'
         : 'Remember this address for refunds';
     final formatError = _formatError;
+    // Suppress the "Add a label" error on the pristine empty field — the hint
+    // already says what to do, and the disabled button signals it can't submit
+    // yet. Surface the error only once the user typed something invalid.
+    final nicknameError = _nicknameController.text.trim().isEmpty
+        ? null
+        : _nicknameError;
 
     return Container(
       key: const ValueKey('swap_address_modal'),
       width: 312,
-      height: 440,
       padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
       decoration: BoxDecoration(
         color: colors.background.ground,
@@ -114,6 +167,7 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
         children: [
           Row(
             children: [
@@ -136,111 +190,143 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
             ],
           ),
           const SizedBox(height: 16),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
-              child: SingleChildScrollView(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Text(
-                      fieldLabel,
-                      style: AppTypography.labelMedium.copyWith(
-                        color: colors.text.secondary,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    Container(
-                      height: 46,
-                      decoration: BoxDecoration(
-                        color: colors.background.base,
-                        border: Border.all(
-                          color: colors.border.subtle,
-                          width: 1.5,
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  fieldLabel,
+                  style: AppTypography.labelMedium.copyWith(
+                    color: colors.text.secondary,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Container(
+                  height: 46,
+                  decoration: BoxDecoration(
+                    color: colors.background.base,
+                    border: Border.all(color: colors.border.subtle, width: 1.5),
+                    borderRadius: BorderRadius.circular(AppRadii.small),
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 12),
+                          child: TextField(
+                            key: const ValueKey('swap_destination_field'),
+                            controller: _controller,
+                            focusNode: _focusNode,
+                            textInputAction: TextInputAction.done,
+                            onSubmitted: (_) => _submit(),
+                            onChanged: (_) => setState(() {}),
+                            style: AppTypography.labelLarge.copyWith(
+                              color: colors.text.accent,
+                            ),
+                            cursorColor: colors.text.accent,
+                            decoration: InputDecoration.collapsed(
+                              hintText: hint,
+                              hintStyle: AppTypography.labelLarge.copyWith(
+                                color: colors.text.muted,
+                              ),
+                            ),
+                          ),
                         ),
-                        borderRadius: BorderRadius.circular(AppRadii.small),
                       ),
-                      child: Row(
-                        children: [
-                          Expanded(
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 12,
-                              ),
-                              child: TextField(
-                                key: const ValueKey('swap_destination_field'),
-                                controller: _controller,
-                                focusNode: _focusNode,
-                                textInputAction: TextInputAction.done,
-                                onSubmitted: (_) => _submit(),
-                                onChanged: (_) => setState(() {}),
-                                style: AppTypography.labelLarge.copyWith(
-                                  color: colors.text.accent,
-                                ),
-                                cursorColor: colors.text.accent,
-                                decoration: InputDecoration.collapsed(
-                                  hintText: hint,
-                                  hintStyle: AppTypography.labelLarge.copyWith(
-                                    color: colors.text.muted,
-                                  ),
-                                ),
-                              ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 10),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            SwapInlineIconButton(
+                              key: const ValueKey('swap_address_scan_button'),
+                              iconName: AppIcons.qr,
+                              onTap: widget.onScan,
                             ),
-                          ),
-                          Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 10),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                SwapInlineIconButton(
-                                  key: const ValueKey(
-                                    'swap_address_scan_button',
-                                  ),
-                                  iconName: AppIcons.qr,
-                                  onTap: widget.onScan,
-                                ),
-                                const SizedBox(width: 4),
-                                SwapInlineIconButton(
-                                  key: const ValueKey(
-                                    'swap_address_contacts_button',
-                                  ),
-                                  iconName: AppIcons.users,
-                                  onTap: widget.onOpenContacts,
-                                ),
-                              ],
+                            const SizedBox(width: 4),
+                            SwapInlineIconButton(
+                              key: const ValueKey(
+                                'swap_address_contacts_button',
+                              ),
+                              iconName: AppIcons.users,
+                              onTap: widget.onOpenContacts,
                             ),
-                          ),
-                        ],
-                      ),
-                    ),
-                    if (formatError != null) ...[
-                      const SizedBox(height: 8),
-                      Text(
-                        formatError,
-                        key: const ValueKey('swap_destination_format_error'),
-                        style: AppTypography.bodyMedium.copyWith(
-                          color: colors.text.destructive,
+                          ],
                         ),
                       ),
                     ],
-                    const SizedBox(height: 12),
+                  ),
+                ),
+                if (formatError != null) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    formatError,
+                    key: const ValueKey('swap_destination_format_error'),
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: colors.text.destructive,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 12),
+                Text(
+                  description,
+                  style: AppTypography.bodyMedium.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                _AddressRememberToggle(
+                  selected: _rememberAddress,
+                  label: rememberLabel,
+                  onTap: _toggleRemember,
+                ),
+                if (_rememberAddress) ...[
+                  const SizedBox(height: 20),
+                  Text(
+                    'Address label',
+                    style: AppTypography.labelMedium.copyWith(
+                      color: colors.text.secondary,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      _AddressAvatarButton(
+                        profilePictureId: _selectedProfilePictureId,
+                        onTap: () =>
+                            setState(() => _pickingAvatar = !_pickingAvatar),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: _NicknameInputBox(
+                          controller: _nicknameController,
+                          focusNode: _nicknameFocusNode,
+                          onChanged: (_) => setState(() {}),
+                          onSubmitted: (_) => _submit(),
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (nicknameError != null) ...[
+                    const SizedBox(height: 8),
                     Text(
-                      description,
+                      nicknameError,
+                      key: const ValueKey('swap_address_nickname_error'),
                       style: AppTypography.bodyMedium.copyWith(
-                        color: colors.text.accent,
+                        color: colors.text.destructive,
                       ),
                     ),
-                    const SizedBox(height: 16),
-                    _AddressRememberToggle(
-                      selected: _rememberAddress,
-                      label: rememberLabel,
-                      onTap: () {
-                        setState(() => _rememberAddress = !_rememberAddress);
-                      },
+                  ],
+                  if (_pickingAvatar) ...[
+                    const SizedBox(height: 12),
+                    _AvatarPickerStrip(
+                      selectedId: _selectedProfilePictureId,
+                      onSelected: _selectAvatar,
                     ),
                   ],
-                ),
-              ),
+                ],
+              ],
             ),
           ),
           SwapModalButtons(
@@ -248,7 +334,7 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
             cancelKey: const ValueKey('swap_address_cancel_button'),
             onPrimary: _submit,
             onCancel: widget.onCancel,
-            primaryEnabled: formatError == null,
+            primaryEnabled: _canSubmit,
           ),
         ],
       ),
@@ -313,6 +399,190 @@ class _AddressRememberToggle extends StatelessWidget {
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _NicknameInputBox extends StatelessWidget {
+  const _NicknameInputBox({
+    required this.controller,
+    required this.focusNode,
+    required this.onChanged,
+    required this.onSubmitted,
+  });
+
+  final TextEditingController controller;
+  final FocusNode focusNode;
+  final ValueChanged<String> onChanged;
+  final ValueChanged<String> onSubmitted;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Container(
+      height: 46,
+      decoration: BoxDecoration(
+        color: colors.background.base,
+        border: Border.all(color: colors.border.subtle, width: 1.5),
+        borderRadius: BorderRadius.circular(AppRadii.small),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12),
+        child: TextField(
+          key: const ValueKey('swap_address_nickname_field'),
+          controller: controller,
+          focusNode: focusNode,
+          textInputAction: TextInputAction.done,
+          onChanged: onChanged,
+          onSubmitted: onSubmitted,
+          style: AppTypography.labelMedium.copyWith(color: colors.text.accent),
+          cursorColor: colors.text.accent,
+          decoration: InputDecoration.collapsed(
+            hintText: 'Add a label (1-20 characters)',
+            hintStyle: AppTypography.labelMedium.copyWith(
+              color: colors.text.muted,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AddressAvatarButton extends StatelessWidget {
+  const _AddressAvatarButton({
+    required this.profilePictureId,
+    required this.onTap,
+  });
+
+  final String profilePictureId;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        key: const ValueKey('swap_address_avatar_button'),
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: SizedBox(
+          width: 46,
+          height: 46,
+          child: Stack(
+            clipBehavior: Clip.none,
+            alignment: Alignment.center,
+            children: [
+              AppProfilePicture(
+                profilePictureId: profilePictureId,
+                size: AppProfilePictureSize.large,
+              ),
+              Positioned(
+                right: 0,
+                bottom: 0,
+                child: Container(
+                  width: 18,
+                  height: 18,
+                  decoration: BoxDecoration(
+                    color: colors.background.inverse,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Center(
+                    child: AppIcon(
+                      AppIcons.edit,
+                      size: 10,
+                      color: colors.icon.inverse,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AvatarPickerStrip extends StatelessWidget {
+  const _AvatarPickerStrip({required this.selectedId, required this.onSelected});
+
+  final String selectedId;
+  final ValueChanged<String> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        for (final option in kProfilePictureOptions)
+          _AvatarChoice(
+            option: option,
+            selected: option.id == selectedId,
+            onSelected: onSelected,
+          ),
+      ],
+    );
+  }
+}
+
+class _AvatarChoice extends StatelessWidget {
+  const _AvatarChoice({
+    required this.option,
+    required this.selected,
+    required this.onSelected,
+  });
+
+  final ProfilePictureOption option;
+  final bool selected;
+  final ValueChanged<String> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        key: ValueKey('swap_address_avatar_${option.id}'),
+        behavior: HitTestBehavior.opaque,
+        onTap: () => onSelected(option.id),
+        child: SizedBox(
+          width: 36,
+          height: 36,
+          child: Stack(
+            clipBehavior: Clip.none,
+            alignment: Alignment.center,
+            children: [
+              AppProfilePicture(
+                profilePictureId: option.id,
+                size: AppProfilePictureSize.large,
+              ),
+              if (selected)
+                Positioned(
+                  right: -2,
+                  bottom: -2,
+                  child: Container(
+                    width: 18,
+                    height: 18,
+                    decoration: BoxDecoration(
+                      color: colors.background.inverse,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Center(
+                      child: AppIcon(
+                        AppIcons.check,
+                        size: 10,
+                        color: colors.icon.inverse,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/src/features/swap/widgets/swap_address_edit_modal.dart
+++ b/lib/src/features/swap/widgets/swap_address_edit_modal.dart
@@ -332,6 +332,7 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
           SwapModalButtons(
             primaryKey: const ValueKey('swap_address_update_button'),
             cancelKey: const ValueKey('swap_address_cancel_button'),
+            primaryLabel: 'Save',
             onPrimary: _submit,
             onCancel: widget.onCancel,
             primaryEnabled: _canSubmit,

--- a/lib/widgetbook/swap_use_cases.dart
+++ b/lib/widgetbook/swap_use_cases.dart
@@ -83,7 +83,7 @@ Widget buildSwapAddressModalFigmaNode7UseCase(BuildContext context) {
   return _SwapPageModalFrame(
     child: SwapAddressEditModal(
       state: _figmaNode3State,
-      onSubmitted: (_, _) {},
+      onSubmitted: (_, _, _, _) {},
       onScan: () {},
       onOpenContacts: () {},
       onCancel: () {},

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -1540,7 +1540,7 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
     await tester.pumpAndSettle();
 
-    expect(find.text('External USDC address or account'), findsOneWidget);
+    expect(find.text('Ethereum address or account'), findsOneWidget);
     expect(find.text('NEAR or Ethereum address'), findsNothing);
 
     final paneRect = tester.getRect(find.byType(AppDesktopPane));
@@ -1913,6 +1913,18 @@ void main() {
       find.byKey(const ValueKey('swap_address_remember_toggle')),
     );
     await tester.pumpAndSettle();
+
+    // Enabling "remember" requires a nickname before the address can be saved.
+    final beforeNickname = tester.widget<AppButton>(
+      find.byKey(const ValueKey('swap_address_update_button')),
+    );
+    expect(beforeNickname.onPressed, isNull);
+
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_address_nickname_field')),
+      'My USDC',
+    );
+    await tester.pumpAndSettle();
     await tester.tap(find.byKey(const ValueKey('swap_address_update_button')));
     await tester.pumpAndSettle();
 
@@ -1925,10 +1937,152 @@ void main() {
       addressBookRepository.contacts.single.network,
       AddressBookNetwork.ethereum,
     );
-    expect(addressBookRepository.contacts.single.label, 'USDC recipient');
+    expect(addressBookRepository.contacts.single.label, 'My USDC');
   });
 
-  testWidgets('swap address modal filters contacts by token chain ticker', (
+  testWidgets('swap address modal requires a valid nickname to remember', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final addressBookRepository = _FakeAddressBookRepository();
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        seedSwapActivityFixtures: false,
+        addressBookRepository: addressBookRepository,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_destination_field')),
+      '0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb',
+    );
+    await tester.pumpAndSettle();
+
+    // No nickname field until the user opts to remember the address.
+    expect(
+      find.byKey(const ValueKey('swap_address_nickname_field')),
+      findsNothing,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('swap_address_remember_toggle')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('swap_address_nickname_field')),
+      findsOneWidget,
+    );
+
+    // A nickname over the 20-char limit surfaces the shared address-book label
+    // error and keeps the button disabled, so nothing is saved.
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_address_nickname_field')),
+      'this nickname is definitely too long',
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Use 1-20 characters'), findsOneWidget);
+    final blocked = tester.widget<AppButton>(
+      find.byKey(const ValueKey('swap_address_update_button')),
+    );
+    expect(blocked.onPressed, isNull);
+    expect(addressBookRepository.contacts, isEmpty);
+  });
+
+  testWidgets('swap clears the destination only when the chain changes', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        seedSwapActivityFixtures: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(SwapScreen)),
+      listen: false,
+    );
+    final notifier = container.read(swapStateProvider.notifier);
+    const ethAddress = '0x52908400098527886e0f7030069857d2e4169ee7';
+    notifier.updateDestination(ethAddress);
+    await tester.pumpAndSettle();
+
+    // Same chain (Ethereum USDC -> Ethereum DAI): the address is kept.
+    notifier.selectExternalAsset(SwapAsset.dai);
+    await tester.pumpAndSettle();
+    expect(container.read(swapStateProvider).destinationText, ethAddress);
+
+    // Different chain (Ethereum -> Solana): the address is cleared.
+    notifier.selectExternalAsset(SwapAsset.sol);
+    await tester.pumpAndSettle();
+    expect(container.read(swapStateProvider).destinationText, isEmpty);
+  });
+
+  testWidgets('swap address modal saves the chosen avatar with the address', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final addressBookRepository = _FakeAddressBookRepository();
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        seedSwapActivityFixtures: false,
+        addressBookRepository: addressBookRepository,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_destination_field')),
+      '0xdbf03b407c01e7cd3cbea99509d93f8dddc8c6fb',
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('swap_address_remember_toggle')),
+    );
+    await tester.pumpAndSettle();
+
+    // Open the avatar picker and choose a non-default avatar.
+    await tester.tap(find.byKey(const ValueKey('swap_address_avatar_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_address_avatar_samurai')));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_address_nickname_field')),
+      'My USDC',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_address_update_button')));
+    await tester.pumpAndSettle();
+
+    expect(addressBookRepository.contacts, hasLength(1));
+    expect(addressBookRepository.contacts.single.label, 'My USDC');
+    expect(addressBookRepository.contacts.single.profilePictureId, 'samurai');
+  });
+
+  testWidgets('swap address modal shows EVM contacts across chains', (
     tester,
   ) async {
     await _setDesktopViewport(tester);
@@ -1955,8 +2109,60 @@ void main() {
             address: '0xdc2d3454f7baf9f15c98e8f5d6a3cb5a5f1b2c3d',
           ),
           _addressBookContact(
+            id: 'polygon',
+            label: 'Polygon Friend',
+            network: AddressBookNetwork.polygon,
+            address: '0x583031d1113ad414f02576bd6afabfb302140225',
+          ),
+          _addressBookContact(
+            id: 'solana',
+            label: 'Solana Friend',
+            network: AddressBookNetwork.solana,
+            address: '7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs',
+          ),
+        ]),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('swap_address_contacts_button')),
+    );
+    await tester.pumpAndSettle();
+
+    // EVM addresses are interchangeable across chains, so a Polygon contact is
+    // usable as a Base refund/recipient — both EVM contacts show.
+    expect(find.text('Base USDC Friend'), findsOneWidget);
+    expect(find.text('Polygon Friend'), findsOneWidget);
+    // Non-EVM contacts stay hidden.
+    expect(find.text('Solana Friend'), findsNothing);
+  });
+
+  testWidgets('swap address modal keeps non-EVM contact filtering exact', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        swapProvider: _FakeSwapProvider(supportedAssets: const [SwapAsset.sol]),
+        seedSwapActivityFixtures: false,
+        addressBookRepository: _FakeAddressBookRepository([
+          _addressBookContact(
+            id: 'solana',
+            label: 'Solana Friend',
+            network: AddressBookNetwork.solana,
+            address: '7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs',
+          ),
+          _addressBookContact(
             id: 'ethereum',
-            label: 'Ethereum USDC Friend',
+            label: 'Ethereum Friend',
             network: AddressBookNetwork.ethereum,
             address: '0x583031d1113ad414f02576bd6afabfb302140225',
           ),
@@ -1972,8 +2178,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Base USDC Friend'), findsOneWidget);
-    expect(find.text('Ethereum USDC Friend'), findsNothing);
+    // Solana addresses are chain-specific, so only the Solana contact shows.
+    expect(find.text('Solana Friend'), findsOneWidget);
+    expect(find.text('Ethereum Friend'), findsNothing);
   });
 
   testWidgets('fresh swap screen starts without seeded activity or requests', (

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -1998,6 +1998,61 @@ void main() {
     expect(addressBookRepository.contacts, isEmpty);
   });
 
+  testWidgets('swap address modal warns when the address is already saved', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    const existing = '0x52908400098527886e0f7030069857d2e4169ee7';
+    final addressBookRepository = _FakeAddressBookRepository([
+      _addressBookContact(
+        id: 'existing',
+        label: 'Existing',
+        network: AddressBookNetwork.ethereum,
+        address: existing,
+      ),
+    ]);
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        seedSwapActivityFixtures: false,
+        addressBookRepository: addressBookRepository,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_address_summary')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_destination_field')),
+      existing,
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('swap_address_remember_toggle')),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_address_nickname_field')),
+      'Duplicate',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_address_update_button')));
+    // Let the async remember-path run and the toast appear; avoid
+    // pumpAndSettle here since it would wait out the toast's auto-dismiss.
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.text('Already in your address book'), findsOneWidget);
+    // No duplicate created — still just the seeded contact.
+    expect(addressBookRepository.contacts, hasLength(1));
+
+    // Drain the toast's auto-dismiss timer so the test ends cleanly.
+    await tester.pumpAndSettle(const Duration(seconds: 3));
+  });
+
   testWidgets('swap clears the destination only when the chain changes', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary

Polish and fixes for the swap refund/recipient **address modal**:

- **Placeholder** no longer truncates and names the **chain, not the token** (the address belongs to a chain) — e.g. `Ethereum address`, `Solana address`.
- **Refund helper copy** shortened, and the refund chain now follows the selected asset (was hardcoded `on Near`).
- **Save to the address book inline** when *Remember this address* is on: a required **Address label** (1–20 chars, reusing `validateAddressBookLabel`) plus a **profile-picture picker**, both threaded through to `addContact`.
- **Modal grows to fit** instead of scrolling.
- **Clears the destination on a chain change** (e.g. USDC-on-Ethereum → SOL-on-Solana) while keeping it within the same chain (USDC → DAI on Ethereum).
- **Accepts any EVM address for an EVM destination**: the contact picker now surfaces contacts from every EVM chain (e.g. a Polygon address as a Base refund). `AddressBookNetwork.isEvm` is the single source of truth, reused by the address-format validator.

## Testing

- `fvm flutter analyze` — clean
- `fvm flutter test test/features/swap/ test/features/address_book/` — green (incl. new tests: chain-clear, avatar save, EVM cross-chain picker, non-EVM exact filtering)
- `fvm flutter build macos --debug` — builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
