### PR TITLE
[codex] Adjust desktop sidebar padding by platform

### DIFF
--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -28,6 +28,7 @@ import '../widgets/app_profile_picture.dart';
 import '../widgets/app_tappable.dart';
 import '../widgets/app_toast.dart';
 import 'app_desktop_shell.dart';
+import 'desktop_sidebar_spacing.dart';
 
 class AppMainSidebar extends ConsumerStatefulWidget {
   const AppMainSidebar({super.key});
@@ -328,7 +329,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
       child: LayoutBuilder(
         builder: (context, constraints) {
           final compact = constraints.maxHeight < 640;
-          final topPadding = compact ? AppSpacing.s : 40.0;
+          final topPadding = mainSidebarTopPadding(compact: compact);
           final headerNavGap = compact ? AppSpacing.xs : AppSpacing.md;
           final bottomPadding = compact ? AppSpacing.xs : AppSpacing.md;
           final bottomSyncGap = compact ? AppSpacing.xs : AppSpacing.md;
@@ -402,9 +403,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                       active: _matches('/voting'),
                       // Stays tappable while active: _navigateTo requests a
                       // poll-list refresh when re-tapped on /voting.
-                      onTap: isImporting
-                          ? null
-                          : () => _navigateTo('/voting'),
+                      onTap: isImporting ? null : () => _navigateTo('/voting'),
                     ),
                     const SizedBox(height: AppSpacing.xs),
                     AppSidebarItem(

--- a/lib/src/core/layout/desktop_sidebar_spacing.dart
+++ b/lib/src/core/layout/desktop_sidebar_spacing.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform;
+
+import '../theme/app_spacing.dart';
+
+const _macOSWindowControlsTopInset = 40.0;
+
+bool _reservesSpaceForWindowControls(TargetPlatform platform) {
+  return platform == TargetPlatform.macOS;
+}
+
+double mainSidebarTopPadding({
+  required bool compact,
+  TargetPlatform? platform,
+}) {
+  final effectivePlatform = platform ?? defaultTargetPlatform;
+  if (!_reservesSpaceForWindowControls(effectivePlatform)) {
+    return AppSpacing.sm;
+  }
+
+  return compact ? AppSpacing.s : _macOSWindowControlsTopInset;
+}
+
+double onboardingSidebarTopOffset({TargetPlatform? platform}) {
+  final effectivePlatform = platform ?? defaultTargetPlatform;
+  return _reservesSpaceForWindowControls(effectivePlatform)
+      ? _macOSWindowControlsTopInset
+      : 0;
+}

--- a/lib/src/features/onboarding/shared/onboarding_chrome.dart
+++ b/lib/src/features/onboarding/shared/onboarding_chrome.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../core/layout/app_desktop_shell.dart';
+import '../../../core/layout/desktop_sidebar_spacing.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -171,7 +172,7 @@ class OnboardingSidebarChrome extends StatelessWidget {
         children: [
           Positioned.fill(child: illustration),
           Positioned.fill(
-            top: 40,
+            top: onboardingSidebarTopOffset(),
             child: Padding(
               padding: const EdgeInsets.all(AppSpacing.xs),
               child: OnboardingSidebarNav(steps: steps),

--- a/test/core/layout/desktop_sidebar_spacing_test.dart
+++ b/test/core/layout/desktop_sidebar_spacing_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/foundation.dart' show TargetPlatform;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/desktop_sidebar_spacing.dart';
+import 'package:zcash_wallet/src/core/theme/app_spacing.dart';
+
+void main() {
+  group('mainSidebarTopPadding', () {
+    test('keeps the macOS window-controls reserve in regular height', () {
+      expect(
+        mainSidebarTopPadding(compact: false, platform: TargetPlatform.macOS),
+        40,
+      );
+    });
+
+    test('keeps the compact macOS top padding', () {
+      expect(
+        mainSidebarTopPadding(compact: true, platform: TargetPlatform.macOS),
+        AppSpacing.s,
+      );
+    });
+
+    test('matches side padding on Windows and Linux', () {
+      expect(
+        mainSidebarTopPadding(compact: false, platform: TargetPlatform.windows),
+        AppSpacing.sm,
+      );
+      expect(
+        mainSidebarTopPadding(compact: true, platform: TargetPlatform.linux),
+        AppSpacing.sm,
+      );
+    });
+  });
+
+  group('onboardingSidebarTopOffset', () {
+    test('keeps the macOS window-controls reserve', () {
+      expect(onboardingSidebarTopOffset(platform: TargetPlatform.macOS), 40);
+    });
+
+    test('uses the sidebar content padding on Windows and Linux', () {
+      expect(onboardingSidebarTopOffset(platform: TargetPlatform.windows), 0);
+      expect(onboardingSidebarTopOffset(platform: TargetPlatform.linux), 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add a shared desktop sidebar spacing helper that preserves the macOS traffic-light reserve only on macOS.
- Use the helper in the main sidebar and onboarding sidebar chrome.
- Cover macOS, Windows, and Linux spacing behavior with focused unit tests.

## Why
Windows and Linux do not use the same full-window macOS chrome treatment, so the sidebar did not need the extra top reserve that protects macOS window controls. The new values align top spacing with the existing side padding on non-macOS desktop targets while preserving the macOS behavior.

## Validation
- `fvm flutter test test\core\layout\desktop_sidebar_spacing_test.dart test\app_main_sidebar_test.dart`
- `fvm flutter analyze`

Note: local FVM commands still print `Can't load Kernel binary: Invalid SDK hash.` after completing, but the commands exited successfully.