### PR TITLE
[codex] Stabilize activity feed scrolling

### DIFF
--- a/lib/src/core/layout/app_pane_scroll_scaffold.dart
+++ b/lib/src/core/layout/app_pane_scroll_scaffold.dart
@@ -120,6 +120,73 @@ class _AppPaneScrollScaffoldState extends State<AppPaneScrollScaffold> {
   }
 }
 
+/// Shared desktop pane scaffold for screens that need sliver-based lazy
+/// rendering while preserving the pinned toolbar and overlay scrollbar model.
+class AppPaneSliverScrollScaffold extends StatelessWidget {
+  const AppPaneSliverScrollScaffold({
+    required this.toolbar,
+    required this.slivers,
+    this.controller,
+    this.padding,
+    super.key,
+  });
+
+  final Widget toolbar;
+  final List<Widget> slivers;
+  final ScrollController? controller;
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final userPadding = (padding ?? EdgeInsets.zero).resolve(
+      Directionality.of(context),
+    );
+    final contentPadding =
+        const EdgeInsets.only(top: AppPaneScrollScaffold.toolbarHeight) +
+        userPadding;
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        AppPaneScrollbar(
+          controller: controller,
+          scrollbarKey: AppPaneScrollScaffold.scrollbarKey,
+          builder: (context, controller) => CustomScrollView(
+            key: AppPaneScrollScaffold.scrollViewKey,
+            controller: controller,
+            slivers: [
+              if (contentPadding.top > 0)
+                SliverToBoxAdapter(child: SizedBox(height: contentPadding.top)),
+              for (final sliver in slivers)
+                if (contentPadding.horizontal > 0)
+                  SliverPadding(
+                    padding: EdgeInsets.only(
+                      left: contentPadding.left,
+                      right: contentPadding.right,
+                    ),
+                    sliver: sliver,
+                  )
+                else
+                  sliver,
+              if (contentPadding.bottom > 0)
+                SliverToBoxAdapter(
+                  child: SizedBox(height: contentPadding.bottom),
+                ),
+            ],
+          ),
+        ),
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          height: AppPaneScrollScaffold.toolbarHeight,
+          child: toolbar,
+        ),
+      ],
+    );
+  }
+}
+
 /// The pane overlay scrollbar on its own, for panes that bring their own
 /// scroll view (e.g. the home backdrop pane's sliver scroll).
 ///

--- a/lib/src/features/activity/activity_row_mapper.dart
+++ b/lib/src/features/activity/activity_row_mapper.dart
@@ -37,6 +37,7 @@ ActivityRowData buildTransactionActivityRow({
   final isInFlight = isPending && (isInbound || isSent);
 
   return ActivityRowData(
+    stableId: 'tx:${transaction.txidHex}:${_stableTransactionRole(kind)}',
     title: isFailed && isSent
         ? 'Send failed'
         : isInFlight
@@ -81,6 +82,13 @@ ActivityRowData buildTransactionActivityRow({
     timestampText: formatActivityTimestamp(_txTimestamp(transaction)),
     onTap: onTap,
   );
+}
+
+String _stableTransactionRole(String kind) {
+  return switch (kind) {
+    'receiving' => 'received',
+    _ => kind,
+  };
 }
 
 String _transactionAmountText({

--- a/lib/src/features/activity/models/activity_row_data.dart
+++ b/lib/src/features/activity/models/activity_row_data.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 
 class ActivityRowData {
   const ActivityRowData({
+    this.stableId,
     required this.title,
     required this.leadingIconName,
     required this.leadingBackgroundColor,
@@ -26,6 +27,7 @@ class ActivityRowData {
     this.onTap,
   });
 
+  final String? stableId;
   final String title;
   final String leadingIconName;
   final Color leadingBackgroundColor;

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -40,6 +40,8 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
   bool _isLoading = true;
   String? _error;
   String? _activeAccountUuid;
+  int _transactionLoadGeneration = 0;
+  bool _pendingTransactionRefresh = false;
   Timer? _swapActivityRefreshTimer;
   String? _swapActivityRefreshAccountUuid;
 
@@ -47,7 +49,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
   void initState() {
     super.initState();
     _activeAccountUuid = ref.read(accountProvider).value?.activeAccountUuid;
-    _loadTransactions(showLoading: true);
+    _loadTransactions(showLoading: true, clearExisting: true);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       ref.read(appLayoutProvider.notifier).setMode(AppLayoutMode.large);
@@ -63,18 +65,20 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
 
   Future<void> _loadTransactions({
     bool showLoading = false,
-    bool resetPage = false,
+    bool clearExisting = false,
   }) async {
     final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    final generation = ++_transactionLoadGeneration;
+    _pendingTransactionRefresh = false;
     _activeAccountUuid = accountUuid;
 
-    if ((showLoading || resetPage) && mounted) {
+    if ((showLoading || clearExisting) && mounted) {
       setState(() {
         if (showLoading) {
           _isLoading = true;
           _error = null;
         }
-        if (resetPage) {
+        if (clearExisting) {
           _transactions = null;
           _transactionsAccountUuid = accountUuid;
         }
@@ -100,8 +104,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
         network: endpoint.networkName,
         accountUuid: accountUuid,
       );
-      if (!mounted) return;
-      if (accountUuid != ref.read(accountProvider).value?.activeAccountUuid) {
+      if (!_isCurrentTransactionLoad(generation, accountUuid)) {
         return;
       }
       setState(() {
@@ -110,18 +113,54 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
         _isLoading = false;
         _error = null;
       });
+      _runPendingTransactionRefreshIfNeeded(generation, accountUuid);
     } catch (e, st) {
       log('Activity: transaction load failed: $e\n$st');
-      if (!mounted) return;
-      if (accountUuid != ref.read(accountProvider).value?.activeAccountUuid) {
+      if (!_isCurrentTransactionLoad(generation, accountUuid)) {
         return;
       }
+      final hasExistingTransactions =
+          _transactionsAccountUuid == accountUuid && _transactions != null;
+      if (hasExistingTransactions && !clearExisting) return;
       setState(() {
         _transactionsAccountUuid = accountUuid;
         _error = 'Activity could not be loaded.';
         _isLoading = false;
       });
+      _runPendingTransactionRefreshIfNeeded(generation, accountUuid);
     }
+  }
+
+  bool _isCurrentTransactionLoad(int generation, String? accountUuid) {
+    return mounted &&
+        generation == _transactionLoadGeneration &&
+        accountUuid == ref.read(accountProvider).value?.activeAccountUuid;
+  }
+
+  void _runPendingTransactionRefreshIfNeeded(
+    int generation,
+    String accountUuid,
+  ) {
+    if (!_pendingTransactionRefresh) return;
+    if (!_isCurrentTransactionLoad(generation, accountUuid)) return;
+    _pendingTransactionRefresh = false;
+    unawaited(_loadTransactions());
+  }
+
+  void _refreshTransactionsAfterSyncChange() {
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    if (accountUuid == null) return;
+    final hasLoadedTransactions =
+        _transactionsAccountUuid == accountUuid && _transactions != null;
+    if (hasLoadedTransactions) {
+      unawaited(_loadTransactions());
+      return;
+    }
+    if (_isLoading) {
+      _pendingTransactionRefresh = true;
+      return;
+    }
+    unawaited(_loadTransactions(showLoading: true, clearExisting: true));
   }
 
   void _openTransactionStatus(rust_sync.TransactionInfo transaction) {
@@ -235,7 +274,7 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
     ref.listen<AsyncValue<AccountState>>(accountProvider, (previous, next) {
       final nextUuid = next.value?.activeAccountUuid;
       if (nextUuid != _activeAccountUuid) {
-        unawaited(_loadTransactions(showLoading: true, resetPage: true));
+        unawaited(_loadTransactions(showLoading: true, clearExisting: true));
         _syncSwapActivityStatusRefresh();
       }
     });
@@ -243,27 +282,19 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
       final prevSig = _recentSignature(previous?.value);
       final nextSig = _recentSignature(next.value);
       if (prevSig != nextSig) {
-        unawaited(_loadTransactions(resetPage: true));
+        _refreshTransactionsAfterSyncChange();
       }
     });
 
-    final syncState = ref.watch(syncProvider).value;
     final accountUuid = ref.watch(accountProvider).value?.activeAccountUuid;
-    final sync = (syncState ?? SyncState()).scopedToAccount(accountUuid);
-    final hasSyncForActiveAccount =
-        syncState?.hasDataForAccount(accountUuid) ?? false;
     final loadedTransactions = _transactionsAccountUuid == accountUuid
         ? _transactions
         : null;
     final privacyModeEnabled = ref.watch(privacyModeProvider);
     final transactions =
-        loadedTransactions ??
-        (hasSyncForActiveAccount
-            ? sync.recentTransactions
-            : const <rust_sync.TransactionInfo>[]);
+        loadedTransactions ?? const <rust_sync.TransactionInfo>[];
     final canRenderTransactions =
-        accountUuid != null &&
-        (loadedTransactions != null || hasSyncForActiveAccount);
+        accountUuid != null && loadedTransactions != null;
     final swapFeatureEnabled = ref.watch(swapFeatureEnabledProvider);
     final swapItems = accountUuid == null || !swapFeatureEnabled
         ? const <SwapActivityRowItem>[]

--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -348,24 +348,20 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
       sidebar: const AppMainSidebar(),
       pane: AppDesktopPane(
         padding: EdgeInsets.zero,
-        child: AppPaneScrollScaffold(
+        child: AppPaneSliverScrollScaffold(
           toolbar: const AppPaneToolbar(backLinkMinWidth: 60),
           padding: const EdgeInsets.only(top: AppSpacing.sm),
-          child: Align(
-            alignment: Alignment.topCenter,
-            child: SizedBox(
-              width: 420,
-              child: ActivityFeed(
-                sections: sections,
-                rowKeyPrefix: 'activity_screen',
-                isLoading:
-                    _isLoading && !canRenderTransactions && sections.isEmpty,
-                errorText: sections.isEmpty && loadedTransactions == null
-                    ? _error
-                    : null,
-              ),
+          slivers: [
+            ActivityFeedSliver(
+              sections: sections,
+              rowKeyPrefix: 'activity_screen',
+              isLoading:
+                  _isLoading && !canRenderTransactions && sections.isEmpty,
+              errorText: sections.isEmpty && loadedTransactions == null
+                  ? _error
+                  : null,
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/lib/src/features/activity/swap_activity_row_mapper.dart
+++ b/lib/src/features/activity/swap_activity_row_mapper.dart
@@ -99,6 +99,7 @@ ActivityRowData buildSwapActivityRow({
   final progress = _swapActivityProgress(item);
 
   return ActivityRowData(
+    stableId: 'swap:${item.intentId}',
     title: _swapActivityTitle(item.status),
     leadingIconName: AppIcons.swapArrows,
     leadingBackgroundColor: colors.background.neutralSubtleOpacity,
@@ -173,6 +174,8 @@ List<ActivityRowData> _swapActivityChildRows({
         );
   return [
     ActivityRowData(
+      stableId:
+          'swap:${item.intentId}:${receivesZec ? 'received' : 'deposited'}',
       title: receivesZec
           ? 'Received ${receiveAsset.symbol}'
           : 'Deposited ${receiveAsset.symbol}',

--- a/lib/src/features/activity/widgets/activity_feed.dart
+++ b/lib/src/features/activity/widgets/activity_feed.dart
@@ -181,6 +181,12 @@ class _ActivityFeedBody extends StatelessWidget {
   }
 }
 
+ValueKey<String>? _stableRowKey(ActivityRowData row) {
+  final stableId = row.stableId;
+  if (stableId == null || stableId.isEmpty) return null;
+  return ValueKey(stableId);
+}
+
 class _ActivityFeedMessageCard extends StatelessWidget {
   const _ActivityFeedMessageCard({required this.text, this.isError = false});
 
@@ -243,7 +249,9 @@ class _ActivityFeedCard extends StatelessWidget {
               for (var index = 0; index < section.rows.length; index++) ...[
                 if (index > 0) const SizedBox(height: 12),
                 ActivityFeedRowGroup(
-                  key: rowKeyBuilder?.call(),
+                  key:
+                      _stableRowKey(section.rows[index]) ??
+                      rowKeyBuilder?.call(),
                   row: section.rows[index],
                 ),
               ],
@@ -294,7 +302,9 @@ class ActivityFeedRowGroup extends StatelessWidget {
             children: [
               for (final childRow in row.childRows)
                 TweenAnimationBuilder<double>(
-                  key: ValueKey('activity_child_${childRow.title}'),
+                  key: ValueKey(
+                    'activity_child_${childRow.stableId ?? childRow.title}',
+                  ),
                   tween: Tween(begin: 0, end: 1),
                   duration: const Duration(milliseconds: 280),
                   curve: Curves.easeOutCubic,

--- a/lib/src/features/activity/widgets/activity_feed.dart
+++ b/lib/src/features/activity/widgets/activity_feed.dart
@@ -60,6 +60,417 @@ class ActivityFeed extends StatelessWidget {
   }
 }
 
+class ActivityFeedSliver extends StatelessWidget {
+  const ActivityFeedSliver({
+    required this.sections,
+    this.isLoading = false,
+    this.errorText,
+    this.emptyText = 'No activity yet',
+    this.rowKeyPrefix,
+    super.key,
+  });
+
+  final List<ActivityFeedSectionData> sections;
+  final bool isLoading;
+  final String? errorText;
+  final String emptyText;
+  final String? rowKeyPrefix;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = _activityFeedSliverItems(
+      sections: sections,
+      isLoading: isLoading,
+      errorText: errorText,
+      emptyText: emptyText,
+      rowKeyPrefix: rowKeyPrefix,
+    );
+    final childIndexByKey = <Key, int>{
+      for (var index = 0; index < items.length; index++)
+        if (items[index].rowKey != null) items[index].rowKey!: index,
+    };
+    return SliverList(
+      delegate: SliverChildBuilderDelegate(
+        (context, index) {
+          final item = items[index];
+          return _ActivityFeedSliverItemView(key: item.rowKey, item: item);
+        },
+        childCount: items.length,
+        findChildIndexCallback: (key) => childIndexByKey[key],
+      ),
+    );
+  }
+}
+
+List<_ActivityFeedSliverItem> _activityFeedSliverItems({
+  required List<ActivityFeedSectionData> sections,
+  required bool isLoading,
+  required String? errorText,
+  required String emptyText,
+  required String? rowKeyPrefix,
+}) {
+  final message = errorText ?? (isLoading ? 'Loading activity...' : null);
+  final items = <_ActivityFeedSliverItem>[
+    _ActivityFeedSliverItem.title(),
+    _ActivityFeedSliverItem.gap(AppSpacing.base),
+  ];
+
+  if (message != null && sections.isEmpty) {
+    items.add(
+      _ActivityFeedSliverItem.message(message, isError: errorText != null),
+    );
+    return items;
+  }
+  if (sections.isEmpty) {
+    items.add(_ActivityFeedSliverItem.message(emptyText));
+    return items;
+  }
+
+  var rowIndex = 0;
+  for (var sectionIndex = 0; sectionIndex < sections.length; sectionIndex++) {
+    final section = sections[sectionIndex];
+    final rows = section.rows;
+    if (sectionIndex > 0) {
+      items.add(_ActivityFeedSliverItem.gap(AppSpacing.md));
+    }
+    items.add(
+      _ActivityFeedSliverItem.sectionHeader(
+        section.title,
+        segmentPosition: rows.isEmpty
+            ? _ActivityFeedCardSegmentPosition.single
+            : _ActivityFeedCardSegmentPosition.first,
+        hasRows: rows.isNotEmpty,
+      ),
+    );
+    for (var index = 0; index < rows.length; index++) {
+      final row = rows[index];
+      final stableKey = _stableRowKey(row);
+      final rowKey = stableKey ?? _fallbackRowKey(rowKeyPrefix, rowIndex);
+      if (stableKey == null && rowKeyPrefix != null) {
+        rowIndex += 1;
+      }
+      items.add(
+        _ActivityFeedSliverItem.row(
+          row,
+          rowKey: rowKey,
+          segmentPosition: index == rows.length - 1
+              ? _ActivityFeedCardSegmentPosition.last
+              : _ActivityFeedCardSegmentPosition.middle,
+          hasTopGap: index > 0,
+        ),
+      );
+    }
+  }
+  items.add(_ActivityFeedSliverItem.gap(AppSpacing.base));
+  return items;
+}
+
+ValueKey<String>? _fallbackRowKey(String? rowKeyPrefix, int rowIndex) {
+  if (rowKeyPrefix == null) return null;
+  return ValueKey('${rowKeyPrefix}_row_$rowIndex');
+}
+
+enum _ActivityFeedSliverItemType { title, gap, message, sectionHeader, row }
+
+enum _ActivityFeedCardSegmentPosition { single, first, middle, last }
+
+class _ActivityFeedSliverItem {
+  const _ActivityFeedSliverItem._({
+    required this.type,
+    this.height,
+    this.text,
+    this.isError = false,
+    this.row,
+    this.rowKey,
+    this.segmentPosition,
+    this.hasRows = false,
+    this.hasTopGap = false,
+  });
+
+  factory _ActivityFeedSliverItem.title() {
+    return const _ActivityFeedSliverItem._(
+      type: _ActivityFeedSliverItemType.title,
+    );
+  }
+
+  factory _ActivityFeedSliverItem.gap(double height) {
+    return _ActivityFeedSliverItem._(
+      type: _ActivityFeedSliverItemType.gap,
+      height: height,
+    );
+  }
+
+  factory _ActivityFeedSliverItem.message(String text, {bool isError = false}) {
+    return _ActivityFeedSliverItem._(
+      type: _ActivityFeedSliverItemType.message,
+      text: text,
+      isError: isError,
+    );
+  }
+
+  factory _ActivityFeedSliverItem.sectionHeader(
+    String title, {
+    required _ActivityFeedCardSegmentPosition segmentPosition,
+    required bool hasRows,
+  }) {
+    return _ActivityFeedSliverItem._(
+      type: _ActivityFeedSliverItemType.sectionHeader,
+      text: title,
+      segmentPosition: segmentPosition,
+      hasRows: hasRows,
+    );
+  }
+
+  factory _ActivityFeedSliverItem.row(
+    ActivityRowData row, {
+    required _ActivityFeedCardSegmentPosition segmentPosition,
+    required bool hasTopGap,
+    ValueKey<String>? rowKey,
+  }) {
+    return _ActivityFeedSliverItem._(
+      type: _ActivityFeedSliverItemType.row,
+      row: row,
+      rowKey: rowKey,
+      segmentPosition: segmentPosition,
+      hasTopGap: hasTopGap,
+    );
+  }
+
+  final _ActivityFeedSliverItemType type;
+  final double? height;
+  final String? text;
+  final bool isError;
+  final ActivityRowData? row;
+  final ValueKey<String>? rowKey;
+  final _ActivityFeedCardSegmentPosition? segmentPosition;
+  final bool hasRows;
+  final bool hasTopGap;
+}
+
+class _ActivityFeedSliverItemView extends StatelessWidget {
+  const _ActivityFeedSliverItemView({required this.item, super.key});
+
+  final _ActivityFeedSliverItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (item.type) {
+      _ActivityFeedSliverItemType.title => const _ActivityFeedCentered(
+        width: 420,
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: AppSpacing.s),
+          child: _ActivityFeedTitleRow(),
+        ),
+      ),
+      _ActivityFeedSliverItemType.gap => SizedBox(height: item.height),
+      _ActivityFeedSliverItemType.message => _ActivityFeedCentered(
+        width: 396,
+        child: _ActivityFeedMessageCard(
+          text: item.text!,
+          isError: item.isError,
+        ),
+      ),
+      _ActivityFeedSliverItemType.sectionHeader =>
+        _ActivityFeedSectionHeaderSegment(
+          title: item.text!,
+          position: item.segmentPosition!,
+          hasRows: item.hasRows,
+        ),
+      _ActivityFeedSliverItemType.row => _ActivityFeedRowSegment(
+        row: item.row!,
+        position: item.segmentPosition!,
+        hasTopGap: item.hasTopGap,
+      ),
+    };
+  }
+}
+
+class _ActivityFeedCentered extends StatelessWidget {
+  const _ActivityFeedCentered({required this.width, required this.child});
+
+  final double width;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: SizedBox(width: width, child: child),
+    );
+  }
+}
+
+class _ActivityFeedSectionHeaderSegment extends StatelessWidget {
+  const _ActivityFeedSectionHeaderSegment({
+    required this.title,
+    required this.position,
+    required this.hasRows,
+  });
+
+  final String title;
+  final _ActivityFeedCardSegmentPosition position;
+  final bool hasRows;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return _ActivityFeedCardSegment(
+      position: position,
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(16, 24, 16, hasRows ? AppSpacing.s : 24),
+        child: SizedBox(
+          height: 24,
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.xxs),
+            child: Text(
+              title,
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.secondary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ActivityFeedRowSegment extends StatelessWidget {
+  const _ActivityFeedRowSegment({
+    required this.row,
+    required this.position,
+    required this.hasTopGap,
+  });
+
+  final ActivityRowData row;
+  final _ActivityFeedCardSegmentPosition position;
+  final bool hasTopGap;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ActivityFeedCardSegment(
+      position: position,
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(
+          16,
+          hasTopGap ? 12 : 0,
+          16,
+          position == _ActivityFeedCardSegmentPosition.last ? 24 : 0,
+        ),
+        child: ActivityFeedRowGroup(row: row),
+      ),
+    );
+  }
+}
+
+class _ActivityFeedCardSegment extends StatelessWidget {
+  const _ActivityFeedCardSegment({required this.position, required this.child});
+
+  final _ActivityFeedCardSegmentPosition position;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return _ActivityFeedCentered(
+      width: 396,
+      child: CustomPaint(
+        painter: _ActivityFeedCardSegmentShadowPainter(
+          position: position,
+          shadows: appSurfaceShadow(colors),
+        ),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: colors.background.ground,
+            borderRadius: _activityFeedSegmentRadius(position),
+          ),
+          child: child,
+        ),
+      ),
+    );
+  }
+}
+
+class _ActivityFeedCardSegmentShadowPainter extends CustomPainter {
+  const _ActivityFeedCardSegmentShadowPainter({
+    required this.position,
+    required this.shadows,
+  });
+
+  static const _shadowPaintExtent = 24.0;
+
+  final _ActivityFeedCardSegmentPosition position;
+  final List<BoxShadow> shadows;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (shadows.isEmpty) return;
+    final clipPath = _shadowClipPath(size);
+    canvas.save();
+    canvas.clipPath(clipPath);
+    final radius = _activityFeedSegmentRadius(position);
+    final baseRect = Offset.zero & size;
+    for (final shadow in shadows) {
+      final rect = baseRect.inflate(shadow.spreadRadius).shift(shadow.offset);
+      canvas.drawRRect(radius.toRRect(rect), shadow.toPaint());
+    }
+    canvas.restore();
+  }
+
+  Path _shadowClipPath(Size size) {
+    const extent = _shadowPaintExtent;
+    final width = size.width;
+    final height = size.height;
+    final path = Path();
+    switch (position) {
+      case _ActivityFeedCardSegmentPosition.single:
+        path.addRect(
+          Rect.fromLTRB(-extent, -extent, width + extent, height + extent),
+        );
+      case _ActivityFeedCardSegmentPosition.first:
+        path.addRect(Rect.fromLTRB(-extent, -extent, width + extent, height));
+      case _ActivityFeedCardSegmentPosition.middle:
+        path
+          ..addRect(Rect.fromLTRB(-extent, 0, 0, height))
+          ..addRect(Rect.fromLTRB(width, 0, width + extent, height));
+      case _ActivityFeedCardSegmentPosition.last:
+        path.addRect(
+          Rect.fromLTRB(-extent, 0, width + extent, height + extent),
+        );
+    }
+    return path;
+  }
+
+  @override
+  bool shouldRepaint(
+    covariant _ActivityFeedCardSegmentShadowPainter oldDelegate,
+  ) {
+    if (oldDelegate.position != position) return true;
+    if (oldDelegate.shadows.length != shadows.length) return true;
+    for (var index = 0; index < shadows.length; index++) {
+      if (oldDelegate.shadows[index] != shadows[index]) return true;
+    }
+    return false;
+  }
+}
+
+BorderRadius _activityFeedSegmentRadius(
+  _ActivityFeedCardSegmentPosition position,
+) {
+  const radius = Radius.circular(AppRadii.large);
+  return switch (position) {
+    _ActivityFeedCardSegmentPosition.single => const BorderRadius.all(radius),
+    _ActivityFeedCardSegmentPosition.first => const BorderRadius.vertical(
+      top: radius,
+    ),
+    _ActivityFeedCardSegmentPosition.middle => BorderRadius.zero,
+    _ActivityFeedCardSegmentPosition.last => const BorderRadius.vertical(
+      bottom: radius,
+    ),
+  };
+}
+
 class _ActivityFeedTitleRow extends StatelessWidget {
   const _ActivityFeedTitleRow();
 

--- a/test/activity_feed_row_test.dart
+++ b/test/activity_feed_row_test.dart
@@ -368,6 +368,21 @@ void main() {
       findsOneWidget,
     );
   });
+
+  testWidgets('activity feed uses stable row ids when available', (
+    tester,
+  ) async {
+    await _pumpActivityFeed(
+      tester,
+      rows: [
+        _row(title: 'Received', stableId: 'tx:received:received'),
+        _row(title: 'Sent', stableId: 'tx:sent:sent'),
+      ],
+    );
+
+    expect(find.byKey(const ValueKey('tx:received:received')), findsOneWidget);
+    expect(find.byKey(const ValueKey('tx:sent:sent')), findsOneWidget);
+  });
 }
 
 Future<void> _pumpMappedTransactions(
@@ -445,6 +460,7 @@ rust_sync.TransactionInfo _tx({
 
 ActivityRowData _row({
   required String title,
+  String? stableId,
   String leadingIconName = AppIcons.sync,
   String? subtitle,
   String? amountSubtitle,
@@ -454,6 +470,7 @@ ActivityRowData _row({
   VoidCallback? onTap,
 }) {
   return ActivityRowData(
+    stableId: stableId,
     title: title,
     leadingIconName: leadingIconName,
     leadingBackgroundColor: const Color(0xFFE1E1E1),

--- a/test/activity_feed_row_test.dart
+++ b/test/activity_feed_row_test.dart
@@ -383,6 +383,28 @@ void main() {
     expect(find.byKey(const ValueKey('tx:received:received')), findsOneWidget);
     expect(find.byKey(const ValueKey('tx:sent:sent')), findsOneWidget);
   });
+
+  testWidgets('activity feed sliver lazily builds row items', (tester) async {
+    await _pumpActivityFeedSliver(
+      tester,
+      rows: [
+        for (var index = 0; index < 60; index++)
+          _row(title: 'Row $index', stableId: 'row-$index'),
+      ],
+    );
+
+    expect(find.byKey(const ValueKey('row-0')), findsOneWidget);
+    expect(find.byKey(const ValueKey('row-59')), findsNothing);
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('row-59')),
+      240,
+      scrollable: find.byType(Scrollable),
+      maxScrolls: 80,
+    );
+
+    expect(find.byKey(const ValueKey('row-59')), findsOneWidget);
+  });
 }
 
 Future<void> _pumpMappedTransactions(
@@ -431,6 +453,34 @@ Widget _feed(List<ActivityRowData> rows) {
       width: 420,
       child: ActivityFeed(
         sections: [ActivityFeedSectionData(title: 'This week', rows: rows)],
+      ),
+    ),
+  );
+}
+
+Future<void> _pumpActivityFeedSliver(
+  WidgetTester tester, {
+  required List<ActivityRowData> rows,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: Center(
+          child: SizedBox(
+            width: 420,
+            height: 240,
+            child: CustomScrollView(
+              slivers: [
+                ActivityFeedSliver(
+                  sections: [
+                    ActivityFeedSectionData(title: 'This week', rows: rows),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     ),
   );

--- a/test/features/activity/activity_row_mapper_test.dart
+++ b/test/features/activity/activity_row_mapper_test.dart
@@ -41,6 +41,25 @@ void main() {
     expect(row.statusText, 'In progress');
   });
 
+  testWidgets('transaction rows expose a stable identity', (tester) async {
+    final row = await mapRow(tester, _transaction(txKind: 'sent'));
+
+    expect(row.stableId, 'tx:ab12cd34:sent');
+  });
+
+  testWidgets('receive rows keep identity when pending rows are mined', (
+    tester,
+  ) async {
+    final pending = await mapRow(
+      tester,
+      _transaction(txKind: 'receiving', minedHeight: BigInt.zero),
+    );
+    final confirmed = await mapRow(tester, _transaction(txKind: 'received'));
+
+    expect(pending.stableId, 'tx:ab12cd34:received');
+    expect(confirmed.stableId, pending.stableId);
+  });
+
   testWidgets('unconfirmed receive renders as an in-flight loader row', (
     tester,
   ) async {

--- a/test/features/swap/swap_activity_row_mapper_test.dart
+++ b/test/features/swap/swap_activity_row_mapper_test.dart
@@ -45,6 +45,7 @@ void main() {
     );
 
     expect(row!.title, 'Swapping...');
+    expect(row!.stableId, 'swap:swap-1');
     expect(row!.subtitle, 'ZEC Zcash');
     expect(row!.subtitleIconName, isNull);
     expect(row!.amountText, '-0.0030 ZEC');
@@ -179,6 +180,7 @@ void main() {
     expect(row!.statusText, 'Completed');
     expect(row!.leadingProgressValue, isNull);
     expect(row!.childRows, hasLength(1));
+    expect(row!.childRows.single.stableId, 'swap:swap-private:deposited');
     expect(row!.childRows.single.amountText, isNot(contains('0.21')));
     expect(row!.childRows.single.amountText, contains('***'));
   });
@@ -380,6 +382,7 @@ void main() {
       expect(row!.title, 'Swapped');
       expect(row!.childRows, hasLength(1));
       final child = row!.childRows.single;
+      expect(child.stableId, 'swap:swap-receive:received');
       expect(child.title, 'Received ZEC');
       // The absorbed on-chain receive carries the real settled amount, which
       // wins over the quote estimate ('+4.12 ZEC').

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -3889,7 +3889,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
-    final scrollView = tester.widget<SingleChildScrollView>(
+    final scrollView = tester.widget<CustomScrollView>(
       find.byKey(AppPaneScrollScaffold.scrollViewKey),
     );
     final controller = scrollView.controller!;
@@ -3973,6 +3973,13 @@ void main() {
         seedSwapActivityFixtures: false,
         sessionStore: _FakeSwapPersistenceStore(initialIntents: intents),
       ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('swap:swap-page-6')),
+      160,
+      scrollable: find.byType(Scrollable).first,
     );
     await tester.pumpAndSettle();
 

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -3976,8 +3976,8 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.byKey(const ValueKey('activity_screen_row_5')), findsOneWidget);
-    expect(find.byKey(const ValueKey('activity_screen_row_6')), findsOneWidget);
+    expect(find.byKey(const ValueKey('swap:swap-page-5')), findsOneWidget);
+    expect(find.byKey(const ValueKey('swap:swap-page-6')), findsOneWidget);
     final filterLabel = tester.widget<Text>(
       find.byKey(const ValueKey('activity_screen_filter_label')),
     );


### PR DESCRIPTION
## Summary

- Keep loaded Activity rows visible during same-account refreshes so the scroll position does not jump while history reloads.
- Add stable transaction and swap row identities so Flutter can preserve row state across refreshes and reorderings.
- Render the redesigned Activity feed with row-level sliver lazy rendering, preserving the section-card visual treatment with first/middle/last row decoration.

## Validation

- `fvm flutter analyze`
- `fvm flutter test test/activity_feed_row_test.dart`
- `fvm flutter test test/features/swap/swap_screen_test.dart --name "activity page scrolls when swap rows exceed the viewport"`
- `fvm flutter test test/features/swap/swap_screen_test.dart --name "activity page renders all rows in the scroll feed"`
- `fvm flutter test test/app_swap_feature_test.dart test/widgetbook/activity_use_cases_test.dart`
- `git diff --check`