### PR TITLE
Fix voting eligibility and Keystone account detection

### DIFF
--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -251,6 +251,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
               uuid: account.uuid,
               name: account.name,
               order: index,
+              isHardware: account.isHardware,
               isSeedAnchor: account.isSeedAnchor,
             ),
             storedAccount: stored,
@@ -374,7 +375,8 @@ AccountInfo mergeBootstrappedAccountInfo({
     uuid: rustAccount.uuid,
     name: storedAccount?.name ?? rustAccount.name,
     order: storedAccount?.order ?? order,
-    isHardware: storedAccount?.isHardware ?? false,
+    // Rust can recover Keystone accounts when older stored metadata lost this bit.
+    isHardware: (storedAccount?.isHardware ?? false) || rustAccount.isHardware,
     isSeedAnchor: rustAccount.isSeedAnchor,
     profilePictureId:
         storedAccount?.profilePictureId ?? kDefaultProfilePictureId,

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -1040,24 +1040,12 @@ class _KeystoneBundleProgress extends StatelessWidget {
       );
     });
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
+    return Row(
       children: [
-        Row(
-          children: [
-            for (var i = 0; i < segments.length; i++) ...[
-              if (i > 0) const SizedBox(width: AppSpacing.xxs),
-              segments[i],
-            ],
-          ],
-        ),
-        const SizedBox(height: AppSpacing.xxs),
-        Text(
-          '$currentBundle / $bundleCount',
-          style: AppTypography.labelSmall.copyWith(
-            color: colors.text.secondary,
-          ),
-        ),
+        for (var i = 0; i < segments.length; i++) ...[
+          if (i > 0) const SizedBox(width: AppSpacing.xxs),
+          segments[i],
+        ],
       ],
     );
   }

--- a/lib/src/features/voting/voting_error_messages.dart
+++ b/lib/src/features/voting/voting_error_messages.dart
@@ -11,6 +11,12 @@ bool isVotingEligibilityErrorText(String text) {
       _minimumVotingEligibilityPattern.firstMatch(message) != null ||
       lowerMessage.startsWith('this account is not eligible for this ') ||
       lowerMessage.startsWith(
+        'voting requires at least one eligible shielded note bundle with 0.125 zec',
+      ) ||
+      lowerMessage.startsWith(
+        'voting requires at least 0.125 zec in eligible shielded funds',
+      ) ||
+      lowerMessage.startsWith(
         'voting requires at least 5 eligible shielded notes totaling 0.125 zec',
       );
 }
@@ -35,8 +41,9 @@ String friendlyVotingErrorText(String text) {
     final snapshot = heightText == null
         ? 'the voting round snapshot block'
         : 'snapshot block ${formatBlockHeight(int.parse(heightText))}';
-    return 'Voting requires at least 5 eligible shielded notes totaling '
-        '0.125 ZEC at $snapshot. Switch to an eligible account to vote.';
+    return 'Voting requires at least one eligible shielded note bundle with '
+        '0.125 ZEC '
+        'at $snapshot. Switch to an eligible account to vote.';
   }
 
   return message.isEmpty ? 'Voting session action failed.' : message;
@@ -65,6 +72,6 @@ final _noSpendableNotesPattern = RegExp(
 );
 
 final _minimumVotingEligibilityPattern = RegExp(
-  r'minimum voting eligibility requires at least 5 eligible notes and 12500000 zatoshi voting weight; selected \d+ distinct eligible notes with \d+ zatoshi voting weight(?: at snapshot height (\d+))?',
+  r'minimum voting eligibility requires (?:(?:at least 5 eligible notes and )?12500000 zatoshi voting weight|at least one eligible voting bundle with 12500000 zatoshi voting weight); selected (?:(?:\d+ distinct eligible notes with )?\d+ zatoshi voting weight|\d+ distinct notes across eligible bundles with \d+ zatoshi eligible bundle weight)(?: at snapshot height (\d+))?',
   caseSensitive: false,
 );

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -2707,10 +2707,11 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required rust_api.ApiVotingEligibility eligibility,
     required int snapshotHeight,
   }) {
-    return 'minimum voting eligibility requires at least 5 eligible notes and '
-        '12500000 zatoshi voting weight; selected '
-        '${eligibility.distinctNoteCount} distinct eligible notes with '
-        '${eligibility.eligibleWeightZatoshi} zatoshi voting weight at '
+    return 'minimum voting eligibility requires at least one eligible voting '
+        'bundle with 12500000 zatoshi voting weight; selected '
+        '${eligibility.distinctNoteCount} distinct notes across eligible '
+        'bundles with ${eligibility.eligibleWeightZatoshi} zatoshi eligible '
+        'bundle weight at '
         'snapshot height $snapshotHeight';
   }
 

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -178,12 +178,14 @@ class AccountInfo {
   final String name;
   final String unifiedAddress;
   final bool isSeedAnchor;
+  final bool isHardware;
 
   const AccountInfo({
     required this.uuid,
     required this.name,
     required this.unifiedAddress,
     required this.isSeedAnchor,
+    required this.isHardware,
   });
 
   @override
@@ -191,7 +193,8 @@ class AccountInfo {
       uuid.hashCode ^
       name.hashCode ^
       unifiedAddress.hashCode ^
-      isSeedAnchor.hashCode;
+      isSeedAnchor.hashCode ^
+      isHardware.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -201,7 +204,8 @@ class AccountInfo {
           uuid == other.uuid &&
           name == other.name &&
           unifiedAddress == other.unifiedAddress &&
-          isSeedAnchor == other.isSeedAnchor;
+          isSeedAnchor == other.isSeedAnchor &&
+          isHardware == other.isHardware;
 }
 
 /// Result of wallet creation, containing the mnemonic, unified address, and account UUID.

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -5317,13 +5317,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   AccountInfo dco_decode_account_info(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 4)
-      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
+    if (arr.length != 5)
+      throw Exception('unexpected arr length: expect 5 but see ${arr.length}');
     return AccountInfo(
       uuid: dco_decode_String(arr[0]),
       name: dco_decode_String(arr[1]),
       unifiedAddress: dco_decode_String(arr[2]),
       isSeedAnchor: dco_decode_bool(arr[3]),
+      isHardware: dco_decode_bool(arr[4]),
     );
   }
 
@@ -6846,11 +6847,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_name = sse_decode_String(deserializer);
     var var_unifiedAddress = sse_decode_String(deserializer);
     var var_isSeedAnchor = sse_decode_bool(deserializer);
+    var var_isHardware = sse_decode_bool(deserializer);
     return AccountInfo(
       uuid: var_uuid,
       name: var_name,
       unifiedAddress: var_unifiedAddress,
       isSeedAnchor: var_isSeedAnchor,
+      isHardware: var_isHardware,
     );
   }
 
@@ -8829,6 +8832,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.name, serializer);
     sse_encode_String(self.unifiedAddress, serializer);
     sse_encode_bool(self.isSeedAnchor, serializer);
+    sse_encode_bool(self.isHardware, serializer);
   }
 
   @protected

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1350,26 +1350,6 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45824ce0dd12e91ec0c68ebae2a7ed8ae19b70946624c849add59f1d1a62a143"
-dependencies = [
- "arrayvec",
- "bitvec",
- "ff",
- "group",
- "halo2_poseidon",
- "halo2_proofs",
- "lazy_static",
- "pasta_curves",
- "rand",
- "sinsemilla",
- "subtle",
- "uint",
-]
-
-[[package]]
-name = "halo2_gadgets"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2a697cad929f706b7987fe804ad57d43622cd37463ba7e4d662a926fdcfea3"
@@ -1792,7 +1772,7 @@ checksum = "1d0a4887bb71d68b3d0c5db9d42bb76df38b0dff4d261b863dada6383b6c2012"
 dependencies = [
  "anyhow",
  "ff",
- "halo2_gadgets 0.5.0",
+ "halo2_gadgets",
  "hex",
  "pasta_curves",
  "rayon",
@@ -2222,7 +2202,7 @@ dependencies = [
  "fpe",
  "getset",
  "group",
- "halo2_gadgets 0.5.0",
+ "halo2_gadgets",
  "halo2_poseidon",
  "halo2_proofs",
  "hex",
@@ -3958,11 +3938,11 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree"
 version = "0.3.2"
-source = "git+https://github.com/valargroup/zcash_voting?rev=5b164d03cb12b1635deea589e575d461481fed72#5b164d03cb12b1635deea589e575d461481fed72"
+source = "git+https://github.com/valargroup/zcash_voting?rev=faf2bb29c120bf022fa7704f4c7b95909b5e9a2b#faf2bb29c120bf022fa7704f4c7b95909b5e9a2b"
 dependencies = [
  "anyhow",
  "ff",
- "halo2_gadgets 0.4.0",
+ "halo2_gadgets",
  "imt-tree",
  "incrementalmerkletree",
  "lazy_static",
@@ -3974,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.5.2"
-source = "git+https://github.com/valargroup/zcash_voting?rev=5b164d03cb12b1635deea589e575d461481fed72#5b164d03cb12b1635deea589e575d461481fed72"
+source = "git+https://github.com/valargroup/zcash_voting?rev=faf2bb29c120bf022fa7704f4c7b95909b5e9a2b#faf2bb29c120bf022fa7704f4c7b95909b5e9a2b"
 dependencies = [
  "base64",
  "ff",
@@ -3995,7 +3975,7 @@ dependencies = [
  "blake2b_simd",
  "ff",
  "group",
- "halo2_gadgets 0.5.0",
+ "halo2_gadgets",
  "halo2_poseidon",
  "halo2_proofs",
  "incrementalmerkletree",
@@ -4695,7 +4675,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "0.11.0"
-source = "git+https://github.com/valargroup/zcash_voting?rev=5b164d03cb12b1635deea589e575d461481fed72#5b164d03cb12b1635deea589e575d461481fed72"
+source = "git+https://github.com/valargroup/zcash_voting?rev=faf2bb29c120bf022fa7704f4c7b95909b5e9a2b#faf2bb29c120bf022fa7704f4c7b95909b5e9a2b"
 dependencies = [
  "anyhow",
  "base64",
@@ -4704,7 +4684,7 @@ dependencies = [
  "ed25519-dalek",
  "ff",
  "group",
- "halo2_gadgets 0.4.0",
+ "halo2_gadgets",
  "halo2_proofs",
  "hex",
  "http",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3938,7 +3938,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree"
 version = "0.3.2"
-source = "git+https://github.com/valargroup/zcash_voting?rev=faf2bb29c120bf022fa7704f4c7b95909b5e9a2b#faf2bb29c120bf022fa7704f4c7b95909b5e9a2b"
+source = "git+https://github.com/valargroup/zcash_voting?rev=38b0c738ee8773382a817a00166791210d4dcc6d#38b0c738ee8773382a817a00166791210d4dcc6d"
 dependencies = [
  "anyhow",
  "ff",
@@ -3954,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "vote-commitment-tree-client"
 version = "0.5.2"
-source = "git+https://github.com/valargroup/zcash_voting?rev=faf2bb29c120bf022fa7704f4c7b95909b5e9a2b#faf2bb29c120bf022fa7704f4c7b95909b5e9a2b"
+source = "git+https://github.com/valargroup/zcash_voting?rev=38b0c738ee8773382a817a00166791210d4dcc6d#38b0c738ee8773382a817a00166791210d4dcc6d"
 dependencies = [
  "base64",
  "ff",
@@ -4675,7 +4675,7 @@ dependencies = [
 [[package]]
 name = "zcash_voting"
 version = "0.11.0"
-source = "git+https://github.com/valargroup/zcash_voting?rev=faf2bb29c120bf022fa7704f4c7b95909b5e9a2b#faf2bb29c120bf022fa7704f4c7b95909b5e9a2b"
+source = "git+https://github.com/valargroup/zcash_voting?rev=38b0c738ee8773382a817a00166791210d4dcc6d#38b0c738ee8773382a817a00166791210d4dcc6d"
 dependencies = [
  "anyhow",
  "base64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ zcash_client_backend = { version = "0.23", features = [
 ] }
 zcash_client_sqlite = { version = "0.21", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 # Voting clients need PIR lookup support and vote-commitment-tree sync.
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "5b164d03cb12b1635deea589e575d461481fed72", package = "zcash_voting" }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "faf2bb29c120bf022fa7704f4c7b95909b5e9a2b", package = "zcash_voting" }
 # Must match versions used by zcash_client_sqlite to avoid type conflicts
 orchard = "0.14"
 sapling-crypto = { version = "0.7", default-features = false, features = ["circuit"] }
@@ -96,7 +96,7 @@ security-framework = { version = "3.7", features = ["OSX_10_15"] }
 [dev-dependencies]
 tempfile = "3"
 hex = "0.4"
-vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting", rev = "5b164d03cb12b1635deea589e575d461481fed72", package = "vote-commitment-tree" }
+vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting", rev = "faf2bb29c120bf022fa7704f4c7b95909b5e9a2b", package = "vote-commitment-tree" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ zcash_client_backend = { version = "0.23", features = [
 ] }
 zcash_client_sqlite = { version = "0.21", features = ["orchard", "transparent-inputs", "unstable", "serde"] }
 # Voting clients need PIR lookup support and vote-commitment-tree sync.
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "faf2bb29c120bf022fa7704f4c7b95909b5e9a2b", package = "zcash_voting" }
+zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "38b0c738ee8773382a817a00166791210d4dcc6d", package = "zcash_voting" }
 # Must match versions used by zcash_client_sqlite to avoid type conflicts
 orchard = "0.14"
 sapling-crypto = { version = "0.7", default-features = false, features = ["circuit"] }
@@ -96,7 +96,7 @@ security-framework = { version = "3.7", features = ["OSX_10_15"] }
 [dev-dependencies]
 tempfile = "3"
 hex = "0.4"
-vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting", rev = "faf2bb29c120bf022fa7704f4c7b95909b5e9a2b", package = "vote-commitment-tree" }
+vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting", rev = "38b0c738ee8773382a817a00166791210d4dcc6d", package = "vote-commitment-tree" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -27,6 +27,7 @@ pub struct AccountInfo {
     pub name: String,
     pub unified_address: String,
     pub is_seed_anchor: bool,
+    pub is_hardware: bool,
 }
 
 /// Catches panics and converts them to Result<T, String>.
@@ -205,6 +206,7 @@ pub fn list_accounts(db_path: String, network: String) -> Result<Vec<AccountInfo
                 name: a.name,
                 unified_address: a.unified_address,
                 is_seed_anchor: a.is_seed_anchor,
+                is_hardware: a.is_hardware,
             })
             .collect())
     })

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -4763,11 +4763,13 @@ impl SseDecode for crate::api::wallet::AccountInfo {
         let mut var_name = <String>::sse_decode(deserializer);
         let mut var_unifiedAddress = <String>::sse_decode(deserializer);
         let mut var_isSeedAnchor = <bool>::sse_decode(deserializer);
+        let mut var_isHardware = <bool>::sse_decode(deserializer);
         return crate::api::wallet::AccountInfo {
             uuid: var_uuid,
             name: var_name,
             unified_address: var_unifiedAddress,
             is_seed_anchor: var_isSeedAnchor,
+            is_hardware: var_isHardware,
         };
     }
 }
@@ -6712,6 +6714,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::wallet::AccountInfo {
             self.name.into_into_dart().into_dart(),
             self.unified_address.into_into_dart().into_dart(),
             self.is_seed_anchor.into_into_dart().into_dart(),
+            self.is_hardware.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -8419,6 +8422,7 @@ impl SseEncode for crate::api::wallet::AccountInfo {
         <String>::sse_encode(self.name, serializer);
         <String>::sse_encode(self.unified_address, serializer);
         <bool>::sse_encode(self.is_seed_anchor, serializer);
+        <bool>::sse_encode(self.is_hardware, serializer);
     }
 }
 

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -342,6 +342,7 @@ pub struct AccountInfo {
     pub name: String,
     pub unified_address: String,
     pub is_seed_anchor: bool,
+    pub is_hardware: bool,
 }
 
 /// List all accounts in the wallet database.
@@ -359,9 +360,12 @@ pub fn list_accounts(db_path: &str, network: WalletNetwork) -> Result<Vec<Accoun
             .map_err(|e| format!("Failed to get account: {e}"))?
             .ok_or_else(|| format!("Account not found: {}", id.expose_uuid()))?;
 
-        let address = match account.ufvk() {
-            Some(ufvk) => current_receive_address(&db, network, id, ufvk)?,
-            None => String::new(),
+        let (address, is_hardware) = match account.ufvk() {
+            Some(ufvk) => (
+                current_receive_address(&db, network, id, ufvk)?,
+                is_keystone_style_ufvk(ufvk),
+            ),
+            None => (String::new(), false),
         };
 
         accounts.push(AccountInfo {
@@ -369,6 +373,7 @@ pub fn list_accounts(db_path: &str, network: WalletNetwork) -> Result<Vec<Accoun
             name: account.name().unwrap_or("").to_string(),
             unified_address: address,
             is_seed_anchor: matches!(account.source(), AccountSource::Derived { .. }),
+            is_hardware,
         });
     }
 
@@ -612,6 +617,10 @@ fn current_receive_address(
     Ok(address.encode(&network))
 }
 
+fn is_keystone_style_ufvk(ufvk: &UnifiedFullViewingKey) -> bool {
+    ufvk.orchard().is_some() && ufvk.sapling().is_none()
+}
+
 /// Returns the standard shielded address request (Orchard + Sapling, no transparent).
 /// This matches the behavior of zodl/Zashi wallets.
 fn shielded_address_request() -> UnifiedAddressRequest {
@@ -835,6 +844,12 @@ mod tests {
             None,
         )
         .unwrap();
+        let listed_account = list_accounts(db_path_str, WalletNetwork::Main)
+            .unwrap()
+            .into_iter()
+            .find(|account| account.uuid == uuid)
+            .unwrap();
+        assert!(listed_account.is_hardware);
 
         crate::wallet::sync::update_chain_tip(db_path_str, WalletNetwork::Main, 2_500_000).unwrap();
         let shielded_error = crate::wallet::sync::get_next_available_address(
@@ -1207,6 +1222,12 @@ mod tests {
         let (_, address) =
             init_db_and_create_account(db_path_str, WalletNetwork::Main, &seed, None, "test")
                 .unwrap();
+        let listed_account = list_accounts(db_path_str, WalletNetwork::Main)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        assert!(!listed_account.is_hardware);
 
         // Decode and verify receiver types
         let za = zcash_address::ZcashAddress::try_from_encoded(&address).unwrap();

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -53,6 +53,29 @@ void main() {
     expect(merged.isSeedAnchor, isFalse);
   });
 
+  test('mergeBootstrappedAccountInfo recovers Rust hardware metadata', () {
+    const rustAccount = AccountInfo(
+      uuid: 'account-3',
+      name: 'Rust Keystone',
+      order: 1,
+      isHardware: true,
+    );
+    const storedAccount = AccountInfo(
+      uuid: 'account-3',
+      name: 'Stored Keystone',
+      order: 1,
+    );
+
+    final merged = mergeBootstrappedAccountInfo(
+      rustAccount: rustAccount,
+      storedAccount: storedAccount,
+      order: 1,
+    );
+
+    expect(merged.isHardware, isTrue);
+    expect(merged.name, 'Stored Keystone');
+  });
+
   test('empty bootstrap has no password rotation recovery failure', () {
     expect(AppBootstrapState.empty.passwordRotationRecoveryFailed, isFalse);
   });

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -2917,6 +2917,7 @@ void main() {
       ),
     );
     await _pumpUntilFound(tester, find.text('Sign bundle 1 of 2'));
+    expect(find.text('1 / 2'), findsNothing);
 
     await tester.tap(find.text('Scan signature'));
     await tester.pumpAndSettle();
@@ -2924,6 +2925,7 @@ void main() {
     await _pumpUntilFound(tester, find.text('Skip'));
 
     expect(find.text('Sign bundle 2 of 2'), findsOneWidget);
+    expect(find.text('2 / 2'), findsNothing);
     expect(find.text('Skip'), findsOneWidget);
 
     await tester.tap(find.text('Skip'));

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -241,7 +241,8 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'Voting requires at least one eligible shielded note bundle with '
+        '0.125 ZEC '
         'at snapshot block 123. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text(message));
 
@@ -300,7 +301,8 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'Voting requires at least one eligible shielded note bundle with '
+        '0.125 ZEC '
         'at snapshot block 123. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text(message));
 
@@ -342,7 +344,8 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'Voting requires at least one eligible shielded note bundle with '
+        '0.125 ZEC '
         'at snapshot block 123. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text(message));
 
@@ -459,7 +462,8 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'Voting requires at least one eligible shielded note bundle with '
+        '0.125 ZEC '
         'at snapshot block 3,359,740. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text(message));
 
@@ -1704,60 +1708,62 @@ void main() {
     expect(find.text('Review answers'), findsOneWidget);
   });
 
-  testWidgets('proposal detail shows read-only options when eligibility fails', (
-    tester,
-  ) async {
-    await tester.binding.setSurfaceSize(const Size(1152, 768));
-    addTearDown(() async {
-      await tester.binding.setSurfaceSize(null);
-    });
+  testWidgets(
+    'proposal detail shows read-only options when eligibility fails',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1152, 768));
+      addTearDown(() async {
+        await tester.binding.setSurfaceSize(null);
+      });
 
-    final recoveryApi = _MutableVotingRecoveryApi();
-    final container = _statusContainer(
-      accountOverride: _MnemonicAccountNotifier.new,
-      recoveryApi: recoveryApi,
-      rust: _MinimumVotingEligibilityRustApi(recoveryApi),
-      hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
-    );
-    addTearDown(container.dispose);
+      final recoveryApi = _MutableVotingRecoveryApi();
+      final container = _statusContainer(
+        accountOverride: _MnemonicAccountNotifier.new,
+        recoveryApi: recoveryApi,
+        rust: _MinimumVotingEligibilityRustApi(recoveryApi),
+        hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
+      );
+      addTearDown(container.dispose);
 
-    await tester.pumpWidget(
-      UncontrolledProviderScope(
-        container: container,
-        child: _proposalHarness(),
-      ),
-    );
-    await tester.pumpAndSettle();
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: _proposalHarness(),
+        ),
+      );
+      await tester.pumpAndSettle();
 
-    const message =
-        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
-        'at snapshot block 123. Switch to an eligible account to vote.';
-    await _pumpUntilFound(tester, find.text('Not eligible'));
+      const message =
+          'Voting requires at least one eligible shielded note bundle with '
+          '0.125 ZEC '
+          'at snapshot block 123. Switch to an eligible account to vote.';
+      await _pumpUntilFound(tester, find.text('Not eligible'));
 
-    expect(find.text(message), findsNothing);
-    expect(find.text('First proposal'), findsOneWidget);
-    expect(find.text('Voting power 0 ZEC'), findsOneWidget);
-    expect(find.text('Yes'), findsOneWidget);
-    expect(find.text('No'), findsOneWidget);
-    expect(find.text('Review answers'), findsNothing);
-    expect(find.text('Not eligible'), findsOneWidget);
+      expect(find.text(message), findsNothing);
+      expect(find.text('First proposal'), findsOneWidget);
+      expect(find.text('Voting power 0 ZEC'), findsOneWidget);
+      expect(find.text('Yes'), findsOneWidget);
+      expect(find.text('No'), findsOneWidget);
+      expect(find.text('Review answers'), findsNothing);
+      expect(find.text('Not eligible'), findsOneWidget);
 
-    await tester.tap(find.text('Yes'));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('Yes'));
+      await tester.pumpAndSettle();
 
-    expect(container.read(votingDraftProvider(_draftKey)).isEmpty, true);
-    expect(find.text('Not eligible for this voting round'), findsOneWidget);
-    expect(find.text(message), findsOneWidget);
+      expect(container.read(votingDraftProvider(_draftKey)).isEmpty, true);
+      expect(find.text('Not eligible for this voting round'), findsOneWidget);
+      expect(find.text(message), findsOneWidget);
 
-    await tester.tap(find.text('Done'));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('Done'));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Not eligible'));
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('Not eligible'));
+      await tester.pumpAndSettle();
 
-    expect(find.text('Not eligible for this voting round'), findsOneWidget);
-    expect(find.text(message), findsOneWidget);
-  });
+      expect(find.text('Not eligible for this voting round'), findsOneWidget);
+      expect(find.text(message), findsOneWidget);
+    },
+  );
 
   testWidgets('proposal detail hides completed vote when eligibility fails', (
     tester,
@@ -1800,7 +1806,8 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'Voting requires at least one eligible shielded note bundle with '
+        '0.125 ZEC '
         'at snapshot block 123. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text('Not eligible'));
 
@@ -1854,7 +1861,8 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'Voting requires at least one eligible shielded note bundle with '
+        '0.125 ZEC '
         'at snapshot block 123. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text('Not eligible'));
 
@@ -1895,7 +1903,8 @@ void main() {
     await tester.pumpAndSettle();
 
     const message =
-        'Voting requires at least 5 eligible shielded notes totaling 0.125 ZEC '
+        'Voting requires at least one eligible shielded note bundle with '
+        '0.125 ZEC '
         'at snapshot block 123. Switch to an eligible account to vote.';
     await _pumpUntilFound(tester, find.text(message));
 
@@ -3767,9 +3776,11 @@ class _FailingEligibilityVotingSessionNotifier
   @override
   Future<BigInt?> refreshEligibleWeight() async {
     throw Exception(
-      'Invalid input: minimum voting eligibility requires at least 5 eligible '
-      'notes and 12500000 zatoshi voting weight; selected 2 distinct eligible '
-      'notes with 25000000 zatoshi voting weight at snapshot height 3359740',
+      'Invalid input: minimum voting eligibility requires at least one '
+      'eligible voting bundle with 12500000 zatoshi voting weight; selected 0 '
+      'distinct notes across eligible bundles with 0 zatoshi eligible bundle '
+      'weight at snapshot height '
+      '3359740',
     );
   }
 }
@@ -3958,7 +3969,7 @@ class _MinimumVotingEligibilityRustApi extends _VotingStatusRustApi {
     return rust_api.ApiVotingEligibility(
       isEligible: false,
       distinctNoteCount: 2,
-      eligibleWeightZatoshi: BigInt.from(25000000),
+      eligibleWeightZatoshi: BigInt.from(100),
     );
   }
 }

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -6205,9 +6205,7 @@ class FakeVotingRustApi implements VotingRustApi {
     eligibilityCheckCalls++;
     eligibilityAccountUuids.add(ctx.accountUuid);
     return rust_api.ApiVotingEligibility(
-      isEligible:
-          eligibilityEligible ??
-          (eligibilityDistinctNoteCount >= 5 && setupEligibleWeight > 0),
+      isEligible: eligibilityEligible ?? setupEligibleWeight > 0,
       distinctNoteCount: eligibilityDistinctNoteCount,
       eligibleWeightZatoshi: BigInt.from(setupEligibleWeight),
     );


### PR DESCRIPTION
Updates Vizor to the shared voting eligibility fix and changes the in-app copy to describe the real bundle-level rule. It also restores Keystone voting after relaunch by carrying Rust hardware account metadata through bootstrap, so Keystone accounts do not fall back to the software mnemonic path when stored account metadata is stale.

Validation: focused voting status tests, voting provider Keystone reload test, bootstrap metadata test, Rust account classification tests, and flutter analyze.