### PR TITLE
Open manual entry when the import slot grid is tapped

### DIFF
--- a/lib/src/features/onboarding/mobile/mobile_import_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_screens.dart
@@ -206,7 +206,22 @@ class _MobileImportScreenState extends State<MobileImportScreen> {
           ],
         ],
       ),
-      child: ImportSlotsCard(words: _words),
+      // VZR-71: users instinctively tap the slot grid expecting to
+      // type — route the tap into the manual wizard, same as the Enter
+      // manually link. Once a valid phrase fills the card it is a
+      // review surface and the tap is disabled.
+      child: _filled
+          ? ImportSlotsCard(words: _words)
+          : Semantics(
+              button: true,
+              label: 'Enter secret phrase manually',
+              child: GestureDetector(
+                key: const ValueKey('mobile_import_slots'),
+                behavior: HitTestBehavior.opaque,
+                onTap: () => context.push('/import/manual'),
+                child: ImportSlotsCard(words: _words),
+              ),
+            ),
     );
   }
 }

--- a/test/features/onboarding/mobile_import_screens_test.dart
+++ b/test/features/onboarding/mobile_import_screens_test.dart
@@ -63,6 +63,30 @@ void main() {
     expect(find.text('Enter your Secret Passphrase'), findsOneWidget);
   });
 
+  testWidgets('tapping the slot grid opens the manual wizard', (tester) async {
+    await tester.pumpWidget(_app('/import'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_import_slots')));
+    await tester.pumpAndSettle();
+    expect(find.text('Enter your Secret Passphrase'), findsOneWidget);
+  });
+
+  testWidgets('the slot grid stays tappable after a rejected paste', (
+    tester,
+  ) async {
+    _mockClipboard(tester, 'one two three');
+    await tester.pumpWidget(_app('/import'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_import_paste')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_import_slots')));
+    await tester.pumpAndSettle();
+    expect(find.text('Enter your Secret Passphrase'), findsOneWidget);
+  });
+
   testWidgets('word-count validation rejects a short paste', (tester) async {
     _mockClipboard(tester, 'one two three');
     await tester.pumpWidget(_app('/import'));


### PR DESCRIPTION
## Summary
- The 24-slot numbered card reads as an input surface, so users tap it expecting to type — that tap now routes into the word-by-word manual wizard, same as the "Enter manually" link
- Active while the card is empty or showing a rejected paste; once a valid phrase fills the slots the card stays a plain review surface
- Adds a semantics button node ("Enter secret phrase manually") for screen readers

Fixes VZR-71

## Test plan
- New widget tests: tapping the empty grid opens the manual wizard; the grid stays tappable after a rejected paste (mobile lane, passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)