### PR TITLE
[codex] Refine mobile import paste flow

### DIFF
--- a/integration_test/regtest_mobile_fallback_endpoint_test.dart
+++ b/integration_test/regtest_mobile_fallback_endpoint_test.dart
@@ -100,7 +100,6 @@ void main() {
 Future<void> _pasteAndReview(WidgetTester tester) async {
   await Clipboard.setData(const ClipboardData(text: _mnemonic));
   await tapAppButton(tester, const ValueKey('mobile_import_paste'));
-  await tapAppButton(tester, const ValueKey('mobile_import_confirm'));
   await tapAppButton(tester, const ValueKey('mobile_import_review_continue'));
 }
 

--- a/integration_test/regtest_mobile_screenshot_tour_test.dart
+++ b/integration_test/regtest_mobile_screenshot_tour_test.dart
@@ -89,7 +89,9 @@ void main() {
       clipboardGate.complete();
       await pumpUntil(
         tester,
-        () => tester.any(find.text("Can’t read clipboard data")),
+        () => tester.any(
+          find.text('Secret Passphrase must be 12, 15, 18, 21, or 24 words'),
+        ),
         description: 'import clipboard error',
       );
       await shot('02b_import_clipboard_error');

--- a/integration_test/regtest_mobile_screenshot_tour_test.dart
+++ b/integration_test/regtest_mobile_screenshot_tour_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -71,6 +73,30 @@ void main() {
       // ── Import flow (funded wallet) ────────────────────────────────
       await tapWidget(tester, const ValueKey('mobile_welcome_import'));
       await shot('02_import_entry');
+      final clipboardGate = Completer<void>();
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.getData') {
+            await clipboardGate.future;
+            return {'text': 'one two three'};
+          }
+          return null;
+        },
+      );
+      await tapAppButton(tester, const ValueKey('mobile_import_paste'));
+      await shot('02a_import_clipboard_reading');
+      clipboardGate.complete();
+      await pumpUntil(
+        tester,
+        () => tester.any(find.text("Can’t read clipboard data")),
+        description: 'import clipboard error',
+      );
+      await shot('02b_import_clipboard_error');
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
       await tapWidget(
         tester,
         const ValueKey('mobile_import_enter_manually'),
@@ -92,14 +118,6 @@ void main() {
       );
       await Clipboard.setData(const ClipboardData(text: _mnemonic));
       await tapAppButton(tester, const ValueKey('mobile_import_paste'));
-      await pumpUntil(
-        tester,
-        () =>
-            tester.any(find.byKey(const ValueKey('mobile_import_confirm'))),
-        description: 'import slots filled',
-      );
-      await shot('02b_import_entry_filled');
-      await tapAppButton(tester, const ValueKey('mobile_import_confirm'));
       await pumpUntil(
         tester,
         () => tester.any(

--- a/integration_test/support/mobile_regtest_flow.dart
+++ b/integration_test/support/mobile_regtest_flow.dart
@@ -307,8 +307,7 @@ Future<void> importWalletViaPaste(
   await tapWidget(tester, const ValueKey('mobile_welcome_import'));
   await Clipboard.setData(ClipboardData(text: mnemonic));
   await tapAppButton(tester, const ValueKey('mobile_import_paste'));
-  // Paste fills the slots in place; confirm moves to the review screen.
-  await tapAppButton(tester, const ValueKey('mobile_import_confirm'));
+  // A valid paste now opens the review screen directly.
   await tapAppButton(tester, const ValueKey('mobile_import_review_continue'));
   // Block height is a real text field on the system keyboard.
   await tapWidget(

--- a/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
@@ -105,8 +105,7 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
   /// are pure lowercase a–z, so anything else (spaces, commas, numbered
   /// "1." prefixes, punctuation) is treated as a separator — a phrase
   /// copied in almost any shape tokenises cleanly.
-  List<String> _tokenize(String raw) =>
-      raw.toLowerCase().split(RegExp(r'[^a-z]+')).where((t) => t.isNotEmpty).toList();
+  List<String> _tokenize(String raw) => parseMnemonicWords(raw);
 
   void _onChanged(String value) {
     final tokens = _tokenize(value);

--- a/lib/src/features/onboarding/mobile/mobile_import_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_screens.dart
@@ -6,15 +6,13 @@ import '../../../../main.dart' show log;
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
-import '../../../core/widgets/app_toast.dart';
 import '../../../rust/api/wallet.dart' as rust_wallet;
 import 'mobile_onboarding_scaffold.dart';
 
-/// Mnemonic lengths the wallet accepts. The Figma frames show a fixed
-/// 24-slot card; shorter standard phrases are accepted anyway and the
-/// counter simply stops early (WIP-design gap filled deliberately).
+/// Mnemonic lengths the wallet accepts from clipboard or manual entry.
 const kMnemonicWordCounts = [12, 15, 18, 21, 24];
 const kMnemonicMaxWords = 24;
+const _kImportSeedCardWidth = 361.0;
 
 /// Words ready for review, carried between the import steps.
 class MobileImportReviewArgs {
@@ -42,10 +40,11 @@ String? validateImportedMnemonic(List<String> words) {
   return null;
 }
 
-/// Import entry — Figma `Import — Secret Passprhase Paste` /
-/// `Clipboard Errors` (4575:108577 / 4575:108752): the empty numbered
-/// slots with a paste action, clipboard problems surfaced as toasts,
-/// and an Enter Manually link into the word-by-word wizard.
+enum _ImportPastePhase { idle, reading, error }
+
+/// Import entry — Figma `Import — Secret Passprhase Paste`
+/// (4575:108577 / 4746:82920 / 4746:22880): a clipboard-reading card
+/// with idle, loading, and error states, plus a manual-entry link.
 class MobileImportScreen extends StatefulWidget {
   const MobileImportScreen({super.key});
 
@@ -54,254 +53,227 @@ class MobileImportScreen extends StatefulWidget {
 }
 
 class _MobileImportScreenState extends State<MobileImportScreen> {
-  List<String> _words = const [];
-  String? _error;
+  _ImportPastePhase _phase = _ImportPastePhase.idle;
 
   Future<void> _paste() async {
+    if (_phase == _ImportPastePhase.reading) return;
+    setState(() => _phase = _ImportPastePhase.reading);
+
     String? text;
     try {
       text = (await Clipboard.getData(Clipboard.kTextPlain))?.text;
     } catch (e) {
       log('MobileImport: ERROR reading clipboard: $e');
-      if (mounted) {
-        showAppToast(
-          context,
-          "Can't read clipboard data",
-          iconName: AppIcons.cross,
-        );
-      }
+      if (mounted) setState(() => _phase = _ImportPastePhase.error);
       return;
     }
+    if (!mounted) return;
+
     final words = (text ?? '')
         .split(RegExp(r'\s+'))
         .where((w) => w.isNotEmpty)
         .map((w) => w.toLowerCase())
         .toList();
     if (words.isEmpty) {
-      if (!mounted) return;
-      setState(() {
-        _words = const [];
-        _error = null;
-      });
-      showAppToast(context, 'Clipboard is empty', iconName: AppIcons.cross);
+      setState(() => _phase = _ImportPastePhase.error);
       return;
     }
     final error = validateImportedMnemonic(words);
-    setState(() {
-      _words = words;
-      _error = error;
-    });
-  }
-
-  void _clear() {
-    setState(() {
-      _words = const [];
-      _error = null;
-    });
-  }
-
-  void _confirm() {
-    context.push(
+    if (error != null) {
+      log('MobileImport: rejected clipboard mnemonic: $error');
+      setState(() => _phase = _ImportPastePhase.error);
+      return;
+    }
+    setState(() => _phase = _ImportPastePhase.idle);
+    if (!mounted) return;
+    await context.push(
       '/import/review',
-      extra: MobileImportReviewArgs(words: _words),
+      extra: MobileImportReviewArgs(words: words),
     );
   }
 
-  bool get _filled => _words.isNotEmpty && _error == null;
-
   @override
   Widget build(BuildContext context) {
-    final colors = context.colors;
     return MobileOnboardingStepScaffold(
       progress: 0.2,
       onBack: () => Navigator.of(context).maybePop(),
-      title: 'Import Your Wallet',
+      title: 'Import Wallet',
       // Line break matches the Figma subtitle wrap.
-      subtitle: 'Paste your Secret Passphrase or\nenter it manually word by word.',
-      bottomArea: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
+      subtitle:
+          'Paste your Secret Passphrase or\nenter it manually word by word.',
+      child: Column(
         children: [
-          if (_error != null) ...[
-            Text(
-              _error!,
-              textAlign: TextAlign.center,
-              style: AppTypography.bodySmall.copyWith(
-                color: colors.text.destructive,
-              ),
-            ),
-            const SizedBox(height: AppSpacing.xs),
-          ],
-          if (_filled) ...[
-            // Pasted state — Figma fills the slots in place and swaps
-            // the actions for confirm / clear.
-            AppButton(
-              key: const ValueKey('mobile_import_confirm'),
-              expand: true,
-              onPressed: _confirm,
-              trailing: const AppIcon(AppIcons.chevronForward),
-              child: const Text('Confirm & import'),
-            ),
-            const SizedBox(height: AppSpacing.xs),
-            Semantics(
-              button: true,
-              child: GestureDetector(
-                key: const ValueKey('mobile_import_clear'),
-                behavior: HitTestBehavior.opaque,
-                onTap: _clear,
-                child: SizedBox(
-                  height: 44,
-                  child: Center(
-                    child: Text(
-                      'Clear secret phrase',
-                      style: AppTypography.labelLarge.copyWith(
-                        color: colors.text.primary,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ] else ...[
-            AppButton(
-              key: const ValueKey('mobile_import_paste'),
-              expand: true,
-              onPressed: _paste,
-              // No explicit icon color: AppButton's IconTheme tints it
-              // with the label color (white on the primary fill).
-              leading: const AppIcon(AppIcons.copy),
-              child: const Text('Paste secret phrase'),
-            ),
-            const SizedBox(height: AppSpacing.xs),
-            Semantics(
-              button: true,
-              child: GestureDetector(
-                key: const ValueKey('mobile_import_enter_manually'),
-                behavior: HitTestBehavior.opaque,
-                onTap: () => context.push('/import/manual'),
-                child: SizedBox(
-                  height: 44,
-                  child: Center(
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        AppIcon(
-                          AppIcons.edit,
-                          size: AppIconSize.medium,
-                          color: colors.text.primary,
-                        ),
-                        const SizedBox(width: AppSpacing.xs),
-                        Text(
-                          'Enter manually',
-                          style: AppTypography.labelLarge.copyWith(
-                            color: colors.text.primary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
+          const SizedBox(height: AppSpacing.xs),
+          _ImportPasteCard(phase: _phase, onPaste: _paste),
+          const SizedBox(height: AppSpacing.base),
+          _ManualImportLink(onTap: () => context.push('/import/manual')),
         ],
       ),
-      // VZR-71: users instinctively tap the slot grid expecting to
-      // type — route the tap into the manual wizard, same as the Enter
-      // manually link. Once a valid phrase fills the card it is a
-      // review surface and the tap is disabled.
-      child: _filled
-          ? ImportSlotsCard(words: _words)
-          : Semantics(
-              button: true,
-              label: 'Enter secret phrase manually',
-              child: GestureDetector(
-                key: const ValueKey('mobile_import_slots'),
-                behavior: HitTestBehavior.opaque,
-                onTap: () => context.push('/import/manual'),
-                child: ImportSlotsCard(words: _words),
-              ),
-            ),
     );
   }
 }
 
-/// The dark numbered-slot card from the clipboard frame: empty
-/// underlined slots that fill as words arrive.
-class ImportSlotsCard extends StatelessWidget {
-  const ImportSlotsCard({required this.words, super.key});
+class _ImportPasteCard extends StatelessWidget {
+  const _ImportPasteCard({required this.phase, required this.onPaste});
 
-  final List<String> words;
+  final _ImportPastePhase phase;
+  final VoidCallback onPaste;
+
+  bool get _isError => phase == _ImportPastePhase.error;
+  bool get _isReading => phase == _ImportPastePhase.reading;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final slotCount = words.length > kMnemonicMaxWords
-        ? words.length
-        : kMnemonicMaxWords;
-    final rows = (slotCount / 3).ceil();
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.md,
-        vertical: AppSpacing.lg,
-      ),
-      decoration: BoxDecoration(
-        color: colors.background.homeCard,
-        borderRadius: BorderRadius.circular(AppRadii.xLarge),
-      ),
-      child: Column(
-        children: [
-          for (var row = 0; row < rows; row++) ...[
-            // 8 px between rows puts the underlines on the 37 px pitch
-            // of the Figma slot grid.
-            if (row > 0) const SizedBox(height: AppSpacing.xs),
-            Row(
+    final cardHeight = phase == _ImportPastePhase.idle ? 370.0 : 390.0;
+    final verticalPadding = phase == _ImportPastePhase.idle
+        ? AppSpacing.lg
+        : AppSpacing.base;
+    final contentGap = phase == _ImportPastePhase.idle
+        ? AppSpacing.lg - 3
+        : AppSpacing.base - 1;
+    final iconColor = _isError
+        ? colors.text.destructive
+        : colors.text.homeCard.withValues(alpha: 0.5);
+
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: _kImportSeedCardWidth),
+      child: SizedBox(
+        width: double.infinity,
+        height: cardHeight,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: colors.background.homeCard,
+            borderRadius: BorderRadius.circular(AppRadii.xLarge),
+          ),
+          child: Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: AppSpacing.md,
+              vertical: verticalPadding,
+            ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                for (var col = 0; col < 3; col++) ...[
-                  if (col > 0) const SizedBox(width: AppSpacing.s),
-                  Expanded(child: _slot(context, row * 3 + col)),
-                ],
+                AppIcon(AppIcons.importWallet, size: 33, color: iconColor),
+                SizedBox(height: contentGap),
+                _ImportPasteCardText(isError: _isError),
+                SizedBox(height: contentGap),
+                IgnorePointer(
+                  ignoring: _isReading,
+                  child: AppButton(
+                    key: const ValueKey('mobile_import_paste'),
+                    onPressed: onPaste,
+                    variant: AppButtonVariant.secondary,
+                    size: AppButtonSize.medium,
+                    height: 36,
+                    minWidth: 96,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.s,
+                    ),
+                    leading: AppIcon(
+                      _isError
+                          ? AppIcons.renew
+                          : _isReading
+                          ? AppIcons.loader
+                          : AppIcons.copy,
+                    ),
+                    child: Text(
+                      _isError
+                          ? 'Try again'
+                          : _isReading
+                          ? 'Reading...'
+                          : 'Paste',
+                    ),
+                  ),
+                ),
               ],
             ),
-          ],
-        ],
+          ),
+        ),
       ),
     );
   }
+}
 
-  Widget _slot(BuildContext context, int index) {
+class _ImportPasteCardText extends StatelessWidget {
+  const _ImportPasteCardText({required this.isError});
+
+  final bool isError;
+
+  @override
+  Widget build(BuildContext context) {
     final colors = context.colors;
-    final word = index < words.length ? words[index] : null;
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          children: [
-            Text(
-              '${index + 1}'.padLeft(2, '0'),
-              style: AppTypography.codeSmall.copyWith(
-                color: colors.text.homeCard.withValues(alpha: 0.45),
-              ),
-            ),
-            const SizedBox(width: AppSpacing.xxs),
-            Expanded(
-              child: Text(
-                word ?? '',
-                overflow: TextOverflow.ellipsis,
-                style: AppTypography.bodyMedium.copyWith(
-                  color: colors.text.homeCard,
-                ),
-              ),
-            ),
-          ],
+        Text(
+          isError ? "Can’t read clipboard data" : 'Paste from clipboard',
+          textAlign: TextAlign.center,
+          style: AppTypography.bodyLarge.copyWith(
+            color: isError ? colors.text.destructive : colors.text.homeCard,
+            fontWeight: FontWeight.w600,
+          ),
         ),
-        const SizedBox(height: 2),
-        Container(
-          height: 1,
-          color: colors.text.homeCard.withValues(alpha: 0.25),
+        const SizedBox(height: AppSpacing.s),
+        Text(
+          'Accept 12, 15, 18, 21 or 24-\nword Secret Passphrases',
+          textAlign: TextAlign.center,
+          softWrap: false,
+          overflow: TextOverflow.visible,
+          style: AppTypography.bodyMediumStrong.copyWith(
+            color: colors.text.homeCard.withValues(alpha: 0.5),
+          ),
         ),
       ],
+    );
+  }
+}
+
+class _ManualImportLink extends StatelessWidget {
+  const _ManualImportLink({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: _kImportSeedCardWidth),
+      child: Semantics(
+        button: true,
+        child: GestureDetector(
+          key: const ValueKey('mobile_import_enter_manually'),
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: SizedBox(
+            height: 50,
+            width: double.infinity,
+            child: Center(
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  AppIcon(
+                    AppIcons.edit,
+                    size: 20,
+                    color: colors.button.ghost.label,
+                  ),
+                  const SizedBox(width: AppSpacing.xs),
+                  Flexible(
+                    fit: FlexFit.loose,
+                    child: Text(
+                      'Enter Secret Passphrase manually',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.button.ghost.label,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/src/features/onboarding/mobile/mobile_import_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_screens.dart
@@ -19,6 +19,7 @@ const _kImportPasteCardMinHeight = 320.0;
 const _kImportManualLinkHeight = 50.0;
 const _kImportContentTopGap = AppSpacing.xs;
 const _kImportContentGap = AppSpacing.base;
+const _kImportContentBottomReserve = 90.0;
 const _kClipboardReadError = "Can’t read clipboard data";
 const _kClipboardEmptyError = "Clipboard doesn’t contain a Secret Passphrase";
 const _kMnemonicWordCountError =
@@ -194,7 +195,8 @@ class _ImportPasteContent extends StatelessWidget {
         final fixedHeight =
             _kImportContentTopGap +
             _kImportContentGap +
-            _kImportManualLinkHeight;
+            _kImportManualLinkHeight +
+            _kImportContentBottomReserve;
 
         final availableCardHeight = constraints.hasBoundedHeight
             ? constraints.maxHeight - fixedHeight
@@ -219,6 +221,7 @@ class _ImportPasteContent extends StatelessWidget {
             ),
             const SizedBox(height: _kImportContentGap),
             _ManualImportLink(onTap: onEnterManually),
+            const SizedBox(height: _kImportContentBottomReserve),
           ],
         );
 

--- a/lib/src/features/onboarding/mobile/mobile_import_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_screens.dart
@@ -13,6 +13,12 @@ import 'mobile_onboarding_scaffold.dart';
 const kMnemonicWordCounts = [12, 15, 18, 21, 24];
 const kMnemonicMaxWords = 24;
 const _kImportSeedCardWidth = 361.0;
+const _kImportPasteCardIdleHeight = 370.0;
+const _kImportPasteCardActiveHeight = 390.0;
+const _kImportPasteCardMinHeight = 320.0;
+const _kImportManualLinkHeight = 50.0;
+const _kImportContentTopGap = AppSpacing.xs;
+const _kImportContentGap = AppSpacing.base;
 const _kClipboardReadError = "Can’t read clipboard data";
 const _kClipboardEmptyError = "Clipboard doesn’t contain a Secret Passphrase";
 const _kMnemonicWordCountError =
@@ -153,29 +159,85 @@ class _MobileImportScreenState extends State<MobileImportScreen> {
       // Line break matches the Figma subtitle wrap.
       subtitle:
           'Paste your Secret Passphrase or\nenter it manually word by word.',
-      child: Column(
-        children: [
-          const SizedBox(height: AppSpacing.xs),
-          _ImportPasteCard(
-            phase: _phase,
-            errorTitle: _errorTitle,
-            onPaste: _paste,
-          ),
-          const SizedBox(height: AppSpacing.base),
-          _ManualImportLink(onTap: () => context.push('/import/manual')),
-        ],
+      scrollable: false,
+      child: _ImportPasteContent(
+        phase: _phase,
+        errorTitle: _errorTitle,
+        onPaste: _paste,
+        onEnterManually: () => context.push('/import/manual'),
       ),
+    );
+  }
+}
+
+class _ImportPasteContent extends StatelessWidget {
+  const _ImportPasteContent({
+    required this.phase,
+    required this.errorTitle,
+    required this.onPaste,
+    required this.onEnterManually,
+  });
+
+  final _ImportPastePhase phase;
+  final String errorTitle;
+  final VoidCallback onPaste;
+  final VoidCallback onEnterManually;
+
+  double get _preferredCardHeight => phase == _ImportPastePhase.idle
+      ? _kImportPasteCardIdleHeight
+      : _kImportPasteCardActiveHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final fixedHeight =
+            _kImportContentTopGap +
+            _kImportContentGap +
+            _kImportManualLinkHeight;
+
+        final availableCardHeight = constraints.hasBoundedHeight
+            ? constraints.maxHeight - fixedHeight
+            : _preferredCardHeight;
+        final shouldScroll =
+            constraints.hasBoundedHeight &&
+            availableCardHeight < _kImportPasteCardMinHeight;
+        final cardHeight = shouldScroll
+            ? _kImportPasteCardMinHeight
+            : availableCardHeight
+                  .clamp(_kImportPasteCardMinHeight, _preferredCardHeight)
+                  .toDouble();
+        final content = Column(
+          mainAxisSize: shouldScroll ? MainAxisSize.min : MainAxisSize.max,
+          children: [
+            const SizedBox(height: _kImportContentTopGap),
+            _ImportPasteCard(
+              height: cardHeight,
+              phase: phase,
+              errorTitle: errorTitle,
+              onPaste: onPaste,
+            ),
+            const SizedBox(height: _kImportContentGap),
+            _ManualImportLink(onTap: onEnterManually),
+          ],
+        );
+
+        if (!shouldScroll) return content;
+        return SingleChildScrollView(child: content);
+      },
     );
   }
 }
 
 class _ImportPasteCard extends StatelessWidget {
   const _ImportPasteCard({
+    required this.height,
     required this.phase,
     required this.errorTitle,
     required this.onPaste,
   });
 
+  final double height;
   final _ImportPastePhase phase;
   final String errorTitle;
   final VoidCallback onPaste;
@@ -183,16 +245,30 @@ class _ImportPasteCard extends StatelessWidget {
   bool get _isError => phase == _ImportPastePhase.error;
   bool get _isReading => phase == _ImportPastePhase.reading;
 
+  double get _preferredHeight => phase == _ImportPastePhase.idle
+      ? _kImportPasteCardIdleHeight
+      : _kImportPasteCardActiveHeight;
+
+  double _scaled(double min, double max) {
+    final range = _preferredHeight - _kImportPasteCardMinHeight;
+    if (range <= 0) return max;
+    final t = ((height - _kImportPasteCardMinHeight) / range)
+        .clamp(0.0, 1.0)
+        .toDouble();
+    return min + ((max - min) * t);
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final cardHeight = phase == _ImportPastePhase.idle ? 370.0 : 390.0;
-    final verticalPadding = phase == _ImportPastePhase.idle
+    final preferredVerticalPadding = phase == _ImportPastePhase.idle
         ? AppSpacing.lg
         : AppSpacing.base;
-    final contentGap = phase == _ImportPastePhase.idle
+    final preferredContentGap = phase == _ImportPastePhase.idle
         ? AppSpacing.lg - 3
         : AppSpacing.base - 1;
+    final verticalPadding = _scaled(AppSpacing.base, preferredVerticalPadding);
+    final contentGap = _scaled(AppSpacing.sm, preferredContentGap);
     final iconColor = _isError
         ? colors.text.destructive
         : colors.text.homeCard.withValues(alpha: 0.5);
@@ -200,8 +276,9 @@ class _ImportPasteCard extends StatelessWidget {
     return ConstrainedBox(
       constraints: const BoxConstraints(maxWidth: _kImportSeedCardWidth),
       child: SizedBox(
+        key: const ValueKey('mobile_import_paste_card'),
         width: double.infinity,
-        height: cardHeight,
+        height: height,
         child: DecoratedBox(
           decoration: BoxDecoration(
             color: colors.background.homeCard,

--- a/lib/src/features/onboarding/mobile/mobile_import_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_screens.dart
@@ -13,6 +13,15 @@ import 'mobile_onboarding_scaffold.dart';
 const kMnemonicWordCounts = [12, 15, 18, 21, 24];
 const kMnemonicMaxWords = 24;
 const _kImportSeedCardWidth = 361.0;
+const _kClipboardReadError = "Can’t read clipboard data";
+const _kClipboardEmptyError = "Clipboard doesn’t contain a Secret Passphrase";
+const _kMnemonicWordCountError =
+    'Secret Passphrase must be 12, 15, 18, 21, or 24 words';
+const _kMnemonicUnknownWordsError =
+    "Some words aren’t in the passphrase word list";
+const _kMnemonicInvalidError = "That Secret Passphrase isn’t valid";
+const _kMnemonicValidationUnavailableError =
+    "That passphrase couldn't be checked. Try again.";
 
 /// Words ready for review, carried between the import steps.
 class MobileImportReviewArgs {
@@ -23,19 +32,40 @@ class MobileImportReviewArgs {
   String get mnemonic => words.join(' ');
 }
 
+/// Normalises pasted mnemonic-like text into candidate BIP-39 words.
+///
+/// English BIP-39 words are lowercase ASCII letters, so numbers,
+/// punctuation, commas, and copied list prefixes like `1.` are separators.
+List<String> parseMnemonicWords(String raw) => raw
+    .toLowerCase()
+    .split(RegExp(r'[^a-z]+'))
+    .where((word) => word.isNotEmpty)
+    .toList();
+
 /// Validates a candidate phrase; returns an error message or null.
-String? validateImportedMnemonic(List<String> words) {
+String? validateImportedMnemonic(
+  List<String> words, {
+  Set<String>? wordList,
+  bool Function(String mnemonic)? validateMnemonic,
+}) {
+  if (words.isEmpty) return _kClipboardEmptyError;
   if (!kMnemonicWordCounts.contains(words.length)) {
-    return 'A secret passphrase has 12, 15, 18, 21, or 24 words — '
-        'found ${words.length}.';
+    return _kMnemonicWordCountError;
+  }
+  if (wordList != null && words.any((word) => !wordList.contains(word))) {
+    return _kMnemonicUnknownWordsError;
   }
   try {
-    if (!rust_wallet.validateMnemonic(mnemonic: words.join(' '))) {
-      return "That passphrase isn't valid. Check the words and try again.";
+    final mnemonic = words.join(' ');
+    final isValid =
+        validateMnemonic?.call(mnemonic) ??
+        rust_wallet.validateMnemonic(mnemonic: mnemonic);
+    if (!isValid) {
+      return _kMnemonicInvalidError;
     }
   } catch (e) {
     log('validateImportedMnemonic: ERROR: $e');
-    return "That passphrase couldn't be checked. Try again.";
+    return _kMnemonicValidationUnavailableError;
   }
   return null;
 }
@@ -46,7 +76,14 @@ enum _ImportPastePhase { idle, reading, error }
 /// (4575:108577 / 4746:82920 / 4746:22880): a clipboard-reading card
 /// with idle, loading, and error states, plus a manual-entry link.
 class MobileImportScreen extends StatefulWidget {
-  const MobileImportScreen({super.key});
+  const MobileImportScreen({
+    this.mnemonicWordListOverride,
+    this.validateMnemonicOverride,
+    super.key,
+  });
+
+  final List<String>? mnemonicWordListOverride;
+  final bool Function(String mnemonic)? validateMnemonicOverride;
 
   @override
   State<MobileImportScreen> createState() => _MobileImportScreenState();
@@ -54,6 +91,25 @@ class MobileImportScreen extends StatefulWidget {
 
 class _MobileImportScreenState extends State<MobileImportScreen> {
   _ImportPastePhase _phase = _ImportPastePhase.idle;
+  String _errorTitle = _kClipboardReadError;
+
+  Set<String>? _wordList() {
+    final override = widget.mnemonicWordListOverride;
+    if (override != null) return override.toSet();
+    try {
+      return rust_wallet.mnemonicWordList().toSet();
+    } catch (e) {
+      log('MobileImport: ERROR loading mnemonic word list: $e');
+      return null;
+    }
+  }
+
+  void _showError(String title) {
+    setState(() {
+      _phase = _ImportPastePhase.error;
+      _errorTitle = title;
+    });
+  }
 
   Future<void> _paste() async {
     if (_phase == _ImportPastePhase.reading) return;
@@ -64,24 +120,20 @@ class _MobileImportScreenState extends State<MobileImportScreen> {
       text = (await Clipboard.getData(Clipboard.kTextPlain))?.text;
     } catch (e) {
       log('MobileImport: ERROR reading clipboard: $e');
-      if (mounted) setState(() => _phase = _ImportPastePhase.error);
+      if (mounted) _showError(_kClipboardReadError);
       return;
     }
     if (!mounted) return;
 
-    final words = (text ?? '')
-        .split(RegExp(r'\s+'))
-        .where((w) => w.isNotEmpty)
-        .map((w) => w.toLowerCase())
-        .toList();
-    if (words.isEmpty) {
-      setState(() => _phase = _ImportPastePhase.error);
-      return;
-    }
-    final error = validateImportedMnemonic(words);
+    final words = parseMnemonicWords(text ?? '');
+    final error = validateImportedMnemonic(
+      words,
+      wordList: kMnemonicWordCounts.contains(words.length) ? _wordList() : null,
+      validateMnemonic: widget.validateMnemonicOverride,
+    );
     if (error != null) {
       log('MobileImport: rejected clipboard mnemonic: $error');
-      setState(() => _phase = _ImportPastePhase.error);
+      _showError(error);
       return;
     }
     setState(() => _phase = _ImportPastePhase.idle);
@@ -104,7 +156,11 @@ class _MobileImportScreenState extends State<MobileImportScreen> {
       child: Column(
         children: [
           const SizedBox(height: AppSpacing.xs),
-          _ImportPasteCard(phase: _phase, onPaste: _paste),
+          _ImportPasteCard(
+            phase: _phase,
+            errorTitle: _errorTitle,
+            onPaste: _paste,
+          ),
           const SizedBox(height: AppSpacing.base),
           _ManualImportLink(onTap: () => context.push('/import/manual')),
         ],
@@ -114,9 +170,14 @@ class _MobileImportScreenState extends State<MobileImportScreen> {
 }
 
 class _ImportPasteCard extends StatelessWidget {
-  const _ImportPasteCard({required this.phase, required this.onPaste});
+  const _ImportPasteCard({
+    required this.phase,
+    required this.errorTitle,
+    required this.onPaste,
+  });
 
   final _ImportPastePhase phase;
+  final String errorTitle;
   final VoidCallback onPaste;
 
   bool get _isError => phase == _ImportPastePhase.error;
@@ -156,7 +217,7 @@ class _ImportPasteCard extends StatelessWidget {
               children: [
                 AppIcon(AppIcons.importWallet, size: 33, color: iconColor),
                 SizedBox(height: contentGap),
-                _ImportPasteCardText(isError: _isError),
+                _ImportPasteCardText(isError: _isError, errorTitle: errorTitle),
                 SizedBox(height: contentGap),
                 IgnorePointer(
                   ignoring: _isReading,
@@ -196,9 +257,10 @@ class _ImportPasteCard extends StatelessWidget {
 }
 
 class _ImportPasteCardText extends StatelessWidget {
-  const _ImportPasteCardText({required this.isError});
+  const _ImportPasteCardText({required this.isError, required this.errorTitle});
 
   final bool isError;
+  final String errorTitle;
 
   @override
   Widget build(BuildContext context) {
@@ -206,7 +268,7 @@ class _ImportPasteCardText extends StatelessWidget {
     return Column(
       children: [
         Text(
-          isError ? "Can’t read clipboard data" : 'Paste from clipboard',
+          isError ? errorTitle : 'Paste from clipboard',
           textAlign: TextAlign.center,
           style: AppTypography.bodyLarge.copyWith(
             color: isError ? colors.text.destructive : colors.text.homeCard,

--- a/test/features/onboarding/mobile_import_screens_test.dart
+++ b/test/features/onboarding/mobile_import_screens_test.dart
@@ -136,7 +136,7 @@ void main() {
   testWidgets('shrinks the paste card before the manual link leaves view', (
     tester,
   ) async {
-    setViewport(const Size(520, 700));
+    setViewport(const Size(520, 820));
     await tester.pumpWidget(_pasteApp());
     await tester.pumpAndSettle();
 
@@ -149,7 +149,7 @@ void main() {
 
     expect(cardHeight, lessThan(370));
     expect(cardHeight, greaterThanOrEqualTo(320));
-    expect(manualBottom, lessThanOrEqualTo(700));
+    expect(manualBottom, lessThanOrEqualTo(820 - 80));
   });
 
   testWidgets('uses scrolling instead of shrinking the paste card too far', (

--- a/test/features/onboarding/mobile_import_screens_test.dart
+++ b/test/features/onboarding/mobile_import_screens_test.dart
@@ -12,6 +12,8 @@ import 'package:zcash_wallet/src/core/navigation/mobile_onboarding_routes.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_screens.dart';
 
+const _wordList = ['abandon', 'ability', 'able', 'about', 'zebra'];
+
 Widget _app(String initialLocation) {
   final router = GoRouter(
     initialLocation: initialLocation,
@@ -21,6 +23,21 @@ Widget _app(String initialLocation) {
     child: MaterialApp.router(
       routerConfig: router,
       builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+    ),
+  );
+}
+
+Widget _pasteApp({
+  List<String>? mnemonicWordListOverride = _wordList,
+  bool Function(String mnemonic)? validateMnemonicOverride,
+}) {
+  return ProviderScope(
+    child: MaterialApp(
+      builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+      home: MobileImportScreen(
+        mnemonicWordListOverride: mnemonicWordListOverride,
+        validateMnemonicOverride: validateMnemonicOverride ?? (_) => false,
+      ),
     ),
   );
 }
@@ -48,12 +65,39 @@ void _mockClipboard(
   );
 }
 
+void _mockClipboardFailure(WidgetTester tester) {
+  tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    SystemChannels.platform,
+    (call) async {
+      if (call.method == 'Clipboard.getData') {
+        throw PlatformException(code: 'clipboard_unavailable');
+      }
+      return null;
+    },
+  );
+  addTearDown(
+    () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      null,
+    ),
+  );
+}
+
 void main() {
   setUp(() {
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
     binding.platformDispatcher.views.first
       ..physicalSize = const Size(520, 1300)
       ..devicePixelRatio = 1.0;
+  });
+
+  test('normalises pasted mnemonic-like text', () {
+    expect(parseMnemonicWords('1. Abandon, 2) ability\n3: able; 4/about'), [
+      'abandon',
+      'ability',
+      'able',
+      'about',
+    ]);
   });
 
   testWidgets('the entry offers paste and the manual wizard link', (
@@ -97,7 +141,40 @@ void main() {
     tester,
   ) async {
     _mockClipboard(tester, 'one two three');
-    await tester.pumpWidget(_app('/import'));
+    await tester.pumpWidget(_pasteApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_import_paste')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Secret Passphrase must be 12, 15, 18, 21, or 24 words'),
+      findsOneWidget,
+    );
+    expect(find.text('Try again'), findsOneWidget);
+    expect(find.text('one'), findsNothing);
+  });
+
+  testWidgets('an empty clipboard shows the inline error card', (tester) async {
+    _mockClipboard(tester, '   ');
+    await tester.pumpWidget(_pasteApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_import_paste')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text("Clipboard doesn’t contain a Secret Passphrase"),
+      findsOneWidget,
+    );
+    expect(find.text('Try again'), findsOneWidget);
+  });
+
+  testWidgets('clipboard read failures keep the clipboard error message', (
+    tester,
+  ) async {
+    _mockClipboardFailure(tester);
+    await tester.pumpWidget(_pasteApp());
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('mobile_import_paste')));
@@ -105,18 +182,44 @@ void main() {
 
     expect(find.text("Can’t read clipboard data"), findsOneWidget);
     expect(find.text('Try again'), findsOneWidget);
-    expect(find.text('one'), findsNothing);
   });
 
-  testWidgets('an empty clipboard shows the inline error card', (tester) async {
-    _mockClipboard(tester, '   ');
-    await tester.pumpWidget(_app('/import'));
+  testWidgets('paste rejects words outside the mnemonic word list', (
+    tester,
+  ) async {
+    _mockClipboard(
+      tester,
+      'abandon ability able about zebra abandon ability able about zebra '
+      'abandon notaword',
+    );
+    await tester.pumpWidget(_pasteApp());
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('mobile_import_paste')));
     await tester.pumpAndSettle();
 
-    expect(find.text("Can’t read clipboard data"), findsOneWidget);
+    expect(
+      find.text("Some words aren’t in the passphrase word list"),
+      findsOneWidget,
+    );
+    expect(find.text('Try again'), findsOneWidget);
+  });
+
+  testWidgets('paste separates invalid mnemonic checksum from read failures', (
+    tester,
+  ) async {
+    _mockClipboard(
+      tester,
+      '1. abandon, 2. ability, 3. able, 4. about, 5. zebra, 6. abandon, '
+      '7. ability, 8. able, 9. about, 10. zebra, 11. abandon, 12. ability',
+    );
+    await tester.pumpWidget(_pasteApp(validateMnemonicOverride: (_) => false));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_import_paste')));
+    await tester.pumpAndSettle();
+
+    expect(find.text("That Secret Passphrase isn’t valid"), findsOneWidget);
     expect(find.text('Try again'), findsOneWidget);
   });
 }

--- a/test/features/onboarding/mobile_import_screens_test.dart
+++ b/test/features/onboarding/mobile_import_screens_test.dart
@@ -13,6 +13,7 @@ import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_screens.dart';
 
 const _wordList = ['abandon', 'ability', 'able', 'about', 'zebra'];
+const _pasteCardKey = ValueKey('mobile_import_paste_card');
 
 Widget _app(String initialLocation) {
   final router = GoRouter(
@@ -84,11 +85,15 @@ void _mockClipboardFailure(WidgetTester tester) {
 }
 
 void main() {
-  setUp(() {
+  void setViewport(Size size) {
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
     binding.platformDispatcher.views.first
-      ..physicalSize = const Size(520, 1300)
+      ..physicalSize = size
       ..devicePixelRatio = 1.0;
+  }
+
+  setUp(() {
+    setViewport(const Size(520, 1300));
   });
 
   test('normalises pasted mnemonic-like text', () {
@@ -117,6 +122,45 @@ void main() {
     );
     await tester.pumpAndSettle();
     expect(find.text('Enter your Secret Passphrase'), findsOneWidget);
+  });
+
+  testWidgets('keeps the Figma card height on the baseline viewport', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_pasteApp());
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(find.byKey(_pasteCardKey)).height, 370);
+  });
+
+  testWidgets('shrinks the paste card before the manual link leaves view', (
+    tester,
+  ) async {
+    setViewport(const Size(520, 700));
+    await tester.pumpWidget(_pasteApp());
+    await tester.pumpAndSettle();
+
+    final cardHeight = tester.getSize(find.byKey(_pasteCardKey)).height;
+    final manualBottom = tester
+        .getBottomLeft(
+          find.byKey(const ValueKey('mobile_import_enter_manually')),
+        )
+        .dy;
+
+    expect(cardHeight, lessThan(370));
+    expect(cardHeight, greaterThanOrEqualTo(320));
+    expect(manualBottom, lessThanOrEqualTo(700));
+  });
+
+  testWidgets('uses scrolling instead of shrinking the paste card too far', (
+    tester,
+  ) async {
+    setViewport(const Size(520, 560));
+    await tester.pumpWidget(_pasteApp());
+    await tester.pumpAndSettle();
+
+    expect(tester.getSize(find.byKey(_pasteCardKey)).height, 320);
+    expect(find.byType(SingleChildScrollView), findsOneWidget);
   });
 
   testWidgets('paste shows a reading state while clipboard data resolves', (

--- a/test/features/onboarding/mobile_import_screens_test.dart
+++ b/test/features/onboarding/mobile_import_screens_test.dart
@@ -1,6 +1,8 @@
 @Tags(['mobile'])
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -23,11 +25,18 @@ Widget _app(String initialLocation) {
   );
 }
 
-void _mockClipboard(WidgetTester tester, String? text) {
+void _mockClipboard(
+  WidgetTester tester,
+  String? text, {
+  Completer<void>? gate,
+}) {
   tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
     SystemChannels.platform,
     (call) async {
-      if (call.method == 'Clipboard.getData') return {'text': text};
+      if (call.method == 'Clipboard.getData') {
+        if (gate != null) await gate.future;
+        return {'text': text};
+      }
       return null;
     },
   );
@@ -53,8 +62,11 @@ void main() {
     await tester.pumpWidget(_app('/import'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Import Your Wallet'), findsOneWidget);
+    expect(find.text('Import Wallet'), findsOneWidget);
     expect(find.byType(MobileImportScreen), findsOneWidget);
+    expect(find.text('Paste from clipboard'), findsOneWidget);
+    expect(find.text('Paste'), findsOneWidget);
+    expect(find.text('Enter Secret Passphrase manually'), findsOneWidget);
 
     await tester.tap(
       find.byKey(const ValueKey('mobile_import_enter_manually')),
@@ -63,16 +75,25 @@ void main() {
     expect(find.text('Enter your Secret Passphrase'), findsOneWidget);
   });
 
-  testWidgets('tapping the slot grid opens the manual wizard', (tester) async {
+  testWidgets('paste shows a reading state while clipboard data resolves', (
+    tester,
+  ) async {
+    final gate = Completer<void>();
+    _mockClipboard(tester, '   ', gate: gate);
     await tester.pumpWidget(_app('/import'));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(const ValueKey('mobile_import_slots')));
+    await tester.tap(find.byKey(const ValueKey('mobile_import_paste')));
+    await tester.pump();
+
+    expect(find.text('Reading...'), findsOneWidget);
+    expect(find.text('Paste from clipboard'), findsOneWidget);
+
+    gate.complete();
     await tester.pumpAndSettle();
-    expect(find.text('Enter your Secret Passphrase'), findsOneWidget);
   });
 
-  testWidgets('the slot grid stays tappable after a rejected paste', (
+  testWidgets('word-count validation shows the inline error card', (
     tester,
   ) async {
     _mockClipboard(tester, 'one two three');
@@ -82,34 +103,20 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('mobile_import_paste')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(const ValueKey('mobile_import_slots')));
-    await tester.pumpAndSettle();
-    expect(find.text('Enter your Secret Passphrase'), findsOneWidget);
+    expect(find.text("Can’t read clipboard data"), findsOneWidget);
+    expect(find.text('Try again'), findsOneWidget);
+    expect(find.text('one'), findsNothing);
   });
 
-  testWidgets('word-count validation rejects a short paste', (tester) async {
-    _mockClipboard(tester, 'one two three');
-    await tester.pumpWidget(_app('/import'));
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.byKey(const ValueKey('mobile_import_paste')));
-    await tester.pumpAndSettle();
-
-    expect(find.textContaining('found 3'), findsOneWidget);
-    // The pasted words still render into the slot card for inspection.
-    expect(find.text('one'), findsOneWidget);
-  });
-
-  testWidgets('an empty clipboard surfaces a toast', (tester) async {
+  testWidgets('an empty clipboard shows the inline error card', (tester) async {
     _mockClipboard(tester, '   ');
     await tester.pumpWidget(_app('/import'));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('mobile_import_paste')));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
-    expect(find.text('Clipboard is empty'), findsOneWidget);
-    await tester.pump(const Duration(seconds: 3));
-    expect(find.text('Clipboard is empty'), findsNothing);
+    expect(find.text("Can’t read clipboard data"), findsOneWidget);
+    expect(find.text('Try again'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Updates the mobile import wallet paste entry screen to match the revised Figma card-based idle/loading/error states.
- Shares the manual-entry mnemonic text normalization with clipboard paste, including numbering and punctuation cleanup.
- Adds more specific clipboard/mnemonic validation errors for empty clipboard, word-count mismatch, unknown BIP-39 words, invalid mnemonic checksum, and clipboard read failures.
- Makes the paste card adaptive on shorter mobile heights, preserving the baseline card size where possible and switching to scroll once the card reaches its minimum height.

## Validation
- `fvm flutter test test/features/onboarding/mobile_import_screens_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `fvm flutter test test/features/onboarding/mobile_import_manual_screen_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `fvm flutter analyze`
- iOS simulator e2e screenshot capture for the import entry idle/loading/error states during the redesign pass.