### PR TITLE
Add ZIP-320 TEX address support for Zcash sends

### DIFF
--- a/integration_test/regtest_tex_send_test.dart
+++ b/integration_test/regtest_tex_send_test.dart
@@ -1,0 +1,627 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
+
+const _network = String.fromEnvironment(
+  'ZCASH_E2E_NETWORK',
+  defaultValue: 'regtest',
+);
+const _lightwalletdUrl = String.fromEnvironment(
+  'ZCASH_E2E_LIGHTWALLETD_URL',
+  defaultValue: 'http://127.0.0.1:9067',
+);
+const _zcashdRpcUrl = String.fromEnvironment(
+  'ZCASH_E2E_ZCASHD_RPC_URL',
+  defaultValue: 'http://127.0.0.1:18232',
+);
+const _texAddress = String.fromEnvironment('ZCASH_E2E_TEX_ADDRESS');
+const _zcashdRpcUser = 'zcash';
+const _zcashdRpcPassword = 'zcash';
+const _accountsKey = 'zcash_accounts';
+const _firstMnemonic =
+    'winter shiver fetch refuse absurd mail pistol eight market lounge manual '
+    'roast miracle ethics found child scare curve congress renew salute pig '
+    'better used';
+const _secondMnemonic =
+    'return try reason flat civil wolf dwarf announce toddler uphold equip '
+    'range neck proof gauge east rifle swim tray twin venue fossil will '
+    'version';
+const _password = 'Vizor123!';
+const _sendAmount = '0.25';
+final _sendZatoshi = BigInt.from(25_000_000);
+final _currencyTicker = kZcashDefaultCurrencyTicker;
+final _currencyTickerLower = _currencyTicker.toLowerCase();
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeZcashWalletRuntime();
+  });
+
+  testWidgets(
+    'sends shielded funds to a regtest TEX address',
+    (tester) async {
+      if (_texAddress.isEmpty) {
+        fail('Set ZCASH_E2E_TEX_ADDRESS for the regtest TEX send test.');
+      }
+
+      addTearDown(() async {
+        await _cleanupE2eWalletState();
+      });
+
+      await _cleanupE2eWalletState();
+
+      _log('pumping app');
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+
+      await _importFirstWallet(tester);
+      await _waitForBalance(tester, shielded: '1.25 $_currencyTickerLower');
+
+      await _openAddAccountFlow(tester);
+      await _importAdditionalWallet(tester);
+      await _waitForHome(tester);
+      final senderAccountUuid = await _accountUuidAtOrder(0);
+      final receiverAccountUuid = await _accountUuidAtOrder(1);
+
+      final validation = await rust_sync.validateAddress(address: _texAddress);
+      expect(validation.isValid, isTrue);
+      expect(validation.addressType, 'tex');
+      expect(_texAddress, startsWith('texregtest1'));
+      _log('validated receiver TEX address $_texAddress');
+
+      await _openWallet(tester);
+      await _switchAccount(tester, 0);
+      await _waitForBalance(tester, shielded: '1.25 $_currencyTickerLower');
+      final expectedSenderFee = await _estimateSendFee(
+        accountUuid: senderAccountUuid,
+        toAddress: _texAddress,
+        amountZatoshi: _sendZatoshi,
+      );
+
+      await _sendToAddress(tester, _texAddress, _sendAmount);
+      await _waitForHistoryEntry(
+        tester,
+        accountUuid: senderAccountUuid,
+        txKind: 'sent',
+        displayAmount: _sendZatoshi,
+        pending: true,
+        expectedFee: expectedSenderFee,
+      );
+      await _mineRegtestBlocks(10);
+
+      await _openWallet(tester);
+      await _switchAccount(tester, 1);
+      await _waitForBalance(
+        tester,
+        transparent: 'Transparent balance: $_sendAmount $_currencyTicker',
+        timeout: const Duration(minutes: 5),
+      );
+      await _waitForHistoryEntry(
+        tester,
+        accountUuid: receiverAccountUuid,
+        txKind: 'received',
+        displayAmount: _sendZatoshi,
+        pending: false,
+        timeout: const Duration(minutes: 5),
+      );
+      await _expectActivityRow(
+        tester,
+        const ValueKey('home_activity_row_0'),
+        title: 'Received',
+        amount: '+$_sendAmount $_currencyTicker',
+        status: 'Completed',
+      );
+      await _openActivity(tester);
+      await _expectActivityRow(
+        tester,
+        const ValueKey('activity_screen_row_0'),
+        title: 'Received',
+        amount: '+$_sendAmount $_currencyTicker',
+        status: 'Completed',
+      );
+      _log('receiver transparent TEX activity matched');
+    },
+    timeout: const Timeout(Duration(minutes: 12)),
+  );
+}
+
+Future<void> _importFirstWallet(WidgetTester tester) async {
+  _log('importing first wallet');
+  await _tapAppButton(tester, const ValueKey('welcome_import_wallet_button'));
+  await _enterText(
+    tester,
+    const ValueKey('import_mnemonic_first_word_field'),
+    _firstMnemonic,
+  );
+  await _tapAppButton(tester, const ValueKey('import_secret_submit_button'));
+  await _tapAppButton(tester, const ValueKey('import_birthday_skip_button'));
+  await _tapAppButton(
+    tester,
+    const ValueKey('unknown_birthday_confirm_button'),
+  );
+  await _enterText(
+    tester,
+    const ValueKey('set_password_password_field'),
+    _password,
+  );
+  await _enterText(
+    tester,
+    const ValueKey('set_password_confirm_field'),
+    _password,
+  );
+  await _tapAppButton(tester, const ValueKey('set_password_submit_button'));
+  await _waitForHome(tester);
+  _log('first wallet imported');
+}
+
+Future<void> _importAdditionalWallet(WidgetTester tester) async {
+  _log('importing second wallet');
+  await _tapAppButton(tester, const ValueKey('welcome_import_wallet_button'));
+  await _enterText(
+    tester,
+    const ValueKey('import_mnemonic_first_word_field'),
+    _secondMnemonic,
+  );
+  await _tapAppButton(tester, const ValueKey('import_secret_submit_button'));
+  await _tapAppButton(tester, const ValueKey('import_birthday_skip_button'));
+  await _tapAppButton(
+    tester,
+    const ValueKey('unknown_birthday_confirm_button'),
+  );
+  await _waitForHome(tester);
+  _log('second wallet imported');
+}
+
+Future<void> _openAddAccountFlow(WidgetTester tester) async {
+  _log('opening add-account flow');
+  await _tapWidget(tester, const ValueKey('sidebar_accounts_button'));
+  await _tapAppButton(tester, const ValueKey('accounts_add_account_button'));
+  await _pumpUntil(
+    tester,
+    () =>
+        tester.any(find.byKey(const ValueKey('welcome_import_wallet_button'))),
+    description: 'add-account welcome import button',
+  );
+}
+
+Future<void> _sendToAddress(
+  WidgetTester tester,
+  String address,
+  String amount,
+) async {
+  _log('sending $amount $_currencyTicker to TEX recipient');
+  await _tapAppButton(tester, const ValueKey('home_send_button'));
+  await _enterText(tester, const ValueKey('send_address_field'), address);
+  await _enterText(tester, const ValueKey('send_amount_field'), amount);
+  await _tapAppButton(
+    tester,
+    const ValueKey('send_review_button'),
+    timeout: const Duration(minutes: 1),
+  );
+  await _tapAppButton(
+    tester,
+    const ValueKey('send_confirm_button'),
+    timeout: const Duration(minutes: 1),
+  );
+  await _pumpUntil(
+    tester,
+    () => tester.any(find.byKey(const ValueKey('send_status_succeeded'))),
+    description: 'send status to succeed',
+    timeout: const Duration(minutes: 4),
+  );
+  _log('TEX send succeeded');
+}
+
+Future<BigInt> _estimateSendFee({
+  required String accountUuid,
+  required String toAddress,
+  required BigInt amountZatoshi,
+}) async {
+  final dbPath = await getWalletDbPath();
+  return rust_sync.estimateFee(
+    dbPath: dbPath,
+    network: _network,
+    accountUuid: accountUuid,
+    toAddress: toAddress,
+    amountZatoshi: amountZatoshi,
+  );
+}
+
+Future<void> _mineRegtestBlocks(int blocks) async {
+  _log('mining $blocks regtest blocks');
+
+  final before = await _zcashdRpc<int>('getblockcount');
+  await _zcashdRpc<List<Object?>>('generate', [blocks]);
+  final targetHeight = before + blocks;
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+
+  while (DateTime.now().isBefore(deadline)) {
+    final lightwalletdHeight = await rust_wallet.getLatestBlockHeight(
+      lightwalletdUrl: _lightwalletdUrl,
+    );
+    if (lightwalletdHeight.toInt() >= targetHeight) {
+      _log('lightwalletd reached mined height $targetHeight');
+      return;
+    }
+    await Future<void>.delayed(const Duration(seconds: 1));
+  }
+
+  throw StateError('Timed out waiting for lightwalletd height $targetHeight.');
+}
+
+Future<T> _zcashdRpc<T>(
+  String method, [
+  List<Object?> params = const [],
+]) async {
+  final client = HttpClient();
+  try {
+    final request = await client.postUrl(Uri.parse(_zcashdRpcUrl));
+    final credentials = base64Encode(
+      utf8.encode('$_zcashdRpcUser:$_zcashdRpcPassword'),
+    );
+    request.headers
+      ..set(HttpHeaders.authorizationHeader, 'Basic $credentials')
+      ..contentType = ContentType.json;
+    request.write(
+      jsonEncode({
+        'jsonrpc': '1.0',
+        'id': 'regtest-tex-e2e',
+        'method': method,
+        'params': params,
+      }),
+    );
+
+    final response = await request.close();
+    final body = await utf8.decoder.bind(response).join();
+    if (response.statusCode != HttpStatus.ok) {
+      throw StateError(
+        'zcashd RPC $method failed: HTTP ${response.statusCode}',
+      );
+    }
+
+    final decoded = jsonDecode(body) as Map<String, Object?>;
+    final error = decoded['error'];
+    if (error != null) {
+      throw StateError('zcashd RPC $method failed: $error');
+    }
+    return decoded['result'] as T;
+  } finally {
+    client.close(force: true);
+  }
+}
+
+Future<void> _openWallet(WidgetTester tester) async {
+  if (tester.any(find.byKey(const ValueKey('home_shielded_balance_text')))) {
+    return;
+  }
+  await _tapWidget(tester, const ValueKey('sidebar_home_button'));
+  await _waitForHome(tester);
+}
+
+Future<void> _openActivity(WidgetTester tester) async {
+  await _tapWidget(tester, const ValueKey('sidebar_activity_button'));
+  await _pumpUntil(
+    tester,
+    () => tester.any(find.byKey(const ValueKey('activity_screen_row_0'))),
+    description: 'activity screen rows to render',
+    timeout: const Duration(minutes: 1),
+  );
+}
+
+Future<void> _switchAccount(WidgetTester tester, int accountOrder) async {
+  _log('switching to account order $accountOrder');
+  final accountUuid = await _accountUuidAtOrder(accountOrder);
+  await _tapWidget(tester, const ValueKey('sidebar_accounts_button'));
+  await _tapWidget(tester, ValueKey('accounts_other_row_$accountUuid'));
+  await _waitForHome(tester);
+}
+
+Future<void> _waitForHome(WidgetTester tester) async {
+  await _pumpUntil(
+    tester,
+    () => tester.any(find.byKey(const ValueKey('home_shielded_balance_text'))),
+    description: 'home balance card to render',
+    timeout: const Duration(minutes: 1),
+  );
+}
+
+Future<String> _accountUuidAtOrder(int order) async {
+  final rawAccounts = await AppSecureStore.instance.readString(_accountsKey);
+  if (rawAccounts == null || rawAccounts.trim().isEmpty) {
+    fail('Expected stored accounts before reading account order $order.');
+  }
+
+  final decoded = jsonDecode(rawAccounts);
+  if (decoded is! List) {
+    fail('Expected stored accounts to be a JSON list.');
+  }
+
+  final accounts = <AccountInfo>[];
+  for (final entry in decoded) {
+    if (entry is! Map) {
+      fail('Expected stored account entry to be a JSON object.');
+    }
+    accounts.add(AccountInfo.fromJson(Map<String, dynamic>.from(entry)));
+  }
+  accounts.sort((a, b) => a.order.compareTo(b.order));
+
+  if (order >= accounts.length) {
+    fail('Expected account order $order, got ${accounts.length} accounts.');
+  }
+  return accounts[order].uuid;
+}
+
+Future<void> _waitForHistoryEntry(
+  WidgetTester tester, {
+  required String accountUuid,
+  required String txKind,
+  required BigInt displayAmount,
+  required bool pending,
+  BigInt? expectedFee,
+  Duration timeout = const Duration(minutes: 2),
+}) async {
+  final dbPath = await getWalletDbPath();
+  final deadline = DateTime.now().add(timeout);
+  Object? lastError;
+  var lastHistorySummary = '<not read>';
+
+  while (DateTime.now().isBefore(deadline)) {
+    try {
+      final history = await rust_sync.getTransactionHistory(
+        dbPath: dbPath,
+        network: _network,
+        limit: 20,
+        accountUuid: accountUuid,
+      );
+      lastHistorySummary = history
+          .map(
+            (tx) =>
+                '${tx.txidHex}:${tx.txKind}:${tx.displayAmount}:'
+                'fee=${tx.fee}:mined=${tx.minedHeight}:'
+                'expired=${tx.expiredUnmined}',
+          )
+          .join(', ');
+      if (history.any(
+        (tx) =>
+            tx.txKind == txKind &&
+            tx.displayAmount == displayAmount &&
+            (expectedFee == null || tx.fee == expectedFee) &&
+            (tx.minedHeight == BigInt.zero) == pending &&
+            !tx.expiredUnmined,
+      )) {
+        final feeText = expectedFee == null ? '' : ' fee=$expectedFee';
+        _log('history matched $txKind tx amount=$displayAmount$feeText');
+        return;
+      }
+    } catch (e) {
+      lastError = e;
+    }
+
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail(
+    'Timed out waiting for history $txKind amount=$displayAmount '
+    'fee=$expectedFee pending=$pending. '
+    'Observed history: $lastHistorySummary.$error',
+  );
+}
+
+Future<void> _waitForBalance(
+  WidgetTester tester, {
+  String? shielded,
+  String? transparent,
+  Duration timeout = const Duration(minutes: 4),
+}) async {
+  if (shielded != null) {
+    await _pumpUntil(
+      tester,
+      () => _keyedTextEquals(
+        tester,
+        const ValueKey('home_shielded_balance_text'),
+        shielded,
+      ),
+      description: 'shielded balance to show $shielded',
+      timeout: timeout,
+    );
+    _log('shielded balance matched: $shielded');
+  }
+  if (transparent != null) {
+    await _pumpUntil(
+      tester,
+      () => _keyedTextEquals(
+        tester,
+        const ValueKey('home_transparent_balance_text'),
+        transparent,
+      ),
+      description: 'transparent balance to show $transparent',
+      timeout: timeout,
+    );
+    _log('transparent balance matched: $transparent');
+  }
+}
+
+Future<void> _expectActivityRow(
+  WidgetTester tester,
+  Key key, {
+  required String title,
+  required String amount,
+  required String status,
+}) async {
+  await _pumpUntil(
+    tester,
+    () {
+      final texts = _textSetIn(tester, find.byKey(key));
+      return texts.contains(title) &&
+          texts.contains(amount) &&
+          texts.contains(status);
+    },
+    description: '$key activity row to show $title $amount $status',
+    timeout: const Duration(minutes: 2),
+  );
+  _log('activity row matched: $title $amount $status');
+}
+
+Future<void> _cleanupE2eWalletState() async {
+  if (kZcashDefaultNetworkName != ZcashNetwork.regtest.name) {
+    throw StateError(
+      'Refusing to clean wallet state without ZCASH_DEFAULT_NETWORK=regtest.',
+    );
+  }
+
+  final storage = AppSecureStore.instance;
+  final dbName = await getWalletDbName();
+
+  _log('cleaning regtest wallet state');
+  await _stopRustWorkForCleanup();
+
+  await storage.deleteAll();
+
+  final supportDir = await getWalletSupportDirectory();
+  if (!supportDir.existsSync()) return;
+
+  for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
+    final file = File('${supportDir.path}${Platform.pathSeparator}$name');
+    if (file.existsSync()) file.deleteSync();
+  }
+}
+
+Future<void> _stopRustWorkForCleanup() async {
+  rust_sync.setSyncMode(mode: 0);
+  rust_sync.cancelFullSync();
+  rust_sync.stopMempoolObserver();
+
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  while ((rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) &&
+      DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  if (rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) {
+    _log(
+      'timed out waiting for Rust work to stop; continuing E2E storage cleanup',
+    );
+  }
+}
+
+Future<void> _tapAppButton(
+  WidgetTester tester,
+  Key key, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () =>
+        tester.any(finder) &&
+        tester.widget<AppButton>(finder).onPressed != null,
+    description: '$key button to be enabled',
+    timeout: timeout,
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _tapWidget(
+  WidgetTester tester,
+  Key key, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () => tester.any(finder),
+    description: '$key widget to render',
+    timeout: timeout,
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _enterText(WidgetTester tester, Key key, String text) async {
+  final editable = find.descendant(
+    of: find.byKey(key),
+    matching: find.byType(EditableText),
+  );
+  await _pumpUntil(
+    tester,
+    () => tester.any(editable),
+    description: '$key editable text field',
+  );
+  await tester.tap(editable);
+  await tester.enterText(editable, text);
+  await tester.pump(const Duration(milliseconds: 100));
+  _log('entered text into $key');
+}
+
+bool _keyedTextEquals(WidgetTester tester, Key key, String expected) {
+  return _textForKey(tester, key) == expected;
+}
+
+String? _textForKey(WidgetTester tester, Key key) {
+  final finder = find.byKey(key);
+  if (!tester.any(finder)) return null;
+  final widget = tester.widget<Text>(finder);
+  return widget.data;
+}
+
+Set<String> _textSetIn(WidgetTester tester, Finder finder) {
+  if (!tester.any(finder)) return const {};
+  final texts = find.descendant(of: finder, matching: find.byType(Text));
+  return tester
+      .widgetList<Text>(texts)
+      .map((text) => text.data)
+      .whereType<String>()
+      .toSet();
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  required String description,
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final end = DateTime.now().add(timeout);
+  Object? lastError;
+  var polls = 0;
+  while (DateTime.now().isBefore(end)) {
+    try {
+      if (condition()) return;
+    } catch (e) {
+      lastError = e;
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    polls++;
+    if (polls % 25 == 0) {
+      _log('still waiting for $description');
+    }
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail('Timed out waiting for $description.$error');
+}
+
+void _log(String message) {
+  debugPrint('[regtest-tex-e2e] $message');
+}

--- a/lib/src/core/config/network_config.dart
+++ b/lib/src/core/config/network_config.dart
@@ -33,6 +33,12 @@ enum ZcashNetwork {
     regtest => 'uregtest1',
   };
 
+  String get texPrefix => switch (this) {
+    mainnet => 'tex1',
+    testnet => 'textest1',
+    regtest => 'texregtest1',
+  };
+
   int get defaultPort => switch (this) {
     mainnet => 9067,
     testnet => 18232,

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart'
         TargetPlatform,
         debugPrint,
         defaultTargetPlatform,
+        kDebugMode,
         kIsWeb,
         visibleForTesting;
 import 'package:flutter/services.dart' show PlatformException;
@@ -31,6 +32,9 @@ const _accountMnemonicKeyPrefix = 'zcash_account_mnemonic_';
 const _accountMnemonicMigrationCompleteKey =
     'zcash_mnemonic_storage_migrated_v1';
 const _votingHotkeyKeyPrefix = 'zcash_account_voting_hotkey_';
+const _e2eUseFirstUnlockMnemonicKeychain = bool.fromEnvironment(
+  'ZCASH_E2E_FIRST_UNLOCK_MNEMONIC_KEYCHAIN',
+);
 
 class PasswordRotationRecoveryFailedException implements Exception {
   const PasswordRotationRecoveryFailedException();
@@ -102,7 +106,9 @@ class AppSecureStore {
           : AndroidOptions(sharedPreferencesName: service),
       mOptions: MacOsOptions(
         accountName: macOsService,
-        accessibility: KeychainAccessibility.unlocked,
+        accessibility: kDebugMode && _e2eUseFirstUnlockMnemonicKeychain
+            ? KeychainAccessibility.first_unlock
+            : KeychainAccessibility.unlocked,
         usesDataProtectionKeychain: true,
       ),
     );

--- a/lib/src/features/address_book/models/address_format_validator.dart
+++ b/lib/src/features/address_book/models/address_format_validator.dart
@@ -108,8 +108,8 @@ bool _isNearAddress(String value) {
 
 bool _isZcashAddress(String value, ZcashNetwork net) {
   final lower = value.toLowerCase();
-  // Bech32(m): unified + sapling addresses for this network only.
-  final bechPrefixes = [net.uaPrefix, '${net.saplingPrefix}1'];
+  // Bech32(m): unified + sapling + TEX addresses for this network only.
+  final bechPrefixes = [net.uaPrefix, '${net.saplingPrefix}1', net.texPrefix];
   for (final prefix in bechPrefixes) {
     if (lower.startsWith(prefix)) {
       return value.length >= 8 && _bech32Body.hasMatch(lower);

--- a/lib/src/features/send/screens/send_review_screen.dart
+++ b/lib/src/features/send/screens/send_review_screen.dart
@@ -569,7 +569,7 @@ class _SendReviewReceiptCard extends StatelessWidget {
           Positioned(
             top: 23,
             right: 18,
-            child: _SendReviewStatusBadge(isShielded: args.isShielded),
+            child: _SendReviewStatusBadge(addressType: args.addressType),
           ),
           Positioned(
             left: AppSpacing.sm,
@@ -764,9 +764,17 @@ class _SendReviewSavedRecipientValue extends StatelessWidget {
 }
 
 class _SendReviewStatusBadge extends StatelessWidget {
-  const _SendReviewStatusBadge({required this.isShielded});
+  const _SendReviewStatusBadge({required this.addressType});
 
-  final bool isShielded;
+  final String addressType;
+
+  bool get isShielded => addressType == 'unified' || addressType == 'sapling';
+
+  String get label => addressType == 'tex'
+      ? 'TEX'
+      : isShielded
+      ? 'Shielded'
+      : 'Transparent';
 
   @override
   Widget build(BuildContext context) {
@@ -775,7 +783,7 @@ class _SendReviewStatusBadge extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(
-          isShielded ? 'Shielded' : 'Transparent',
+          label,
           style: AppTypography.labelLarge.copyWith(
             color: isShielded ? colors.text.success : colors.text.muted,
           ),

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -33,6 +33,10 @@ import '../../address_book/widgets/address_book_contact_picker_modal.dart';
 import '../models/send_prefill_args.dart';
 import 'send_review_screen.dart';
 
+final sendWalletDbPathProvider = Provider<Future<String> Function()>((ref) {
+  return getWalletDbPath;
+});
+
 class SendScreen extends ConsumerStatefulWidget {
   const SendScreen({super.key, this.prefill});
 
@@ -46,9 +50,10 @@ class _SendScreenState extends ConsumerState<SendScreen> {
   @override
   Widget build(BuildContext context) {
     final walletAsync = ref.watch(walletProvider);
-    final activeAccountUuid = ref.watch(
-      accountProvider.select((value) => value.value?.activeAccountUuid),
-    );
+    final accountState = ref.watch(accountProvider).value;
+    final activeAccountUuid = accountState?.activeAccountUuid;
+    final activeAccountIsHardware =
+        accountState?.activeAccount?.isHardware ?? false;
     final sync = ref.watch(
       syncProvider.select(
         (value) =>
@@ -61,6 +66,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       key: ValueKey('$activeAccountUuid:${widget.prefill?.fingerprint ?? ''}'),
       walletAsync: walletAsync,
       activeAccountUuid: activeAccountUuid,
+      activeAccountIsHardware: activeAccountIsHardware,
       spendableBalance: spendableBalance,
       prefill: widget.prefill,
     );
@@ -72,12 +78,14 @@ class _SendComposeBody extends ConsumerStatefulWidget {
     super.key,
     required this.walletAsync,
     required this.activeAccountUuid,
+    required this.activeAccountIsHardware,
     required this.spendableBalance,
     this.prefill,
   });
 
   final AsyncValue<WalletState> walletAsync;
   final String? activeAccountUuid;
+  final bool activeAccountIsHardware;
   final BigInt spendableBalance;
   final SendPrefillArgs? prefill;
 
@@ -158,6 +166,8 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   static const _singleLineFieldGap = AppSpacing.xs;
   static const _multilineFieldOverlayReserve = 24.0;
   static const _maxDebounceDuration = Duration(milliseconds: 300);
+  static const _hardwareTexUnsupportedText =
+      'Keystone does not support TEX sends yet.';
   final _addressController = _AddressTextEditingController();
   final _amountController = TextEditingController();
   final _memoController = TextEditingController();
@@ -294,11 +304,12 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       final nextAddressType = result.isValid ? result.addressType : 'invalid';
       setState(() {
         _addressType = nextAddressType;
-        if (nextAddressType == 'transparent') {
+        if (_isTransparentLikeType(nextAddressType)) {
           _messageExpanded = false;
         }
       });
-      if (nextAddressType == 'transparent' && _memoController.text.isNotEmpty) {
+      if (_isTransparentLikeType(nextAddressType) &&
+          _memoController.text.isNotEmpty) {
         _memoController.clear();
       }
       _handleAddressValidationSettled();
@@ -362,15 +373,45 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   bool get _isShieldedAddress =>
       _addressType == 'unified' || _addressType == 'sapling';
 
-  bool get _isConfirmedTransparentAddress => _addressType == 'transparent';
+  bool get _isTexAddress => _addressType == 'tex';
 
-  bool get _showMemoControls => !_isConfirmedTransparentAddress;
+  bool get _isTransparentLikeAddress => _isTransparentLikeType(_addressType);
+
+  bool _isTransparentLikeType(String addressType) =>
+      addressType == 'transparent' || addressType == 'tex';
+
+  bool get _showMemoControls => !_isTransparentLikeAddress;
 
   String get _effectiveMemo =>
-      _isConfirmedTransparentAddress ? '' : _memoController.text.trim();
+      _isTransparentLikeAddress ? '' : _memoController.text.trim();
+
+  BigInt get _availableBalanceForCurrentAddress => widget.spendableBalance;
+
+  String get _insufficientBalanceText =>
+      _isTexAddress ? 'Insufficient balance' : 'Insufficient shielded balance';
+
+  String get _insufficientBalanceToCoverFeeText =>
+      '$_insufficientBalanceText to cover fee';
+
+  String get _insufficientBalanceIncludingFeeText =>
+      '$_insufficientBalanceText including fee';
+
+  String get _insufficientBalanceToCoverAmountAndFeeText =>
+      '$_insufficientBalanceText to cover amount and fee.';
+
+  String _insufficientBalanceWithFeeText(String feeText) =>
+      '$_insufficientBalanceText (fee: $feeText)';
+
+  bool get _isHardwareTexSend =>
+      _isTexAddress && widget.activeAccountIsHardware;
 
   bool get _showAmountError =>
-      _amountError != null && _amountError!.trim().isNotEmpty;
+      _amountError != null &&
+      _amountError!.trim().isNotEmpty &&
+      _amountError != _hardwareTexUnsupportedText;
+
+  String? get _ctaWarningText =>
+      _isHardwareTexSend ? _hardwareTexUnsupportedText : null;
 
   bool get _hasCurrentMaxQuote {
     final quote = _maxQuote;
@@ -397,6 +438,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       !_isResolvingMax &&
       _hasValidAddress &&
       _isAmountValid &&
+      !_isHardwareTexSend &&
       (!_isMaxMode || _hasCurrentMaxQuote) &&
       _memoError == null &&
       (_isShieldedAddress || _effectiveMemo.isEmpty);
@@ -414,6 +456,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   String? _maxEstimatePreconditionError() {
     if (widget.activeAccountUuid == null) return 'No active account';
     if (!_hasValidAddress) return 'Enter a valid address to use Max';
+    if (_isHardwareTexSend) return _hardwareTexUnsupportedText;
     return _memoError;
   }
 
@@ -450,7 +493,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     if (accountUuid == null || !_isMaxMode || seq != _maxSeq) return;
 
     try {
-      final dbPath = await getWalletDbPath();
+      final dbPath = await ref.read(sendWalletDbPathProvider).call();
       final endpoint = ref.read(rpcEndpointProvider);
       if (!mounted || !_isMaxMode || seq != _maxSeq) return;
 
@@ -468,7 +511,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         setState(() {
           _isResolvingMax = false;
           _maxQuote = null;
-          _amountError = 'Insufficient shielded balance to cover fee';
+          _amountError = _insufficientBalanceToCoverFeeText;
         });
         return;
       }
@@ -500,7 +543,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         _isResolvingMax = false;
         _maxQuote = null;
         if (msg.contains('insufficient')) {
-          _amountError = 'Insufficient shielded balance to cover fee';
+          _amountError = _insufficientBalanceToCoverFeeText;
         } else {
           _amountError = 'Max amount unavailable';
         }
@@ -526,14 +569,6 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       return;
     }
 
-    // Quick balance pre-check
-    final spendable = widget.spendableBalance;
-    if (zatoshi > spendable) {
-      setState(() => _amountError = 'Insufficient shielded balance');
-      return;
-    }
-
-    // Need valid address to estimate fee
     final address = _addressController.text.trim();
     if (address.isEmpty ||
         _addressType == 'invalid' ||
@@ -543,8 +578,21 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       return;
     }
 
+    if (_isHardwareTexSend) {
+      setState(() => _amountError = _hardwareTexUnsupportedText);
+      return;
+    }
+
+    final available = _availableBalanceForCurrentAddress;
+    if (zatoshi > available) {
+      setState(() => _amountError = _insufficientBalanceText);
+      return;
+    }
+
+    setState(() => _amountError = null);
+
     try {
-      final dbPath = await getWalletDbPath();
+      final dbPath = await ref.read(sendWalletDbPathProvider).call();
       final endpoint = ref.read(rpcEndpointProvider);
       if (!mounted || seq != _validateSeq) return;
       final memo = _effectiveMemo;
@@ -566,11 +614,9 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       if (!mounted || seq != _validateSeq) return;
 
       final totalNeeded = zatoshi + fee;
-      if (totalNeeded > spendable) {
+      if (totalNeeded > available) {
         final feeText = ZecAmount.fromZatoshi(fee).fee.toString();
-        setState(
-          () => _amountError = 'Insufficient shielded balance (fee: $feeText)',
-        );
+        setState(() => _amountError = _insufficientBalanceWithFeeText(feeText));
       } else {
         setState(() => _amountError = null);
       }
@@ -578,9 +624,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       if (!mounted || seq != _validateSeq) return;
       final msg = e.toString();
       if (msg.contains('InsufficientFunds') || msg.contains('insufficient')) {
-        setState(
-          () => _amountError = 'Insufficient shielded balance including fee',
-        );
+        setState(() => _amountError = _insufficientBalanceIncludingFeeText);
       } else {
         log('Send: fee estimation failed (non-blocking): $e');
         setState(() => _amountError = null);
@@ -593,7 +637,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   String _friendlyError(String raw) {
     final lower = raw.toLowerCase();
     if (lower.contains('insufficientfunds') || lower.contains('insufficient')) {
-      return 'Insufficient shielded balance to cover amount and fee.';
+      return _insufficientBalanceToCoverAmountAndFeeText;
     }
     if (lower.contains('grpc connect failed') ||
         lower.contains('connection refused') ||
@@ -646,6 +690,14 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         return;
       }
 
+      if (_isHardwareTexSend) {
+        setState(() {
+          _error = _hardwareTexUnsupportedText;
+          _isSending = false;
+        });
+        return;
+      }
+
       if (amountZatoshi == null || amountZatoshi <= BigInt.zero) {
         setState(() {
           _error = 'Invalid amount';
@@ -663,17 +715,17 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       }
 
       // Check balance before proposing
-      final spendable = widget.spendableBalance;
-      if (amountZatoshi > spendable) {
+      final available = _availableBalanceForCurrentAddress;
+      if (amountZatoshi > available) {
         setState(() {
-          _error = 'Insufficient shielded balance.';
+          _error = '$_insufficientBalanceText.';
           _isSending = false;
         });
         return;
       }
 
       final memo = _effectiveMemo;
-      final dbPath = await getWalletDbPath();
+      final dbPath = await ref.read(sendWalletDbPathProvider).call();
       final endpoint = ref.read(rpcEndpointProvider);
       if (!mounted) return;
 
@@ -741,9 +793,9 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
 
   @override
   Widget build(BuildContext context) {
-    final spendable = widget.spendableBalance;
+    final available = _availableBalanceForCurrentAddress;
     final visibleSpendableText = ZecAmount.fromZatoshi(
-      spendable,
+      available,
     ).pretty(denomStyle: ZecDenomStyle.upper).toString();
     final spendableText = hideAmountIfPrivacyMode(
       visibleSpendableText,
@@ -763,6 +815,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     final addressMessage = switch (_addressType) {
       'unified' || 'sapling' => 'Shielded Address',
       'transparent' => 'Transparent Address',
+      'tex' => 'TEX address',
       'invalid' => 'Invalid address',
       'error' => 'Address validation failed',
       _ => null,
@@ -778,7 +831,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         size: 16,
         color: colors.text.destructive,
       ),
-      'transparent' => AppIcon(
+      'transparent' || 'tex' => AppIcon(
         AppIcons.transparentBalance,
         size: 16,
         color: colors.icon.muted,
@@ -786,9 +839,8 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       _ => null,
     };
     final addressMessageStyle = switch (_addressType) {
-      'transparent' => AppTypography.labelMedium.copyWith(
-        color: colors.text.muted,
-      ),
+      'transparent' ||
+      'tex' => AppTypography.labelMedium.copyWith(color: colors.text.muted),
       _ => null,
     };
     final messageFieldVisible =
@@ -824,6 +876,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                       Expanded(
                         child: _SendComposeLayout(
                           messageFieldVisible: messageFieldVisible,
+                          ctaWarningText: _ctaWarningText,
                           reviewButton: AppButton(
                             key: const ValueKey('send_review_button'),
                             onPressed: _canReview ? _openReview : null,
@@ -1136,6 +1189,7 @@ class _SendPrefillNotice extends StatelessWidget {
 class _SendComposeLayout extends StatelessWidget {
   const _SendComposeLayout({
     required this.messageFieldVisible,
+    required this.ctaWarningText,
     required this.child,
     required this.reviewButton,
   });
@@ -1150,6 +1204,7 @@ class _SendComposeLayout extends StatelessWidget {
   static const _expandedBottomGap = 10.0;
 
   final bool messageFieldVisible;
+  final String? ctaWarningText;
   final Widget child;
   final Widget reviewButton;
 
@@ -1183,6 +1238,14 @@ class _SendComposeLayout extends StatelessWidget {
           ),
         ),
         const SizedBox(height: _contentToButtonGap),
+        if (ctaWarningText != null) ...[
+          SizedBox(
+            key: const ValueKey('send_cta_warning'),
+            width: _reviewButtonWidth,
+            child: _SendGlobalError(message: ctaWarningText!),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+        ],
         SizedBox(width: _reviewButtonWidth, child: reviewButton),
       ],
     );

--- a/lib/src/features/swap/providers/swap_hardware_signing_service.dart
+++ b/lib/src/features/swap/providers/swap_hardware_signing_service.dart
@@ -65,6 +65,7 @@ class RustSwapHardwareSigningService implements SwapHardwareSigningService {
     if (depositAddress == null || depositAddress.isEmpty) {
       throw StateError('Swap deposit address is missing');
     }
+    await _rejectTexDepositForKeystone(depositAddress);
 
     final amountZatoshi = zecDepositAmountZatoshiForIntent(intent);
     final dbPath = await getWalletDbPath();
@@ -174,6 +175,13 @@ class RustSwapHardwareSigningService implements SwapHardwareSigningService {
       log('SwapHardwareSigning: refreshAfterSend failed: $e');
     }
     return result;
+  }
+}
+
+Future<void> _rejectTexDepositForKeystone(String address) async {
+  final validation = await rust_sync.validateAddress(address: address);
+  if (validation.isValid && validation.addressType == 'tex') {
+    throw UnsupportedError('Keystone does not support TEX sends yet.');
   }
 }
 

--- a/lib/src/features/swap/widgets/swap_keystone_signing_overlay.dart
+++ b/lib/src/features/swap/widgets/swap_keystone_signing_overlay.dart
@@ -304,6 +304,9 @@ class _SwapKeystoneSigningOverlayState
 
   String _friendlyError(Object error) {
     final lower = error.toString().toLowerCase();
+    if (lower.contains('does not support tex')) {
+      return 'Keystone does not support TEX sends yet.';
+    }
     if (lower.contains('sapling') || lower.contains('download')) {
       return 'Required proving parameters could not be prepared.';
     }

--- a/rust/examples/regtest_wallet_addresses.rs
+++ b/rust/examples/regtest_wallet_addresses.rs
@@ -1,5 +1,20 @@
 use rust_lib_zcash_wallet::api::wallet;
 use serde_json::json;
+use zcash_address::{ConversionError, ToAddress, TryFromAddress, ZcashAddress};
+use zcash_protocol::consensus::NetworkType;
+
+struct P2pkhBytes([u8; 20]);
+
+impl TryFromAddress for P2pkhBytes {
+    type Error = &'static str;
+
+    fn try_from_transparent_p2pkh(
+        _net: NetworkType,
+        data: [u8; 20],
+    ) -> Result<Self, ConversionError<Self::Error>> {
+        Ok(P2pkhBytes(data))
+    }
+}
 
 fn main() {
     let mnemonic = std::env::args()
@@ -25,6 +40,7 @@ fn main() {
         Some(result.account_uuid.clone()),
     )
     .expect("transparent address");
+    let tex_address = tex_address_for_transparent(&transparent_address);
 
     println!(
         "{}",
@@ -32,6 +48,16 @@ fn main() {
             "accountUuid": result.account_uuid,
             "unifiedAddress": result.unified_address,
             "transparentAddress": transparent_address,
+            "texAddress": tex_address,
         })
     );
+}
+
+fn tex_address_for_transparent(transparent_address: &str) -> String {
+    let P2pkhBytes(data) = transparent_address
+        .parse::<ZcashAddress>()
+        .expect("parse transparent address")
+        .convert_if_network(NetworkType::Regtest)
+        .expect("regtest transparent P2PKH address");
+    ZcashAddress::from_tex(NetworkType::Regtest, data).to_string()
 }

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -343,16 +343,18 @@ pub fn rewind_to_height(db_path: &str, network: WalletNetwork, height: u64) -> R
 
 pub fn validate_address(address: &str) -> Result<String, String> {
     use zcash_address::ZcashAddress;
-    let addr = ZcashAddress::try_from_encoded(address).map_err(|e| format!("Invalid: {e}"))?;
-    let debug = format!("{:?}", addr);
-    if debug.contains("Unified") {
-        Ok("unified".into())
-    } else if debug.contains("Sapling") {
-        Ok("sapling".into())
-    } else if debug.contains("P2pkh") || debug.contains("P2sh") {
-        Ok("transparent".into())
-    } else {
-        Ok("unknown".into())
+    use zcash_keys::address::Address;
+
+    let addr: Address = ZcashAddress::try_from_encoded(address)
+        .map_err(|e| format!("Invalid: {e}"))?
+        .convert()
+        .map_err(|e| format!("Invalid: {e}"))?;
+
+    match addr {
+        Address::Unified(_) => Ok("unified".into()),
+        Address::Sapling(_) => Ok("sapling".into()),
+        Address::Transparent(_) => Ok("transparent".into()),
+        Address::Tex(_) => Ok("tex".into()),
     }
 }
 
@@ -471,6 +473,36 @@ mod tests {
         // with proposals that a parallel test might genuinely insert.
         static COUNTER: AtomicU64 = AtomicU64::new(1_000_000_000);
         COUNTER.fetch_add(1, Ordering::Relaxed)
+    }
+
+    #[test]
+    fn validate_address_classifies_tex_addresses() {
+        assert_eq!(
+            validate_address("tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte").unwrap(),
+            "tex"
+        );
+        assert_eq!(
+            validate_address("textest1qyqszqgpqyqszqgpqyqszqgpqyqszqgpfcjgfy").unwrap(),
+            "tex"
+        );
+    }
+
+    #[test]
+    fn validate_address_rejects_invalid_address() {
+        assert!(validate_address("not-an-address").is_err());
+    }
+
+    #[test]
+    fn validate_address_rejects_sprout_addresses() {
+        use zcash_address::ToAddress;
+
+        let sprout = zcash_address::ZcashAddress::from_sprout(
+            zcash_protocol::consensus::NetworkType::Main,
+            [0; 64],
+        )
+        .to_string();
+
+        assert!(validate_address(&sprout).is_err());
     }
 
     #[test]

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -413,6 +413,8 @@ pub fn get_transaction_history(
         })
         .collect();
     let external_send_keys = build_external_send_keys(&bases, &summaries);
+    let suppressed_funding_step_fees =
+        build_suppressed_funding_step_fees(&bases, &summaries, &external_send_keys);
 
     let mut visible = Vec::new();
     for base in &bases {
@@ -421,7 +423,15 @@ pub fn get_transaction_history(
             continue;
         }
 
-        visible.extend(classify_history_tx(base, &summary));
+        let extra_sent_fee = if summary.has_external_transparent_send {
+            funding_step_key(base)
+                .and_then(|key| suppressed_funding_step_fees.get(&key).copied())
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        visible.extend(classify_history_tx(base, &summary, extra_sent_fee));
     }
 
     visible.retain(|tx| {
@@ -963,6 +973,33 @@ fn build_external_send_keys(
         .collect()
 }
 
+fn build_suppressed_funding_step_fees(
+    bases: &[TxBase],
+    summaries: &HashMap<Vec<u8>, ActivitySummary>,
+    external_send_keys: &HashSet<(String, i64)>,
+) -> HashMap<(String, i64), u64> {
+    let mut fees = HashMap::new();
+
+    for base in bases {
+        let summary = summaries.get(&base.txid).cloned().unwrap_or_default();
+        if !should_suppress_funding_step(base, &summary, external_send_keys) {
+            continue;
+        }
+        if let Some(key) = funding_step_key(base) {
+            let entry = fees.entry(key).or_insert(0_u64);
+            *entry = entry.saturating_add(base.fee);
+        }
+    }
+
+    fees
+}
+
+fn funding_step_key(base: &TxBase) -> Option<(String, i64)> {
+    base.created
+        .as_ref()
+        .map(|created| (created.clone(), base.expiry_key()))
+}
+
 fn should_suppress_funding_step(
     base: &TxBase,
     summary: &ActivitySummary,
@@ -980,7 +1017,11 @@ fn should_suppress_funding_step(
             .contains(&(base.created.clone().unwrap_or_default(), base.expiry_key()))
 }
 
-fn classify_history_tx(base: &TxBase, summary: &ActivitySummary) -> Vec<ClassifiedTx> {
+fn classify_history_tx(
+    base: &TxBase,
+    summary: &ActivitySummary,
+    extra_sent_fee: u64,
+) -> Vec<ClassifiedTx> {
     if base.is_shielding {
         let amount = if summary.shielded.amount > 0 {
             summary.shielded.amount
@@ -994,13 +1035,14 @@ fn classify_history_tx(base: &TxBase, summary: &ActivitySummary) -> Vec<Classifi
 
     let mut rows = Vec::new();
     if summary.sent.amount > 0 {
-        rows.push(build_classified_tx(
+        rows.push(build_classified_tx_with_fee(
             base,
             "sent",
             summary.sent.amount,
             summary.sent.display_pool(),
             summary.sent.has_transparent,
             1,
+            base.fee.saturating_add(extra_sent_fee),
         ));
     }
     if summary.received.amount > 0 {
@@ -1068,6 +1110,26 @@ fn build_classified_tx(
     is_transparent: bool,
     row_order: u8,
 ) -> ClassifiedTx {
+    build_classified_tx_with_fee(
+        base,
+        tx_kind,
+        display_amount,
+        display_pool,
+        is_transparent,
+        row_order,
+        base.fee,
+    )
+}
+
+fn build_classified_tx_with_fee(
+    base: &TxBase,
+    tx_kind: &str,
+    display_amount: u64,
+    display_pool: &str,
+    is_transparent: bool,
+    row_order: u8,
+    fee: u64,
+) -> ClassifiedTx {
     let sort_timestamp = base.display_timestamp();
     ClassifiedTx {
         info: TransactionInfo {
@@ -1075,7 +1137,7 @@ fn build_classified_tx(
             mined_height: base.mined_height.unwrap_or(0) as u64,
             expired_unmined: base.expired_unmined,
             account_balance_delta: base.account_balance_delta,
-            fee: base.fee,
+            fee,
             block_time: base.block_time,
             is_transparent,
             tx_kind: tx_kind.to_string(),
@@ -1849,6 +1911,7 @@ mod tests {
             false,
             Some(created),
         );
+        set_history_fee(&db, &funding_step, 40_000);
         insert_output_with_address(
             &db,
             &funding_step,
@@ -1874,6 +1937,7 @@ mod tests {
             false,
             Some(created),
         );
+        set_history_fee(&db, &external_send, 10_000);
         insert_output(
             &db,
             &external_send,
@@ -1896,6 +1960,7 @@ mod tests {
         assert_eq!(got[0].txid_hex, hex::encode(external_send));
         assert_eq!(got[0].tx_kind, "sent");
         assert_eq!(got[0].display_amount, 10_000_000);
+        assert_eq!(got[0].fee, 50_000);
     }
 
     #[test]

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -286,6 +286,7 @@ pub(crate) struct ExportBirthdayAnchor {
 #[derive(Clone)]
 struct TxBase {
     txid: Vec<u8>,
+    transaction_id: i64,
     mined_height: Option<u32>,
     expired_unmined: bool,
     account_balance_delta: i64,
@@ -366,8 +367,17 @@ struct ActivitySummary {
     sent: ActivityAmounts,
     received: ActivityAmounts,
     shielded: ActivityAmounts,
+    own_transparent_output_amount: u64,
     has_own_transparent_output: bool,
     has_external_transparent_send: bool,
+}
+
+type FundingStepMatchKey = (String, i64, u64);
+
+#[derive(Default)]
+struct SuppressedFundingStepFees {
+    suppressed_funding_txids: HashSet<i64>,
+    extra_fee_by_external_txid: HashMap<i64, u64>,
 }
 
 struct ClassifiedTx {
@@ -419,13 +429,18 @@ pub fn get_transaction_history(
     let mut visible = Vec::new();
     for base in &bases {
         let summary = summaries.get(&base.txid).cloned().unwrap_or_default();
-        if should_suppress_funding_step(base, &summary, &external_send_keys) {
+        if suppressed_funding_step_fees
+            .suppressed_funding_txids
+            .contains(&base.transaction_id)
+        {
             continue;
         }
 
         let extra_sent_fee = if summary.has_external_transparent_send {
-            funding_step_key(base)
-                .and_then(|key| suppressed_funding_step_fees.get(&key).copied())
+            suppressed_funding_step_fees
+                .extra_fee_by_external_txid
+                .get(&base.transaction_id)
+                .copied()
                 .unwrap_or(0)
         } else {
             0
@@ -589,6 +604,7 @@ fn read_history_base_by_txid(
             r#"
         SELECT
             vt.txid,
+            COALESCE(tx.id_tx, -1) AS transaction_id,
             vt.mined_height,
             vt.expired_unmined,
             vt.account_balance_delta,
@@ -614,18 +630,19 @@ fn read_history_base_by_txid(
         .query_row(rusqlite::params![account_uuid, txid], |row| {
             Ok(TxBase {
                 txid: row.get(0)?,
-                mined_height: row.get(1)?,
-                expired_unmined: row.get(2)?,
-                account_balance_delta: row.get(3)?,
-                fee: row.get::<_, i64>(4)?.unsigned_abs(),
-                block_time: row.get::<_, i64>(5)?.unsigned_abs(),
-                total_spent: row.get::<_, i64>(6)?.unsigned_abs(),
-                total_received: row.get::<_, i64>(7)?.unsigned_abs(),
-                is_shielding: row.get(8)?,
-                expiry_height: row.get(9)?,
-                tx_index: row.get(10)?,
-                created: row.get(11)?,
-                created_time: row.get::<_, i64>(12)?.unsigned_abs(),
+                transaction_id: row.get(1)?,
+                mined_height: row.get(2)?,
+                expired_unmined: row.get(3)?,
+                account_balance_delta: row.get(4)?,
+                fee: row.get::<_, i64>(5)?.unsigned_abs(),
+                block_time: row.get::<_, i64>(6)?.unsigned_abs(),
+                total_spent: row.get::<_, i64>(7)?.unsigned_abs(),
+                total_received: row.get::<_, i64>(8)?.unsigned_abs(),
+                is_shielding: row.get(9)?,
+                expiry_height: row.get(10)?,
+                tx_index: row.get(11)?,
+                created: row.get(12)?,
+                created_time: row.get::<_, i64>(13)?.unsigned_abs(),
             })
         })
         .optional()
@@ -643,6 +660,7 @@ fn read_history_bases(
             r#"
         SELECT
             vt.txid,
+            COALESCE(tx.id_tx, -1) AS transaction_id,
             vt.mined_height,
             vt.expired_unmined,
             vt.account_balance_delta,
@@ -666,18 +684,19 @@ fn read_history_bases(
         .query_map(rusqlite::params![account_uuid], |row| {
             Ok(TxBase {
                 txid: row.get(0)?,
-                mined_height: row.get(1)?,
-                expired_unmined: row.get(2)?,
-                account_balance_delta: row.get(3)?,
-                fee: row.get::<_, i64>(4)?.unsigned_abs(),
-                block_time: row.get::<_, i64>(5)?.unsigned_abs(),
-                total_spent: row.get::<_, i64>(6)?.unsigned_abs(),
-                total_received: row.get::<_, i64>(7)?.unsigned_abs(),
-                is_shielding: row.get(8)?,
-                expiry_height: row.get(9)?,
-                tx_index: row.get(10)?,
-                created: row.get(11)?,
-                created_time: row.get::<_, i64>(12)?.unsigned_abs(),
+                transaction_id: row.get(1)?,
+                mined_height: row.get(2)?,
+                expired_unmined: row.get(3)?,
+                account_balance_delta: row.get(4)?,
+                fee: row.get::<_, i64>(5)?.unsigned_abs(),
+                block_time: row.get::<_, i64>(6)?.unsigned_abs(),
+                total_spent: row.get::<_, i64>(7)?.unsigned_abs(),
+                total_received: row.get::<_, i64>(8)?.unsigned_abs(),
+                is_shielding: row.get(9)?,
+                expiry_height: row.get(10)?,
+                tx_index: row.get(11)?,
+                created: row.get(12)?,
+                created_time: row.get::<_, i64>(13)?.unsigned_abs(),
             })
         })
         .map_err(|e| format!("Query error: {e}"))?;
@@ -869,6 +888,9 @@ fn summarize_activity_outputs(
 
         if output.output_pool == 0 && from_own && to_own {
             summary.has_own_transparent_output = true;
+            summary.own_transparent_output_amount = summary
+                .own_transparent_output_amount
+                .saturating_add(output.value);
         }
 
         let visible_self_output = from_own && to_own && is_user_visible_self_output(output);
@@ -957,53 +979,113 @@ fn decode_text_memo(memo: Option<&[u8]>) -> Option<String> {
 fn build_external_send_keys(
     bases: &[TxBase],
     summaries: &HashMap<Vec<u8>, ActivitySummary>,
-) -> HashSet<(String, i64)> {
-    bases
-        .iter()
-        .filter_map(|base| {
-            let summary = summaries.get(&base.txid)?;
-            if summary.has_external_transparent_send {
-                base.created
-                    .as_ref()
-                    .map(|created| (created.clone(), base.expiry_key()))
-            } else {
-                None
-            }
-        })
-        .collect()
+) -> HashSet<FundingStepMatchKey> {
+    let mut keys = HashSet::new();
+
+    for base in bases {
+        let Some(summary) = summaries.get(&base.txid) else {
+            continue;
+        };
+        let Some(key) = external_send_key(base, summary) else {
+            continue;
+        };
+        keys.insert(key);
+    }
+
+    keys
 }
 
 fn build_suppressed_funding_step_fees(
     bases: &[TxBase],
     summaries: &HashMap<Vec<u8>, ActivitySummary>,
-    external_send_keys: &HashSet<(String, i64)>,
-) -> HashMap<(String, i64), u64> {
-    let mut fees = HashMap::new();
+    external_send_keys: &HashSet<FundingStepMatchKey>,
+) -> SuppressedFundingStepFees {
+    let mut funding_by_key: HashMap<FundingStepMatchKey, Vec<(i64, u64)>> = HashMap::new();
+    let mut external_by_key: HashMap<FundingStepMatchKey, Vec<i64>> = HashMap::new();
 
     for base in bases {
         let summary = summaries.get(&base.txid).cloned().unwrap_or_default();
-        if !should_suppress_funding_step(base, &summary, external_send_keys) {
-            continue;
+        if let Some(key) = external_send_key(base, &summary) {
+            external_by_key
+                .entry(key)
+                .or_default()
+                .push(base.transaction_id);
         }
-        if let Some(key) = funding_step_key(base) {
-            let entry = fees.entry(key).or_insert(0_u64);
-            *entry = entry.saturating_add(base.fee);
+
+        if should_suppress_funding_step(base, &summary, external_send_keys) {
+            if let Some(key) = funding_step_key(base, &summary) {
+                funding_by_key
+                    .entry(key)
+                    .or_default()
+                    .push((base.transaction_id, base.fee));
+            }
         }
     }
 
-    fees
+    let mut matched = SuppressedFundingStepFees::default();
+    for (key, mut funding_steps) in funding_by_key {
+        let Some(mut external_sends) = external_by_key.remove(&key) else {
+            continue;
+        };
+
+        funding_steps.sort_by_key(|(transaction_id, _)| *transaction_id);
+        external_sends.sort_unstable();
+
+        let mut external_index = 0;
+        for (funding_transaction_id, funding_fee) in funding_steps {
+            while external_index < external_sends.len()
+                && external_sends[external_index] <= funding_transaction_id
+            {
+                external_index += 1;
+            }
+
+            let Some(external_transaction_id) = external_sends.get(external_index).copied() else {
+                continue;
+            };
+            external_index += 1;
+
+            matched
+                .suppressed_funding_txids
+                .insert(funding_transaction_id);
+            let entry = matched
+                .extra_fee_by_external_txid
+                .entry(external_transaction_id)
+                .or_insert(0);
+            *entry = entry.saturating_add(funding_fee);
+        }
+    }
+
+    matched
 }
 
-fn funding_step_key(base: &TxBase) -> Option<(String, i64)> {
+fn external_send_key(base: &TxBase, summary: &ActivitySummary) -> Option<FundingStepMatchKey> {
+    if !summary.has_external_transparent_send || base.total_spent == 0 || base.transaction_id < 0 {
+        return None;
+    }
+
     base.created
         .as_ref()
-        .map(|created| (created.clone(), base.expiry_key()))
+        .map(|created| (created.clone(), base.expiry_key(), base.total_spent))
+}
+
+fn funding_step_key(base: &TxBase, summary: &ActivitySummary) -> Option<FundingStepMatchKey> {
+    if summary.own_transparent_output_amount == 0 || base.transaction_id < 0 {
+        return None;
+    }
+
+    base.created.as_ref().map(|created| {
+        (
+            created.clone(),
+            base.expiry_key(),
+            summary.own_transparent_output_amount,
+        )
+    })
 }
 
 fn should_suppress_funding_step(
     base: &TxBase,
     summary: &ActivitySummary,
-    external_send_keys: &HashSet<(String, i64)>,
+    external_send_keys: &HashSet<FundingStepMatchKey>,
 ) -> bool {
     !base.is_shielding
         && base.total_spent > 0
@@ -1013,8 +1095,9 @@ fn should_suppress_funding_step(
         && summary.sent.amount == 0
         && summary.received.amount == 0
         && summary.has_own_transparent_output
-        && external_send_keys
-            .contains(&(base.created.clone().unwrap_or_default(), base.expiry_key()))
+        && funding_step_key(base, summary)
+            .map(|key| external_send_keys.contains(&key))
+            .unwrap_or(false)
 }
 
 fn classify_history_tx(
@@ -1706,6 +1789,73 @@ mod tests {
         .unwrap();
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn insert_zip320_history_pair(
+        db: &NamedTempFile,
+        account: uuid::Uuid,
+        funding_step: &[u8],
+        external_send: &[u8],
+        created: &str,
+        funding_tx_index: i64,
+        external_tx_index: i64,
+        expiry_height: i64,
+        funding_amount: i64,
+        funding_fee: i64,
+        external_fee: i64,
+    ) {
+        let send_amount = funding_amount - external_fee;
+
+        insert_history_tx(
+            db,
+            account,
+            funding_step,
+            None,
+            funding_tx_index,
+            Some(expiry_height),
+            -funding_fee,
+            funding_amount + funding_fee,
+            funding_amount,
+            false,
+            Some(created),
+        );
+        set_history_fee(db, funding_step, funding_fee);
+        insert_output_with_address(
+            db,
+            funding_step,
+            0,
+            Some(account),
+            Some(account),
+            funding_amount,
+            false,
+            Some("t-ephemeral"),
+            Some(2),
+        );
+
+        insert_history_tx(
+            db,
+            account,
+            external_send,
+            None,
+            external_tx_index,
+            Some(expiry_height),
+            -funding_amount,
+            funding_amount,
+            0,
+            false,
+            Some(created),
+        );
+        set_history_fee(db, external_send, external_fee);
+        insert_output(
+            db,
+            external_send,
+            0,
+            Some(account),
+            None,
+            send_amount,
+            false,
+        );
+    }
+
     fn set_account_birthday(db: &NamedTempFile, account: uuid::Uuid, birthday_height: i64) {
         let conn = rusqlite::Connection::open(db.path()).unwrap();
         ensure_account_row(&conn, account);
@@ -1961,6 +2111,134 @@ mod tests {
         assert_eq!(got[0].tx_kind, "sent");
         assert_eq!(got[0].display_amount, 10_000_000);
         assert_eq!(got[0].fee, 50_000);
+    }
+
+    #[test]
+    fn history_pairs_suppressed_funding_fees_by_transparent_amount() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let external_send_a = fake_txid(0xA3);
+        let funding_step_a = fake_txid(0xA4);
+        let external_send_b = fake_txid(0xA5);
+        let funding_step_b = fake_txid(0xA6);
+        let created = "2026-04-28T13:03:00Z";
+
+        insert_zip320_history_pair(
+            &db,
+            account,
+            &funding_step_a,
+            &external_send_a,
+            created,
+            4,
+            3,
+            1_000_100,
+            10_010_000,
+            40_000,
+            10_000,
+        );
+        insert_zip320_history_pair(
+            &db,
+            account,
+            &funding_step_b,
+            &external_send_b,
+            created,
+            2,
+            1,
+            1_000_100,
+            20_015_000,
+            50_000,
+            15_000,
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 2);
+
+        let row_a = got
+            .iter()
+            .find(|tx| tx.txid_hex == hex::encode(external_send_a))
+            .unwrap();
+        assert_eq!(row_a.tx_kind, "sent");
+        assert_eq!(row_a.display_amount, 10_000_000);
+        assert_eq!(row_a.fee, 50_000);
+
+        let row_b = got
+            .iter()
+            .find(|tx| tx.txid_hex == hex::encode(external_send_b))
+            .unwrap();
+        assert_eq!(row_b.tx_kind, "sent");
+        assert_eq!(row_b.display_amount, 20_000_000);
+        assert_eq!(row_b.fee, 65_000);
+    }
+
+    #[test]
+    fn history_pairs_same_amount_funding_fees_by_insert_order() {
+        let db = fresh_history_db();
+        let account = test_account_uuid();
+        let external_send_a = fake_txid(0xA7);
+        let funding_step_a = fake_txid(0xA8);
+        let external_send_b = fake_txid(0xA9);
+        let funding_step_b = fake_txid(0xAA);
+        let created = "2026-04-28T13:03:00Z";
+
+        insert_zip320_history_pair(
+            &db,
+            account,
+            &funding_step_a,
+            &external_send_a,
+            created,
+            4,
+            3,
+            1_000_100,
+            10_010_000,
+            40_000,
+            10_000,
+        );
+        insert_zip320_history_pair(
+            &db,
+            account,
+            &funding_step_b,
+            &external_send_b,
+            created,
+            2,
+            1,
+            1_000_100,
+            10_010_000,
+            50_000,
+            10_000,
+        );
+
+        let got = get_transaction_history(
+            db.path().to_str().unwrap(),
+            WalletNetwork::Test,
+            None,
+            &account.to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(got.len(), 2);
+
+        let row_a = got
+            .iter()
+            .find(|tx| tx.txid_hex == hex::encode(external_send_a))
+            .unwrap();
+        assert_eq!(row_a.tx_kind, "sent");
+        assert_eq!(row_a.display_amount, 10_000_000);
+        assert_eq!(row_a.fee, 50_000);
+
+        let row_b = got
+            .iter()
+            .find(|tx| tx.txid_hex == hex::encode(external_send_b))
+            .unwrap();
+        assert_eq!(row_b.tx_kind, "sent");
+        assert_eq!(row_b.display_amount, 10_000_000);
+        assert_eq!(row_b.fee, 60_000);
     }
 
     #[test]

--- a/scripts/e2e/flutter-macos-regtest-tex-send.sh
+++ b/scripts/e2e/flutter-macos-regtest-tex-send.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SENDER_MNEMONIC="winter shiver fetch refuse absurd mail pistol eight market lounge manual roast miracle ethics found child scare curve congress renew salute pig better used"
+RECEIVER_MNEMONIC="return try reason flat civil wolf dwarf announce toddler uphold equip range neck proof gauge east rifle swim tray twin venue fossil will version"
+SHIELDED_AMOUNT="1.25"
+CONFIRMING_BLOCKS="${E2E_CONFIRMING_BLOCKS:-10}"
+LIGHTWALLETD_URL="${E2E_LIGHTWALLETD_URL:-http://127.0.0.1:9067}"
+ZCASHD_RPC_URL="${E2E_ZCASHD_RPC_URL:-http://127.0.0.1:18232}"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+json_field() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+data = json.loads(sys.argv[1])
+print(data[sys.argv[2]])
+PY
+}
+
+require_cmd cargo
+require_cmd docker
+require_cmd fvm
+require_cmd python3
+
+cd "$ROOT_DIR"
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+sender_addresses_json="$(cd rust && cargo run --quiet --example regtest_wallet_addresses -- "$SENDER_MNEMONIC")"
+receiver_addresses_json="$(cd rust && cargo run --quiet --example regtest_wallet_addresses -- "$RECEIVER_MNEMONIC")"
+sender_unified_address="$(json_field "$sender_addresses_json" unifiedAddress)"
+receiver_tex_address="$(json_field "$receiver_addresses_json" texAddress)"
+
+echo "funding sender shielded address with ${SHIELDED_AMOUNT} TAZ"
+scripts/regtest/fund-wallet.sh "$sender_unified_address" "$SHIELDED_AMOUNT" "$CONFIRMING_BLOCKS" >/dev/null
+
+echo "running Flutter macOS TEX send integration test"
+fvm flutter test \
+  integration_test/regtest_tex_send_test.dart \
+  -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
+  --dart-define=ZCASH_E2E_FIRST_UNLOCK_MNEMONIC_KEYCHAIN=true \
+  --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$LIGHTWALLETD_URL" \
+  --dart-define=ZCASH_E2E_ZCASHD_RPC_URL="$ZCASHD_RPC_URL" \
+  --dart-define=ZCASH_E2E_TEX_ADDRESS="$receiver_tex_address"

--- a/test/features/address_book/address_book_screen_test.dart
+++ b/test/features/address_book/address_book_screen_test.dart
@@ -71,6 +71,50 @@ void main() {
     expect(find.text('No contacts yet'), findsNothing);
   });
 
+  testWidgets('creates a Zcash contact for a TEX address without warning', (
+    tester,
+  ) async {
+    const texAddress = 'tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte';
+    await _setDesktopViewport(tester);
+    final repo = _FakeAddressBookRepository();
+
+    await tester.pumpWidget(_addressBookHarness(repo));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey('address_book_add_contact_button')),
+    );
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('address_book_contact_label_field')),
+      'Exchange',
+    );
+    await tester.enterText(
+      find.byKey(const ValueKey('address_book_contact_address_field')),
+      texAddress,
+    );
+    await tester.pump();
+
+    expect(find.text('Invalid Zcash address'), findsNothing);
+    expect(
+      tester
+          .widget<AppButton>(
+            find.byKey(const ValueKey('address_book_contact_submit_button')),
+          )
+          .onPressed,
+      isNotNull,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('address_book_contact_submit_button')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(repo.contacts, hasLength(1));
+    expect(repo.contacts.single.network, AddressBookNetwork.zcash);
+    expect(repo.contacts.single.address, texAddress);
+  });
+
   testWidgets('warns about a malformed address but still allows saving', (
     tester,
   ) async {
@@ -108,10 +152,7 @@ void main() {
     );
     await tester.pump();
 
-    expect(
-      find.text("Invalid EVM address"),
-      findsOneWidget,
-    );
+    expect(find.text("Invalid EVM address"), findsOneWidget);
     // Soft warning: the save button stays enabled.
     expect(
       tester

--- a/test/features/address_book/address_format_validator_test.dart
+++ b/test/features/address_book/address_format_validator_test.dart
@@ -61,8 +61,10 @@ void main() {
       });
 
       test('rejects wrong length', () {
-        expect(addressFormatIssue(AddressBookNetwork.ethereum, '0x1234'),
-            isNotNull);
+        expect(
+          addressFormatIssue(AddressBookNetwork.ethereum, '0x1234'),
+          isNotNull,
+        );
       });
 
       test('rejects non-hex characters', () {
@@ -303,6 +305,37 @@ void main() {
         );
       });
 
+      test('accepts TEX addresses for the active Zcash network', () {
+        const mainnetTex = 'tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte';
+        const testnetTex = 'textest1qyqszqgpqyqszqgpqyqszqgpqyqszqgpfcjgfy';
+        const regtestTex = 'texregtest1qyqszqgpqyqszqgpqyqszqgpqyqszqgpfcjgfy';
+
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            mainnetTex,
+            zcashNetwork: ZcashNetwork.mainnet,
+          ),
+          isNull,
+        );
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            testnetTex,
+            zcashNetwork: ZcashNetwork.testnet,
+          ),
+          isNull,
+        );
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            regtestTex,
+            zcashNetwork: ZcashNetwork.regtest,
+          ),
+          isNull,
+        );
+      });
+
       test('rejects an EVM address tagged as Zcash', () {
         expect(
           addressFormatIssue(
@@ -337,11 +370,18 @@ void main() {
           ),
           isNotNull,
         );
+        expect(
+          addressFormatIssue(
+            AddressBookNetwork.zcash,
+            'textest1qyqszqgpqyqszqgpqyqszqgpqyqszqgpfcjgfy',
+            zcashNetwork: ZcashNetwork.mainnet,
+          ),
+          isNotNull,
+        );
       });
 
       test('honours the active Zcash network for its own prefixes', () {
-        const testnetUa =
-            'utest1qpw508d6qejxtdg4y5r3zarvary0c5xw7kqqqqqq';
+        const testnetUa = 'utest1qpw508d6qejxtdg4y5r3zarvary0c5xw7kqqqqqq';
         expect(
           addressFormatIssue(
             AddressBookNetwork.zcash,
@@ -452,7 +492,9 @@ void main() {
 
       test('rejects uppercase / invalid characters', () {
         expect(
-            addressFormatIssue(AddressBookNetwork.near, 'Alice.NEAR'), isNotNull);
+          addressFormatIssue(AddressBookNetwork.near, 'Alice.NEAR'),
+          isNotNull,
+        );
         expect(addressFormatIssue(AddressBookNetwork.near, 'a'), isNotNull);
       });
 

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -136,6 +136,23 @@ void main() {
     expect(find.text('Transparent'), findsOneWidget);
   });
 
+  testWidgets('TEX preview uses TEX transparent-style badge', (tester) async {
+    await _setDesktopViewport(tester);
+    await tester.pumpWidget(
+      _sendReviewHarness(_reviewArgs(addressType: 'tex')),
+    );
+    await tester.pump();
+
+    final transparentIcon = tester
+        .widgetList<AppIcon>(find.byType(AppIcon))
+        .singleWhere((icon) => icon.name == AppIcons.transparentBalance);
+
+    expect(transparentIcon.size, 20);
+    expect(transparentIcon.color, AppThemeData.light.colors.icon.muted);
+    expect(find.text('TEX'), findsOneWidget);
+    expect(find.text('Shielded'), findsNothing);
+  });
+
   testWidgets('shortens recipient address with Figma-style middle ellipsis', (
     tester,
   ) async {

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -15,8 +15,17 @@ import 'package:zcash_wallet/src/rust/api/sync.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _RustApiFake rustApi;
+
   setUpAll(() {
-    RustLib.initMock(api: _RustApiFake());
+    rustApi = _RustApiFake();
+    RustLib.initMock(api: rustApi);
+  });
+
+  setUp(() {
+    rustApi.reset();
   });
 
   tearDownAll(RustLib.dispose);
@@ -124,11 +133,169 @@ void main() {
     expect(find.text('Add a message'), findsNothing);
     expect(find.text('Encrypted, for Shielded Addresses only.'), findsNothing);
   });
+
+  testWidgets('hides imported memo controls for TEX recipients', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _sendHarness(
+        prefill: const SendPrefillArgs(
+          id: 'zip321-tex',
+          source: 'ZIP-321',
+          address: _texAddress,
+          amountText: '0.5',
+          memoText: 'TEX memo',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+
+    expect(find.text('TEX address'), findsOneWidget);
+    expect(find.text('TEX memo'), findsNothing);
+    expect(find.text('Add a message'), findsNothing);
+    expect(find.text('Encrypted, for Shielded Addresses only.'), findsNothing);
+  });
+
+  testWidgets('TEX review uses shielded balance and raw address', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _sendHarness(
+        spendableBalance: BigInt.from(2000000000),
+        transparentBalance: BigInt.from(2000000000),
+        prefill: const SendPrefillArgs(
+          id: 'zip321-tex-balance',
+          source: 'ZIP-321',
+          address: _texAddress,
+          amountText: '1.0',
+          memoText: 'Dropped memo',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Insufficient shielded balance'), findsNothing);
+    expect(find.text('Insufficient balance'), findsNothing);
+
+    await tester.tap(find.text('Review'));
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(rustApi.proposeSendCalls, 1);
+    expect(rustApi.lastProposeToAddress, _texAddress);
+    expect(rustApi.lastProposeMemo, isNull);
+  });
+
+  testWidgets('TEX ignores transparent balance for availability', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _sendHarness(
+        spendableBalance: BigInt.from(50000000),
+        transparentBalance: BigInt.from(2000000000),
+        prefill: const SendPrefillArgs(
+          id: 'zip321-tex-transparent-ignored',
+          source: 'ZIP-321',
+          address: _texAddress,
+          amountText: '1.0',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Insufficient balance'), findsOneWidget);
+
+    await tester.tap(find.text('Review'));
+    await tester.pumpAndSettle();
+
+    expect(rustApi.proposeSendCalls, 0);
+  });
+
+  testWidgets('hardware TEX sends are blocked inline before proposal', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _sendHarness(
+        bootstrap: _hardwareBootstrap,
+        spendableBalance: BigInt.from(2000000000),
+        prefill: const SendPrefillArgs(
+          id: 'hardware-tex',
+          source: 'ZIP-321',
+          address: _texAddress,
+          amountText: '0.5',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Keystone does not support TEX sends yet.'),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('send_cta_warning')), findsOneWidget);
+
+    await tester.tap(find.text('Review'));
+    await tester.pumpAndSettle();
+
+    expect(rustApi.proposeSendCalls, 0);
+  });
+
+  testWidgets('hardware TEX address explains unsupported state before amount', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _sendHarness(
+        bootstrap: _hardwareBootstrap,
+        spendableBalance: BigInt.from(2000000000),
+        prefill: const SendPrefillArgs(
+          id: 'hardware-tex-no-amount',
+          source: 'ZIP-321',
+          address: _texAddress,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+
+    expect(_fieldText(tester, 'send_amount_field'), isEmpty);
+    expect(
+      find.text('Keystone does not support TEX sends yet.'),
+      findsOneWidget,
+    );
+    expect(find.byKey(const ValueKey('send_cta_warning')), findsOneWidget);
+    expect(find.text('TEX address'), findsOneWidget);
+    expect(rustApi.proposeSendCalls, 0);
+  });
 }
 
 Widget _sendHarness({
   SendPrefillArgs? prefill,
   AddressBookRepository? addressBookRepository,
+  AppBootstrapState? bootstrap,
+  BigInt? spendableBalance,
+  BigInt? transparentBalance,
 }) {
   final router = GoRouter(
     initialLocation: '/send',
@@ -143,8 +310,14 @@ Widget _sendHarness({
 
   return ProviderScope(
     overrides: [
-      appBootstrapProvider.overrideWithValue(_bootstrap),
-      syncProvider.overrideWith(_FakeSyncNotifier.new),
+      appBootstrapProvider.overrideWithValue(bootstrap ?? _bootstrap),
+      sendWalletDbPathProvider.overrideWithValue(() async => '/tmp/test.db'),
+      syncProvider.overrideWith(
+        () => _FakeSyncNotifier(
+          spendableBalance: spendableBalance ?? BigInt.from(500000000),
+          transparentBalance: transparentBalance ?? BigInt.zero,
+        ),
+      ),
       if (addressBookRepository != null)
         addressBookRepositoryProvider.overrideWithValue(addressBookRepository),
     ],
@@ -223,21 +396,67 @@ final _bootstrap = AppBootstrapState(
   passwordRotationRecoveryFailed: false,
 );
 
+final _hardwareBootstrap = AppBootstrapState(
+  initialLocation: '/send',
+  initialAccountState: const AccountState(
+    accounts: [
+      AccountInfo(
+        uuid: 'account-1',
+        name: 'Keystone',
+        order: 0,
+        isHardware: true,
+      ),
+    ],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1activeaddress',
+  ),
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: kZcashDefaultNetworkName,
+  rpcEndpointConfig: defaultRpcEndpointConfig(kZcashDefaultNetworkName),
+  themeMode: ThemeMode.system,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);
+
 class _FakeSyncNotifier extends SyncNotifier {
+  _FakeSyncNotifier({
+    required this.spendableBalance,
+    required this.transparentBalance,
+  });
+
+  final BigInt spendableBalance;
+  final BigInt transparentBalance;
+
   @override
   Future<SyncState> build() async => SyncState(
     accountUuid: 'account-1',
     hasAccountScopedData: true,
-    spendableBalance: BigInt.from(500000000),
-    totalBalance: BigInt.from(500000000),
+    spendableBalance: spendableBalance,
+    transparentBalance: transparentBalance,
+    totalBalance: spendableBalance + transparentBalance,
   );
 }
 
 class _RustApiFake implements RustLibApi {
+  int proposeSendCalls = 0;
+  String? lastProposeToAddress;
+  String? lastProposeMemo;
+
+  void reset() {
+    proposeSendCalls = 0;
+    lastProposeToAddress = null;
+    lastProposeMemo = null;
+  }
+
   @override
   Future<AddressValidationResult> crateApiSyncValidateAddress({
     required String address,
   }) async {
+    if (address == _texAddress) {
+      return const AddressValidationResult(isValid: true, addressType: 'tex');
+    }
     if (address == _transparentAddress) {
       return const AddressValidationResult(
         isValid: true,
@@ -260,9 +479,30 @@ class _RustApiFake implements RustLibApi {
   }
 
   @override
+  Future<ProposalResult> crateApiSyncProposeSend({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String sendFlowId,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+  }) async {
+    proposeSendCalls++;
+    lastProposeToAddress = toAddress;
+    lastProposeMemo = memo;
+    return ProposalResult(
+      proposalId: BigInt.one,
+      needsSaplingParams: false,
+      feeZatoshi: BigInt.from(10000),
+    );
+  }
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 const _shieldedAddress =
     'u1testshieldedaddress000000000000000000000000000000000000000000000000000';
 const _transparentAddress = 't1transparentdestination0000000000000000000';
+const _texAddress = 'tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte';

--- a/test/features/swap/swap_deposit_amount_test.dart
+++ b/test/features/swap/swap_deposit_amount_test.dart
@@ -1,9 +1,25 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_deposit_sender.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_hardware_signing_service.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart';
+import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
 void main() {
+  late _RustApiFake rustApi;
+
+  setUpAll(() {
+    rustApi = _RustApiFake();
+    RustLib.initMock(api: rustApi);
+  });
+
+  setUp(() {
+    rustApi.reset();
+  });
+
+  tearDownAll(RustLib.dispose);
+
   test('software ZEC deposit uses quote base units, not display text', () {
     final quote = _quote(
       sellAmountTextOverride: '0.001 ZEC',
@@ -39,6 +55,32 @@ void main() {
       throwsA(isA<StateError>()),
     );
   });
+
+  test('hardware ZEC deposit rejects TEX before proposal', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final service = container.read(swapHardwareSigningServiceProvider);
+
+    await expectLater(
+      service.createZecDepositPczt(
+        accountUuid: 'account-1',
+        intent: _intent(
+          sellAmount: '1.0 ZEC',
+          sellAmountBaseUnits: BigInt.from(100000000),
+          depositAddress: _texAddress,
+        ),
+      ),
+      throwsA(
+        isA<UnsupportedError>().having(
+          (error) => error.message,
+          'message',
+          'Keystone does not support TEX sends yet.',
+        ),
+      ),
+    );
+    expect(rustApi.proposeSendCalls, 0);
+  });
 }
 
 SwapQuote _quote({
@@ -67,7 +109,11 @@ SwapQuote _quote({
   );
 }
 
-SwapIntent _intent({required String sellAmount, BigInt? sellAmountBaseUnits}) {
+SwapIntent _intent({
+  required String sellAmount,
+  BigInt? sellAmountBaseUnits,
+  String depositAddress = 't1deposit',
+}) {
   return SwapIntent(
     id: 't1deposit',
     pair: 'ZEC -> USDC',
@@ -79,6 +125,50 @@ SwapIntent _intent({required String sellAmount, BigInt? sellAmountBaseUnits}) {
     nextAction: 'Sign deposit',
     direction: SwapDirection.zecToExternal,
     externalAsset: SwapAsset.usdc,
-    depositAddress: 't1deposit',
+    depositAddress: depositAddress,
   );
 }
+
+class _RustApiFake implements RustLibApi {
+  int proposeSendCalls = 0;
+
+  void reset() {
+    proposeSendCalls = 0;
+  }
+
+  @override
+  Future<AddressValidationResult> crateApiSyncValidateAddress({
+    required String address,
+  }) async {
+    if (address == _texAddress) {
+      return const AddressValidationResult(isValid: true, addressType: 'tex');
+    }
+    return const AddressValidationResult(
+      isValid: true,
+      addressType: 'transparent',
+    );
+  }
+
+  @override
+  Future<ProposalResult> crateApiSyncProposeSend({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String sendFlowId,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+  }) async {
+    proposeSendCalls++;
+    return ProposalResult(
+      proposalId: BigInt.one,
+      needsSaplingParams: false,
+      feeZatoshi: BigInt.from(10000),
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+const _texAddress = 'tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte';

--- a/test/features/swap/zip321_payment_request_test.dart
+++ b/test/features/swap/zip321_payment_request_test.dart
@@ -45,6 +45,15 @@ void main() {
       expect(request.primaryPayment.memoIsBinary, isFalse);
     });
 
+    test('rejects memos for TEX payment handoff', () {
+      expect(
+        () => Zip321PaymentRequest.parse(
+          'zcash:tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte?amount=1&memo=VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg',
+        ),
+        throwsA(isA<Zip321ParseException>()),
+      );
+    });
+
     test('parses binary memos as unsupported by the swap flow', () {
       final request = Zip321PaymentRequest.parse(
         'zcash:u1zip321destination?amount=1&memo=_w',


### PR DESCRIPTION
## Summary

- Add typed TEX address classification for Zcash address validation and reject invalid/Sprout addresses earlier.
- Enable software sends to TEX recipients:
  - treat TEX as transparent-like for memo handling
  - keep TEX sends funded from shielded spendable balance
  - show TEX-specific send/review UI states
  - block Keystone TEX sends before proposal creation
- Block Keystone swap deposit PCZT creation for TEX deposit addresses.
- Keep ZIP-320 two-step sends user-visible as one Activity item by hiding the internal funding step and aggregating its fee into the final send row.
- Add regtest TEX send E2E coverage, including sender-side history fee assertion and receiver transparent balance/activity checks.

## Testing

- `fvm flutter analyze`
- `fvm flutter test test/features/send/send_screen_test.dart test/features/send/send_review_screen_test.dart test/features/swap/swap_deposit_amount_test.dart test/features/address_book/address_format_validator_test.dart test/features/address_book/address_book_screen_test.dart test/features/swap/zip321_payment_request_test.dart`
- `cd rust && cargo test validate_address`
- `cd rust && cargo test history_suppresses_funding_step_after_limit_filtering`
- `scripts/e2e/flutter-macos-regtest-tex-send.sh`

## Notes

- TEX sends are supported for software accounts only.
- Keystone TEX sends are intentionally blocked because Keystone does not support TEX sends yet.
- Activity shows the final recipient transaction as one send item and reports the aggregate ZIP-320 fee.
