### PR TITLE
Suppress false insufficient-balance errors while syncing

### DIFF
--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -954,22 +954,63 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     return 'Enter amount to continue';
   }
 
-  bool _recheckAmountBeforeReview() {
+  Future<bool> _recheckAmountBeforeReview() async {
     final zatoshi = parseZecAmount(_amountText.trim());
     if (zatoshi == null || zatoshi <= BigInt.zero) return false;
     if (!_isSyncedToTip) return true;
 
-    final fee = _feeZatoshi;
-    final required = fee == null ? zatoshi : zatoshi + fee;
-    if (required <= _spendable) return true;
+    final seq = ++_validateSeq;
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    if (accountUuid == null) return false;
 
-    setState(() => _amountError = 'Not enough ZEC');
-    return false;
+    try {
+      final dbPath = await widget.loadWalletDbPath();
+      final endpoint = ref.read(rpcEndpointProvider);
+      if (!mounted || seq != _validateSeq) return false;
+      final fee = await (widget.estimateFee ?? rust_sync.estimateFee)(
+        dbPath: dbPath,
+        network: endpoint.networkName,
+        accountUuid: accountUuid,
+        toAddress: _addressController.text.trim(),
+        amountZatoshi: zatoshi,
+        memo: _effectiveMemo.isNotEmpty ? _effectiveMemo : null,
+      );
+      if (!mounted || seq != _validateSeq) return false;
+
+      final required = zatoshi + fee;
+      if (required <= _spendable) {
+        setState(() {
+          _amountError = null;
+          _feeZatoshi = fee;
+        });
+        return true;
+      }
+
+      setState(() {
+        _amountError = _notEnoughZecText;
+        _feeZatoshi = fee;
+      });
+      return false;
+    } catch (e) {
+      if (!mounted || seq != _validateSeq) return false;
+      final failure = classifySendFailure(e);
+      if (failure == SendFailureKind.insufficientFunds) {
+        setState(() => _amountError = _notEnoughZecText);
+        return false;
+      }
+      if (failure.isWaitingForSync) {
+        setState(() => _amountError = null);
+        return true;
+      }
+      log('MobileSend: review amount recheck failed (non-blocking): $e');
+      return true;
+    }
   }
 
-  void _continueToReview() {
+  Future<void> _continueToReview() async {
     if (!_amountReady) return;
-    if (!_recheckAmountBeforeReview()) return;
+    if (!await _recheckAmountBeforeReview()) return;
+    if (!mounted) return;
     _amountFocus.unfocus();
     if (widget.useRouteSteps) {
       unawaited(

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -954,8 +954,22 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     return 'Enter amount to continue';
   }
 
+  bool _recheckAmountBeforeReview() {
+    final zatoshi = parseZecAmount(_amountText.trim());
+    if (zatoshi == null || zatoshi <= BigInt.zero) return false;
+    if (!_isSyncedToTip) return true;
+
+    final fee = _feeZatoshi;
+    final required = fee == null ? zatoshi : zatoshi + fee;
+    if (required <= _spendable) return true;
+
+    setState(() => _amountError = 'Not enough ZEC');
+    return false;
+  }
+
   void _continueToReview() {
     if (!_amountReady) return;
+    if (!_recheckAmountBeforeReview()) return;
     _amountFocus.unfocus();
     if (widget.useRouteSteps) {
       unawaited(

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -31,6 +31,7 @@ import '../../../../providers/rpc_endpoint_provider.dart';
 import '../../../../providers/sync_provider.dart';
 import '../../../../providers/zec_price_change_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
+import '../../../../services/send_failure.dart';
 import '../../../address_book/models/address_book_contact.dart';
 import '../../../address_book/providers/address_book_provider.dart';
 import '../../services/send_flow.dart';
@@ -705,6 +706,13 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     _maxQuote = null;
   }
 
+  bool get _isSyncedToTip {
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    return (ref.read(syncProvider).value ?? SyncState())
+        .scopedToAccount(accountUuid)
+        .isSyncedToTip;
+  }
+
   void _handleAmountChanged(String value) {
     if (_amountInputIsUsd) {
       _handleFiatAmountChanged(value);
@@ -884,7 +892,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       setState(() => _amountError = '');
       return;
     }
-    if (zatoshi > _spendable) {
+    if (_isSyncedToTip && zatoshi > _spendable) {
       setState(() => _amountError = _notEnoughZecText);
       return;
     }
@@ -907,7 +915,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         memo: _effectiveMemo.isNotEmpty ? _effectiveMemo : null,
       );
       if (!mounted || seq != _validateSeq) return;
-      if (zatoshi + fee > _spendable) {
+      if (_isSyncedToTip && zatoshi + fee > _spendable) {
         setState(() => _amountError = _notEnoughZecText);
       } else {
         setState(() {
@@ -917,9 +925,11 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       }
     } catch (e) {
       if (!mounted || seq != _validateSeq) return;
-      final msg = e.toString();
-      if (msg.contains('InsufficientFunds') || msg.contains('insufficient')) {
+      final failure = classifySendFailure(e);
+      if (failure == SendFailureKind.insufficientFunds) {
         setState(() => _amountError = _notEnoughZecText);
+      } else if (failure.isWaitingForSync) {
+        setState(() => _amountError = null);
       } else {
         log('MobileSend: fee estimation failed (non-blocking): $e');
         setState(() => _amountError = null);
@@ -1060,10 +1070,13 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     } catch (e) {
       log('MobileSend: propose error: $e');
       if (!mounted) return;
+      final failure = classifySendFailure(e);
       setState(() {
         _isConfirmingSend = false;
         _phase = _SendPhase.failed;
-        _error = friendlyProposeSendError(e.toString());
+        _error = failure.isWaitingForSync
+            ? 'Still syncing. Try again once sync finishes.'
+            : friendlyProposeSendError(e.toString());
       });
       return;
     }

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -527,7 +527,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         if (failure == SendFailureKind.insufficientFunds) {
           _amountError = _insufficientBalanceToCoverFeeText;
         } else if (failure.isWaitingForSync) {
-          _amountError = '';
+          _amountError = 'Still syncing. Try again once sync finishes.';
         } else {
           _amountError = 'Max amount unavailable';
         }

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -595,7 +595,8 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       if (!mounted || seq != _validateSeq) return;
 
       final totalNeeded = zatoshi + fee;
-      if (widget.isSyncedToTip && totalNeeded > available) {
+      final latestAvailable = _availableBalanceForCurrentAddress;
+      if (widget.isSyncedToTip && totalNeeded > latestAvailable) {
         final feeText = ZecAmount.fromZatoshi(fee).fee.toString();
         setState(() => _amountError = _insufficientBalanceWithFeeText(feeText));
       } else {

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -26,6 +26,7 @@ import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
+import '../../../services/send_failure.dart';
 import '../../address_book/models/address_book_contact.dart';
 import '../../address_book/widgets/address_book_contact_picker_modal.dart';
 import '../models/send_prefill_args.dart';
@@ -66,6 +67,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       activeAccountUuid: activeAccountUuid,
       activeAccountIsHardware: activeAccountIsHardware,
       spendableBalance: spendableBalance,
+      isSyncedToTip: sync.isSyncedToTip,
       prefill: widget.prefill,
     );
   }
@@ -78,6 +80,7 @@ class _SendComposeBody extends ConsumerStatefulWidget {
     required this.activeAccountUuid,
     required this.activeAccountIsHardware,
     required this.spendableBalance,
+    required this.isSyncedToTip,
     this.prefill,
   });
 
@@ -85,6 +88,7 @@ class _SendComposeBody extends ConsumerStatefulWidget {
   final String? activeAccountUuid;
   final bool activeAccountIsHardware;
   final BigInt spendableBalance;
+  final bool isSyncedToTip;
   final SendPrefillArgs? prefill;
 
   @override
@@ -516,12 +520,14 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       });
     } catch (e) {
       if (!mounted || !_isMaxMode || seq != _maxSeq) return;
-      final msg = e.toString().toLowerCase();
+      final failure = classifySendFailure(e);
       setState(() {
         _isResolvingMax = false;
         _maxQuote = null;
-        if (msg.contains('insufficient')) {
+        if (failure == SendFailureKind.insufficientFunds) {
           _amountError = _insufficientBalanceToCoverFeeText;
+        } else if (failure.isWaitingForSync) {
+          _amountError = '';
         } else {
           _amountError = 'Max amount unavailable';
         }
@@ -561,7 +567,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       return;
     }
     final available = _availableBalanceForCurrentAddress;
-    if (zatoshi > available) {
+    if (widget.isSyncedToTip && zatoshi > available) {
       setState(() => _amountError = _insufficientBalanceText);
       return;
     }
@@ -589,7 +595,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       if (!mounted || seq != _validateSeq) return;
 
       final totalNeeded = zatoshi + fee;
-      if (totalNeeded > available) {
+      if (widget.isSyncedToTip && totalNeeded > available) {
         final feeText = ZecAmount.fromZatoshi(fee).fee.toString();
         setState(() => _amountError = _insufficientBalanceWithFeeText(feeText));
       } else {
@@ -597,9 +603,11 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       }
     } catch (e) {
       if (!mounted || seq != _validateSeq) return;
-      final msg = e.toString();
-      if (msg.contains('InsufficientFunds') || msg.contains('insufficient')) {
+      final failure = classifySendFailure(e);
+      if (failure == SendFailureKind.insufficientFunds) {
         setState(() => _amountError = _insufficientBalanceIncludingFeeText);
+      } else if (failure.isWaitingForSync) {
+        setState(() => _amountError = null);
       } else {
         log('Send: fee estimation failed (non-blocking): $e');
         setState(() => _amountError = null);
@@ -663,7 +671,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
 
       // Check balance before proposing
       final available = _availableBalanceForCurrentAddress;
-      if (amountZatoshi > available) {
+      if (widget.isSyncedToTip && amountZatoshi > available) {
         setState(() {
           _error = '$_insufficientBalanceText.';
           _isSending = false;
@@ -704,8 +712,11 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     } catch (e) {
       log('Send: review preparation error: $e');
       if (!mounted) return;
+      final failure = classifySendFailure(e);
       setState(() {
-        _error = friendlyProposeSendError(e.toString());
+        _error = failure.isWaitingForSync
+            ? 'Still syncing. Try again once sync finishes.'
+            : friendlyProposeSendError(e.toString());
         _isSending = false;
       });
     } finally {

--- a/lib/src/features/swap/providers/swap_max_amount_estimator.dart
+++ b/lib/src/features/swap/providers/swap_max_amount_estimator.dart
@@ -7,6 +7,7 @@ import '../../../providers/sync_provider.dart';
 import '../../../providers/receive_address_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
+import '../../../services/send_failure.dart';
 
 final swapMaxAmountEstimatorProvider = Provider<SwapMaxAmountEstimator>((ref) {
   return RustSwapMaxAmountEstimator(ref);
@@ -83,9 +84,7 @@ Future<BigInt> findMaxZecAmountByFeeProbe({
 }
 
 bool _isInsufficientFundsError(Object error) {
-  final msg = error.toString().toLowerCase();
-  return msg.contains('insufficient balance') ||
-      msg.contains('insufficient funds');
+  return classifySendFailure(error) == SendFailureKind.insufficientFunds;
 }
 
 String _shortSwapValue(String? value) {

--- a/lib/src/features/swap/providers/swap_state_provider.dart
+++ b/lib/src/features/swap/providers/swap_state_provider.dart
@@ -11,6 +11,7 @@ import '../models/swap_models.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
+import '../../../services/send_failure.dart';
 import 'swap_activity_tracker.dart';
 import 'swap_deposit_sender.dart';
 import 'swap_failure_policy.dart';
@@ -32,6 +33,12 @@ class SwapNotifier extends Notifier<SwapState> {
 
   String? get _activeAccountUuidOrNull =>
       ref.read(accountProvider).value?.activeAccountUuid;
+
+  bool _isSyncedToTip(String accountUuid) {
+    return (ref.read(syncProvider).value ?? SyncState())
+        .scopedToAccount(accountUuid)
+        .isSyncedToTip;
+  }
 
   String? _accountUuidForIntent(SwapIntent intent) {
     final activeAccountUuid = _activeAccountUuidOrNull;
@@ -307,7 +314,9 @@ class SwapNotifier extends Notifier<SwapState> {
       if (maxZatoshi <= BigInt.zero) {
         state = state.copyWith(
           maxAmountLoading: false,
-          maxAmountError: 'Insufficient shielded balance to cover fee',
+          maxAmountError: _isSyncedToTip(accountUuid)
+              ? 'Insufficient shielded balance to cover fee'
+              : 'Still syncing. Try again once sync finishes.',
         );
         return;
       }
@@ -337,10 +346,12 @@ class SwapNotifier extends Notifier<SwapState> {
         state = state.copyWith(maxAmountLoading: false);
         return;
       }
-      final msg = e.toString().toLowerCase();
+      final failure = classifySendFailure(e);
       state = state.copyWith(
         maxAmountLoading: false,
-        maxAmountError: msg.contains('insufficient')
+        maxAmountError: failure.isWaitingForSync
+            ? 'Still syncing. Try again once sync finishes.'
+            : failure == SendFailureKind.insufficientFunds
             ? 'Insufficient shielded balance to cover fee'
             : 'Max amount unavailable',
       );
@@ -536,12 +547,12 @@ class SwapNotifier extends Notifier<SwapState> {
           'Swap: live ZEC deposit preflight failed '
           'quote=${_shortSwapValue(quote.providerQuoteId)} error=$e',
         );
+        final failure = classifySendFailure(e);
         state = state.copyWith(
           startSubmitting: false,
-          statusError: swapFailureMessage(
-            SwapFailureOperation.sendZecDeposit,
-            e,
-          ),
+          statusError: failure.isWaitingForSync
+              ? 'Still syncing. Try again once sync finishes.'
+              : swapFailureMessage(SwapFailureOperation.sendZecDeposit, e),
         );
         return false;
       }

--- a/lib/src/features/swap/screens/mobile/mobile_swap_review_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_review_screen.dart
@@ -134,7 +134,8 @@ class _MobileSwapReviewScreenState
       swapState.reviewAccountUuid,
     );
     final startBlockedReason =
-        swapReviewQuoteExceedsAvailableZec(quote, sync.spendableBalance)
+        sync.isSyncedToTip &&
+            swapReviewQuoteExceedsAvailableZec(quote, sync.spendableBalance)
         ? "You don't have enough ZEC for this swap. Try a smaller amount."
         : null;
 

--- a/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
@@ -365,7 +365,6 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
                           Expanded(
                             child: _MobileSwapReviewButton(
                               state: swapState,
-                              zecAvailableZatoshi: sync.spendableBalance,
                               onOpenDestinationAddress: () =>
                                   _openModal(_SwapModalSurface.addressEditor),
                               onReviewQuote: openReview,
@@ -411,29 +410,19 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
 class _MobileSwapReviewButton extends StatelessWidget {
   const _MobileSwapReviewButton({
     required this.state,
-    required this.zecAvailableZatoshi,
     required this.onOpenDestinationAddress,
     required this.onReviewQuote,
   });
 
   final SwapState state;
-  final BigInt zecAvailableZatoshi;
   final VoidCallback onOpenDestinationAddress;
   final VoidCallback onReviewQuote;
-
-  bool get _balanceExceeded {
-    if (!state.direction.sendsZec) return false;
-    final amount = parseZecAmount(state.amountText.trim());
-    if (amount == null || amount <= BigInt.zero) return false;
-    return amount >= zecAvailableZatoshi;
-  }
 
   @override
   Widget build(BuildContext context) {
     final needsDestinationAddress = state.destinationText.trim().isEmpty;
     final destinationFormatError = state.destinationAddressFormatError;
-    final balanceExceeded = _balanceExceeded;
-    final canReview = state.canReviewQuote && !balanceExceeded;
+    final canReview = state.canReviewQuote;
     final onPressed = needsDestinationAddress
         ? onOpenDestinationAddress
         : canReview
@@ -444,11 +433,7 @@ class _MobileSwapReviewButton extends StatelessWidget {
               ? 'Add recipient address'
               : 'Add refund address')
         : destinationFormatError ??
-              (balanceExceeded
-                  ? 'Not enough ZEC'
-                  : state.quoteLoading
-                  ? 'Getting quote'
-                  : 'Continue to review');
+              (state.quoteLoading ? 'Getting quote' : 'Continue to review');
 
     return AppButton(
       key: const ValueKey('mobile_swap_review_button'),

--- a/lib/src/features/swap/screens/swap_review_screen.dart
+++ b/lib/src/features/swap/screens/swap_review_screen.dart
@@ -126,7 +126,8 @@ class _SwapReviewScreenState extends ConsumerState<SwapReviewScreen> {
       ),
     );
     final startBlockedReason =
-        swapReviewQuoteExceedsAvailableZec(quote, sync.spendableBalance)
+        sync.isSyncedToTip &&
+            swapReviewQuoteExceedsAvailableZec(quote, sync.spendableBalance)
         ? "You don't have enough ZEC for this swap. Try a smaller amount."
         : null;
 

--- a/lib/src/features/swap/screens/swap_screen.dart
+++ b/lib/src/features/swap/screens/swap_screen.dart
@@ -283,7 +283,6 @@ class _SwapScreenState extends ConsumerState<SwapScreen> {
                         const SizedBox(height: AppSpacing.md),
                         _SwapReviewFooter(
                           state: swapState,
-                          zecAvailableZatoshi: sync.spendableBalance,
                           onOpenDestinationAddress: _openAddressEditor,
                           onReviewQuote: openReview,
                         ),
@@ -412,25 +411,19 @@ class _SwapPageTitle extends StatelessWidget {
 class _SwapReviewFooter extends StatelessWidget {
   const _SwapReviewFooter({
     required this.state,
-    required this.zecAvailableZatoshi,
     required this.onOpenDestinationAddress,
     required this.onReviewQuote,
   });
 
   final SwapState state;
-  final BigInt zecAvailableZatoshi;
   final VoidCallback onOpenDestinationAddress;
   final VoidCallback onReviewQuote;
 
   @override
   Widget build(BuildContext context) {
-    final balanceExceeded = _reviewAmountExceedsAvailableZec(
-      state,
-      zecAvailableZatoshi,
-    );
     final needsDestinationAddress = state.destinationText.trim().isEmpty;
     final destinationFormatError = state.destinationAddressFormatError;
-    final canReview = state.canReviewQuote && !balanceExceeded;
+    final canReview = state.canReviewQuote;
     final onPressed = needsDestinationAddress
         ? onOpenDestinationAddress
         : canReview
@@ -440,15 +433,10 @@ class _SwapReviewFooter extends StatelessWidget {
     final label = needsDestinationAddress
         ? _destinationAddressActionLabel(state)
         : destinationFormatError ??
-              (balanceExceeded
-                  ? 'Not enough ZEC'
-                  : state.quoteLoading
-                  ? 'Getting quote'
-                  : 'Review swap');
+              (state.quoteLoading ? 'Getting quote' : 'Review swap');
     final reviewReady =
         !needsDestinationAddress &&
         destinationFormatError == null &&
-        !balanceExceeded &&
         !state.quoteLoading;
 
     return Center(
@@ -510,21 +498,4 @@ String _destinationAddressActionLabel(SwapState state) {
   return state.direction.sendsZec
       ? 'Add recipient address'
       : 'Add refund address';
-}
-
-bool _reviewAmountExceedsAvailableZec(
-  SwapState state,
-  BigInt availableZatoshi,
-) {
-  if (!state.direction.sendsZec) return false;
-  return _zecAmountTextExceedsAvailable(state.amountText, availableZatoshi);
-}
-
-bool _zecAmountTextExceedsAvailable(
-  String amountText,
-  BigInt availableZatoshi,
-) {
-  final amount = parseZecAmount(amountText);
-  if (amount == null || amount <= BigInt.zero) return false;
-  return amount >= availableZatoshi;
 }

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -71,6 +71,9 @@ class SyncState {
   BigInt get pendingBalance =>
       transparentPendingBalance + saplingPendingBalance + orchardPendingBalance;
 
+  bool get isSyncedToTip =>
+      !isSyncing && chainTipHeight > 0 && scannedHeight >= chainTipHeight;
+
   SyncState({
     this.accountUuid,
     bool hasAccountScopedData = false,

--- a/lib/src/services/send_failure.dart
+++ b/lib/src/services/send_failure.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart'
+    show AnyhowException;
+
+enum SendFailureKind {
+  syncInProgress,
+  scanRequired,
+  insufficientFunds,
+  unknown,
+}
+
+extension SendFailureKindChecks on SendFailureKind {
+  bool get isWaitingForSync =>
+      this == SendFailureKind.syncInProgress ||
+      this == SendFailureKind.scanRequired;
+}
+
+SendFailureKind classifySendFailure(Object error) {
+  final raw = error is AnyhowException ? error.message : error.toString();
+  const markers = {
+    'sync_in_progress|': SendFailureKind.syncInProgress,
+    'scan_required|': SendFailureKind.scanRequired,
+    'insufficient_funds|': SendFailureKind.insufficientFunds,
+  };
+
+  for (final entry in markers.entries) {
+    if (raw.contains(entry.key)) return entry.value;
+  }
+
+  return SendFailureKind.unknown;
+}

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -651,6 +651,7 @@ pub fn propose_send(
             &to_address,
             amount_zatoshi,
             memo.as_deref(),
+            is_sync_running(),
         )?;
         Ok(ProposalResult {
             proposal_id: r.proposal_id,
@@ -678,6 +679,7 @@ pub fn estimate_fee(
             &to_address,
             amount_zatoshi,
             memo.as_deref(),
+            is_sync_running(),
         )
     })
 }
@@ -698,6 +700,7 @@ pub fn estimate_send_max(
             &account_uuid,
             &to_address,
             memo.as_deref(),
+            is_sync_running(),
         )?;
         Ok(SendMaxEstimateResult {
             amount_zatoshi: r.amount_zatoshi,

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -136,6 +136,9 @@ pub(crate) struct ShieldTransparentPcztResult {
 }
 
 const SHIELDING_THRESHOLD_ZATOSHI: u64 = 100_000;
+const SEND_FAILURE_SYNC_IN_PROGRESS: &str = "sync_in_progress";
+const SEND_FAILURE_SCAN_REQUIRED: &str = "scan_required";
+const SEND_FAILURE_INSUFFICIENT_FUNDS: &str = "insufficient_funds";
 
 struct RetainAllNotes;
 
@@ -208,6 +211,7 @@ pub fn propose_send(
     to_address: &str,
     amount_zatoshi: u64,
     memo_str: Option<&str>,
+    sync_running: bool,
 ) -> Result<ProposalResult, String> {
     use zcash_protocol::{PoolType, ShieldedProtocol as SP};
 
@@ -237,7 +241,7 @@ pub fn propose_send(
         .map_err(|e| format!("Cannot create payment: {e:?}"))?;
     let request = TransactionRequest::new(vec![payment]).map_err(|e| format!("{e:?}"))?;
 
-    let proposal = propose_transfer::<_, _, _, _, Infallible>(
+    let proposal = match propose_transfer::<_, _, _, _, Infallible>(
         &mut db,
         &network,
         account_id,
@@ -246,8 +250,17 @@ pub fn propose_send(
         request,
         ConfirmationsPolicy::default(),
         None,
-    )
-    .map_err(|e| format!("Propose failed: {e}"))?;
+    ) {
+        Ok(proposal) => proposal,
+        Err(e) => {
+            return Err(classify_send_build_error(
+                &db,
+                "Propose failed",
+                e,
+                sync_running,
+            ))
+        }
+    };
 
     let needs_sapling = proposal
         .steps()
@@ -293,6 +306,7 @@ pub fn estimate_fee(
     to_address: &str,
     amount_zatoshi: u64,
     memo_str: Option<&str>,
+    sync_running: bool,
 ) -> Result<u64, String> {
     let mut db = open_wallet_db_for_read(db_path, network)?;
     let account_id = parse_account_uuid(account_uuid)?;
@@ -316,7 +330,7 @@ pub fn estimate_fee(
         .map_err(|e| format!("Cannot create payment: {e:?}"))?;
     let request = TransactionRequest::new(vec![payment]).map_err(|e| format!("{e:?}"))?;
 
-    let proposal = propose_transfer::<_, _, _, _, Infallible>(
+    let proposal = match propose_transfer::<_, _, _, _, Infallible>(
         &mut db,
         &network,
         account_id,
@@ -325,8 +339,17 @@ pub fn estimate_fee(
         request,
         ConfirmationsPolicy::default(),
         None,
-    )
-    .map_err(|e| format!("Propose failed: {e}"))?;
+    ) {
+        Ok(proposal) => proposal,
+        Err(e) => {
+            return Err(classify_send_build_error(
+                &db,
+                "Propose failed",
+                e,
+                sync_running,
+            ))
+        }
+    };
 
     let fee: u64 = proposal
         .steps()
@@ -349,11 +372,77 @@ pub(crate) fn estimate_send_max(
     account_uuid: &str,
     to_address: &str,
     memo_str: Option<&str>,
+    sync_running: bool,
 ) -> Result<SendMaxEstimateResult, String> {
     let mut db = open_wallet_db_for_read(db_path, network)?;
     let account_id = parse_account_uuid(account_uuid)?;
-    let proposal = build_send_max_proposal(&mut db, network, account_id, to_address, memo_str)?;
+    let proposal = match build_send_max_proposal(&mut db, network, account_id, to_address, memo_str)
+    {
+        Ok(proposal) => proposal,
+        Err(e) => {
+            return Err(classify_send_build_error(
+                &db,
+                "Propose max failed",
+                e,
+                sync_running,
+            ))
+        }
+    };
     summarize_send_max_proposal(&proposal)
+}
+
+fn classify_send_build_error(
+    db: &WalletDatabase,
+    context: &str,
+    error: impl std::fmt::Display,
+    sync_running: bool,
+) -> String {
+    let detail = format!("{context}: {error}");
+    let code = send_build_error_code(
+        &detail,
+        shortfall_is_final(wallet_is_synced_to_tip(db), sync_running),
+    );
+
+    match code {
+        Some(code) => format!("{code}|{detail}"),
+        None => detail,
+    }
+}
+
+fn shortfall_is_final(synced_to_tip: bool, sync_running: bool) -> bool {
+    synced_to_tip && !sync_running
+}
+
+fn send_build_error_code(detail: &str, shortfall_is_final: bool) -> Option<&'static str> {
+    let lower = detail.to_lowercase();
+    if lower.contains("scanrequired")
+        || lower.contains("scan required")
+        || lower.contains("scan_required")
+        || lower.contains("must scan blocks first")
+    {
+        Some(SEND_FAILURE_SCAN_REQUIRED)
+    } else if lower.contains("wallet must sync before sending max") {
+        Some(SEND_FAILURE_SYNC_IN_PROGRESS)
+    } else if lower.contains("insufficient") {
+        Some(if shortfall_is_final {
+            SEND_FAILURE_INSUFFICIENT_FUNDS
+        } else {
+            SEND_FAILURE_SYNC_IN_PROGRESS
+        })
+    } else {
+        None
+    }
+}
+
+fn wallet_is_synced_to_tip(db: &WalletDatabase) -> bool {
+    db.get_wallet_summary(ConfirmationsPolicy::default())
+        .ok()
+        .flatten()
+        .map(|summary| {
+            u32::from(summary.chain_tip_height()) > 0
+                && summary.fully_scanned_height() >= summary.chain_tip_height()
+        })
+        .unwrap_or(false)
 }
 
 /// Dry-run the transparent shielding proposal path without creating or
@@ -1378,6 +1467,52 @@ mod tests {
 
     fn receiver(value: u64, scope: TransparentKeyScope) -> (TransparentKeyOrigin, Balance) {
         (TransparentKeyOrigin::Derived { scope }, balance(value))
+    }
+
+    #[test]
+    fn send_build_error_code_marks_insufficient_as_syncing_until_synced() {
+        assert_eq!(
+            send_build_error_code("Propose failed: InsufficientFunds", false),
+            Some(SEND_FAILURE_SYNC_IN_PROGRESS)
+        );
+        assert_eq!(
+            send_build_error_code("Propose failed: InsufficientFunds", true),
+            Some(SEND_FAILURE_INSUFFICIENT_FUNDS)
+        );
+    }
+
+    #[test]
+    fn active_sync_keeps_shortfall_non_final_even_when_db_is_synced() {
+        assert!(!shortfall_is_final(true, true));
+        assert!(shortfall_is_final(true, false));
+        assert!(!shortfall_is_final(false, false));
+    }
+
+    #[test]
+    fn send_build_error_code_marks_scan_required() {
+        assert_eq!(
+            send_build_error_code("Propose failed: Must scan blocks first", false),
+            Some(SEND_FAILURE_SCAN_REQUIRED)
+        );
+    }
+
+    #[test]
+    fn send_build_error_code_marks_send_max_sync_required() {
+        assert_eq!(
+            send_build_error_code(
+                "Propose max failed: Wallet must sync before sending max",
+                false
+            ),
+            Some(SEND_FAILURE_SYNC_IN_PROGRESS)
+        );
+    }
+
+    #[test]
+    fn send_build_error_code_leaves_unknown_errors_uncoded() {
+        assert_eq!(
+            send_build_error_code("Propose failed: network unavailable", false),
+            None
+        );
     }
 
     #[test]

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -413,6 +413,18 @@ fn shortfall_is_final(synced_to_tip: bool, sync_running: bool) -> bool {
     synced_to_tip && !sync_running
 }
 
+// Classification is coupled to the *Display* text of librustzcash errors and to the
+// custom error strings produced by this module's send-max builders. Pinned to
+// zcash_client_backend 0.23.0:
+//   - Error::InsufficientFunds => "Insufficient balance (have …, need … including fee)"
+//     (zcash_client_backend/src/data_api/error.rs:208)
+//   - Error::ScanRequired      => "Must scan blocks first"
+//     (zcash_client_backend/src/data_api/error.rs:212)
+//   - build_send_max_proposal  => "Wallet must sync before sending max" /
+//                                 "Insufficient shielded balance to cover fee"
+// If a crate bump changes any of these strings, the regression-canary tests below
+// (send_build_error_code_*) go red. Re-verify the substring matchers before updating the
+// literals — a silent miss here reintroduces the VZR-42 false "insufficient" symptom.
 fn send_build_error_code(detail: &str, shortfall_is_final: bool) -> Option<&'static str> {
     let lower = detail.to_lowercase();
     if lower.contains("scanrequired")
@@ -1471,12 +1483,34 @@ mod tests {
 
     #[test]
     fn send_build_error_code_marks_insufficient_as_syncing_until_synced() {
+        // Representative of the real zcash_client_backend 0.23.0 Display for
+        // Error::InsufficientFunds (data_api/error.rs:208) — exercises the final vs
+        // non-final branch on the actual string prod feeds (not the variant name).
+        // The crate-coupling canary that breaks on a Display *rename* is
+        // `classifier_matches_real_librustzcash_display` below.
+        let insufficient = "Propose failed: Insufficient balance (have 0, need 210000 including fee)";
         assert_eq!(
-            send_build_error_code("Propose failed: InsufficientFunds", false),
+            send_build_error_code(insufficient, false),
             Some(SEND_FAILURE_SYNC_IN_PROGRESS)
         );
         assert_eq!(
-            send_build_error_code("Propose failed: InsufficientFunds", true),
+            send_build_error_code(insufficient, true),
+            Some(SEND_FAILURE_INSUFFICIENT_FUNDS)
+        );
+    }
+
+    #[test]
+    fn send_build_error_code_marks_send_max_insufficient_shortfall() {
+        // Custom string from build_transparent_recipient_send_max_proposal_from_notes; it
+        // carries no code prefix, so estimate_send_max relies on this substring match to map
+        // a mid-sync send-max shortfall to "still syncing" instead of a raw `unknown` error.
+        let detail = "Propose max failed: Insufficient shielded balance to cover fee";
+        assert_eq!(
+            send_build_error_code(detail, false),
+            Some(SEND_FAILURE_SYNC_IN_PROGRESS)
+        );
+        assert_eq!(
+            send_build_error_code(detail, true),
             Some(SEND_FAILURE_INSUFFICIENT_FUNDS)
         );
     }
@@ -1490,6 +1524,7 @@ mod tests {
 
     #[test]
     fn send_build_error_code_marks_scan_required() {
+        // Real zcash_client_backend 0.23.0 Display for Error::ScanRequired (data_api/error.rs:212).
         assert_eq!(
             send_build_error_code("Propose failed: Must scan blocks first", false),
             Some(SEND_FAILURE_SCAN_REQUIRED)
@@ -1512,6 +1547,53 @@ mod tests {
         assert_eq!(
             send_build_error_code("Propose failed: network unavailable", false),
             None
+        );
+    }
+
+    /// Crate-coupling canary: construct the REAL librustzcash error variants and run their
+    /// actual Display output through the classifier. Unlike the literal-based tests above,
+    /// this fails if a zcash_client_backend bump renames the Error::InsufficientFunds /
+    /// Error::ScanRequired Display text so the substring matchers stop firing — which would
+    /// otherwise silently reintroduce the VZR-42 false-"insufficient" symptom in the field.
+    #[test]
+    fn classifier_matches_real_librustzcash_display() {
+        use zcash_client_backend::data_api::error::Error;
+
+        // Every generic only needs to satisfy the Display bound; Infallible does.
+        type ConcreteError =
+            Error<Infallible, Infallible, Infallible, Infallible, Infallible, Infallible>;
+
+        let insufficient: ConcreteError = Error::InsufficientFunds {
+            available: Zatoshis::ZERO,
+            required: Zatoshis::ZERO,
+        };
+        let scan_required: ConcreteError = Error::ScanRequired;
+
+        // The real Display must still contain the tokens send_build_error_code keys on.
+        assert!(
+            insufficient.to_string().to_lowercase().contains("insufficient"),
+            "Error::InsufficientFunds Display changed: {insufficient}"
+        );
+        assert!(
+            scan_required
+                .to_string()
+                .to_lowercase()
+                .contains("must scan blocks first"),
+            "Error::ScanRequired Display changed: {scan_required}"
+        );
+
+        // End-to-end through the production classifier on that real Display text.
+        assert_eq!(
+            send_build_error_code(&format!("Propose failed: {insufficient}"), true),
+            Some(SEND_FAILURE_INSUFFICIENT_FUNDS)
+        );
+        assert_eq!(
+            send_build_error_code(&format!("Propose failed: {insufficient}"), false),
+            Some(SEND_FAILURE_SYNC_IN_PROGRESS)
+        );
+        assert_eq!(
+            send_build_error_code(&format!("Propose failed: {scan_required}"), false),
+            Some(SEND_FAILURE_SCAN_REQUIRED)
         );
     }
 

--- a/rust/tests/regtest_send.rs
+++ b/rust/tests/regtest_send.rs
@@ -2,8 +2,10 @@ mod common;
 
 use common::{
     add_account_with_birthday, create_wallet, ensure_regtest_up, exclusive_regtest, execute_send,
-    fund_wallet, get_balance, get_transaction_history, mine_blocks, sync_wallet,
+    fund_wallet, get_balance, get_transaction_history, mine_blocks, path_str, sync_wallet,
+    REGTEST_NETWORK,
 };
+use rust_lib_zcash_wallet::api::sync as sync_api;
 
 #[test]
 #[ignore = "requires Dockerized zcashd/lightwalletd regtest services"]
@@ -124,5 +126,102 @@ fn imported_second_account_can_send_using_its_own_seed() {
         receiver_after.spendable >= 60_000_000,
         "receiver should see at least 0.6 ZEC after imported-account send, got {}",
         receiver_after.spendable
+    );
+}
+
+/// VZR-42 integration guard: a real `propose_transfer` shortfall must be classified by
+/// sync state, not surfaced as an always-final error. This exercises end to end what the
+/// unit tests can only fake (they feed hand-written error strings):
+///   1. not synced to tip -> a shortfall is coded retryable (`sync_in_progress|` /
+///      `scan_required|`) and NEVER `insufficient_funds|` (the exact VZR-42 symptom:
+///      a false "insufficient" must not block Review while the wallet is still catching up)
+///   2. synced + genuine overspend -> FINAL `insufficient_funds|` (the fix must NOT
+///      over-suppress once the wallet is idle at tip)
+///   3. synced + affordable amount -> the proposal builds (recovery path works)
+///
+/// The middle/last cases reach `propose_send` through the public API on a fully-synced
+/// wallet, so `is_sync_running()` is false and `wallet_is_synced_to_tip(db)` is true —
+/// the only state in which a shortfall is allowed to be final.
+#[test]
+#[ignore = "requires Dockerized zcashd/lightwalletd regtest services"]
+fn propose_send_codes_shortfall_by_sync_state() {
+    let _guard = exclusive_regtest();
+    ensure_regtest_up();
+
+    let (sender_dir, sender_wallet) = create_wallet("Sender");
+    let sender_db = sender_dir.path().join("zcash_wallet.db");
+    let (_receiver_dir, receiver_wallet) = create_wallet("Receiver");
+    let db_str = path_str(&sender_db);
+    let send_flow_id = "regtest-vzr42-flow";
+    // 10,000 ZEC — far beyond any test balance, so propose_transfer must report a shortfall.
+    let overspend: u64 = 1_000_000_000_000;
+
+    // 1. Before any sync the wallet is not synced to tip, so a shortfall must be coded as
+    //    retryable, never as a final insufficient_funds (the VZR-42 false-block symptom).
+    let unsynced_err = sync_api::propose_send(
+        db_str.clone(),
+        REGTEST_NETWORK.into(),
+        sender_wallet.account_uuid.clone(),
+        send_flow_id.into(),
+        receiver_wallet.unified_address.clone(),
+        50_000_000,
+        None,
+    )
+    .err()
+    .expect("propose on an unsynced wallet must fail to build a proposal");
+    assert!(
+        !unsynced_err.contains("insufficient_funds|"),
+        "an unsynced wallet must NOT report a final insufficient shortfall (VZR-42), got: {unsynced_err}"
+    );
+    assert!(
+        unsynced_err.contains("sync_in_progress|") || unsynced_err.contains("scan_required|"),
+        "an unsynced shortfall should be coded as waiting-for-sync, got: {unsynced_err}"
+    );
+
+    // Fund + sync to tip.
+    fund_wallet(&sender_wallet.unified_address, "1.0");
+    sync_wallet(&sender_db);
+    let before = get_balance(&sender_db, &sender_wallet.account_uuid);
+    assert!(
+        before.spendable >= 90_000_000,
+        "expected ~1 ZEC spendable after sync, got {}",
+        before.spendable
+    );
+
+    // 2. Synced + genuine overspend: now the shortfall is FINAL insufficient_funds.
+    let final_err = sync_api::propose_send(
+        db_str.clone(),
+        REGTEST_NETWORK.into(),
+        sender_wallet.account_uuid.clone(),
+        send_flow_id.into(),
+        receiver_wallet.unified_address.clone(),
+        overspend,
+        None,
+    )
+    .err()
+    .expect("overspend on a synced wallet must fail to build a proposal");
+    assert!(
+        final_err.contains("insufficient_funds|"),
+        "synced overspend should be coded final insufficient, got: {final_err}"
+    );
+    assert!(
+        !final_err.contains("sync_in_progress|") && !final_err.contains("scan_required|"),
+        "synced overspend must not be masked as still-syncing, got: {final_err}"
+    );
+
+    // 3. Synced + affordable amount: the normal path still builds a proposal.
+    let ok = sync_api::propose_send(
+        db_str.clone(),
+        REGTEST_NETWORK.into(),
+        sender_wallet.account_uuid.clone(),
+        send_flow_id.into(),
+        receiver_wallet.unified_address.clone(),
+        50_000_000,
+        None,
+    );
+    assert!(
+        ok.is_ok(),
+        "an affordable amount on a synced wallet should propose cleanly, got: {:?}",
+        ok.err()
     );
 }

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -31,6 +31,7 @@ const _invalidAddress = 'not-an-address';
 
 var _proposeSendSucceeds = false;
 Completer<ProposalResult>? _proposeSendCompleter;
+Object? _proposeSendError;
 int _estimateSendMaxCalls = 0;
 String? _lastEstimateSendMaxToAddress;
 String? _lastEstimateSendMaxMemo;
@@ -109,6 +110,8 @@ class _RustApiFake implements RustLibApi {
   }) async {
     final completer = _proposeSendCompleter;
     if (completer != null) return completer.future;
+    final error = _proposeSendError;
+    if (error != null) throw error;
     if (!_proposeSendSucceeds) {
       throw StateError('proposal failed');
     }
@@ -152,10 +155,17 @@ AppBootstrapState _bootstrap({AccountState? accountState}) => AppBootstrapState(
 );
 
 class _FakeSyncNotifier extends SyncNotifier {
+  _FakeSyncNotifier({required this.syncedToTip});
+
+  final bool syncedToTip;
+
   @override
   Future<SyncState> build() async => SyncState(
     accountUuid: 'account-1',
     hasAccountScopedData: true,
+    isSyncing: !syncedToTip,
+    scannedHeight: syncedToTip ? 100 : 80,
+    chainTipHeight: 100,
     spendableBalance: BigInt.from(500000000), // 5 ZEC
     totalBalance: BigInt.from(500000000),
   );
@@ -181,6 +191,7 @@ Widget _app({
   MobileSendScanner? openScanner,
   String? initialRecipient,
   MobileSendAddressValidator? validateAddress,
+  bool syncedToTip = true,
 }) {
   final router = GoRouter(
     initialLocation: '/send',
@@ -202,7 +213,9 @@ Widget _app({
       appBootstrapProvider.overrideWithValue(
         _bootstrap(accountState: accountState),
       ),
-      syncProvider.overrideWith(_FakeSyncNotifier.new),
+      syncProvider.overrideWith(
+        () => _FakeSyncNotifier(syncedToTip: syncedToTip),
+      ),
       zecMarketDataSourceProvider.overrideWithValue(
         const _FakeMarketDataSource(),
       ),
@@ -329,7 +342,7 @@ Widget _sendFlowRouterApp({MobileSendFeeEstimator? estimateFee}) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
-      syncProvider.overrideWith(_FakeSyncNotifier.new),
+      syncProvider.overrideWith(() => _FakeSyncNotifier(syncedToTip: true)),
       zecMarketDataSourceProvider.overrideWithValue(
         const _FakeMarketDataSource(),
       ),
@@ -429,6 +442,7 @@ void main() {
   setUp(() {
     _proposeSendSucceeds = false;
     _proposeSendCompleter = null;
+    _proposeSendError = null;
     _estimateSendMaxCalls = 0;
     _lastEstimateSendMaxToAddress = null;
     _lastEstimateSendMaxMemo = null;
@@ -1486,6 +1500,41 @@ void main() {
     expect(
       feeText.data,
       ZecAmount.fromZatoshi(BigInt.from(20000)).fee.toString(),
+    );
+  });
+
+  testWidgets('mid-sync spendable shortfall does not block review', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app(syncedToTip: false));
+    await tester.pumpAndSettle();
+    await _toAmountStep(tester, _shieldedAddress);
+
+    // 9 ZEC is above the 5 ZEC currently scanned fixture, but sync has not
+    // reached the tip yet, so this is not a final insufficient-funds verdict.
+    await _enterAmount(tester, '9');
+
+    expect(find.text('Not enough ZEC'), findsNothing);
+    expect(find.text('Finish & review'), findsOneWidget);
+  });
+
+  testWidgets('coded syncing propose error stays on review', (tester) async {
+    _proposeSendError = StateError('sync_in_progress|have 5, need 9');
+
+    await tester.pumpWidget(_app(syncedToTip: false));
+    await tester.pumpAndSettle();
+    await _toReviewStep(tester, amount: '9');
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Still syncing. Try again once sync finishes.'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Insufficient shielded balance to cover amount and fee.'),
+      findsNothing,
     );
   });
 

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -252,7 +252,7 @@ Widget _amountStepWithPriceLoadingApp() {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
-      syncProvider.overrideWith(_FakeSyncNotifier.new),
+      syncProvider.overrideWith(() => _FakeSyncNotifier(syncedToTip: true)),
       zecHomeUsdUnitPriceProvider.overrideWithValue(null),
       addressBookRepositoryProvider.overrideWithValue(
         _FakeAddressBookRepository(const []),

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -157,10 +157,17 @@ AppBootstrapState _bootstrap({AccountState? accountState}) => AppBootstrapState(
 class _FakeSyncNotifier extends SyncNotifier {
   _FakeSyncNotifier({required this.syncedToTip});
 
-  final bool syncedToTip;
+  bool syncedToTip;
+
+  void setSyncedToTip(bool value) {
+    syncedToTip = value;
+    state = AsyncData(_syncState());
+  }
 
   @override
-  Future<SyncState> build() async => SyncState(
+  Future<SyncState> build() async => _syncState();
+
+  SyncState _syncState() => SyncState(
     accountUuid: 'account-1',
     hasAccountScopedData: true,
     isSyncing: !syncedToTip,
@@ -1516,6 +1523,30 @@ void main() {
 
     expect(find.text('Not enough ZEC'), findsNothing);
     expect(find.text('Finish & review'), findsOneWidget);
+  });
+
+  testWidgets('review rechecks amount after sync reaches tip', (tester) async {
+    await tester.pumpWidget(_app(syncedToTip: false));
+    await tester.pumpAndSettle();
+    await _toAmountStep(tester, _shieldedAddress);
+
+    await _enterAmount(tester, '9');
+    expect(find.text('Not enough ZEC'), findsNothing);
+    expect(find.text('Finish & review'), findsOneWidget);
+
+    final notifier =
+        ProviderScope.containerOf(
+              tester.element(find.byType(MobileSendScreen)),
+            ).read(syncProvider.notifier)
+            as _FakeSyncNotifier;
+    notifier.setSyncedToTip(true);
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_review_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Not enough ZEC'), findsOneWidget);
+    expect(find.byKey(const ValueKey('mobile_send_confirm')), findsNothing);
   });
 
   testWidgets('coded syncing propose error stays on review', (tester) async {

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -198,6 +198,7 @@ Widget _app({
   MobileSendScanner? openScanner,
   String? initialRecipient,
   MobileSendAddressValidator? validateAddress,
+  MobileSendFeeEstimator? estimateFee,
   bool syncedToTip = true,
 }) {
   final router = GoRouter(
@@ -210,6 +211,7 @@ Widget _app({
           openScanner: openScanner ?? (_) async => null,
           initialRecipient: initialRecipient,
           validateAddress: validateAddress,
+          estimateFee: estimateFee,
         ),
       ),
       GoRoute(path: '/home', builder: (_, _) => const Text('home')),
@@ -1545,6 +1547,56 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('mobile_send_review_button')));
     await tester.pumpAndSettle();
 
+    expect(find.text('Not enough ZEC'), findsOneWidget);
+    expect(find.byKey(const ValueKey('mobile_send_confirm')), findsNothing);
+  });
+
+  testWidgets('review re-estimates fee after sync reaches tip', (tester) async {
+    var allowFeeEstimate = false;
+    var feeCalls = 0;
+    await tester.pumpWidget(
+      _app(
+        syncedToTip: false,
+        estimateFee:
+            ({
+              required dbPath,
+              required network,
+              required accountUuid,
+              required toAddress,
+              required amountZatoshi,
+              memo,
+            }) async {
+              feeCalls++;
+              if (!allowFeeEstimate) {
+                throw StateError('sync_in_progress|wallet is still scanning');
+              }
+              return BigInt.from(10000);
+            },
+      ),
+    );
+    await tester.pumpAndSettle();
+    await _toAmountStep(tester, _shieldedAddress);
+
+    // 4.99995 ZEC is below the 5 ZEC spendable fixture, but adding the
+    // 0.0001 ZEC fee makes the final synced total insufficient.
+    await _enterAmount(tester, '4.99995');
+    expect(feeCalls, 1);
+    expect(find.text('Not enough ZEC'), findsNothing);
+    expect(find.text('Finish & review'), findsOneWidget);
+
+    final notifier =
+        ProviderScope.containerOf(
+              tester.element(find.byType(MobileSendScreen)),
+            ).read(syncProvider.notifier)
+            as _FakeSyncNotifier;
+    notifier.setSyncedToTip(true);
+    allowFeeEstimate = true;
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_review_button')));
+    await tester.pumpAndSettle();
+
+    expect(feeCalls, 2);
     expect(find.text('Not enough ZEC'), findsOneWidget);
     expect(find.byKey(const ValueKey('mobile_send_confirm')), findsNothing);
   });

--- a/test/features/send/send_failure_test.dart
+++ b/test/features/send/send_failure_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/services/send_failure.dart';
+
+void main() {
+  group('classifySendFailure', () {
+    test('parses stable coded failures', () {
+      expect(
+        classifySendFailure('sync_in_progress|have 1, need 2'),
+        SendFailureKind.syncInProgress,
+      );
+      expect(
+        classifySendFailure('scan_required|anchor unavailable'),
+        SendFailureKind.scanRequired,
+      );
+      expect(
+        classifySendFailure('insufficient_funds|have 1, need 2'),
+        SendFailureKind.insufficientFunds,
+      );
+    });
+
+    test('does not classify legacy free-form insufficient text', () {
+      expect(
+        classifySendFailure('Propose failed: insufficient funds'),
+        SendFailureKind.unknown,
+      );
+    });
+
+    test('treats sync and scan failures as waiting for sync', () {
+      expect(SendFailureKind.syncInProgress.isWaitingForSync, isTrue);
+      expect(SendFailureKind.scanRequired.isWaitingForSync, isTrue);
+      expect(SendFailureKind.insufficientFunds.isWaitingForSync, isFalse);
+      expect(SendFailureKind.unknown.isWaitingForSync, isFalse);
+    });
+  });
+}

--- a/test/features/send/send_failure_test.dart
+++ b/test/features/send/send_failure_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_rust_bridge/flutter_rust_bridge.dart' show AnyhowException;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/services/send_failure.dart';
 
@@ -14,6 +15,24 @@ void main() {
       );
       expect(
         classifySendFailure('insufficient_funds|have 1, need 2'),
+        SendFailureKind.insufficientFunds,
+      );
+    });
+
+    test('reads the coded marker from a real FRB AnyhowException', () {
+      // FRB decodes a Rust `Err(String)` into AnyhowException(message)
+      // (frb_generated.dart: `return AnyhowException(raw as String)`), so this is the
+      // actual runtime type the send/swap call sites catch. Pins the .message branch.
+      expect(
+        classifySendFailure(
+          AnyhowException('sync_in_progress|Propose failed: Insufficient balance'),
+        ),
+        SendFailureKind.syncInProgress,
+      );
+      expect(
+        classifySendFailure(
+          AnyhowException('insufficient_funds|Propose failed: Insufficient balance'),
+        ),
         SendFailureKind.insufficientFunds,
       );
     });

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -454,6 +456,41 @@ void main() {
     expect(rustApi.proposeSendCalls, 1);
   });
 
+  testWidgets('fee estimate uses latest spendable balance after sync update', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    rustApi.estimateFeeCompleter = Completer<BigInt>();
+
+    await tester.pumpWidget(
+      _sendHarness(syncedToTip: false, spendableBalance: BigInt.from(50000000)),
+    );
+    await tester.pump();
+
+    await tester.enterText(_editableIn('send_address_field'), _shieldedAddress);
+    await tester.pump();
+    await tester.enterText(_editableIn('send_amount_field'), '1.0');
+    await tester.pump();
+
+    final notifier =
+        ProviderScope.containerOf(
+              tester.element(find.byType(SendScreen)),
+            ).read(syncProvider.notifier)
+            as _FakeSyncNotifier;
+    notifier.updateSyncState(
+      syncedToTip: true,
+      spendableBalance: BigInt.from(200000000),
+    );
+    await tester.pump();
+
+    rustApi.estimateFeeCompleter!.complete(BigInt.from(10000));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.textContaining('Insufficient'), findsNothing);
+    expect(find.byKey(const ValueKey('send_review_button')), findsOneWidget);
+  });
+
   testWidgets('hardware TEX sends are blocked inline before proposal', (
     tester,
   ) async {
@@ -666,12 +703,20 @@ class _FakeSyncNotifier extends SyncNotifier {
     required this.syncedToTip,
   });
 
-  final BigInt spendableBalance;
-  final BigInt transparentBalance;
-  final bool syncedToTip;
+  BigInt spendableBalance;
+  BigInt transparentBalance;
+  bool syncedToTip;
+
+  void updateSyncState({BigInt? spendableBalance, bool? syncedToTip}) {
+    this.spendableBalance = spendableBalance ?? this.spendableBalance;
+    this.syncedToTip = syncedToTip ?? this.syncedToTip;
+    state = AsyncData(_syncState());
+  }
 
   @override
-  Future<SyncState> build() async => SyncState(
+  Future<SyncState> build() async => _syncState();
+
+  SyncState _syncState() => SyncState(
     accountUuid: 'account-1',
     hasAccountScopedData: true,
     isSyncing: !syncedToTip,
@@ -690,6 +735,7 @@ class _RustApiFake implements RustLibApi {
   String? lastProposeMemo;
   String? lastEstimateSendMaxToAddress;
   String? lastEstimateSendMaxMemo;
+  Completer<BigInt>? estimateFeeCompleter;
 
   void reset() {
     proposeSendCalls = 0;
@@ -698,6 +744,7 @@ class _RustApiFake implements RustLibApi {
     lastProposeMemo = null;
     lastEstimateSendMaxToAddress = null;
     lastEstimateSendMaxMemo = null;
+    estimateFeeCompleter = null;
   }
 
   @override
@@ -725,6 +772,8 @@ class _RustApiFake implements RustLibApi {
     required BigInt amountZatoshi,
     String? memo,
   }) async {
+    final completer = estimateFeeCompleter;
+    if (completer != null) return completer.future;
     return BigInt.from(10000);
   }
 

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -330,6 +330,35 @@ void main() {
     expect(find.text('Max amount unavailable'), findsNothing);
   });
 
+  testWidgets('Max syncing failure asks the user to wait', (tester) async {
+    await _setDesktopViewport(tester);
+    rustApi.estimateSendMaxError = StateError(
+      'sync_in_progress|wallet is still scanning',
+    );
+
+    await tester.pumpWidget(
+      _sendHarness(spendableBalance: BigInt.from(500000000)),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      _editableIn('send_address_field'),
+      _transparentAddress,
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.textContaining('Max:'));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(rustApi.estimateSendMaxCalls, 1);
+    expect(
+      find.text('Still syncing. Try again once sync finishes.'),
+      findsOneWidget,
+    );
+    expect(find.text('Max amount unavailable'), findsNothing);
+  });
+
   testWidgets('hides imported memo controls for TEX recipients', (
     tester,
   ) async {
@@ -736,6 +765,7 @@ class _RustApiFake implements RustLibApi {
   String? lastEstimateSendMaxToAddress;
   String? lastEstimateSendMaxMemo;
   Completer<BigInt>? estimateFeeCompleter;
+  Object? estimateSendMaxError;
 
   void reset() {
     proposeSendCalls = 0;
@@ -745,6 +775,7 @@ class _RustApiFake implements RustLibApi {
     lastEstimateSendMaxToAddress = null;
     lastEstimateSendMaxMemo = null;
     estimateFeeCompleter = null;
+    estimateSendMaxError = null;
   }
 
   @override
@@ -788,6 +819,8 @@ class _RustApiFake implements RustLibApi {
     estimateSendMaxCalls++;
     lastEstimateSendMaxToAddress = toAddress;
     lastEstimateSendMaxMemo = memo;
+    final error = estimateSendMaxError;
+    if (error != null) throw error;
     return SendMaxEstimateResult(
       amountZatoshi: BigInt.from(499990000),
       feeZatoshi: BigInt.from(10000),

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -344,9 +344,9 @@ void main() {
         ),
       ),
     );
-    await tester.pumpAndSettle();
+    await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(find.text('Shielded → Shielded'), findsNothing);
     expect(find.text('Shielded → Transparent'), findsNothing);
@@ -419,6 +419,39 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(rustApi.proposeSendCalls, 0);
+  });
+
+  testWidgets('mid-sync spendable shortfall still reaches proposal', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _sendHarness(
+        syncedToTip: false,
+        spendableBalance: BigInt.from(50000000),
+        prefill: const SendPrefillArgs(
+          id: 'mid-sync-shortfall',
+          source: 'ZIP-321',
+          address: _shieldedAddress,
+          amountText: '1.0',
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
+
+    expect(find.text('Insufficient balance'), findsNothing);
+
+    await tester.tap(find.text('Review'));
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    });
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(rustApi.proposeSendCalls, 1);
   });
 
   testWidgets('hardware TEX sends are blocked inline before proposal', (
@@ -498,6 +531,7 @@ Widget _sendHarness({
   AppBootstrapState? bootstrap,
   BigInt? spendableBalance,
   BigInt? transparentBalance,
+  bool syncedToTip = true,
 }) {
   final router = GoRouter(
     initialLocation: '/send',
@@ -518,6 +552,7 @@ Widget _sendHarness({
         () => _FakeSyncNotifier(
           spendableBalance: spendableBalance ?? BigInt.from(500000000),
           transparentBalance: transparentBalance ?? BigInt.zero,
+          syncedToTip: syncedToTip,
         ),
       ),
       if (addressBookRepository != null)
@@ -628,15 +663,20 @@ class _FakeSyncNotifier extends SyncNotifier {
   _FakeSyncNotifier({
     required this.spendableBalance,
     required this.transparentBalance,
+    required this.syncedToTip,
   });
 
   final BigInt spendableBalance;
   final BigInt transparentBalance;
+  final bool syncedToTip;
 
   @override
   Future<SyncState> build() async => SyncState(
     accountUuid: 'account-1',
     hasAccountScopedData: true,
+    isSyncing: !syncedToTip,
+    scannedHeight: syncedToTip ? 100 : 80,
+    chainTipHeight: 100,
     spendableBalance: spendableBalance,
     transparentBalance: transparentBalance,
     totalBalance: spendableBalance + transparentBalance,

--- a/test/features/swap/mobile_swap_modal_route_test.dart
+++ b/test/features/swap/mobile_swap_modal_route_test.dart
@@ -53,19 +53,25 @@ AppBootstrapState _bootstrap() => AppBootstrapState(
   passwordRotationRecoveryFailed: false,
 );
 
-Widget _app({_MobileDelayedQuoteSwapProvider? swapProvider}) => ProviderScope(
+Widget _app({
+  _MobileDelayedQuoteSwapProvider? swapProvider,
+  SyncState? syncState,
+}) => ProviderScope(
   overrides: [
     appBootstrapProvider.overrideWithValue(_bootstrap()),
     if (swapProvider != null)
       swapIntentProvider.overrideWithValue(swapProvider),
     syncProvider.overrideWith(
       () => FakeSyncNotifier(
-        SyncState(
-          accountUuid: 'account-1',
-          hasAccountScopedData: true,
-          orchardBalance: BigInt.from(100000000),
-          spendableBalance: BigInt.from(100000000),
-        ),
+        syncState ??
+            SyncState(
+              accountUuid: 'account-1',
+              hasAccountScopedData: true,
+              scannedHeight: 100,
+              chainTipHeight: 100,
+              orchardBalance: BigInt.from(100000000),
+              spendableBalance: BigInt.from(100000000),
+            ),
       ),
     ),
   ],
@@ -324,6 +330,53 @@ void main() {
     expect(identical(stateBefore, stateAfter), isTrue);
     expect(stateAfter.widget.focusNode.hasFocus, isTrue);
   });
+
+  testWidgets(
+    'swap composer defers the balance block while sync is incomplete',
+    (tester) async {
+      await tester.pumpWidget(
+        _app(
+          syncState: SyncState(
+            accountUuid: 'account-1',
+            hasAccountScopedData: true,
+            scannedHeight: 50,
+            chainTipHeight: 100,
+            orchardBalance: BigInt.from(100000000),
+            spendableBalance: BigInt.from(100000000),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.bySemanticsLabel('Swap').last);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const ValueKey('swap_amount_field')),
+        '1',
+      );
+      await tester.tap(find.text('Add recipient address'));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const ValueKey('swap_destination_field')),
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
+      await tester.tap(
+        find.byKey(const ValueKey('swap_address_update_button')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Continue to review'), findsOneWidget);
+      expect(find.text('Not enough ZEC'), findsNothing);
+      expect(
+        tester
+            .widget<AppButton>(
+              find.byKey(const ValueKey('mobile_swap_review_button')),
+            )
+            .onPressed,
+        isNotNull,
+      );
+    },
+  );
 
   testWidgets(
     'review quote loading shows loader and disables slippage settings',

--- a/test/features/swap/support/swap_screen_test_fakes.dart
+++ b/test/features/swap/support/swap_screen_test_fakes.dart
@@ -23,10 +23,12 @@ class _FakeReceiveAddressService extends ReceiveAddressService {
 class _FakeSwapSyncNotifier extends SyncNotifier {
   _FakeSwapSyncNotifier(
     this.spendableBalance, {
+    this.syncedToTip = true,
     this.recentTransactions = const [],
   });
 
   final BigInt spendableBalance;
+  final bool syncedToTip;
   final List<rust_sync.TransactionInfo> recentTransactions;
   var restartCount = 0;
 
@@ -34,6 +36,9 @@ class _FakeSwapSyncNotifier extends SyncNotifier {
   Future<SyncState> build() async => SyncState(
     accountUuid: 'account-1',
     hasAccountScopedData: true,
+    isSyncing: !syncedToTip,
+    scannedHeight: syncedToTip ? 100 : 50,
+    chainTipHeight: 100,
     spendableBalance: spendableBalance,
     totalBalance: spendableBalance,
     recentTransactions: recentTransactions,
@@ -46,15 +51,18 @@ class _FakeSwapSyncNotifier extends SyncNotifier {
 }
 
 class _FakeSwapMaxAmountEstimator implements SwapMaxAmountEstimator {
-  _FakeSwapMaxAmountEstimator({BigInt? maxZatoshi})
+  _FakeSwapMaxAmountEstimator({BigInt? maxZatoshi, this.error})
     : maxZatoshi = maxZatoshi ?? BigInt.zero;
 
   final BigInt maxZatoshi;
+  final Object? error;
   final requests = <String>[];
 
   @override
   Future<BigInt> estimateMaxZecSellAmount({required String accountUuid}) async {
     requests.add(accountUuid);
+    final error = this.error;
+    if (error != null) throw error;
     return maxZatoshi;
   }
 }

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -2464,6 +2464,78 @@ void main() {
     expect(_fieldText(tester, 'swap_amount_field'), '1.2339');
   });
 
+  testWidgets('ZEC max amount asks the user to wait while sync is incomplete', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final maxEstimator = _FakeSwapMaxAmountEstimator();
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        seedSwapActivityFixtures: false,
+        syncedToTip: false,
+        spendableBalance: BigInt.zero,
+        maxAmountEstimator: maxEstimator,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_max_amount_button')));
+    await tester.pumpAndSettle();
+
+    expect(maxEstimator.requests, ['account-1']);
+    expect(
+      find.text('Still syncing. Try again once sync finishes.'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Insufficient shielded balance to cover fee'),
+      findsNothing,
+    );
+    expect(find.text('Max amount unavailable'), findsNothing);
+  });
+
+  testWidgets('ZEC max amount maps coded syncing errors to wait copy', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final maxEstimator = _FakeSwapMaxAmountEstimator(
+      error: Exception('sync_in_progress|have 0, need 210000'),
+    );
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        seedSwapActivityFixtures: false,
+        syncedToTip: false,
+        spendableBalance: BigInt.from(100000000),
+        maxAmountEstimator: maxEstimator,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_max_amount_button')));
+    await tester.pumpAndSettle();
+
+    expect(maxEstimator.requests, ['account-1']);
+    expect(
+      find.text('Still syncing. Try again once sync finishes.'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Insufficient shielded balance to cover fee'),
+      findsNothing,
+    );
+    expect(find.text('Max amount unavailable'), findsNothing);
+  });
+
   testWidgets('ZEC max amount ignores stale result after account switch', (
     tester,
   ) async {
@@ -2510,7 +2582,7 @@ void main() {
   });
 
   testWidgets(
-    'ZEC review is disabled when the amount reaches available balance',
+    'ZEC composer allows review when the amount reaches available balance',
     (tester) async {
       await _setDesktopViewport(tester);
       final swapProvider = _FakeSwapProvider();
@@ -2539,16 +2611,70 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Max: 1 ZEC'), findsOneWidget);
-      expect(find.text('Not enough ZEC'), findsOneWidget);
+      expect(find.text('Review swap'), findsOneWidget);
+      expect(find.text('Not enough ZEC'), findsNothing);
 
       await tester.tap(find.byKey(const ValueKey('swap_review_button')));
       await tester.pumpAndSettle();
 
-      expect(swapProvider.requests, isEmpty);
+      expect(swapProvider.requests, hasLength(1));
       expect(
         find.byKey(const ValueKey('swap_review_cancel_button')),
-        findsNothing,
+        findsOneWidget,
       );
+      expect(
+        find.text(
+          "You don't have enough ZEC for this swap. Try a smaller amount.",
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Not enough ZEC'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'ZEC composer defers the balance block while sync is incomplete',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      final swapProvider = _FakeSwapProvider();
+
+      await tester.pumpWidget(
+        _routerHarness(
+          GoRouter(
+            initialLocation: '/swap',
+            routes: [_swapRoute(), _swapActivityRoute()],
+          ),
+          seedSwapActivityFixtures: false,
+          spendableBalance: BigInt.from(100000000),
+          syncedToTip: false,
+          swapProvider: swapProvider,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const ValueKey('swap_amount_field')),
+        '1',
+      );
+      await _enterDestinationText(
+        tester,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Max: 1 ZEC'), findsOneWidget);
+      expect(find.text('Review swap'), findsOneWidget);
+      expect(find.text('Not enough ZEC'), findsNothing);
+
+      await tester.tap(find.byKey(const ValueKey('swap_review_button')));
+      await tester.pumpAndSettle();
+
+      expect(swapProvider.requests, hasLength(1));
+      expect(
+        find.byKey(const ValueKey('swap_review_cancel_button')),
+        findsOneWidget,
+      );
+      expect(find.text('Not enough ZEC'), findsNothing);
     },
   );
 
@@ -5540,6 +5666,55 @@ void main() {
     },
   );
 
+  testWidgets(
+    'exact-output review defers the balance block while sync is incomplete',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      final swapProvider = _DriftingExactOutputSwapProvider();
+
+      await tester.pumpWidget(
+        _routerHarness(
+          GoRouter(
+            initialLocation: '/swap',
+            routes: [_swapRoute(), _swapActivityRoute()],
+          ),
+          swapProvider: swapProvider,
+          spendableBalance: BigInt.from(155000000),
+          syncedToTip: false,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const ValueKey('swap_receive_amount_field')),
+        '105.26',
+      );
+      await _enterDestinationText(
+        tester,
+        '0x52908400098527886e0f7030069857d2e4169ee7',
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const ValueKey('swap_review_button')));
+      await tester.pumpAndSettle();
+
+      _expectReviewInfoAmountFits(
+        tester,
+        sideKey: const ValueKey('swap_review_info_pay'),
+        amountText: '1.6000 ZEC',
+      );
+      expect(
+        find.text(
+          "You don't have enough ZEC for this swap. Try a smaller amount.",
+        ),
+        findsNothing,
+      );
+      expect(find.text('Confirm swap'), findsOneWidget);
+      expect(find.text('Not enough ZEC'), findsNothing);
+      expect(swapProvider.startedQuotes, isEmpty);
+    },
+  );
+
   testWidgets('review summary fiat values use the live exact-input quote', (
     tester,
   ) async {
@@ -6967,6 +7142,60 @@ void main() {
     expect(find.textContaining('Insufficient balance'), findsNothing);
   });
 
+  testWidgets('ZEC deposit preflight syncing error asks the user to wait', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final swapProvider = _FakeSwapProvider();
+    final depositSender = _FakeSwapDepositSender(
+      preflightError: Exception('sync_in_progress|have 0, need 210000'),
+    );
+    final sessionStore = _FakeSwapPersistenceStore();
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(
+          initialLocation: '/swap',
+          routes: [_swapRoute(), _swapActivityRoute()],
+        ),
+        swapProvider: swapProvider,
+        depositSender: depositSender,
+        sessionStore: sessionStore,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_amount_field')),
+      '0.002',
+    );
+    await _enterDestinationText(
+      tester,
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_review_button')));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.byKey(const ValueKey('swap_start_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_start_button')));
+    await tester.pumpAndSettle();
+
+    expect(depositSender.preflightRequests, hasLength(1));
+    expect(depositSender.requests, isEmpty);
+    expect(swapProvider.startedQuotes, isEmpty);
+    expect(sessionStore.savedIntents, isEmpty);
+    expect(
+      find.textContaining('Still syncing. Try again once sync finishes.'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('ZEC deposit could not be prepared.'),
+      findsNothing,
+    );
+  });
+
   testWidgets('hardware ZEC swaps open deposit page before Keystone signing', (
     tester,
   ) async {
@@ -7685,6 +7914,7 @@ Widget _routerHarness(
   RpcEndpointChainNameGetter? failoverChainNameGetter,
   RpcEndpointLatestBlockHeightGetter? failoverHeightGetter,
   List<rust_sync.TransactionInfo> recentTransactions = const [],
+  bool syncedToTip = true,
 }) {
   final fixtureIntents = seedSwapActivityFixtures
       ? _accountScopedSwapActivityFixtureIntents()
@@ -7702,6 +7932,7 @@ Widget _routerHarness(
       syncProvider.overrideWith(
         () => _FakeSwapSyncNotifier(
           spendableBalance ?? BigInt.from(10000000000),
+          syncedToTip: syncedToTip,
           recentTransactions: recentTransactions,
         ),
       ),

--- a/test/sync_state_test.dart
+++ b/test/sync_state_test.dart
@@ -138,6 +138,34 @@ void main() {
     expect(completed.totalBalance, BigInt.from(123));
     expect(completed.recentTransactions, hasLength(1));
   });
+
+  group('isSyncedToTip', () {
+    test('is false without a chain tip', () {
+      expect(SyncState().isSyncedToTip, isFalse);
+    });
+
+    test('is false while sync is actively running', () {
+      final state = SyncState(
+        isSyncing: true,
+        scannedHeight: 100,
+        chainTipHeight: 100,
+      );
+
+      expect(state.isSyncedToTip, isFalse);
+    });
+
+    test('is false until the fully scanned height reaches the tip', () {
+      final state = SyncState(scannedHeight: 99, chainTipHeight: 100);
+
+      expect(state.isSyncedToTip, isFalse);
+    });
+
+    test('is true when fully scanned to a non-zero tip', () {
+      final state = SyncState(scannedHeight: 100, chainTipHeight: 100);
+
+      expect(state.isSyncedToTip, isTrue);
+    });
+  });
 }
 
 rust_sync.TransactionInfo _tx(String txidHex) {


### PR DESCRIPTION
## Problem

While the wallet is still scanning, the local spendable balance can be transiently lower than the eventual spendable balance. Send and ZEC swap paths treated those mid-sync shortfalls as final insufficient-funds errors, which could block Review or surface misleading balance copy even though retrying after sync would succeed.

## Approach

Keep the fix small and avoid a separate readiness state:

- Rust send proposal builders prefix proposal-building failures with stable failure codes only when the error is actionable for UI classification: `sync_in_progress`, `scan_required`, or `insufficient_funds`.
- Rust treats active sync as non-final for shortfall classification, even if the wallet DB summary still appears synced to its last stored tip.
- Dart adds a lightweight `SendFailureKind` parser for those coded Rust errors.
- `SyncState.isSyncedToTip` is a computed getter from the existing sync fields; it is used only to decide when a local spendable shortfall is final.
- Desktop and mobile send no longer block on local spendable shortfall until sync is actually at tip.
- Desktop send re-reads spendable balance after async fee estimates before deciding whether amount + fee is insufficient.
- Mobile send rechecks the current synced spendable balance before moving from amount entry to review, so a stale mid-sync valid amount becomes blocked once sync reaches tip.
- ZEC swap composer no longer treats the current spendable balance as an authority for quote review; it lets a valid quote reach review.
- ZEC swap MAX maps zero estimates and coded syncing failures to the existing “Still syncing” copy while sync is incomplete.
- ZEC swap review keeps the local balance block only when sync is at tip, then lets ZEC send preflight make the authoritative call.
- ZEC swap preflight maps coded syncing errors to the existing “Still syncing” copy instead of a generic wallet-preflight failure.

## Scope

This PR covers send and the ZEC-send side of swap. It does not change non-ZEC deposit flows or broaden generic swap failure handling.

## Behavior

- Mid-sync shortfall: Review/preflight is allowed to reach Rust, and coded syncing failures ask the user to wait.
- Active-sync shortfall: Rust keeps insufficient-funds proposal failures classified as `sync_in_progress` until sync has stopped and the DB is synced to tip.
- Desktop send in-flight fee estimate: if sync updates spendable balance while fee estimation is pending, the final amount + fee comparison uses the latest spendable balance.
- Mobile send stale amount: if sync reaches tip before the user taps Review, the amount screen rechecks the final balance and restores “Not enough ZEC” instead of navigating to review.
- Mid-sync ZEC swap MAX: zero estimates and coded syncing failures ask the user to wait instead of showing insufficient-balance or generic max-unavailable copy.
- Fully synced send shortfall: the existing insufficient-balance behavior remains final and blocking.
- Fully synced ZEC swap composer shortfall: quote review is still allowed, but the review/start path can block on the live quote amount.
- Unknown proposal errors still follow the existing generic failure paths.

## Testing

Latest targeted validation after the desktop fee-estimate recheck:

- `fvm flutter test test/features/send/send_screen_test.dart`
- `fvm flutter analyze`
- `git diff --check`

Targeted validation after the mobile review recheck:

- `fvm flutter test test/features/send/mobile_send_screen_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `fvm flutter analyze`
- `git diff --check`

Validation after rebasing onto `origin/main` (`f18df5ef`):

- `fvm flutter test test/features/send/mobile_send_screen_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `fvm flutter test test/features/send/send_screen_test.dart test/features/send/send_failure_test.dart test/features/swap/swap_screen_test.dart`
- `fvm flutter test test/features/swap/mobile_swap_modal_route_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `fvm flutter analyze`
- `cd rust && cargo test wallet::sync::send::tests`
- `git diff --check`

Earlier validation before the latest main rebase:

- `fvm flutter test` → 1388 passed / 47 skipped
- `cd rust && cargo test --lib` → 179 passed / 1 ignored
