### PR TITLE
Make the mobile syncing effect more visible

### DIFF
--- a/lib/src/core/layout/mobile/mobile_top_nav.dart
+++ b/lib/src/core/layout/mobile/mobile_top_nav.dart
@@ -313,11 +313,12 @@ abstract final class _SyncStatusMotion {
   /// Kept narrow for a gentle, low-contrast sparkle.
   static const _bandHalf = 0.18;
 
-  /// Edge-bar glow breathing range (shadow blur radius + alpha).
+  /// Edge-bar glow breathing range (shadow blur radius + alpha). Kept gentle
+  /// so the syncing glow stays subtle rather than vibrant.
   static const _minGlowBlur = 8.0;
-  static const _maxGlowBlur = 16.0;
-  static const _minGlowAlpha = 0.35;
-  static const _maxGlowAlpha = 0.7;
+  static const _maxGlowBlur = 13.0;
+  static const _minGlowAlpha = 0.2;
+  static const _maxGlowAlpha = 0.45;
 
   /// 0 → 1 → 0 once per [period].
   static double _breath(double t) => (1 - math.cos(2 * math.pi * t)) / 2;

--- a/lib/src/core/layout/mobile/mobile_top_nav_account.dart
+++ b/lib/src/core/layout/mobile/mobile_top_nav_account.dart
@@ -28,12 +28,12 @@ class MobileTopNavAccount extends ConsumerWidget {
 
     final isSyncing = status.kind == SyncStatusKind.syncing;
     // Synced reads fully green: label `sync.text` (GreenPrimitives.p900) +
-    // vivid green bar `sync.lightSuccess`. Syncing reads muted: the label is
-    // the same green at 65% (`sync.textSyncing`, slightly less saturated) and
-    // the shimmer peaks at the full synced green to preview it. The bar uses a
-    // neutral grey (`text.muted` = p500, identical in both modes) so it never
-    // muddies to olive on a light background the way a 65%-alpha dark green
-    // would; it goes vivid green only once synced.
+    // vivid green bar `sync.lightSuccess`. Syncing reads muted: the label
+    // rests at the synced green @ 65% (`sync.textSyncing`) and the shimmer
+    // peaks at the bright `sync.lightSuccess`, so the sweep stays visible on a
+    // light background. The bar stays a neutral grey (`text.muted` = p500,
+    // identical in both modes) so it never muddies to olive, and its glow is
+    // tuned down (see `_SyncStatusMotion`) so syncing reads calm, not vibrant.
     final (labelColor, indicatorColor, highlightColor) = switch (status.kind) {
       SyncStatusKind.synced => (
         colors.sync.text, // green label
@@ -41,9 +41,9 @@ class MobileTopNavAccount extends ConsumerWidget {
         colors.sync.text,
       ),
       SyncStatusKind.syncing => (
-        colors.sync.textSyncing, // muted green (synced green @ 65%)
-        colors.text.muted, // neutral grey bar (both modes)
-        colors.sync.text, // shimmer peak = the synced green
+        colors.sync.textSyncing, // muted green resting (synced green @ 65%)
+        colors.text.muted, // neutral grey bar (subtle glow)
+        colors.sync.lightSuccess, // bright shimmer peak
       ),
       SyncStatusKind.failed => (
         colors.sync.textError,

--- a/lib/widgetbook/mobile_shell_use_cases.dart
+++ b/lib/widgetbook/mobile_shell_use_cases.dart
@@ -54,7 +54,7 @@ Widget buildMobileTopNavVariantsUseCase(BuildContext context) {
           syncLabel: '20% Syncing...',
           syncLabelColor: context.colors.sync.textSyncing,
           syncIndicatorColor: context.colors.text.muted,
-          syncHighlightColor: context.colors.sync.text,
+          syncHighlightColor: context.colors.sync.lightSuccess,
           syncAnimated: true,
           onAccountTap: () {},
         ),

--- a/test/core/layout/mobile/mobile_shell_components_test.dart
+++ b/test/core/layout/mobile/mobile_shell_components_test.dart
@@ -44,7 +44,7 @@ void main() {
           syncLabel: '20% Syncing...',
           syncLabelColor: AppThemeData.dark.colors.sync.textSyncing,
           syncIndicatorColor: AppThemeData.dark.colors.text.muted,
-          syncHighlightColor: AppThemeData.dark.colors.sync.text,
+          syncHighlightColor: AppThemeData.dark.colors.sync.lightSuccess,
           syncAnimated: true,
         ),
       ),
@@ -80,7 +80,7 @@ void main() {
               syncLabel: '20% Syncing...',
               syncLabelColor: mutedGreen,
               syncIndicatorColor: greyBar,
-              syncHighlightColor: AppThemeData.dark.colors.sync.text,
+              syncHighlightColor: AppThemeData.dark.colors.sync.lightSuccess,
               syncAnimated: true,
             ),
           ),
@@ -88,9 +88,9 @@ void main() {
       ),
     );
 
-    // No shimmer mask; the label keeps its muted (less-saturated) green base
-    // and the edge bar is a neutral grey. The full synced green only appears
-    // as the animated shimmer peak.
+    // No shimmer mask; the label keeps its muted green base and the edge bar
+    // is a neutral grey. The brighter shimmer peak only appears in the
+    // animated state.
     expect(find.byType(ShaderMask), findsNothing);
     final label = tester.widget<Text>(find.text('20% Syncing...'));
     expect(label.style?.color, mutedGreen);


### PR DESCRIPTION
## What

Follow-up to the merged mobile syncing animation (#217). The effect was hard to notice in **light mode**, so this brightens the shimmer and calms the glow — without changing the grey-while-syncing identity.

- **Shimmer peak** now sweeps to the bright `sync.lightSuccess` (was the darker `sync.text`, a low-contrast forest green in light mode), so the sweep pops on a light background.
- **Edge-bar glow** toned down — breathing alpha `0.2–0.45` (was `0.35–0.7`), max blur `13` (was `16`) — so the syncing bar reads calm rather than vibrant.
- The bar itself stays the neutral grey `text.muted` (syncing) → vivid green `sync.lightSuccess` (synced), unchanged.

## Test plan

- `fvm flutter analyze` — clean.
- Mobile lane: `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile` — 8/8 (tests + widgetbook updated to the brighter shimmer peak).
- Verified live on the iPhone 17 Pro simulator in both dark and light mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)