### PR TITLE
[Draft] Scaffold Sprout parameter download and migration to Orchard

### DIFF
--- a/docs/sprout-migration.md
+++ b/docs/sprout-migration.md
@@ -1,0 +1,51 @@
+# Sprout Migration Support
+
+Issue: [#228](https://github.com/chainapsis/vizor-wallet/issues/228)
+
+## Goal
+
+Add an advanced feature that lets users with legacy Sprout funds download the
+Sprout parameters and migrate those funds into the modern Orchard pool (with
+Sapling as a possible intermediate step).
+
+## Current State
+
+- Vizor supports transparent, Sapling, Orchard, and Unified Addresses.
+- `validate_address` explicitly rejects Sprout addresses.
+- Sapling proving parameters (`sapling-spend.params` and `sapling-output.params`)
+  are downloaded on demand; Orchard requires no trusted-setup parameters.
+
+## High-Level Plan
+
+1. **Parameter download**
+   - Download `sprout-proving.key` and `sprout-verifying.key` from a trusted
+     Zcash mirror (e.g., `https://download.z.cash/downloads/`).
+   - Verify file integrity with published SHA-256 checksums.
+   - Cache the files in a well-known directory (similar to Sapling params).
+
+2. **Sprout viewing support**
+   - Allow Sprout keys to be imported for migration only.
+   - Detect Sprout notes during a limited scan or via migration-specific RPCs.
+
+3. **Migration transaction**
+   - Build a transaction that spends Sprout notes and creates Orchard (or
+     Sapling) notes.
+   - Re-use the existing proposal/execution flow where possible.
+   - Gate the UI behind an "Advanced" or "Legacy Sprout migration" section.
+
+## Open Questions
+
+- Total size of Sprout parameters and whether mobile storage/network limits
+  make this feasible.
+- Whether `librustzcash` exposes the necessary Sprout note detection and
+  spend APIs.
+- Whether Sprout-to-Orchard migration needs to be done directly or via a
+  Sprout-to-Sapling step.
+- How to communicate the trusted-setup implications of Sprout parameters to
+  users.
+
+## Related Code
+
+- `rust/src/wallet/sync/mod.rs` — address validation
+- `rust/src/wallet/sync.rs` — send/proposal flow
+- `lib/src/features/send/screens/send_screen.dart` — send UI and param download

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -493,6 +493,10 @@ mod tests {
     }
 
     #[test]
+    // TODO(#228): This rejection is correct for normal sends, but will need to
+    // become conditional once advanced Sprout migration is implemented. Sprout
+    // addresses should still be rejected for receive/show unless the user is in
+    // the legacy-migration flow.
     fn validate_address_rejects_sprout_addresses() {
         use zcash_address::ToAddress;
 


### PR DESCRIPTION
## Summary

Add an advanced feature that allows users who hold funds in legacy Sprout addresses to download the Sprout parameters and migrate/upgrade those funds to Orchard (or Sapling as an intermediate step).

## Background

- Vizor currently supports transparent, Sapling, Orchard, and Unified Addresses (Sapling + Orchard).
- Sprout addresses are explicitly rejected by `validate_address` (see `validate_address_rejects_sprout_addresses` test in `rust/src/wallet/sync/mod.rs`).
- Sprout is the original Zcash shielded pool and is deprecated; many users still have legacy Sprout funds that need a migration path.

## Proposed Feature

1. **Sprout parameter download**
   - Download `sprout-proving.key` and `sprout-verifying.key` from a trusted source (e.g., Zcash download server).
   - Verify checksums/signatures after download.
   - Cache parameters locally so the download is one-time.

2. **Sprout address support (read-only / migration only)**
   - Allow validating and viewing Sprout addresses in the wallet.
   - Detect Sprout notes belonging to imported keys during sync.

3. **Fund migration / upgrade**
   - Provide a way to migrate Sprout funds to Orchard (or Sapling → Orchard).
   - This is likely a multi-step transaction that consumes Sprout notes and creates Orchard notes.
   - Should be gated behind an "Advanced" or "Legacy migration" UI section because Sprout parameters are large and the flow is complex.

## Motivation

Without this feature, users with legacy Sprout funds cannot use Vizor to manage or migrate those funds. Providing a migration path improves accessibility and helps users move funds from the deprecated Sprout pool into the modern Orchard pool.

## Open Questions / Considerations

- What is the total size of the Sprout parameters? Are they larger than Sapling params (~50 MB)?
- Does the current `librustzcash` stack expose APIs for Sprout note detection and migration transactions?
- Should migration be Orchard-direct, or Sapling-then-Orchard?
- How should the UI communicate that this is an advanced / legacy feature?
- Are there security implications for downloading legacy Sprout parameters?

## Related Code

- `rust/src/wallet/sync/mod.rs` — address validation and Sprout rejection test
- `rust/src/wallet/sync.rs` — send/propose flow
- `lib/src/features/send/screens/send_screen.dart` — send UI and parameter download flow

---

This is a large feature; it probably warrants a design doc before implementation.
