### PR TITLE
Soften the passcode keypad haptics

### DIFF
--- a/lib/src/core/feedback/app_haptics.dart
+++ b/lib/src/core/feedback/app_haptics.dart
@@ -1,18 +1,20 @@
 import 'package:flutter/services.dart';
 
-/// Haptic vocabulary for the passcode surfaces.
+/// Haptic vocabulary for the passcode surfaces and the mobile tab bar.
 ///
 /// All methods are fire-and-forget safe — call them unawaited so a slow
 /// platform round trip never delays input handling.
 abstract final class AppHaptics {
   static const _channel = MethodChannel('com.zcash.wallet/haptics');
 
-  /// A passcode digit key press.
-  static Future<void> digit() => HapticFeedback.mediumImpact();
+  /// A passcode digit key press — a short, light tap (iOS
+  /// UIImpactFeedbackGenerator(.light)).
+  static Future<void> digit() => HapticFeedback.lightImpact();
 
-  /// Auxiliary keys (delete, biometric retry) — one step softer than
-  /// the digits.
-  static Future<void> auxiliaryKey() => HapticFeedback.lightImpact();
+  /// Auxiliary keys (delete, biometric retry) and tab switches — the
+  /// subtle selection tick (iOS UISelectionFeedbackGenerator), one step
+  /// softer than the digits.
+  static Future<void> auxiliaryKey() => HapticFeedback.selectionClick();
 
   /// A rejected passcode. Native notification-error where the platform
   /// has one (iOS UINotificationFeedbackGenerator(.error), Android

--- a/test/features/onboarding/mobile_unlock_screen_test.dart
+++ b/test/features/onboarding/mobile_unlock_screen_test.dart
@@ -142,7 +142,7 @@ void main() {
       AppSecureStore.instance.clearSessionPassword();
     });
 
-    testWidgets('digits knock medium and a wrong passcode buzzes the error', (
+    testWidgets('digits tap light and a wrong passcode buzzes the error', (
       tester,
     ) async {
       await AppSecureStore.instance.configurePassword('123456');
@@ -183,11 +183,11 @@ void main() {
 
       await tester.tap(find.bySemanticsLabel('Digit 1'));
       await tester.pump();
-      expect(impactTypes, ['HapticFeedbackType.mediumImpact']);
+      expect(impactTypes, ['HapticFeedbackType.lightImpact']);
 
       await tester.tap(find.bySemanticsLabel('Delete digit'));
       await tester.pump();
-      expect(impactTypes.last, 'HapticFeedbackType.lightImpact');
+      expect(impactTypes.last, 'HapticFeedbackType.selectionClick');
 
       // A full wrong passcode lands the error haptic exactly once.
       for (final d in '999999'.split('')) {


### PR DESCRIPTION
## Summary
- Digit keys drop from a medium impact to a short light tap (`HapticFeedback.lightImpact`)
- Auxiliary keys (delete, biometric retry — and tab switches, which share the vocabulary) move to the subtle selection tick (`selectionClick`)
- Error buzz unchanged

Fixes VZR-76

## Test plan
- `mobile_unlock_screen_test.dart` haptics group updated to the new vocabulary (mobile lane, passing)
- Haptic strength can't be felt in the simulator — needs a quick on-device feel check; if `selectionClick` reads as dead on Android, fall back to `lightImpact` for auxiliary keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)