### PR TITLE
[codex] Add import account selection modal

### DIFF
--- a/lib/src/features/onboarding/import/import_account_discovery_modal.dart
+++ b/lib/src/features/onboarding/import/import_account_discovery_modal.dart
@@ -9,12 +9,14 @@ import '../../../rust/api/wallet.dart' as rust_wallet;
 class ImportAccountDiscoveryModal extends StatefulWidget {
   const ImportAccountDiscoveryModal({
     required this.accounts,
+    required this.allowEmptySelection,
     required this.onConfirm,
     required this.onCancel,
     super.key,
   });
 
   final List<rust_wallet.SoftwareWalletDiscoveredAccount> accounts;
+  final bool allowEmptySelection;
   final ValueChanged<List<int>> onConfirm;
   final VoidCallback onCancel;
 
@@ -63,6 +65,9 @@ class _ImportAccountDiscoveryModalState
   }
 
   void _confirm() {
+    if (_selectedAccountIndices.isEmpty && !widget.allowEmptySelection) {
+      return;
+    }
     final selected = [
       for (final account in widget.accounts)
         if (_selectedAccountIndices.contains(account.zip32AccountIndex))
@@ -75,7 +80,7 @@ class _ImportAccountDiscoveryModalState
   Widget build(BuildContext context) {
     final colors = context.colors;
     final selectedCount = _selectedAccountIndices.length;
-    final primaryLabel = selectedCount == 0 ? 'Continue' : 'Import';
+    final canConfirm = selectedCount > 0 || widget.allowEmptySelection;
 
     return AppPaneModalOverlay(
       onDismiss: widget.onCancel,
@@ -176,11 +181,11 @@ class _ImportAccountDiscoveryModalState
                     key: const ValueKey(
                       'import_account_discovery_confirm_button',
                     ),
-                    onPressed: _confirm,
+                    onPressed: canConfirm ? _confirm : null,
                     variant: AppButtonVariant.primary,
                     minWidth: 120,
                     trailing: const AppIcon(AppIcons.chevronForward),
-                    child: Text(primaryLabel),
+                    child: const Text('Import'),
                   ),
                 ),
               ],

--- a/lib/src/features/onboarding/import/import_account_discovery_modal.dart
+++ b/lib/src/features/onboarding/import/import_account_discovery_modal.dart
@@ -1,0 +1,320 @@
+import 'package:flutter/widgets.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_pane_modal_overlay.dart';
+import '../../../rust/api/wallet.dart' as rust_wallet;
+
+class ImportAccountDiscoveryModal extends StatefulWidget {
+  const ImportAccountDiscoveryModal({
+    required this.accounts,
+    required this.onConfirm,
+    required this.onCancel,
+    super.key,
+  });
+
+  final List<rust_wallet.SoftwareWalletDiscoveredAccount> accounts;
+  final ValueChanged<List<int>> onConfirm;
+  final VoidCallback onCancel;
+
+  @override
+  State<ImportAccountDiscoveryModal> createState() =>
+      _ImportAccountDiscoveryModalState();
+}
+
+class _ImportAccountDiscoveryModalState
+    extends State<ImportAccountDiscoveryModal> {
+  static const _modalWidth = 420.0;
+  static const _maxListHeight = 280.0;
+
+  late Set<int> _selectedAccountIndices;
+  final _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedAccountIndices = {
+      for (final account in widget.accounts) account.zip32AccountIndex,
+    };
+  }
+
+  @override
+  void didUpdateWidget(covariant ImportAccountDiscoveryModal oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.accounts == widget.accounts) return;
+    _selectedAccountIndices = {
+      for (final account in widget.accounts) account.zip32AccountIndex,
+    };
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _toggle(int accountIndex) {
+    setState(() {
+      if (!_selectedAccountIndices.add(accountIndex)) {
+        _selectedAccountIndices.remove(accountIndex);
+      }
+    });
+  }
+
+  void _confirm() {
+    final selected = [
+      for (final account in widget.accounts)
+        if (_selectedAccountIndices.contains(account.zip32AccountIndex))
+          account.zip32AccountIndex,
+    ];
+    widget.onConfirm(selected);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final selectedCount = _selectedAccountIndices.length;
+    final primaryLabel = selectedCount == 0 ? 'Continue' : 'Import';
+
+    return AppPaneModalOverlay(
+      onDismiss: widget.onCancel,
+      child: Container(
+        width: _modalWidth,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: AppSpacing.md,
+        ),
+        decoration: BoxDecoration(
+          color: colors.background.ground,
+          borderRadius: BorderRadius.circular(AppRadii.large),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: colors.background.neutralSubtleOpacity,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Center(
+                    child: AppIcon(
+                      AppIcons.users,
+                      size: AppIconSize.medium,
+                      color: colors.icon.regular,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.xs),
+                Expanded(
+                  child: Text(
+                    'Additional accounts found',
+                    style: AppTypography.bodyLarge.copyWith(
+                      color: colors.text.accent,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+              child: Text(
+                'Choose the additional accounts to import.',
+                style: AppTypography.bodyMedium.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.sm),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: _maxListHeight),
+              child: RawScrollbar(
+                controller: _scrollController,
+                thumbVisibility: widget.accounts.length > 3,
+                child: ListView.separated(
+                  controller: _scrollController,
+                  shrinkWrap: true,
+                  padding: EdgeInsets.zero,
+                  itemCount: widget.accounts.length,
+                  separatorBuilder: (_, _) =>
+                      const SizedBox(height: AppSpacing.xs),
+                  itemBuilder: (context, index) {
+                    final account = widget.accounts[index];
+                    final selected = _selectedAccountIndices.contains(
+                      account.zip32AccountIndex,
+                    );
+                    return _DiscoveredAccountRow(
+                      account: account,
+                      selected: selected,
+                      onTap: () => _toggle(account.zip32AccountIndex),
+                    );
+                  },
+                ),
+              ),
+            ),
+            const SizedBox(height: AppSpacing.md),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                AppButton(
+                  key: const ValueKey('import_account_discovery_cancel_button'),
+                  onPressed: widget.onCancel,
+                  variant: AppButtonVariant.ghost,
+                  minWidth: 96,
+                  child: const Text('Cancel'),
+                ),
+                const SizedBox(width: AppSpacing.xs),
+                Expanded(
+                  child: AppButton(
+                    key: const ValueKey(
+                      'import_account_discovery_confirm_button',
+                    ),
+                    onPressed: _confirm,
+                    variant: AppButtonVariant.primary,
+                    minWidth: 120,
+                    trailing: const AppIcon(AppIcons.chevronForward),
+                    child: Text(primaryLabel),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DiscoveredAccountRow extends StatelessWidget {
+  const _DiscoveredAccountRow({
+    required this.account,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final rust_wallet.SoftwareWalletDiscoveredAccount account;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final borderColor = selected ? colors.border.strong : colors.border.regular;
+
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: 'Account ${account.zip32AccountIndex}',
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          key: ValueKey(
+            'import_account_discovery_row_${account.zip32AccountIndex}',
+          ),
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: Container(
+            height: 68,
+            padding: const EdgeInsets.only(
+              left: AppSpacing.xs,
+              right: AppSpacing.s,
+              top: AppSpacing.xxs,
+              bottom: AppSpacing.xxs,
+            ),
+            decoration: BoxDecoration(
+              border: Border.all(color: borderColor, width: selected ? 2 : 1.5),
+              borderRadius: BorderRadius.circular(AppRadii.medium),
+            ),
+            child: Row(
+              children: [
+                AppIcon(
+                  AppIcons.transparentBalance,
+                  size: 18,
+                  color: colors.icon.accent,
+                ),
+                const SizedBox(width: AppSpacing.xs),
+                Expanded(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Account ${account.zip32AccountIndex}',
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTypography.labelLarge.copyWith(
+                          color: colors.text.accent,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        _shortAddress(account.firstTransparentAddress),
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTypography.codeSmall.copyWith(
+                          color: colors.text.secondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.xs),
+                _AccountToggle(
+                  selected: selected,
+                  accountIndex: account.zip32AccountIndex,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _shortAddress(String address) {
+    if (address.length <= 28) return address;
+    return '${address.substring(0, 12)} ... ${address.substring(address.length - 12)}';
+  }
+}
+
+class _AccountToggle extends StatelessWidget {
+  const _AccountToggle({required this.selected, required this.accountIndex});
+
+  final bool selected;
+  final int accountIndex;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final trackColor = selected
+        ? colors.background.inverse
+        : colors.background.neutralSubtleOpacity;
+    final knobColor = selected ? colors.icon.inverse : colors.icon.regular;
+
+    return AnimatedContainer(
+      key: ValueKey('import_account_discovery_toggle_$accountIndex'),
+      duration: const Duration(milliseconds: 140),
+      curve: Curves.easeOut,
+      width: 36,
+      height: 20,
+      padding: const EdgeInsets.all(2),
+      decoration: BoxDecoration(
+        color: trackColor,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Align(
+        alignment: selected ? Alignment.centerRight : Alignment.centerLeft,
+        child: Container(
+          width: 16,
+          height: 16,
+          decoration: BoxDecoration(color: knobColor, shape: BoxShape.circle),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/onboarding/import/import_account_discovery_modal.dart
+++ b/lib/src/features/onboarding/import/import_account_discovery_modal.dart
@@ -165,30 +165,34 @@ class _ImportAccountDiscoveryModalState
               ),
             ),
             const SizedBox(height: AppSpacing.md),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                AppButton(
-                  key: const ValueKey('import_account_discovery_cancel_button'),
-                  onPressed: widget.onCancel,
-                  variant: AppButtonVariant.ghost,
-                  minWidth: 96,
-                  child: const Text('Cancel'),
-                ),
-                const SizedBox(width: AppSpacing.xs),
-                Expanded(
-                  child: AppButton(
-                    key: const ValueKey(
-                      'import_account_discovery_confirm_button',
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final buttonWidth = (constraints.maxWidth - AppSpacing.xs) / 2;
+                return Row(
+                  children: [
+                    AppButton(
+                      key: const ValueKey(
+                        'import_account_discovery_cancel_button',
+                      ),
+                      onPressed: widget.onCancel,
+                      variant: AppButtonVariant.ghost,
+                      minWidth: buttonWidth,
+                      child: const Text('Cancel'),
                     ),
-                    onPressed: canConfirm ? _confirm : null,
-                    variant: AppButtonVariant.primary,
-                    minWidth: 120,
-                    trailing: const AppIcon(AppIcons.chevronForward),
-                    child: const Text('Import'),
-                  ),
-                ),
-              ],
+                    const SizedBox(width: AppSpacing.xs),
+                    AppButton(
+                      key: const ValueKey(
+                        'import_account_discovery_confirm_button',
+                      ),
+                      onPressed: canConfirm ? _confirm : null,
+                      variant: AppButtonVariant.primary,
+                      minWidth: buttonWidth,
+                      trailing: const AppIcon(AppIcons.chevronForward),
+                      child: const Text('Import'),
+                    ),
+                  ],
+                );
+              },
             ),
           ],
         ),

--- a/lib/src/features/onboarding/import/import_account_discovery_modal.dart
+++ b/lib/src/features/onboarding/import/import_account_discovery_modal.dart
@@ -1,15 +1,24 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 
+import '../../../core/formatting/zec_amount.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
 import '../../../rust/api/wallet.dart' as rust_wallet;
 
+typedef ImportAccountTransparentBalanceLoader =
+    Future<BigInt> Function(
+      rust_wallet.SoftwareWalletDiscoveredAccount account,
+    );
+
 class ImportAccountDiscoveryModal extends StatefulWidget {
   const ImportAccountDiscoveryModal({
     required this.accounts,
     required this.allowEmptySelection,
+    required this.loadTransparentBalance,
     required this.onConfirm,
     required this.onCancel,
     super.key,
@@ -17,6 +26,7 @@ class ImportAccountDiscoveryModal extends StatefulWidget {
 
   final List<rust_wallet.SoftwareWalletDiscoveredAccount> accounts;
   final bool allowEmptySelection;
+  final ImportAccountTransparentBalanceLoader loadTransparentBalance;
   final ValueChanged<List<int>> onConfirm;
   final VoidCallback onCancel;
 
@@ -29,29 +39,96 @@ class _ImportAccountDiscoveryModalState
     extends State<ImportAccountDiscoveryModal> {
   static const _modalWidth = 420.0;
   static const _maxListHeight = 280.0;
+  static const _maxConcurrentBalanceLoads = 2;
 
   late Set<int> _selectedAccountIndices;
+  late Map<int, _TransparentBalanceState> _transparentBalanceStates;
   final _scrollController = ScrollController();
+  int _balanceLoadGeneration = 0;
+  int _nextBalanceLoadIndex = 0;
 
   @override
   void initState() {
     super.initState();
-    _selectedAccountIndices = {
-      for (final account in widget.accounts) account.zip32AccountIndex,
-    };
+    _resetSelectedAccounts();
+    _resetTransparentBalanceStates();
+    _scheduleTransparentBalanceLoads();
   }
 
   @override
   void didUpdateWidget(covariant ImportAccountDiscoveryModal oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.accounts == widget.accounts) return;
+    _resetSelectedAccounts();
+    _resetTransparentBalanceStates();
+    _scheduleTransparentBalanceLoads();
+  }
+
+  void _resetSelectedAccounts() {
     _selectedAccountIndices = {
       for (final account in widget.accounts) account.zip32AccountIndex,
     };
   }
 
+  void _resetTransparentBalanceStates() {
+    _transparentBalanceStates = {
+      for (final account in widget.accounts)
+        account.zip32AccountIndex: const _TransparentBalanceState.loading(),
+    };
+  }
+
+  void _scheduleTransparentBalanceLoads() {
+    final generation = ++_balanceLoadGeneration;
+    _nextBalanceLoadIndex = 0;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || generation != _balanceLoadGeneration) return;
+      _startTransparentBalanceLoads(generation);
+    });
+  }
+
+  void _startTransparentBalanceLoads(int generation) {
+    final workerCount = widget.accounts.length < _maxConcurrentBalanceLoads
+        ? widget.accounts.length
+        : _maxConcurrentBalanceLoads;
+    for (var i = 0; i < workerCount; i++) {
+      unawaited(_loadTransparentBalances(generation));
+    }
+  }
+
+  Future<void> _loadTransparentBalances(int generation) async {
+    while (mounted && generation == _balanceLoadGeneration) {
+      final account = _takeNextBalanceLoadAccount(generation);
+      if (account == null) return;
+
+      final accountIndex = account.zip32AccountIndex;
+      try {
+        final balance = await widget.loadTransparentBalance(account);
+        if (!mounted || generation != _balanceLoadGeneration) return;
+        setState(() {
+          _transparentBalanceStates[accountIndex] =
+              _TransparentBalanceState.loaded(balance);
+        });
+      } catch (_) {
+        if (!mounted || generation != _balanceLoadGeneration) return;
+        setState(() {
+          _transparentBalanceStates[accountIndex] =
+              const _TransparentBalanceState.failed();
+        });
+      }
+    }
+  }
+
+  rust_wallet.SoftwareWalletDiscoveredAccount? _takeNextBalanceLoadAccount(
+    int generation,
+  ) {
+    if (generation != _balanceLoadGeneration) return null;
+    if (_nextBalanceLoadIndex >= widget.accounts.length) return null;
+    return widget.accounts[_nextBalanceLoadIndex++];
+  }
+
   @override
   void dispose() {
+    _balanceLoadGeneration++;
     _scrollController.dispose();
     super.dispose();
   }
@@ -158,6 +235,10 @@ class _ImportAccountDiscoveryModalState
                     return _DiscoveredAccountRow(
                       account: account,
                       selected: selected,
+                      transparentBalanceState:
+                          _transparentBalanceStates[account
+                              .zip32AccountIndex] ??
+                          const _TransparentBalanceState.loading(),
                       onTap: () => _toggle(account.zip32AccountIndex),
                     );
                   },
@@ -205,11 +286,13 @@ class _DiscoveredAccountRow extends StatelessWidget {
   const _DiscoveredAccountRow({
     required this.account,
     required this.selected,
+    required this.transparentBalanceState,
     required this.onTap,
   });
 
   final rust_wallet.SoftwareWalletDiscoveredAccount account;
   final bool selected;
+  final _TransparentBalanceState transparentBalanceState;
   final VoidCallback onTap;
 
   @override
@@ -273,6 +356,13 @@ class _DiscoveredAccountRow extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(width: AppSpacing.xs),
+                SizedBox(
+                  width: 112,
+                  child: _TransparentBalancePreviewLabel(
+                    state: transparentBalanceState,
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.xs),
                 _AccountToggle(
                   selected: selected,
                   accountIndex: account.zip32AccountIndex,
@@ -288,6 +378,72 @@ class _DiscoveredAccountRow extends StatelessWidget {
   String _shortAddress(String address) {
     if (address.length <= 28) return address;
     return '${address.substring(0, 12)} ... ${address.substring(address.length - 12)}';
+  }
+}
+
+enum _TransparentBalanceStatus { loading, loaded, failed }
+
+class _TransparentBalanceState {
+  const _TransparentBalanceState.loading()
+    : status = _TransparentBalanceStatus.loading,
+      zatoshi = null;
+
+  const _TransparentBalanceState.loaded(this.zatoshi)
+    : status = _TransparentBalanceStatus.loaded;
+
+  const _TransparentBalanceState.failed()
+    : status = _TransparentBalanceStatus.failed,
+      zatoshi = null;
+
+  final _TransparentBalanceStatus status;
+  final BigInt? zatoshi;
+}
+
+class _TransparentBalancePreviewLabel extends StatelessWidget {
+  const _TransparentBalancePreviewLabel({required this.state});
+
+  final _TransparentBalanceState state;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final balanceText = switch (state.status) {
+      _TransparentBalanceStatus.loading => 'Loading',
+      _TransparentBalanceStatus.failed => '-',
+      _TransparentBalanceStatus.loaded => ZecAmount.fromZatoshi(
+        state.zatoshi ?? BigInt.zero,
+      ).activity.toString(),
+    };
+    final color = switch (state.status) {
+      _TransparentBalanceStatus.loading => colors.text.secondary,
+      _TransparentBalanceStatus.failed => colors.text.secondary,
+      _TransparentBalanceStatus.loaded => colors.text.accent,
+    };
+
+    return Column(
+      key: const ValueKey('import_account_discovery_balance_label'),
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Text(
+          'Transparent',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.end,
+          style: AppTypography.labelMedium.copyWith(
+            color: colors.text.secondary,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          balanceText,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.end,
+          style: AppTypography.labelMedium.copyWith(color: color),
+        ),
+      ],
+    );
   }
 }
 

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart' as material;
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -13,8 +15,10 @@ import '../../../providers/app_security_provider.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
 import '../../../providers/wallet_mutation_guard.dart';
+import '../../../rust/api/wallet.dart' as rust_wallet;
 import '../shared/onboarding_error_messages.dart';
 import '../shared/onboarding_flow_args.dart';
+import 'import_account_discovery_modal.dart';
 import 'import_birthday_estimator.dart';
 import 'import_birthday_calendar_overlay.dart';
 import 'import_birthday_unknown_height_modal.dart';
@@ -22,7 +26,12 @@ import 'import_split_view.dart';
 
 enum ImportBirthdayTab { date, blockHeight }
 
-enum _ImportWalletSubmitPhase { idle, stoppingSync, importing }
+enum _ImportWalletSubmitPhase {
+  idle,
+  discoveringAccounts,
+  stoppingSync,
+  importing,
+}
 
 class ImportWalletBirthdayScreen extends ConsumerStatefulWidget {
   const ImportWalletBirthdayScreen({required this.args, super.key});
@@ -53,6 +62,9 @@ class _ImportWalletBirthdayScreenState
   bool _isCalendarOpen = false;
   bool _isUnknownBirthdayConfirmOpen = false;
   _ImportWalletSubmitPhase _submitPhase = _ImportWalletSubmitPhase.idle;
+  List<rust_wallet.SoftwareWalletDiscoveredAccount>?
+  _accountDiscoveryCandidates;
+  Completer<List<int>?>? _accountDiscoveryCompleter;
   String? _metadataError;
   String? _submitError;
   DateTime? _calendarInitialDate;
@@ -218,6 +230,25 @@ class _ImportWalletBirthdayScreenState
     });
   }
 
+  void _confirmAccountDiscovery(List<int> accountIndices) {
+    final completer = _accountDiscoveryCompleter;
+    setState(() {
+      _accountDiscoveryCandidates = null;
+      _accountDiscoveryCompleter = null;
+    });
+    completer?.complete(accountIndices);
+  }
+
+  void _dismissAccountDiscovery() {
+    final completer = _accountDiscoveryCompleter;
+    setState(() {
+      _accountDiscoveryCandidates = null;
+      _accountDiscoveryCompleter = null;
+      _submitPhase = _ImportWalletSubmitPhase.idle;
+    });
+    completer?.complete(null);
+  }
+
   Future<void> _confirmUnknownBirthday() async {
     if (_isSubmitting) return;
     setState(() {
@@ -267,6 +298,17 @@ class _ImportWalletBirthdayScreenState
     });
 
     try {
+      final selectedAdditionalAccountIndices =
+          await _resolveAdditionalAccountIndices(
+            mnemonic: mnemonic,
+            birthdayHeight: birthdayHeight,
+          );
+      if (selectedAdditionalAccountIndices == null) return;
+      if (!mounted) return;
+      setState(() {
+        _submitPhase = _ImportWalletSubmitPhase.importing;
+      });
+
       final security = ref.read(appSecurityProvider);
       if (!security.isPasswordConfigured) {
         if (!mounted) return;
@@ -275,6 +317,7 @@ class _ImportWalletBirthdayScreenState
           extra: SetPasswordScreenArgs.importWallet(
             mnemonic: mnemonic,
             birthdayHeight: birthdayHeight,
+            selectedAdditionalAccountIndices: selectedAdditionalAccountIndices,
           ),
         );
         return;
@@ -287,6 +330,7 @@ class _ImportWalletBirthdayScreenState
         () => accountNotifier.importAccount(
           mnemonic: mnemonic,
           birthdayHeight: birthdayHeight,
+          additionalAccountIndices: selectedAdditionalAccountIndices,
         ),
         onStoppingSync: () {
           if (!mounted) return;
@@ -311,6 +355,32 @@ class _ImportWalletBirthdayScreenState
       });
       return;
     }
+  }
+
+  Future<List<int>?> _resolveAdditionalAccountIndices({
+    required String mnemonic,
+    required int birthdayHeight,
+  }) async {
+    setState(() {
+      _submitPhase = _ImportWalletSubmitPhase.discoveringAccounts;
+    });
+
+    final candidates = await ref
+        .read(accountProvider.notifier)
+        .discoverAdditionalSoftwareAccounts(
+          mnemonic: mnemonic,
+          birthdayHeight: birthdayHeight,
+        );
+    if (!mounted) return null;
+    if (candidates.isEmpty) return const [];
+
+    final completer = Completer<List<int>?>();
+    setState(() {
+      _accountDiscoveryCandidates = candidates;
+      _accountDiscoveryCompleter = completer;
+      _submitPhase = _ImportWalletSubmitPhase.idle;
+    });
+    return completer.future;
   }
 
   int? _resolvedBirthdayHeight() {
@@ -371,6 +441,7 @@ class _ImportWalletBirthdayScreenState
     final calendarFirstDate = _calendarFirstDate;
     final calendarLastDate = _calendarLastDate;
     final buttonLabel = switch (_submitPhase) {
+      _ImportWalletSubmitPhase.discoveringAccounts => 'Checking accounts...',
       _ImportWalletSubmitPhase.stoppingSync => 'Stop syncing...',
       _ImportWalletSubmitPhase.importing => 'Importing...',
       _ImportWalletSubmitPhase.idle =>
@@ -380,7 +451,13 @@ class _ImportWalletBirthdayScreenState
     };
 
     return ImportOnboardingTrailingPane(
-      overlay: _isUnknownBirthdayConfirmOpen
+      overlay: _accountDiscoveryCandidates != null
+          ? ImportAccountDiscoveryModal(
+              accounts: _accountDiscoveryCandidates!,
+              onConfirm: _confirmAccountDiscovery,
+              onCancel: _dismissAccountDiscovery,
+            )
+          : _isUnknownBirthdayConfirmOpen
           ? ImportBirthdayUnknownHeightModal(
               onConfirm: _confirmUnknownBirthday,
               onCancel: _dismissUnknownBirthdayConfirmation,

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -470,6 +470,7 @@ class _ImportWalletBirthdayScreenState
           ? ImportAccountDiscoveryModal(
               accounts: _accountDiscoveryCandidates!,
               allowEmptySelection: _accountDiscoveryAllowsEmptySelection,
+              loadTransparentBalance: _loadAccountDiscoveryTransparentBalance,
               onConfirm: _confirmAccountDiscovery,
               onCancel: _dismissAccountDiscovery,
             )
@@ -614,6 +615,17 @@ class _ImportWalletBirthdayScreenState
         ],
       ),
     );
+  }
+
+  Future<BigInt> _loadAccountDiscoveryTransparentBalance(
+    rust_wallet.SoftwareWalletDiscoveredAccount account,
+  ) {
+    return ref
+        .read(accountProvider.notifier)
+        .previewSoftwareAccountTransparentBalance(
+          mnemonic: widget.args.mnemonic,
+          accountIndex: account.zip32AccountIndex,
+        );
   }
 }
 

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -89,6 +89,7 @@ class _ImportWalletBirthdayScreenState
 
   @override
   void dispose() {
+    _completeAccountDiscovery(null);
     _manualHeightFocusNode
       ..removeListener(_handleFocusChanged)
       ..dispose();
@@ -232,24 +233,36 @@ class _ImportWalletBirthdayScreenState
   }
 
   void _confirmAccountDiscovery(List<int> accountIndices) {
-    final completer = _accountDiscoveryCompleter;
-    setState(() {
-      _accountDiscoveryCandidates = null;
-      _accountDiscoveryCompleter = null;
-      _accountDiscoveryAllowsEmptySelection = true;
-    });
-    completer?.complete(accountIndices);
+    _completeAccountDiscovery(accountIndices, updateState: true);
   }
 
   void _dismissAccountDiscovery() {
-    final completer = _accountDiscoveryCompleter;
+    _completeAccountDiscovery(null, updateState: true);
     setState(() {
+      _submitPhase = _ImportWalletSubmitPhase.idle;
+    });
+  }
+
+  void _completeAccountDiscovery(
+    List<int>? accountIndices, {
+    bool updateState = false,
+  }) {
+    final completer = _accountDiscoveryCompleter;
+    void clearDiscoveryState() {
       _accountDiscoveryCandidates = null;
       _accountDiscoveryCompleter = null;
       _accountDiscoveryAllowsEmptySelection = true;
-      _submitPhase = _ImportWalletSubmitPhase.idle;
-    });
-    completer?.complete(null);
+    }
+
+    if (updateState && mounted) {
+      setState(clearDiscoveryState);
+    } else {
+      clearDiscoveryState();
+    }
+
+    if (completer != null && !completer.isCompleted) {
+      completer.complete(accountIndices);
+    }
   }
 
   Future<void> _confirmUnknownBirthday() async {

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -65,6 +65,7 @@ class _ImportWalletBirthdayScreenState
   List<rust_wallet.SoftwareWalletDiscoveredAccount>?
   _accountDiscoveryCandidates;
   Completer<List<int>?>? _accountDiscoveryCompleter;
+  bool _accountDiscoveryAllowsEmptySelection = true;
   String? _metadataError;
   String? _submitError;
   DateTime? _calendarInitialDate;
@@ -235,6 +236,7 @@ class _ImportWalletBirthdayScreenState
     setState(() {
       _accountDiscoveryCandidates = null;
       _accountDiscoveryCompleter = null;
+      _accountDiscoveryAllowsEmptySelection = true;
     });
     completer?.complete(accountIndices);
   }
@@ -244,6 +246,7 @@ class _ImportWalletBirthdayScreenState
     setState(() {
       _accountDiscoveryCandidates = null;
       _accountDiscoveryCompleter = null;
+      _accountDiscoveryAllowsEmptySelection = true;
       _submitPhase = _ImportWalletSubmitPhase.idle;
     });
     completer?.complete(null);
@@ -298,19 +301,14 @@ class _ImportWalletBirthdayScreenState
     });
 
     try {
-      final selectedAdditionalAccountIndices =
-          await _resolveAdditionalAccountIndices(
-            mnemonic: mnemonic,
-            birthdayHeight: birthdayHeight,
-          );
-      if (selectedAdditionalAccountIndices == null) return;
-      if (!mounted) return;
-      setState(() {
-        _submitPhase = _ImportWalletSubmitPhase.importing;
-      });
-
       final security = ref.read(appSecurityProvider);
       if (!security.isPasswordConfigured) {
+        final selectedAdditionalAccountIndices =
+            await _resolveAdditionalAccountIndices(
+              mnemonic: mnemonic,
+              birthdayHeight: birthdayHeight,
+            );
+        if (selectedAdditionalAccountIndices == null) return;
         if (!mounted) return;
         context.go(
           '/import/set-password',
@@ -325,13 +323,26 @@ class _ImportWalletBirthdayScreenState
 
       final accountNotifier = ref.read(accountProvider.notifier);
       final router = GoRouter.of(context);
-      await runWithSyncPausedForAccountMutation(
+      final imported = await runWithSyncPausedForAccountMutation(
         ref,
-        () => accountNotifier.importAccount(
-          mnemonic: mnemonic,
-          birthdayHeight: birthdayHeight,
-          additionalAccountIndices: selectedAdditionalAccountIndices,
-        ),
+        () async {
+          final selectedAdditionalAccountIndices =
+              await _resolveAdditionalAccountIndices(
+                mnemonic: mnemonic,
+                birthdayHeight: birthdayHeight,
+              );
+          if (selectedAdditionalAccountIndices == null) return false;
+          if (!mounted) return false;
+          setState(() {
+            _submitPhase = _ImportWalletSubmitPhase.importing;
+          });
+          await accountNotifier.importAccount(
+            mnemonic: mnemonic,
+            birthdayHeight: birthdayHeight,
+            additionalAccountIndices: selectedAdditionalAccountIndices,
+          );
+          return true;
+        },
         onStoppingSync: () {
           if (!mounted) return;
           setState(() {
@@ -345,6 +356,7 @@ class _ImportWalletBirthdayScreenState
           });
         },
       );
+      if (!imported || !mounted) return;
       router.go('/home');
     } catch (e, st) {
       log('ImportWalletBirthdayScreen._submit: ERROR: $e\n$st');
@@ -365,19 +377,22 @@ class _ImportWalletBirthdayScreenState
       _submitPhase = _ImportWalletSubmitPhase.discoveringAccounts;
     });
 
-    final candidates = await ref
+    final discovery = await ref
         .read(accountProvider.notifier)
         .discoverAdditionalSoftwareAccounts(
           mnemonic: mnemonic,
           birthdayHeight: birthdayHeight,
         );
     if (!mounted) return null;
+    final candidates = discovery.accounts;
     if (candidates.isEmpty) return const [];
 
     final completer = Completer<List<int>?>();
     setState(() {
       _accountDiscoveryCandidates = candidates;
       _accountDiscoveryCompleter = completer;
+      _accountDiscoveryAllowsEmptySelection =
+          !discovery.primaryAccountAlreadyExists;
       _submitPhase = _ImportWalletSubmitPhase.idle;
     });
     return completer.future;
@@ -454,6 +469,7 @@ class _ImportWalletBirthdayScreenState
       overlay: _accountDiscoveryCandidates != null
           ? ImportAccountDiscoveryModal(
               accounts: _accountDiscoveryCandidates!,
+              allowEmptySelection: _accountDiscoveryAllowsEmptySelection,
               onConfirm: _confirmAccountDiscovery,
               onCancel: _dismissAccountDiscovery,
             )

--- a/lib/src/features/onboarding/shared/onboarding_flow_args.dart
+++ b/lib/src/features/onboarding/shared/onboarding_flow_args.dart
@@ -16,10 +16,12 @@ class ImportBirthdayArgs {
   const ImportBirthdayArgs({
     required this.mnemonic,
     this.initialBirthdayHeight,
+    this.selectedAdditionalAccountIndices = const [],
   });
 
   final String mnemonic;
   final int? initialBirthdayHeight;
+  final List<int> selectedAdditionalAccountIndices;
 }
 
 class SetPasswordScreenArgs {
@@ -27,6 +29,7 @@ class SetPasswordScreenArgs {
     required this.flow,
     this.mnemonic,
     this.birthdayHeight,
+    this.selectedAdditionalAccountIndices = const [],
     this.keystoneAccountName,
     this.keystoneUfvk,
     this.keystoneSeedFingerprint,
@@ -39,10 +42,12 @@ class SetPasswordScreenArgs {
   const SetPasswordScreenArgs.importWallet({
     required String mnemonic,
     required int birthdayHeight,
+    List<int> selectedAdditionalAccountIndices = const [],
   }) : this._(
          flow: SetPasswordFlow.importWallet,
          mnemonic: mnemonic,
          birthdayHeight: birthdayHeight,
+         selectedAdditionalAccountIndices: selectedAdditionalAccountIndices,
        );
 
   const SetPasswordScreenArgs.importKeystone({
@@ -63,6 +68,7 @@ class SetPasswordScreenArgs {
   final SetPasswordFlow flow;
   final String? mnemonic;
   final int? birthdayHeight;
+  final List<int> selectedAdditionalAccountIndices;
   final String? keystoneAccountName;
   final String? keystoneUfvk;
   final List<int>? keystoneSeedFingerprint;
@@ -91,6 +97,7 @@ class SetPasswordScreenArgs {
     SetPasswordFlow.importWallet => ImportBirthdayArgs(
       mnemonic: requiredMnemonic,
       initialBirthdayHeight: importBirthdayHeight,
+      selectedAdditionalAccountIndices: selectedAdditionalAccountIndices,
     ),
     SetPasswordFlow.importKeystone => this,
   };

--- a/lib/src/features/onboarding/shared/set_password_screen.dart
+++ b/lib/src/features/onboarding/shared/set_password_screen.dart
@@ -101,6 +101,8 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
                 await accountNotifier.importAccount(
                   mnemonic: args.requiredMnemonic,
                   birthdayHeight: args.importBirthdayHeight,
+                  additionalAccountIndices:
+                      args.selectedAdditionalAccountIndices,
                 );
               case SetPasswordFlow.importKeystone:
                 await accountNotifier.importKeystoneAccount(

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -323,6 +323,30 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     }
   }
 
+  Future<BigInt> previewSoftwareAccountTransparentBalance({
+    required String mnemonic,
+    required int accountIndex,
+  }) async {
+    try {
+      final endpoint = ref.read(rpcEndpointProvider);
+      final accounts = state.value?.accounts ?? const <AccountInfo>[];
+      final isFirstWalletAccount = accounts.isEmpty;
+      final network = isFirstWalletAccount
+          ? endpoint.networkName
+          : await _getNetwork();
+
+      return rust_wallet.previewSoftwareAccountTransparentBalance(
+        mnemonic: mnemonic,
+        network: network,
+        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+        zip32AccountIndex: accountIndex,
+      );
+    } catch (e, st) {
+      log('previewSoftwareAccountTransparentBalance: ERROR: $e\n$st');
+      rethrow;
+    }
+  }
+
   /// Switch active account.
   Future<void> switchAccount(String uuid) async {
     final previousActiveUuid = state.value?.activeAccountUuid;

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -211,6 +211,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     required String mnemonic,
     int? birthdayHeight,
     String? name,
+    List<int> additionalAccountIndices = const [],
   }) async {
     try {
       final dbPath = await _getDbPath();
@@ -236,9 +237,9 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
         network: network,
         dbPath: dbPath,
         firstAccountName: accountName,
-        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
         isFirstWalletAccount: isFirstWalletAccount,
         nextAccountNumber: accounts.length + 1,
+        additionalAccountIndices: additionalAccountIndices,
       );
       if (result.accounts.isEmpty) {
         throw StateError('Software wallet import did not return an account.');
@@ -288,6 +289,36 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       );
     } catch (e, st) {
       log('importAccount: ERROR: $e\n$st');
+      rethrow;
+    }
+  }
+
+  Future<List<rust_wallet.SoftwareWalletDiscoveredAccount>>
+  discoverAdditionalSoftwareAccounts({
+    required String mnemonic,
+    int? birthdayHeight,
+  }) async {
+    try {
+      final dbPath = await _getDbPath();
+      final endpoint = ref.read(rpcEndpointProvider);
+      final accounts = state.value?.accounts ?? const <AccountInfo>[];
+      final isFirstWalletAccount = accounts.isEmpty;
+      final network = isFirstWalletAccount
+          ? endpoint.networkName
+          : await _getNetwork();
+
+      return rust_wallet.discoverSoftwareWalletImportAccounts(
+        mnemonic: mnemonic,
+        birthdayHeight: birthdayHeight != null
+            ? BigInt.from(birthdayHeight)
+            : null,
+        network: network,
+        dbPath: dbPath,
+        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+        isFirstWalletAccount: isFirstWalletAccount,
+      );
+    } catch (e, st) {
+      log('discoverAdditionalSoftwareAccounts: ERROR: $e\n$st');
       rethrow;
     }
   }

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -293,7 +293,7 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     }
   }
 
-  Future<List<rust_wallet.SoftwareWalletDiscoveredAccount>>
+  Future<rust_wallet.SoftwareWalletImportDiscoveryResult>
   discoverAdditionalSoftwareAccounts({
     required String mnemonic,
     int? birthdayHeight,

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -66,7 +66,7 @@ Future<AccountCreationResult> addAccount({
 
 /// Discover higher ZIP32 software accounts with transparent history that are
 /// not already present in the wallet DB for this mnemonic.
-Future<List<SoftwareWalletDiscoveredAccount>>
+Future<SoftwareWalletImportDiscoveryResult>
 discoverSoftwareWalletImportAccounts({
   required String mnemonic,
   BigInt? birthdayHeight,
@@ -308,6 +308,28 @@ class SoftwareWalletImportAccount {
           zip32AccountIndex == other.zip32AccountIndex &&
           name == other.name &&
           isSeedAnchor == other.isSeedAnchor;
+}
+
+/// Software account discovery result for an import attempt.
+class SoftwareWalletImportDiscoveryResult {
+  final bool primaryAccountAlreadyExists;
+  final List<SoftwareWalletDiscoveredAccount> accounts;
+
+  const SoftwareWalletImportDiscoveryResult({
+    required this.primaryAccountAlreadyExists,
+    required this.accounts,
+  });
+
+  @override
+  int get hashCode => primaryAccountAlreadyExists.hashCode ^ accounts.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SoftwareWalletImportDiscoveryResult &&
+          runtimeType == other.runtimeType &&
+          primaryAccountAlreadyExists == other.primaryAccountAlreadyExists &&
+          accounts == other.accounts;
 }
 
 /// Result of software mnemonic import with ZIP32 account discovery.

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -6,7 +6,7 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `catch`, `discover_software_account_at_index`, `discover_used_software_accounts`, `discovery_start_height`, `import_discovered_software_wallet_accounts`, `parse_network_and_migrate`
+// These functions are ignored because they are not marked as `pub`: `catch`, `discover_software_account_at_index`, `discover_used_software_accounts`, `discovery_start_height`, `import_discovered_software_wallet_accounts`, `parse_network_and_migrate`, `preview_transparent_balance_for_addresses`
 
 /// Get the latest block height from lightwalletd.
 Future<BigInt> getLatestBlockHeight({required String lightwalletdUrl}) =>
@@ -82,6 +82,24 @@ discoverSoftwareWalletImportAccounts({
   lightwalletdUrl: lightwalletdUrl,
   isFirstWalletAccount: isFirstWalletAccount,
 );
+
+/// Preview the spendable transparent UTXO balance for a software ZIP32 account.
+///
+/// This does not import the account or touch the wallet DB. It checks a bounded
+/// standard BIP44 transparent address range so the onboarding modal can update
+/// balance rows after discovery has already returned.
+Future<BigInt> previewSoftwareAccountTransparentBalance({
+  required String mnemonic,
+  required String network,
+  required String lightwalletdUrl,
+  required int zip32AccountIndex,
+}) =>
+    RustLib.instance.api.crateApiWalletPreviewSoftwareAccountTransparentBalance(
+      mnemonic: mnemonic,
+      network: network,
+      lightwalletdUrl: lightwalletdUrl,
+      zip32AccountIndex: zip32AccountIndex,
+    );
 
 /// Import a software mnemonic. `account'=0` must be imported successfully;
 /// higher account indices are imported only when selected by the caller.

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -6,7 +6,7 @@
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `catch`, `discover_used_software_account_indices`, `discovery_start_height`, `parse_network_and_migrate`, `software_account_first_taddr_has_history`
+// These functions are ignored because they are not marked as `pub`: `catch`, `discover_software_account_at_index`, `discover_used_software_accounts`, `discovery_start_height`, `import_discovered_software_wallet_accounts`, `parse_network_and_migrate`
 
 /// Get the latest block height from lightwalletd.
 Future<BigInt> getLatestBlockHeight({required String lightwalletdUrl}) =>
@@ -64,9 +64,27 @@ Future<AccountCreationResult> addAccount({
   birthdayHeight: birthdayHeight,
 );
 
-/// Import a software mnemonic and discover additional ZIP32 accounts with
-/// transparent history. `account'=0` must be imported successfully; discovery
-/// for higher account indices is best-effort.
+/// Discover higher ZIP32 software accounts with transparent history that are
+/// not already present in the wallet DB for this mnemonic.
+Future<List<SoftwareWalletDiscoveredAccount>>
+discoverSoftwareWalletImportAccounts({
+  required String mnemonic,
+  BigInt? birthdayHeight,
+  required String network,
+  required String dbPath,
+  required String lightwalletdUrl,
+  required bool isFirstWalletAccount,
+}) => RustLib.instance.api.crateApiWalletDiscoverSoftwareWalletImportAccounts(
+  mnemonic: mnemonic,
+  birthdayHeight: birthdayHeight,
+  network: network,
+  dbPath: dbPath,
+  lightwalletdUrl: lightwalletdUrl,
+  isFirstWalletAccount: isFirstWalletAccount,
+);
+
+/// Import a software mnemonic. `account'=0` must be imported successfully;
+/// higher account indices are imported only when selected by the caller.
 Future<SoftwareWalletImportWithDiscoveryResult>
 importSoftwareWalletWithAccountDiscovery({
   required String mnemonic,
@@ -74,9 +92,9 @@ importSoftwareWalletWithAccountDiscovery({
   required String network,
   required String dbPath,
   String? firstAccountName,
-  required String lightwalletdUrl,
   required bool isFirstWalletAccount,
   required int nextAccountNumber,
+  required List<int> additionalAccountIndices,
 }) =>
     RustLib.instance.api.crateApiWalletImportSoftwareWalletWithAccountDiscovery(
       mnemonic: mnemonic,
@@ -84,9 +102,9 @@ importSoftwareWalletWithAccountDiscovery({
       network: network,
       dbPath: dbPath,
       firstAccountName: firstAccountName,
-      lightwalletdUrl: lightwalletdUrl,
       isFirstWalletAccount: isFirstWalletAccount,
       nextAccountNumber: nextAccountNumber,
+      additionalAccountIndices: additionalAccountIndices,
     );
 
 /// Import a hardware wallet account using a UFVK (no mnemonic/seed needed).
@@ -231,6 +249,29 @@ class AccountInfo {
           unifiedAddress == other.unifiedAddress &&
           isSeedAnchor == other.isSeedAnchor &&
           isHardware == other.isHardware;
+}
+
+/// A higher ZIP32 software account that can be imported by user choice.
+class SoftwareWalletDiscoveredAccount {
+  final int zip32AccountIndex;
+  final String firstTransparentAddress;
+
+  const SoftwareWalletDiscoveredAccount({
+    required this.zip32AccountIndex,
+    required this.firstTransparentAddress,
+  });
+
+  @override
+  int get hashCode =>
+      zip32AccountIndex.hashCode ^ firstTransparentAddress.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SoftwareWalletDiscoveredAccount &&
+          runtimeType == other.runtimeType &&
+          zip32AccountIndex == other.zip32AccountIndex &&
+          firstTransparentAddress == other.firstTransparentAddress;
 }
 
 /// A software account created by mnemonic import.

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1389930982;
+  int get rustContentHash => -1895016467;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -263,6 +263,16 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiSyncDiscardProposal({
     required BigInt proposalId,
     required String sendFlowId,
+  });
+
+  Future<List<SoftwareWalletDiscoveredAccount>>
+  crateApiWalletDiscoverSoftwareWalletImportAccounts({
+    required String mnemonic,
+    BigInt? birthdayHeight,
+    required String network,
+    required String dbPath,
+    required String lightwalletdUrl,
+    required bool isFirstWalletAccount,
   });
 
   Future<String> crateApiKeystoneEncodePcztToUr({required List<int> pcztBytes});
@@ -467,9 +477,9 @@ abstract class RustLibApi extends BaseApi {
     required String network,
     required String dbPath,
     String? firstAccountName,
-    required String lightwalletdUrl,
     required bool isFirstWalletAccount,
     required int nextAccountNumber,
+    required List<int> additionalAccountIndices,
   });
 
   Future<WalletImportResult> crateApiWalletImportWallet({
@@ -1958,6 +1968,65 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<List<SoftwareWalletDiscoveredAccount>>
+  crateApiWalletDiscoverSoftwareWalletImportAccounts({
+    required String mnemonic,
+    BigInt? birthdayHeight,
+    required String network,
+    required String dbPath,
+    required String lightwalletdUrl,
+    required bool isFirstWalletAccount,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(mnemonic, serializer);
+          sse_encode_opt_box_autoadd_u_64(birthdayHeight, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_bool(isFirstWalletAccount, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 29,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_software_wallet_discovered_account,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletDiscoverSoftwareWalletImportAccountsConstMeta,
+        argValues: [
+          mnemonic,
+          birthdayHeight,
+          network,
+          dbPath,
+          lightwalletdUrl,
+          isFirstWalletAccount,
+        ],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiWalletDiscoverSoftwareWalletImportAccountsConstMeta =>
+      const TaskConstMeta(
+        debugName: "discover_software_wallet_import_accounts",
+        argNames: [
+          "mnemonic",
+          "birthdayHeight",
+          "network",
+          "dbPath",
+          "lightwalletdUrl",
+          "isFirstWalletAccount",
+        ],
+      );
+
+  @override
   Future<String> crateApiKeystoneEncodePcztToUr({
     required List<int> pcztBytes,
   }) {
@@ -1969,7 +2038,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 29,
+            funcId: 30,
             port: port_,
           );
         },
@@ -2004,7 +2073,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 30,
+            funcId: 31,
             port: port_,
           );
         },
@@ -2041,7 +2110,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 31,
+            funcId: 32,
             port: port_,
           );
         },
@@ -2076,7 +2145,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 32,
+            funcId: 33,
             port: port_,
           );
         },
@@ -2119,7 +2188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 33,
+            funcId: 34,
             port: port_,
           );
         },
@@ -2173,7 +2242,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -2218,7 +2287,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -2280,7 +2349,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -2342,7 +2411,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -2385,7 +2454,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 38)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 39)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2421,7 +2490,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 40,
             port: port_,
           );
         },
@@ -2460,7 +2529,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 41,
             port: port_,
           );
         },
@@ -2497,7 +2566,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -2531,7 +2600,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -2558,7 +2627,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(cachePath, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 43)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 44)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2590,7 +2659,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -2627,7 +2696,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -2660,7 +2729,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -2693,7 +2762,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 47,
+            funcId: 48,
             port: port_,
           );
         },
@@ -2732,7 +2801,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -2767,7 +2836,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -2806,7 +2875,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 50,
+            funcId: 51,
             port: port_,
           );
         },
@@ -2842,7 +2911,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 51,
+            funcId: 52,
             port: port_,
           );
         },
@@ -2879,7 +2948,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -2906,7 +2975,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -2936,7 +3005,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 55,
             port: port_,
           );
         },
@@ -2970,7 +3039,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 55,
+            funcId: 56,
             port: port_,
           );
         },
@@ -3008,7 +3077,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(txidHex, serializer);
           sse_encode_String(txKind, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_transaction_detail,
@@ -3045,7 +3114,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 58,
             port: port_,
           );
         },
@@ -3082,7 +3151,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 58,
+            funcId: 59,
             port: port_,
           );
         },
@@ -3119,7 +3188,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },
@@ -3147,7 +3216,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 61)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3187,7 +3256,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 62,
             port: port_,
           );
         },
@@ -3232,9 +3301,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String network,
     required String dbPath,
     String? firstAccountName,
-    required String lightwalletdUrl,
     required bool isFirstWalletAccount,
     required int nextAccountNumber,
+    required List<int> additionalAccountIndices,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -3245,13 +3314,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(network, serializer);
           sse_encode_String(dbPath, serializer);
           sse_encode_opt_String(firstAccountName, serializer);
-          sse_encode_String(lightwalletdUrl, serializer);
           sse_encode_bool(isFirstWalletAccount, serializer);
           sse_encode_u_32(nextAccountNumber, serializer);
+          sse_encode_list_prim_u_32_loose(additionalAccountIndices, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 63,
             port: port_,
           );
         },
@@ -3268,9 +3337,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           network,
           dbPath,
           firstAccountName,
-          lightwalletdUrl,
           isFirstWalletAccount,
           nextAccountNumber,
+          additionalAccountIndices,
         ],
         apiImpl: this,
       ),
@@ -3287,9 +3356,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "network",
           "dbPath",
           "firstAccountName",
-          "lightwalletdUrl",
           "isFirstWalletAccount",
           "nextAccountNumber",
+          "additionalAccountIndices",
         ],
       );
 
@@ -3313,7 +3382,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 64,
             port: port_,
           );
         },
@@ -3348,7 +3417,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 65,
             port: port_,
           );
         },
@@ -3379,7 +3448,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_64(nowSeconds, serializer);
           sse_encode_u_64(ceremonyStartSeconds, serializer);
           sse_encode_u_64(voteEndTimeSeconds, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 65)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3403,7 +3472,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 66)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3428,7 +3497,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3450,7 +3519,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3477,7 +3546,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_64(ceremonyStartSeconds, serializer);
           sse_encode_u_64(voteEndTimeSeconds, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_u_64,
@@ -3510,7 +3579,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 70,
+            funcId: 71,
             port: port_,
           );
         },
@@ -3550,7 +3619,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 72,
             port: port_,
           );
         },
@@ -3593,7 +3662,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 73,
             port: port_,
           );
         },
@@ -3650,7 +3719,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 74,
             port: port_,
           );
         },
@@ -3691,7 +3760,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -3721,7 +3790,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 76,
             port: port_,
           );
         },
@@ -3756,7 +3825,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 77,
             port: port_,
           );
         },
@@ -3799,7 +3868,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 78,
             port: port_,
           );
         },
@@ -3853,7 +3922,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 79,
             port: port_,
           );
         },
@@ -3898,7 +3967,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 80,
             port: port_,
           );
         },
@@ -3956,7 +4025,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 81,
             port: port_,
           );
         },
@@ -4017,7 +4086,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 82,
             port: port_,
           );
         },
@@ -4076,7 +4145,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 83,
             port: port_,
           );
         },
@@ -4123,7 +4192,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 84,
             port: port_,
           );
         },
@@ -4168,7 +4237,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 85,
             port: port_,
           );
         },
@@ -4195,7 +4264,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 85)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4227,7 +4296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 87,
             port: port_,
           );
         },
@@ -4264,7 +4333,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 88,
             port: port_,
           );
         },
@@ -4299,7 +4368,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 89,
             port: port_,
           );
         },
@@ -4341,7 +4410,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 90,
             port: port_,
           );
         },
@@ -4378,7 +4447,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4416,7 +4485,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 92,
             port: port_,
           );
         },
@@ -4469,7 +4538,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -4537,7 +4606,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 94,
             port: port_,
           );
         },
@@ -4581,7 +4650,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 94)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 95)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4615,7 +4684,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 96,
             port: port_,
           );
         },
@@ -4648,7 +4717,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -4688,7 +4757,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 98,
             port: port_,
           );
         },
@@ -4729,7 +4798,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 99,
             port: port_,
           );
         },
@@ -4783,7 +4852,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 100,
             port: port_,
           );
         },
@@ -4833,7 +4902,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 100,
+              funcId: 101,
               port: port_,
             );
           },
@@ -4874,7 +4943,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 101,
+              funcId: 102,
               port: port_,
             );
           },
@@ -4906,7 +4975,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 103,
           )!;
         },
         codec: SseCodec(
@@ -4947,7 +5016,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 104,
             port: port_,
           );
         },
@@ -4998,7 +5067,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 105,
             port: port_,
           );
         },
@@ -5037,7 +5106,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 106,
             port: port_,
           );
         },
@@ -5080,7 +5149,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 107,
             port: port_,
           );
         },
@@ -5130,7 +5199,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 108,
             port: port_,
           );
         },
@@ -5162,7 +5231,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 109,
             port: port_,
           );
         },
@@ -5190,7 +5259,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
           )!;
         },
         codec: SseCodec(
@@ -5222,7 +5291,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5259,7 +5328,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5290,7 +5359,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
           )!;
         },
         codec: SseCodec(
@@ -5321,7 +5390,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
             port: port_,
           );
         },
@@ -6082,6 +6151,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<SoftwareWalletDiscoveredAccount>
+  dco_decode_list_software_wallet_discovered_account(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_software_wallet_discovered_account)
+        .toList();
+  }
+
+  @protected
   List<SoftwareWalletImportAccount>
   dco_decode_list_software_wallet_import_account(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -6526,6 +6604,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return SignedVoteCommitmentsView(
       bundleIndex: dco_decode_u_32(arr[0]),
       commitments: dco_decode_list_signed_vote_commitment_view(arr[1]),
+    );
+  }
+
+  @protected
+  SoftwareWalletDiscoveredAccount dco_decode_software_wallet_discovered_account(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return SoftwareWalletDiscoveredAccount(
+      zip32AccountIndex: dco_decode_u_32(arr[0]),
+      firstTransparentAddress: dco_decode_String(arr[1]),
     );
   }
 
@@ -7851,6 +7943,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<SoftwareWalletDiscoveredAccount>
+  sse_decode_list_software_wallet_discovered_account(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <SoftwareWalletDiscoveredAccount>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_software_wallet_discovered_account(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<SoftwareWalletImportAccount>
   sse_decode_list_software_wallet_import_account(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -8464,6 +8571,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return SignedVoteCommitmentsView(
       bundleIndex: var_bundleIndex,
       commitments: var_commitments,
+    );
+  }
+
+  @protected
+  SoftwareWalletDiscoveredAccount sse_decode_software_wallet_discovered_account(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_zip32AccountIndex = sse_decode_u_32(deserializer);
+    var var_firstTransparentAddress = sse_decode_String(deserializer);
+    return SoftwareWalletDiscoveredAccount(
+      zip32AccountIndex: var_zip32AccountIndex,
+      firstTransparentAddress: var_firstTransparentAddress,
     );
   }
 
@@ -9745,6 +9865,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_software_wallet_discovered_account(
+    List<SoftwareWalletDiscoveredAccount> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_software_wallet_discovered_account(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_software_wallet_import_account(
     List<SoftwareWalletImportAccount> self,
     SseSerializer serializer,
@@ -10225,6 +10357,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_32(self.bundleIndex, serializer);
     sse_encode_list_signed_vote_commitment_view(self.commitments, serializer);
+  }
+
+  @protected
+  void sse_encode_software_wallet_discovered_account(
+    SoftwareWalletDiscoveredAccount self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_32(self.zip32AccountIndex, serializer);
+    sse_encode_String(self.firstTransparentAddress, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -265,7 +265,7 @@ abstract class RustLibApi extends BaseApi {
     required String sendFlowId,
   });
 
-  Future<List<SoftwareWalletDiscoveredAccount>>
+  Future<SoftwareWalletImportDiscoveryResult>
   crateApiWalletDiscoverSoftwareWalletImportAccounts({
     required String mnemonic,
     BigInt? birthdayHeight,
@@ -1968,7 +1968,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<List<SoftwareWalletDiscoveredAccount>>
+  Future<SoftwareWalletImportDiscoveryResult>
   crateApiWalletDiscoverSoftwareWalletImportAccounts({
     required String mnemonic,
     BigInt? birthdayHeight,
@@ -1995,7 +1995,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
         },
         codec: SseCodec(
-          decodeSuccessData: sse_decode_list_software_wallet_discovered_account,
+          decodeSuccessData: sse_decode_software_wallet_import_discovery_result,
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiWalletDiscoverSoftwareWalletImportAccountsConstMeta,
@@ -6639,6 +6639,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  SoftwareWalletImportDiscoveryResult
+  dco_decode_software_wallet_import_discovery_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return SoftwareWalletImportDiscoveryResult(
+      primaryAccountAlreadyExists: dco_decode_bool(arr[0]),
+      accounts: dco_decode_list_software_wallet_discovered_account(arr[1]),
+    );
+  }
+
+  @protected
   SoftwareWalletImportWithDiscoveryResult
   dco_decode_software_wallet_import_with_discovery_result(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -8607,6 +8620,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  SoftwareWalletImportDiscoveryResult
+  sse_decode_software_wallet_import_discovery_result(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_primaryAccountAlreadyExists = sse_decode_bool(deserializer);
+    var var_accounts = sse_decode_list_software_wallet_discovered_account(
+      deserializer,
+    );
+    return SoftwareWalletImportDiscoveryResult(
+      primaryAccountAlreadyExists: var_primaryAccountAlreadyExists,
+      accounts: var_accounts,
+    );
+  }
+
+  @protected
   SoftwareWalletImportWithDiscoveryResult
   sse_decode_software_wallet_import_with_discovery_result(
     SseDeserializer deserializer,
@@ -10380,6 +10409,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_u_32(self.zip32AccountIndex, serializer);
     sse_encode_String(self.name, serializer);
     sse_encode_bool(self.isSeedAnchor, serializer);
+  }
+
+  @protected
+  void sse_encode_software_wallet_import_discovery_result(
+    SoftwareWalletImportDiscoveryResult self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_bool(self.primaryAccountAlreadyExists, serializer);
+    sse_encode_list_software_wallet_discovered_account(
+      self.accounts,
+      serializer,
+    );
   }
 
   @protected

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -1895016467;
+  int get rustContentHash => 165336228;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -567,6 +567,13 @@ abstract class RustLibApi extends BaseApi {
     required String pirServerUrl,
     required List<int> storedHotkeySecret,
     required int bundleIndex,
+  });
+
+  Future<BigInt> crateApiWalletPreviewSoftwareAccountTransparentBalance({
+    required String mnemonic,
+    required String network,
+    required String lightwalletdUrl,
+    required int zip32AccountIndex,
   });
 
   Future<ProposalResult> crateApiSyncProposeSend({
@@ -3944,6 +3951,52 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<BigInt> crateApiWalletPreviewSoftwareAccountTransparentBalance({
+    required String mnemonic,
+    required String network,
+    required String lightwalletdUrl,
+    required int zip32AccountIndex,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(mnemonic, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(lightwalletdUrl, serializer);
+          sse_encode_u_32(zip32AccountIndex, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 80,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_u_64,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta:
+            kCrateApiWalletPreviewSoftwareAccountTransparentBalanceConstMeta,
+        argValues: [mnemonic, network, lightwalletdUrl, zip32AccountIndex],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiWalletPreviewSoftwareAccountTransparentBalanceConstMeta =>
+      const TaskConstMeta(
+        debugName: "preview_software_account_transparent_balance",
+        argNames: [
+          "mnemonic",
+          "network",
+          "lightwalletdUrl",
+          "zip32AccountIndex",
+        ],
+      );
+
+  @override
   Future<ProposalResult> crateApiSyncProposeSend({
     required String dbPath,
     required String network,
@@ -3967,7 +4020,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 81,
             port: port_,
           );
         },
@@ -4025,7 +4078,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 82,
             port: port_,
           );
         },
@@ -4086,7 +4139,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 83,
             port: port_,
           );
         },
@@ -4145,7 +4198,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 84,
             port: port_,
           );
         },
@@ -4192,7 +4245,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 85,
             port: port_,
           );
         },
@@ -4237,7 +4290,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 86,
             port: port_,
           );
         },
@@ -4264,7 +4317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 86)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 87)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4296,7 +4349,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 88,
             port: port_,
           );
         },
@@ -4333,7 +4386,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 89,
             port: port_,
           );
         },
@@ -4368,7 +4421,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 90,
             port: port_,
           );
         },
@@ -4410,7 +4463,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4447,7 +4500,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 92,
             port: port_,
           );
         },
@@ -4485,7 +4538,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -4538,7 +4591,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 94,
             port: port_,
           );
         },
@@ -4606,7 +4659,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 95,
             port: port_,
           );
         },
@@ -4650,7 +4703,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 95)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 96)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4684,7 +4737,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -4717,7 +4770,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 98,
             port: port_,
           );
         },
@@ -4757,7 +4810,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 99,
             port: port_,
           );
         },
@@ -4798,7 +4851,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 100,
             port: port_,
           );
         },
@@ -4852,7 +4905,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 101,
             port: port_,
           );
         },
@@ -4902,7 +4955,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 101,
+              funcId: 102,
               port: port_,
             );
           },
@@ -4943,7 +4996,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 102,
+              funcId: 103,
               port: port_,
             );
           },
@@ -4975,7 +5028,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 104,
           )!;
         },
         codec: SseCodec(
@@ -5016,7 +5069,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 105,
             port: port_,
           );
         },
@@ -5067,7 +5120,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 106,
             port: port_,
           );
         },
@@ -5106,7 +5159,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 107,
             port: port_,
           );
         },
@@ -5149,7 +5202,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 108,
             port: port_,
           );
         },
@@ -5199,7 +5252,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 109,
             port: port_,
           );
         },
@@ -5231,7 +5284,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
             port: port_,
           );
         },
@@ -5259,7 +5312,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
           )!;
         },
         codec: SseCodec(
@@ -5291,7 +5344,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5328,7 +5381,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
             port: port_,
           );
         },
@@ -5359,7 +5412,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
           )!;
         },
         codec: SseCodec(
@@ -5390,7 +5443,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -296,6 +296,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  List<SoftwareWalletDiscoveredAccount>
+  dco_decode_list_software_wallet_discovered_account(dynamic raw);
+
+  @protected
   List<SoftwareWalletImportAccount>
   dco_decode_list_software_wallet_import_account(dynamic raw);
 
@@ -428,6 +432,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SignedVoteCommitmentsView dco_decode_signed_vote_commitments_view(
+    dynamic raw,
+  );
+
+  @protected
+  SoftwareWalletDiscoveredAccount dco_decode_software_wallet_discovered_account(
     dynamic raw,
   );
 
@@ -853,6 +862,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  List<SoftwareWalletDiscoveredAccount>
+  sse_decode_list_software_wallet_discovered_account(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<SoftwareWalletImportAccount>
   sse_decode_list_software_wallet_import_account(SseDeserializer deserializer);
 
@@ -1017,6 +1032,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SignedVoteCommitmentsView sse_decode_signed_vote_commitments_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SoftwareWalletDiscoveredAccount sse_decode_software_wallet_discovered_account(
     SseDeserializer deserializer,
   );
 
@@ -1540,6 +1560,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_software_wallet_discovered_account(
+    List<SoftwareWalletDiscoveredAccount> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_software_wallet_import_account(
     List<SoftwareWalletImportAccount> self,
     SseSerializer serializer,
@@ -1740,6 +1766,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_signed_vote_commitments_view(
     SignedVoteCommitmentsView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_software_wallet_discovered_account(
+    SoftwareWalletDiscoveredAccount self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -446,6 +446,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  SoftwareWalletImportDiscoveryResult
+  dco_decode_software_wallet_import_discovery_result(dynamic raw);
+
+  @protected
   SoftwareWalletImportWithDiscoveryResult
   dco_decode_software_wallet_import_with_discovery_result(dynamic raw);
 
@@ -1042,6 +1046,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SoftwareWalletImportAccount sse_decode_software_wallet_import_account(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SoftwareWalletImportDiscoveryResult
+  sse_decode_software_wallet_import_discovery_result(
     SseDeserializer deserializer,
   );
 
@@ -1778,6 +1788,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_software_wallet_import_account(
     SoftwareWalletImportAccount self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_software_wallet_import_discovery_result(
+    SoftwareWalletImportDiscoveryResult self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -298,6 +298,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  List<SoftwareWalletDiscoveredAccount>
+  dco_decode_list_software_wallet_discovered_account(dynamic raw);
+
+  @protected
   List<SoftwareWalletImportAccount>
   dco_decode_list_software_wallet_import_account(dynamic raw);
 
@@ -430,6 +434,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SignedVoteCommitmentsView dco_decode_signed_vote_commitments_view(
+    dynamic raw,
+  );
+
+  @protected
+  SoftwareWalletDiscoveredAccount dco_decode_software_wallet_discovered_account(
     dynamic raw,
   );
 
@@ -855,6 +864,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  List<SoftwareWalletDiscoveredAccount>
+  sse_decode_list_software_wallet_discovered_account(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<SoftwareWalletImportAccount>
   sse_decode_list_software_wallet_import_account(SseDeserializer deserializer);
 
@@ -1019,6 +1034,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SignedVoteCommitmentsView sse_decode_signed_vote_commitments_view(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SoftwareWalletDiscoveredAccount sse_decode_software_wallet_discovered_account(
     SseDeserializer deserializer,
   );
 
@@ -1542,6 +1562,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_software_wallet_discovered_account(
+    List<SoftwareWalletDiscoveredAccount> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_software_wallet_import_account(
     List<SoftwareWalletImportAccount> self,
     SseSerializer serializer,
@@ -1742,6 +1768,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_signed_vote_commitments_view(
     SignedVoteCommitmentsView self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_software_wallet_discovered_account(
+    SoftwareWalletDiscoveredAccount self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -448,6 +448,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  SoftwareWalletImportDiscoveryResult
+  dco_decode_software_wallet_import_discovery_result(dynamic raw);
+
+  @protected
   SoftwareWalletImportWithDiscoveryResult
   dco_decode_software_wallet_import_with_discovery_result(dynamic raw);
 
@@ -1044,6 +1048,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   SoftwareWalletImportAccount sse_decode_software_wallet_import_account(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SoftwareWalletImportDiscoveryResult
+  sse_decode_software_wallet_import_discovery_result(
     SseDeserializer deserializer,
   );
 
@@ -1780,6 +1790,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_software_wallet_import_account(
     SoftwareWalletImportAccount self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_software_wallet_import_discovery_result(
+    SoftwareWalletImportDiscoveryResult self,
     SseSerializer serializer,
   );
 

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -1,12 +1,15 @@
 use std::panic;
 
 use crate::wallet::{keys, network::WalletNetwork};
-use tonic::transport::Channel;
-use zcash_client_backend::proto::service::compact_tx_streamer_client::CompactTxStreamerClient;
+use tonic::{transport::Channel, Request};
+use zcash_client_backend::proto::service::{
+    self, compact_tx_streamer_client::CompactTxStreamerClient,
+};
 use zcash_protocol::consensus::{NetworkUpgrade, Parameters};
 
 const SOFTWARE_ACCOUNT_DISCOVERY_MAX_INDEX: u32 = 20;
 const SOFTWARE_ACCOUNT_DISCOVERY_BATCHES: &[(u32, u32)] = &[(1, 4), (5, 9), (10, 14), (15, 20)];
+const SOFTWARE_ACCOUNT_BALANCE_PREVIEW_ADDRESSES_PER_SCOPE: u32 = 20;
 
 /// Result of wallet creation, containing the mnemonic, unified address, and account UUID.
 pub struct WalletCreationResult {
@@ -248,6 +251,35 @@ pub fn discover_software_wallet_import_accounts(
             primary_account_already_exists,
             accounts,
         })
+    })
+}
+
+/// Preview the spendable transparent UTXO balance for a software ZIP32 account.
+///
+/// This does not import the account or touch the wallet DB. It checks a bounded
+/// standard BIP44 transparent address range so the onboarding modal can update
+/// balance rows after discovery has already returned.
+pub fn preview_software_account_transparent_balance(
+    mnemonic: String,
+    network: String,
+    lightwalletd_url: String,
+    zip32_account_index: u32,
+) -> Result<u64, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        let seed = keys::mnemonic_to_seed(&mnemonic)?;
+        let addresses = keys::software_account_transparent_addresses(
+            network,
+            &seed,
+            zip32_account_index,
+            SOFTWARE_ACCOUNT_BALANCE_PREVIEW_ADDRESSES_PER_SCOPE,
+        )?;
+
+        let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
+        rt.block_on(preview_transparent_balance_for_addresses(
+            &lightwalletd_url,
+            addresses,
+        ))
     })
 }
 
@@ -553,6 +585,43 @@ fn discovery_start_height(network: WalletNetwork, birthday_height: Option<u64>) 
             .map(|h| u32::from(h) as u64)
             .unwrap_or(0)
     })
+}
+
+async fn preview_transparent_balance_for_addresses(
+    lightwalletd_url: &str,
+    addresses: Vec<String>,
+) -> Result<u64, String> {
+    if addresses.is_empty() {
+        return Ok(0);
+    }
+
+    let mut client = crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url)
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut stream = client
+        .get_address_utxos_stream(Request::new(service::GetAddressUtxosArg {
+            addresses,
+            start_height: 0,
+            max_entries: 0,
+        }))
+        .await
+        .map_err(|e| format!("get_address_utxos_stream: {e}"))?
+        .into_inner();
+
+    let mut balance = 0u64;
+    while let Some(reply) = stream
+        .message()
+        .await
+        .map_err(|e| format!("get_address_utxos_stream message: {e}"))?
+    {
+        let value = u64::try_from(reply.value_zat)
+            .map_err(|_| format!("invalid transparent UTXO value: {}", reply.value_zat))?;
+        balance = balance
+            .checked_add(value)
+            .ok_or_else(|| "transparent balance preview overflow".to_string())?;
+    }
+
+    Ok(balance)
 }
 
 /// Import a hardware wallet account using a UFVK (no mnemonic/seed needed).

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -33,6 +33,12 @@ pub struct SoftwareWalletImportWithDiscoveryResult {
     pub did_import_primary_account: bool,
 }
 
+/// A higher ZIP32 software account that can be imported by user choice.
+pub struct SoftwareWalletDiscoveredAccount {
+    pub zip32_account_index: u32,
+    pub first_transparent_address: String,
+}
+
 /// A software account created by mnemonic import.
 pub struct SoftwareWalletImportAccount {
     pub account_uuid: String,
@@ -187,18 +193,61 @@ pub fn add_account(
     })
 }
 
-/// Import a software mnemonic and discover additional ZIP32 accounts with
-/// transparent history. `account'=0` must be imported successfully; discovery
-/// for higher account indices is best-effort.
+/// Discover higher ZIP32 software accounts with transparent history that are
+/// not already present in the wallet DB for this mnemonic.
+pub fn discover_software_wallet_import_accounts(
+    mnemonic: String,
+    birthday_height: Option<u64>,
+    network: String,
+    db_path: String,
+    lightwalletd_url: String,
+    is_first_wallet_account: bool,
+) -> Result<Vec<SoftwareWalletDiscoveredAccount>, String> {
+    catch(|| {
+        let network = if is_first_wallet_account {
+            keys::parse_network(&network)?
+        } else {
+            parse_network_and_migrate(&db_path, &network)?
+        };
+        let seed = keys::mnemonic_to_seed(&mnemonic)?;
+        let existing_seed_accounts = if is_first_wallet_account {
+            None
+        } else {
+            Some(keys::existing_software_seed_account_state(
+                &db_path, network, &seed,
+            )?)
+        };
+
+        let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
+        let discovered_accounts = rt.block_on(discover_used_software_accounts(
+            network,
+            &seed,
+            birthday_height,
+            &lightwalletd_url,
+        ));
+
+        Ok(discovered_accounts
+            .into_iter()
+            .filter(|account| {
+                !existing_seed_accounts
+                    .as_ref()
+                    .is_some_and(|state| state.contains(account.zip32_account_index))
+            })
+            .collect())
+    })
+}
+
+/// Import a software mnemonic. `account'=0` must be imported successfully;
+/// higher account indices are imported only when selected by the caller.
 pub fn import_software_wallet_with_account_discovery(
     mnemonic: String,
     birthday_height: Option<u64>,
     network: String,
     db_path: String,
     first_account_name: Option<String>,
-    lightwalletd_url: String,
     is_first_wallet_account: bool,
     next_account_number: u32,
+    additional_account_indices: Vec<u32>,
 ) -> Result<SoftwareWalletImportWithDiscoveryResult, String> {
     catch(|| {
         let network = if is_first_wallet_account {
@@ -211,14 +260,10 @@ pub fn import_software_wallet_with_account_discovery(
         let first_name = first_account_name
             .filter(|name| !name.trim().is_empty())
             .unwrap_or_else(|| format!("Account {first_account_number}"));
-
-        let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
-        let discovered_indices = rt.block_on(discover_used_software_account_indices(
-            network,
-            &seed,
-            birthday_height,
-            &lightwalletd_url,
-        ));
+        let mut additional_account_indices = additional_account_indices;
+        additional_account_indices.retain(|index| *index != 0);
+        additional_account_indices.sort_unstable();
+        additional_account_indices.dedup();
 
         import_discovered_software_wallet_accounts(
             network,
@@ -228,7 +273,7 @@ pub fn import_software_wallet_with_account_discovery(
             first_name,
             is_first_wallet_account,
             first_account_number,
-            discovered_indices,
+            additional_account_indices,
         )
     })
 }
@@ -369,12 +414,12 @@ fn import_discovered_software_wallet_accounts(
     })
 }
 
-async fn discover_used_software_account_indices(
+async fn discover_used_software_accounts(
     network: WalletNetwork,
     seed: &secrecy::SecretVec<u8>,
     birthday_height: Option<u64>,
     lightwalletd_url: &str,
-) -> Vec<u32> {
+) -> Vec<SoftwareWalletDiscoveredAccount> {
     let start_height = discovery_start_height(network, birthday_height);
     let mut client = match crate::wallet::sync_engine::open_lwd_channel(lightwalletd_url).await {
         Ok(client) => client,
@@ -401,7 +446,7 @@ async fn discover_used_software_account_indices(
     for &(start, end) in SOFTWARE_ACCOUNT_DISCOVERY_BATCHES {
         let mut found_in_batch = false;
         for account_index in start..=end.min(SOFTWARE_ACCOUNT_DISCOVERY_MAX_INDEX) {
-            if software_account_first_taddr_has_history(
+            if let Some(account) = discover_software_account_at_index(
                 &mut client,
                 network,
                 seed,
@@ -411,7 +456,7 @@ async fn discover_used_software_account_indices(
             )
             .await
             {
-                discovered.push(account_index);
+                discovered.push(account);
                 found_in_batch = true;
             }
         }
@@ -423,14 +468,14 @@ async fn discover_used_software_account_indices(
     discovered
 }
 
-async fn software_account_first_taddr_has_history(
+async fn discover_software_account_at_index(
     client: &mut CompactTxStreamerClient<Channel>,
     network: WalletNetwork,
     seed: &secrecy::SecretVec<u8>,
     account_index: u32,
     start_height: u64,
     tip_height: u64,
-) -> bool {
+) -> Option<SoftwareWalletDiscoveredAccount> {
     let address = match keys::software_account_first_external_transparent_address(
         network,
         seed,
@@ -441,7 +486,7 @@ async fn software_account_first_taddr_has_history(
             log::warn!(
                     "software account discovery: could not derive account {account_index} transparent address: {e}"
                 );
-            return false;
+            return None;
         }
     };
 
@@ -458,7 +503,7 @@ async fn software_account_first_taddr_has_history(
             log::warn!(
                 "software account discovery: failed to query account {account_index} address {address} from {start_height} to {tip_height}: {e}"
             );
-            return false;
+            return None;
         }
     };
 
@@ -472,14 +517,17 @@ async fn software_account_first_taddr_has_history(
             log::info!(
                 "software account discovery: account {account_index} has transparent history"
             );
-            true
+            Some(SoftwareWalletDiscoveredAccount {
+                zip32_account_index: account_index,
+                first_transparent_address: address,
+            })
         }
-        Ok(None) => false,
+        Ok(None) => None,
         Err(e) => {
             log::warn!(
                 "software account discovery: failed while reading account {account_index} address {address} from {start_height} to {tip_height}: {e}"
             );
-            false
+            None
         }
     }
 }

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -39,6 +39,12 @@ pub struct SoftwareWalletDiscoveredAccount {
     pub first_transparent_address: String,
 }
 
+/// Software account discovery result for an import attempt.
+pub struct SoftwareWalletImportDiscoveryResult {
+    pub primary_account_already_exists: bool,
+    pub accounts: Vec<SoftwareWalletDiscoveredAccount>,
+}
+
 /// A software account created by mnemonic import.
 pub struct SoftwareWalletImportAccount {
     pub account_uuid: String,
@@ -202,7 +208,7 @@ pub fn discover_software_wallet_import_accounts(
     db_path: String,
     lightwalletd_url: String,
     is_first_wallet_account: bool,
-) -> Result<Vec<SoftwareWalletDiscoveredAccount>, String> {
+) -> Result<SoftwareWalletImportDiscoveryResult, String> {
     catch(|| {
         let network = if is_first_wallet_account {
             keys::parse_network(&network)?
@@ -217,6 +223,9 @@ pub fn discover_software_wallet_import_accounts(
                 &db_path, network, &seed,
             )?)
         };
+        let primary_account_already_exists = existing_seed_accounts
+            .as_ref()
+            .is_some_and(|state| state.contains(0));
 
         let rt = tokio::runtime::Runtime::new().map_err(|e| format!("tokio: {e}"))?;
         let discovered_accounts = rt.block_on(discover_used_software_accounts(
@@ -226,14 +235,19 @@ pub fn discover_software_wallet_import_accounts(
             &lightwalletd_url,
         ));
 
-        Ok(discovered_accounts
+        let accounts = discovered_accounts
             .into_iter()
             .filter(|account| {
                 !existing_seed_accounts
                     .as_ref()
                     .is_some_and(|state| state.contains(account.zip32_account_index))
             })
-            .collect())
+            .collect();
+
+        Ok(SoftwareWalletImportDiscoveryResult {
+            primary_account_already_exists,
+            accounts,
+        })
     })
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -6291,6 +6291,19 @@ impl SseDecode for crate::api::wallet::SoftwareWalletImportAccount {
     }
 }
 
+impl SseDecode for crate::api::wallet::SoftwareWalletImportDiscoveryResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_primaryAccountAlreadyExists = <bool>::sse_decode(deserializer);
+        let mut var_accounts =
+            <Vec<crate::api::wallet::SoftwareWalletDiscoveredAccount>>::sse_decode(deserializer);
+        return crate::api::wallet::SoftwareWalletImportDiscoveryResult {
+            primary_account_already_exists: var_primaryAccountAlreadyExists,
+            accounts: var_accounts,
+        };
+    }
+}
+
 impl SseDecode for crate::api::wallet::SoftwareWalletImportWithDiscoveryResult {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -8060,6 +8073,29 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::SoftwareWalletImportA
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::wallet::SoftwareWalletImportDiscoveryResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.primary_account_already_exists
+                .into_into_dart()
+                .into_dart(),
+            self.accounts.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::wallet::SoftwareWalletImportDiscoveryResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::SoftwareWalletImportDiscoveryResult>
+    for crate::api::wallet::SoftwareWalletImportDiscoveryResult
+{
+    fn into_into_dart(self) -> crate::api::wallet::SoftwareWalletImportDiscoveryResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::wallet::SoftwareWalletImportWithDiscoveryResult {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
@@ -9671,6 +9707,17 @@ impl SseEncode for crate::api::wallet::SoftwareWalletImportAccount {
         <u32>::sse_encode(self.zip32_account_index, serializer);
         <String>::sse_encode(self.name, serializer);
         <bool>::sse_encode(self.is_seed_anchor, serializer);
+    }
+}
+
+impl SseEncode for crate::api::wallet::SoftwareWalletImportDiscoveryResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.primary_account_already_exists, serializer);
+        <Vec<crate::api::wallet::SoftwareWalletDiscoveredAccount>>::sse_encode(
+            self.accounts,
+            serializer,
+        );
     }
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1389930982;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1895016467;
 
 // Section: executor
 
@@ -1105,6 +1105,51 @@ fn wire__crate__api__sync__discard_proposal_impl(
                     let output_ok = Result::<_, ()>::Ok({
                         crate::api::sync::discard_proposal(api_proposal_id, api_send_flow_id);
                     })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet__discover_software_wallet_import_accounts_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "discover_software_wallet_import_accounts",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_mnemonic = <String>::sse_decode(&mut deserializer);
+            let api_birthday_height = <Option<u64>>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_is_first_wallet_account = <bool>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::wallet::discover_software_wallet_import_accounts(
+                        api_mnemonic,
+                        api_birthday_height,
+                        api_network,
+                        api_db_path,
+                        api_lightwalletd_url,
+                        api_is_first_wallet_account,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -2397,9 +2442,9 @@ fn wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_first_account_name = <Option<String>>::sse_decode(&mut deserializer);
-            let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
             let api_is_first_wallet_account = <bool>::sse_decode(&mut deserializer);
             let api_next_account_number = <u32>::sse_decode(&mut deserializer);
+            let api_additional_account_indices = <Vec<u32>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -2410,9 +2455,9 @@ fn wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(
                             api_network,
                             api_db_path,
                             api_first_account_name,
-                            api_lightwalletd_url,
                             api_is_first_wallet_account,
                             api_next_account_number,
+                            api_additional_account_indices,
                         )?;
                     Ok(output_ok)
                 })())
@@ -5597,6 +5642,20 @@ impl SseDecode for Vec<zcash_voting::wire::SignedVoteCommitmentView> {
     }
 }
 
+impl SseDecode for Vec<crate::api::wallet::SoftwareWalletDiscoveredAccount> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(
+                <crate::api::wallet::SoftwareWalletDiscoveredAccount>::sse_decode(deserializer),
+            );
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::api::wallet::SoftwareWalletImportAccount> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -6202,6 +6261,18 @@ impl SseDecode for zcash_voting::wire::SignedVoteCommitmentsView {
     }
 }
 
+impl SseDecode for crate::api::wallet::SoftwareWalletDiscoveredAccount {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_zip32AccountIndex = <u32>::sse_decode(deserializer);
+        let mut var_firstTransparentAddress = <String>::sse_decode(deserializer);
+        return crate::api::wallet::SoftwareWalletDiscoveredAccount {
+            zip32_account_index: var_zip32AccountIndex,
+            first_transparent_address: var_firstTransparentAddress,
+        };
+    }
+}
+
 impl SseDecode for crate::api::wallet::SoftwareWalletImportAccount {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -6673,75 +6744,76 @@ fn pde_ffi_dispatcher_primary_impl(
 26 => wire__crate__api__voting__delete_voting_account_state_impl(port, ptr, rust_vec_len, data_len),
 27 => wire__crate__api__secret__derive_secret_password_verifier_impl(port, ptr, rust_vec_len, data_len),
 28 => wire__crate__api__sync__discard_proposal_impl(port, ptr, rust_vec_len, data_len),
-29 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
-30 => wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len),
-31 => wire__crate__api__secret__encrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
-32 => wire__crate__api__wallet__ensure_wallet_db_migrated_impl(port, ptr, rust_vec_len, data_len),
-33 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
-34 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
-35 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
-36 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-37 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
-39 => wire__crate__api__voting__generate_van_witness_impl(port, ptr, rust_vec_len, data_len),
-40 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
-41 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
-42 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
-44 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
-45 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
-46 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
-47 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
-48 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
-49 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
-50 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
-51 => wire__crate__api__voting__get_round_recovery_state_impl(port, ptr, rust_vec_len, data_len),
-52 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
-54 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-55 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
-57 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
-58 => wire__crate__api__wallet__get_transparent_address_impl(port, ptr, rust_vec_len, data_len),
-59 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-61 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
-62 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
-63 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-64 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-70 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-71 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-72 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
-73 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-75 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-76 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
-77 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
-78 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-79 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-80 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-81 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-82 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-83 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-86 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
-90 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-91 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-92 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-93 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-95 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-97 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-99 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-100 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-103 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-104 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-105 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-106 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-107 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-108 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+29 => wire__crate__api__wallet__discover_software_wallet_import_accounts_impl(port, ptr, rust_vec_len, data_len),
+30 => wire__crate__api__keystone__encode_pczt_to_ur_impl(port, ptr, rust_vec_len, data_len),
+31 => wire__crate__api__keystone__encode_pczt_ur_parts_impl(port, ptr, rust_vec_len, data_len),
+32 => wire__crate__api__secret__encrypt_secret_payload_impl(port, ptr, rust_vec_len, data_len),
+33 => wire__crate__api__wallet__ensure_wallet_db_migrated_impl(port, ptr, rust_vec_len, data_len),
+34 => wire__crate__api__sync__estimate_fee_impl(port, ptr, rust_vec_len, data_len),
+35 => wire__crate__api__sync__estimate_send_max_impl(port, ptr, rust_vec_len, data_len),
+36 => wire__crate__api__sync__execute_proposal_impl(port, ptr, rust_vec_len, data_len),
+37 => wire__crate__api__sync__execute_proposal_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+38 => wire__crate__api__sync__extract_and_broadcast_pczt_impl(port, ptr, rust_vec_len, data_len),
+40 => wire__crate__api__voting__generate_van_witness_impl(port, ptr, rust_vec_len, data_len),
+41 => wire__crate__api__voting__generate_voting_hotkey_impl(port, ptr, rust_vec_len, data_len),
+42 => wire__crate__api__sync__get_balance_impl(port, ptr, rust_vec_len, data_len),
+43 => wire__crate__api__sync__get_block_time_impl(port, ptr, rust_vec_len, data_len),
+45 => wire__crate__api__sync__get_export_birthday_height_impl(port, ptr, rust_vec_len, data_len),
+46 => wire__crate__api__voting__get_keystone_signatures_impl(port, ptr, rust_vec_len, data_len),
+47 => wire__crate__api__wallet__get_latest_block_height_impl(port, ptr, rust_vec_len, data_len),
+48 => wire__crate__api__wallet__get_lightwalletd_chain_name_impl(port, ptr, rust_vec_len, data_len),
+49 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
+50 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
+51 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
+52 => wire__crate__api__voting__get_round_recovery_state_impl(port, ptr, rust_vec_len, data_len),
+53 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
+55 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+56 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
+58 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
+59 => wire__crate__api__wallet__get_transparent_address_impl(port, ptr, rust_vec_len, data_len),
+60 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+62 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
+63 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
+64 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+65 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+71 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+72 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+73 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
+74 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+76 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+77 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
+78 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+80 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+82 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+88 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+92 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+96 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+99 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+101 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+102 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+104 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+105 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+106 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+107 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+108 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+109 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -6755,24 +6827,24 @@ fn pde_ffi_dispatcher_sync_impl(
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
         8 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        56 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        65 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
-        66 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        69 => {
+        39 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        66 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
+        67 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
+        68 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        70 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        74 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        85 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        94 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        102 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        109 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        112 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        75 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        86 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        95 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        103 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        110 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        113 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -7940,6 +8012,27 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<zcash_voting::wire::SignedVote
 {
     fn into_into_dart(self) -> FrbWrapper<zcash_voting::wire::SignedVoteCommitmentsView> {
         self.into()
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::wallet::SoftwareWalletDiscoveredAccount {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.zip32_account_index.into_into_dart().into_dart(),
+            self.first_transparent_address.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::wallet::SoftwareWalletDiscoveredAccount
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::wallet::SoftwareWalletDiscoveredAccount>
+    for crate::api::wallet::SoftwareWalletDiscoveredAccount
+{
+    fn into_into_dart(self) -> crate::api::wallet::SoftwareWalletDiscoveredAccount {
+        self
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -9124,6 +9217,16 @@ impl SseEncode for Vec<zcash_voting::wire::SignedVoteCommitmentView> {
     }
 }
 
+impl SseEncode for Vec<crate::api::wallet::SoftwareWalletDiscoveredAccount> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::wallet::SoftwareWalletDiscoveredAccount>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<crate::api::wallet::SoftwareWalletImportAccount> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -9549,6 +9652,14 @@ impl SseEncode for zcash_voting::wire::SignedVoteCommitmentsView {
             self.commitments,
             serializer,
         );
+    }
+}
+
+impl SseEncode for crate::api::wallet::SoftwareWalletDiscoveredAccount {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u32>::sse_encode(self.zip32_account_index, serializer);
+        <String>::sse_encode(self.first_transparent_address, serializer);
     }
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1895016467;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 165336228;
 
 // Section: executor
 
@@ -3059,6 +3059,48 @@ fn wire__crate__api__voting__precompute_delegation_pir_impl(
                     })()
                     .await,
                 )
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet__preview_software_account_transparent_balance_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "preview_software_account_transparent_balance",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_mnemonic = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_lightwalletd_url = <String>::sse_decode(&mut deserializer);
+            let api_zip32_account_index = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok =
+                        crate::api::wallet::preview_software_account_transparent_balance(
+                            api_mnemonic,
+                            api_network,
+                            api_lightwalletd_url,
+                            api_zip32_account_index,
+                        )?;
+                    Ok(output_ok)
+                })())
             }
         },
     )
@@ -6797,36 +6839,37 @@ fn pde_ffi_dispatcher_primary_impl(
 77 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
 78 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
 79 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-80 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-81 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-82 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-83 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-90 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
-91 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-92 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-93 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-94 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-97 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-99 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-100 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-104 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-105 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-106 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-107 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-108 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-109 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+80 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+82 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+88 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
+92 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+99 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+101 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+102 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+105 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+106 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+107 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+108 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+109 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -6853,11 +6896,11 @@ fn pde_ffi_dispatcher_sync_impl(
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
         75 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        86 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        95 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        103 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        110 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        113 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        87 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        104 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        111 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        114 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -241,6 +241,51 @@ pub fn software_account_first_external_transparent_address(
     ))
 }
 
+/// Return the standard transparent receivers for `account'` across the first
+/// external and internal BIP44 address indexes.
+pub fn software_account_transparent_addresses(
+    network: WalletNetwork,
+    seed: &SecretVec<u8>,
+    account_index: u32,
+    address_count_per_scope: u32,
+) -> Result<Vec<String>, String> {
+    let ufvk = software_account_ufvk(network, seed, account_index)?;
+    let transparent_key = ufvk
+        .transparent()
+        .ok_or("Software account does not have a transparent key")?;
+    let external_ivk = transparent_key
+        .derive_external_ivk()
+        .map_err(|e| format!("Failed to derive transparent external IVK: {e}"))?;
+    let internal_ivk = transparent_key
+        .derive_internal_ivk()
+        .map_err(|e| format!("Failed to derive transparent internal IVK: {e}"))?;
+
+    let mut addresses = Vec::with_capacity(address_count_per_scope as usize * 2);
+    for i in 0..address_count_per_scope {
+        let child_index = NonHardenedChildIndex::from_index(i)
+            .ok_or_else(|| format!("Invalid transparent address index: {i}"))?;
+        let external_taddr = external_ivk
+            .derive_address(child_index)
+            .map_err(|e| format!("Failed to derive transparent external address {i}: {e}"))?;
+        addresses.push(encode_transparent_address(
+            &network.b58_pubkey_address_prefix(),
+            &network.b58_script_address_prefix(),
+            &external_taddr,
+        ));
+
+        let internal_taddr = internal_ivk
+            .derive_address(child_index)
+            .map_err(|e| format!("Failed to derive transparent internal address {i}: {e}"))?;
+        addresses.push(encode_transparent_address(
+            &network.b58_pubkey_address_prefix(),
+            &network.b58_script_address_prefix(),
+            &internal_taddr,
+        ));
+    }
+
+    Ok(addresses)
+}
+
 fn import_ufvk_account(
     db_path: &str,
     network: WalletNetwork,
@@ -926,6 +971,26 @@ mod tests {
         assert!(account_0.starts_with("t1"));
         assert!(account_1.starts_with("t1"));
         assert_ne!(account_0, account_1);
+    }
+
+    #[test]
+    fn test_software_transparent_address_preview_range_includes_first_external_address() {
+        let phrase = generate_mnemonic();
+        let seed = mnemonic_to_seed(&phrase).unwrap();
+
+        let first_external =
+            software_account_first_external_transparent_address(WalletNetwork::Main, &seed, 1)
+                .unwrap();
+        let addresses =
+            software_account_transparent_addresses(WalletNetwork::Main, &seed, 1, 2).unwrap();
+
+        assert_eq!(addresses.len(), 4);
+        assert_eq!(addresses[0], first_external);
+        assert!(addresses.iter().all(|address| address.starts_with("t1")));
+        assert_eq!(
+            addresses.iter().collect::<HashSet<_>>().len(),
+            addresses.len()
+        );
     }
 
     #[test]

--- a/test/features/onboarding/import_wallet_birthday_screen_test.dart
+++ b/test/features/onboarding/import_wallet_birthday_screen_test.dart
@@ -123,6 +123,32 @@ void main() {
 
     expect(selected, isNull);
   });
+
+  testWidgets('account discovery modal action buttons split available width', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_modalHarness(onConfirm: (_) {}));
+
+    final cancelSize = tester.getSize(
+      find.descendant(
+        of: find.byKey(
+          const ValueKey('import_account_discovery_cancel_button'),
+        ),
+        matching: find.byType(AnimatedContainer),
+      ),
+    );
+    final confirmSize = tester.getSize(
+      find.descendant(
+        of: find.byKey(
+          const ValueKey('import_account_discovery_confirm_button'),
+        ),
+        matching: find.byType(AnimatedContainer),
+      ),
+    );
+
+    expect((cancelSize.width - confirmSize.width).abs(), lessThan(0.1));
+    expect(cancelSize.width, greaterThan(160));
+  });
 }
 
 Future<void> _setDesktopSurface(WidgetTester tester) async {

--- a/test/features/onboarding/import_wallet_birthday_screen_test.dart
+++ b/test/features/onboarding/import_wallet_birthday_screen_test.dart
@@ -149,6 +149,41 @@ void main() {
     expect((cancelSize.width - confirmSize.width).abs(), lessThan(0.1));
     expect(cancelSize.width, greaterThan(160));
   });
+
+  testWidgets('account discovery modal updates transparent balance previews', (
+    tester,
+  ) async {
+    final account1Balance = Completer<BigInt>();
+    final account2Balance = Completer<BigInt>();
+
+    await tester.pumpWidget(
+      _modalHarness(
+        onConfirm: (_) {},
+        loadTransparentBalance: (account) {
+          return switch (account.zip32AccountIndex) {
+            1 => account1Balance.future,
+            2 => account2Balance.future,
+            _ => Future.error(StateError('unexpected account')),
+          };
+        },
+      ),
+    );
+
+    expect(find.text('Transparent'), findsNWidgets(2));
+    expect(find.text('Loading'), findsNWidgets(2));
+
+    account1Balance.complete(BigInt.from(123456789));
+    await tester.pump();
+
+    expect(find.text('1.2345 ZEC'), findsOneWidget);
+    expect(find.text('Loading'), findsOneWidget);
+
+    account2Balance.completeError(Exception('utxo unavailable'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('-'), findsOneWidget);
+  });
 }
 
 Future<void> _setDesktopSurface(WidgetTester tester) async {
@@ -184,6 +219,7 @@ Widget _birthdayHarness({
 
 Widget _modalHarness({
   bool allowEmptySelection = true,
+  ImportAccountTransparentBalanceLoader? loadTransparentBalance,
   required ValueChanged<List<int>> onConfirm,
 }) {
   return MaterialApp(
@@ -209,6 +245,8 @@ Widget _modalHarness({
                   ),
                 ],
                 allowEmptySelection: allowEmptySelection,
+                loadTransparentBalance:
+                    loadTransparentBalance ?? ((_) async => BigInt.zero),
                 onConfirm: onConfirm,
                 onCancel: () {},
               ),

--- a/test/features/onboarding/import_wallet_birthday_screen_test.dart
+++ b/test/features/onboarding/import_wallet_birthday_screen_test.dart
@@ -99,6 +99,30 @@ void main() {
 
     expect(selected, [2]);
   });
+
+  testWidgets('account discovery modal blocks empty selection when required', (
+    tester,
+  ) async {
+    List<int>? selected;
+
+    await tester.pumpWidget(
+      _modalHarness(
+        allowEmptySelection: false,
+        onConfirm: (value) => selected = value,
+      ),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('import_account_discovery_row_1')),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('import_account_discovery_row_2')),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('import_account_discovery_confirm_button')),
+    );
+
+    expect(selected, isNull);
+  });
 }
 
 Future<void> _setDesktopSurface(WidgetTester tester) async {
@@ -132,7 +156,10 @@ Widget _birthdayHarness({
   );
 }
 
-Widget _modalHarness({required ValueChanged<List<int>> onConfirm}) {
+Widget _modalHarness({
+  bool allowEmptySelection = true,
+  required ValueChanged<List<int>> onConfirm,
+}) {
   return MaterialApp(
     home: MediaQuery(
       data: const MediaQueryData(textScaler: TextScaler.linear(1)),
@@ -155,6 +182,7 @@ Widget _modalHarness({required ValueChanged<List<int>> onConfirm}) {
                         't1UhrwzXxQBmduARnkbYqkKFSUMN6VAx9QS',
                   ),
                 ],
+                allowEmptySelection: allowEmptySelection,
                 onConfirm: onConfirm,
                 onCancel: () {},
               ),

--- a/test/features/onboarding/import_wallet_birthday_screen_test.dart
+++ b/test/features/onboarding/import_wallet_birthday_screen_test.dart
@@ -6,11 +6,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/onboarding/import/import_account_discovery_modal.dart';
 import 'package:zcash_wallet/src/features/onboarding/import/import_birthday_calendar_overlay.dart';
 import 'package:zcash_wallet/src/features/onboarding/import/import_birthday_estimator.dart';
 import 'package:zcash_wallet/src/features/onboarding/import/import_wallet_birthday_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args.dart';
 import 'package:zcash_wallet/src/providers/rpc_endpoint_failover_provider.dart';
+import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
 
 void main() {
   testWidgets('birthday tab labels show a click cursor', (tester) async {
@@ -64,6 +66,39 @@ void main() {
     metadataCompleter.complete(_metadataFixture());
     await tester.pump();
   });
+
+  testWidgets('account discovery modal imports all candidates by default', (
+    tester,
+  ) async {
+    List<int>? selected;
+
+    await tester.pumpWidget(
+      _modalHarness(onConfirm: (value) => selected = value),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('import_account_discovery_confirm_button')),
+    );
+
+    expect(selected, [1, 2]);
+  });
+
+  testWidgets('account discovery modal removes toggled off candidates', (
+    tester,
+  ) async {
+    List<int>? selected;
+
+    await tester.pumpWidget(
+      _modalHarness(onConfirm: (value) => selected = value),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('import_account_discovery_row_1')),
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('import_account_discovery_confirm_button')),
+    );
+
+    expect(selected, [2]);
+  });
 }
 
 Future<void> _setDesktopSurface(WidgetTester tester) async {
@@ -90,6 +125,40 @@ Widget _birthdayHarness({
           data: AppThemeData.light,
           child: const ImportWalletBirthdayScreen(
             args: ImportBirthdayArgs(mnemonic: 'test mnemonic'),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Widget _modalHarness({required ValueChanged<List<int>> onConfirm}) {
+  return MaterialApp(
+    home: MediaQuery(
+      data: const MediaQueryData(textScaler: TextScaler.linear(1)),
+      child: AppTheme(
+        data: AppThemeData.light,
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Stack(
+            children: [
+              ImportAccountDiscoveryModal(
+                accounts: const [
+                  rust_wallet.SoftwareWalletDiscoveredAccount(
+                    zip32AccountIndex: 1,
+                    firstTransparentAddress:
+                        't1VzLrfU8ZRs3xEGzR84xHWL2QK7C9Tt6yV',
+                  ),
+                  rust_wallet.SoftwareWalletDiscoveredAccount(
+                    zip32AccountIndex: 2,
+                    firstTransparentAddress:
+                        't1UhrwzXxQBmduARnkbYqkKFSUMN6VAx9QS',
+                  ),
+                ],
+                onConfirm: onConfirm,
+                onCancel: () {},
+              ),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- Split software wallet import into discovery and selected-account import steps.
- Show an account-selection modal when additional importable accounts are found, with account toggles and transparent balance previews loaded after the modal appears.
- Keep account 0 mandatory and hidden from the additional-account list, and pass selected accounts through password setup imports.

## Validation
- flutter_rust_bridge_codegen generate
- cargo fmt
- fvm dart format
- cargo test test_software_transparent_address_preview_range_includes_first_external_address
- fvm flutter test test/features/onboarding/import_wallet_birthday_screen_test.dart
- fvm flutter analyze
- git diff --check