### PR TITLE
[codex] Simplify send recipient field labels

### DIFF
--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -28,8 +28,6 @@ import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import '../../address_book/models/address_book_contact.dart';
-import '../../address_book/models/address_book_label_lookup.dart';
-import '../../address_book/providers/address_book_provider.dart';
 import '../../address_book/widgets/address_book_contact_picker_modal.dart';
 import '../models/send_prefill_args.dart';
 import 'send_review_screen.dart';
@@ -810,17 +808,6 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       _ => null,
     };
     final addressHasText = _addressController.text.trim().isNotEmpty;
-    // The contacts button doubles as the detected-contact display: any path
-    // that puts a known Zcash address in the field (picker, Send ZEC prefill,
-    // paste, typing) resolves to the contact's label automatically.
-    final addressBookContacts =
-        ref.watch(addressBookProvider).value?.contacts ??
-        const <AddressBookContact>[];
-    final contactLabel = addressBookLabelFor(
-      contacts: addressBookContacts,
-      network: AddressBookNetwork.zcash,
-      address: _addressController.text,
-    );
     final addressLeadingIcon = switch (_addressType) {
       'unified' || 'sapling' => AppIcons.shieldKeyhole,
       'transparent' || 'tex' => AppIcons.transparentBalance,
@@ -898,7 +885,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                             key: const ValueKey('send_address_field'),
                             label: 'Send to',
                             rightSlot: _SendContactsLabelButton(
-                              label: contactLabel ?? 'Contacts',
+                              label: 'Contacts',
                               onTap: _openContactPicker,
                             ),
                             tone: addressTone,

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -797,8 +797,6 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       _ => AppTextFieldTone.neutral,
     };
     final addressMessage = switch (_addressType) {
-      'unified' || 'sapling' => 'Shielded → Shielded',
-      'transparent' || 'tex' => 'Shielded → Transparent',
       'invalid' => 'Invalid address',
       'error' => 'Address validation failed',
       _ => null,
@@ -808,15 +806,6 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         AppIcons.warning,
         size: 16,
         color: colors.text.destructive,
-      ),
-      _ => null,
-    };
-    final addressMessageStyle = switch (_addressType) {
-      'unified' || 'sapling' => AppTypography.labelMedium.copyWith(
-        color: colors.text.brandCrimson,
-      ),
-      'transparent' || 'tex' => AppTypography.labelMedium.copyWith(
-        color: colors.text.secondary,
       ),
       _ => null,
     };
@@ -923,7 +912,6 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                             ),
                             messageText: addressMessage,
                             messageIcon: addressMessageIcon,
-                            messageStyle: addressMessageStyle,
                             onChanged: (_) => _handleAddressChanged(),
                             keyboardType: TextInputType.text,
                             showClearButton: true,

--- a/lib/src/features/send/widgets/send_compose_view.dart
+++ b/lib/src/features/send/widgets/send_compose_view.dart
@@ -5,21 +5,18 @@ import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_text_field.dart';
 
-/// Source→destination shielding route for the recipient indicator shown
-/// beneath the address field.
+/// Recipient address type used to choose the leading icon.
 ///
 /// The wallet always spends from the shielded pool (sapling + orchard), so
-/// the source side is always "Shielded"; only the destination varies with
-/// the recipient address type.
+/// the spend source does not need a separate field-level caption.
 enum SendPoolRoute {
-  /// No address entered yet — no route caption shown.
+  /// No address entered yet.
   unknown,
 
-  /// Recipient is a unified/sapling (shielded) address. Crimson caption.
+  /// Recipient is a unified/sapling (shielded) address.
   shieldedToShielded,
 
-  /// Recipient is a transparent address. Neutral/grey caption; memo is
-  /// unavailable.
+  /// Recipient is a transparent address; memo is unavailable.
   shieldedToTransparent,
 }
 
@@ -42,13 +39,8 @@ enum SendMemoMode {
 /// validated in Widgetbook before it is wired into `send_screen.dart`.
 /// Callbacks are optional and default to no-ops in previews.
 ///
-/// The recipient pool indicator and the memo over-limit error both ride on
-/// [AppTextField.messageText] + [AppTextField.tone]:
-/// * crimson `Shielded → Shielded` uses a custom [AppTextField.messageStyle]
-///   over the neutral tone (no leading caption icon),
-/// * grey `Shielded → Transparent` uses the neutral secondary color,
-/// * the memo `Message is too long` error uses [AppTextFieldTone.destructive]
-///   (warning icon + destructive text).
+/// Validation and memo over-limit errors ride on [AppTextField.messageText] +
+/// [AppTextField.tone].
 class SendComposeView extends StatelessWidget {
   const SendComposeView({
     super.key,
@@ -116,10 +108,9 @@ class SendComposeView extends StatelessWidget {
   final double contentWidth;
   final double reviewButtonWidth;
 
-  // Reserved space for the caption overlay that AppTextField paints just
-  // below each field (pool indicator / validation error). Mirrors the
-  // current send screen's spacing so the compose layout stays vertically
-  // balanced.
+  // Reserved space for the message overlay that AppTextField paints just below
+  // each field. Mirrors the current send screen's spacing so the compose
+  // layout stays vertically balanced.
   static const _overlayReserve = 20.0;
   static const _fieldGap = AppSpacing.xs;
   static const _multilineOverlayReserve = 24.0;
@@ -229,18 +220,6 @@ class SendComposeView extends StatelessWidget {
       SendPoolRoute.shieldedToShielded => colors.icon.brandCrimson,
       SendPoolRoute.shieldedToTransparent => colors.icon.muted,
     };
-    final (String? caption, Color? captionColor) = switch (route) {
-      SendPoolRoute.unknown => (null, null),
-      SendPoolRoute.shieldedToShielded => (
-        'Shielded → Shielded',
-        colors.text.brandCrimson,
-      ),
-      SendPoolRoute.shieldedToTransparent => (
-        'Shielded → Transparent',
-        colors.text.secondary,
-      ),
-    };
-
     return AppTextField(
       key: const ValueKey('send_address_field'),
       label: 'Send to',
@@ -251,10 +230,6 @@ class SendComposeView extends StatelessWidget {
       initialValue: recipientText,
       hintText: recipientHint,
       leading: AppIcon(leadingName, size: 20, color: leadingColor),
-      messageText: caption,
-      messageStyle: caption == null
-          ? null
-          : AppTypography.labelMedium.copyWith(color: captionColor),
       showClearButton: true,
       keyboardType: TextInputType.text,
     );

--- a/lib/src/features/send/widgets/send_compose_view.dart
+++ b/lib/src/features/send/widgets/send_compose_view.dart
@@ -48,7 +48,6 @@ class SendComposeView extends StatelessWidget {
     this.recipientText = '',
     this.recipientHint = 'Zcash address',
     this.route = SendPoolRoute.unknown,
-    this.contactName,
     this.amountText = '',
     this.amountHint = '0.00',
     this.maxLabel = 'Max: 150 ZEC',
@@ -76,10 +75,6 @@ class SendComposeView extends StatelessWidget {
   final String recipientText;
   final String recipientHint;
   final SendPoolRoute route;
-
-  /// When non-null, the right-hand link shows the selected contact's name
-  /// (e.g. `Mike`) instead of the default `Contacts` affordance.
-  final String? contactName;
 
   // Amount field.
   final String amountText;
@@ -223,10 +218,7 @@ class SendComposeView extends StatelessWidget {
     return AppTextField(
       key: const ValueKey('send_address_field'),
       label: 'Send to',
-      rightSlot: _SendRecipientLink(
-        label: contactName ?? 'Contacts',
-        onTap: onContactsPressed,
-      ),
+      rightSlot: _SendRecipientLink(onTap: onContactsPressed),
       initialValue: recipientText,
       hintText: recipientHint,
       leading: AppIcon(leadingName, size: 20, color: leadingColor),
@@ -306,12 +298,10 @@ class SendComposeView extends StatelessWidget {
   static void _noop() {}
 }
 
-/// Right-hand "Send to" affordance: shows `Contacts ›` by default, or the
-/// selected contact's name once one is picked.
+/// Right-hand "Send to" affordance for opening the contact picker.
 class _SendRecipientLink extends StatelessWidget {
-  const _SendRecipientLink({required this.label, this.onTap});
+  const _SendRecipientLink({this.onTap});
 
-  final String label;
   final VoidCallback? onTap;
 
   @override
@@ -323,7 +313,7 @@ class _SendRecipientLink extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           Text(
-            label,
+            'Contacts',
             style: AppTypography.labelMedium.copyWith(
               color: colors.text.secondary,
             ),

--- a/lib/widgetbook/send_use_cases.dart
+++ b/lib/widgetbook/send_use_cases.dart
@@ -70,14 +70,13 @@ Widget buildSendTransparentUseCase(BuildContext context) {
   );
 }
 
-/// A contact was picked: the "Send to" link reflects the contact name
-/// ("Mike ›") instead of "Contacts ›".
+/// A contact-backed address is filled, but the picker affordance stays as
+/// `Contacts ›`.
 Widget buildSendContactSelectedUseCase(BuildContext context) {
   return const _SendPageFrame(
     child: SendComposeView(
       recipientText: _sampleUnifiedAddress,
       route: SendPoolRoute.shieldedToShielded,
-      contactName: 'Mike',
       amountText: '125.12',
       amountFocused: true,
       memoMode: SendMemoMode.expanded,

--- a/lib/widgetbook/send_use_cases.dart
+++ b/lib/widgetbook/send_use_cases.dart
@@ -25,7 +25,7 @@ Widget buildSendEmptyUseCase(BuildContext context) {
   return const _SendPageFrame(child: SendComposeView());
 }
 
-/// Shielded → Shielded, amount entered, memo expanded, Review enabled.
+/// Shielded recipient, amount entered, memo expanded, Review enabled.
 Widget buildSendShieldedFilledUseCase(BuildContext context) {
   return const _SendPageFrame(
     child: SendComposeView(
@@ -39,8 +39,8 @@ Widget buildSendShieldedFilledUseCase(BuildContext context) {
   );
 }
 
-/// Shielded → Shielded with a memo over the 512-byte limit: destructive
-/// tone, "Message is too long", Review disabled.
+/// Shielded recipient with a memo over the 512-byte limit: destructive tone,
+/// "Message is too long", Review disabled.
 Widget buildSendMemoTooLongUseCase(BuildContext context) {
   return const _SendPageFrame(
     child: SendComposeView(
@@ -56,8 +56,7 @@ Widget buildSendMemoTooLongUseCase(BuildContext context) {
   );
 }
 
-/// Transparent recipient: grey "Shielded → Transparent" route, memo hidden,
-/// Review enabled.
+/// Transparent recipient: memo hidden, Review enabled.
 Widget buildSendTransparentUseCase(BuildContext context) {
   return const _SendPageFrame(
     child: SendComposeView(

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -160,10 +160,11 @@ void main() {
       findsNothing,
     );
     expect(_fieldText(tester, 'send_address_field'), _shieldedAddress);
-    expect(find.text('Alice'), findsOneWidget);
+    expect(find.text('Alice'), findsNothing);
+    expect(find.text('Contacts'), findsOneWidget);
   });
 
-  testWidgets('detects the contact name for prefilled and cleared addresses', (
+  testWidgets('keeps contacts label for prefilled and cleared addresses', (
     tester,
   ) async {
     await _setDesktopViewport(tester);
@@ -188,13 +189,10 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    // The Send ZEC prefill path resolves the contact label on the contacts
-    // button without going through the picker.
     expect(_fieldText(tester, 'send_address_field'), _shieldedAddress);
-    expect(find.text('Alice'), findsOneWidget);
-    expect(find.text('Contacts'), findsNothing);
+    expect(find.text('Alice'), findsNothing);
+    expect(find.text('Contacts'), findsOneWidget);
 
-    // Clearing the address falls back to the plain picker affordance.
     await tester.enterText(
       find.byKey(const ValueKey('send_address_field')),
       '',

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -263,7 +263,8 @@ void main() {
     await tester.enterText(_editableIn('send_address_field'), _shieldedAddress);
     await tester.pumpAndSettle();
 
-    expect(find.text('Shielded → Shielded'), findsOneWidget);
+    expect(find.text('Shielded → Shielded'), findsNothing);
+    expect(find.text('Shielded → Transparent'), findsNothing);
     expect(find.text('Add a memo'), findsOneWidget);
     expect(
       tester.getSize(find.byKey(const ValueKey('send_add_memo_card'))),
@@ -293,7 +294,8 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Shielded → Transparent'), findsOneWidget);
+    expect(find.text('Shielded → Shielded'), findsNothing);
+    expect(find.text('Shielded → Transparent'), findsNothing);
     expect(find.text('Transparent memo'), findsNothing);
     expect(find.text('Add a memo'), findsNothing);
     expect(find.text('Encrypted, for shielded addresses only.'), findsNothing);
@@ -321,7 +323,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500));
     await tester.pumpAndSettle();
 
-    expect(find.text('Shielded → Transparent'), findsOneWidget);
+    expect(find.text('Shielded → Shielded'), findsNothing);
+    expect(find.text('Shielded → Transparent'), findsNothing);
     expect(find.text('TEX memo'), findsNothing);
     expect(find.text('Add a message'), findsNothing);
     expect(find.text('Encrypted, for Shielded Addresses only.'), findsNothing);
@@ -452,7 +455,8 @@ void main() {
       findsOneWidget,
     );
     expect(find.byKey(const ValueKey('send_cta_warning')), findsOneWidget);
-    expect(find.text('Shielded → Transparent'), findsOneWidget);
+    expect(find.text('Shielded → Shielded'), findsNothing);
+    expect(find.text('Shielded → Transparent'), findsNothing);
     expect(rustApi.proposeSendCalls, 0);
   });
 }

--- a/test/widgetbook/send_use_cases_test.dart
+++ b/test/widgetbook/send_use_cases_test.dart
@@ -40,33 +40,30 @@ void main() {
     expect(find.text('Review'), findsOneWidget);
   });
 
-  testWidgets(
-    'send filled use cases render recipient and selected contact states',
-    (tester) async {
-      await _pumpSendUseCase(tester, buildSendShieldedFilledUseCase);
+  testWidgets('send filled use cases keep the contacts picker label stable', (
+    tester,
+  ) async {
+    await _pumpSendUseCase(tester, buildSendShieldedFilledUseCase);
 
-      expect(tester.takeException(), isNull);
-      expect(find.text('Shielded → Shielded'), findsNothing);
-      expect(find.text('Shielded → Transparent'), findsNothing);
-      expect(find.text('125.12'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+    expect(find.text('Shielded → Shielded'), findsNothing);
+    expect(find.text('Shielded → Transparent'), findsNothing);
+    expect(find.text('125.12'), findsOneWidget);
 
-      await _pumpSendUseCase(tester, buildSendTransparentUseCase);
+    await _pumpSendUseCase(tester, buildSendTransparentUseCase);
 
-      expect(tester.takeException(), isNull);
-      expect(find.text('Shielded → Shielded'), findsNothing);
-      expect(find.text('Shielded → Transparent'), findsNothing);
-      expect(find.text('Add a memo'), findsNothing);
-      expect(
-        find.text('Encrypted, for shielded addresses only.'),
-        findsNothing,
-      );
+    expect(tester.takeException(), isNull);
+    expect(find.text('Shielded → Shielded'), findsNothing);
+    expect(find.text('Shielded → Transparent'), findsNothing);
+    expect(find.text('Add a memo'), findsNothing);
+    expect(find.text('Encrypted, for shielded addresses only.'), findsNothing);
 
-      await _pumpSendUseCase(tester, buildSendContactSelectedUseCase);
+    await _pumpSendUseCase(tester, buildSendContactSelectedUseCase);
 
-      expect(tester.takeException(), isNull);
-      expect(find.text('Mike'), findsOneWidget);
-    },
-  );
+    expect(tester.takeException(), isNull);
+    expect(find.text('Mike'), findsNothing);
+    expect(find.text('Contacts'), findsOneWidget);
+  });
 }
 
 Future<void> _pumpSendUseCase(

--- a/test/widgetbook/send_use_cases_test.dart
+++ b/test/widgetbook/send_use_cases_test.dart
@@ -32,10 +32,7 @@ void main() {
     final backLabelStyle = tester.widget<Text>(backLabelFinder).style;
     expect(backLabelStyle?.fontSize, 14);
     expect(backLabelStyle?.height, 16 / 14);
-    expect(
-      backLabelStyle?.color,
-      AppThemeData.light.colors.button.ghost.label,
-    );
+    expect(backLabelStyle?.color, AppThemeData.light.colors.button.ghost.label);
     expect(
       tester.getTopLeft(backLabelFinder).dx,
       moreOrLessEquals(316, epsilon: 0.1),
@@ -44,18 +41,20 @@ void main() {
   });
 
   testWidgets(
-    'send filled use cases render route and selected contact states',
+    'send filled use cases render recipient and selected contact states',
     (tester) async {
       await _pumpSendUseCase(tester, buildSendShieldedFilledUseCase);
 
       expect(tester.takeException(), isNull);
-      expect(find.text('Shielded → Shielded'), findsOneWidget);
+      expect(find.text('Shielded → Shielded'), findsNothing);
+      expect(find.text('Shielded → Transparent'), findsNothing);
       expect(find.text('125.12'), findsOneWidget);
 
       await _pumpSendUseCase(tester, buildSendTransparentUseCase);
 
       expect(tester.takeException(), isNull);
-      expect(find.text('Shielded → Transparent'), findsOneWidget);
+      expect(find.text('Shielded → Shielded'), findsNothing);
+      expect(find.text('Shielded → Transparent'), findsNothing);
       expect(find.text('Add a memo'), findsNothing);
       expect(
         find.text('Encrypted, for shielded addresses only.'),


### PR DESCRIPTION
## What changed
- remove the send compose route captions under the recipient field
- keep the recipient field action label fixed as `Contacts` even when the address matches a saved contact
- update Widgetbook previews and send-screen tests to match the new behavior

## Why
- the route captions did not add useful context and could read like an error state
- the right-side affordance is an action to open the contact picker, so its label should stay stable instead of turning into recipient display text

## Impact
- the send compose screen is more predictable and less warning-like
- recipient/contact names still appear where they belong, such as review and status surfaces

## Validation
- `fvm flutter test test/features/send/send_screen_test.dart test/widgetbook/send_use_cases_test.dart`
- `fvm flutter analyze`
