### PR TITLE
[codex] Use CoinGecko price in mobile wallet screens

### DIFF
--- a/fastlane/android/Fastfile
+++ b/fastlane/android/Fastfile
@@ -76,6 +76,7 @@ platform :android do
   desc "Build Android release AAB for Google Play"
   lane :build do
     metadata = android_release_metadata
+    coingecko_price_base_url = ENV.fetch("VIZOR_COINGECKO_PRICE_BASE_URL", "https://api.coingecko.com/api/v3")
 
     sh(
       [
@@ -85,6 +86,7 @@ platform :android do
         # Store builds must compile the mobile token set — release
         # builds have no form-factor guard (see AGENTS.md).
         "--dart-define=VIZOR_FORM_FACTOR=mobile",
+        "--dart-define=#{shell_escape("VIZOR_COINGECKO_PRICE_BASE_URL=#{coingecko_price_base_url}")}",
         "--build-name", shell_escape(metadata.fetch(:version)),
         "--build-number", shell_escape(metadata.fetch(:build_number))
       ].join(" ")

--- a/fastlane/ios/Fastfile
+++ b/fastlane/ios/Fastfile
@@ -225,6 +225,7 @@ platform :ios do
   desc "Build iOS IPA for App Store Connect"
   lane :build do
     metadata = ios_release_metadata
+    coingecko_price_base_url = ENV.fetch("VIZOR_COINGECKO_PRICE_BASE_URL", "https://api.coingecko.com/api/v3")
     keychain = setup_ios_signing_keychain
     profile_mapping = sync_ios_match!(keychain)
     configure_ios_code_signing!(profile_mapping)
@@ -238,6 +239,7 @@ platform :ios do
           # Store builds must compile the mobile token set — release
           # builds have no form-factor guard (see AGENTS.md).
           "--dart-define=VIZOR_FORM_FACTOR=mobile",
+          "--dart-define=#{shell_escape("VIZOR_COINGECKO_PRICE_BASE_URL=#{coingecko_price_base_url}")}",
           "--build-name", shell_escape(metadata.fetch(:version)),
           "--build-number", shell_escape(metadata.fetch(:build_number)),
           "--export-options-plist", shell_escape(export_options_path)

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -15,6 +15,7 @@ import '../../../../core/widgets/app_icon.dart';
 import '../../../../providers/account_provider.dart';
 import '../../../../providers/privacy_mode_provider.dart';
 import '../../../../providers/sync_provider.dart';
+import '../../../../providers/zec_price_change_provider.dart';
 import '../../../accounts/widgets/mobile/mobile_accounts_sheet.dart';
 import '../../../activity/activity_feed_sections.dart';
 import '../../../activity/activity_row_mapper.dart';
@@ -101,6 +102,16 @@ class _HomeContent extends ConsumerWidget {
         sync.saplingPendingBalance +
         sync.orchardPendingBalance;
     final hasBalance = shieldedBalance > BigInt.zero;
+    final zecUsdUnitPrice = ref.watch(zecHomeUsdUnitPriceProvider);
+    final fiatBalanceText = fiatTextForZatoshi(
+      shieldedBalance,
+      zecUsdUnitPrice: zecUsdUnitPrice,
+    );
+    final shieldedFiatBalanceText =
+        privacyModeEnabled && fiatBalanceText != null
+        ? fixedPrivacyMask()
+        : fiatBalanceText;
+    final priceChange24hPct = ref.watch(zecPriceChange24hPctProvider);
 
     final uuid = activeAccountUuid;
     final swapItems = uuid == null
@@ -161,6 +172,8 @@ class _HomeContent extends ConsumerWidget {
           balanceText: privacyModeEnabled
               ? fixedPrivacyMask()
               : ZecAmount.fromZatoshi(shieldedBalance).balance.amountText,
+          fiatBalanceText: shieldedFiatBalanceText,
+          priceChange24hPct: priceChange24hPct,
           privacyModeEnabled: privacyModeEnabled,
           onTogglePrivacyMode: onTogglePrivacyMode,
         ),
@@ -224,24 +237,32 @@ class _HomeContent extends ConsumerWidget {
 class _BalanceCard extends StatelessWidget {
   const _BalanceCard({
     required this.balanceText,
+    required this.fiatBalanceText,
+    required this.priceChange24hPct,
     required this.privacyModeEnabled,
     required this.onTogglePrivacyMode,
   });
 
   final String balanceText;
+  final String? fiatBalanceText;
+  final double? priceChange24hPct;
   final bool privacyModeEnabled;
   final VoidCallback onTogglePrivacyMode;
-
-  // TODO(pricing): live fiat value and 24h change need a price feed
-  // that desktop doesn't have yet either; design-literal placeholder
-  // until that lands as separate work.
-  static const _fiatPlaceholder = '\$1,200.12';
-  static const _changePlaceholder = ' + 13.12% (24h)';
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
     final cardText = colors.text.homeCard;
+    final roundedPriceChangePct = priceChange24hPct == null
+        ? null
+        : roundZecPriceChange24hPct(priceChange24hPct!);
+    final priceChangeColor = roundedPriceChangePct == null
+        ? null
+        : roundedPriceChangePct > 0
+        ? colors.text.positiveStrong
+        : roundedPriceChangePct < 0
+        ? colors.text.destructive
+        : cardText;
 
     return Container(
       height: 200,
@@ -277,27 +298,38 @@ class _BalanceCard extends StatelessWidget {
             ],
           ),
           const Spacer(),
-          Text.rich(
-            TextSpan(
+          if (fiatBalanceText != null) ...[
+            Row(
               children: [
-                TextSpan(
-                  text: _fiatPlaceholder,
-                  style: AppTypography.labelLarge.copyWith(
-                    fontWeight: FontWeight.w400,
-                    color: cardText.withValues(alpha: 0.8),
+                Flexible(
+                  child: Text(
+                    fiatBalanceText!,
+                    key: const ValueKey('mobile_home_balance_fiat_text'),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.labelLarge.copyWith(
+                      fontWeight: FontWeight.w400,
+                      color: cardText.withValues(alpha: 0.8),
+                    ),
                   ),
                 ),
-                TextSpan(
-                  text: _changePlaceholder,
-                  style: AppTypography.labelLarge.copyWith(
-                    fontWeight: FontWeight.w400,
-                    color: colors.text.positiveStrong,
+                if (priceChangeColor != null) ...[
+                  const SizedBox(width: AppSpacing.xs),
+                  Text(
+                    formatZecPriceChange24hPct(priceChange24hPct!),
+                    key: const ValueKey(
+                      'mobile_home_balance_price_change_text',
+                    ),
+                    style: AppTypography.labelLarge.copyWith(
+                      fontWeight: FontWeight.w400,
+                      color: priceChangeColor,
+                    ),
                   ),
-                ),
+                ],
               ],
             ),
-          ),
-          const SizedBox(height: AppSpacing.xs),
+            const SizedBox(height: AppSpacing.xs),
+          ],
           Text.rich(
             key: const ValueKey('mobile_home_shielded_balance'),
             TextSpan(

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -22,6 +22,7 @@ import '../../../../core/widgets/mobile/mobile_surface_card.dart';
 import '../../../../providers/account_provider.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
 import '../../../../providers/sync_provider.dart';
+import '../../../../providers/zec_price_change_provider.dart';
 import '../../../../rust/api/sync.dart' as rust_sync;
 import '../../../address_book/models/address_book_contact.dart';
 import '../../../address_book/providers/address_book_provider.dart';
@@ -952,6 +953,13 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     final amountText =
         ZecAmount.tryParse(_amountText)?.activityDetail.toString() ??
         '$_amountText ZEC';
+    final amountZatoshi = parseZecAmount(_amountText.trim());
+    final amountFiatText = amountZatoshi == null
+        ? null
+        : fiatTextForZatoshi(
+            amountZatoshi,
+            zecUsdUnitPrice: ref.watch(zecHomeUsdUnitPriceProvider),
+          );
     final feeText = _feeZatoshi == null
         ? '—'
         : ZecAmount.fromZatoshi(_feeZatoshi!).fee.toString();
@@ -1006,6 +1014,18 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                             color: colors.text.accent,
                           ),
                         ),
+                        if (amountFiatText != null) ...[
+                          const SizedBox(height: AppSpacing.xxs),
+                          Text(
+                            amountFiatText,
+                            key: const ValueKey(
+                              'mobile_send_review_amount_fiat',
+                            ),
+                            style: AppTypography.labelMedium.copyWith(
+                              color: colors.text.secondary,
+                            ),
+                          ),
+                        ],
                       ],
                     ),
                   ),

--- a/lib/src/features/send/screens/mobile/mobile_send_status_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_status_screen.dart
@@ -14,6 +14,7 @@ import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/app_toast.dart';
 import '../../../../providers/rpc_endpoint_failover_provider.dart';
+import '../../../../providers/zec_price_change_provider.dart';
 import '../../../activity/activity_row_mapper.dart'
     show formatActivityTimestamp;
 import '../../services/send_flow.dart';
@@ -164,6 +165,10 @@ class _MobileSendStatusScreenState
         ? _error ?? "Transaction couldn't be sent."
         : null;
     final txid = _protocolTxid;
+    final amountFiatText = fiatTextForZatoshi(
+      args.amountZatoshi,
+      zecUsdUnitPrice: ref.watch(zecHomeUsdUnitPriceProvider),
+    );
 
     return PopScope<void>(
       canPop: false,
@@ -207,6 +212,18 @@ class _MobileSendStatusScreenState
                                   args.amountZatoshi,
                                 ).activityDetail.toString(),
                                 leading: const _ZecCoinBadge(),
+                                bottom: amountFiatText == null
+                                    ? null
+                                    : Text(
+                                        amountFiatText,
+                                        key: const ValueKey(
+                                          'mobile_send_status_amount_fiat',
+                                        ),
+                                        style: AppTypography.labelMedium
+                                            .copyWith(
+                                              color: colors.text.secondary,
+                                            ),
+                                      ),
                               ),
                               const SizedBox(height: AppSpacing.xs),
                               const _FlowArrow(),

--- a/lib/src/providers/zec_price_change_provider.dart
+++ b/lib/src/providers/zec_price_change_provider.dart
@@ -1,0 +1,188 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../main.dart' show log;
+import '../core/config/swap_feature_config.dart';
+import '../core/formatting/zec_amount.dart';
+import '../features/swap/models/swap_fiat_value_formatting.dart';
+
+const kVizorCoinGeckoPriceBaseUrlEnvKey = 'VIZOR_COINGECKO_PRICE_BASE_URL';
+const kVizorCoinGeckoDefaultPriceBaseUrl = 'https://api.coingecko.com/api/v3';
+const kVizorCoinGeckoPriceBaseUrl = String.fromEnvironment(
+  kVizorCoinGeckoPriceBaseUrlEnvKey,
+  defaultValue: kVizorCoinGeckoDefaultPriceBaseUrl,
+);
+
+class ZecMarketData {
+  const ZecMarketData({required this.usdPrice, this.change24hPct});
+
+  final double usdPrice;
+  final double? change24hPct;
+}
+
+/// Non-swap ZEC market data source. Swap keeps using its provider-specific
+/// pricing snapshot; this source is for mobile wallet-native ZEC displays.
+abstract interface class ZecMarketDataSource {
+  /// Returns the current ZEC/USD price plus optional 24h change percentage
+  /// points (e.g. `-0.26` for -0.26%), or null when unavailable.
+  Future<ZecMarketData?> fetchMarketData();
+}
+
+class CoinGeckoZecMarketDataSource implements ZecMarketDataSource {
+  CoinGeckoZecMarketDataSource({
+    HttpClient? client,
+    Uri? baseUri,
+    this.timeout = const Duration(seconds: 12),
+  }) : _client = client ?? HttpClient(),
+       _baseUri = baseUri ?? Uri.parse(kVizorCoinGeckoPriceBaseUrl);
+
+  final HttpClient _client;
+  final Uri _baseUri;
+  final Duration timeout;
+
+  @override
+  Future<ZecMarketData?> fetchMarketData() async {
+    final endpoint = coinGeckoSimplePriceUri(_baseUri);
+    try {
+      final request = await _client.getUrl(endpoint).timeout(timeout);
+      request.headers.set(HttpHeaders.acceptHeader, 'application/json');
+      final response = await request.close().timeout(timeout);
+      final body = await utf8.decoder.bind(response).join();
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        log('zecMarketData: CoinGecko returned ${response.statusCode}');
+        return null;
+      }
+      return parseZecMarketData(body);
+    } catch (e) {
+      log('zecMarketData: fetch failed: $e');
+      return null;
+    }
+  }
+}
+
+Uri coinGeckoSimplePriceUri(Uri baseUri) {
+  final basePath = baseUri.path.replaceFirst(RegExp(r'/+$'), '');
+  return baseUri.replace(
+    path: '$basePath/simple/price',
+    queryParameters: const {
+      'ids': 'zcash',
+      'names': 'Zcash',
+      'symbols': 'zec',
+      'vs_currencies': 'usd',
+      'include_24hr_change': 'true',
+    },
+  );
+}
+
+/// Parses CoinGecko `/simple/price` into the market data model. Returns null
+/// when the required ZEC/USD price is missing or unusable.
+ZecMarketData? parseZecMarketData(String body) {
+  try {
+    final decoded = jsonDecode(body);
+    if (decoded is! Map<String, dynamic>) return null;
+    final zcash = decoded['zcash'];
+    if (zcash is! Map<String, dynamic>) return null;
+
+    final usdRaw = zcash['usd'];
+    if (usdRaw is! num) return null;
+    final usdPrice = usdRaw.toDouble();
+    if (!usdPrice.isFinite || usdPrice <= 0) return null;
+
+    final changeRaw = zcash['usd_24h_change'];
+    final change24hPct = changeRaw is num && changeRaw.toDouble().isFinite
+        ? changeRaw.toDouble()
+        : null;
+
+    return ZecMarketData(usdPrice: usdPrice, change24hPct: change24hPct);
+  } catch (_) {
+    return null;
+  }
+}
+
+double? parseZecPriceChange24hPct(String body) {
+  return parseZecMarketData(body)?.change24hPct;
+}
+
+const zecMarketDataRefreshInterval = Duration(minutes: 3);
+
+final zecMarketDataSourceProvider = Provider<ZecMarketDataSource>((ref) {
+  return CoinGeckoZecMarketDataSource();
+});
+
+/// Latest known non-swap ZEC market data, or null until the first successful
+/// fetch. Stays on the last known value across transient fetch failures.
+final zecHomeMarketDataProvider =
+    NotifierProvider.autoDispose<ZecHomeMarketDataNotifier, ZecMarketData?>(
+      ZecHomeMarketDataNotifier.new,
+    );
+
+class ZecHomeMarketDataNotifier extends Notifier<ZecMarketData?> {
+  Timer? _timer;
+  int _epoch = 0;
+
+  @override
+  ZecMarketData? build() {
+    _timer?.cancel();
+    final epoch = ++_epoch;
+    if (!ref.watch(swapFeatureEnabledProvider)) return null;
+    final source = ref.watch(zecMarketDataSourceProvider);
+
+    ref.onDispose(() {
+      _epoch++;
+      _timer?.cancel();
+    });
+
+    Future<void> tick() async {
+      final data = await source.fetchMarketData();
+      if (epoch != _epoch) return;
+      if (data != null) state = data;
+      _timer = Timer(zecMarketDataRefreshInterval, () => unawaited(tick()));
+    }
+
+    scheduleMicrotask(() {
+      if (epoch == _epoch) unawaited(tick());
+    });
+    return null;
+  }
+}
+
+final zecHomeUsdUnitPriceProvider = Provider.autoDispose<double?>((ref) {
+  return ref.watch(zecHomeMarketDataProvider)?.usdPrice;
+});
+
+final zecPriceChange24hPctProvider = Provider.autoDispose<double?>((ref) {
+  return ref.watch(zecHomeMarketDataProvider)?.change24hPct;
+});
+
+/// "$250.12"-style fiat text for a zatoshi amount, or null when the amount
+/// or [zecUsdUnitPrice] cannot be priced.
+String? fiatTextForZatoshi(BigInt zatoshi, {required double? zecUsdUnitPrice}) {
+  if (zatoshi <= BigInt.zero ||
+      zecUsdUnitPrice == null ||
+      !zecUsdUnitPrice.isFinite ||
+      zecUsdUnitPrice <= 0) {
+    return null;
+  }
+  final zec = zatoshi.toDouble() / zatoshiPerZec.toDouble();
+  if (!zec.isFinite || zec <= 0) return null;
+  return swapFormatCompactFiatValue(zec * zecUsdUnitPrice);
+}
+
+/// Rounds to the displayed 2-decimal precision so text and color agree, e.g.
+/// -0.004 renders as a neutral "0.00%", not a red zero.
+double roundZecPriceChange24hPct(double pct) {
+  return double.parse(pct.toStringAsFixed(2));
+}
+
+/// "+ 1.25% (24h)" / "- 0.26% (24h)" / "0.00% (24h)" badge text for a 24h
+/// change percentage.
+String formatZecPriceChange24hPct(double pct) {
+  final rounded = roundZecPriceChange24hPct(pct);
+  if (rounded == 0) return '0.00% (24h)';
+  return rounded > 0
+      ? '+ ${rounded.toStringAsFixed(2)}% (24h)'
+      : '- ${rounded.abs().toStringAsFixed(2)}% (24h)';
+}

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -14,6 +14,7 @@ import 'package:zcash_wallet/src/features/home/screens/mobile/mobile_home_screen
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/privacy_mode_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 import '../../fakes/fake_sync_notifier.dart';
@@ -25,6 +26,15 @@ class _FakePrivacyModeNotifier extends PrivacyModeNotifier {
   Future<void> set(bool enabled) async {
     state = enabled;
   }
+}
+
+class _FakeMarketDataSource implements ZecMarketDataSource {
+  const _FakeMarketDataSource(this.data);
+
+  final ZecMarketData? data;
+
+  @override
+  Future<ZecMarketData?> fetchMarketData() async => data;
 }
 
 const _accountState = AccountState(
@@ -53,7 +63,13 @@ AppBootstrapState _bootstrap() => AppBootstrapState(
   passwordRotationRecoveryFailed: false,
 );
 
-Widget _app(SyncState syncState) {
+Widget _app(
+  SyncState syncState, {
+  ZecMarketData? marketData = const ZecMarketData(
+    usdPrice: 70,
+    change24hPct: 13.12,
+  ),
+}) {
   final router = GoRouter(
     initialLocation: '/home',
     routes: [
@@ -72,6 +88,9 @@ Widget _app(SyncState syncState) {
       appBootstrapProvider.overrideWithValue(_bootstrap()),
       syncProvider.overrideWith(() => FakeSyncNotifier(syncState)),
       privacyModeProvider.overrideWith(_FakePrivacyModeNotifier.new),
+      zecMarketDataSourceProvider.overrideWithValue(
+        _FakeMarketDataSource(marketData),
+      ),
     ],
     child: MaterialApp.router(
       routerConfig: router,
@@ -132,8 +151,11 @@ void main() {
       _app(_syncedState(orchardBalance: BigInt.from(14312000000))),
     );
     await tester.pump();
+    await tester.pump();
 
     expect(find.textContaining('143.12', findRichText: true), findsOneWidget);
+    expect(find.text(r'$10.02K'), findsOneWidget);
+    expect(find.text('+ 13.12% (24h)'), findsOneWidget);
     expect(find.text('Send'), findsOneWidget);
     expect(find.text('Receive'), findsOneWidget);
     expect(find.text('No activity, yet...'), findsOneWidget);
@@ -156,15 +178,17 @@ void main() {
       _app(_syncedState(orchardBalance: BigInt.from(14312000000))),
     );
     await tester.pump();
+    await tester.pump();
 
     await tester.tap(find.bySemanticsLabel('Hide balance'));
     await tester.pump();
 
     expect(
       find.textContaining(fixedPrivacyMask(), findRichText: true),
-      findsOneWidget,
+      findsAtLeastNWidgets(2),
     );
     expect(find.textContaining('143.12', findRichText: true), findsNothing);
+    expect(find.text(r'$10.02K'), findsNothing);
   });
 
   testWidgets('shows up to ten recent activity rows', (tester) async {

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:zcash_wallet/src/features/address_book/providers/address_book_pr
 import 'package:zcash_wallet/src/features/send/screens/mobile/mobile_send_screen.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
@@ -58,6 +59,14 @@ class _RustApiFake implements RustLibApi {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+class _FakeMarketDataSource implements ZecMarketDataSource {
+  const _FakeMarketDataSource();
+
+  @override
+  Future<ZecMarketData?> fetchMarketData() async {
+    return const ZecMarketData(usdPrice: 70);
+  }
+}
 
 AppBootstrapState _bootstrap() => AppBootstrapState(
   initialLocation: '/send',
@@ -115,6 +124,9 @@ Widget _app({List<AddressBookContact> contacts = const []}) {
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
       syncProvider.overrideWith(_FakeSyncNotifier.new),
+      zecMarketDataSourceProvider.overrideWithValue(
+        const _FakeMarketDataSource(),
+      ),
       addressBookRepositoryProvider.overrideWithValue(
         _FakeAddressBookRepository(contacts),
       ),
@@ -225,9 +237,7 @@ void main() {
     expect(find.text('Alice'), findsOneWidget);
   });
 
-  testWidgets('the amount step enforces the spendable balance', (
-    tester,
-  ) async {
+  testWidgets('the amount step enforces the spendable balance', (tester) async {
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
     await _toAmountStep(tester, _shieldedAddress);
@@ -279,6 +289,7 @@ void main() {
     await _toReviewStep(tester);
 
     expect(find.text('Review Send'), findsOneWidget);
+    expect(find.text(r'$105.00'), findsOneWidget);
     expect(find.text('Add short encrypted message'), findsOneWidget);
     expect(find.text('Tx fee'), findsOneWidget);
     expect(find.text('Confirm & Send'), findsOneWidget);

--- a/test/features/send/mobile_send_status_screen_test.dart
+++ b/test/features/send/mobile_send_status_screen_test.dart
@@ -6,9 +6,11 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/config/swap_feature_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/send/screens/mobile/mobile_send_status_screen.dart';
 import 'package:zcash_wallet/src/features/send/services/send_flow.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 
 const _address =
     'u1l8xunezsvhq8fgzfl7404m450nwnd76zshe7f5dxv5z3w4gthawuwukdn5aalh6g'
@@ -28,8 +30,23 @@ final _args = SendReviewArgs(
   memo: 'thanks!',
 );
 
+class _FakeMarketDataSource implements ZecMarketDataSource {
+  const _FakeMarketDataSource();
+
+  @override
+  Future<ZecMarketData?> fetchMarketData() async {
+    return const ZecMarketData(usdPrice: 70);
+  }
+}
+
 Widget _app({required MobileSendBroadcastRunner broadcastRunner}) {
   return ProviderScope(
+    overrides: [
+      swapFeatureEnabledProvider.overrideWithValue(true),
+      zecMarketDataSourceProvider.overrideWithValue(
+        const _FakeMarketDataSource(),
+      ),
+    ],
     child: MaterialApp(
       home: AppTheme(
         data: AppThemeData.light,
@@ -65,6 +82,7 @@ void main() {
     expect(find.text('Sending...'), findsOneWidget);
     expect(find.text('In progress'), findsOneWidget);
     expect(find.text('123.12 ZEC'), findsOneWidget);
+    expect(find.text(r'$8.62K'), findsOneWidget);
     expect(find.text('To'), findsOneWidget);
 
     broadcast.complete(

--- a/test/providers/zec_price_change_provider_test.dart
+++ b/test/providers/zec_price_change_provider_test.dart
@@ -1,0 +1,134 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/config/swap_feature_config.dart';
+import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
+
+class _FakeSource implements ZecMarketDataSource {
+  _FakeSource(this.data);
+
+  final ZecMarketData? data;
+  int fetchCount = 0;
+
+  @override
+  Future<ZecMarketData?> fetchMarketData() async {
+    fetchCount += 1;
+    return data;
+  }
+}
+
+void main() {
+  group('parseZecMarketData', () {
+    test('reads ZEC price and 24h change from a CoinGecko response', () {
+      final data = parseZecMarketData(
+        '{"zcash":{"usd":33.45,"usd_24h_change":-0.25852}}',
+      );
+
+      expect(data?.usdPrice, 33.45);
+      expect(data?.change24hPct, -0.25852);
+    });
+
+    test('allows a missing or null 24h change when price is usable', () {
+      expect(
+        parseZecMarketData('{"zcash":{"usd":33.45}}')?.change24hPct,
+        isNull,
+      );
+      expect(
+        parseZecMarketData(
+          '{"zcash":{"usd":33.45,"usd_24h_change":null}}',
+        )?.usdPrice,
+        33.45,
+      );
+    });
+
+    test('returns null for malformed and unusable price bodies', () {
+      expect(parseZecMarketData('{}'), isNull);
+      expect(parseZecMarketData('{"cosmos":{"usd":1.2}}'), isNull);
+      expect(parseZecMarketData('{"zcash":"fast"}'), isNull);
+      expect(parseZecMarketData('{"zcash":null}'), isNull);
+      expect(parseZecMarketData('{"zcash":{"usd":"33.45"}}'), isNull);
+      expect(parseZecMarketData('{"zcash":{"usd":0}}'), isNull);
+      expect(parseZecMarketData('[]'), isNull);
+      expect(parseZecMarketData('not json'), isNull);
+    });
+
+    test('builds the CoinGecko simple price URL from a base URL', () {
+      final uri = coinGeckoSimplePriceUri(
+        Uri.parse('https://api.coingecko.com/api/v3/'),
+      );
+
+      expect(
+        uri.toString(),
+        'https://api.coingecko.com/api/v3/simple/price?'
+        'ids=zcash&names=Zcash&symbols=zec&vs_currencies=usd&'
+        'include_24hr_change=true',
+      );
+    });
+  });
+
+  group('formatZecPriceChange24hPct', () {
+    test('signs and rounds to two decimals with a 24h label', () {
+      expect(formatZecPriceChange24hPct(1.253), '+ 1.25% (24h)');
+      expect(formatZecPriceChange24hPct(-0.25852), '- 0.26% (24h)');
+      expect(formatZecPriceChange24hPct(12.0), '+ 12.00% (24h)');
+    });
+
+    test('normalizes near-zero values to an unsigned zero', () {
+      expect(formatZecPriceChange24hPct(0), '0.00% (24h)');
+      expect(formatZecPriceChange24hPct(0.004), '0.00% (24h)');
+      expect(formatZecPriceChange24hPct(-0.004), '0.00% (24h)');
+    });
+  });
+
+  group('zecHomeMarketDataProvider', () {
+    ProviderContainer makeContainer({
+      required bool swapEnabled,
+      required ZecMarketDataSource source,
+    }) {
+      final container = ProviderContainer(
+        overrides: [
+          swapFeatureEnabledProvider.overrideWithValue(swapEnabled),
+          zecMarketDataSourceProvider.overrideWithValue(source),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('exposes the fetched market data after the first tick', () async {
+      final source = _FakeSource(
+        const ZecMarketData(usdPrice: 33.45, change24hPct: -0.26),
+      );
+      final container = makeContainer(swapEnabled: true, source: source);
+      final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
+
+      expect(sub.read(), isNull);
+      await Future<void>.delayed(Duration.zero);
+      expect(sub.read()?.usdPrice, 33.45);
+      expect(container.read(zecHomeUsdUnitPriceProvider), 33.45);
+      expect(container.read(zecPriceChange24hPctProvider), -0.26);
+      expect(source.fetchCount, 1);
+    });
+
+    test('stays null when the source has no value yet', () async {
+      final source = _FakeSource(null);
+      final container = makeContainer(swapEnabled: true, source: source);
+      final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
+
+      await Future<void>.delayed(Duration.zero);
+      expect(sub.read(), isNull);
+      expect(source.fetchCount, 1);
+    });
+
+    test('does not fetch while market-price UI is disabled', () async {
+      final source = _FakeSource(
+        const ZecMarketData(usdPrice: 33.45, change24hPct: 5.0),
+      );
+      final container = makeContainer(swapEnabled: false, source: source);
+      final sub = container.listen(zecHomeMarketDataProvider, (_, _) {});
+
+      await Future<void>.delayed(Duration.zero);
+      expect(sub.read(), isNull);
+      expect(source.fetchCount, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add a CoinGecko-backed ZEC market data provider with `VIZOR_COINGECKO_PRICE_BASE_URL` override support.
- Replace mobile Home placeholder fiat/24h change copy with live market data.
- Show CoinGecko-derived fiat sub-labels on mobile Send review/status amount rows.
- Pass the CoinGecko base URL dart-define through iOS and Android Fastlane release builds.

## Validation
- `fvm flutter test test/providers/zec_price_change_provider_test.dart test/features/home/mobile_home_screen_test.dart test/features/send/mobile_send_screen_test.dart test/features/send/mobile_send_status_screen_test.dart`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/home/mobile_home_screen_test.dart test/features/send/mobile_send_screen_test.dart test/features/send/mobile_send_status_screen_test.dart`
- `fvm flutter analyze`
- `ruby -c fastlane/ios/Fastfile`
- `ruby -c fastlane/android/Fastfile`