### PR TITLE
Add an add-account button to the mobile accounts page

### DIFF
--- a/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
+++ b/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
@@ -340,6 +340,19 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
                         ],
                       ),
                     ],
+                    // VZR-73: the page-level add affordance, mirroring
+                    // the accounts sheet and the desktop accounts page.
+                    const SizedBox(height: AppSpacing.sm),
+                    AppButton(
+                      key: const ValueKey('mobile_accounts_add_account'),
+                      variant: AppButtonVariant.secondary,
+                      expand: true,
+                      onPressed: _busy
+                          ? null
+                          : () => context.push('/add-account'),
+                      leading: const AppIcon(AppIcons.addNew),
+                      child: const Text('Add account'),
+                    ),
                   ],
                 ),
               ),

--- a/test/features/accounts/mobile_accounts_screen_test.dart
+++ b/test/features/accounts/mobile_accounts_screen_test.dart
@@ -4,6 +4,7 @@ library;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
@@ -37,14 +38,27 @@ AppBootstrapState _bootstrap(AccountState accounts) => AppBootstrapState(
 );
 
 Widget _app(AccountState accounts) {
+  final router = GoRouter(
+    initialLocation: '/accounts',
+    routes: [
+      GoRoute(
+        path: '/accounts',
+        builder: (_, _) => const MobileAccountsScreen(),
+      ),
+      GoRoute(
+        path: '/add-account',
+        builder: (_, _) => const Text('add account route'),
+      ),
+    ],
+  );
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap(accounts)),
       syncProvider.overrideWith(() => FakeSyncNotifier(SyncState())),
     ],
-    child: MaterialApp(
+    child: MaterialApp.router(
+      routerConfig: router,
       builder: (_, c) => AppTheme(data: AppThemeData.light, child: c!),
-      home: const MobileAccountsScreen(),
     ),
   );
 }
@@ -143,6 +157,26 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('mobile_account_edit_save')));
     await tester.pump();
     expect(find.text('Account name'), findsOneWidget);
+  });
+
+  testWidgets('add account routes to the add-account flow', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        AccountState(
+          accounts: [_account('a', 'Knight', isSeedAnchor: true)],
+          activeAccountUuid: 'a',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final button = find.byKey(const ValueKey('mobile_accounts_add_account'));
+    expect(button, findsOneWidget);
+    expect(find.text('Add account'), findsOneWidget);
+
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+    expect(find.text('add account route'), findsOneWidget);
   });
 
   testWidgets('remove asks for confirmation with the design copy', (


### PR DESCRIPTION
## Summary
- The accounts page only listed existing accounts; adding one required backing out to the accounts sheet
- Appends a secondary "Add account" button below the account groups, routing into the same `/add-account` flow the sheet and the desktop accounts page use
- Disabled while an edit/removal is in flight (`_busy`)

Fixes VZR-73

## Test plan
- Test harness converted to `MaterialApp.router` with an `/add-account` probe route; new test asserts the button navigates there (mobile lane, passing; existing four tests unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)