### PR TITLE
[codex] Support variable mnemonic import lengths

### DIFF
--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -35,6 +35,8 @@ class ImportSecretPassphraseScreen extends ConsumerStatefulWidget {
 
 class _ImportSecretPassphraseScreenState
     extends ConsumerState<ImportSecretPassphraseScreen> {
+  static const _minImportWordCount = 12;
+  static const _wordCountStep = 3;
   static const _wordCount = 24;
   static const _gridWidth = 588.0;
   static const _titleWidth = 504.0;
@@ -94,15 +96,32 @@ class _ImportSecretPassphraseScreenState
       .map((controller) => controller.text.trim().toLowerCase())
       .toList();
 
-  String get _mnemonic => _normalizedWords.join(' ');
+  List<String> get _enteredWordCells {
+    final words = _normalizedWords;
+    final lastEnteredIndex = words.lastIndexWhere((word) => word.isNotEmpty);
+    if (lastEnteredIndex < 0) return const [];
+    return words.take(lastEnteredIndex + 1).toList();
+  }
 
-  bool get _hasAllWords => _normalizedWords.every((word) => word.isNotEmpty);
+  String get _mnemonic => _enteredWordCells.join(' ');
+
+  bool get _hasContiguousMnemonicWords =>
+      _enteredWordCells.every((word) => word.isNotEmpty);
+
+  bool get _hasSupportedMnemonicWordCount {
+    final count = _enteredWordCells.length;
+    return count >= _minImportWordCount &&
+        count <= _wordCount &&
+        count % _wordCountStep == 0;
+  }
 
   bool get _hasEnteredMnemonicWords =>
       _controllers.any((controller) => controller.text.trim().isNotEmpty);
 
   bool get _isMnemonicValid =>
-      _hasAllWords && rust_wallet.validateMnemonic(mnemonic: _mnemonic);
+      _hasContiguousMnemonicWords &&
+      _hasSupportedMnemonicWordCount &&
+      rust_wallet.validateMnemonic(mnemonic: _mnemonic);
 
   bool get _canSubmit => !_isSubmitting && _isMnemonicValid;
 
@@ -188,7 +207,7 @@ class _ImportSecretPassphraseScreenState
   String? get _errorText {
     if (_submitError != null) return _submitError;
     if (_showValidationError && !_isMnemonicValid) {
-      return 'Enter a valid 24-word Secret Passphrase.';
+      return 'Enter a valid secret passphrase with 12, 15, 18, 21, or 24 words.';
     }
     return null;
   }

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -32,6 +32,9 @@ use crate::wallet::{
 
 const DUPLICATE_SOFTWARE_ACCOUNT_MESSAGE: &str = "This account is already in your wallet.";
 const DUPLICATE_KEYSTONE_ACCOUNT_MESSAGE: &str = "This Keystone account is already in your wallet.";
+const MIN_MNEMONIC_WORD_COUNT: usize = 12;
+const MAX_MNEMONIC_WORD_COUNT: usize = 24;
+const MNEMONIC_WORD_COUNT_STEP: usize = 3;
 
 fn map_account_import_error(
     error: SqliteClientError,
@@ -79,9 +82,22 @@ pub fn mnemonic_word_list() -> Vec<String> {
         .collect()
 }
 
+fn is_supported_mnemonic_word_count(count: usize) -> bool {
+    count >= MIN_MNEMONIC_WORD_COUNT
+        && count <= MAX_MNEMONIC_WORD_COUNT
+        && count % MNEMONIC_WORD_COUNT_STEP == 0
+}
+
 /// Convert a mnemonic phrase to a 64-byte seed wrapped in SecretVec.
 /// The seed is zeroized from memory when the SecretVec is dropped.
 pub fn mnemonic_to_seed(phrase: &str) -> Result<SecretVec<u8>, String> {
+    let word_count = phrase.split_whitespace().count();
+    if !is_supported_mnemonic_word_count(word_count) {
+        return Err(
+            "Invalid mnemonic word count: expected 12, 15, 18, 21, or 24 words".to_string(),
+        );
+    }
+
     let mnemonic =
         Mnemonic::<English>::from_phrase(phrase).map_err(|e| format!("Invalid mnemonic: {e}"))?;
     let seed = Zeroizing::new(mnemonic.to_seed(""));
@@ -664,6 +680,36 @@ mod tests {
         let phrase = generate_mnemonic();
         let seed = mnemonic_to_seed(&phrase).unwrap();
         assert_eq!(seed.expose_secret().len(), 64);
+    }
+
+    #[test]
+    fn test_mnemonic_to_seed_accepts_supported_word_counts() {
+        for count in [
+            Count::Words12,
+            Count::Words15,
+            Count::Words18,
+            Count::Words21,
+            Count::Words24,
+        ] {
+            let phrase = Mnemonic::<English>::generate(count).phrase().to_string();
+            let seed = mnemonic_to_seed(&phrase).unwrap();
+            assert_eq!(seed.expose_secret().len(), 64);
+        }
+    }
+
+    #[test]
+    fn test_mnemonic_to_seed_rejects_unsupported_word_counts() {
+        for count in [11, 13, 25] {
+            let phrase = std::iter::repeat("abandon")
+                .take(count)
+                .collect::<Vec<_>>()
+                .join(" ");
+            let error = match mnemonic_to_seed(&phrase) {
+                Ok(_) => panic!("unsupported mnemonic word count should be rejected"),
+                Err(error) => error,
+            };
+            assert!(error.contains("expected 12, 15, 18, 21, or 24 words"));
+        }
     }
 
     #[test]

--- a/test/features/onboarding/import_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/import_secret_passphrase_screen_test.dart
@@ -11,13 +11,17 @@ import 'package:flutter/widgets.dart'
         ScrollableState,
         Size,
         SizedBox,
+        ValueKey,
         Widget;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/privacy/sensitive_privacy_overlay.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/onboarding/import/import_secret_passphrase_screen.dart';
+import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
 void main() {
@@ -221,6 +225,61 @@ void main() {
   });
 
   testWidgets(
+    'submits a valid 12-word mnemonic without requiring empty fields',
+    (tester) async {
+      ImportBirthdayArgs? submittedArgs;
+      final router = _importPassphraseRouter((args) => submittedArgs = args);
+      addTearDown(router.dispose);
+
+      await _setDesktopViewport(tester);
+      await tester.pumpWidget(_routerHarness(router));
+      await _enterWords(tester, 12);
+
+      expect(_submitButton(tester).onPressed, isNotNull);
+
+      await tester.tap(find.byKey(_submitButtonKey));
+      await tester.pumpAndSettle();
+
+      expect(submittedArgs?.mnemonic, _words(12).join(' '));
+    },
+  );
+
+  testWidgets('accepts supported mnemonic lengths and rejects partial steps', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(_importPassphraseScreen());
+
+    await _enterWords(tester, 12);
+    expect(_submitButton(tester).onPressed, isNotNull);
+
+    await tester.enterText(_wordField(12), _wordAt(12));
+    await tester.pump();
+    expect(_submitButton(tester).onPressed, isNull);
+
+    await tester.enterText(_wordField(13), _wordAt(13));
+    await tester.enterText(_wordField(14), _wordAt(14));
+    await tester.pump();
+    expect(_submitButton(tester).onPressed, isNotNull);
+  });
+
+  testWidgets(
+    'rejects mnemonic words with a gap before the last entered word',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      await tester.pumpWidget(_importPassphraseScreen());
+
+      await _enterWords(tester, 12);
+      expect(_submitButton(tester).onPressed, isNotNull);
+
+      await tester.enterText(_wordField(5), '');
+      await tester.pump();
+
+      expect(_submitButton(tester).onPressed, isNull);
+    },
+  );
+
+  testWidgets(
     'privacy shield ignores empty focused words when focus is unsafe',
     (tester) async {
       final controller = SensitivePrivacyOverlayController(
@@ -354,11 +413,67 @@ Widget _importPassphraseScreen({
   );
 }
 
+GoRouter _importPassphraseRouter(
+  void Function(ImportBirthdayArgs args) onSubmit,
+) {
+  return GoRouter(
+    initialLocation: '/import',
+    routes: [
+      GoRoute(
+        path: '/import',
+        builder: (_, _) => const Scaffold(body: ImportSecretPassphraseScreen()),
+      ),
+      GoRoute(
+        path: '/import/birthday',
+        builder: (_, state) {
+          onSubmit(state.extra as ImportBirthdayArgs);
+          return const SizedBox.shrink();
+        },
+      ),
+      GoRoute(path: '/welcome', builder: (_, _) => const SizedBox.shrink()),
+    ],
+  );
+}
+
+Widget _routerHarness(GoRouter router) {
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+    ],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, child) => AppTheme(
+        data: AppThemeData.light,
+        child: child ?? const SizedBox.shrink(),
+      ),
+    ),
+  );
+}
+
 Finder _wordField(int index) => find.byType(TextField).at(index);
 
 TextField _textField(WidgetTester tester, int index) {
   return tester.widget<TextField>(_wordField(index));
 }
+
+const _submitButtonKey = ValueKey('import_secret_submit_button');
+
+AppButton _submitButton(WidgetTester tester) {
+  return tester.widget<AppButton>(find.byKey(_submitButtonKey));
+}
+
+Future<void> _enterWords(WidgetTester tester, int count) async {
+  for (var index = 0; index < count; index++) {
+    await tester.enterText(_wordField(index), _wordAt(index));
+  }
+  await tester.pump();
+}
+
+List<String> _words(int count) {
+  return List.generate(count, _wordAt);
+}
+
+String _wordAt(int index) => _wordList[index % _wordList.length];
 
 class _RustApiFake implements RustLibApi {
   @override
@@ -366,7 +481,8 @@ class _RustApiFake implements RustLibApi {
 
   @override
   bool crateApiWalletValidateMnemonic({required String mnemonic}) {
-    return mnemonic.trim().split(RegExp(r'\s+')).length == 24;
+    final count = mnemonic.trim().split(RegExp(r'\s+')).length;
+    return count >= 12 && count <= 24 && count % 3 == 0;
   }
 
   @override


### PR DESCRIPTION
## Summary
- Allow imported secret passphrases with 12, 15, 18, 21, or 24 words while keeping the 24-field UI.
- Submit only the contiguous entered mnemonic words, so filling the first 12 fields imports a 12-word phrase.
- Add Rust-side word-count validation and focused Flutter/Rust tests for supported and unsupported lengths.

## Validation
- `.fvm/flutter_sdk/bin/flutter test test/features/onboarding/import_secret_passphrase_screen_test.dart`
- `.fvm/flutter_sdk/bin/flutter analyze`
- `cd rust && cargo test mnemonic`

## Notes
- `fvm` was not on PATH in this environment, so validation used the project `.fvm/flutter_sdk` symlink directly.