### PR TITLE
Clarify activity sender states

### DIFF
--- a/lib/src/features/activity/screens/activity_screen.dart
+++ b/lib/src/features/activity/screens/activity_screen.dart
@@ -311,22 +311,31 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
         : SwapActivityLegAbsorption.empty;
     final swapReceiveTxByIntent = absorption.receiveTxByIntent;
 
-    final entries = <_ActivityEntry>[
-      if (canRenderTransactions)
-        for (final tx in transactions)
-          if (!absorption.absorbs(tx))
-            _ActivityEntry(
-              timestamp: _transactionActivityTimestamp(tx),
-              row: buildTransactionActivityRow(
-                context: context,
-                transaction: tx,
-                privacyModeEnabled: privacyModeEnabled,
-                onTap: () => _openTransactionStatus(tx),
-              ),
+    final entries = <_ActivityEntry>[];
+    var sourceOrder = 0;
+    if (canRenderTransactions) {
+      for (final tx in transactions) {
+        if (absorption.absorbs(tx)) continue;
+        entries.add(
+          _ActivityEntry(
+            sortKey: activitySortKeyForTransaction(
+              tx,
+              sourceOrder: sourceOrder++,
             ),
-      for (final item in swapItems)
+            row: buildTransactionActivityRow(
+              context: context,
+              transaction: tx,
+              privacyModeEnabled: privacyModeEnabled,
+              onTap: () => _openTransactionStatus(tx),
+            ),
+          ),
+        );
+      }
+    }
+    for (final item in swapItems) {
+      entries.add(
         _ActivityEntry(
-          timestamp: item.activityTimestamp,
+          sortKey: activitySortKeyForSwapItem(item, sourceOrder: sourceOrder++),
           row: buildSwapActivityRow(
             context: context,
             item: item,
@@ -341,7 +350,9 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
             },
           ),
         ),
-    ]..sort(_compareActivityEntries);
+      );
+    }
+    entries.sort(_compareActivityEntries);
     final sections = _activityFeedSections(entries);
 
     return AppDesktopShell(
@@ -369,15 +380,78 @@ class _ActivityScreenState extends ConsumerState<ActivityScreen> {
 }
 
 class _ActivityEntry {
-  const _ActivityEntry({required this.timestamp, required this.row});
+  const _ActivityEntry({required this.sortKey, required this.row});
 
-  final DateTime? timestamp;
+  final ActivityEntrySortKey sortKey;
   final ActivityRowData row;
 }
 
 int _compareActivityEntries(_ActivityEntry a, _ActivityEntry b) {
+  return compareActivityEntrySortKeys(a.sortKey, b.sortKey);
+}
+
+@visibleForTesting
+class ActivityEntrySortKey {
+  const ActivityEntrySortKey({
+    required this.timestamp,
+    required this.isPendingTransaction,
+    required this.sourceOrder,
+  });
+
+  final DateTime? timestamp;
+  final bool isPendingTransaction;
+  final int sourceOrder;
+}
+
+@visibleForTesting
+ActivityEntrySortKey activitySortKeyForTransaction(
+  rust_sync.TransactionInfo tx, {
+  required int sourceOrder,
+}) {
+  return ActivityEntrySortKey(
+    timestamp: _transactionActivityTimestamp(tx),
+    isPendingTransaction: isPendingActivityTransaction(tx),
+    sourceOrder: sourceOrder,
+  );
+}
+
+@visibleForTesting
+ActivityEntrySortKey activitySortKeyForSwapItem(
+  SwapActivityRowItem item, {
+  required int sourceOrder,
+}) {
+  return ActivityEntrySortKey(
+    timestamp: item.activityTimestamp,
+    isPendingTransaction: false,
+    sourceOrder: sourceOrder,
+  );
+}
+
+@visibleForTesting
+bool isPendingActivityTransaction(rust_sync.TransactionInfo tx) {
+  return tx.minedHeight == BigInt.zero && !tx.expiredUnmined;
+}
+
+@visibleForTesting
+int compareActivityEntrySortKeys(
+  ActivityEntrySortKey a,
+  ActivityEntrySortKey b,
+) {
+  final aMissingTimestampPending =
+      a.isPendingTransaction && a.timestamp == null;
+  final bMissingTimestampPending =
+      b.isPendingTransaction && b.timestamp == null;
+  if (aMissingTimestampPending != bMissingTimestampPending) {
+    return aMissingTimestampPending ? -1 : 1;
+  }
   final aTime = a.timestamp;
   final bTime = b.timestamp;
+  final timeComparison = _compareActivityTimestamps(aTime, bTime);
+  if (timeComparison != 0) return timeComparison;
+  return a.sourceOrder.compareTo(b.sourceOrder);
+}
+
+int _compareActivityTimestamps(DateTime? aTime, DateTime? bTime) {
   if (aTime == null && bTime == null) return 0;
   if (aTime == null) return 1;
   if (bTime == null) return -1;
@@ -398,7 +472,7 @@ List<ActivityFeedSectionData> _activityFeedSections(
   String? currentTitle;
 
   for (final entry in entries) {
-    final title = _activitySectionTitle(entry.timestamp);
+    final title = activitySectionTitleForSortKey(entry.sortKey);
     if (title != currentTitle) {
       currentTitle = title;
       currentRows = <ActivityRowData>[];
@@ -410,12 +484,24 @@ List<ActivityFeedSectionData> _activityFeedSections(
   return sections;
 }
 
-String _activitySectionTitle(DateTime? timestamp) {
+@visibleForTesting
+String activitySectionTitleForSortKey(
+  ActivityEntrySortKey sortKey, {
+  DateTime? now,
+}) {
+  if (sortKey.isPendingTransaction && sortKey.timestamp == null) {
+    return 'This week';
+  }
+  return activitySectionTitleForTimestamp(sortKey.timestamp, now: now);
+}
+
+@visibleForTesting
+String activitySectionTitleForTimestamp(DateTime? timestamp, {DateTime? now}) {
   if (timestamp == null) return 'Earlier';
 
   final local = timestamp.toLocal();
-  final now = DateTime.now();
-  final weekStart = _startOfWeek(now);
+  final reference = now ?? DateTime.now();
+  final weekStart = _startOfWeek(reference);
   final nextWeekStart = weekStart.add(const Duration(days: 7));
   if (!local.isBefore(weekStart) && local.isBefore(nextWeekStart)) {
     return 'This week';

--- a/lib/src/features/activity/screens/activity_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/activity_transaction_status_screen.dart
@@ -478,7 +478,9 @@ class _ActivityTransactionStatusScreenState
         timestampText: _timestampText(tx),
         txIdText: tx.txidHex,
         fromRecipient: fromRecipient,
-        unknownFromPool: hasFromAddress ? null : fromPool,
+        unknownFromKind: hasFromAddress
+            ? null
+            : _unknownFromKindForSourcePool(fromPool),
         isShieldedSource:
             fromPool == 'shielded' ||
             (hasFromAddress && _isShieldedZcashAddress(fromAddress)),
@@ -498,6 +500,13 @@ class _ActivityTransactionStatusScreenState
         onTxIdPressed: () => unawaited(_openTransactionExplorer()),
       ),
     );
+  }
+
+  ReceivedReceiptUnknownFromKind? _unknownFromKindForSourcePool(String? pool) {
+    if (pool == null || pool.isEmpty) return null;
+    return pool == 'shielded'
+        ? ReceivedReceiptUnknownFromKind.shieldedSender
+        : ReceivedReceiptUnknownFromKind.unknownSender;
   }
 
   Widget _sentContent(

--- a/lib/src/features/activity/widgets/received_receipt_view.dart
+++ b/lib/src/features/activity/widgets/received_receipt_view.dart
@@ -21,6 +21,8 @@ const _receivedFeeHelpTooltip =
 /// send-specific refund copy or dark-card treatment.
 enum ReceivedReceiptStatus { inProgress, completed, failed }
 
+enum ReceivedReceiptUnknownFromKind { shieldedSender, unknownSender }
+
 /// Static content of the redesigned received-transaction receipt: status
 /// title, optional From row joined to the Amount Review Info row by an
 /// arrow-down connector, and the Review Wrap detail card.
@@ -37,7 +39,7 @@ class ReceivedReceiptView extends StatelessWidget {
     required this.txIdText,
     this.status = ReceivedReceiptStatus.completed,
     this.fromRecipient,
-    this.unknownFromPool,
+    this.unknownFromKind,
     this.isShieldedSource = false,
     this.feeText,
     this.receivingAddress,
@@ -64,11 +66,11 @@ class ReceivedReceiptView extends StatelessWidget {
   final ReceivedReceiptStatus status;
 
   /// Sender display data. The From row (and its arrow connector) is omitted
-  /// when null unless [unknownFromPool] is present.
+  /// when null unless [unknownFromKind] is present.
   final SendReviewRecipient? fromRecipient;
 
-  /// Sender pool when the exact source address is unavailable.
-  final String? unknownFromPool;
+  /// Why the exact source address is unavailable.
+  final ReceivedReceiptUnknownFromKind? unknownFromKind;
 
   /// Pool badge under the From row: shielded (shield keyhole + "Shielded")
   /// vs transparent (transparent-balance glyph + "Transparent").
@@ -109,11 +111,7 @@ class ReceivedReceiptView extends StatelessWidget {
     final colors = context.colors;
     final memo = memoText?.trim();
     final fromRecipient = this.fromRecipient;
-    final unknownFromPool = this.unknownFromPool?.trim().toLowerCase();
-    final hasUnknownFrom =
-        fromRecipient == null &&
-        unknownFromPool != null &&
-        unknownFromPool.isNotEmpty;
+    final unknownFromKind = fromRecipient == null ? this.unknownFromKind : null;
     final title = switch (status) {
       ReceivedReceiptStatus.inProgress => 'Receive in progress...',
       ReceivedReceiptStatus.completed => 'Received successfully',
@@ -156,11 +154,11 @@ class ReceivedReceiptView extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              if (fromRecipient != null || hasUnknownFrom) ...[
+              if (fromRecipient != null || unknownFromKind != null) ...[
                 if (fromRecipient != null)
                   _fromRow(context, fromRecipient)
                 else
-                  _unknownFromRow(context, unknownFromPool!),
+                  _unknownFromRow(context, unknownFromKind!),
                 const _ReceivedArrowSeparator(),
               ],
               ReviewInfoRow(
@@ -271,21 +269,22 @@ class ReceivedReceiptView extends StatelessWidget {
     };
   }
 
-  Widget _unknownFromRow(BuildContext context, String pool) {
-    final isKnownPool = pool == 'shielded' || pool == 'transparent';
-    final isShielded = pool == 'shielded';
+  Widget _unknownFromRow(
+    BuildContext context,
+    ReceivedReceiptUnknownFromKind kind,
+  ) {
+    final isShieldedSender =
+        kind == ReceivedReceiptUnknownFromKind.shieldedSender;
 
     return ReviewInfoRow(
       label: 'From',
-      value: 'Unknown sender',
+      value: isShieldedSender ? 'Shielded sender' : 'Unknown sender',
       leading: const ReviewInfoIconCircle(iconName: AppIcons.wallet),
-      bottomLeftIconName: isKnownPool ? _poolIconName(isShielded) : null,
-      bottomLeftIconColor: isKnownPool
-          ? _poolIconColor(context, isShielded)
+      bottomLeftIconName: isShieldedSender ? _poolIconName(true) : null,
+      bottomLeftIconColor: isShieldedSender
+          ? _poolIconColor(context, true)
           : null,
-      bottomLeftText: isKnownPool
-          ? (isShielded ? 'Shielded' : 'Transparent')
-          : null,
+      bottomLeftText: isShieldedSender ? 'Shielded' : null,
     );
   }
 }

--- a/lib/widgetbook/received_receipt_use_cases.dart
+++ b/lib/widgetbook/received_receipt_use_cases.dart
@@ -74,7 +74,7 @@ Widget buildReceivedReceiptTransparentToShieldedUseCase(BuildContext context) {
 Widget buildReceivedReceiptShieldedToShieldedUseCase(BuildContext context) {
   return _ReceivedReceiptFrame(
     child: ReceivedReceiptView(
-      unknownFromPool: 'shielded',
+      unknownFromKind: ReceivedReceiptUnknownFromKind.shieldedSender,
       isShieldedSource: true,
       amountText: '120 ZEC',
       receivingAddress: _shieldedReceivingAddress,
@@ -119,7 +119,7 @@ Widget buildReceivedReceiptInProgressUseCase(BuildContext context) {
   return _ReceivedReceiptFrame(
     child: ReceivedReceiptView(
       status: ReceivedReceiptStatus.inProgress,
-      unknownFromPool: 'unknown',
+      unknownFromKind: ReceivedReceiptUnknownFromKind.unknownSender,
       amountText: '120 ZEC',
       receivingAddress: _transparentReceivingAddress,
       timestampText: '25 May, 13:30',

--- a/test/features/activity/activity_screen_sorting_test.dart
+++ b/test/features/activity/activity_screen_sorting_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/features/activity/screens/activity_screen.dart';
+import 'package:zcash_wallet/src/features/activity/swap_activity_row_mapper.dart';
+import 'package:zcash_wallet/src/features/swap/domain/swap_intent_status.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+
+void main() {
+  test(
+    'pending transactions without timestamps sort before timestamped activity',
+    () {
+      final pending = activitySortKeyForTransaction(
+        _transaction(
+          txidHex: 'pending',
+          minedHeight: BigInt.zero,
+          blockTime: BigInt.zero,
+          createdTime: BigInt.zero,
+        ),
+        sourceOrder: 0,
+      );
+      final confirmed = activitySortKeyForTransaction(
+        _transaction(
+          txidHex: 'confirmed',
+          blockTime: BigInt.from(1800000000),
+          createdTime: BigInt.from(1800000000),
+        ),
+        sourceOrder: 1,
+      );
+
+      final sorted = [confirmed, pending]..sort(compareActivityEntrySortKeys);
+
+      expect(sorted.first, same(pending));
+      expect(activitySectionTitleForSortKey(pending), 'This week');
+    },
+  );
+
+  test('pending transactions with timestamps keep timestamp ordering', () {
+    final olderPending = activitySortKeyForTransaction(
+      _transaction(
+        txidHex: 'older-pending',
+        minedHeight: BigInt.zero,
+        blockTime: BigInt.from(1780000000),
+        createdTime: BigInt.from(1780000000),
+      ),
+      sourceOrder: 0,
+    );
+    final newerConfirmed = activitySortKeyForTransaction(
+      _transaction(
+        txidHex: 'newer-confirmed',
+        blockTime: BigInt.from(1800000000),
+        createdTime: BigInt.from(1800000000),
+      ),
+      sourceOrder: 1,
+    );
+
+    final sorted = [olderPending, newerConfirmed]
+      ..sort(compareActivityEntrySortKeys);
+
+    expect(olderPending.isPendingTransaction, isTrue);
+    expect(sorted.first, same(newerConfirmed));
+    expect(
+      activitySectionTitleForSortKey(
+        olderPending,
+        now: DateTime.utc(2026, 6, 16),
+      ),
+      'May 2026',
+    );
+  });
+
+  test('expired unmined transactions do not receive pending priority', () {
+    final expired = activitySortKeyForTransaction(
+      _transaction(
+        txidHex: 'expired',
+        minedHeight: BigInt.zero,
+        expiredUnmined: true,
+        blockTime: BigInt.zero,
+        createdTime: BigInt.zero,
+      ),
+      sourceOrder: 0,
+    );
+    final confirmed = activitySortKeyForTransaction(
+      _transaction(
+        txidHex: 'confirmed',
+        blockTime: BigInt.from(1800000000),
+        createdTime: BigInt.from(1800000000),
+      ),
+      sourceOrder: 1,
+    );
+
+    final sorted = [expired, confirmed]..sort(compareActivityEntrySortKeys);
+
+    expect(expired.isPendingTransaction, isFalse);
+    expect(sorted.first, same(confirmed));
+    expect(activitySectionTitleForSortKey(expired), 'Earlier');
+  });
+
+  test(
+    'swap rows keep timestamp ordering regardless of in-progress status',
+    () {
+      final olderProcessing = activitySortKeyForSwapItem(
+        _swapItem(
+          status: SwapIntentStatus.processing,
+          timestamp: DateTime.utc(2026, 6, 10, 12),
+        ),
+        sourceOrder: 0,
+      );
+      final newerCompleted = activitySortKeyForSwapItem(
+        _swapItem(
+          status: SwapIntentStatus.complete,
+          timestamp: DateTime.utc(2026, 6, 12, 12),
+        ),
+        sourceOrder: 1,
+      );
+
+      final sorted = [olderProcessing, newerCompleted]
+        ..sort(compareActivityEntrySortKeys);
+
+      expect(olderProcessing.isPendingTransaction, isFalse);
+      expect(sorted.first, same(newerCompleted));
+    },
+  );
+}
+
+rust_sync.TransactionInfo _transaction({
+  required String txidHex,
+  BigInt? minedHeight,
+  bool expiredUnmined = false,
+  BigInt? blockTime,
+  BigInt? createdTime,
+}) {
+  return rust_sync.TransactionInfo(
+    txidHex: txidHex,
+    minedHeight: minedHeight ?? BigInt.from(2500000),
+    expiredUnmined: expiredUnmined,
+    accountBalanceDelta: 0,
+    fee: BigInt.zero,
+    blockTime: blockTime ?? BigInt.from(1800000000),
+    isTransparent: false,
+    txKind: expiredUnmined ? 'sent' : 'received',
+    displayAmount: BigInt.from(120000000),
+    displayPool: 'shielded',
+    createdTime: createdTime ?? BigInt.from(1800000000),
+  );
+}
+
+SwapActivityRowItem _swapItem({
+  required SwapIntentStatus status,
+  required DateTime timestamp,
+}) {
+  return SwapActivityRowItem(
+    intentId: 'swap-${status.name}',
+    providerLabel: 'NEAR Intents',
+    sellAmountText: '1 ZEC',
+    receiveEstimateText: '+10 USDC',
+    status: status,
+    activityTimestamp: timestamp,
+  );
+}

--- a/test/features/activity/activity_transaction_status_screen_test.dart
+++ b/test/features/activity/activity_transaction_status_screen_test.dart
@@ -74,6 +74,36 @@ void main() {
     expect(find.text('Network fee'), findsNothing);
   });
 
+  testWidgets('labels shielded-source receives as shielded sender', (
+    tester,
+  ) async {
+    await _pumpScreen(
+      tester,
+      args: ActivityTransactionStatusArgs(
+        txidHex: _txidHex,
+        txKind: 'received',
+        initialTransaction: _transaction(txKind: 'received'),
+        initialDetail: _detail(
+          txKind: 'received',
+          sourcePool: 'shielded',
+          outputs: [
+            rust_sync.TransactionDetailOutput(
+              address: _recipientAddress,
+              amountZatoshi: BigInt.from(12000000000),
+              pool: 'shielded',
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.byType(ReceivedReceiptView), findsOneWidget);
+    expect(find.text('Shielded sender'), findsOneWidget);
+    expect(find.text('Unknown sender'), findsNothing);
+    expect(find.text('Shielded'), findsOneWidget);
+    expect(find.text('Show full address'), findsNothing);
+  });
+
   testWidgets('shows the fee row for a receive with a known fee', (
     tester,
   ) async {

--- a/test/features/activity/received_receipt_view_test.dart
+++ b/test/features/activity/received_receipt_view_test.dart
@@ -127,7 +127,7 @@ void main() {
     await _pump(
       tester,
       ReceivedReceiptView(
-        unknownFromPool: 'shielded',
+        unknownFromKind: ReceivedReceiptUnknownFromKind.shieldedSender,
         isShieldedSource: true,
         amountText: '120 ZEC',
         receivingAddress: _shieldedReceivingAddress,
@@ -139,17 +139,20 @@ void main() {
     );
 
     expect(find.text('Message'), findsNothing);
-    expect(find.text('Unknown sender'), findsOneWidget);
+    expect(find.text('Shielded sender'), findsOneWidget);
+    expect(find.text('Unknown sender'), findsNothing);
     expect(find.text('Shielded'), findsOneWidget);
     expect(find.text('Transparent'), findsNothing);
     expect(find.textContaining(' ... '), findsOneWidget);
   });
 
-  testWidgets('renders an unknown transparent source row', (tester) async {
+  testWidgets('renders an unknown source row without a pool badge', (
+    tester,
+  ) async {
     await _pump(
       tester,
       const ReceivedReceiptView(
-        unknownFromPool: 'transparent',
+        unknownFromKind: ReceivedReceiptUnknownFromKind.unknownSender,
         amountText: '120 ZEC',
         receivingAddress: _transparentReceivingAddress,
         timestampText: '25 May, 13:30',
@@ -159,7 +162,8 @@ void main() {
 
     expect(find.text('From'), findsOneWidget);
     expect(find.text('Unknown sender'), findsOneWidget);
-    expect(find.text('Transparent'), findsOneWidget);
+    expect(find.text('Transparent'), findsNothing);
+    expect(find.text('Shielded'), findsNothing);
     expect(find.text('Show full address'), findsNothing);
     expect(
       find.byWidgetPredicate(

--- a/test/widgetbook/received_receipt_use_cases_test.dart
+++ b/test/widgetbook/received_receipt_use_cases_test.dart
@@ -49,7 +49,8 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(find.byType(ReceivedReceiptView), findsOneWidget);
     expect(find.text('Message'), findsNothing);
-    expect(find.text('Unknown sender'), findsOneWidget);
+    expect(find.text('Shielded sender'), findsOneWidget);
+    expect(find.text('Unknown sender'), findsNothing);
     expect(find.text('Shielded'), findsOneWidget);
     expect(find.text('Completed'), findsOneWidget);
   });


### PR DESCRIPTION
## Summary
- keep pending received transactions without timestamps at the top of activity while preserving timestamp ordering otherwise
- distinguish shielded senders from truly unknown senders on received transaction details
- update received receipt widgetbook fixtures and focused tests

## Validation
- fvm flutter test test/features/activity/activity_screen_sorting_test.dart
- fvm flutter test test/features/activity/received_receipt_view_test.dart test/features/activity/activity_transaction_status_screen_test.dart test/widgetbook/received_receipt_use_cases_test.dart
- fvm flutter analyze
- git diff --check