### PR TITLE
Dissolve home content under the top nav with an eased fade

### DIFF
--- a/lib/src/core/layout/mobile/mobile_top_scroll_fade.dart
+++ b/lib/src/core/layout/mobile/mobile_top_scroll_fade.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/widgets.dart';
+
+import '../../theme/app_theme.dart';
+
+/// Soft top edge for tab-root scroll areas (VZR-74): a window-colored
+/// gradient overlay that dissolves content under the top nav instead of
+/// the scroll viewport's hard clip.
+///
+/// Scroll-aware — fully transparent at rest so resting content keeps
+/// its crisp edge, eased in over the first [AppSpacing.md] of scroll.
+/// The gradient samples a smoothstep curve rather than the default
+/// two-stop linear ramp, so the dissolve reads as a slow fade.
+class MobileTopScrollFade extends StatefulWidget {
+  const MobileTopScrollFade({
+    required this.child,
+    this.height = 40,
+    super.key,
+  });
+
+  /// The scrollable content the fade overlays.
+  final Widget child;
+
+  /// Height of the fade band below the top edge.
+  final double height;
+
+  @override
+  State<MobileTopScrollFade> createState() => _MobileTopScrollFadeState();
+}
+
+class _MobileTopScrollFadeState extends State<MobileTopScrollFade> {
+  double _opacity = 0;
+
+  // Smoothstep 3t² − 2t³ sampled at six points — an eased dissolve
+  // from fully window-colored at the clip edge to transparent.
+  static const _stops = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0];
+  static const _alphas = [1.0, 0.896, 0.648, 0.352, 0.104, 0.0];
+
+  bool _onScroll(ScrollNotification notification) {
+    if (notification.depth != 0) return false;
+    final next = (notification.metrics.extentBefore / AppSpacing.md).clamp(
+      0.0,
+      1.0,
+    );
+    if (next != _opacity) setState(() => _opacity = next);
+    return false; // Observe only — let the notification bubble on.
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final window = context.colors.background.window;
+    return NotificationListener<ScrollNotification>(
+      onNotification: _onScroll,
+      child: Stack(
+        children: [
+          widget.child,
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            height: widget.height,
+            child: IgnorePointer(
+              child: Opacity(
+                opacity: _opacity,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      stops: _stops,
+                      colors: [
+                        for (var i = 0; i < _stops.length; i++)
+                          window.withValues(alpha: _alphas[i]),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -7,6 +7,7 @@ import '../../../../core/config/network_config.dart';
 import '../../../../core/formatting/zec_amount.dart';
 import '../../../../core/layout/mobile/app_mobile_tab_bar.dart';
 import '../../../../core/layout/mobile/mobile_top_nav_account.dart';
+import '../../../../core/layout/mobile/mobile_top_scroll_fade.dart';
 import '../../../../core/privacy/privacy_mask.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/app_button.dart';
@@ -58,15 +59,19 @@ class MobileHomeScreen extends ConsumerWidget {
               ),
             ),
             Expanded(
-              child: isImporting
-                  ? _ImportingView(progress: sync.displayPercentage)
-                  : _HomeContent(
-                      sync: sync,
-                      activeAccountUuid: activeAccountUuid,
-                      privacyModeEnabled: privacyModeEnabled,
-                      onTogglePrivacyMode: () =>
-                          ref.read(privacyModeProvider.notifier).toggle(),
-                    ),
+              // VZR-74: dissolve scrolled content under the top nav
+              // with a soft eased fade instead of a hard clip line.
+              child: MobileTopScrollFade(
+                child: isImporting
+                    ? _ImportingView(progress: sync.displayPercentage)
+                    : _HomeContent(
+                        sync: sync,
+                        activeAccountUuid: activeAccountUuid,
+                        privacyModeEnabled: privacyModeEnabled,
+                        onTogglePrivacyMode: () =>
+                            ref.read(privacyModeProvider.notifier).toggle(),
+                      ),
+              ),
             ),
           ],
         ),

--- a/test/core/layout/mobile/mobile_top_scroll_fade_test.dart
+++ b/test/core/layout/mobile/mobile_top_scroll_fade_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/mobile/mobile_top_scroll_fade.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+
+Widget _app(Widget home) {
+  return MaterialApp(
+    builder: (_, c) => AppTheme(data: AppThemeData.dark, child: c!),
+    home: home,
+  );
+}
+
+Widget _fadeOverList({void Function()? onFirstRowTap}) {
+  return MobileTopScrollFade(
+    child: ListView(
+      children: [
+        GestureDetector(
+          key: const ValueKey('first_row'),
+          behavior: HitTestBehavior.opaque,
+          onTap: onFirstRowTap,
+          child: const SizedBox(height: 48),
+        ),
+        for (var i = 0; i < 40; i++) SizedBox(height: 48, child: Text('$i')),
+      ],
+    ),
+  );
+}
+
+Finder get _overlayOpacity => find.descendant(
+  of: find.byType(MobileTopScrollFade),
+  matching: find.byType(Opacity),
+);
+
+void main() {
+  testWidgets('invisible at rest, eased in once scrolled, gone again at the '
+      'top', (tester) async {
+    await tester.pumpWidget(_app(_fadeOverList()));
+
+    expect(tester.widget<Opacity>(_overlayOpacity).opacity, 0);
+
+    await tester.drag(find.byType(ListView), const Offset(0, -100));
+    await tester.pump();
+    expect(tester.widget<Opacity>(_overlayOpacity).opacity, 1);
+
+    await tester.drag(find.byType(ListView), const Offset(0, 200));
+    await tester.pumpAndSettle();
+    expect(tester.widget<Opacity>(_overlayOpacity).opacity, 0);
+  });
+
+  testWidgets('the fade samples a smoothstep curve, not a two-stop ramp', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app(_fadeOverList()));
+
+    final box = tester.widget<DecoratedBox>(
+      find.descendant(of: _overlayOpacity, matching: find.byType(DecoratedBox)),
+    );
+    final gradient =
+        (box.decoration as BoxDecoration).gradient! as LinearGradient;
+
+    expect(gradient.stops, [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]);
+    final alphas = [for (final color in gradient.colors) color.a];
+    expect(alphas.first, 1.0);
+    expect(alphas.last, 0.0);
+    // Interior samples follow smoothstep 3t² − 2t³.
+    expect(alphas[1], closeTo(0.896, 0.005));
+    expect(alphas[2], closeTo(0.648, 0.005));
+    expect(alphas[3], closeTo(0.352, 0.005));
+    expect(alphas[4], closeTo(0.104, 0.005));
+  });
+
+  testWidgets('the overlay never intercepts taps in the fade band', (
+    tester,
+  ) async {
+    var taps = 0;
+    await tester.pumpWidget(_app(_fadeOverList(onFirstRowTap: () => taps++)));
+
+    // The first row sits inside the 40px overlay band; the tap must
+    // reach it through the IgnorePointer.
+    await tester.tapAt(
+      tester.getTopLeft(find.byType(MobileTopScrollFade)) +
+          const Offset(40, 10),
+    );
+    expect(taps, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- Scrolled home content hard-clipped at the list viewport's top edge right under the nav
- New `MobileTopScrollFade` overlays the first 40px with a window-colored gradient sampling a smoothstep curve (six stops — not a two-stop linear ramp), easing in over the first 24px of scroll
- Resting frame stays pixel-identical (overlay opacity 0 at rest); `IgnorePointer` keeps taps passing through; applied to the home tab — other tab roots can adopt the same one-line wrap later

Fixes VZR-74

## Test plan
- New widget tests: invisible at rest / eased in once scrolled / gone again at top; pins the six smoothstep stops; taps pass through the fade band (default lane, passing)
- Home screen tests unaffected (mobile lane, passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)