### PR TITLE
Keep the birthday date picker steady while browsing months

### DIFF
--- a/ios/Runner/DatePickerHandler.swift
+++ b/ios/Runner/DatePickerHandler.swift
@@ -151,6 +151,11 @@ private final class DatePickerSheetViewController: UIViewController,
   private let maxDate: Date
   private var pickedDate: Date?
   private var finished = false
+  /// Largest calendar fitting height seen so far. The detent is
+  /// monotonic — it grows for 6-week months and never shrinks back for
+  /// 5-week ones — so browsing months doesn't bounce the sheet
+  /// (VZR-75).
+  private var maxCalendarFitHeight: CGFloat = 0
 
   init(
     initialDate: Date?,
@@ -176,10 +181,14 @@ private final class DatePickerSheetViewController: UIViewController,
           let fit = self.calendarView
             .systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
             .height
+          self.maxCalendarFitHeight = max(self.maxCalendarFitHeight, fit)
           // Grabber + vertical padding + home-indicator safe area; the
           // floor covers the pre-layout pass where the fitting height
           // is still zero (Apple's minimum calendar size is 320x371).
-          return min(max(fit + 56, 380), context.maximumDetentValue)
+          return min(
+            max(self.maxCalendarFitHeight + 56, 380),
+            context.maximumDetentValue
+          )
         }
       ]
     }
@@ -225,9 +234,16 @@ private final class DatePickerSheetViewController: UIViewController,
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    // The custom detent resolves before the calendar has a width; once
-    // laid out, re-resolve so the sheet settles at the true fit height.
-    sheetPresentationController?.invalidateDetents()
+    // The custom detent resolves before the calendar has a width, and
+    // 6-week months fit taller than 5-week ones. Re-resolve only when
+    // the calendar outgrows the tallest height seen so far — never on
+    // shrink — so month navigation doesn't bounce the sheet (VZR-75).
+    let fit = calendarView
+      .systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+      .height
+    if fit > maxCalendarFitHeight, let sheet = sheetPresentationController {
+      sheet.animateChanges { sheet.invalidateDetents() }
+    }
   }
 
   override func viewDidDisappear(_ animated: Bool) {

--- a/lib/src/features/onboarding/import/import_birthday_calendar_overlay.dart
+++ b/lib/src/features/onboarding/import/import_birthday_calendar_overlay.dart
@@ -70,6 +70,10 @@ class _ImportBirthdayCalendarPanelState
   static const _panelWidth = 312.0;
   static const _calendarWidth = 280.0;
   static const _cellSize = 40.0;
+  // Weekday row + the fixed six-week day grid. Month/year grids center
+  // within the same box so mode switches and paging never reflow the
+  // panel (VZR-75).
+  static const _modeAreaHeight = _cellSize * 7;
   static const _weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
   late DateTime _visibleMonth;
@@ -234,39 +238,44 @@ class _ImportBirthdayCalendarPanelState
               const SizedBox(height: AppSpacing.xs),
               const AppDecorativeDivider(width: _calendarWidth),
               const SizedBox(height: AppSpacing.xs),
-              ...switch (_selectionMode) {
-                _CalendarSelectionMode.day => [
-                  _WeekdayRow(weekdays: _weekdays),
-                  _DayGrid(
-                    visibleMonth: _visibleMonth,
-                    selectedDate: widget.selectedDate,
-                    firstDate: widget.firstDate,
-                    lastDate: widget.lastDate,
-                    cellSize: _cellSize,
-                    onDateSelected: widget.onDateSelected,
+              SizedBox(
+                height: _modeAreaHeight,
+                child: switch (_selectionMode) {
+                  _CalendarSelectionMode.day => Column(
+                    children: [
+                      _WeekdayRow(weekdays: _weekdays),
+                      _DayGrid(
+                        visibleMonth: _visibleMonth,
+                        selectedDate: widget.selectedDate,
+                        firstDate: widget.firstDate,
+                        lastDate: widget.lastDate,
+                        cellSize: _cellSize,
+                        onDateSelected: widget.onDateSelected,
+                      ),
+                    ],
                   ),
-                ],
-                _CalendarSelectionMode.month => [
-                  _MonthGrid(
-                    visibleYear: _visibleMonth.year,
-                    selectedMonth: widget.selectedDate ?? _visibleMonth,
-                    firstMonth: _firstMonth,
-                    lastMonth: _lastMonth,
-                    width: _calendarWidth,
-                    onMonthSelected: _selectMonth,
+                  _CalendarSelectionMode.month => Center(
+                    child: _MonthGrid(
+                      visibleYear: _visibleMonth.year,
+                      selectedMonth: widget.selectedDate ?? _visibleMonth,
+                      firstMonth: _firstMonth,
+                      lastMonth: _lastMonth,
+                      width: _calendarWidth,
+                      onMonthSelected: _selectMonth,
+                    ),
                   ),
-                ],
-                _CalendarSelectionMode.year => [
-                  _YearGrid(
-                    pageStartYear: _visibleYearPageStart,
-                    selectedYear: (widget.selectedDate ?? _visibleMonth).year,
-                    firstYear: _firstMonth.year,
-                    lastYear: _lastMonth.year,
-                    width: _calendarWidth,
-                    onYearSelected: _selectYear,
+                  _CalendarSelectionMode.year => Center(
+                    child: _YearGrid(
+                      pageStartYear: _visibleYearPageStart,
+                      selectedYear: (widget.selectedDate ?? _visibleMonth).year,
+                      firstYear: _firstMonth.year,
+                      lastYear: _lastMonth.year,
+                      width: _calendarWidth,
+                      onYearSelected: _selectYear,
+                    ),
                   ),
-                ],
-              },
+                },
+              ),
             ],
           ),
         ),
@@ -609,15 +618,11 @@ class _DayGrid extends StatelessWidget {
   Widget build(BuildContext context) {
     final firstOfMonth = _monthStart(visibleMonth);
     final leadingDays = firstOfMonth.weekday % DateTime.daysPerWeek;
-    final daysInMonth = DateTime(
-      visibleMonth.year,
-      visibleMonth.month + 1,
-      0,
-    ).day;
-    final minimumCells = leadingDays + daysInMonth;
-    final neededRows = _ceilDiv(minimumCells, DateTime.daysPerWeek);
-    final rowCount = neededRows < 5 ? 5 : neededRows;
-    final cellCount = rowCount * DateTime.daysPerWeek;
+    // Always six weeks: the tallest month layout, so paging between
+    // months never changes the grid height (VZR-75). Trailing cells
+    // render adjacent-month days disabled and muted, as before.
+    const rowCount = 6;
+    const cellCount = rowCount * DateTime.daysPerWeek;
     final firstCellDate = firstOfMonth.subtract(Duration(days: leadingDays));
 
     return SizedBox(
@@ -737,10 +742,6 @@ bool _isDateBefore(DateTime value, DateTime boundary) {
 
 bool _isDateAfter(DateTime value, DateTime boundary) {
   return _dateOnly(value).isAfter(_dateOnly(boundary));
-}
-
-int _ceilDiv(int value, int divisor) {
-  return (value + divisor - 1) ~/ divisor;
 }
 
 DateTime _clampMonth(DateTime value, DateTime firstMonth, DateTime lastMonth) {

--- a/test/features/onboarding/import_birthday_calendar_panel_test.dart
+++ b/test/features/onboarding/import_birthday_calendar_panel_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/features/onboarding/import/import_birthday_calendar_overlay.dart';
+
+Widget _app({DateTime? initialMonth}) {
+  return MaterialApp(
+    builder: (_, c) => AppTheme(data: AppThemeData.light, child: c!),
+    home: Center(
+      child: ImportBirthdayCalendarPanel(
+        initialMonth: initialMonth ?? DateTime(2026, 7),
+        selectedDate: null,
+        firstDate: DateTime(2020, 1, 1),
+        lastDate: DateTime(2026, 12, 31),
+        onDateSelected: (_) {},
+      ),
+    ),
+  );
+}
+
+Finder _navButton(String iconName) {
+  return find.byWidgetPredicate(
+    (widget) => widget is AppIcon && widget.name == iconName,
+  );
+}
+
+void main() {
+  // VZR-75: the panel must keep one fixed size while paging months and
+  // switching between the day / month / year modes — a 5-row month
+  // jumping to a 6-row month used to reflow the whole sheet.
+  testWidgets('the panel height never changes across months and modes', (
+    tester,
+  ) async {
+    // July 2026 lays out in 5 weeks; August 2026 needs 6.
+    await tester.pumpWidget(_app(initialMonth: DateTime(2026, 7)));
+
+    final panel = find.byType(ImportBirthdayCalendarPanel);
+    final size = tester.getSize(panel);
+
+    // Page into the 6-row month and back.
+    await tester.tap(_navButton(AppIcons.chevronForward));
+    await tester.pump();
+    expect(find.text('August 2026'), findsOneWidget);
+    expect(tester.getSize(panel), size);
+
+    await tester.tap(_navButton(AppIcons.chevronBackward));
+    await tester.pump();
+    expect(find.text('July 2026'), findsOneWidget);
+    expect(tester.getSize(panel), size);
+
+    // Mode switches reuse the same box: day -> month -> year.
+    await tester.tap(find.text('July 2026'));
+    await tester.pump();
+    expect(find.text('Jan'), findsOneWidget);
+    expect(tester.getSize(panel), size);
+
+    await tester.tap(find.text('2026'));
+    await tester.pump();
+    expect(find.text('2025'), findsOneWidget);
+    expect(tester.getSize(panel), size);
+
+    // Year paging keeps it stable too.
+    await tester.tap(_navButton(AppIcons.chevronBackward));
+    await tester.pump();
+    expect(tester.getSize(panel), size);
+  });
+
+  testWidgets('the day grid always shows six weeks', (tester) async {
+    // February 2026 starts on a Sunday and spans exactly 4 weeks — the
+    // shortest possible layout still renders six rows of cells.
+    await tester.pumpWidget(_app(initialMonth: DateTime(2026, 2)));
+
+    final panel = find.byType(ImportBirthdayCalendarPanel);
+    final shortMonthSize = tester.getSize(panel);
+
+    await tester.tap(_navButton(AppIcons.chevronForward));
+    await tester.pump();
+    expect(find.text('March 2026'), findsOneWidget);
+    expect(tester.getSize(panel), shortMonthSize);
+  });
+}


### PR DESCRIPTION
## Summary
- Month navigation bounced the pickers because their height tracked the 5- vs 6-week month layouts
- Native iOS sheet (`DatePickerHandler.swift`): the custom detent now resolves monotonically — grows once for a 6-week month (animated via `animateChanges`) and never shrinks back — instead of `invalidateDetents()` on every layout pass
- Flutter fallback calendar (Android + failure path): fixed six-week day grid, and the month/year grids render inside the same fixed-height box, so paging and mode switches never reflow the panel

Fixes VZR-75

## Test plan
- New `import_birthday_calendar_panel_test.dart`: panel height pinned across 5↔6-row month paging, day/month/year mode switches, and year paging (default lane, passing; the panel is shared with desktop)
- Swift side verified by building and running on the iOS simulator; manual check: birthday step → calendar → chevron July→August 2026 (5→6 rows) — sheet must not bounce

🤖 Generated with [Claude Code](https://claude.com/claude-code)