### PR TITLE
Improve minor UI fixes

### DIFF
--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -505,10 +505,26 @@ class _SidebarAccountHeader extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: AppSpacing.xxs),
-                  _SidebarBalancePrivacyButton(
-                    balanceLabel: balanceLabel,
-                    privacyModeEnabled: privacyModeEnabled,
-                    onTap: onTogglePrivacyMode,
+                  Row(
+                    children: [
+                      Flexible(
+                        fit: FlexFit.loose,
+                        child: Text(
+                          balanceLabel,
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTypography.labelLarge.copyWith(
+                            color: colors.text.secondary,
+                            fontWeight: FontWeight.w400,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.xxs),
+                      _SidebarHideBalanceButton(
+                        enabled: true,
+                        privacyModeEnabled: privacyModeEnabled,
+                        onTap: onTogglePrivacyMode,
+                      ),
+                    ],
                   ),
                 ],
               ),
@@ -586,14 +602,14 @@ class _SidebarAccountAvatar extends StatelessWidget {
   }
 }
 
-class _SidebarBalancePrivacyButton extends StatelessWidget {
-  const _SidebarBalancePrivacyButton({
-    required this.balanceLabel,
+class _SidebarHideBalanceButton extends StatelessWidget {
+  const _SidebarHideBalanceButton({
+    required this.enabled,
     required this.privacyModeEnabled,
     required this.onTap,
   });
 
-  final String balanceLabel;
+  final bool enabled;
   final bool privacyModeEnabled;
   final VoidCallback onTap;
 
@@ -602,35 +618,25 @@ class _SidebarBalancePrivacyButton extends StatelessWidget {
     final colors = context.colors;
     return Semantics(
       button: true,
-      enabled: true,
+      enabled: enabled,
       label: privacyModeEnabled ? 'Show balance' : 'Hide balance',
       child: MouseRegion(
-        cursor: SystemMouseCursors.click,
+        cursor: enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
-          onTap: onTap,
-          child: Row(
-            key: const ValueKey('sidebar_balance_privacy_button'),
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Flexible(
-                fit: FlexFit.loose,
-                child: Text(
-                  balanceLabel,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTypography.labelLarge.copyWith(
-                    color: colors.text.secondary,
-                    fontWeight: FontWeight.w400,
-                  ),
-                ),
-              ),
-              const SizedBox(width: AppSpacing.xxs),
-              AppIcon(
+          onTap: enabled ? onTap : null,
+          child: SizedBox(
+            width: 16,
+            height: 16,
+            child: Center(
+              child: AppIcon(
                 privacyModeEnabled ? AppIcons.eyeClosed : AppIcons.eye,
                 size: 16,
-                color: colors.icon.regular.withValues(alpha: 0.72),
+                color: colors.icon.regular.withValues(
+                  alpha: enabled ? 0.72 : 0.38,
+                ),
               ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -90,6 +90,11 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
     context.go('/add-account');
   }
 
+  void _openActivity() {
+    if (_matchedLocation == '/activity') return;
+    context.go('/activity');
+  }
+
   void _toggleAccountMenu({
     required List<AccountInfo> accounts,
     required String? activeAccountUuid,
@@ -379,9 +384,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                       iconName: isImporting ? AppIcons.loader : AppIcons.home,
                       iconAnimated: !isImporting,
                       active: _homeShouldBeActive,
-                      onTap: isImporting || _isHomeRoute
-                          ? null
-                          : () => _navigateTo('/home'),
+                      onTap: isImporting ? null : () => _navigateTo('/home'),
                     ),
                     if (swapFeatureEnabled) ...[
                       const SizedBox(height: AppSpacing.xs),
@@ -390,9 +393,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                         label: 'Swap',
                         iconName: AppIcons.swapArrows,
                         active: _matches('/swap'),
-                        onTap: isImporting || _matches('/swap')
-                            ? null
-                            : () => _navigateTo('/swap'),
+                        onTap: isImporting ? null : () => _navigateTo('/swap'),
                       ),
                     ],
                     const SizedBox(height: AppSpacing.xs),
@@ -413,18 +414,14 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                       active: _matches('/activity'),
                       // Stays tappable on detail subroutes (tx/swap status)
                       // as a way back to the main activity feed.
-                      onTap: isImporting || _matchedLocation == '/activity'
-                          ? null
-                          : () => context.go('/activity'),
+                      onTap: isImporting ? null : _openActivity,
                     ),
                     const Spacer(),
                     AppSidebarItem(
                       label: 'Settings',
                       iconName: AppIcons.cog,
                       active: _matches('/settings'),
-                      onTap: _matches('/settings')
-                          ? null
-                          : () => _navigateTo('/settings'),
+                      onTap: () => _navigateTo('/settings'),
                     ),
                     const SizedBox(height: AppSpacing.xs),
                     AppSidebarItem(

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -95,6 +95,11 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
     context.go('/activity');
   }
 
+  void _openSettings() {
+    if (_matchedLocation == '/settings') return;
+    context.go('/settings');
+  }
+
   void _toggleAccountMenu({
     required List<AccountInfo> accounts,
     required String? activeAccountUuid,
@@ -421,7 +426,7 @@ class _AppMainSidebarState extends ConsumerState<AppMainSidebar> {
                       label: 'Settings',
                       iconName: AppIcons.cog,
                       active: _matches('/settings'),
-                      onTap: () => _navigateTo('/settings'),
+                      onTap: _openSettings,
                     ),
                     const SizedBox(height: AppSpacing.xs),
                     AppSidebarItem(

--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -505,26 +505,10 @@ class _SidebarAccountHeader extends StatelessWidget {
                     ],
                   ),
                   const SizedBox(height: AppSpacing.xxs),
-                  Row(
-                    children: [
-                      Flexible(
-                        fit: FlexFit.loose,
-                        child: Text(
-                          balanceLabel,
-                          overflow: TextOverflow.ellipsis,
-                          style: AppTypography.labelLarge.copyWith(
-                            color: colors.text.secondary,
-                            fontWeight: FontWeight.w400,
-                          ),
-                        ),
-                      ),
-                      const SizedBox(width: AppSpacing.xxs),
-                      _SidebarHideBalanceButton(
-                        enabled: true,
-                        privacyModeEnabled: privacyModeEnabled,
-                        onTap: onTogglePrivacyMode,
-                      ),
-                    ],
+                  _SidebarBalancePrivacyButton(
+                    balanceLabel: balanceLabel,
+                    privacyModeEnabled: privacyModeEnabled,
+                    onTap: onTogglePrivacyMode,
                   ),
                 ],
               ),
@@ -602,14 +586,14 @@ class _SidebarAccountAvatar extends StatelessWidget {
   }
 }
 
-class _SidebarHideBalanceButton extends StatelessWidget {
-  const _SidebarHideBalanceButton({
-    required this.enabled,
+class _SidebarBalancePrivacyButton extends StatelessWidget {
+  const _SidebarBalancePrivacyButton({
+    required this.balanceLabel,
     required this.privacyModeEnabled,
     required this.onTap,
   });
 
-  final bool enabled;
+  final String balanceLabel;
   final bool privacyModeEnabled;
   final VoidCallback onTap;
 
@@ -618,25 +602,35 @@ class _SidebarHideBalanceButton extends StatelessWidget {
     final colors = context.colors;
     return Semantics(
       button: true,
-      enabled: enabled,
+      enabled: true,
       label: privacyModeEnabled ? 'Show balance' : 'Hide balance',
       child: MouseRegion(
-        cursor: enabled ? SystemMouseCursors.click : SystemMouseCursors.basic,
+        cursor: SystemMouseCursors.click,
         child: GestureDetector(
           behavior: HitTestBehavior.opaque,
-          onTap: enabled ? onTap : null,
-          child: SizedBox(
-            width: 16,
-            height: 16,
-            child: Center(
-              child: AppIcon(
-                privacyModeEnabled ? AppIcons.eyeClosed : AppIcons.eye,
-                size: 16,
-                color: colors.icon.regular.withValues(
-                  alpha: enabled ? 0.72 : 0.38,
+          onTap: onTap,
+          child: Row(
+            key: const ValueKey('sidebar_balance_privacy_button'),
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(
+                fit: FlexFit.loose,
+                child: Text(
+                  balanceLabel,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTypography.labelLarge.copyWith(
+                    color: colors.text.secondary,
+                    fontWeight: FontWeight.w400,
+                  ),
                 ),
               ),
-            ),
+              const SizedBox(width: AppSpacing.xxs),
+              AppIcon(
+                privacyModeEnabled ? AppIcons.eyeClosed : AppIcons.eye,
+                size: 16,
+                color: colors.icon.regular.withValues(alpha: 0.72),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/src/core/widgets/app_chip.dart
+++ b/lib/src/core/widgets/app_chip.dart
@@ -19,6 +19,8 @@ class AppChip extends StatelessWidget {
     this.trailing,
     this.type = AppChipType.defaultText,
     this.width,
+    this.minWidth,
+    this.labelOverflow = TextOverflow.ellipsis,
   });
 
   final String? leadingText;
@@ -27,28 +29,30 @@ class AppChip extends StatelessWidget {
   final Widget? trailing;
   final AppChipType type;
   final double? width;
+  final double? minWidth;
+  final TextOverflow? labelOverflow;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final resolvedWidth =
-        width ??
-        switch (type) {
-          AppChipType.defaultText => 80.0,
-          AppChipType.icons => null,
-        };
+    final defaultFixedWidth = switch (type) {
+      AppChipType.defaultText => 80.0,
+      AppChipType.icons => null,
+    };
+    final fixedWidth = width ?? (minWidth == null ? defaultFixedWidth : null);
+    final resolvedMinWidth = fixedWidth ?? minWidth ?? 0;
     final hasLeadingIcon = leading != null;
     final hasTrailingIcon = trailing != null;
     return ConstrainedBox(
       constraints: BoxConstraints(
         minHeight: 26,
-        minWidth: resolvedWidth ?? 0,
-        maxWidth: resolvedWidth ?? double.infinity,
+        minWidth: resolvedMinWidth,
+        maxWidth: fixedWidth ?? double.infinity,
       ),
       child: Padding(
         padding: const EdgeInsets.all(AppSpacing.xxs),
         child: Row(
-          mainAxisSize: resolvedWidth == null
+          mainAxisSize: fixedWidth == null
               ? MainAxisSize.min
               : MainAxisSize.max,
           children: [
@@ -69,14 +73,12 @@ class AppChip extends StatelessWidget {
               ),
               const SizedBox(width: AppSpacing.xxs),
             ],
-            Flexible(
-              child: Text(
-                label,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: AppTypography.labelLarge.copyWith(
-                  color: colors.text.accent,
-                ),
+            _AppChipLabel(
+              fixedWidth: fixedWidth != null,
+              label: label,
+              overflow: labelOverflow,
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.accent,
               ),
             ),
             if (hasTrailingIcon) ...[
@@ -91,5 +93,26 @@ class AppChip extends StatelessWidget {
         ),
       ),
     );
+  }
+}
+
+class _AppChipLabel extends StatelessWidget {
+  const _AppChipLabel({
+    required this.fixedWidth,
+    required this.label,
+    required this.overflow,
+    required this.style,
+  });
+
+  final bool fixedWidth;
+  final String label;
+  final TextOverflow? overflow;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Text(label, maxLines: 1, overflow: overflow, style: style);
+    if (!fixedWidth) return text;
+    return Flexible(child: text);
   }
 }

--- a/lib/src/features/activity/widgets/activity_feed.dart
+++ b/lib/src/features/activity/widgets/activity_feed.dart
@@ -491,51 +491,6 @@ class _ActivityFeedTitleRow extends StatelessWidget {
               ),
             ),
           ),
-          const Positioned(right: 0, top: 8, child: _ActivityFilterButton()),
-        ],
-      ),
-    );
-  }
-}
-
-class _ActivityFilterButton extends StatelessWidget {
-  const _ActivityFilterButton();
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-    return SizedBox(
-      key: const ValueKey('activity_screen_filter_button'),
-      width: 62,
-      height: 24,
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.end,
-        children: [
-          SizedBox(
-            width: 42,
-            child: Align(
-              alignment: Alignment.centerRight,
-              child: FittedBox(
-                fit: BoxFit.scaleDown,
-                alignment: Alignment.centerRight,
-                child: Text(
-                  key: const ValueKey('activity_screen_filter_label'),
-                  'Filter',
-                  style: AppTypography.labelMedium.copyWith(
-                    color: colors.text.disabled,
-                    letterSpacing: 0,
-                  ),
-                ),
-              ),
-            ),
-          ),
-          const SizedBox(width: AppSpacing.xxs),
-          AppIcon(
-            AppIcons.filter,
-            key: const ValueKey('activity_screen_filter_icon'),
-            size: 16,
-            color: colors.icon.disabled,
-          ),
         ],
       ),
     );

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -1597,9 +1597,6 @@ class _HomeDesktopActionButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final fg = primary
-        ? colors.button.primary.label
-        : colors.button.secondary.label;
     return _HomeDesktopInteractiveTarget(
       semanticsLabel: label,
       onTap: onTap,
@@ -1616,6 +1613,11 @@ class _HomeDesktopActionButton extends StatelessWidget {
                   ? colors.button.primary.bgHover
                   : colors.button.primary.bg
             : colors.state.focusRing;
+        final fg = primary
+            ? hovered
+                  ? colors.button.primary.labelHover
+                  : colors.button.primary.label
+            : colors.button.secondary.label;
 
         return SizedBox(
           height: 44,

--- a/lib/src/features/onboarding/create/secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/create/secret_passphrase_screen.dart
@@ -445,36 +445,41 @@ class _SeedPhraseCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final height = revealed ? 340.0 : 258.0;
+    final card = DecoratedBox(
+      decoration: BoxDecoration(
+        color: colors.background.homeCard,
+        borderRadius: BorderRadius.circular(AppRadii.large),
+      ),
+      child: switch ((isLoading, error != null, mnemonic)) {
+        (true, _, _) => const Center(child: CircularProgressIndicator()),
+        (_, true, _) => _ErrorState(message: error!),
+        (_, _, String value) =>
+          revealed
+              ? _SeedPhraseRevealContent(
+                  mnemonic: value,
+                  copied: copied,
+                  onCopyPressed: onCopyPressed,
+                )
+              : const Padding(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: AppSpacing.md,
+                    vertical: AppSpacing.base,
+                  ),
+                  child: Center(child: _HiddenWarning()),
+                ),
+        _ => const SizedBox.shrink(),
+      },
+    );
 
     return SizedBox(
       width: double.infinity,
-      height: height,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: colors.background.homeCard,
-          borderRadius: BorderRadius.circular(AppRadii.large),
-        ),
-        child: switch ((isLoading, error != null, mnemonic)) {
-          (true, _, _) => const Center(child: CircularProgressIndicator()),
-          (_, true, _) => _ErrorState(message: error!),
-          (_, _, String value) =>
-            revealed
-                ? _SeedPhraseRevealContent(
-                    mnemonic: value,
-                    copied: copied,
-                    onCopyPressed: onCopyPressed,
-                  )
-                : const Padding(
-                    padding: EdgeInsets.symmetric(
-                      horizontal: AppSpacing.md,
-                      vertical: AppSpacing.base,
-                    ),
-                    child: Center(child: _HiddenWarning()),
-                  ),
-          _ => const SizedBox.shrink(),
-        },
-      ),
+      height: revealed ? null : 258,
+      child: revealed
+          ? ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 340),
+              child: card,
+            )
+          : card,
     );
   }
 }
@@ -549,14 +554,12 @@ class _SeedPhraseRevealContent extends StatelessWidget {
     final textColor = colors.text.homeCard;
     return Stack(
       children: [
-        Positioned.fill(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSpacing.md,
-              vertical: AppSpacing.base,
-            ),
-            child: _SeedGrid(mnemonic: mnemonic, textColor: textColor),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.md,
+            vertical: AppSpacing.base,
           ),
+          child: _SeedGrid(mnemonic: mnemonic, textColor: textColor),
         ),
         Positioned(
           top: AppSpacing.s,
@@ -578,6 +581,7 @@ class _SeedGrid extends StatelessWidget {
   Widget build(BuildContext context) {
     final words = mnemonic.split(' ');
     return Column(
+      mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Row(
@@ -622,35 +626,31 @@ class _SeedPhraseChip extends StatelessWidget {
   final String word;
   final Color textColor;
 
-  static const double _width = 90;
+  static const double _minWidth = 90;
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: _width,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(minHeight: 25),
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.xxs),
-          child: Row(
-            children: [
-              Text(
-                index.toString().padLeft(2, '0'),
-                style: AppTypography.codeSmall.copyWith(
-                  color: textColor.withValues(alpha: 0.5),
-                ),
+    return ConstrainedBox(
+      key: ValueKey('seed_phrase_word_$index'),
+      constraints: const BoxConstraints(minWidth: _minWidth, minHeight: 25),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xxs),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              index.toString().padLeft(2, '0'),
+              style: AppTypography.codeSmall.copyWith(
+                color: textColor.withValues(alpha: 0.5),
               ),
-              const SizedBox(width: AppSpacing.xxs),
-              Flexible(
-                child: Text(
-                  word,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTypography.labelLarge.copyWith(color: textColor),
-                ),
-              ),
-            ],
-          ),
+            ),
+            const SizedBox(width: AppSpacing.xxs),
+            Text(
+              word,
+              maxLines: 1,
+              style: AppTypography.labelLarge.copyWith(color: textColor),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -460,7 +460,6 @@ class _ImportWalletBirthdayScreenState
   }
 
   String? get _dateMessage {
-    if (_submitError != null && _submitError!.isNotEmpty) return _submitError;
     if (_metadataError != null) return _metadataError;
     return null;
   }
@@ -611,10 +610,15 @@ class _ImportWalletBirthdayScreenState
                 ),
                 const SizedBox(height: AppSpacing.md),
                 SizedBox(
-                  width: _buttonWidth,
+                  width: _widgetWidth,
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
+                      if (_submitError != null &&
+                          _submitError!.trim().isNotEmpty) ...[
+                        _InlineMessage(text: _submitError, centered: true),
+                        const SizedBox(height: AppSpacing.s),
+                      ],
                       AppButton(
                         key: const ValueKey('import_birthday_submit_button'),
                         onPressed: _isSubmitEnabled ? _submit : null,
@@ -890,9 +894,10 @@ class _BlockHeightField extends StatelessWidget {
 }
 
 class _InlineMessage extends StatelessWidget {
-  const _InlineMessage({required this.text});
+  const _InlineMessage({required this.text, this.centered = false});
 
   final String? text;
+  final bool centered;
 
   @override
   Widget build(BuildContext context) {
@@ -901,19 +906,26 @@ class _InlineMessage extends StatelessWidget {
     }
     final colors = context.colors;
     final errorColor = colors.border.utilityDestructive;
+    final messageText = Text(
+      text!,
+      textAlign: centered ? TextAlign.center : null,
+      style: AppTypography.labelLarge.copyWith(
+        color: errorColor,
+        fontWeight: FontWeight.w400,
+      ),
+    );
     return Row(
+      mainAxisAlignment: centered
+          ? MainAxisAlignment.center
+          : MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         AppIcon(AppIcons.warning, size: 16, color: errorColor),
         const SizedBox(width: AppSpacing.xxs),
-        Expanded(
-          child: Text(
-            text!,
-            style: AppTypography.labelLarge.copyWith(
-              color: errorColor,
-              fontWeight: FontWeight.w400,
-            ),
-          ),
-        ),
+        if (centered)
+          Flexible(child: messageText)
+        else
+          Expanded(child: messageText),
       ],
     );
   }

--- a/lib/src/features/onboarding/keystone/keystone_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/keystone/keystone_wallet_birthday_screen.dart
@@ -351,7 +351,6 @@ class _KeystoneWalletBirthdayScreenState
   }
 
   String? get _dateMessage {
-    if (_submitError != null && _submitError!.isNotEmpty) return _submitError;
     if (_metadataError != null) return _metadataError;
     return null;
   }
@@ -488,10 +487,15 @@ class _KeystoneWalletBirthdayScreenState
                 ),
                 const SizedBox(height: AppSpacing.md),
                 SizedBox(
-                  width: _buttonWidth,
+                  width: _widgetWidth,
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
+                      if (_submitError != null &&
+                          _submitError!.trim().isNotEmpty) ...[
+                        _InlineMessage(text: _submitError, centered: true),
+                        const SizedBox(height: AppSpacing.s),
+                      ],
                       AppButton(
                         key: const ValueKey('keystone_birthday_submit_button'),
                         onPressed: _isSubmitEnabled ? _submit : null,
@@ -756,9 +760,10 @@ class _BlockHeightField extends StatelessWidget {
 }
 
 class _InlineMessage extends StatelessWidget {
-  const _InlineMessage({required this.text});
+  const _InlineMessage({required this.text, this.centered = false});
 
   final String? text;
+  final bool centered;
 
   @override
   Widget build(BuildContext context) {
@@ -767,19 +772,26 @@ class _InlineMessage extends StatelessWidget {
     }
     final colors = context.colors;
     final errorColor = colors.border.utilityDestructive;
+    final messageText = Text(
+      text!,
+      textAlign: centered ? TextAlign.center : null,
+      style: AppTypography.labelLarge.copyWith(
+        color: errorColor,
+        fontWeight: FontWeight.w400,
+      ),
+    );
     return Row(
+      mainAxisAlignment: centered
+          ? MainAxisAlignment.center
+          : MainAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         AppIcon(AppIcons.warning, size: 16, color: errorColor),
         const SizedBox(width: AppSpacing.xxs),
-        Expanded(
-          child: Text(
-            text!,
-            style: AppTypography.labelLarge.copyWith(
-              color: errorColor,
-              fontWeight: FontWeight.w400,
-            ),
-          ),
-        ),
+        if (centered)
+          Flexible(child: messageText)
+        else
+          Expanded(child: messageText),
       ],
     );
   }

--- a/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
@@ -580,7 +580,9 @@ class _SeedWordsCard extends StatelessWidget {
                   children: [
                     for (var i = 0; i < words.length; i++)
                       AppChip(
-                        width: 90,
+                        key: ValueKey('settings_seed_phrase_word_${i + 1}'),
+                        minWidth: 90,
+                        labelOverflow: TextOverflow.visible,
                         leadingText: '${i + 1}'.padLeft(2, '0'),
                         label: words[i],
                       ),

--- a/test/app_main_sidebar_test.dart
+++ b/test/app_main_sidebar_test.dart
@@ -325,6 +325,26 @@ void main() {
     expect(find.text('settings'), findsOneWidget);
   });
 
+  testWidgets('sidebar Settings item returns detail routes to the root', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _sidebarHarness(_syncedSyncState, initialLocation: '/settings/endpoint'),
+    );
+    await tester.pump();
+
+    final item = _sidebarItemWithLabel(tester, 'Settings');
+    expect(item.active, isTrue);
+    expect(item.onTap, isNotNull);
+    expect(find.text('settings endpoint'), findsOneWidget);
+
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('settings'), findsOneWidget);
+    expect(find.text('settings endpoint'), findsNothing);
+  });
+
   testWidgets('sidebar keeps primary navigation item spacing consistent', (
     tester,
   ) async {
@@ -689,6 +709,13 @@ Widget _sidebarHarness(
         builder: (_, _) => const AppDesktopShell(
           sidebar: AppMainSidebar(),
           pane: AppDesktopPane(child: Text('settings')),
+        ),
+      ),
+      GoRoute(
+        path: '/settings/endpoint',
+        builder: (_, _) => const AppDesktopShell(
+          sidebar: AppMainSidebar(),
+          pane: AppDesktopPane(child: Text('settings endpoint')),
         ),
       ),
       GoRoute(

--- a/test/app_main_sidebar_test.dart
+++ b/test/app_main_sidebar_test.dart
@@ -10,7 +10,6 @@ import 'package:zcash_wallet/src/core/layout/app_main_sidebar.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
-import 'package:zcash_wallet/src/providers/privacy_mode_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_failure.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 
@@ -107,49 +106,6 @@ void main() {
     expect(find.text('home route'), findsOneWidget);
     expect(find.text('receive route'), findsNothing);
   });
-
-  testWidgets(
-    'sidebar balance text toggles privacy without opening account popover',
-    (tester) async {
-      await tester.pumpWidget(
-        _sidebarHarness(
-          SyncState(
-            accountUuid: 'account-1',
-            hasAccountScopedData: true,
-            totalBalance: BigInt.from(990000),
-          ),
-        ),
-      );
-      await tester.pump();
-
-      expect(find.text('0.0099 ZEC'), findsOneWidget);
-
-      await tester.tap(find.text('0.0099 ZEC'));
-      await tester.pump();
-
-      expect(find.text('****** ZEC'), findsOneWidget);
-      expect(
-        find.byKey(const ValueKey('sidebar_accounts_popover')),
-        findsNothing,
-      );
-
-      await tester.tap(find.text('****** ZEC'));
-      await tester.pump();
-
-      expect(find.text('0.0099 ZEC'), findsOneWidget);
-      expect(
-        find.byKey(const ValueKey('sidebar_accounts_popover')),
-        findsNothing,
-      );
-
-      await tester.tap(find.byKey(const ValueKey('sidebar_accounts_button')));
-      await tester.pump();
-      expect(
-        find.byKey(const ValueKey('sidebar_accounts_popover')),
-        findsOneWidget,
-      );
-    },
-  );
 
   testWidgets('sidebar accounts popover shows boundaries and click cursors', (
     tester,
@@ -660,7 +616,6 @@ Widget _sidebarHarness(
     overrides: [
       appBootstrapProvider.overrideWithValue(bootstrap),
       syncProvider.overrideWith(() => _FakeSyncNotifier(syncState)),
-      privacyModeProvider.overrideWith(_FakePrivacyModeNotifier.new),
       swapFeatureEnabledProvider.overrideWithValue(swapEnabled),
     ],
     child: MaterialApp.router(
@@ -785,11 +740,4 @@ class _FakeSyncNotifier extends SyncNotifier {
 
   @override
   Future<SyncState> build() async => initialState;
-}
-
-class _FakePrivacyModeNotifier extends PrivacyModeNotifier {
-  @override
-  Future<void> set(bool enabled) async {
-    state = enabled;
-  }
 }

--- a/test/app_main_sidebar_test.dart
+++ b/test/app_main_sidebar_test.dart
@@ -10,6 +10,7 @@ import 'package:zcash_wallet/src/core/layout/app_main_sidebar.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/privacy_mode_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_failure.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 
@@ -106,6 +107,49 @@ void main() {
     expect(find.text('home route'), findsOneWidget);
     expect(find.text('receive route'), findsNothing);
   });
+
+  testWidgets(
+    'sidebar balance text toggles privacy without opening account popover',
+    (tester) async {
+      await tester.pumpWidget(
+        _sidebarHarness(
+          SyncState(
+            accountUuid: 'account-1',
+            hasAccountScopedData: true,
+            totalBalance: BigInt.from(990000),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('0.0099 ZEC'), findsOneWidget);
+
+      await tester.tap(find.text('0.0099 ZEC'));
+      await tester.pump();
+
+      expect(find.text('****** ZEC'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('sidebar_accounts_popover')),
+        findsNothing,
+      );
+
+      await tester.tap(find.text('****** ZEC'));
+      await tester.pump();
+
+      expect(find.text('0.0099 ZEC'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('sidebar_accounts_popover')),
+        findsNothing,
+      );
+
+      await tester.tap(find.byKey(const ValueKey('sidebar_accounts_button')));
+      await tester.pump();
+      expect(
+        find.byKey(const ValueKey('sidebar_accounts_popover')),
+        findsOneWidget,
+      );
+    },
+  );
 
   testWidgets('sidebar accounts popover shows boundaries and click cursors', (
     tester,
@@ -616,6 +660,7 @@ Widget _sidebarHarness(
     overrides: [
       appBootstrapProvider.overrideWithValue(bootstrap),
       syncProvider.overrideWith(() => _FakeSyncNotifier(syncState)),
+      privacyModeProvider.overrideWith(_FakePrivacyModeNotifier.new),
       swapFeatureEnabledProvider.overrideWithValue(swapEnabled),
     ],
     child: MaterialApp.router(
@@ -740,4 +785,11 @@ class _FakeSyncNotifier extends SyncNotifier {
 
   @override
   Future<SyncState> build() async => initialState;
+}
+
+class _FakePrivacyModeNotifier extends PrivacyModeNotifier {
+  @override
+  Future<void> set(bool enabled) async {
+    state = enabled;
+  }
 }

--- a/test/app_main_sidebar_test.dart
+++ b/test/app_main_sidebar_test.dart
@@ -107,6 +107,34 @@ void main() {
     expect(find.text('receive route'), findsNothing);
   });
 
+  testWidgets('sidebar keeps exact active navigation items clickable', (
+    tester,
+  ) async {
+    final cases = [
+      (route: '/home', label: 'Home'),
+      (route: '/swap', label: 'Swap'),
+      (route: '/voting', label: 'Vote'),
+      (route: '/activity', label: 'Activity'),
+      (route: '/settings', label: 'Settings'),
+    ];
+
+    for (final entry in cases) {
+      await tester.pumpWidget(
+        _sidebarHarness(_syncedSyncState, initialLocation: entry.route),
+      );
+      await tester.pump();
+
+      final item = _sidebarItemWithLabel(tester, entry.label);
+      expect(item.active, isTrue, reason: entry.label);
+      expect(item.onTap, isNotNull, reason: entry.label);
+      expect(_cursorForText(tester, entry.label), SystemMouseCursors.click);
+
+      await tester.tap(find.text(entry.label));
+      await tester.pumpAndSettle();
+      expect(find.text(entry.label), findsOneWidget);
+    }
+  });
+
   testWidgets('sidebar accounts popover shows boundaries and click cursors', (
     tester,
   ) async {
@@ -263,6 +291,28 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('activity'), findsOneWidget);
+  });
+
+  testWidgets('sidebar Activity item returns detail routes to the feed', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _sidebarHarness(_syncedSyncState, initialLocation: '/activity/detail'),
+    );
+    await tester.pump();
+
+    final item = tester.widget<AppSidebarItem>(
+      find.byKey(const ValueKey('sidebar_activity_button')),
+    );
+    expect(item.active, isTrue);
+    expect(item.onTap, isNotNull);
+    expect(find.text('activity detail'), findsOneWidget);
+
+    await tester.tap(find.text('Activity'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('activity'), findsOneWidget);
+    expect(find.text('activity detail'), findsNothing);
   });
 
   testWidgets('sidebar Settings item opens the settings route', (tester) async {
@@ -539,6 +589,12 @@ BoxDecoration _boxDecorationByKey(WidgetTester tester, Key key) {
   return container.decoration! as BoxDecoration;
 }
 
+AppSidebarItem _sidebarItemWithLabel(WidgetTester tester, String label) {
+  return tester
+      .widgetList<AppSidebarItem>(find.byType(AppSidebarItem))
+      .singleWhere((item) => item.label == label);
+}
+
 MouseCursor _cursorForText(WidgetTester tester, String text) {
   final mouseRegion = tester.widget<MouseRegion>(
     find
@@ -596,14 +652,45 @@ Widget _sidebarHarness(
           pane: AppDesktopPane(child: Text('receive route')),
         ),
       ),
-      GoRoute(path: '/swap', builder: (_, _) => const Text('swap')),
-      GoRoute(path: '/voting', builder: (_, _) => const Text('voting')),
+      GoRoute(
+        path: '/swap',
+        builder: (_, _) => const AppDesktopShell(
+          sidebar: AppMainSidebar(),
+          pane: AppDesktopPane(child: Text('swap')),
+        ),
+      ),
+      GoRoute(
+        path: '/voting',
+        builder: (_, _) => const AppDesktopShell(
+          sidebar: AppMainSidebar(),
+          pane: AppDesktopPane(child: Text('voting')),
+        ),
+      ),
       GoRoute(
         path: '/address-book',
         builder: (_, _) => const Text('address book'),
       ),
-      GoRoute(path: '/activity', builder: (_, _) => const Text('activity')),
-      GoRoute(path: '/settings', builder: (_, _) => const Text('settings')),
+      GoRoute(
+        path: '/activity',
+        builder: (_, _) => const AppDesktopShell(
+          sidebar: AppMainSidebar(),
+          pane: AppDesktopPane(child: Text('activity')),
+        ),
+      ),
+      GoRoute(
+        path: '/activity/detail',
+        builder: (_, _) => const AppDesktopShell(
+          sidebar: AppMainSidebar(),
+          pane: AppDesktopPane(child: Text('activity detail')),
+        ),
+      ),
+      GoRoute(
+        path: '/settings',
+        builder: (_, _) => const AppDesktopShell(
+          sidebar: AppMainSidebar(),
+          pane: AppDesktopPane(child: Text('settings')),
+        ),
+      ),
       GoRoute(
         path: '/add-account',
         builder: (_, _) => const Text('add account'),

--- a/test/core/widgets/app_chip_test.dart
+++ b/test/core/widgets/app_chip_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_chip.dart';
+
+void main() {
+  testWidgets('AppChip can use min width without truncating the label', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: AppChip(
+                key: ValueKey('mnemonic_chip'),
+                minWidth: 90,
+                leadingText: '01',
+                label: 'acknowledge',
+                labelOverflow: TextOverflow.visible,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      tester.getSize(find.byKey(const ValueKey('mnemonic_chip'))).width,
+      greaterThan(90),
+    );
+
+    final label = tester.widget<Text>(find.text('acknowledge'));
+    expect(label.overflow, TextOverflow.visible);
+  });
+
+  testWidgets('AppChip keeps default text chips fixed width', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AppTheme(
+          data: AppThemeData.light,
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: AppChip(
+                key: ValueKey('fixed_chip'),
+                leadingText: '01',
+                label: 'acknowledge',
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byKey(const ValueKey('fixed_chip'))).width, 80);
+
+    final label = tester.widget<Text>(find.text('acknowledge'));
+    expect(label.overflow, TextOverflow.ellipsis);
+  });
+}

--- a/test/features/home/home_desktop_screen_test.dart
+++ b/test/features/home/home_desktop_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show PointerDeviceKind;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -231,6 +233,43 @@ void main() {
     await _pumpUntilPresent(tester, find.byType(SendScreen));
 
     expect(find.byType(SendScreen), findsOneWidget);
+  });
+
+  testWidgets('home desktop send hover uses dark primary label hover color', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _appHarness(
+        '/home',
+        themeMode: ThemeMode.dark,
+        syncState: SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          orchardBalance: BigInt.from(14_312_000_000),
+          spendableBalance: BigInt.from(14_312_000_000),
+          totalBalance: BigInt.from(14_312_000_000),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final sendButton = find.byKey(const ValueKey('home_desktop_send_button'));
+    final sendText = find.descendant(
+      of: sendButton,
+      matching: find.text('Send'),
+    );
+
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(mouse.removePointer);
+    await mouse.addPointer(location: Offset.zero);
+    await mouse.moveTo(tester.getCenter(sendButton));
+    await tester.pump();
+
+    final textWidget = tester.widget<Text>(sendText);
+    expect(
+      textWidget.style?.color,
+      AppThemeData.dark.colors.button.primary.labelHover,
+    );
   });
 
   testWidgets('home desktop receive action opens receive screen', (
@@ -509,6 +548,7 @@ Widget _appHarness(
   double? priceChange24hPct,
   SyncState? syncState,
   SwapActivityStore? swapActivityStore,
+  ThemeMode themeMode = ThemeMode.system,
 }) {
   return ProviderScope(
     overrides: [
@@ -520,6 +560,7 @@ Widget _appHarness(
           initialLocation,
           privacyModeEnabled: privacyModeEnabled,
           passwordRotationRecoveryFailed: passwordRotationRecoveryFailed,
+          themeMode: themeMode,
         ),
       ),
       syncProvider.overrideWith(
@@ -546,6 +587,7 @@ AppBootstrapState _bootstrap(
   String initialLocation, {
   required bool privacyModeEnabled,
   required bool passwordRotationRecoveryFailed,
+  required ThemeMode themeMode,
 }) {
   return AppBootstrapState(
     initialLocation: initialLocation,
@@ -557,7 +599,7 @@ AppBootstrapState _bootstrap(
     initialSyncSnapshot: AppSyncSnapshot.empty,
     network: 'main',
     rpcEndpointConfig: defaultRpcEndpointConfig('main'),
-    themeMode: ThemeMode.system,
+    themeMode: themeMode,
     privacyModeEnabled: privacyModeEnabled,
     isPasswordConfigured: true,
     isUnlocked: true,

--- a/test/features/onboarding/create_onboarding_mnemonic_test.dart
+++ b/test/features/onboarding/create_onboarding_mnemonic_test.dart
@@ -1,7 +1,7 @@
 import 'dart:ui' show Size;
 
 import 'package:flutter/material.dart' show MaterialApp;
-import 'package:flutter/widgets.dart' show Widget;
+import 'package:flutter/widgets.dart' show Text, ValueKey, Widget;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
@@ -32,6 +32,35 @@ void main() {
     expect(find.text('alpha'), findsOneWidget);
     expect(find.text('xray'), findsOneWidget);
     expect(container.read(createOnboardingMnemonicProvider), _mnemonic);
+  });
+
+  testWidgets('secret passphrase chips expand for long mnemonic words', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    final container = _providerContainer();
+    addTearDown(container.dispose);
+    container
+        .read(createOnboardingMnemonicProvider.notifier)
+        .setMnemonic(_longWordMnemonic);
+    container
+        .read(onboardingSecretPassphraseRevealedProvider.notifier)
+        .setRevealed(true);
+
+    await tester.pumpWidget(
+      _harness(container, const SecretPassphraseScreen()),
+    );
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('acknowledge'), findsOneWidget);
+    expect(
+      tester.getSize(find.byKey(const ValueKey('seed_phrase_word_1'))).width,
+      greaterThan(90),
+    );
+
+    final longWord = tester.widget<Text>(find.text('acknowledge'));
+    expect(longWord.overflow, isNull);
   });
 
   testWidgets('intro clears pending create mnemonic', (tester) async {
@@ -97,3 +126,8 @@ const _mnemonic =
     'alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima '
     'mike november oscar papa quebec romeo sierra tango uniform victor whiskey '
     'xray';
+
+const _longWordMnemonic =
+    'acknowledge bravo charlie delta echo foxtrot golf hotel india juliet kilo '
+    'lima mike november oscar papa quebec romeo sierra tango uniform victor '
+    'whiskey xray';

--- a/test/features/onboarding/import_wallet_birthday_screen_test.dart
+++ b/test/features/onboarding/import_wallet_birthday_screen_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
@@ -11,7 +12,10 @@ import 'package:zcash_wallet/src/features/onboarding/import/import_birthday_cale
 import 'package:zcash_wallet/src/features/onboarding/import/import_birthday_estimator.dart';
 import 'package:zcash_wallet/src/features/onboarding/import/import_wallet_birthday_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 import 'package:zcash_wallet/src/providers/rpc_endpoint_failover_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
 
 void main() {
@@ -91,6 +95,42 @@ void main() {
       AppThemeData.light.colors.border.utilityDestructive,
     );
     expect(textWidget.style?.fontWeight, FontWeight.w400);
+  });
+
+  testWidgets('block height submit failure is shown above the CTA', (
+    tester,
+  ) async {
+    await _setDesktopSurface(tester);
+    await tester.pumpWidget(
+      _birthdayRouterHarness(
+        args: const ImportBirthdayArgs(
+          mnemonic: 'test mnemonic',
+          initialBirthdayHeight: 1000000,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(
+      find.byKey(const ValueKey('import_birthday_submit_button')),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    const message = 'This account is already in your wallet.';
+    final errorText = find.text(message);
+    expect(errorText, findsOneWidget);
+
+    final textWidget = tester.widget<Text>(errorText);
+    expect(textWidget.maxLines, isNull);
+    expect(textWidget.textAlign, TextAlign.center);
+
+    final errorTop = tester.getTopLeft(errorText).dy;
+    final buttonTop = tester
+        .getTopLeft(find.byKey(const ValueKey('import_birthday_submit_button')))
+        .dy;
+    expect(errorTop, lessThan(buttonTop));
   });
 
   testWidgets('account discovery modal imports all candidates by default', (
@@ -256,6 +296,49 @@ Widget _birthdayHarness({
   );
 }
 
+Widget _birthdayRouterHarness({required ImportBirthdayArgs args}) {
+  final router = GoRouter(
+    initialLocation: '/import/birthday',
+    routes: [
+      GoRoute(
+        path: '/import/birthday',
+        builder: (_, _) => ImportWalletBirthdayScreen(args: args),
+      ),
+      GoRoute(path: '/import', builder: (_, _) => const SizedBox.shrink()),
+      GoRoute(
+        path: '/import/set-password',
+        builder: (_, _) => const SizedBox.shrink(),
+      ),
+      GoRoute(path: '/home', builder: (_, _) => const Text('Home')),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+      appSecurityProvider.overrideWith(_ConfiguredAppSecurityNotifier.new),
+      accountProvider.overrideWith(_FailingImportAccountNotifier.new),
+      syncProvider.overrideWith(_NoopSyncNotifier.new),
+      rpcEndpointFailoverProvider.overrideWith(
+        _FakeRpcEndpointFailoverNotifier.new,
+      ),
+    ],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, child) => MediaQuery(
+        data: const MediaQueryData(textScaler: TextScaler.linear(0.5)),
+        child: Material(
+          type: MaterialType.transparency,
+          child: AppTheme(
+            data: AppThemeData.light,
+            child: child ?? const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
 Widget _modalHarness({
   bool allowEmptySelection = true,
   int bip44CoinType = 133,
@@ -372,4 +455,48 @@ class _PendingMetadataRpcEndpointFailoverNotifier
     }
     return action(state.current);
   }
+}
+
+class _ConfiguredAppSecurityNotifier extends AppSecurityNotifier {
+  @override
+  AppSecurityState build() {
+    return const AppSecurityState(isPasswordConfigured: true, isUnlocked: true);
+  }
+}
+
+class _FailingImportAccountNotifier extends AccountNotifier {
+  @override
+  FutureOr<AccountState> build() {
+    return const AccountState();
+  }
+
+  @override
+  Future<rust_wallet.SoftwareWalletImportDiscoveryResult>
+  discoverAdditionalSoftwareAccounts({
+    required String mnemonic,
+    int? birthdayHeight,
+  }) async {
+    return const rust_wallet.SoftwareWalletImportDiscoveryResult(
+      primaryAccountAlreadyExists: false,
+      accounts: [],
+    );
+  }
+
+  @override
+  Future<void> importAccount({
+    required String mnemonic,
+    int? birthdayHeight,
+    String? name,
+    List<int> additionalAccountIndices = const [],
+  }) async {
+    throw Exception('This account is already in your wallet.');
+  }
+}
+
+class _NoopSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncState> build() async => SyncState();
+
+  @override
+  bool needsPauseForWalletMutation() => false;
 }

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -3985,15 +3985,18 @@ void main() {
 
     expect(find.byKey(const ValueKey('swap:swap-page-5')), findsOneWidget);
     expect(find.byKey(const ValueKey('swap:swap-page-6')), findsOneWidget);
-    final filterLabel = tester.widget<Text>(
+    expect(
+      find.byKey(const ValueKey('activity_screen_filter_button')),
+      findsNothing,
+    );
+    expect(
       find.byKey(const ValueKey('activity_screen_filter_label')),
+      findsNothing,
     );
-    expect(filterLabel.style?.color, AppThemeData.light.colors.text.disabled);
-    final filterIcon = tester.widget<AppIcon>(
+    expect(
       find.byKey(const ValueKey('activity_screen_filter_icon')),
+      findsNothing,
     );
-    expect(filterIcon.name, AppIcons.filter);
-    expect(filterIcon.color, AppThemeData.light.colors.icon.disabled);
   });
 
   testWidgets('activity progress detail fits without scrollbar chrome', (

--- a/test/widgetbook/activity_use_cases_test.dart
+++ b/test/widgetbook/activity_use_cases_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart' show MaterialApp;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
-import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/activity/widgets/activity_feed.dart';
 import 'package:zcash_wallet/widgetbook/activity_use_cases.dart';
 
@@ -15,19 +14,19 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.byType(ActivityFeed), findsOneWidget);
       expect(find.text('Activity'), findsWidgets);
-      expect(find.text('Filter'), findsOneWidget);
-
-      final filterLabel = tester.widget<Text>(
+      expect(find.text('Filter'), findsNothing);
+      expect(
+        find.byKey(const ValueKey('activity_screen_filter_button')),
+        findsNothing,
+      );
+      expect(
         find.byKey(const ValueKey('activity_screen_filter_label')),
+        findsNothing,
       );
-      expect(filterLabel.style?.color, AppThemeData.light.colors.text.disabled);
-
-      final filterIcon = tester.widget<AppIcon>(
+      expect(
         find.byKey(const ValueKey('activity_screen_filter_icon')),
+        findsNothing,
       );
-      expect(filterIcon.name, AppIcons.filter);
-      expect(filterIcon.size, 16);
-      expect(filterIcon.color, AppThemeData.light.colors.icon.disabled);
 
       final paneBackground = tester.widget<ColoredBox>(
         find.byKey(const ValueKey('activity_page_pane_background')),


### PR DESCRIPTION
## Summary
- Remove the inactive Activity filter control.
- Prevent mnemonic chips from truncating long words.
- Show onboarding birthday import failures above the CTA across date and block-height flows.
- Keep selected sidebar tabs clickable, including returning Settings detail routes to the Settings root.
- Match the Home Send hover label color to the shared primary button hover token in dark mode.

## Validation
- `fvm flutter test test/features/onboarding/import_wallet_birthday_screen_test.dart`
- `fvm flutter test test/app_main_sidebar_test.dart`
- `fvm flutter test test/features/home/home_desktop_screen_test.dart`
- `fvm flutter analyze`
- `git diff --check`