### PR TITLE
Polish voting review and results metadata

### DIFF
--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -6,6 +6,7 @@ import '../../providers/account_provider.dart';
 import '../../providers/app_security_provider.dart';
 import '../../providers/sync_failure.dart';
 import '../../providers/sync_provider.dart';
+import '../../providers/voting/voting_rounds_provider.dart';
 import '../../providers/voting/voting_submission_guard_provider.dart';
 import '../config/swap_feature_config.dart';
 import '../profile_pictures.dart';
@@ -39,7 +40,12 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
   }
 
   void _navigateTo(String routePath) {
-    if (_matches(routePath)) return;
+    if (_matches(routePath)) {
+      if (routePath == '/voting') {
+        ref.read(votingPollListRefreshRequestProvider.notifier).request();
+      }
+      return;
+    }
     context.go(routePath);
   }
 
@@ -150,9 +156,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                     label: 'Vote',
                     iconName: AppIcons.scroll,
                     active: _matches('/voting'),
-                    onTap: _matches('/voting')
-                        ? null
-                        : () => _navigateTo('/voting'),
+                    onTap: () => _navigateTo('/voting'),
                   ),
                   const SizedBox(height: AppSpacing.xs),
                   AppSidebarItem(

--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -35,10 +35,12 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
   bool _showSettings = false;
   bool _entryRefreshInFlight = true;
   bool _pollListRefreshInFlight = false;
+  Timer? _autoRefreshTimer;
 
   @override
   void initState() {
     super.initState();
+    _startAutoRefreshTimer();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       if (_wasPollListRecentlyRefreshed()) {
@@ -54,6 +56,12 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
       }
       _reloadRoundsWithFreshConfig(entryRefresh: true);
     });
+  }
+
+  @override
+  void dispose() {
+    _stopAutoRefreshTimer();
+    super.dispose();
   }
 
   @override
@@ -200,9 +208,11 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
   }
 
   void _pushRoundRoute(String route) {
+    _stopAutoRefreshTimer();
     unawaited(
       context.push(route).whenComplete(() {
         if (!mounted) return;
+        _startAutoRefreshTimer();
         _reloadRoundsWithFreshConfig();
       }),
     );
@@ -233,6 +243,19 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
   void _handleExternalRefreshRequest() {
     if (!mounted) return;
     _reloadRoundsWithFreshConfig();
+  }
+
+  void _startAutoRefreshTimer() {
+    if (_autoRefreshTimer != null) return;
+    _autoRefreshTimer = Timer.periodic(kVotingPollListAutoRefreshInterval, (_) {
+      if (!mounted) return;
+      _reloadRoundsWithFreshConfig();
+    });
+  }
+
+  void _stopAutoRefreshTimer() {
+    _autoRefreshTimer?.cancel();
+    _autoRefreshTimer = null;
   }
 
   bool _wasPollListRecentlyRefreshed() {

--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -58,6 +58,9 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<int>(votingPollListRefreshRequestProvider, (_, _) {
+      _handleExternalRefreshRequest();
+    });
     final rounds = ref.watch(votingRoundsProvider);
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
@@ -206,6 +209,9 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
   }
 
   void _reloadRoundsWithFreshConfig({bool entryRefresh = false}) {
+    if (!entryRefresh && (_entryRefreshInFlight || _pollListRefreshInFlight)) {
+      return;
+    }
     if (!entryRefresh && ref.read(votingRoundsProvider).hasValue) {
       setState(() {
         _pollListRefreshInFlight = true;
@@ -222,6 +228,11 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
         });
       }),
     );
+  }
+
+  void _handleExternalRefreshRequest() {
+    if (!mounted) return;
+    _reloadRoundsWithFreshConfig();
   }
 
   bool _wasPollListRecentlyRefreshed() {

--- a/lib/src/features/voting/screens/voting_polls_screen.dart
+++ b/lib/src/features/voting/screens/voting_polls_screen.dart
@@ -35,12 +35,10 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
   bool _showSettings = false;
   bool _entryRefreshInFlight = true;
   bool _pollListRefreshInFlight = false;
-  Timer? _autoRefreshTimer;
 
   @override
   void initState() {
     super.initState();
-    _startAutoRefreshTimer();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       if (_wasPollListRecentlyRefreshed()) {
@@ -56,12 +54,6 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
       }
       _reloadRoundsWithFreshConfig(entryRefresh: true);
     });
-  }
-
-  @override
-  void dispose() {
-    _stopAutoRefreshTimer();
-    super.dispose();
   }
 
   @override
@@ -208,11 +200,9 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
   }
 
   void _pushRoundRoute(String route) {
-    _stopAutoRefreshTimer();
     unawaited(
       context.push(route).whenComplete(() {
         if (!mounted) return;
-        _startAutoRefreshTimer();
         _reloadRoundsWithFreshConfig();
       }),
     );
@@ -243,19 +233,6 @@ class _VotingPollsScreenState extends ConsumerState<VotingPollsScreen> {
   void _handleExternalRefreshRequest() {
     if (!mounted) return;
     _reloadRoundsWithFreshConfig();
-  }
-
-  void _startAutoRefreshTimer() {
-    if (_autoRefreshTimer != null) return;
-    _autoRefreshTimer = Timer.periodic(kVotingPollListAutoRefreshInterval, (_) {
-      if (!mounted) return;
-      _reloadRoundsWithFreshConfig();
-    });
-  }
-
-  void _stopAutoRefreshTimer() {
-    _autoRefreshTimer?.cancel();
-    _autoRefreshTimer = null;
   }
 
   bool _wasPollListRecentlyRefreshed() {

--- a/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
+++ b/lib/src/features/voting/screens/voting_proposal_detail_screen.dart
@@ -16,7 +16,6 @@ import '../../../providers/voting/voting_session_provider.dart';
 import '../../../providers/voting/voting_tree_sync_provider.dart';
 import '../../../providers/voting/voting_state.dart';
 import '../../../rust/third_party/zcash_voting/wire.dart' as rust_wire;
-import '../voting_choice_style.dart';
 import '../voting_error_messages.dart';
 import '../voting_flow_models.dart';
 import '../voting_formatters.dart';
@@ -385,8 +384,6 @@ class _ActivePollContent extends StatefulWidget {
 }
 
 class _ActivePollContentState extends State<_ActivePollContent> {
-  bool _descriptionExpanded = false;
-
   Future<void> _showIneligibleDialog() async {
     final message = widget.votingEligibilityErrorMessage;
     if (message == null) return;
@@ -485,10 +482,6 @@ class _ActivePollContentState extends State<_ActivePollContent> {
                         votingPowerPreparing: widget.votingPowerPreparing,
                         votingEligibilityMessage:
                             widget.votingEligibilityMessage,
-                        expanded: _descriptionExpanded,
-                        onToggleDescription: () => setState(() {
-                          _descriptionExpanded = !_descriptionExpanded;
-                        }),
                       );
                     }
                     if (index == widget.proposals.length + 1) {
@@ -514,7 +507,7 @@ class _ActivePollContentState extends State<_ActivePollContent> {
                     final isIneligible =
                         !widget.votingEligibilityConfirmed &&
                         widget.votingEligibilityErrorMessage != null;
-                    return _ProposalCard(
+                    return VotingProposalCard(
                       proposal: proposal,
                       selectedChoice: widget.votingEligibilityConfirmed
                           ? widget.draft.choices[proposal.id]
@@ -699,8 +692,6 @@ class _PollSummary extends StatelessWidget {
     required this.votingPowerZatoshi,
     required this.votingPowerPreparing,
     required this.votingEligibilityMessage,
-    required this.expanded,
-    required this.onToggleDescription,
   });
 
   final String title;
@@ -711,8 +702,6 @@ class _PollSummary extends StatelessWidget {
   final BigInt? votingPowerZatoshi;
   final bool votingPowerPreparing;
   final String? votingEligibilityMessage;
-  final bool expanded;
-  final VoidCallback onToggleDescription;
 
   @override
   Widget build(BuildContext context) {
@@ -796,37 +785,7 @@ class _PollSummary extends StatelessWidget {
         ],
         if (hasDescription) ...[
           const SizedBox(height: AppSpacing.xs),
-          LayoutBuilder(
-            builder: (context, constraints) {
-              final canExpand = _textExceedsSingleLine(
-                context: context,
-                text: description,
-                style: descriptionStyle,
-                maxWidth: constraints.maxWidth,
-              );
-              return Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    description,
-                    maxLines: expanded || !canExpand ? null : 1,
-                    overflow: expanded || !canExpand
-                        ? TextOverflow.visible
-                        : TextOverflow.ellipsis,
-                    style: descriptionStyle,
-                  ),
-                  if (canExpand)
-                    Align(
-                      alignment: Alignment.centerRight,
-                      child: _ViewMoreButton(
-                        expanded: expanded,
-                        onPressed: onToggleDescription,
-                      ),
-                    ),
-                ],
-              );
-            },
-          ),
+          VotingExpandableText(text: description, style: descriptionStyle),
         ],
         if (forumUri != null) ...[
           const SizedBox(height: AppSpacing.xs),
@@ -836,63 +795,6 @@ class _PollSummary extends StatelessWidget {
           ),
         ],
       ],
-    );
-  }
-}
-
-bool _textExceedsSingleLine({
-  required BuildContext context,
-  required String text,
-  required TextStyle style,
-  required double maxWidth,
-}) {
-  if (!maxWidth.isFinite || maxWidth <= 0) return false;
-  final textPainter = TextPainter(
-    text: TextSpan(text: text, style: style),
-    textDirection: Directionality.of(context),
-    textScaler: MediaQuery.textScalerOf(context),
-    maxLines: 1,
-  )..layout(maxWidth: maxWidth);
-  return textPainter.didExceedMaxLines;
-}
-
-class _ViewMoreButton extends StatelessWidget {
-  const _ViewMoreButton({required this.expanded, required this.onPressed});
-
-  final bool expanded;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: onPressed,
-      child: Padding(
-        padding: const EdgeInsets.only(top: AppSpacing.xxs),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              expanded ? 'View less' : 'View more',
-              style: AppTypography.bodyMediumStrong.copyWith(
-                color: colors.text.accent,
-                height: 20 / 14,
-                letterSpacing: 0,
-              ),
-            ),
-            const SizedBox(width: AppSpacing.xxs),
-            Transform.rotate(
-              angle: expanded ? -1.5708 : 1.5708,
-              child: AppIcon(
-                AppIcons.chevronForward,
-                size: 16,
-                color: colors.icon.accent,
-              ),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }
@@ -965,16 +867,21 @@ class _VotedPollContent extends StatelessWidget {
           ),
         ),
         const SizedBox(height: AppSpacing.s),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
-          child: _VotedPollHeader(
-            title: roundTitle,
-            snapshotHeight: snapshotHeight,
-            description: description,
-            forumUri: forumUri,
-            votingPowerZatoshi: votingPowerZatoshi,
-            votingPowerPreparing: votingPowerPreparing,
-            votedAt: votedAt,
+        Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 560),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+              child: _VotedPollHeader(
+                title: roundTitle,
+                snapshotHeight: snapshotHeight,
+                description: description,
+                forumUri: forumUri,
+                votingPowerZatoshi: votingPowerZatoshi,
+                votingPowerPreparing: votingPowerPreparing,
+                votedAt: votedAt,
+              ),
+            ),
           ),
         ),
         const SizedBox(height: AppSpacing.md),
@@ -997,9 +904,13 @@ class _VotedPollContent extends StatelessWidget {
                       const SizedBox(height: AppSpacing.s),
                   itemBuilder: (context, index) {
                     final proposal = proposals[index];
-                    return _VotedProposalCard(
+                    final choice = choicesByProposalId[proposal.id];
+                    return VotingProposalCard(
                       proposal: proposal,
-                      choice: choicesByProposalId[proposal.id],
+                      fallbackForumUri: forumUri,
+                      selectedChoice: choice,
+                      readOnly: true,
+                      statusLabel: choice == null ? 'Skipped' : null,
                     );
                   },
                 ),
@@ -1069,10 +980,8 @@ class _PendingVoteContent extends StatelessWidget {
                   ),
                   if (description.isNotEmpty) ...[
                     const SizedBox(height: AppSpacing.xs),
-                    Text(
-                      description,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
+                    VotingExpandableText(
+                      text: description,
                       style: AppTypography.bodyMedium.copyWith(
                         color: colors.text.secondary,
                       ),
@@ -1141,26 +1050,25 @@ class _VotedPollHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final titleStyle = AppTypography.headlineMedium.copyWith(
+      color: colors.text.accent,
+      fontFamily: 'Geist',
+      fontWeight: FontWeight.w600,
+      fontSize: 20,
+      height: 30 / 20,
+      letterSpacing: 0,
+    );
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Expanded(
-              child: Text(
-                title,
-                style: AppTypography.headlineMedium.copyWith(
-                  color: colors.text.accent,
-                ),
-              ),
-            ),
+            Expanded(child: Text(title, style: titleStyle)),
             const SizedBox(width: AppSpacing.sm),
             Text(
               '#${formatGroupedInteger(snapshotHeight)}',
-              style: AppTypography.headlineSmall.copyWith(
-                color: colors.text.accent,
-              ),
+              style: titleStyle.copyWith(fontWeight: FontWeight.w500),
             ),
           ],
         ),
@@ -1185,10 +1093,8 @@ class _VotedPollHeader extends StatelessWidget {
         ),
         if (description.isNotEmpty) ...[
           const SizedBox(height: AppSpacing.xs),
-          Text(
-            description,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
+          VotingExpandableText(
+            text: description,
             style: AppTypography.bodyMedium.copyWith(
               color: colors.text.secondary,
             ),
@@ -1258,200 +1164,6 @@ class _VotingPowerMeta extends StatelessWidget {
   }
 }
 
-class _VotedProposalCard extends StatelessWidget {
-  const _VotedProposalCard({required this.proposal, required this.choice});
-
-  final VotingProposalView proposal;
-  final int? choice;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    final choiceLabel = _choiceLabel(proposal, choice);
-    final zipBadges = proposal.zipBadges;
-    final forumUri = proposal.forumUri;
-    return Container(
-      padding: const EdgeInsets.all(AppSpacing.sm),
-      decoration: BoxDecoration(
-        color: colors.background.base,
-        borderRadius: BorderRadius.circular(AppRadii.medium),
-        border: Border.all(color: colors.border.subtle),
-        boxShadow: [
-          BoxShadow(
-            color: colors.background.neutralScrim.withValues(alpha: 0.12),
-            offset: const Offset(0, 8),
-            blurRadius: 18,
-            spreadRadius: -12,
-          ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              VotingMetadataBadge('Proposal ${proposal.id}'),
-              const SizedBox(width: AppSpacing.xs),
-              Expanded(
-                child: Align(
-                  alignment: Alignment.centerRight,
-                  child: _ChoiceBadge(choiceLabel),
-                ),
-              ),
-            ],
-          ),
-          if (zipBadges.isNotEmpty || forumUri != null) ...[
-            const SizedBox(height: AppSpacing.s),
-            VotingProposalMetadataRow(zipBadges: zipBadges, forumUri: forumUri),
-          ],
-          const SizedBox(height: AppSpacing.s),
-          Text(
-            proposal.title,
-            style: AppTypography.headlineSmall.copyWith(
-              color: colors.text.accent,
-            ),
-          ),
-          if (proposal.description.isNotEmpty) ...[
-            const SizedBox(height: AppSpacing.xxs),
-            Text(
-              proposal.description,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: AppTypography.bodySmall.copyWith(
-                color: colors.text.secondary,
-              ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _ChoiceBadge extends StatelessWidget {
-  const _ChoiceBadge(this.label);
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    final palette = votingChoicePalette(context, label);
-    return Container(
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.xs,
-        vertical: 2,
-      ),
-      decoration: BoxDecoration(
-        color: palette.background,
-        borderRadius: BorderRadius.circular(AppRadii.xSmall),
-        border: Border.all(color: palette.border),
-      ),
-      child: Text(
-        label,
-        maxLines: 2,
-        overflow: TextOverflow.ellipsis,
-        style: AppTypography.labelMedium.copyWith(color: palette.text),
-      ),
-    );
-  }
-}
-
-class _ProposalCard extends StatelessWidget {
-  const _ProposalCard({
-    required this.proposal,
-    required this.selectedChoice,
-    required this.enabled,
-    required this.onDisabledOptionTap,
-    required this.onChoice,
-  });
-
-  final VotingProposalView proposal;
-  final int? selectedChoice;
-  final bool enabled;
-  final VoidCallback? onDisabledOptionTap;
-  final ValueChanged<int?> onChoice;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    final zipBadges = proposal.zipBadges;
-    final forumUri = proposal.forumUri;
-    return Container(
-      padding: const EdgeInsets.all(AppSpacing.sm),
-      decoration: BoxDecoration(
-        color: colors.background.ground,
-        borderRadius: BorderRadius.circular(AppRadii.medium),
-        border: Border.all(color: colors.border.subtle),
-        boxShadow: const [
-          BoxShadow(
-            color: Color(0x0A231F20),
-            offset: Offset(0, 1),
-            blurRadius: 1,
-            spreadRadius: -0.5,
-          ),
-          BoxShadow(
-            color: Color(0x0A231F20),
-            offset: Offset(0, 3),
-            blurRadius: 3,
-            spreadRadius: -1.5,
-          ),
-          BoxShadow(
-            color: Color(0x0A231F20),
-            offset: Offset(0, 24),
-            blurRadius: 24,
-            spreadRadius: -12,
-          ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (zipBadges.isNotEmpty || forumUri != null) ...[
-            VotingProposalMetadataRow(zipBadges: zipBadges, forumUri: forumUri),
-            const SizedBox(height: AppSpacing.s),
-          ],
-          Text(
-            proposal.title,
-            style: AppTypography.headlineSmall.copyWith(
-              color: colors.text.accent,
-              fontWeight: FontWeight.w600,
-              height: 24 / 16,
-              letterSpacing: 0,
-            ),
-          ),
-          if (proposal.description.isNotEmpty) ...[
-            const SizedBox(height: AppSpacing.xxs),
-            Text(
-              proposal.description,
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: AppTypography.bodySmall.copyWith(
-                color: colors.text.secondary,
-                height: 16 / 12,
-                letterSpacing: 0,
-              ),
-            ),
-          ],
-          const SizedBox(height: AppSpacing.s),
-          for (final option in proposal.options) ...[
-            _OptionRow(
-              option: option,
-              selected: selectedChoice == option.index,
-              enabled: enabled,
-              onDisabledTap: onDisabledOptionTap,
-              onTap: () => onChoice(
-                selectedChoice == option.index ? null : option.index,
-              ),
-            ),
-            if (option != proposal.options.last)
-              const SizedBox(height: AppSpacing.xs),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
 class _CompletedVote {
   const _CompletedVote({
     required this.choicesByProposalId,
@@ -1510,16 +1222,6 @@ class _PendingVoteRecovery {
   }
 }
 
-String _choiceLabel(VotingProposalView proposal, int? choice) {
-  if (choice == null) return 'Skipped';
-  return proposal.options
-      .firstWhere(
-        (option) => option.index == choice,
-        orElse: () => VotingOptionView(index: choice, label: 'Choice $choice'),
-      )
-      .label;
-}
-
 String _roundDescription(Map<String, dynamic> json) {
   for (final key in const ['description', 'body', 'summary']) {
     final value = json[key];
@@ -1543,96 +1245,6 @@ String _daysLeftLabel(DateTime endDate) {
   if (days <= 0) return 'Ends today';
   if (days == 1) return '1 day left';
   return '$days days left';
-}
-
-class _OptionRow extends StatelessWidget {
-  const _OptionRow({
-    required this.option,
-    required this.selected,
-    required this.enabled,
-    required this.onDisabledTap,
-    required this.onTap,
-  });
-
-  final VotingOptionView option;
-  final bool selected;
-  final bool enabled;
-  final VoidCallback? onDisabledTap;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    final description = option.description.trim();
-    final palette = votingChoicePalette(context, option.label);
-    final primaryTextColor = enabled
-        ? selected
-              ? palette.text
-              : colors.text.accent
-        : colors.text.secondary.withValues(alpha: 0.56);
-    final secondaryTextColor = enabled
-        ? selected
-              ? palette.text.withValues(alpha: 0.82)
-              : colors.text.secondary
-        : colors.text.secondary.withValues(alpha: 0.48);
-    return InkWell(
-      borderRadius: BorderRadius.circular(AppRadii.small),
-      onTap: enabled ? onTap : onDisabledTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSpacing.sm,
-          vertical: AppSpacing.xs,
-        ),
-        decoration: BoxDecoration(
-          color: enabled && selected
-              ? palette.background
-              : colors.background.neutralSubtleOpacity,
-          borderRadius: BorderRadius.circular(AppRadii.small),
-          border: Border.all(
-            color: enabled && selected ? palette.border : colors.border.subtle,
-          ),
-        ),
-        child: Row(
-          crossAxisAlignment: description.isEmpty
-              ? CrossAxisAlignment.center
-              : CrossAxisAlignment.start,
-          children: [
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    option.label,
-                    style: AppTypography.labelLarge.copyWith(
-                      color: primaryTextColor,
-                    ),
-                  ),
-                  if (description.isNotEmpty) ...[
-                    const SizedBox(height: AppSpacing.xxs),
-                    Text(
-                      description,
-                      style: AppTypography.bodySmall.copyWith(
-                        color: secondaryTextColor,
-                        height: 16 / 12,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-            const SizedBox(width: AppSpacing.sm),
-            Text(
-              selected ? 'Selected' : 'Choose',
-              style: AppTypography.bodySmall.copyWith(
-                color: enabled && selected ? palette.text : secondaryTextColor,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
 }
 
 class _Message extends StatelessWidget {

--- a/lib/src/features/voting/screens/voting_results_screen.dart
+++ b/lib/src/features/voting/screens/voting_results_screen.dart
@@ -9,7 +9,6 @@ import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/layout/app_main_sidebar.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
-import '../../../core/widgets/app_icon.dart';
 import '../../../providers/voting/voting_config_provider.dart';
 import '../../../providers/voting/voting_service_providers.dart';
 import '../../../providers/voting/voting_session_provider.dart';
@@ -119,7 +118,7 @@ class _VotingResultsScreenState extends ConsumerState<VotingResultsScreen> {
                   }
                   _clearPendingTallyRefresh();
                   return VotingPaneScrollView(
-                    maxWidth: 720,
+                    maxWidth: 560,
                     scrollPadding: const EdgeInsets.only(bottom: AppSpacing.md),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -149,6 +148,9 @@ class _VotingResultsScreenState extends ConsumerState<VotingResultsScreen> {
                                     : AppSpacing.s,
                               ),
                               child: _ResultCard(
+                                key: ValueKey(
+                                  'voting-result-card-${proposals[index].id}',
+                                ),
                                 proposal: proposals[index],
                                 tally: _proposalTally(
                                   result.rawJson,
@@ -192,7 +194,7 @@ class _VotingResultsScreenState extends ConsumerState<VotingResultsScreen> {
   }
 }
 
-class _ResultsHeader extends StatefulWidget {
+class _ResultsHeader extends StatelessWidget {
   const _ResultsHeader({
     required this.title,
     required this.snapshotHeight,
@@ -206,25 +208,9 @@ class _ResultsHeader extends StatefulWidget {
   final Uri? forumUri;
 
   @override
-  State<_ResultsHeader> createState() => _ResultsHeaderState();
-}
-
-class _ResultsHeaderState extends State<_ResultsHeader> {
-  bool _descriptionExpanded = false;
-
-  @override
-  void didUpdateWidget(covariant _ResultsHeader oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.description != widget.description ||
-        oldWidget.forumUri != widget.forumUri) {
-      _descriptionExpanded = false;
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final description = widget.description.trim();
+    final description = this.description.trim();
     final descriptionStyle = AppTypography.bodyMedium.copyWith(
       color: colors.text.secondary,
       height: 20 / 14,
@@ -247,7 +233,7 @@ class _ResultsHeaderState extends State<_ResultsHeader> {
           children: [
             Expanded(
               child: Text(
-                widget.title,
+                title,
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
                 style: titleStyle,
@@ -255,54 +241,20 @@ class _ResultsHeaderState extends State<_ResultsHeader> {
             ),
             const SizedBox(width: AppSpacing.sm),
             Text(
-              '#${formatGroupedInteger(widget.snapshotHeight)}',
+              '#${formatGroupedInteger(snapshotHeight)}',
               style: titleStyle.copyWith(fontWeight: FontWeight.w500),
             ),
           ],
         ),
         if (description.isNotEmpty) ...[
           const SizedBox(height: AppSpacing.xs),
-          LayoutBuilder(
-            builder: (context, constraints) {
-              final canExpand = _textExceedsSingleLine(
-                context: context,
-                text: description,
-                style: descriptionStyle,
-                maxWidth: constraints.maxWidth,
-              );
-              return Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    description,
-                    maxLines: _descriptionExpanded || !canExpand ? null : 1,
-                    overflow: _descriptionExpanded || !canExpand
-                        ? TextOverflow.visible
-                        : TextOverflow.ellipsis,
-                    style: descriptionStyle,
-                  ),
-                  if (canExpand)
-                    Align(
-                      alignment: Alignment.centerRight,
-                      child: _ViewMoreButton(
-                        expanded: _descriptionExpanded,
-                        onPressed: () {
-                          setState(() {
-                            _descriptionExpanded = !_descriptionExpanded;
-                          });
-                        },
-                      ),
-                    ),
-                ],
-              );
-            },
-          ),
+          VotingExpandableText(text: description, style: descriptionStyle),
         ],
-        if (widget.forumUri != null) ...[
+        if (forumUri != null) ...[
           const SizedBox(height: AppSpacing.xs),
           Align(
             alignment: Alignment.centerRight,
-            child: VotingForumLinkButton(uri: widget.forumUri!),
+            child: VotingForumLinkButton(uri: forumUri!),
           ),
         ],
       ],
@@ -312,6 +264,7 @@ class _ResultsHeaderState extends State<_ResultsHeader> {
 
 class _ResultCard extends StatelessWidget {
   const _ResultCard({
+    super.key,
     required this.proposal,
     required this.tally,
     required this.selectedChoice,
@@ -372,8 +325,6 @@ class _ResultCard extends StatelessWidget {
               highlighted: option.index == winningOption,
             ),
           if (selectedLabel != null || total > 0) ...[
-            const SizedBox(height: AppSpacing.xs),
-            Container(height: 1, color: context.colors.border.subtle),
             const SizedBox(height: AppSpacing.xs),
             Row(
               children: [
@@ -483,47 +434,6 @@ class _TallyProgressBar extends StatelessWidget {
   }
 }
 
-class _ViewMoreButton extends StatelessWidget {
-  const _ViewMoreButton({required this.expanded, required this.onPressed});
-
-  final bool expanded;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return GestureDetector(
-      behavior: HitTestBehavior.opaque,
-      onTap: onPressed,
-      child: Padding(
-        padding: const EdgeInsets.only(top: AppSpacing.xxs),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              expanded ? 'View less' : 'View more',
-              style: AppTypography.bodyMediumStrong.copyWith(
-                color: colors.text.accent,
-                height: 20 / 14,
-                letterSpacing: 0,
-              ),
-            ),
-            const SizedBox(width: AppSpacing.xxs),
-            Transform.rotate(
-              angle: expanded ? -1.5708 : 1.5708,
-              child: AppIcon(
-                AppIcons.chevronForward,
-                size: 16,
-                color: colors.icon.accent,
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
 class _Message extends StatelessWidget {
   const _Message(this.message);
 
@@ -584,22 +494,6 @@ int? _selectedChoiceForProposal(VotingSessionState? state, int proposalId) {
     if (choice.proposalId == proposalId) return choice.choice;
   }
   return null;
-}
-
-bool _textExceedsSingleLine({
-  required BuildContext context,
-  required String text,
-  required TextStyle style,
-  required double maxWidth,
-}) {
-  if (!maxWidth.isFinite || maxWidth <= 0) return false;
-  final textPainter = TextPainter(
-    text: TextSpan(text: text, style: style),
-    textDirection: Directionality.of(context),
-    textScaler: MediaQuery.textScalerOf(context),
-    maxLines: 1,
-  )..layout(maxWidth: maxWidth);
-  return textPainter.didExceedMaxLines;
 }
 
 Map<int, num> _proposalTally(Map<String, dynamic> json, int proposalId) {

--- a/lib/src/features/voting/screens/voting_review_screen.dart
+++ b/lib/src/features/voting/screens/voting_review_screen.dart
@@ -11,12 +11,12 @@ import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../providers/voting/voting_session_provider.dart';
 import '../../../providers/voting/voting_state.dart';
-import '../voting_choice_style.dart';
 import '../voting_error_messages.dart';
 import '../voting_flow_models.dart';
 import '../voting_poll_ordering.dart';
 import '../voting_routes.dart';
 import '../widgets/voting_metadata_widgets.dart';
+import '../widgets/voting_pane_scroll_area.dart';
 
 class VotingReviewScreen extends ConsumerStatefulWidget {
   const VotingReviewScreen({super.key, required this.roundId});
@@ -131,7 +131,7 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
     return AppDesktopShell(
       sidebar: const AppMainSidebar(),
       pane: AppDesktopPane(
-        padding: const EdgeInsets.all(AppSpacing.md),
+        padding: EdgeInsets.zero,
         child: session.when(
           skipLoadingOnRefresh: false,
           loading: () => const Center(child: CircularProgressIndicator()),
@@ -181,86 +181,66 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
             return Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
+                const Padding(
+                  padding: EdgeInsets.fromLTRB(
+                    AppSpacing.md,
+                    AppSpacing.md,
+                    AppSpacing.md,
+                    0,
+                  ),
+                  child: Align(
+                    alignment: Alignment.centerLeft,
+                    child: AppRouteBackLink(minWidth: 60),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.s),
                 Expanded(
-                  child: LayoutBuilder(
-                    builder: (context, scrollConstraints) {
-                      return SingleChildScrollView(
-                        child: ConstrainedBox(
-                          constraints: BoxConstraints(
-                            minHeight: scrollConstraints.maxHeight,
-                          ),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.stretch,
-                            children: [
-                              const SizedBox(
-                                height: AppBackLink.height,
-                                child: Align(
-                                  alignment: Alignment.centerLeft,
-                                  child: AppRouteBackLink(minWidth: 60),
-                                ),
-                              ),
-                              const SizedBox(height: AppSpacing.s),
-                              Center(
-                                child: ConstrainedBox(
-                                  constraints: const BoxConstraints(
-                                    maxWidth: 620,
-                                  ),
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.stretch,
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      Text(
-                                        'Review your answers',
-                                        textAlign: TextAlign.center,
-                                        style: AppTypography.displaySmall
-                                            .copyWith(
-                                              color: context.colors.text.accent,
-                                            ),
-                                      ),
-                                      if (roundForumUri != null) ...[
-                                        const SizedBox(height: AppSpacing.xs),
-                                        Align(
-                                          alignment: Alignment.centerRight,
-                                          child: VotingForumLinkButton(
-                                            uri: roundForumUri,
-                                          ),
-                                        ),
-                                      ],
-                                      const SizedBox(height: AppSpacing.md),
-                                      if (state.hasConfirmedVotingEligibility)
-                                        for (final proposal in proposals)
-                                          _ReviewRow(
-                                            proposal: proposal,
-                                            value: _reviewValue(
-                                              proposal,
-                                              draft,
-                                            ),
-                                            skipped:
-                                                draft.choices[proposal.id] ==
-                                                null,
-                                          ),
-                                      if (state.hasConfirmedVotingEligibility &&
-                                          draft.isEmpty) ...[
-                                        const SizedBox(height: AppSpacing.xs),
-                                        const _Message(
-                                          'Choose at least one option before submitting.',
-                                        ),
-                                      ],
-                                      if (eligibilityMessage != null) ...[
-                                        const SizedBox(height: AppSpacing.xs),
-                                        _Message(eligibilityMessage),
-                                      ],
-                                    ],
-                                  ),
-                                ),
-                              ),
-                              const SizedBox(height: AppSpacing.md),
-                            ],
+                  child: VotingPaneScrollView(
+                    maxWidth: 560,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.md,
+                    ),
+                    scrollPadding: const EdgeInsets.only(bottom: AppSpacing.md),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text(
+                          'Review your answers',
+                          textAlign: TextAlign.center,
+                          style: AppTypography.displaySmall.copyWith(
+                            color: context.colors.text.accent,
+                            letterSpacing: 0,
                           ),
                         ),
-                      );
-                    },
+                        const SizedBox(height: AppSpacing.md),
+                        if (state.hasConfirmedVotingEligibility)
+                          for (final entry in proposals.asMap().entries) ...[
+                            VotingProposalCard(
+                              proposal: entry.value,
+                              fallbackForumUri: roundForumUri,
+                              selectedChoice: draft.choices[entry.value.id],
+                              readOnly: true,
+                              statusLabel: draft.choices[entry.value.id] == null
+                                  ? 'Skipped'
+                                  : null,
+                              titleCollapsedMaxLines: 1,
+                            ),
+                            if (entry.key != proposals.length - 1)
+                              const SizedBox(height: AppSpacing.s),
+                          ],
+                        if (state.hasConfirmedVotingEligibility &&
+                            draft.isEmpty) ...[
+                          const SizedBox(height: AppSpacing.xs),
+                          const _Message(
+                            'Choose at least one option before submitting.',
+                          ),
+                        ],
+                        if (eligibilityMessage != null) ...[
+                          const SizedBox(height: AppSpacing.xs),
+                          _Message(eligibilityMessage),
+                        ],
+                      ],
+                    ),
                   ),
                 ),
                 Padding(
@@ -286,17 +266,6 @@ class _VotingReviewScreenState extends ConsumerState<VotingReviewScreen> {
   }
 }
 
-String _reviewValue(VotingProposalView proposal, VotingDraftState draft) {
-  final choice = draft.choices[proposal.id];
-  if (choice == null) return 'Skipped';
-  return proposal.options
-      .firstWhere(
-        (option) => option.index == choice,
-        orElse: () => VotingOptionView(index: choice, label: 'Choice $choice'),
-      )
-      .label;
-}
-
 bool _shouldPrepareVotingPower(VotingSessionState state) {
   return switch (state.phase) {
     VotingSessionPhase.idle ||
@@ -318,65 +287,6 @@ String? _votingEligibilityMessage(
   if (error != null) return friendlyVotingErrorText(error.message);
   if (preparing) return 'Preparing voting power.';
   return 'Voting power unavailable.';
-}
-
-class _ReviewRow extends StatelessWidget {
-  const _ReviewRow({
-    required this.proposal,
-    required this.value,
-    this.skipped = false,
-  });
-
-  final VotingProposalView proposal;
-  final String value;
-  final bool skipped;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    final titleColor = skipped
-        ? colors.text.secondary.withValues(alpha: 0.64)
-        : colors.text.secondary;
-    final valueColor = skipped
-        ? colors.text.secondary.withValues(alpha: 0.72)
-        : votingChoicePalette(context, value).text;
-    final zipBadges = proposal.zipBadges;
-    final forumUri = proposal.forumUri;
-    final titleText = Text(
-      proposal.title,
-      style: AppTypography.bodyMedium.copyWith(color: titleColor),
-    );
-    final valueText = Text(
-      value,
-      maxLines: 2,
-      overflow: TextOverflow.ellipsis,
-      textAlign: TextAlign.left,
-      style: AppTypography.bodyMediumStrong.copyWith(color: valueColor),
-    );
-    return Container(
-      margin: const EdgeInsets.only(bottom: AppSpacing.xs),
-      padding: const EdgeInsets.all(AppSpacing.sm),
-      decoration: BoxDecoration(
-        color: skipped
-            ? colors.background.neutralSubtleOpacity
-            : colors.background.ground.withValues(alpha: 0.78),
-        borderRadius: BorderRadius.circular(AppRadii.medium),
-        border: Border.all(color: colors.border.subtle),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          if (zipBadges.isNotEmpty || forumUri != null) ...[
-            VotingProposalMetadataRow(zipBadges: zipBadges, forumUri: forumUri),
-            const SizedBox(height: AppSpacing.xs),
-          ],
-          titleText,
-          const SizedBox(height: AppSpacing.xxs),
-          valueText,
-        ],
-      ),
-    );
-  }
 }
 
 class _Message extends StatelessWidget {

--- a/lib/src/features/voting/widgets/voting_metadata_widgets.dart
+++ b/lib/src/features/voting/widgets/voting_metadata_widgets.dart
@@ -6,6 +6,8 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
+import '../voting_choice_style.dart';
+import '../voting_flow_models.dart';
 
 class VotingMetadataBadge extends StatelessWidget {
   const VotingMetadataBadge(this.label, {super.key});
@@ -68,17 +70,45 @@ class VotingProposalMetadataRow extends StatelessWidget {
     required this.zipBadges,
     required this.forumUri,
     this.forumLabel = 'Forum discussion',
+    this.trailing,
     super.key,
   });
 
   final List<String> zipBadges;
   final Uri? forumUri;
   final String forumLabel;
+  final Widget? trailing;
 
   @override
   Widget build(BuildContext context) {
-    if (zipBadges.isEmpty && forumUri == null) {
+    final trailing = this.trailing;
+    if (zipBadges.isEmpty && forumUri == null && trailing == null) {
       return const SizedBox.shrink();
+    }
+    if (trailing != null) {
+      final metadata = [
+        for (final badge in zipBadges) VotingMetadataBadge(badge),
+        if (forumUri != null)
+          VotingForumLinkButton(uri: forumUri!, label: forumLabel),
+      ];
+      if (metadata.isEmpty) {
+        return Align(alignment: Alignment.centerRight, child: trailing);
+      }
+      return Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Wrap(
+              spacing: AppSpacing.xs,
+              runSpacing: AppSpacing.xxs,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: metadata,
+            ),
+          ),
+          const SizedBox(width: AppSpacing.xs),
+          trailing,
+        ],
+      );
     }
     if (forumUri == null) {
       return Wrap(
@@ -110,6 +140,369 @@ class VotingProposalMetadataRow extends StatelessWidget {
         const SizedBox(width: AppSpacing.xs),
         VotingForumLinkButton(uri: forumUri!, label: forumLabel),
       ],
+    );
+  }
+}
+
+class VotingProposalCard extends StatelessWidget {
+  const VotingProposalCard({
+    required this.proposal,
+    this.selectedChoice,
+    this.fallbackForumUri,
+    this.enabled = true,
+    this.readOnly = false,
+    this.statusLabel,
+    this.titleCollapsedMaxLines,
+    this.onDisabledOptionTap,
+    this.onChoice,
+    super.key,
+  });
+
+  final VotingProposalView proposal;
+  final int? selectedChoice;
+  final Uri? fallbackForumUri;
+  final bool enabled;
+  final bool readOnly;
+  final String? statusLabel;
+  final int? titleCollapsedMaxLines;
+  final VoidCallback? onDisabledOptionTap;
+  final ValueChanged<int?>? onChoice;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final zipBadges = proposal.zipBadges;
+    final forumUri = proposal.forumUri ?? fallbackForumUri;
+    final statusLabel = this.statusLabel;
+    final titleStyle = AppTypography.headlineSmall.copyWith(
+      color: colors.text.accent,
+      fontWeight: FontWeight.w600,
+      height: 24 / 16,
+      letterSpacing: 0,
+    );
+    final titleCollapsedMaxLines = this.titleCollapsedMaxLines;
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.sm),
+      decoration: BoxDecoration(
+        color: colors.background.ground,
+        borderRadius: BorderRadius.circular(AppRadii.medium),
+        border: Border.all(color: colors.border.subtle),
+        boxShadow: const [
+          BoxShadow(
+            color: Color(0x0A231F20),
+            offset: Offset(0, 1),
+            blurRadius: 1,
+            spreadRadius: -0.5,
+          ),
+          BoxShadow(
+            color: Color(0x0A231F20),
+            offset: Offset(0, 3),
+            blurRadius: 3,
+            spreadRadius: -1.5,
+          ),
+          BoxShadow(
+            color: Color(0x0A231F20),
+            offset: Offset(0, 24),
+            blurRadius: 24,
+            spreadRadius: -12,
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (zipBadges.isNotEmpty ||
+              forumUri != null ||
+              statusLabel != null) ...[
+            VotingProposalMetadataRow(
+              zipBadges: zipBadges,
+              forumUri: forumUri,
+              trailing: statusLabel == null
+                  ? null
+                  : VotingMetadataBadge(statusLabel),
+            ),
+            const SizedBox(height: AppSpacing.s),
+          ],
+          if (titleCollapsedMaxLines == null)
+            Text(proposal.title, style: titleStyle)
+          else
+            VotingExpandableText(
+              text: proposal.title,
+              style: titleStyle,
+              collapsedMaxLines: titleCollapsedMaxLines,
+            ),
+          if (proposal.description.isNotEmpty) ...[
+            const SizedBox(height: AppSpacing.xxs),
+            Text(
+              proposal.description.trim(),
+              style: AppTypography.bodySmall.copyWith(
+                color: colors.text.secondary,
+                height: 16 / 12,
+                letterSpacing: 0,
+              ),
+            ),
+          ],
+          const SizedBox(height: AppSpacing.s),
+          for (final option in proposal.options) ...[
+            _VotingProposalOptionRow(
+              option: option,
+              selected: selectedChoice == option.index,
+              enabled: enabled,
+              readOnly: readOnly,
+              onDisabledTap: onDisabledOptionTap,
+              onTap: () {
+                final onChoice = this.onChoice;
+                if (onChoice == null) return;
+                onChoice(selectedChoice == option.index ? null : option.index);
+              },
+            ),
+            if (option != proposal.options.last)
+              const SizedBox(height: AppSpacing.xs),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _VotingProposalOptionRow extends StatelessWidget {
+  const _VotingProposalOptionRow({
+    required this.option,
+    required this.selected,
+    required this.enabled,
+    required this.readOnly,
+    required this.onDisabledTap,
+    required this.onTap,
+  });
+
+  final VotingOptionView option;
+  final bool selected;
+  final bool enabled;
+  final bool readOnly;
+  final VoidCallback? onDisabledTap;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final description = option.description.trim();
+    final palette = votingChoicePalette(context, option.label);
+    final interactive = enabled && !readOnly;
+    final primaryTextColor = enabled || readOnly
+        ? selected
+              ? palette.text
+              : colors.text.accent
+        : colors.text.secondary.withValues(alpha: 0.56);
+    final secondaryTextColor = enabled || readOnly
+        ? selected
+              ? palette.text.withValues(alpha: 0.82)
+              : colors.text.secondary
+        : colors.text.secondary.withValues(alpha: 0.48);
+    final trailingLabel = selected
+        ? 'Selected'
+        : readOnly
+        ? null
+        : 'Choose';
+    return InkWell(
+      borderRadius: BorderRadius.circular(AppRadii.small),
+      onTap: interactive
+          ? onTap
+          : readOnly
+          ? null
+          : onDisabledTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: AppSpacing.xs,
+        ),
+        decoration: BoxDecoration(
+          color: (enabled || readOnly) && selected
+              ? palette.background
+              : colors.background.neutralSubtleOpacity,
+          borderRadius: BorderRadius.circular(AppRadii.small),
+          border: Border.all(
+            color: (enabled || readOnly) && selected
+                ? palette.border
+                : colors.border.subtle,
+          ),
+        ),
+        child: Row(
+          crossAxisAlignment: description.isEmpty
+              ? CrossAxisAlignment.center
+              : CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    option.label,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: primaryTextColor,
+                    ),
+                  ),
+                  if (description.isNotEmpty) ...[
+                    const SizedBox(height: AppSpacing.xxs),
+                    Text(
+                      description,
+                      style: AppTypography.bodySmall.copyWith(
+                        color: secondaryTextColor,
+                        height: 16 / 12,
+                        letterSpacing: 0,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            if (trailingLabel != null) ...[
+              const SizedBox(width: AppSpacing.sm),
+              Text(
+                trailingLabel,
+                style: AppTypography.bodySmall.copyWith(
+                  color: (enabled || readOnly) && selected
+                      ? palette.text
+                      : secondaryTextColor,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class VotingExpandableText extends StatefulWidget {
+  const VotingExpandableText({
+    required this.text,
+    required this.style,
+    this.collapsedMaxLines = 2,
+    super.key,
+  });
+
+  final String text;
+  final TextStyle style;
+  final int collapsedMaxLines;
+
+  @override
+  State<VotingExpandableText> createState() => _VotingExpandableTextState();
+}
+
+class _VotingExpandableTextState extends State<VotingExpandableText> {
+  bool _expanded = false;
+
+  @override
+  void didUpdateWidget(covariant VotingExpandableText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.text != widget.text ||
+        oldWidget.collapsedMaxLines != widget.collapsedMaxLines) {
+      _expanded = false;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final text = widget.text.trim();
+    if (text.isEmpty) return const SizedBox.shrink();
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final canExpand = _textExceedsMaxLines(
+          context: context,
+          text: text,
+          style: widget.style,
+          maxWidth: constraints.maxWidth,
+          maxLines: widget.collapsedMaxLines,
+        );
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              text,
+              maxLines: _expanded || !canExpand
+                  ? null
+                  : widget.collapsedMaxLines,
+              overflow: _expanded || !canExpand
+                  ? TextOverflow.visible
+                  : TextOverflow.ellipsis,
+              style: widget.style,
+            ),
+            if (canExpand)
+              Align(
+                alignment: Alignment.centerRight,
+                child: _VotingViewMoreButton(
+                  expanded: _expanded,
+                  onPressed: () {
+                    setState(() {
+                      _expanded = !_expanded;
+                    });
+                  },
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+bool _textExceedsMaxLines({
+  required BuildContext context,
+  required String text,
+  required TextStyle style,
+  required double maxWidth,
+  required int maxLines,
+}) {
+  if (!maxWidth.isFinite || maxWidth <= 0) return false;
+  final textPainter = TextPainter(
+    text: TextSpan(text: text, style: style),
+    textDirection: Directionality.of(context),
+    textScaler: MediaQuery.textScalerOf(context),
+    maxLines: maxLines,
+  )..layout(maxWidth: maxWidth);
+  return textPainter.didExceedMaxLines;
+}
+
+class _VotingViewMoreButton extends StatelessWidget {
+  const _VotingViewMoreButton({
+    required this.expanded,
+    required this.onPressed,
+  });
+
+  final bool expanded;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onPressed,
+      child: Padding(
+        padding: const EdgeInsets.only(top: AppSpacing.xxs),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              expanded ? 'View less' : 'View more',
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: colors.text.accent,
+                height: 20 / 14,
+                letterSpacing: 0,
+              ),
+            ),
+            const SizedBox(width: AppSpacing.xxs),
+            Transform.rotate(
+              angle: expanded ? -1.5708 : 1.5708,
+              child: AppIcon(
+                AppIcons.chevronForward,
+                size: 16,
+                color: colors.icon.accent,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/src/features/voting/widgets/voting_metadata_widgets.dart
+++ b/lib/src/features/voting/widgets/voting_metadata_widgets.dart
@@ -174,6 +174,16 @@ class VotingProposalCard extends StatelessWidget {
     final zipBadges = proposal.zipBadges;
     final forumUri = proposal.forumUri ?? fallbackForumUri;
     final statusLabel = this.statusLabel;
+    final selectedChoice = this.selectedChoice;
+    final missingSelectedOption =
+        readOnly &&
+            selectedChoice != null &&
+            !proposal.options.any((option) => option.index == selectedChoice)
+        ? VotingOptionView(
+            index: selectedChoice,
+            label: 'Choice $selectedChoice',
+          )
+        : null;
     final titleStyle = AppTypography.headlineSmall.copyWith(
       color: colors.text.accent,
       fontWeight: FontWeight.w600,
@@ -258,6 +268,18 @@ class VotingProposalCard extends StatelessWidget {
             ),
             if (option != proposal.options.last)
               const SizedBox(height: AppSpacing.xs),
+          ],
+          if (missingSelectedOption != null) ...[
+            if (proposal.options.isNotEmpty)
+              const SizedBox(height: AppSpacing.xs),
+            _VotingProposalOptionRow(
+              option: missingSelectedOption,
+              selected: true,
+              enabled: true,
+              readOnly: true,
+              onDisabledTap: null,
+              onTap: () {},
+            ),
           ],
         ],
       ),

--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -12,6 +12,7 @@ import 'voting_service_providers.dart';
 import 'voting_state.dart';
 
 const kVotingPollListRecentRefreshWindow = Duration(seconds: 10);
+const kVotingPollListAutoRefreshInterval = Duration(seconds: 30);
 DateTime? _lastVotingPollListRefreshAt;
 
 class VotingPollListRefreshRequestNotifier extends Notifier<int> {

--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -14,6 +14,20 @@ import 'voting_state.dart';
 const kVotingPollListRecentRefreshWindow = Duration(seconds: 10);
 DateTime? _lastVotingPollListRefreshAt;
 
+class VotingPollListRefreshRequestNotifier extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void request() {
+    state++;
+  }
+}
+
+final votingPollListRefreshRequestProvider =
+    NotifierProvider<VotingPollListRefreshRequestNotifier, int>(
+      VotingPollListRefreshRequestNotifier.new,
+    );
+
 bool wasVotingPollListRecentlyRefreshed() {
   final refreshedAt = _lastVotingPollListRefreshAt;
   if (refreshedAt == null) return false;

--- a/lib/src/providers/voting/voting_rounds_provider.dart
+++ b/lib/src/providers/voting/voting_rounds_provider.dart
@@ -12,7 +12,6 @@ import 'voting_service_providers.dart';
 import 'voting_state.dart';
 
 const kVotingPollListRecentRefreshWindow = Duration(seconds: 10);
-const kVotingPollListAutoRefreshInterval = Duration(seconds: 30);
 DateTime? _lastVotingPollListRefreshAt;
 
 class VotingPollListRefreshRequestNotifier extends Notifier<int> {

--- a/lib/src/providers/voting/voting_session_provider.dart
+++ b/lib/src/providers/voting/voting_session_provider.dart
@@ -2653,6 +2653,46 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
     required _VotingSessionContext context,
   }) async {
     try {
+      if (_hasPersistedVotingBundles(current: current, context: context)) {
+        final bundleSetup = await ref
+            .read(votingRustApiProvider)
+            .setupDelegationBundles(ctx: _apiRoundContext(context));
+        final refreshedPlan = await _loadResumePlan(context);
+        final refreshedRoundPlan = await _loadRoundPlan(context);
+        final isEligible =
+            bundleSetup.bundleCount > 0 &&
+            bundleSetup.eligibleWeight > BigInt.zero;
+        final successPhase = current.phase == VotingSessionPhase.error
+            ? VotingSessionPhase.idle
+            : current.phase;
+        final base = (state.value ?? current).copyWith(
+          phase: isEligible ? successPhase : VotingSessionPhase.error,
+          config: context.config,
+          round: context.round,
+          resumePlan: refreshedPlan,
+          roundPlan: refreshedRoundPlan,
+          eligibleWeightZatoshi: bundleSetup.eligibleWeight,
+          isHardwareAccount: context.isHardwareAccount,
+          clearError: isEligible,
+        );
+        _setStateForContext(
+          context,
+          isEligible
+              ? base
+              : base.copyWith(
+                  error: VotingSessionError(
+                    message:
+                        'minimum voting eligibility requires at least one '
+                        'eligible voting bundle with 12500000 zatoshi voting '
+                        'weight; selected ${bundleSetup.bundleCount} '
+                        'persisted bundles with ${bundleSetup.eligibleWeight} '
+                        'zatoshi eligible bundle weight at snapshot height '
+                        '${context.round.snapshotHeight}',
+                  ),
+                ),
+        );
+        return;
+      }
       final eligibility = await ref
           .read(votingRustApiProvider)
           .checkVotingEligibility(ctx: _apiRoundContext(context));
@@ -2701,6 +2741,16 @@ class VotingSessionNotifier extends AsyncNotifier<VotingSessionState> {
         ),
       );
     }
+  }
+
+  bool _hasPersistedVotingBundles({
+    required VotingSessionState current,
+    required _VotingSessionContext context,
+  }) {
+    final livePlan = state.value?.resumePlan;
+    return (livePlan?.bundleCount ?? 0) > 0 ||
+        (current.resumePlan?.bundleCount ?? 0) > 0 ||
+        context.resumePlan.bundleCount > 0;
   }
 
   String _minimumVotingEligibilityErrorMessage({

--- a/lib/src/services/voting/voting_config_loader.dart
+++ b/lib/src/services/voting/voting_config_loader.dart
@@ -203,7 +203,9 @@ class VotingConfigLoader {
       staticBytes: staticBytes,
     );
 
-    final dynamicBytes = await _fetchBytes(Uri.parse(dynamicConfigUrl));
+    final dynamicBytes = await _fetchBytes(
+      _dynamicConfigTransportUri(dynamicConfigUrl),
+    );
 
     final resolution = await _resolveVotingConfig(
       source: _source.raw,
@@ -232,4 +234,35 @@ class VotingConfigLoader {
     }
     return response.bodyBytes;
   }
+}
+
+Uri _dynamicConfigTransportUri(String dynamicConfigUrl) {
+  final uri = Uri.parse(dynamicConfigUrl);
+  if (!_isGithubRawBranchUri(uri)) return uri;
+
+  // GitHub raw branch URLs are CDN-cached for several minutes after a merge.
+  // The dynamic config is still verified after fetch, so this only changes
+  // transport freshness for test/stage configs served directly from GitHub.
+  return uri.replace(
+    queryParameters: {
+      ...uri.queryParametersAll,
+      'vizor_cache_bust': [DateTime.now().microsecondsSinceEpoch.toString()],
+    },
+  );
+}
+
+bool _isGithubRawBranchUri(Uri uri) {
+  if (uri.scheme != 'https' || uri.host != 'raw.githubusercontent.com') {
+    return false;
+  }
+  final segments = uri.pathSegments;
+  if (segments.length < 4) return false;
+  final ref = segments[2];
+  if (ref == 'refs' &&
+      segments.length >= 6 &&
+      segments[3] == 'heads' &&
+      segments[4].isNotEmpty) {
+    return true;
+  }
+  return !RegExp(r'^[0-9a-fA-F]{40}$').hasMatch(ref);
 }

--- a/lib/src/services/voting/voting_config_loader.dart
+++ b/lib/src/services/voting/voting_config_loader.dart
@@ -224,7 +224,11 @@ class VotingConfigLoader {
   }
 
   Future<List<int>> _fetchBytes(Uri uri) async {
-    final response = await _httpClient.get(uri, timeout: _timeout);
+    final response = await _httpClient.get(
+      uri,
+      headers: _configFetchHeaders,
+      timeout: _timeout,
+    );
     if (response.statusCode != 200) {
       throw VotingHttpException(
         uri: uri,
@@ -235,6 +239,8 @@ class VotingConfigLoader {
     return response.bodyBytes;
   }
 }
+
+const _configFetchHeaders = {'Cache-Control': 'no-cache', 'Pragma': 'no-cache'};
 
 Uri _dynamicConfigTransportUri(String dynamicConfigUrl) {
   final uri = Uri.parse(dynamicConfigUrl);

--- a/lib/src/services/voting/voting_http.dart
+++ b/lib/src/services/voting/voting_http.dart
@@ -7,7 +7,11 @@ import 'dart:typed_data';
 /// The voting clients are mostly protocol mappers; keeping transport injectable
 /// lets tests assert URLs and JSON bodies without opening sockets.
 abstract interface class VotingHttpClient {
-  Future<VotingHttpResponse> get(Uri uri, {Duration? timeout});
+  Future<VotingHttpResponse> get(
+    Uri uri, {
+    Map<String, String>? headers,
+    Duration? timeout,
+  });
 
   Future<VotingHttpResponse> postJson(
     Uri uri,
@@ -53,8 +57,12 @@ class DartIoVotingHttpClient implements VotingHttpClient {
   final HttpClient _client;
 
   @override
-  Future<VotingHttpResponse> get(Uri uri, {Duration? timeout}) {
-    return _send('GET', uri, timeout: timeout);
+  Future<VotingHttpResponse> get(
+    Uri uri, {
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) {
+    return _send('GET', uri, headers: headers, timeout: timeout);
   }
 
   @override
@@ -81,6 +89,7 @@ class DartIoVotingHttpClient implements VotingHttpClient {
     Uri uri, {
     List<int>? bodyBytes,
     ContentType? contentType,
+    Map<String, String>? headers,
     Duration? timeout,
   }) async {
     Future<VotingHttpResponse> run() async {
@@ -88,6 +97,7 @@ class DartIoVotingHttpClient implements VotingHttpClient {
       if (contentType != null) {
         request.headers.contentType = contentType;
       }
+      headers?.forEach(request.headers.set);
       if (bodyBytes != null) {
         request.add(bodyBytes);
       }

--- a/test/features/voting/voting_metadata_widgets_test.dart
+++ b/test/features/voting/voting_metadata_widgets_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/voting/voting_flow_models.dart';
+import 'package:zcash_wallet/src/features/voting/widgets/voting_metadata_widgets.dart';
+
+void main() {
+  testWidgets('read-only proposal card shows stale selected choice fallback', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const _ThemedHarness(
+        child: Center(
+          child: SizedBox(
+            width: 420,
+            child: VotingProposalCard(
+              proposal: VotingProposalView(
+                id: 1,
+                title: 'Issuance timing',
+                description: 'Select the fee reissuance schedule.',
+                options: [
+                  VotingOptionView(index: 0, label: 'Immediately'),
+                  VotingOptionView(index: 1, label: 'Later'),
+                ],
+              ),
+              selectedChoice: 4,
+              readOnly: true,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Immediately'), findsOneWidget);
+    expect(find.text('Later'), findsOneWidget);
+    expect(find.text('Choice 4'), findsOneWidget);
+    expect(find.text('Selected'), findsOneWidget);
+    expect(find.text('Choose'), findsNothing);
+  });
+}
+
+class _ThemedHarness extends StatelessWidget {
+  const _ThemedHarness({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: Scaffold(
+          body: Directionality(textDirection: TextDirection.ltr, child: child),
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/voting/voting_polls_screen_test.dart
+++ b/test/features/voting/voting_polls_screen_test.dart
@@ -179,6 +179,65 @@ void main() {
     },
   );
 
+  testWidgets('poll list refreshes periodically while open', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    late _TrackingVotingRoundsNotifier roundsNotifier;
+    late _TrackingVotingConfigNotifier configNotifier;
+    final router = GoRouter(
+      initialLocation: '/voting',
+      routes: [
+        GoRoute(path: '/voting', builder: (_, _) => const VotingPollsScreen()),
+        GoRoute(path: '/accounts', builder: (_, _) => const Text('accounts')),
+        GoRoute(path: '/home', builder: (_, _) => const Text('home')),
+        GoRoute(
+          path: '/address-book',
+          builder: (_, _) => const Text('address book'),
+        ),
+        GoRoute(path: '/activity', builder: (_, _) => const Text('activity')),
+        GoRoute(path: '/settings', builder: (_, _) => const Text('settings')),
+        GoRoute(path: '/about', builder: (_, _) => const Text('about')),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          accountProvider.overrideWith(_SoftwareAccountNotifier.new),
+          syncProvider.overrideWith(_NoopSyncNotifier.new),
+          swapFeatureEnabledProvider.overrideWithValue(false),
+          votingConfigProvider.overrideWith(() {
+            configNotifier = _TrackingVotingConfigNotifier();
+            return configNotifier;
+          }),
+          votingRoundsProvider.overrideWith(() {
+            roundsNotifier = _TrackingVotingRoundsNotifier();
+            return roundsNotifier;
+          }),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, child) =>
+              AppTheme(data: AppThemeData.light, child: child!),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(roundsNotifier.reloadCount, 1);
+    expect(configNotifier.refreshCount, 1);
+
+    await tester.pump(kVotingPollListAutoRefreshInterval);
+    await tester.pumpAndSettle();
+
+    expect(roundsNotifier.reloadCount, 2);
+    expect(configNotifier.refreshCount, 2);
+    expect(find.text('View results'), findsOneWidget);
+  });
+
   testWidgets('account reload shows loading instead of previous account rows', (
     tester,
   ) async {

--- a/test/features/voting/voting_polls_screen_test.dart
+++ b/test/features/voting/voting_polls_screen_test.dart
@@ -76,6 +76,12 @@ void main() {
     expect(roundsNotifier.reloadCount, 1);
     expect(configNotifier.refreshCount, 1);
 
+    await tester.tap(find.byKey(const ValueKey('sidebar_voting_button')));
+    await tester.pumpAndSettle();
+
+    expect(roundsNotifier.reloadCount, 2);
+    expect(configNotifier.refreshCount, 2);
+
     final returnReload = Completer<void>();
     roundsNotifier.nextReload = returnReload.future;
 
@@ -83,14 +89,14 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('results route'), findsOneWidget);
-    expect(roundsNotifier.reloadCount, 1);
+    expect(roundsNotifier.reloadCount, 2);
 
     router.pop();
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 300));
 
-    expect(roundsNotifier.reloadCount, 2);
-    expect(configNotifier.refreshCount, 2);
+    expect(roundsNotifier.reloadCount, 3);
+    expect(configNotifier.refreshCount, 3);
     expect(find.byType(CircularProgressIndicator), findsNothing);
     expect(find.text('View results'), findsOneWidget);
 

--- a/test/features/voting/voting_polls_screen_test.dart
+++ b/test/features/voting/voting_polls_screen_test.dart
@@ -179,65 +179,6 @@ void main() {
     },
   );
 
-  testWidgets('poll list refreshes periodically while open', (tester) async {
-    await tester.binding.setSurfaceSize(const Size(1512, 982));
-    addTearDown(() async {
-      await tester.binding.setSurfaceSize(null);
-    });
-
-    late _TrackingVotingRoundsNotifier roundsNotifier;
-    late _TrackingVotingConfigNotifier configNotifier;
-    final router = GoRouter(
-      initialLocation: '/voting',
-      routes: [
-        GoRoute(path: '/voting', builder: (_, _) => const VotingPollsScreen()),
-        GoRoute(path: '/accounts', builder: (_, _) => const Text('accounts')),
-        GoRoute(path: '/home', builder: (_, _) => const Text('home')),
-        GoRoute(
-          path: '/address-book',
-          builder: (_, _) => const Text('address book'),
-        ),
-        GoRoute(path: '/activity', builder: (_, _) => const Text('activity')),
-        GoRoute(path: '/settings', builder: (_, _) => const Text('settings')),
-        GoRoute(path: '/about', builder: (_, _) => const Text('about')),
-      ],
-    );
-
-    await tester.pumpWidget(
-      ProviderScope(
-        overrides: [
-          accountProvider.overrideWith(_SoftwareAccountNotifier.new),
-          syncProvider.overrideWith(_NoopSyncNotifier.new),
-          swapFeatureEnabledProvider.overrideWithValue(false),
-          votingConfigProvider.overrideWith(() {
-            configNotifier = _TrackingVotingConfigNotifier();
-            return configNotifier;
-          }),
-          votingRoundsProvider.overrideWith(() {
-            roundsNotifier = _TrackingVotingRoundsNotifier();
-            return roundsNotifier;
-          }),
-        ],
-        child: MaterialApp.router(
-          routerConfig: router,
-          builder: (_, child) =>
-              AppTheme(data: AppThemeData.light, child: child!),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    expect(roundsNotifier.reloadCount, 1);
-    expect(configNotifier.refreshCount, 1);
-
-    await tester.pump(kVotingPollListAutoRefreshInterval);
-    await tester.pumpAndSettle();
-
-    expect(roundsNotifier.reloadCount, 2);
-    expect(configNotifier.refreshCount, 2);
-    expect(find.text('View results'), findsOneWidget);
-  });
-
   testWidgets('account reload shows loading instead of previous account rows', (
     tester,
   ) async {

--- a/test/features/voting/voting_status_screen_test.dart
+++ b/test/features/voting/voting_status_screen_test.dart
@@ -22,6 +22,7 @@ import 'package:zcash_wallet/src/features/voting/voting_recovery_api.dart';
 import 'package:zcash_wallet/src/features/voting/voting_recovery_service.dart';
 import 'package:zcash_wallet/src/features/voting/voting_resume_plan.dart';
 import 'package:zcash_wallet/src/features/voting/voting_routes.dart';
+import 'package:zcash_wallet/src/features/voting/widgets/voting_metadata_widgets.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/providers/voting/voting_config_provider.dart';
@@ -1414,7 +1415,7 @@ void main() {
     expect(container.read(votingDraftProvider(_draftKey)).isEmpty, true);
   });
 
-  testWidgets('proposal detail shows View more when description truncates', (
+  testWidgets('proposal detail collapses long poll descriptions', (
     tester,
   ) async {
     await tester.binding.setSurfaceSize(const Size(1152, 768));
@@ -1448,7 +1449,13 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    expect(find.text(longDescription), findsOneWidget);
     expect(find.text('View more'), findsOneWidget);
+
+    await tester.tap(find.text('View more'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('View less'), findsOneWidget);
   });
 
   testWidgets('proposal detail shows completed vote with stale local draft', (
@@ -1459,6 +1466,26 @@ void main() {
       await tester.binding.setSurfaceSize(null);
     });
 
+    const proposalDescription =
+        'The fee-burning component of the Network Sustainability Mechanism is '
+        'already approved. The issuance smoothing component is unresolved and '
+        'needs enough text to overflow the completed vote card.';
+    final longRoundDescription = List.filled(
+      8,
+      'Completed poll description that should collapse behind the view more control.',
+    ).join(' ');
+    final round = _roundStatusJson()
+      ..['summary'] = longRoundDescription
+      ..['forum_link'] = 'https://forum.zcashcommunity.com/t/zip-233'
+      ..['proposals'] = [
+        _proposalJson(1, 'First proposal', ['Yes', 'No'])
+          ..['zip_number'] = 'ZIP 233'
+          ..['description'] = proposalDescription,
+      ];
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
+    );
     final recoveryApi = _MutableVotingRecoveryApi()
       ..roundPlan = apiRoundPlan(
         roundId: _roundId,
@@ -1476,6 +1503,7 @@ void main() {
         ),
       );
     final container = _statusContainer(
+      http: http,
       accountOverride: _MnemonicAccountNotifier.new,
       recoveryApi: recoveryApi,
       rust: _VotingStatusRustApi(recoveryApi),
@@ -1492,7 +1520,74 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.textContaining('Voted'), findsOneWidget);
+    expect(find.text('Proposal 1'), findsNothing);
+    expect(find.text('ZIP-233'), findsOneWidget);
+    expect(find.text('Forum discussion'), findsNWidgets(2));
+    expect(find.text(longRoundDescription), findsOneWidget);
+    expect(find.text('View more'), findsOneWidget);
+    final headerSnapshotRight = tester.getTopRight(find.text('#123')).dx;
+    final cardRight = tester
+        .getTopRight(find.byType(VotingProposalCard).first)
+        .dx;
+    expect(headerSnapshotRight, lessThanOrEqualTo(cardRight));
+    final completedTitle = tester.widget<Text>(find.text('Poll'));
+    expect(completedTitle.style?.fontFamily, 'Geist');
+    expect(completedTitle.style?.fontSize, 20);
+    expect(completedTitle.style?.fontWeight, FontWeight.w600);
+    final completedSnapshot = tester.widget<Text>(find.text('#123'));
+    expect(completedSnapshot.style?.fontFamily, 'Geist');
+    expect(completedSnapshot.style?.fontSize, 20);
+    await tester.tap(find.text('View more'));
+    await tester.pumpAndSettle();
+    expect(find.text('View less'), findsOneWidget);
+    expect(find.text(proposalDescription), findsOneWidget);
+    expect(find.text('Yes'), findsOneWidget);
+    expect(find.text('No'), findsOneWidget);
+    expect(find.text('Selected'), findsOneWidget);
+    expect(find.text('Choose'), findsNothing);
     expect(find.text('Review answers'), findsNothing);
+  });
+
+  testWidgets('proposal detail shows long question descriptions in full', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    const proposalDescription =
+        'The fee-burning component of the Network Sustainability Mechanism is '
+        'already approved. The issuance smoothing component is unresolved. '
+        'This longer description should be expandable on the vote card.';
+    final round = _roundStatusJson()
+      ..['proposals'] = [
+        _proposalJson(1, 'First proposal', ['Yes', 'No'])
+          ..['description'] = proposalDescription,
+      ];
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
+    );
+    final recoveryApi = _MutableVotingRecoveryApi();
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _NoMnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _VotingStatusRustApi(recoveryApi),
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(proposalDescription), findsOneWidget);
+    expect(find.text('View more'), findsNothing);
   });
 
   testWidgets('proposal detail routes non-active rounds to results', (
@@ -1967,14 +2062,22 @@ void main() {
 
     const optionDescription =
         'Mint option explanation for detail screens only.';
+    const proposalDescription =
+        'This completed proposal description should remain fully visible on '
+        'the tally screen without an expansion control.';
+    final longRoundDescription = List.filled(
+      8,
+      'Completed poll description that should collapse behind the view more control.',
+    ).join(' ');
     final round = _roundStatusJson()
       ..['status'] = 'closed'
-      ..['summary'] = 'Completed poll'
+      ..['summary'] = longRoundDescription
       ..['proposals'] = [
         _proposalJson(1, 'First proposal', ['Yes', 'No']),
         {
           'id': 2,
           'title': 'Second proposal',
+          'description': proposalDescription,
           'zip_number': 'ZIP 231',
           'forum_url': 'https://forum.zcashcommunity.com/t/zip-231',
           'options': [
@@ -2020,7 +2123,11 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Poll'), findsOneWidget);
-    expect(find.text('Completed poll'), findsOneWidget);
+    expect(find.text(longRoundDescription), findsOneWidget);
+    expect(find.text('View more'), findsOneWidget);
+    await tester.tap(find.text('View more'));
+    await tester.pumpAndSettle();
+    expect(find.text('View less'), findsOneWidget);
     expect(find.text('Results'), findsOneWidget);
     expect(find.text('First proposal'), findsOneWidget);
     expect(find.text('Yes'), findsOneWidget);
@@ -2028,8 +2135,13 @@ void main() {
     expect(find.text('No'), findsOneWidget);
     expect(find.text('0.25 ZEC'), findsOneWidget);
     expect(find.text('Total: 0.75 ZEC'), findsOneWidget);
+    expect(
+      tester.getSize(find.byKey(const ValueKey('voting-result-card-1'))).width,
+      lessThanOrEqualTo(560),
+    );
     expect(find.text('Voted: Yes'), findsOneWidget);
     expect(find.text('Second proposal'), findsOneWidget);
+    expect(find.text(proposalDescription), findsOneWidget);
     expect(find.text('ZIP-231'), findsOneWidget);
     expect(find.text('Forum discussion'), findsOneWidget);
     expect(find.text('Mint'), findsOneWidget);
@@ -2225,7 +2337,8 @@ void main() {
     });
 
     final firstProposal = _proposalJson(1, 'First proposal', ['Yes', 'No'])
-      ..['zip_number'] = 'ZIP 233';
+      ..['zip_number'] = 'ZIP 233'
+      ..['forum_url'] = 'https://forum.zcashcommunity.com/t/zip-233';
     final round = _roundStatusJson()
       ..['forum_link'] = 'https://forum.zcashcommunity.com/t/zip-233'
       ..['proposals'] = [
@@ -2269,11 +2382,16 @@ void main() {
     expect(find.text('Review your answers'), findsOneWidget);
     expect(find.text('Confirm & submit'), findsOneWidget);
     expect(find.text('ZIP-233'), findsOneWidget);
-    expect(find.text('Forum discussion'), findsOneWidget);
+    expect(find.text('Forum discussion'), findsNWidgets(2));
     expect(find.text('First proposal'), findsOneWidget);
     expect(find.text('Yes'), findsOneWidget);
+    expect(find.text('No'), findsOneWidget);
     expect(find.text('Second proposal'), findsOneWidget);
+    expect(find.text('Aye'), findsOneWidget);
+    expect(find.text('Nay'), findsOneWidget);
     expect(find.text('Skipped'), findsOneWidget);
+    expect(find.text('Selected'), findsOneWidget);
+    expect(find.text('Choose'), findsNothing);
 
     await tester.tap(find.text('Confirm & submit'));
     await tester.pumpAndSettle();
@@ -2281,7 +2399,7 @@ void main() {
     expect(find.text('status account: account-1'), findsOneWidget);
   });
 
-  testWidgets('review uses short option label without option description', (
+  testWidgets('review shows full proposal card with selected choice', (
     tester,
   ) async {
     await tester.binding.setSurfaceSize(const Size(1152, 768));
@@ -2289,20 +2407,24 @@ void main() {
       await tester.binding.setSurfaceSize(null);
     });
 
-    final longDescription =
+    final longOptionDescription =
         'Keep the existing halving schedule for new ZEC. Only fees and '
         'donated funds are smoothed and reissued.';
+    final longQuestionDescription =
+        'Question about the NSM issuance smoothing policy. The proposal '
+        'description should remain visible on the review screen and be '
+        'expandable when it does not fit in the compact row.';
     final round = _roundStatusJson()
       ..['proposals'] = [
         {
           'id': 1,
           'title': 'NSM issuance smoothing',
-          'description': 'Question about the NSM issuance smoothing policy.',
+          'description': longQuestionDescription,
           'options': [
             {
               'index': 0,
               'label': 'Preserve halvings',
-              'description': longDescription,
+              'description': longOptionDescription,
             },
             {
               'index': 1,
@@ -2334,7 +2456,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Preserve halvings'), findsOneWidget);
-    expect(find.text(longDescription), findsOneWidget);
+    expect(find.text(longOptionDescription), findsOneWidget);
 
     await tester.tap(find.text('Preserve halvings'));
     await tester.pumpAndSettle();
@@ -2343,7 +2465,115 @@ void main() {
 
     expect(find.text('Review your answers'), findsOneWidget);
     expect(find.text('Preserve halvings'), findsOneWidget);
-    expect(find.text(longDescription), findsNothing);
+    expect(find.text(longQuestionDescription), findsOneWidget);
+    expect(find.text('View more'), findsNothing);
+    expect(find.text(longOptionDescription), findsOneWidget);
+    expect(find.text('Selected'), findsOneWidget);
+    expect(find.text('Choose'), findsNothing);
+  });
+
+  testWidgets('review hides the poll description', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final longRoundDescription = List.filled(
+      8,
+      'Poll description that should not render on review.',
+    ).join(' ');
+    final round = _roundStatusJson()
+      ..['summary'] = longRoundDescription
+      ..['proposals'] = [
+        _proposalJson(1, 'First proposal', ['Yes', 'No']),
+      ];
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
+    );
+    final recoveryApi = _MutableVotingRecoveryApi();
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _NoMnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _VotingStatusRustApi(recoveryApi),
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Yes'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.text('Review answers'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Review answers'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review your answers'), findsOneWidget);
+    final reviewTitle = tester.widget<Text>(find.text('Review your answers'));
+    expect(reviewTitle.textAlign, TextAlign.center);
+    expect(reviewTitle.style?.fontFamily, 'Libre Caslon Text');
+    expect(reviewTitle.style?.fontSize, 36);
+    expect(reviewTitle.style?.letterSpacing, 0);
+    expect(find.text(longRoundDescription), findsNothing);
+    expect(find.text('View more'), findsNothing);
+  });
+
+  testWidgets('review expands long proposal titles', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1152, 768));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final longProposalTitle = [
+      'Welcome',
+      'to the full Network Sustainability Mechanism proposal title',
+      'that needs more than one line on the review screen',
+    ].join(' ');
+    final round = _roundStatusJson()
+      ..['proposals'] = [
+        _proposalJson(1, longProposalTitle, ['Yes', 'No']),
+      ];
+    final http = FakeVotingHttpClient(
+      responses: _votingHttpResponses()
+        ..['/shielded-vote/v1/round/$_roundId'] = {'round': round},
+    );
+    final recoveryApi = _MutableVotingRecoveryApi();
+    final container = _statusContainer(
+      http: http,
+      accountOverride: _NoMnemonicAccountNotifier.new,
+      recoveryApi: recoveryApi,
+      rust: _VotingStatusRustApi(recoveryApi),
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: _proposalHarness(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Yes'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Review answers'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review your answers'), findsOneWidget);
+    expect(find.text(longProposalTitle), findsOneWidget);
+    expect(find.text('View more'), findsOneWidget);
+
+    await tester.tap(find.text('View more'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('View less'), findsOneWidget);
   });
 
   testWidgets('review screen scrolls long ballots without overflowing', (
@@ -2888,6 +3118,12 @@ void main() {
     );
     final recoveryApi = _MutableVotingRecoveryApi()
       ..state = _recoveryState(bundleCount: 2);
+    final rust = _VotingStatusRustApi(
+      recoveryApi,
+      bundleCount: 2,
+      eligibilityWeightZatoshi: BigInt.from(200),
+      setupWeightPerBundle: BigInt.from(100),
+    );
     final container = _statusContainer(
       http: http,
       accountOverride: _HardwareAccountNotifier.new,
@@ -2895,7 +3131,7 @@ void main() {
       accountIsHardware: true,
       hardwareAccountUuids: const {'hardware-1'},
       recoveryApi: recoveryApi,
-      rust: _VotingStatusRustApi(recoveryApi, bundleCount: 2),
+      rust: rust,
       hotkeyStore: const _FakeVotingHotkeyStore([9, 9, 9]),
     );
     addTearDown(container.dispose);
@@ -2937,6 +3173,11 @@ void main() {
     await _pumpUntilFound(tester, find.text('submission confirmed route'));
 
     expect(find.text('submission confirmed route'), findsOneWidget);
+    const key = VotingSessionKey(roundId: _roundId, accountUuid: 'hardware-1');
+    final submissionState = container
+        .read(votingSubmissionSessionProvider(key))
+        .value;
+    expect(submissionState?.eligibleWeightZatoshi, BigInt.from(100));
     expect(
       http.requests.any(
         (request) =>
@@ -4119,13 +4360,18 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
   _VotingStatusRustApi(
     this.recoveryApi, {
     this.bundleCount = 1,
+    this.eligibilityWeightZatoshi,
+    this.setupWeightPerBundle,
     this.shareTrackingDelaySeconds,
-  });
+  }) : _persistedBundleCount = bundleCount;
 
   final _MutableVotingRecoveryApi recoveryApi;
   final int bundleCount;
+  final BigInt? eligibilityWeightZatoshi;
+  final BigInt? setupWeightPerBundle;
   final BigInt? shareTrackingDelaySeconds;
   final storedKeystoneSignatures = <int, rust_wire.KeystoneSignatureRecord>{};
+  int _persistedBundleCount;
   int setupDelegationBundleCalls = 0;
   int eligibilityCheckCalls = 0;
   int keystoneDelegationRequestCalls = 0;
@@ -4136,9 +4382,12 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
     required rust_api.ApiVotingRoundContext ctx,
   }) async {
     setupDelegationBundleCalls++;
+    final eligibleWeight = setupWeightPerBundle == null
+        ? BigInt.from(100)
+        : setupWeightPerBundle! * BigInt.from(_persistedBundleCount);
     return rust_round.BundleLayout(
-      bundleCount: bundleCount,
-      eligibleWeight: BigInt.from(100),
+      bundleCount: _persistedBundleCount,
+      eligibleWeight: eligibleWeight,
       droppedCount: 0,
     );
   }
@@ -4148,10 +4397,11 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
     required rust_api.ApiVotingRoundContext ctx,
   }) async {
     eligibilityCheckCalls++;
+    final eligibleWeight = eligibilityWeightZatoshi ?? BigInt.from(100);
     return rust_api.ApiVotingEligibility(
-      isEligible: true,
+      isEligible: eligibleWeight > BigInt.zero,
       distinctNoteCount: 5,
-      eligibleWeightZatoshi: BigInt.from(100),
+      eligibleWeightZatoshi: eligibleWeight,
     );
   }
 
@@ -4236,6 +4486,7 @@ class _VotingStatusRustApi extends _NoopVotingRustApi {
     for (final bundleIndex in removed) {
       storedKeystoneSignatures.remove(bundleIndex);
     }
+    _persistedBundleCount = keepCount;
     recoveryApi.state = _recoveryState(bundleCount: keepCount);
     return bundleCount - keepCount;
   }

--- a/test/providers/voting/voting_config_provider_test.dart
+++ b/test/providers/voting/voting_config_provider_test.dart
@@ -190,7 +190,11 @@ class _NoopVotingHttpClient implements VotingHttpClient {
   const _NoopVotingHttpClient();
 
   @override
-  Future<VotingHttpResponse> get(Uri uri, {Duration? timeout}) async {
+  Future<VotingHttpResponse> get(
+    Uri uri, {
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
     throw UnimplementedError('HTTP should not be used in this test.');
   }
 

--- a/test/providers/voting/voting_providers_test.dart
+++ b/test/providers/voting/voting_providers_test.dart
@@ -428,6 +428,104 @@ void main() {
   });
 
   test(
+    'poll refresh shows newly authenticated round with same endpoints',
+    () async {
+      const newRoundId =
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+      var authenticatedRoundIds = const [kRoundId];
+      final responses = <String, Object>{
+        'https://voting.example/static-voting-config.json': staticConfigJson(),
+        'https://voting.example/dynamic-voting-config.json':
+            dynamicConfigJson(),
+        '/shielded-vote/v1/rounds': {
+          'rounds': [
+            {
+              'vote_round_id': kRoundId,
+              'title': 'Initial poll',
+              'status': 'active',
+            },
+          ],
+        },
+      };
+      final http = FakeVotingHttpClient(responses: responses);
+      final container = ProviderContainer(
+        overrides: [
+          votingConfigSourceStoreProvider.overrideWithValue(
+            FakeVotingConfigSourceStore(),
+          ),
+          votingHttpClientProvider.overrideWithValue(http),
+          votingConfigLoaderProvider.overrideWithValue(
+            VotingConfigLoader(
+              httpClient: http,
+              sourceUrl: 'https://voting.example/static-voting-config.json',
+              resolveStaticVotingConfig: fakeResolveStaticVotingConfig,
+              resolveVotingConfig:
+                  ({
+                    required source,
+                    required staticBytes,
+                    required dynamicBytes,
+                    previous,
+                  }) => fakeResolveVotingConfig(
+                    dynamicBytes: dynamicBytes,
+                    previous: previous,
+                    authenticatedRoundIds: authenticatedRoundIds,
+                    switchKind: previous == null
+                        ? rust_config.ConfigSwitchKind.initialLoad
+                        : rust_config.ConfigSwitchKind.unchanged,
+                  ),
+            ),
+          ),
+          votingActiveAccountUuidProvider.overrideWithValue(() async => null),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final initial = await container.read(votingRoundsProvider.future);
+      expect(initial.map((round) => round.title), ['Initial poll']);
+
+      authenticatedRoundIds = const [kRoundId, newRoundId];
+      final dynamicConfig = dynamicConfigJson();
+      dynamicConfig['rounds'] = {
+        ...dynamicConfig['rounds'] as Map<String, dynamic>,
+        newRoundId: {
+          'auth_version': 1,
+          'ea_pk': _bytes1x32Base64,
+          'signatures': [
+            {'key_id': 'demo', 'alg': 'ed25519', 'sig': _bytes12x64Base64},
+          ],
+        },
+      };
+      responses['https://voting.example/dynamic-voting-config.json'] =
+          dynamicConfig;
+      responses['/shielded-vote/v1/rounds'] = {
+        'rounds': [
+          {
+            'vote_round_id': kRoundId,
+            'title': 'Initial poll',
+            'status': 'active',
+          },
+          {
+            'vote_round_id': newRoundId,
+            'title': 'New poll',
+            'status': 'active',
+          },
+        ],
+      };
+
+      await refreshVotingPollList(
+        config: container.read(votingConfigProvider.notifier),
+        readRounds: () => container.read(votingRoundsProvider.notifier),
+      );
+      final refreshed = container.read(votingRoundsProvider).requireValue;
+
+      expect(refreshed.map((round) => round.title), [
+        'Initial poll',
+        'New poll',
+      ]);
+    },
+  );
+
+  test(
     'config source change invalidates rounds provider on initial load',
     () async {
       const firstSource = 'https://voting-a.example/static-voting-config.json';
@@ -5251,13 +5349,17 @@ class _GatedVotingHttpClient extends FakeVotingHttpClient {
   }
 
   @override
-  Future<VotingHttpResponse> get(Uri uri, {Duration? timeout}) async {
+  Future<VotingHttpResponse> get(
+    Uri uri, {
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
     _recordGet(uri.path);
     final gates = _getGates[uri.path];
     if (gates != null && gates.isNotEmpty) {
       await gates.removeAt(0).future;
     }
-    return super.get(uri, timeout: timeout);
+    return super.get(uri, headers: headers, timeout: timeout);
   }
 
   void _recordGet(String path) {

--- a/test/services/voting/fake_voting_http.dart
+++ b/test/services/voting/fake_voting_http.dart
@@ -11,8 +11,14 @@ class FakeVotingHttpClient implements VotingHttpClient {
   FakeVotingHttpClient({this.responses = const {}});
 
   @override
-  Future<VotingHttpResponse> get(Uri uri, {Duration? timeout}) async {
-    requests.add(FakeVotingHttpRequest('GET', uri, timeout: timeout));
+  Future<VotingHttpResponse> get(
+    Uri uri, {
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
+    requests.add(
+      FakeVotingHttpRequest('GET', uri, headers: headers, timeout: timeout),
+    );
     return _responseFor(uri);
   }
 
@@ -62,9 +68,16 @@ class FakeVotingHttpRequest {
   final String method;
   final Uri uri;
   final Map<String, dynamic>? body;
+  final Map<String, String>? headers;
   final Duration? timeout;
 
-  const FakeVotingHttpRequest(this.method, this.uri, {this.body, this.timeout});
+  const FakeVotingHttpRequest(
+    this.method,
+    this.uri, {
+    this.body,
+    this.headers,
+    this.timeout,
+  });
 }
 
 class SequentialVotingHttpResponses {

--- a/test/services/voting/voting_config_loader_test.dart
+++ b/test/services/voting/voting_config_loader_test.dart
@@ -162,6 +162,10 @@ void main() {
       'https://voting.example/static-voting-config.json',
       dynamicUrl,
     ]);
+    expect(http.requests.map((request) => request.headers), [
+      {'Cache-Control': 'no-cache', 'Pragma': 'no-cache'},
+      {'Cache-Control': 'no-cache', 'Pragma': 'no-cache'},
+    ]);
   });
 
   test('load cache-busts GitHub raw branch dynamic config', () async {
@@ -209,6 +213,10 @@ void main() {
     expect(dynamicRequest.uri.scheme, 'https');
     expect(dynamicRequest.uri.host, 'raw.githubusercontent.com');
     expect(dynamicRequest.uri.queryParameters['vizor_cache_bust'], isNotEmpty);
+    expect(dynamicRequest.headers, {
+      'Cache-Control': 'no-cache',
+      'Pragma': 'no-cache',
+    });
   });
 
   test('load does not cache-bust GitHub raw pinned dynamic config', () async {

--- a/test/services/voting/voting_config_loader_test.dart
+++ b/test/services/voting/voting_config_loader_test.dart
@@ -103,7 +103,9 @@ void main() {
   });
 
   test('allows static config sources without checksum', () {
-    final source = parseStaticVotingConfigSource('https://example.com/static.json');
+    final source = parseStaticVotingConfigSource(
+      'https://example.com/static.json',
+    );
     expect(source.uri.toString(), 'https://example.com/static.json');
     expect(source.sha256Hex, isNull);
     expect(source.raw, 'https://example.com/static.json');
@@ -156,6 +158,95 @@ void main() {
       resolution.config.pirEndpointUrls.single.toString(),
       'https://pir.example',
     );
+    expect(http.requests.map((request) => request.uri.toString()), [
+      'https://voting.example/static-voting-config.json',
+      dynamicUrl,
+    ]);
+  });
+
+  test('load cache-busts GitHub raw branch dynamic config', () async {
+    final staticSource = parseStaticVotingConfigSource(
+      'https://voting.example/static-voting-config.json?checksum=sha256:'
+      '0000000000000000000000000000000000000000000000000000000000000000',
+    );
+    const dynamicUrl =
+        'https://raw.githubusercontent.com/valargroup/'
+        'token-holder-voting-config/main/stage/dynamic-voting-config.json';
+    final http = FakeVotingHttpClient(
+      responses: {
+        staticSource.uri.toString(): '{"static":true}',
+        '/valargroup/token-holder-voting-config/main/stage/dynamic-voting-config.json':
+            '{"dynamic":true}',
+      },
+    );
+    final loader = VotingConfigLoader(
+      httpClient: http,
+      sourceUrl: staticSource.raw,
+      resolveStaticVotingConfig:
+          ({required source, required staticBytes}) async => dynamicUrl,
+      resolveVotingConfig:
+          ({
+            required source,
+            required staticBytes,
+            required dynamicBytes,
+            previous,
+          }) async {
+            expect(dynamicBytes, utf8.encode('{"dynamic":true}'));
+            return rust_config_api.VotingConfigResolution(
+              config: _resolvedConfig(),
+              switchKind: rust_config.ConfigSwitchKind.initialLoad,
+            );
+          },
+    );
+
+    await loader.load();
+
+    final dynamicRequest = http.requests.singleWhere(
+      (request) =>
+          request.uri.path ==
+          '/valargroup/token-holder-voting-config/main/stage/dynamic-voting-config.json',
+    );
+    expect(dynamicRequest.uri.scheme, 'https');
+    expect(dynamicRequest.uri.host, 'raw.githubusercontent.com');
+    expect(dynamicRequest.uri.queryParameters['vizor_cache_bust'], isNotEmpty);
+  });
+
+  test('load does not cache-bust GitHub raw pinned dynamic config', () async {
+    final staticSource = parseStaticVotingConfigSource(
+      'https://voting.example/static-voting-config.json?checksum=sha256:'
+      '0000000000000000000000000000000000000000000000000000000000000000',
+    );
+    const dynamicUrl =
+        'https://raw.githubusercontent.com/valargroup/'
+        'token-holder-voting-config/671f76403eea8aaf64a87cb484c4b0cdaea596db/'
+        'prod/dynamic-voting-config.json';
+    final http = FakeVotingHttpClient(
+      responses: {
+        staticSource.uri.toString(): '{"static":true}',
+        dynamicUrl: '{"dynamic":true}',
+      },
+    );
+    final loader = VotingConfigLoader(
+      httpClient: http,
+      sourceUrl: staticSource.raw,
+      resolveStaticVotingConfig:
+          ({required source, required staticBytes}) async => dynamicUrl,
+      resolveVotingConfig:
+          ({
+            required source,
+            required staticBytes,
+            required dynamicBytes,
+            previous,
+          }) async {
+            return rust_config_api.VotingConfigResolution(
+              config: _resolvedConfig(),
+              switchKind: rust_config.ConfigSwitchKind.initialLoad,
+            );
+          },
+    );
+
+    await loader.load();
+
     expect(http.requests.map((request) => request.uri.toString()), [
       'https://voting.example/static-voting-config.json',
       dynamicUrl,


### PR DESCRIPTION
Removes generated proposal-number badges from voted proposal cards, and uses ZIP and forum metadata in that space instead. Also keeps review/results metadata presentation aligned by showing proposal forum links, narrowing results cards, and removing the extra total divider.

Validation:
- fvm flutter test test/features/voting/voting_status_screen_test.dart --name "proposal detail shows completed vote with stale local draft|results screen renders flat tally rows as ZEC totals|reviewing partial votes warns and marks skipped rows|status screen blocks mixed delegation recovery without draft"
- fvm flutter analyze
- git diff --check