### PR TITLE
Rebalance the unlock screen around the dynamic island

### DIFF
--- a/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../core/layout/mobile/mobile_bottom_safe_area.dart';
 import '../../../core/feedback/app_haptics.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../providers/account_provider.dart';
@@ -170,75 +171,90 @@ class _MobileUnlockScreenState extends ConsumerState<MobileUnlockScreen> {
     final colors = context.colors;
     return Scaffold(
       backgroundColor: colors.background.window,
+      // Bottom edge follows the MobileBottomSafeArea policy: the
+      // trailing 24px of column padding already clears the iOS home
+      // indicator, so skipping the 34px inset keeps the numpad from
+      // floating high above the screen edge (VZR-72).
       body: SafeArea(
-        child: Column(
-          children: [
-            const Spacer(),
-            Image.asset(
-              'assets/illustrations/welcome_badge.png',
-              width: 50,
-              height: 50,
-            ),
-            const SizedBox(height: AppSpacing.base),
-            Text(
-              'Welcome Back',
-              textAlign: TextAlign.center,
-              style: AppTypography.displayLarge.copyWith(
-                color: colors.text.accent,
+        bottom: false,
+        child: MobileBottomSafeArea(
+          bottomPadding: AppSpacing.md,
+          child: Column(
+            children: [
+              // Deliberate clearance below the status bar / dynamic
+              // island so the badge never crowds it; the Spacers keep
+              // the welcome group centered in what remains.
+              const SizedBox(height: AppSpacing.md),
+              const Spacer(),
+              Image.asset(
+                'assets/illustrations/welcome_badge.png',
+                width: 50,
+                height: 50,
               ),
-            ),
-            const SizedBox(height: AppSpacing.s),
-            Text(
-              _submitting
-                  ? 'Opening your wallet...'
-                  : 'Enter your passcode to open Vizor',
-              textAlign: TextAlign.center,
-              style: AppTypography.bodyMedium.copyWith(
-                color: colors.text.secondary,
+              const SizedBox(height: AppSpacing.base),
+              Text(
+                'Welcome Back',
+                textAlign: TextAlign.center,
+                style: AppTypography.displayLarge.copyWith(
+                  color: colors.text.accent,
+                ),
               ),
-            ),
-            const SizedBox(height: AppSpacing.lg),
-            PasscodeDots(length: kMobilePasscodeLength, filled: _entry.length),
-            SizedBox(
-              // Tall enough to hold the error message ~30 px below the
-              // dots, where the Sign In Passcode frame places it.
-              height: 84,
-              child: Center(
-                child: _error == null
-                    ? null
-                    : Text(
-                        _error!,
-                        textAlign: TextAlign.center,
-                        style: AppTypography.bodyMedium.copyWith(
-                          color: colors.text.destructive,
+              const SizedBox(height: AppSpacing.s),
+              Text(
+                _submitting
+                    ? 'Opening your wallet...'
+                    : 'Enter your passcode to open Vizor',
+                textAlign: TextAlign.center,
+                style: AppTypography.bodyMedium.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+              const SizedBox(height: AppSpacing.lg),
+              PasscodeDots(
+                length: kMobilePasscodeLength,
+                filled: _entry.length,
+              ),
+              SizedBox(
+                // Tall enough to hold the error message ~30 px below
+                // the dots, where the Sign In Passcode frame places it.
+                height: 84,
+                child: Center(
+                  child: _error == null
+                      ? null
+                      : Text(
+                          _error!,
+                          textAlign: TextAlign.center,
+                          style: AppTypography.bodyMedium.copyWith(
+                            color: colors.text.destructive,
+                          ),
                         ),
-                      ),
+                ),
               ),
-            ),
-            const Spacer(),
-            Builder(
-              builder: (context) {
-                final biometric =
-                    ref.watch(biometricUnlockProvider).value ??
-                    BiometricUnlockState.initial;
-                return PasscodeNumpad(
-                  onDigit: _onDigit,
-                  onBackspace: _onBackspace,
-                  canDelete: _entry.isNotEmpty,
-                  onHelp: _submitting ? null : _showForgotPasscodeSheet,
-                  onBiometric: biometric.usable && !_submitting
-                      ? () => unawaited(_tryBiometricUnlock())
-                      : null,
-                  biometricIcon:
-                      biometric.availability.kind == BiometricKind.face
-                      ? Icons.face
-                      : Icons.fingerprint,
-                  enabled: !_submitting,
-                );
-              },
-            ),
-            const SizedBox(height: AppSpacing.md),
-          ],
+              const Spacer(),
+              Builder(
+                builder: (context) {
+                  final biometric =
+                      ref.watch(biometricUnlockProvider).value ??
+                      BiometricUnlockState.initial;
+                  return PasscodeNumpad(
+                    onDigit: _onDigit,
+                    onBackspace: _onBackspace,
+                    canDelete: _entry.isNotEmpty,
+                    onHelp: _submitting ? null : _showForgotPasscodeSheet,
+                    onBiometric: biometric.usable && !_submitting
+                        ? () => unawaited(_tryBiometricUnlock())
+                        : null,
+                    biometricIcon:
+                        biometric.availability.kind == BiometricKind.face
+                        ? Icons.face
+                        : Icons.fingerprint,
+                    enabled: !_submitting,
+                  );
+                },
+              ),
+              const SizedBox(height: AppSpacing.md),
+            ],
+          ),
         ),
       ),
     );

--- a/test/features/onboarding/mobile_unlock_screen_test.dart
+++ b/test/features/onboarding/mobile_unlock_screen_test.dart
@@ -3,6 +3,8 @@ library;
 
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart'
+    show debugDefaultTargetPlatformOverride;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
@@ -68,14 +70,24 @@ const faceAvailability = BiometricAvailability(
   kind: BiometricKind.face,
 );
 
-Widget _app({FakeBiometricUnlock? biometric}) {
+Widget _app({FakeBiometricUnlock? biometric, EdgeInsets? insets}) {
   return ProviderScope(
     overrides: [
       if (biometric != null)
         biometricUnlockServiceProvider.overrideWithValue(biometric),
     ],
     child: MaterialApp(
-      builder: (_, c) => AppTheme(data: AppThemeData.light, child: c!),
+      builder: (context, c) {
+        final themed = AppTheme(data: AppThemeData.light, child: c!);
+        if (insets == null) return themed;
+        // Simulated device safe-area insets for geometry tests.
+        return MediaQuery(
+          data: MediaQuery.of(
+            context,
+          ).copyWith(padding: insets, viewPadding: insets),
+          child: themed,
+        );
+      },
       home: const MobileUnlockScreen(),
     ),
   );
@@ -134,6 +146,50 @@ void main() {
     await tester.tap(find.bySemanticsLabel('Delete digit'));
     await tester.pump();
     expect(find.bySemanticsLabel('Delete digit'), findsNothing);
+  });
+
+  group('vertical balance (VZR-72)', () {
+    // iPhone 15 Pro-class insets: 59px island/status top, 34px home
+    // indicator bottom.
+    const insets = EdgeInsets.only(top: 59, bottom: 34);
+
+    testWidgets('iOS skips the home-indicator inset and clears the island', (
+      tester,
+    ) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+      await tester.pumpWidget(_app(insets: insets));
+      await tester.pump();
+
+      // Bottom gap is the column's own 24px padding — the 34px inset
+      // is skipped per the MobileBottomSafeArea policy.
+      final screenHeight = tester
+          .getSize(find.byType(MobileUnlockScreen))
+          .height;
+      final numpadBottom = tester.getBottomLeft(find.byType(PasscodeNumpad)).dy;
+      expect(numpadBottom, screenHeight - AppSpacing.md);
+
+      // The badge keeps a deliberate clearance below the island.
+      final badgeTop = tester.getTopLeft(find.byType(Image)).dy;
+      expect(badgeTop, greaterThanOrEqualTo(insets.top + AppSpacing.md));
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('Android keeps the navigation-bar inset', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      await tester.pumpWidget(_app(insets: insets));
+      await tester.pump();
+
+      final screenHeight = tester
+          .getSize(find.byType(MobileUnlockScreen))
+          .height;
+      final numpadBottom = tester.getBottomLeft(find.byType(PasscodeNumpad)).dy;
+      expect(numpadBottom, screenHeight - insets.bottom - AppSpacing.md);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
   });
 
   group('haptics', () {


### PR DESCRIPTION
## Summary
- Full-canvas centering left the badge ~10px under the dynamic island while the bottom stacked the 34px home-indicator inset on the column's own 24px padding (58px dead space)
- Adds a deliberate 24px clearance below the status bar and adopts the documented `MobileBottomSafeArea` policy for the numpad edge — badge clears the island, bottom gap is 24px on iOS
- Android keeps its navigation-bar inset (policy-preserved)

Fixes VZR-72

## Test plan
- New geometry test group with injected iPhone-class insets (top 59 / bottom 34): iOS pins numpad bottom = screen − 24 and badge ≥ island + 24; Android pins the kept inset (mobile lane, passing)
- Known pre-existing tightness on SE-class screens gets 24px tighter — flagged for a separate scroll-fallback ticket if QA hits it

🤖 Generated with [Claude Code](https://claude.com/claude-code)