### PR TITLE
[codex] Add medium haptic to home balance hide/reveal

### DIFF
--- a/lib/src/core/feedback/app_haptics.dart
+++ b/lib/src/core/feedback/app_haptics.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 
-/// Haptic vocabulary for the passcode surfaces and the mobile tab bar.
+/// Haptic vocabulary for passcode surfaces, mobile navigation, and
+/// privacy controls.
 ///
 /// All methods are fire-and-forget safe — call them unawaited so a slow
 /// platform round trip never delays input handling.
@@ -15,6 +16,10 @@ abstract final class AppHaptics {
   /// subtle selection tick (iOS UISelectionFeedbackGenerator), one step
   /// softer than the digits.
   static Future<void> auxiliaryKey() => HapticFeedback.selectionClick();
+
+  /// Privacy visibility toggles — a more deliberate medium tap (iOS
+  /// UIImpactFeedbackGenerator(.medium)).
+  static Future<void> privacyToggle() => HapticFeedback.mediumImpact();
 
   /// A rejected passcode. Native notification-error where the platform
   /// has one (iOS UINotificationFeedbackGenerator(.error), Android

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../../core/feedback/app_haptics.dart';
 import '../../../../core/formatting/sync_status_label.dart';
 import '../../../../core/config/network_config.dart';
 import '../../../../core/formatting/zec_amount.dart';
@@ -334,7 +337,10 @@ class _PrivacyEyeButton extends StatelessWidget {
       button: true,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: onTap,
+        onTap: () {
+          unawaited(AppHaptics.privacyToggle());
+          onTap();
+        },
         child: Container(
           // 40 px disc, a step lighter than the card (#393C3C on
           // #2E3232), per the Figma privacy toggle.

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -152,6 +153,23 @@ void main() {
   });
 
   testWidgets('privacy eye masks the balance', (tester) async {
+    final impactTypes = <Object?>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'HapticFeedback.vibrate') {
+          impactTypes.add(call.arguments);
+        }
+        return null;
+      },
+    );
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      ),
+    );
+
     await tester.pumpWidget(
       _app(_syncedState(orchardBalance: BigInt.from(14312000000))),
     );
@@ -164,6 +182,7 @@ void main() {
       find.textContaining(fixedPrivacyMask(), findRichText: true),
       findsOneWidget,
     );
+    expect(impactTypes, ['HapticFeedbackType.mediumImpact']);
     expect(find.textContaining('143.12', findRichText: true), findsNothing);
   });
 


### PR DESCRIPTION
## Summary

- Adds a medium haptic helper to the shared `AppHaptics` vocabulary.
- Triggers that haptic when the mobile home shielded-balance eye button hides or reveals the balance.
- Extends the mobile home widget test to assert the privacy toggle sends `HapticFeedbackType.mediumImpact`.

## Linear

VZR-79

## Validation

- `fvm dart format lib/src/core/feedback/app_haptics.dart lib/src/features/home/screens/mobile/mobile_home_screen.dart test/features/home/mobile_home_screen_test.dart`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/home/mobile_home_screen_test.dart`
- `fvm flutter analyze`
