### PR TITLE
Reusable mobile bottom-sheet template + swap modal migration

### DIFF
--- a/lib/src/core/layout/mobile/mobile_sheet.dart
+++ b/lib/src/core/layout/mobile/mobile_sheet.dart
@@ -1,0 +1,622 @@
+import 'package:flutter/material.dart' show Material, showModalBottomSheet;
+import 'package:flutter/physics.dart';
+import 'package:flutter/widgets.dart';
+
+import '../../theme/app_theme.dart';
+import '../../widgets/app_icon.dart';
+
+// ---------------------------------------------------------------------------
+// Layout & motion tuning for the standard mobile sheet. Grouped here so the
+// feel can be adjusted in one place.
+// ---------------------------------------------------------------------------
+
+/// Fraction of the screen height the sheet stops below the top, so the page
+/// title stays visible behind it and the status bar is never covered.
+/// Larger reveals more of the page; smaller makes the sheet taller.
+const double _kTopGapFraction = 0.15;
+
+/// Grabber pill dimensions.
+const double _kGrabberWidth = 36;
+const double _kGrabberHeight = 5;
+
+/// Circular close button and its icon.
+const double _kCloseButtonSize = 40;
+const double _kCloseIconSize = 18;
+
+/// Over-pull: furthest the sheet rubber-bands taller when dragged up, plus
+/// how far the spring may overshoot that while settling.
+const double _kMaxOverpull = 30;
+const double _kOverpullOvershoot = 12;
+
+/// Dismiss: downward drag distance / fling velocity past which releasing
+/// dismisses, and how long the slide-off-screen close takes.
+const double _kDismissDragThreshold = 110;
+const double _kDismissFlingVelocity = 800;
+const Duration _kDismissSlideDuration = Duration(milliseconds: 180);
+
+/// Spring-back after an over-pull. Lower damping = livelier bounce;
+/// 15.5 (ratio ~0.40) settles with a small overshoot.
+const SpringDescription _kSpringBack = SpringDescription(
+  mass: 1,
+  stiffness: 380,
+  damping: 15.5,
+);
+const double _kMaxSpringVelocity = 2000;
+
+/// Floor height for a content-sized sheet, so short forms / empty states
+/// don't render as a cramped sliver.
+const double _kMinContentHeight = 400;
+
+/// Over-pull height gain for a drag [value] (negative = pulled up), eased and
+/// capped at the rubber-band limit plus its settle overshoot.
+double _overpullStretch(double value) =>
+    value < 0 ? (-value).clamp(0.0, _kMaxOverpull + _kOverpullOvershoot) : 0.0;
+
+/// Downward slide for a drag [value] (positive = pulled down toward dismiss).
+double _slideDown(double value) => value > 0 ? value : 0.0;
+
+/// The tallest a sheet may stand: the full screen minus the top gap (so the
+/// page title stays visible) and the keyboard inset.
+double _sheetCapHeight(double screenHeight, double keyboardInset) =>
+    screenHeight - keyboardInset - screenHeight * _kTopGapFraction;
+
+/// Shows the standard mobile modal: a full-screen, edge-to-edge bottom
+/// sheet. It rises from the bottom to just below the status bar, with the
+/// top corners rounded and the bottom flush with the screen edge.
+///
+/// Dismiss by swiping down, tapping the scrim, Android back, or the
+/// [MobileSheetScaffold] close button. Pair the [builder] with
+/// [MobileSheetScaffold] for the grabber + header chrome and the
+/// over-pull / drag-to-dismiss behavior.
+///
+/// This is the platform-standard counterpart to the floating
+/// [showAppMobileSheet] card; new modals should adopt this presentation.
+Future<T?> showMobileSheet<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool isDismissible = true,
+}) {
+  final colors = context.colors;
+  return showModalBottomSheet<T>(
+    context: context,
+    isDismissible: isDismissible,
+    isScrollControlled: true,
+    // Root navigator so the sheet and its scrim cover the floating tab
+    // bar (the shell paints the bar outside the branch navigators).
+    useRootNavigator: true,
+    // The scaffold draws its own surface, radius and grabber, so the
+    // sheet itself is transparent with no default elevation.
+    backgroundColor: const Color(0x00000000),
+    elevation: 0,
+    barrierColor: colors.background.neutralScrim,
+    builder: builder,
+  );
+}
+
+/// The chrome for a full-screen [showMobileSheet]: a top-rounded,
+/// edge-to-edge surface that fills from just below the status bar to the
+/// screen bottom, with a drag grabber, a header ([title] + a floating
+/// close button or [trailing]) and the [child] body.
+///
+/// The top chrome (grabber + header) is the drag zone: pull up for a
+/// rubber-band expand that springs back, pull down to dismiss. The body
+/// owns its own padding; the scaffold supplies the surface, grabber,
+/// header, keyboard avoidance and gesture behavior.
+class MobileSheetScaffold extends StatefulWidget {
+  const MobileSheetScaffold({
+    required this.title,
+    required this.child,
+    this.trailing,
+    this.onBack,
+    this.expand = false,
+    this.fillBody = false,
+    this.formBody = false,
+    super.key,
+  });
+
+  final String title;
+  final Widget child;
+
+  /// Right-aligned action. Defaults to a circular close button that pops
+  /// the sheet.
+  final Widget? trailing;
+
+  /// When set, a back chevron is shown at the top-left (for a 2nd-level
+  /// view inside the same sheet). The title shifts right to clear it.
+  final VoidCallback? onBack;
+
+  /// When true the sheet fills the screen (minus the top gap) and [child]
+  /// must take an [Expanded]-friendly slot — for long, scrollable content
+  /// like a list. When false (default) the sheet hugs [child]'s height for
+  /// short forms; over-pull lifts it rather than expanding.
+  final bool expand;
+
+  /// Content-sized only: when true, [child] is stretched to a fixed (min)
+  /// height and given an [Expanded]-friendly slot. Use for a body that owns
+  /// its own scroll (e.g. a bounded `ListView` with a centered empty state)
+  /// where the content has no single natural height to hug.
+  final bool fillBody;
+
+  /// Content-sized adaptive form: pair with a [MobileSheetFormBody] child.
+  /// The sheet height follows the content across three levels — short
+  /// content sits at the [_kMinContentHeight] floor with the body centered;
+  /// taller content grows the sheet to hug it; content past the top-gap cap
+  /// pins the sheet at full height and scrolls the body. In every case the
+  /// [MobileSheetFormBody] actions stay pinned to the very bottom.
+  final bool formBody;
+
+  @override
+  State<MobileSheetScaffold> createState() => _MobileSheetScaffoldState();
+}
+
+class _MobileSheetScaffoldState extends State<MobileSheetScaffold>
+    with SingleTickerProviderStateMixin {
+  /// Drag position: 0 at rest, negative when pulled up (expands), positive
+  /// when pulled down (slides toward dismiss).
+  late final AnimationController _overpull;
+  double _rawDrag = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _overpull = AnimationController.unbounded(vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _overpull.dispose();
+    super.dispose();
+  }
+
+  void _onDragStart(DragStartDetails _) {
+    _overpull.stop();
+    _rawDrag = 0;
+  }
+
+  void _onDragUpdate(DragUpdateDetails details) {
+    _rawDrag += details.delta.dy;
+    // Up: resisted over-pull (expands the sheet). Down: follow the finger
+    // 1:1 toward dismiss.
+    _overpull.value = _rawDrag < 0 ? -_rubberBand(-_rawDrag) : _rawDrag;
+  }
+
+  void _onDragEnd(DragEndDetails details) {
+    final velocity = details.velocity.pixelsPerSecond.dy;
+    // Dragged/flung down far enough → dismiss; otherwise spring back.
+    if (_rawDrag > _kDismissDragThreshold ||
+        velocity > _kDismissFlingVelocity) {
+      _dismiss();
+      return;
+    }
+    _overpull.animateWith(
+      SpringSimulation(
+        _kSpringBack,
+        _overpull.value,
+        0,
+        velocity.clamp(-_kMaxSpringVelocity, _kMaxSpringVelocity),
+      ),
+    );
+  }
+
+  void _dismiss() {
+    // Slide the rest of the way down, then pop — a continuous close rather
+    // than snapping back before the route's exit transition.
+    _overpull
+        .animateTo(
+          MediaQuery.of(context).size.height,
+          duration: _kDismissSlideDuration,
+          curve: Curves.easeIn,
+        )
+        .whenComplete(() {
+          if (mounted) Navigator.of(context).pop();
+        });
+  }
+
+  /// Asymptotic damping: tracks the finger early, eases to [_kMaxOverpull].
+  double _rubberBand(double distance) =>
+      _kMaxOverpull * (1 - 1 / (distance / _kMaxOverpull + 1));
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final media = MediaQuery.of(context);
+    final keyboardInset = media.viewInsets.bottom;
+
+    return widget.expand
+        ? _buildExpanded(context, colors, media, keyboardInset)
+        : _buildHugging(context, colors, keyboardInset);
+  }
+
+  /// Full-screen variant: fills the screen below a top gap, body lives in an
+  /// [Expanded], and over-pull EXPANDS the sheet so it reveals more content
+  /// with no bottom gap.
+  Widget _buildExpanded(
+    BuildContext context,
+    AppColors colors,
+    MediaQueryData media,
+    double keyboardInset,
+  ) {
+    // Stop short of the very top (keeps the page title visible behind the
+    // sheet, never covers the status bar). When the keyboard is open, shrink
+    // by its height AND lift above it so the sheet fills the gap-to-keyboard
+    // band instead of collapsing to the middle.
+    final height = _sheetCapHeight(media.size.height, keyboardInset);
+    final surface = _surface(
+      colors,
+      Expanded(child: widget.child),
+      expand: true,
+    );
+    return AnimatedBuilder(
+      animation: _overpull,
+      builder: (context, sheet) {
+        final value = _overpull.value;
+        return Transform.translate(
+          offset: Offset(0, _slideDown(value)),
+          child: Padding(
+            padding: EdgeInsets.only(bottom: keyboardInset),
+            child: SizedBox(
+              height: height + _overpullStretch(value),
+              width: double.infinity,
+              child: sheet,
+            ),
+          ),
+        );
+      },
+      child: surface,
+    );
+  }
+
+  /// Content-sized variant: hugs [child]'s height at the bottom. There's no
+  /// extra content to reveal, so over-pull lifts the whole sheet (resisted)
+  /// and springs back; pull-down still dismisses.
+  Widget _buildHugging(
+    BuildContext context,
+    AppColors colors,
+    double keyboardInset,
+  ) {
+    final media = MediaQuery.of(context);
+    final screenHeight = media.size.height;
+    // Read the home-indicator inset from the raw view (the modal zeroes
+    // MediaQuery padding) so the hugging content clears it.
+    final bottomSafe = MediaQueryData.fromView(View.of(context)).padding.bottom;
+    return AnimatedBuilder(
+      animation: _overpull,
+      builder: (context, _) {
+        final value = _overpull.value;
+        // Up: grow the body's bottom padding so the sheet stretches taller
+        // while staying anchored to the screen edge — the form lifts with the
+        // finger and the sheet's own surface fills below it (no scrim gap).
+        // Down: slide the whole sheet toward dismiss.
+        final stretch = _overpullStretch(value);
+        final slideDown = _slideDown(value);
+        // The adaptive form sheet keeps its overpull as a height gain (the
+        // floor and cap both grow with `stretch`) rather than bottom padding,
+        // so the body re-centres in the taller surface. Other modes still pad
+        // the bottom for the over-pull lift + home-indicator clearance.
+        if (widget.formBody) {
+          final effMax = _sheetCapHeight(screenHeight, keyboardInset) + stretch;
+          final effMin = (_kMinContentHeight + stretch).clamp(0.0, effMax);
+          final formSized = ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: effMax),
+            child: _SheetFormMetrics(
+              // The body only needs the floor↔cap slack to know how far it
+              // may shrink below the cap before it must centre / pin.
+              slack: effMax - effMin,
+              child: _surface(
+                colors,
+                Padding(
+                  padding: EdgeInsets.only(bottom: bottomSafe),
+                  child: widget.child,
+                ),
+                expand: false,
+                flexBody: true,
+              ),
+            ),
+          );
+          return Transform.translate(
+            offset: Offset(0, slideDown),
+            child: Padding(
+              padding: EdgeInsets.only(bottom: keyboardInset),
+              child: formSized,
+            ),
+          );
+        }
+
+        final body = Padding(
+          padding: EdgeInsets.only(bottom: bottomSafe + stretch),
+          child: widget.child,
+        );
+
+        final Widget sized;
+        if (widget.fillBody) {
+          // Give the body a fixed (min) height so a body that ends in
+          // buttons keeps them pinned to the very bottom; the body itself
+          // scrolls if its content is taller. Capped to stay below the top
+          // gap and above the keyboard.
+          final maxHeight = _sheetCapHeight(screenHeight, keyboardInset);
+          final target = _kMinContentHeight + stretch;
+          final fillHeight = target < maxHeight ? target : maxHeight;
+          sized = SizedBox(
+            height: fillHeight,
+            width: double.infinity,
+            child: _surface(colors, Expanded(child: body), expand: true),
+          );
+        } else {
+          // Hug the content, but never below the min — and grow that min with
+          // the over-pull so a short sheet still visibly stretches.
+          sized = ConstrainedBox(
+            constraints: BoxConstraints(
+              minHeight: _kMinContentHeight + stretch,
+            ),
+            child: SizedBox(
+              width: double.infinity,
+              child: _surface(colors, body, expand: false),
+            ),
+          );
+        }
+        return Transform.translate(
+          offset: Offset(0, slideDown),
+          child: Padding(
+            padding: EdgeInsets.only(bottom: keyboardInset),
+            child: sized,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _surface(
+    AppColors colors,
+    Widget body, {
+    required bool expand,
+    bool flexBody = false,
+  }) {
+    final hasBack = widget.onBack != null;
+    final dragZone = GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onVerticalDragStart: _onDragStart,
+      onVerticalDragUpdate: _onDragUpdate,
+      onVerticalDragEnd: _onDragEnd,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const _SheetGrabber(),
+          _SheetHeader(title: widget.title),
+        ],
+      ),
+    );
+    // The adaptive form body holds its own `Flexible` content slot, so it must
+    // receive a bounded height — a bare non-flex child of a Column is given
+    // unbounded main-axis constraints. `Flexible(loose)` bounds it to the
+    // leftover height while still letting the sheet hug shorter content.
+    final bodySlot = flexBody
+        ? Flexible(fit: FlexFit.loose, child: body)
+        : body;
+    return Material(
+      color: colors.background.base,
+      clipBehavior: Clip.antiAlias,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(
+          top: Radius.circular(AppRadii.xLarge),
+        ),
+      ),
+      child: Stack(
+        children: [
+          Column(
+            mainAxisSize: expand ? MainAxisSize.max : MainAxisSize.min,
+            children: [dragZone, bodySlot],
+          ),
+          // Back chevron for a 2nd-level view, mirrored to the close button.
+          if (hasBack)
+            Positioned(
+              top: AppSpacing.sm,
+              left: AppSpacing.sm,
+              child: _SheetCornerButton(
+                semanticLabel: 'Back',
+                iconName: AppIcons.chevronBackward,
+                keyValue: 'mobile_sheet_back_button',
+                onTap: widget.onBack!,
+              ),
+            ),
+          Positioned(
+            top: AppSpacing.sm,
+            right: AppSpacing.sm,
+            child:
+                widget.trailing ??
+                _SheetCornerButton(
+                  semanticLabel: 'Close',
+                  iconName: AppIcons.cross,
+                  keyValue: 'mobile_sheet_close_button',
+                  onTap: () => Navigator.of(context).pop(),
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Body layout for a content-sized adaptive form sheet (use with
+/// [MobileSheetScaffold] `formBody: true`): [content] occupies the space
+/// above [actions], which stay pinned to the very bottom.
+///
+/// The body drives the sheet's height across three levels:
+/// 1. **Short content** — the sheet rests at its [_kMinContentHeight] floor
+///    and the content is vertically centred in the slack above the actions.
+/// 2. **Medium content** — the sheet grows to hug the content exactly.
+/// 3. **Tall content** — the sheet caps at the top-gap height and the content
+///    scrolls; the actions remain pinned.
+///
+/// `Flexible(loose)` lets the body hug (levels 1–2) rather than fill, while a
+/// floor derived from the scaffold's slack ([_SheetFormMetrics]) keeps the
+/// content centred at the minimum height and the actions on the bottom edge.
+class MobileSheetFormBody extends StatelessWidget {
+  const MobileSheetFormBody({
+    required this.content,
+    required this.actions,
+    super.key,
+  });
+
+  final Widget content;
+  final Widget actions;
+
+  @override
+  Widget build(BuildContext context) {
+    final slack = _SheetFormMetrics.of(context).slack;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Flexible(
+          fit: FlexFit.loose,
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              // `maxHeight` is the room left for the content after the actions
+              // and chrome. Subtracting the slack yields the content-area
+              // height when the sheet sits at its floor — the minimum the
+              // scroll area must occupy so short content centres and the
+              // actions stay pinned at the bottom.
+              final contentFloor = (constraints.maxHeight - slack).clamp(
+                0.0,
+                constraints.maxHeight,
+              );
+              return SingleChildScrollView(
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minHeight: contentFloor),
+                  // IntrinsicHeight lets the content centre within (or grow
+                  // past) the floor without a flex child.
+                  child: IntrinsicHeight(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [content],
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        actions,
+      ],
+    );
+  }
+}
+
+/// Carries the adaptive form sheet's floor↔cap slack from
+/// [MobileSheetScaffold] down to its [MobileSheetFormBody], so the body can
+/// compute the content-area floor without re-deriving the screen geometry.
+class _SheetFormMetrics extends InheritedWidget {
+  const _SheetFormMetrics({required this.slack, required super.child});
+
+  final double slack;
+
+  static _SheetFormMetrics of(BuildContext context) {
+    final metrics = context
+        .dependOnInheritedWidgetOfExactType<_SheetFormMetrics>();
+    assert(metrics != null, 'MobileSheetFormBody requires formBody: true');
+    return metrics!;
+  }
+
+  @override
+  bool updateShouldNotify(_SheetFormMetrics oldWidget) =>
+      slack != oldWidget.slack;
+}
+
+class _SheetGrabber extends StatelessWidget {
+  const _SheetGrabber();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.s, bottom: AppSpacing.xs),
+      child: Center(
+        child: Container(
+          key: const ValueKey('mobile_sheet_grabber'),
+          width: _kGrabberWidth,
+          height: _kGrabberHeight,
+          decoration: BoxDecoration(
+            color: colors.border.medium,
+            borderRadius: BorderRadius.circular(AppRadii.full),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SheetHeader extends StatelessWidget {
+  const _SheetHeader({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      // Symmetric clearance for the absolute corner buttons keeps the title
+      // horizontally centered whether or not a back chevron is present.
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.xl,
+        AppSpacing.xs,
+        AppSpacing.xl,
+        AppSpacing.s,
+      ),
+      child: Text(
+        title,
+        textAlign: TextAlign.center,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: AppTypography.headlineSmall.copyWith(
+          color: colors.text.accent,
+          letterSpacing: 0,
+        ),
+      ),
+    );
+  }
+}
+
+/// A circular top-corner sheet action (close or back), styled identically.
+class _SheetCornerButton extends StatelessWidget {
+  const _SheetCornerButton({
+    required this.semanticLabel,
+    required this.iconName,
+    required this.keyValue,
+    required this.onTap,
+  });
+
+  final String semanticLabel;
+  final String iconName;
+  final String keyValue;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Semantics(
+      label: semanticLabel,
+      button: true,
+      child: GestureDetector(
+        key: ValueKey(keyValue),
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          width: _kCloseButtonSize,
+          height: _kCloseButtonSize,
+          decoration: BoxDecoration(
+            color: colors.background.raised,
+            shape: BoxShape.circle,
+          ),
+          child: Center(
+            child: AppIcon(
+              iconName,
+              size: _kCloseIconSize,
+              color: colors.icon.accent,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/address_book/widgets/address_book_contact_picker_modal.dart
+++ b/lib/src/features/address_book/widgets/address_book_contact_picker_modal.dart
@@ -62,6 +62,15 @@ class _AddressBookContactPickerModalState
     super.dispose();
   }
 
+  /// Whether the address book has any contacts in the picker's networks
+  /// (ignoring the search query) — drives hiding the search field when there
+  /// is nothing to search.
+  bool _hasContactsForNetworks(AddressBookState state) {
+    final networks = widget.networks.toSet();
+    if (networks.isEmpty) return false;
+    return state.contacts.any((c) => networks.contains(c.network));
+  }
+
   List<AddressBookContact> _filteredContacts(AddressBookState state) {
     final networks = widget.networks.toSet();
     if (networks.isEmpty) return const [];
@@ -78,29 +87,41 @@ class _AddressBookContactPickerModalState
     ];
   }
 
+  Widget _buildContactsList(List<AddressBookContact> contacts) {
+    // Both the desktop card and the mobile sheet give the list a bounded
+    // height (Expanded), so it fills and scrolls internally.
+    return _ContactPickerList(
+      contacts: contacts,
+      showNetwork: widget.networks.length > 1,
+      onSelected: widget.onSelected,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
     final contactsAsync = ref.watch(addressBookProvider);
 
-    // On mobile the swap modal route wraps this in the shared
-    // MobileModalCard (base surface, radius 32, bottom-anchored), so the
-    // surface is full-width, draws no card, and the list scrolls within a
-    // bounded height that the card hugs. Desktop keeps the fixed card.
+    // On mobile this is hosted in a fill-body MobileSheetScaffold which
+    // supplies the grabber, title and close button, so the mobile branch is
+    // chromeless and full-width and fills the sheet body (centering the empty
+    // message, scrolling a populated list). Desktop keeps the fixed centered
+    // card with its own header.
     final isMobile = kAppFormFactor == AppFormFactor.mobile;
 
     return Container(
       key: const ValueKey('address_book_contact_picker_modal'),
       width: isMobile ? double.infinity : 312,
       height: isMobile ? null : 440,
-      // Container requires a decoration to clip; the mobile card (with no
-      // decoration here) is clipped by the MobileModalCard surface.
+      // Container requires a decoration to clip; the mobile sheet (with no
+      // decoration here) is clipped by the sheet surface.
       clipBehavior: isMobile ? Clip.none : Clip.antiAlias,
-      // Desktop fills to the card edge (bottom 0); mobile hugs, so the
-      // content needs its own bottom breathing room.
+      // The mobile sheet header is supplied by the scaffold, so no top inset
+      // there; mobile hugs, so the content needs its own bottom breathing
+      // room. Desktop fills to the card edge (bottom 0).
       padding: EdgeInsets.fromLTRB(
         AppSpacing.sm,
-        AppSpacing.md,
+        isMobile ? 0 : AppSpacing.md,
         AppSpacing.sm,
         isMobile ? AppSpacing.md : 0,
       ),
@@ -112,98 +133,91 @@ class _AddressBookContactPickerModalState
               boxShadow: _modalSurfaceShadows,
             ),
       child: Column(
-        mainAxisSize: isMobile ? MainAxisSize.min : MainAxisSize.max,
+        mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  widget.title,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTypography.bodyLarge.copyWith(
-                    color: colors.text.accent,
-                    fontWeight: FontWeight.w600,
+          if (!isMobile)
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    widget.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.bodyLarge.copyWith(
+                      color: colors.text.accent,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
                 ),
+                const SizedBox(width: AppSpacing.xs),
+                _ContactPickerIconButton(
+                  semanticLabel: 'Close contacts',
+                  iconName: AppIcons.cross,
+                  onTap: widget.onCancel,
+                ),
+              ],
+            ),
+          Expanded(
+            child: contactsAsync.when(
+              loading: () => const Center(
+                child: SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: AppIcon(AppIcons.loader, size: 18),
+                ),
               ),
-              const SizedBox(width: AppSpacing.xs),
-              _ContactPickerIconButton(
-                semanticLabel: 'Close contacts',
-                iconName: AppIcons.cross,
-                onTap: widget.onCancel,
+              error: (_, _) => const _ContactPickerEmptyResult(
+                title: "Couldn't load contacts. Try again.",
               ),
-            ],
-          ),
-          _pickerExpandOrBound(
-            isMobile,
-            child: Padding(
-              padding: const EdgeInsets.only(top: AppSpacing.sm),
-              child: Column(
-                mainAxisSize: isMobile ? MainAxisSize.min : MainAxisSize.max,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.only(top: AppSpacing.xs),
-                    child: AppTextField(
-                      key: const ValueKey('address_book_contact_picker_search'),
-                      label: 'Search',
-                      showLabel: false,
-                      controller: _queryController,
-                      focusNode: _queryFocusNode,
-                      hintText: widget.searchHint,
-                      leading: const AppIcon(AppIcons.search),
-                      leadingSlotWidth: AppInputSizing.iconWrapWidth,
-                      trailingSlotWidth: 40,
-                      inputHorizontalPadding: AppSpacing.s,
-                      showClearButton: true,
-                      onChanged: (_) => setState(() {}),
-                      onClear: () => setState(() {}),
-                    ),
-                  ),
-                  const SizedBox(height: AppSpacing.md),
-                  _pickerExpandOrBound(
-                    isMobile,
-                    child: contactsAsync.when(
-                      loading: () => const Center(
-                        child: SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: AppIcon(AppIcons.loader, size: 18),
+              data: (state) {
+                // No saved contacts for these networks → just the empty
+                // message (centered in the filled body); a search field would
+                // have nothing to search.
+                if (!_hasContactsForNetworks(state)) {
+                  return _ContactPickerEmptyResult(title: widget.emptyTitle);
+                }
+                final contacts = _filteredContacts(state);
+                return Padding(
+                  padding: const EdgeInsets.only(top: AppSpacing.sm),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.max,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(top: AppSpacing.xs),
+                        child: AppTextField(
+                          key: const ValueKey(
+                            'address_book_contact_picker_search',
+                          ),
+                          label: 'Search',
+                          showLabel: false,
+                          controller: _queryController,
+                          focusNode: _queryFocusNode,
+                          hintText: widget.searchHint,
+                          leading: const AppIcon(AppIcons.search),
+                          leadingSlotWidth: AppInputSizing.iconWrapWidth,
+                          trailingSlotWidth: 40,
+                          inputHorizontalPadding: AppSpacing.s,
+                          showClearButton: true,
+                          onChanged: (_) => setState(() {}),
+                          onClear: () => setState(() {}),
                         ),
                       ),
-                      error: (_, _) => const _ContactPickerEmptyResult(
-                        title: "Couldn't load contacts. Try again.",
-                      ),
-                      data: (state) {
-                        final contacts = _filteredContacts(state);
-                        if (contacts.isEmpty) {
-                          return _ContactPickerEmptyResult(
-                            title: widget.emptyTitle,
-                          );
-                        }
-                        final list = _ContactPickerList(
-                          contacts: contacts,
-                          showNetwork: widget.networks.length > 1,
-                          shrinkWrap: isMobile,
-                          onSelected: widget.onSelected,
-                        );
-                        // Mobile hugs the card to the list within a bound;
-                        // desktop fills the fixed-height card.
-                        return isMobile
-                            ? ConstrainedBox(
-                                constraints: const BoxConstraints(
-                                  maxHeight: 420,
-                                ),
-                                child: list,
+                      const SizedBox(height: AppSpacing.md),
+                      // Search yielded nothing but contacts exist → keep the
+                      // field so the query can be cleared.
+                      Expanded(
+                        child: contacts.isEmpty
+                            ? _ContactPickerEmptyResult(
+                                title: widget.emptyTitle,
                               )
-                            : list;
-                      },
-                    ),
+                            : _buildContactsList(contacts),
+                      ),
+                    ],
                   ),
-                ],
-              ),
+                );
+              },
             ),
           ),
         ],
@@ -212,27 +226,16 @@ class _AddressBookContactPickerModalState
   }
 }
 
-/// Desktop fills the fixed-height card ([Expanded]); mobile lets the
-/// search/list area flow so the card hugs its content (the populated list
-/// bounds its own height separately).
-Widget _pickerExpandOrBound(bool mobile, {required Widget child}) =>
-    mobile ? child : Expanded(child: child);
-
 class _ContactPickerList extends StatefulWidget {
   const _ContactPickerList({
     required this.contacts,
     required this.showNetwork,
     required this.onSelected,
-    this.shrinkWrap = false,
   });
 
   final List<AddressBookContact> contacts;
   final bool showNetwork;
   final ValueChanged<AddressBookContact> onSelected;
-
-  /// Mobile hugs the list to its content within a bounded height; desktop
-  /// fills the fixed-height card.
-  final bool shrinkWrap;
 
   @override
   State<_ContactPickerList> createState() => _ContactPickerListState();
@@ -273,7 +276,7 @@ class _ContactPickerListState extends State<_ContactPickerList> {
           child: ListView.separated(
             controller: _scrollController,
             padding: EdgeInsets.zero,
-            shrinkWrap: widget.shrinkWrap,
+            shrinkWrap: false,
             itemCount: widget.contacts.length,
             separatorBuilder: (_, _) => const SizedBox(height: AppSpacing.xs),
             itemBuilder: (context, index) {

--- a/lib/src/features/swap/models/swap_state.dart
+++ b/lib/src/features/swap/models/swap_state.dart
@@ -53,6 +53,7 @@ class SwapState {
     this.receiveFiatText = '',
     this.slippageBps = defaultSwapSlippageBps,
     this.supportedExternalAssets = swapExternalAssets,
+    this.externalAssetsLoading = true,
     this.indicativeExternalPerZec = const {},
     this.indicativeUsdPrices = const {},
     this.reviewQuote,
@@ -85,6 +86,11 @@ class SwapState {
   final String receiveFiatText;
   final int slippageBps;
   final List<SwapAsset> supportedExternalAssets;
+
+  /// True until the live (multi-chain) external asset list has been fetched
+  /// for the first time. While true the asset picker shows skeleton rows
+  /// instead of the static fallback list.
+  final bool externalAssetsLoading;
   final Map<SwapAsset, double> indicativeExternalPerZec;
   final Map<SwapAsset, double> indicativeUsdPrices;
   final SwapQuote? reviewQuote;
@@ -257,6 +263,7 @@ class SwapState {
     String? receiveFiatText,
     int? slippageBps,
     List<SwapAsset>? supportedExternalAssets,
+    bool? externalAssetsLoading,
     Map<SwapAsset, double>? indicativeExternalPerZec,
     Map<SwapAsset, double>? indicativeUsdPrices,
     SwapQuote? reviewQuote,
@@ -296,6 +303,8 @@ class SwapState {
       slippageBps: slippageBps ?? this.slippageBps,
       supportedExternalAssets:
           supportedExternalAssets ?? this.supportedExternalAssets,
+      externalAssetsLoading:
+          externalAssetsLoading ?? this.externalAssetsLoading,
       indicativeExternalPerZec:
           indicativeExternalPerZec ?? this.indicativeExternalPerZec,
       indicativeUsdPrices: indicativeUsdPrices ?? this.indicativeUsdPrices,

--- a/lib/src/features/swap/providers/swap_state_provider.dart
+++ b/lib/src/features/swap/providers/swap_state_provider.dart
@@ -368,12 +368,16 @@ class SwapNotifier extends Notifier<SwapState> {
         for (final asset in liveAssets)
           if (asset != SwapAsset.zec) asset,
       ];
-      if (supported.isEmpty) return;
+      if (supported.isEmpty) {
+        state = state.copyWith(externalAssetsLoading: false);
+        return;
+      }
       final selected =
           _supportedAssetFor(state.externalAsset, supported) ?? supported.first;
       final selectedChanged = selected != state.externalAsset;
       var nextState = state.copyWith(
         supportedExternalAssets: supported,
+        externalAssetsLoading: false,
         indicativeExternalPerZec:
             pricing?.externalPerZec ?? state.indicativeExternalPerZec,
         indicativeUsdPrices: pricing?.usdPrices ?? state.indicativeUsdPrices,
@@ -395,6 +399,7 @@ class SwapNotifier extends Notifier<SwapState> {
       );
     } catch (_) {
       // Keep the static fallback so the swap flow remains usable offline.
+      state = state.copyWith(externalAssetsLoading: false);
     }
   }
 

--- a/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
@@ -5,7 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/formatting/zec_amount.dart';
-import '../../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../../core/layout/mobile/mobile_sheet.dart';
 import '../../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/app_button.dart';
@@ -13,7 +13,6 @@ import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/app_toast.dart';
 import '../../../../providers/account_provider.dart';
 import '../../../../providers/sync_provider.dart';
-import '../../../address_book/models/address_book_contact.dart';
 import '../../../address_book/providers/address_book_provider.dart';
 import '../../../address_book/widgets/address_book_contact_picker_modal.dart';
 import '../../../address_scan/domain/address_scan_payload.dart';
@@ -26,14 +25,6 @@ import '../../widgets/swap_asset_selector_modal.dart';
 import '../../widgets/swap_near_intents_attribution.dart';
 import '../../widgets/mobile/mobile_swap_composer_ticket.dart';
 import '../../widgets/mobile/mobile_swap_slippage_stepper_modal.dart';
-
-enum _SwapModalSurface {
-  assetSelector,
-  addressEditor,
-  addressScanner,
-  contactPicker,
-  slippageSettings,
-}
 
 /// Mobile swap composer — Figma `Swap` / `Swap v1` (4691:102452,
 /// 4686:101421): the same NEAR-intents composer as the desktop pane,
@@ -51,161 +42,70 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
     debugLabel: 'mobile_swap_toast_overlay_context',
   );
 
-  /// A ValueNotifier (rather than plain setState state) because the
-  /// modal route lives on the root navigator and doesn't rebuild with
-  /// this screen — its content listens to this directly.
-  final ValueNotifier<_SwapModalSurface?> _swapModal =
-      ValueNotifier<_SwapModalSurface?>(null);
-  bool _modalRouteOpen = false;
-
-  @override
-  void dispose() {
-    _swapModal.dispose();
-    super.dispose();
-  }
-
-  void _openModal(_SwapModalSurface surface) {
-    setState(() => _swapModal.value = surface);
-    if (_modalRouteOpen) return;
-    _modalRouteOpen = true;
-    // One root-navigator dialog hosts every surface: the scrim must
-    // cover the status bar and the floating tab bar (the shell paints
-    // the bar above this screen, so an inline overlay can't reach it —
-    // same convention as showAppMobileSheet). Surface switches (editor
-    // → scanner → contacts → editor) swap content inside the open
-    // route instead of re-navigating.
+  /// The asset selector on the standard full-screen sheet
+  /// ([showMobileSheet] + [MobileSheetScaffold]). A Consumer keeps the
+  /// list in sync with swap state while the sheet is open.
+  void _openAssetSelector() {
     unawaited(
-      showGeneralDialog<void>(
+      showMobileSheet<void>(
         context: context,
-        useRootNavigator: true,
-        barrierDismissible: true,
-        barrierLabel: 'Dismiss',
-        barrierColor: context.colors.background.neutralScrim,
-        transitionDuration: Duration.zero,
-        pageBuilder: (_, _, _) => _buildSwapModal(),
-      ).whenComplete(() {
-        _modalRouteOpen = false;
-        if (mounted) setState(() => _swapModal.value = null);
-      }),
-    );
-  }
-
-  void _closeSwapModal() {
-    if (_modalRouteOpen) {
-      // State resets in the route's whenComplete.
-      Navigator.of(context, rootNavigator: true).pop();
-      return;
-    }
-    if (_swapModal.value != null) {
-      setState(() => _swapModal.value = null);
-    }
-  }
-
-  void _selectAddressBookContact(AddressBookContact contact) {
-    ref.read(swapStateProvider.notifier).updateDestination(contact.address);
-    _closeSwapModal();
-  }
-
-  /// Content of the root modal route: re-renders on surface switches
-  /// via [_swapModal] and on swap state changes via its own Consumer
-  /// (the route doesn't rebuild with the screen). Empty space around
-  /// the card falls through to the dialog barrier, which dismisses.
-  Widget _buildSwapModal() {
-    return ValueListenableBuilder<_SwapModalSurface?>(
-      valueListenable: _swapModal,
-      builder: (context, surface, _) {
-        if (surface == null) return const SizedBox.shrink();
-        return Consumer(
+        builder: (sheetContext) => Consumer(
           builder: (context, ref, _) {
             final swapState = ref.watch(swapStateProvider);
-            final swapNotifier = ref.read(swapStateProvider.notifier);
-            // The address scanner is a full-bleed camera surface (Figma
-            // `Address QR` 4697:106096) — the same chrome as the send
-            // recipient scan — so it bypasses the bottom-anchored card.
-            if (surface == _SwapModalSurface.addressScanner) {
-              return MobileAddressScanView(
-                resolve: (raw) async {
-                  final address = normalizeAddressScanPayload(raw);
-                  if (address == null || address.isEmpty) {
-                    return const MobileScanOutcome.rejected(
-                      'QR code did not include an address.',
-                    );
-                  }
-                  return MobileScanOutcome.accepted(address);
-                },
-                onScanned: (value) {
-                  swapNotifier.updateDestination(value);
-                  _closeSwapModal();
-                },
-                onClose: _closeSwapModal,
-              );
-            }
-            final surfaceContent = switch (surface) {
-              _SwapModalSurface.assetSelector => SwapAssetSelectorModal(
+            return MobileSheetScaffold(
+              title: 'Select asset',
+              expand: true,
+              child: SwapAssetSelectorModal(
                 assets: swapState.supportedExternalAssets,
                 selected: swapState.externalAsset,
+                loading: swapState.externalAssetsLoading,
                 onSelected: (asset) {
-                  swapNotifier.selectExternalAsset(asset);
-                  _closeSwapModal();
+                  ref
+                      .read(swapStateProvider.notifier)
+                      .selectExternalAsset(asset);
+                  Navigator.of(sheetContext).pop();
                 },
-              ),
-              _SwapModalSurface.addressEditor => SwapAddressEditModal(
-                state: swapState,
-                onSubmitted: (value, remember, nickname, profilePictureId) {
-                  if (remember) {
-                    unawaited(
-                      _rememberSwapAddress(
-                        value,
-                        swapState,
-                        nickname,
-                        profilePictureId,
-                      ),
-                    );
-                  }
-                  swapNotifier.updateDestination(value);
-                  _closeSwapModal();
-                },
-                onScan: () => _openModal(_SwapModalSurface.addressScanner),
-                onOpenContacts: () =>
-                    _openModal(_SwapModalSurface.contactPicker),
-                onCancel: _closeSwapModal,
-              ),
-              // Handled full-bleed above, before this switch.
-              _SwapModalSurface.addressScanner => const SizedBox.shrink(),
-              _SwapModalSurface.contactPicker => AddressBookContactPickerModal(
-                title: swapContactPickerTitle(swapState),
-                networks: swapContactPickerNetworks(swapState),
-                emptyTitle: swapContactPickerEmptyTitle(swapState),
-                onSelected: _selectAddressBookContact,
-                onCancel: () => _openModal(_SwapModalSurface.addressEditor),
-              ),
-              _SwapModalSurface.slippageSettings =>
-                MobileSwapSlippageStepperModal(
-                  slippageBps: swapState.slippageBps,
-                  onSubmitted: (value) {
-                    swapNotifier.updateSlippageBps(value);
-                    _closeSwapModal();
-                  },
-                  onCancel: _closeSwapModal,
-                ),
-            };
-            // The shared base card provides the ground surface, radius,
-            // side margins, bottom gap and keyboard avoidance — the same
-            // chrome as showAppMobileSheet — so the swap modals match the
-            // other mobile modals. Bottom-anchored and full-width.
-            return SafeArea(
-              bottom: false,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  const Spacer(),
-                  MobileModalCard(child: surfaceContent),
-                ],
               ),
             );
           },
-        );
-      },
+        ),
+      ),
+    );
+  }
+
+  /// Slippage editor on a content-sized standard sheet (hugs its form).
+  void _openSlippage() {
+    final swapState = ref.read(swapStateProvider);
+    final swapNotifier = ref.read(swapStateProvider.notifier);
+    unawaited(
+      showMobileSheet<void>(
+        context: context,
+        builder: (sheetContext) => MobileSheetScaffold(
+          title: 'Slippage',
+          formBody: true,
+          child: MobileSwapSlippageStepperModal(
+            slippageBps: swapState.slippageBps,
+            onSubmitted: (value) {
+              swapNotifier.updateSlippageBps(value);
+              Navigator.of(sheetContext).pop();
+            },
+            onCancel: () => Navigator.of(sheetContext).pop(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// One sheet for the recipient/refund flow: the editor, with the contacts
+  /// picker shown as a 2nd-level view inside the same sheet (back chevron),
+  /// and the QR scanner pushed full-screen over it. See [_SwapAddressSheet].
+  void _openAddressEditor() {
+    unawaited(
+      showMobileSheet<void>(
+        context: context,
+        builder: (_) =>
+            _SwapAddressSheet(onRememberAddress: _rememberSwapAddress),
+      ),
     );
   }
 
@@ -260,13 +160,6 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
 
   @override
   Widget build(BuildContext context) {
-    ref.listen<String?>(
-      accountProvider.select((value) => value.value?.activeAccountUuid),
-      (previous, next) {
-        if (previous == next || !mounted) return;
-        _closeSwapModal();
-      },
-    );
     final swapState = ref.watch(swapStateProvider);
     final swapNotifier = ref.read(swapStateProvider.notifier);
     final accountState = ref.watch(accountProvider).value;
@@ -330,10 +223,8 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
                             swapNotifier.updateReceiveAmountFiat,
                         onToggleFiatInputMode: swapNotifier.toggleFiatInputMode,
                         onToggleDirection: swapNotifier.toggleDirection,
-                        onOpenExternalAssetPicker: () =>
-                            _openModal(_SwapModalSurface.assetSelector),
-                        onOpenDestinationAddress: () =>
-                            _openModal(_SwapModalSurface.addressEditor),
+                        onOpenExternalAssetPicker: _openAssetSelector,
+                        onOpenDestinationAddress: _openAddressEditor,
                         onUseMaxZecAmount: swapNotifier.useMaxZecAmount,
                         zecAvailableText: zecAvailableText,
                       ),
@@ -343,8 +234,7 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
                           AppButton(
                             key: const ValueKey('swap_settings_button'),
                             variant: AppButtonVariant.secondary,
-                            onPressed: () =>
-                                _openModal(_SwapModalSurface.slippageSettings),
+                            onPressed: _openSlippage,
                             trailing: const AppIcon(AppIcons.cog),
                             child: Text(
                               formatSwapSlippage(swapState.slippageBps),
@@ -355,8 +245,7 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
                             child: _MobileSwapReviewButton(
                               state: swapState,
                               zecAvailableZatoshi: sync.spendableBalance,
-                              onOpenDestinationAddress: () =>
-                                  _openModal(_SwapModalSurface.addressEditor),
+                              onOpenDestinationAddress: _openAddressEditor,
                               onReviewQuote: openReview,
                             ),
                           ),
@@ -390,6 +279,115 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+enum _AddressSheetView { editor, contacts }
+
+/// The recipient/refund flow in a single content-sized sheet. The editor is
+/// the base view; tapping contacts swaps the sheet content to the picker
+/// (a back chevron returns to the editor), and the QR scanner is pushed
+/// full-screen over the sheet. Watching swap state means an address chosen
+/// via scan/contacts flows into the editor's field.
+class _SwapAddressSheet extends ConsumerStatefulWidget {
+  const _SwapAddressSheet({required this.onRememberAddress});
+
+  final Future<void> Function(
+    String value,
+    SwapState swapState,
+    String? nickname,
+    String profilePictureId,
+  )
+  onRememberAddress;
+
+  @override
+  ConsumerState<_SwapAddressSheet> createState() => _SwapAddressSheetState();
+}
+
+class _SwapAddressSheetState extends ConsumerState<_SwapAddressSheet> {
+  _AddressSheetView _view = _AddressSheetView.editor;
+
+  void _showEditor() => setState(() => _view = _AddressSheetView.editor);
+  void _showContacts() => setState(() => _view = _AddressSheetView.contacts);
+
+  void _openScanner() {
+    unawaited(
+      Navigator.of(context, rootNavigator: true).push<void>(
+        PageRouteBuilder<void>(
+          opaque: true,
+          pageBuilder: (routeContext, _, _) => MobileAddressScanView(
+            resolve: (raw) async {
+              final address = normalizeAddressScanPayload(raw);
+              if (address == null || address.isEmpty) {
+                return const MobileScanOutcome.rejected(
+                  'QR code did not include an address.',
+                );
+              }
+              return MobileScanOutcome.accepted(address);
+            },
+            onScanned: (value) {
+              ref.read(swapStateProvider.notifier).updateDestination(value);
+              Navigator.of(routeContext).pop();
+            },
+            onClose: () => Navigator.of(routeContext).pop(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final swapState = ref.watch(swapStateProvider);
+    final notifier = ref.read(swapStateProvider.notifier);
+
+    if (_view == _AddressSheetView.contacts) {
+      final title = swapContactPickerTitle(swapState);
+      return MobileSheetScaffold(
+        title: title,
+        onBack: _showEditor,
+        fillBody: true,
+        child: AddressBookContactPickerModal(
+          title: title,
+          networks: swapContactPickerNetworks(swapState),
+          emptyTitle: swapContactPickerEmptyTitle(swapState),
+          onSelected: (contact) {
+            notifier.updateDestination(contact.address);
+            _showEditor();
+          },
+          onCancel: _showEditor,
+        ),
+      );
+    }
+
+    final asset = swapState.externalAsset;
+    final title = swapState.direction.sendsZec
+        ? '${asset.symbol} recipient address'
+        : '${asset.symbol} refund address';
+    return MobileSheetScaffold(
+      title: title,
+      formBody: true,
+      child: SwapAddressEditModal(
+        state: swapState,
+        onSubmitted: (value, remember, nickname, profilePictureId) {
+          if (remember) {
+            unawaited(
+              widget.onRememberAddress(
+                value,
+                swapState,
+                nickname,
+                profilePictureId,
+              ),
+            );
+          }
+          notifier.updateDestination(value);
+          Navigator.of(context).pop();
+        },
+        onScan: _openScanner,
+        onOpenContacts: _showContacts,
+        onCancel: () => Navigator.of(context).pop(),
       ),
     );
   }

--- a/lib/src/features/swap/widgets/mobile/mobile_swap_slippage_stepper_modal.dart
+++ b/lib/src/features/swap/widgets/mobile/mobile_swap_slippage_stepper_modal.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart' show InputDecoration, TextField;
 import 'package:flutter/services.dart' show FilteringTextInputFormatter;
 import 'package:flutter/widgets.dart';
 
+import '../../../../core/layout/mobile/mobile_sheet.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/app_button.dart';
-import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/comma_to_dot_input_formatter.dart';
 
 /// Mobile slippage editor — Figma `Slippage` (4700:121854 / 4700:123165 /
@@ -93,157 +93,126 @@ class _MobileSwapSlippageStepperModalState
     // Out-of-range turns the value and message the destructive magenta
     // tone (Figma 4700:123470); in-range stays the primary serif colour.
     final valueColor = invalid ? colors.text.destructive : colors.text.primary;
-    // Content only — the swap modal route wraps this in the shared
-    // MobileModalCard (base surface, radius 32, bottom-anchored).
+    // The slippage value reuses the largest display token (40px); the unit
+    // suffix sits one step down so it stays proportional.
+    final valueStyle = AppTypography.displayLarge.copyWith(color: valueColor);
+    final unitStyle = AppTypography.headlineLarge.copyWith(
+      color: colors.text.secondary,
+    );
+    // Content only — hosted in a content-sized MobileSheetScaffold which
+    // supplies the grabber, "Slippage" title and close button.
     return Padding(
       padding: const EdgeInsets.fromLTRB(
         AppSpacing.sm,
-        AppSpacing.md,
+        AppSpacing.s,
         AppSpacing.sm,
         AppSpacing.md,
       ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Row(
-            children: [
-              Expanded(
-                child: Text(
-                  'Slippage',
-                  style: AppTypography.headlineSmall.copyWith(
-                    color: colors.text.accent,
-                  ),
+      child: MobileSheetFormBody(
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                _StepperButton(
+                  key: const ValueKey('mobile_swap_slippage_minus'),
+                  label: '-',
+                  enabled: (_bps ?? _minBps) > _minBps,
+                  onTap: () => _step(-1),
                 ),
-              ),
-              Semantics(
-                label: 'Close',
-                button: true,
-                child: GestureDetector(
-                  behavior: HitTestBehavior.opaque,
-                  onTap: widget.onCancel,
-                  child: Container(
-                    width: 32,
-                    height: 32,
-                    decoration: BoxDecoration(
-                      color: colors.background.raised,
-                      shape: BoxShape.circle,
-                    ),
-                    child: Center(
-                      child: AppIcon(
-                        AppIcons.cross,
-                        size: AppIconSize.medium,
-                        color: colors.icon.accent,
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: AppSpacing.md),
-          Row(
-            children: [
-              _StepperButton(
-                key: const ValueKey('mobile_swap_slippage_minus'),
-                label: '-',
-                enabled: (_bps ?? _minBps) > _minBps,
-                onTap: () => _step(-1),
-              ),
-              Expanded(
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Flexible(
-                      child: IntrinsicWidth(
-                        child: TextField(
-                          key: const ValueKey('mobile_swap_slippage_value'),
-                          controller: _controller,
-                          focusNode: _focusNode,
-                          autofocus: true,
-                          onChanged: _onChanged,
-                          textAlign: TextAlign.center,
-                          keyboardType: const TextInputType.numberWithOptions(
-                            decimal: true,
-                          ),
-                          inputFormatters: [
-                            // The decimal-pad key follows the device
-                            // locale; normalise a comma to the period the
-                            // filter keeps.
-                            const CommaToDotInputFormatter(),
-                            FilteringTextInputFormatter.allow(
-                              RegExp(r'[0-9.]'),
+                Expanded(
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Flexible(
+                        child: IntrinsicWidth(
+                          child: TextField(
+                            key: const ValueKey('mobile_swap_slippage_value'),
+                            controller: _controller,
+                            focusNode: _focusNode,
+                            onChanged: _onChanged,
+                            textAlign: TextAlign.center,
+                            keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true,
                             ),
-                          ],
-                          style: AppTypography.headlineLarge.copyWith(
-                            color: valueColor,
-                          ),
-                          cursorColor: colors.text.accent,
-                          cursorWidth: 2,
-                          cursorRadius: const Radius.circular(AppRadii.full),
-                          decoration: const InputDecoration.collapsed(
-                            hintText: '0',
+                            inputFormatters: [
+                              // The decimal-pad key follows the device
+                              // locale; normalise a comma to the period the
+                              // filter keeps.
+                              const CommaToDotInputFormatter(),
+                              FilteringTextInputFormatter.allow(
+                                RegExp(r'[0-9.]'),
+                              ),
+                            ],
+                            style: valueStyle,
+                            cursorColor: colors.text.accent,
+                            cursorWidth: 2,
+                            cursorRadius: const Radius.circular(AppRadii.full),
+                            decoration: const InputDecoration.collapsed(
+                              hintText: '0',
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                    Text(
-                      ' %',
-                      style: AppTypography.headlineMedium.copyWith(
-                        color: colors.text.secondary,
-                      ),
-                    ),
-                  ],
+                      Text(' %', style: unitStyle),
+                    ],
+                  ),
+                ),
+                _StepperButton(
+                  key: const ValueKey('mobile_swap_slippage_plus'),
+                  label: '+',
+                  enabled: (_bps ?? _maxBps) < _maxBps,
+                  onTap: () => _step(1),
+                ),
+              ],
+            ),
+            if (invalid) ...[
+              const SizedBox(height: AppSpacing.s),
+              Text(
+                'Slippage must be 0.1 - 5%',
+                key: const ValueKey('mobile_swap_slippage_error'),
+                textAlign: TextAlign.center,
+                style: AppTypography.bodySmall.copyWith(
+                  color: colors.text.destructive,
                 ),
               ),
-              _StepperButton(
-                key: const ValueKey('mobile_swap_slippage_plus'),
-                label: '+',
-                enabled: (_bps ?? _maxBps) < _maxBps,
-                onTap: () => _step(1),
-              ),
             ],
-          ),
-          if (invalid) ...[
-            const SizedBox(height: AppSpacing.s),
-            Text(
-              'Slippage must be 0.1 - 5%',
-              key: const ValueKey('mobile_swap_slippage_error'),
-              textAlign: TextAlign.center,
-              style: AppTypography.bodySmall.copyWith(
-                color: colors.text.destructive,
-              ),
-            ),
           ],
-          const SizedBox(height: AppSpacing.md),
-          AppButton(
-            key: const ValueKey('swap_slippage_update_button'),
-            expand: true,
-            onPressed: _canUpdate ? () => widget.onSubmitted(_bps!) : null,
-            child: const Text('Update'),
-          ),
-          const SizedBox(height: AppSpacing.s),
-          Semantics(
-            button: true,
-            child: GestureDetector(
-              key: const ValueKey('swap_slippage_cancel_button'),
-              behavior: HitTestBehavior.opaque,
-              onTap: widget.onCancel,
-              child: SizedBox(
-                height: 44,
-                child: Center(
-                  child: Text(
-                    'Cancel',
-                    style: AppTypography.labelLarge.copyWith(
-                      color: colors.text.primary,
+        ),
+        actions: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            AppButton(
+              key: const ValueKey('swap_slippage_update_button'),
+              expand: true,
+              onPressed: _canUpdate ? () => widget.onSubmitted(_bps!) : null,
+              child: const Text('Update'),
+            ),
+            const SizedBox(height: AppSpacing.s),
+            Semantics(
+              button: true,
+              child: GestureDetector(
+                key: const ValueKey('swap_slippage_cancel_button'),
+                behavior: HitTestBehavior.opaque,
+                onTap: widget.onCancel,
+                child: SizedBox(
+                  height: 44,
+                  child: Center(
+                    child: Text(
+                      'Cancel',
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.text.primary,
+                      ),
                     ),
                   ),
                 ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/src/features/swap/widgets/swap_address_edit_modal.dart
+++ b/lib/src/features/swap/widgets/swap_address_edit_modal.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../../core/layout/app_form_factor.dart';
+import '../../../core/layout/mobile/mobile_sheet.dart';
 import '../../../core/profile_pictures.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -158,195 +159,202 @@ class _SwapAddressEditModalState extends State<SwapAddressEditModal> {
         ? null
         : _nicknameError;
 
-    // On mobile the swap modal route wraps this in the shared
-    // MobileModalCard (base surface, radius 32, 16px side margins,
-    // bottom-anchored), so the surface is full-width and draws no card of
-    // its own. Desktop keeps the fixed centered card.
+    // On mobile this is hosted in a content-sized MobileSheetScaffold which
+    // supplies the grabber, title and close button, so the mobile branch is
+    // chromeless and full-width. Desktop keeps the fixed centered card with
+    // its own header.
     final isMobile = kAppFormFactor == AppFormFactor.mobile;
+
+    // The form fields and the pinned Save/Cancel actions are shared between
+    // the desktop card and the mobile sheet; only the surrounding chrome and
+    // layout differ (desktop hugs inside a fixed card with its own header;
+    // mobile fills a content-sized sheet, scrolling the form when it is too
+    // tall while keeping the actions pinned at the bottom).
+    final form = Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            fieldLabel,
+            style: AppTypography.labelMedium.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Container(
+            height: 46,
+            decoration: BoxDecoration(
+              color: colors.background.base,
+              border: Border.all(color: colors.border.subtle, width: 1.5),
+              borderRadius: BorderRadius.circular(AppRadii.small),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    child: TextField(
+                      key: const ValueKey('swap_destination_field'),
+                      controller: _controller,
+                      focusNode: _focusNode,
+                      textInputAction: TextInputAction.done,
+                      onSubmitted: (_) => _submit(),
+                      onChanged: (_) => setState(() {}),
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.text.accent,
+                      ),
+                      cursorColor: colors.text.accent,
+                      decoration: InputDecoration.collapsed(
+                        hintText: hint,
+                        hintStyle: AppTypography.labelLarge.copyWith(
+                          color: colors.text.muted,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SwapInlineIconButton(
+                        key: const ValueKey('swap_address_scan_button'),
+                        iconName: AppIcons.qr,
+                        onTap: widget.onScan,
+                      ),
+                      const SizedBox(width: 4),
+                      SwapInlineIconButton(
+                        key: const ValueKey('swap_address_contacts_button'),
+                        iconName: AppIcons.users,
+                        onTap: widget.onOpenContacts,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (formatError != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              formatError,
+              key: const ValueKey('swap_destination_format_error'),
+              style: AppTypography.bodyMedium.copyWith(
+                color: colors.text.destructive,
+              ),
+            ),
+          ],
+          const SizedBox(height: 12),
+          Text(
+            description,
+            style: AppTypography.bodyMedium.copyWith(color: colors.text.accent),
+          ),
+          const SizedBox(height: 16),
+          _AddressRememberToggle(
+            selected: _rememberAddress,
+            label: rememberLabel,
+            onTap: _toggleRemember,
+          ),
+          if (_rememberAddress) ...[
+            const SizedBox(height: 20),
+            Text(
+              'Address label',
+              style: AppTypography.labelMedium.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                _AddressAvatarButton(
+                  profilePictureId: _selectedProfilePictureId,
+                  onTap: () => setState(() => _pickingAvatar = !_pickingAvatar),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _NicknameInputBox(
+                    controller: _nicknameController,
+                    focusNode: _nicknameFocusNode,
+                    onChanged: (_) => setState(() {}),
+                    onSubmitted: (_) => _submit(),
+                  ),
+                ),
+              ],
+            ),
+            if (nicknameError != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                nicknameError,
+                key: const ValueKey('swap_address_nickname_error'),
+                style: AppTypography.bodyMedium.copyWith(
+                  color: colors.text.destructive,
+                ),
+              ),
+            ],
+            if (_pickingAvatar) ...[
+              const SizedBox(height: 12),
+              _AvatarPickerStrip(
+                selectedId: _selectedProfilePictureId,
+                onSelected: _selectAvatar,
+              ),
+            ],
+          ],
+        ],
+      ),
+    );
+
+    final actions = SwapModalButtons(
+      primaryKey: const ValueKey('swap_address_update_button'),
+      cancelKey: const ValueKey('swap_address_cancel_button'),
+      primaryLabel: 'Save',
+      onPrimary: _submit,
+      onCancel: widget.onCancel,
+      primaryEnabled: _canSubmit,
+    );
+
     return Container(
       key: const ValueKey('swap_address_modal'),
       width: isMobile ? double.infinity : 312,
-      padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+      padding: EdgeInsets.fromLTRB(16, isMobile ? 0 : 24, 16, 16),
       decoration: isMobile
           ? null
           : BoxDecoration(
               color: colors.background.ground,
               borderRadius: BorderRadius.circular(AppRadii.large),
             ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Row(
-            children: [
-              SwapModalIconBadge(
-                iconName: AppIcons.wallet,
-                iconColor: colors.icon.regular,
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: Text(
-                  title,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTypography.bodyLarge.copyWith(
-                    fontWeight: FontWeight.w500,
-                    color: colors.text.accent,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 16),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
-            child: Column(
+      child: isMobile
+          ? MobileSheetFormBody(content: form, actions: actions)
+          : Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
               children: [
-                Text(
-                  fieldLabel,
-                  style: AppTypography.labelMedium.copyWith(
-                    color: colors.text.secondary,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Container(
-                  height: 46,
-                  decoration: BoxDecoration(
-                    color: colors.background.base,
-                    border: Border.all(color: colors.border.subtle, width: 1.5),
-                    borderRadius: BorderRadius.circular(AppRadii.small),
-                  ),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 12),
-                          child: TextField(
-                            key: const ValueKey('swap_destination_field'),
-                            controller: _controller,
-                            focusNode: _focusNode,
-                            textInputAction: TextInputAction.done,
-                            onSubmitted: (_) => _submit(),
-                            onChanged: (_) => setState(() {}),
-                            style: AppTypography.labelLarge.copyWith(
-                              color: colors.text.accent,
-                            ),
-                            cursorColor: colors.text.accent,
-                            decoration: InputDecoration.collapsed(
-                              hintText: hint,
-                              hintStyle: AppTypography.labelLarge.copyWith(
-                                color: colors.text.muted,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 10),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            SwapInlineIconButton(
-                              key: const ValueKey('swap_address_scan_button'),
-                              iconName: AppIcons.qr,
-                              onTap: widget.onScan,
-                            ),
-                            const SizedBox(width: 4),
-                            SwapInlineIconButton(
-                              key: const ValueKey(
-                                'swap_address_contacts_button',
-                              ),
-                              iconName: AppIcons.users,
-                              onTap: widget.onOpenContacts,
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                if (formatError != null) ...[
-                  const SizedBox(height: 8),
-                  Text(
-                    formatError,
-                    key: const ValueKey('swap_destination_format_error'),
-                    style: AppTypography.bodyMedium.copyWith(
-                      color: colors.text.destructive,
+                Row(
+                  children: [
+                    SwapModalIconBadge(
+                      iconName: AppIcons.wallet,
+                      iconColor: colors.icon.regular,
                     ),
-                  ),
-                ],
-                const SizedBox(height: 12),
-                Text(
-                  description,
-                  style: AppTypography.bodyMedium.copyWith(
-                    color: colors.text.accent,
-                  ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTypography.bodyLarge.copyWith(
+                          fontWeight: FontWeight.w500,
+                          color: colors.text.accent,
+                        ),
+                      ),
+                    ),
+                  ],
                 ),
                 const SizedBox(height: 16),
-                _AddressRememberToggle(
-                  selected: _rememberAddress,
-                  label: rememberLabel,
-                  onTap: _toggleRemember,
-                ),
-                if (_rememberAddress) ...[
-                  const SizedBox(height: 20),
-                  Text(
-                    'Address label',
-                    style: AppTypography.labelMedium.copyWith(
-                      color: colors.text.secondary,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Row(
-                    children: [
-                      _AddressAvatarButton(
-                        profilePictureId: _selectedProfilePictureId,
-                        onTap: () =>
-                            setState(() => _pickingAvatar = !_pickingAvatar),
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: _NicknameInputBox(
-                          controller: _nicknameController,
-                          focusNode: _nicknameFocusNode,
-                          onChanged: (_) => setState(() {}),
-                          onSubmitted: (_) => _submit(),
-                        ),
-                      ),
-                    ],
-                  ),
-                  if (nicknameError != null) ...[
-                    const SizedBox(height: 8),
-                    Text(
-                      nicknameError,
-                      key: const ValueKey('swap_address_nickname_error'),
-                      style: AppTypography.bodyMedium.copyWith(
-                        color: colors.text.destructive,
-                      ),
-                    ),
-                  ],
-                  if (_pickingAvatar) ...[
-                    const SizedBox(height: 12),
-                    _AvatarPickerStrip(
-                      selectedId: _selectedProfilePictureId,
-                      onSelected: _selectAvatar,
-                    ),
-                  ],
-                ],
+                form,
+                actions,
               ],
             ),
-          ),
-          SwapModalButtons(
-            primaryKey: const ValueKey('swap_address_update_button'),
-            cancelKey: const ValueKey('swap_address_cancel_button'),
-            primaryLabel: 'Save',
-            onPrimary: _submit,
-            onCancel: widget.onCancel,
-            primaryEnabled: _canSubmit,
-          ),
-        ],
-      ),
     );
   }
 }

--- a/lib/src/features/swap/widgets/swap_asset_selector_modal.dart
+++ b/lib/src/features/swap/widgets/swap_asset_selector_modal.dart
@@ -15,6 +15,7 @@ class SwapAssetSelectorModal extends StatefulWidget {
     required this.selected,
     required this.onSelected,
     this.initialQuery = '',
+    this.loading = false,
     super.key,
   });
 
@@ -22,6 +23,10 @@ class SwapAssetSelectorModal extends StatefulWidget {
   final SwapAsset selected;
   final ValueChanged<SwapAsset> onSelected;
   final String initialQuery;
+
+  /// While true the list shows skeleton rows instead of assets — used on
+  /// mobile during the first live (multi-chain) asset fetch.
+  final bool loading;
 
   @override
   State<SwapAssetSelectorModal> createState() => _SwapAssetSelectorModalState();
@@ -45,10 +50,15 @@ class _SwapAssetSelectorModalState extends State<SwapAssetSelectorModal> {
     _focusNode = FocusNode(debugLabel: 'SwapAssetSelectorSearch');
     _scrollController = ScrollController();
     _focusNode.addListener(_handleFocusChanged);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      _focusNode.requestFocus();
-    });
+    // Desktop opens straight into the search field (compact fixed card).
+    // The mobile full-screen sheet opens at full height showing the most
+    // assets; the keyboard is summoned only when the user taps search.
+    if (kAppFormFactor != AppFormFactor.mobile) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _focusNode.requestFocus();
+      });
+    }
   }
 
   @override
@@ -89,32 +99,157 @@ class _SwapAssetSelectorModalState extends State<SwapAssetSelectorModal> {
     final searchBorderColor = _focusNode.hasFocus || hasQuery
         ? colors.border.medium
         : colors.border.regular;
-
-    // On mobile the swap modal route wraps this in the shared
-    // MobileModalCard (base surface, radius 32, bottom-anchored), so the
-    // surface is full-width, draws no card, and the list scrolls within a
-    // bounded height that the card hugs. Desktop keeps the fixed card.
     final isMobile = kAppFormFactor == AppFormFactor.mobile;
+    // The full-screen sheet body reaches the screen bottom, so the list
+    // pads its scroll content by the home-indicator inset (read from the
+    // raw view — the modal zeroes MediaQuery padding) instead of leaving a
+    // visible gap that crops the last row.
+    final listBottomInset = isMobile
+        ? MediaQueryData.fromView(View.of(context)).padding.bottom
+        : 0.0;
 
+    final searchField = Container(
+      height: 46,
+      decoration: BoxDecoration(
+        color: colors.background.ground,
+        border: Border.all(color: searchBorderColor, width: 1.5),
+        borderRadius: BorderRadius.circular(AppRadii.small),
+      ),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 32,
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: AppIcon(
+                AppIcons.search,
+                size: 20,
+                color: colors.icon.accent,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              child: TextField(
+                key: const ValueKey('swap_asset_search_field'),
+                controller: _queryController,
+                focusNode: _focusNode,
+                onChanged: (_) => setState(() {}),
+                textInputAction: TextInputAction.search,
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.accent,
+                ),
+                cursorColor: colors.text.accent,
+                decoration: InputDecoration.collapsed(
+                  hintText: 'Search token or chain',
+                  hintStyle: AppTypography.labelLarge.copyWith(
+                    color: colors.text.muted,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          if (hasQuery)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 10),
+              child: SwapInlineIconButton(
+                key: const ValueKey('swap_asset_search_clear_button'),
+                iconName: AppIcons.cross,
+                onTap: _clearQuery,
+              ),
+            ),
+        ],
+      ),
+    );
+
+    final Widget listChild = widget.loading
+        ? const _AssetSelectorSkeleton()
+        : assets.isEmpty
+        ? Center(
+            child: SizedBox(
+              width: 112,
+              child: Text(
+                'No tokens or chains found',
+                textAlign: TextAlign.center,
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+            ),
+          )
+        : RawScrollbar(
+            key: const ValueKey('swap_asset_selector_scrollbar'),
+            controller: _scrollController,
+            thumbVisibility: assets.length > 5,
+            radius: const Radius.circular(AppRadii.full),
+            thickness: 6,
+            mainAxisMargin: 3,
+            crossAxisMargin: 3,
+            thumbColor: colors.background.overlay,
+            child: Padding(
+              key: const ValueKey('swap_asset_selector_list_gutter'),
+              padding: const EdgeInsets.only(right: AppSpacing.sm),
+              child: ScrollConfiguration(
+                behavior: ScrollConfiguration.of(
+                  context,
+                ).copyWith(scrollbars: false),
+                child: ListView.separated(
+                  controller: _scrollController,
+                  padding: EdgeInsets.only(bottom: listBottomInset),
+                  itemCount: assets.length,
+                  separatorBuilder: (_, _) =>
+                      const SizedBox(height: AppSpacing.xxs),
+                  itemBuilder: (context, index) {
+                    final asset = assets[index];
+                    return _AssetMenuRow(
+                      asset: asset,
+                      selected: widget.selected == asset,
+                      onTap: () => widget.onSelected(asset),
+                    );
+                  },
+                ),
+              ),
+            ),
+          );
+
+    if (isMobile) {
+      // Chromeless body for the full-screen MobileSheetScaffold: the sheet
+      // provides the grabber, "Select asset" title and close button, so
+      // this fills the sheet with the search field and a list that expands
+      // to the available height.
+      return Padding(
+        key: const ValueKey('swap_external_asset_menu'),
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.sm,
+          AppSpacing.s,
+          AppSpacing.sm,
+          0,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            searchField,
+            const SizedBox(height: AppSpacing.s),
+            Expanded(child: listChild),
+          ],
+        ),
+      );
+    }
+
+    // Desktop: fixed card with its own header, surface and shadow.
     return Container(
       key: const ValueKey('swap_external_asset_menu'),
-      width: isMobile ? double.infinity : 312,
-      height: isMobile ? null : 440,
-      // Container requires a decoration to clip; the mobile card (with no
-      // decoration here) is clipped by the MobileModalCard surface.
-      clipBehavior: isMobile ? Clip.none : Clip.antiAlias,
-      // Desktop fills to the card edge (bottom 0); mobile hugs, so the
-      // content needs its own bottom breathing room.
-      padding: EdgeInsets.fromLTRB(16, 24, 16, isMobile ? AppSpacing.md : 0),
-      decoration: isMobile
-          ? null
-          : BoxDecoration(
-              color: colors.background.base,
-              borderRadius: BorderRadius.circular(AppRadii.large),
-              boxShadow: _modalSurfaceShadows,
-            ),
+      width: 312,
+      height: 440,
+      clipBehavior: Clip.antiAlias,
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 0),
+      decoration: BoxDecoration(
+        color: colors.background.base,
+        borderRadius: BorderRadius.circular(AppRadii.large),
+        boxShadow: _modalSurfaceShadows,
+      ),
       child: Column(
-        mainAxisSize: isMobile ? MainAxisSize.min : MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Row(
@@ -136,112 +271,88 @@ class _SwapAssetSelectorModalState extends State<SwapAssetSelectorModal> {
             ],
           ),
           const SizedBox(height: 16),
-          Container(
-            height: 46,
-            decoration: BoxDecoration(
-              color: colors.background.ground,
-              border: Border.all(color: searchBorderColor, width: 1.5),
-              borderRadius: BorderRadius.circular(AppRadii.small),
-            ),
-            child: Row(
-              children: [
-                SizedBox(
-                  width: 32,
-                  child: Align(
-                    alignment: Alignment.centerRight,
-                    child: AppIcon(
-                      AppIcons.search,
-                      size: 20,
-                      color: colors.icon.accent,
-                    ),
-                  ),
-                ),
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 12),
-                    child: TextField(
-                      key: const ValueKey('swap_asset_search_field'),
-                      controller: _queryController,
-                      focusNode: _focusNode,
-                      onChanged: (_) => setState(() {}),
-                      textInputAction: TextInputAction.search,
-                      style: AppTypography.labelLarge.copyWith(
-                        color: colors.text.accent,
-                      ),
-                      cursorColor: colors.text.accent,
-                      decoration: InputDecoration.collapsed(
-                        hintText: 'Search token or chain',
-                        hintStyle: AppTypography.labelLarge.copyWith(
-                          color: colors.text.muted,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-                if (hasQuery)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 10),
-                    child: SwapInlineIconButton(
-                      key: const ValueKey('swap_asset_search_clear_button'),
-                      iconName: AppIcons.cross,
-                      onTap: _clearQuery,
-                    ),
-                  ),
-              ],
-            ),
-          ),
+          searchField,
           const SizedBox(height: 8),
-          _swapAssetListArea(
-            isMobile,
-            bounded: assets.isNotEmpty,
-            child: assets.isEmpty
-                ? Center(
-                    child: SizedBox(
-                      width: 112,
-                      child: Text(
-                        'No tokens or chains found',
-                        textAlign: TextAlign.center,
-                        style: AppTypography.labelLarge.copyWith(
-                          color: colors.text.secondary,
-                        ),
-                      ),
-                    ),
-                  )
-                : RawScrollbar(
-                    key: const ValueKey('swap_asset_selector_scrollbar'),
-                    controller: _scrollController,
-                    thumbVisibility: assets.length > 5,
-                    radius: const Radius.circular(AppRadii.full),
-                    thickness: 6,
-                    mainAxisMargin: 3,
-                    crossAxisMargin: 3,
-                    thumbColor: colors.background.overlay,
-                    child: Padding(
-                      key: const ValueKey('swap_asset_selector_list_gutter'),
-                      padding: const EdgeInsets.only(right: AppSpacing.sm),
-                      child: ScrollConfiguration(
-                        behavior: ScrollConfiguration.of(
-                          context,
-                        ).copyWith(scrollbars: false),
-                        child: ListView.separated(
-                          controller: _scrollController,
-                          padding: EdgeInsets.zero,
-                          shrinkWrap: isMobile,
-                          itemCount: assets.length,
-                          separatorBuilder: (_, _) =>
-                              const SizedBox(height: AppSpacing.xxs),
-                          itemBuilder: (context, index) {
-                            final asset = assets[index];
-                            return _AssetMenuRow(
-                              asset: asset,
-                              selected: widget.selected == asset,
-                              onTap: () => widget.onSelected(asset),
-                            );
-                          },
-                        ),
-                      ),
-                    ),
-                  ),
+          Expanded(child: listChild),
+        ],
+      ),
+    );
+  }
+}
+
+/// Placeholder rows shown while the live asset list is being fetched. A
+/// gentle opacity pulse signals loading without a third-party shimmer dep.
+class _AssetSelectorSkeleton extends StatefulWidget {
+  const _AssetSelectorSkeleton();
+
+  @override
+  State<_AssetSelectorSkeleton> createState() => _AssetSelectorSkeletonState();
+}
+
+class _AssetSelectorSkeletonState extends State<_AssetSelectorSkeleton>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 900),
+    )..repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      key: const ValueKey('swap_asset_selector_skeleton'),
+      opacity: Tween<double>(begin: 0.45, end: 1.0).animate(
+        CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+      ),
+      // Lazily fills the available height: the list only builds the rows
+      // that fit the viewport and clips the rest, so there's no blank gap
+      // below and no overflow on short viewports.
+      child: ListView.separated(
+        physics: const NeverScrollableScrollPhysics(),
+        padding: EdgeInsets.zero,
+        itemCount: 20,
+        separatorBuilder: (_, _) => const SizedBox(height: AppSpacing.xxs),
+        itemBuilder: (_, _) => const _AssetSkeletonRow(),
+      ),
+    );
+  }
+}
+
+class _AssetSkeletonRow extends StatelessWidget {
+  const _AssetSkeletonRow();
+
+  @override
+  Widget build(BuildContext context) {
+    final block = context.colors.background.neutralSubtleOpacity;
+    return SizedBox(
+      height: 44,
+      child: Row(
+        children: [
+          Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(color: block, shape: BoxShape.circle),
+          ),
+          const SizedBox(width: 8),
+          Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _SkeletonBar(color: block, width: 84, height: 12),
+              const SizedBox(height: 6),
+              _SkeletonBar(color: block, width: 120, height: 10),
+            ],
           ),
         ],
       ),
@@ -249,24 +360,28 @@ class _SwapAssetSelectorModalState extends State<SwapAssetSelectorModal> {
   }
 }
 
-/// Desktop fills the fixed-height card with the list ([Expanded]); mobile
-/// lets the card hug its content, so a populated list scrolls within a
-/// bounded height ([ConstrainedBox] + a shrink-wrapped list), matching the
-/// other mobile list sheets. The empty state ([bounded] false) hugs its
-/// text instead of reserving the full bound.
-Widget _swapAssetListArea(
-  bool mobile, {
-  bool bounded = true,
-  required Widget child,
-}) {
-  if (!mobile) return Expanded(child: child);
-  if (bounded) {
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxHeight: 420),
-      child: child,
+class _SkeletonBar extends StatelessWidget {
+  const _SkeletonBar({
+    required this.color,
+    required this.width,
+    required this.height,
+  });
+
+  final Color color;
+  final double width;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(AppRadii.full),
+      ),
     );
   }
-  return child;
 }
 
 class _AssetMenuRow extends StatelessWidget {

--- a/lib/src/features/swap/widgets/swap_modal_controls.dart
+++ b/lib/src/features/swap/widgets/swap_modal_controls.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 
+import '../../../core/layout/app_form_factor.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -78,29 +79,59 @@ class SwapModalButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Mobile sheets want the actions to span the full width; desktop keeps its
+    // original fixed-min-width pill layout untouched.
+    final isMobile = kAppFormFactor == AppFormFactor.mobile;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        AppButton(
-          key: primaryKey,
-          onPressed: primaryEnabled ? onPrimary : null,
-          variant: AppButtonVariant.primary,
-          size: AppButtonSize.large,
-          minWidth: 280,
-          child: SizedBox(
-            width: 220,
+        if (isMobile)
+          AppButton(
+            key: primaryKey,
+            onPressed: primaryEnabled ? onPrimary : null,
+            variant: AppButtonVariant.primary,
+            size: AppButtonSize.large,
+            expand: true,
+            // Fill the width; the label is Flexible-bounded so a long label
+            // (e.g. the out-of-range slippage message) scales down to one line
+            // instead of overflowing the pill.
+            constrainContent: true,
             child: FittedBox(fit: BoxFit.scaleDown, child: Text(primaryLabel)),
+          )
+        else
+          AppButton(
+            key: primaryKey,
+            onPressed: primaryEnabled ? onPrimary : null,
+            variant: AppButtonVariant.primary,
+            size: AppButtonSize.large,
+            minWidth: 280,
+            child: SizedBox(
+              width: 220,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(primaryLabel),
+              ),
+            ),
           ),
-        ),
         const SizedBox(height: 12),
-        AppButton(
-          key: cancelKey,
-          onPressed: onCancel,
-          variant: AppButtonVariant.ghost,
-          size: AppButtonSize.large,
-          minWidth: 280,
-          child: const Text('Cancel'),
-        ),
+        if (isMobile)
+          AppButton(
+            key: cancelKey,
+            onPressed: onCancel,
+            variant: AppButtonVariant.ghost,
+            size: AppButtonSize.large,
+            expand: true,
+            child: const Text('Cancel'),
+          )
+        else
+          AppButton(
+            key: cancelKey,
+            onPressed: onCancel,
+            variant: AppButtonVariant.ghost,
+            size: AppButtonSize.large,
+            minWidth: 280,
+            child: const Text('Cancel'),
+          ),
       ],
     );
   }

--- a/test/core/layout/mobile/mobile_sheet_form_body_test.dart
+++ b/test/core/layout/mobile/mobile_sheet_form_body_test.dart
@@ -1,0 +1,103 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/mobile/mobile_sheet.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+
+/// Pins the adaptive `formBody` template's three height levels (AGENTS-spec):
+/// 1. short content → min-height floor, content centred, actions pinned;
+/// 2. medium content → sheet hugs the content, actions pinned;
+/// 3. tall content → sheet caps below the top gap, body scrolls, actions
+///    still pinned to the bottom.
+void main() {
+  const grabber = ValueKey('mobile_sheet_grabber');
+  const content = ValueKey('form_content');
+  const actions = ValueKey('form_actions');
+
+  // Floor / cap constants mirrored from mobile_sheet.dart.
+  const minContentHeight = 400.0;
+  const topGapFraction = 0.15;
+  const actionsHeight = 60.0;
+
+  Future<double> openWithContentHeight(
+    WidgetTester tester,
+    double contentHeight,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        builder: (context, child) =>
+            AppTheme(data: AppThemeData.light, child: child!),
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: GestureDetector(
+                onTap: () => showMobileSheet<void>(
+                  context: context,
+                  builder: (_) => MobileSheetScaffold(
+                    title: 'Form',
+                    formBody: true,
+                    child: MobileSheetFormBody(
+                      content: SizedBox(key: content, height: contentHeight),
+                      actions: const SizedBox(
+                        key: actions,
+                        height: actionsHeight,
+                      ),
+                    ),
+                  ),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    return tester.view.physicalSize.height / tester.view.devicePixelRatio;
+  }
+
+  // The grabber sits AppSpacing.s below the rounded surface's top edge, so
+  // back it out to get the true sheet top.
+  double sheetTop(WidgetTester tester) =>
+      tester.getTopLeft(find.byKey(grabber)).dy - AppSpacing.s;
+
+  double actionsBottom(WidgetTester tester) =>
+      tester.getBottomLeft(find.byKey(actions)).dy;
+
+  testWidgets('level 1: short content rests at the min-height floor', (
+    tester,
+  ) async {
+    final screen = await openWithContentHeight(tester, 80);
+    // Sheet height = screen - top → equals the floor for short content.
+    expect(screen - sheetTop(tester), closeTo(minContentHeight, 1));
+    // Actions are pinned at the very bottom (above the home-indicator inset,
+    // which is zero in the test view).
+    expect(actionsBottom(tester), closeTo(screen, 1));
+  });
+
+  testWidgets('level 2: medium content grows the sheet to hug it', (
+    tester,
+  ) async {
+    // Tall enough to exceed the floor but still fit under the cap.
+    final screen = await openWithContentHeight(tester, 360);
+    final height = screen - sheetTop(tester);
+    expect(height, greaterThan(minContentHeight + 1));
+    expect(height, lessThan(screen * (1 - topGapFraction)));
+    expect(actionsBottom(tester), closeTo(screen, 1));
+  });
+
+  testWidgets('level 3: tall content caps below the top gap and scrolls', (
+    tester,
+  ) async {
+    final screen = await openWithContentHeight(tester, 5000);
+    final top = sheetTop(tester);
+    // Capped at the top-gap height, not pushed off-screen.
+    expect(top, closeTo(screen * topGapFraction, 1));
+    // Body scrolls; actions stay pinned at the bottom.
+    expect(find.byType(Scrollable), findsWidgets);
+    expect(actionsBottom(tester), closeTo(screen, 1));
+  });
+}

--- a/test/features/swap/mobile_asset_selector_sheet_test.dart
+++ b/test/features/swap/mobile_asset_selector_sheet_test.dart
@@ -1,0 +1,243 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/mobile/mobile_sheet.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/swap/domain/swap_asset.dart';
+import 'package:zcash_wallet/src/features/swap/widgets/swap_asset_selector_modal.dart';
+
+void main() {
+  Future<void> pumpHost(
+    WidgetTester tester, {
+    required List<SwapAsset> assets,
+    required SwapAsset selected,
+    required ValueChanged<SwapAsset> onSelected,
+    bool loading = false,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        // AppTheme above the Navigator so root-navigator sheets inherit it,
+        // mirroring the app's MaterialApp.builder wiring.
+        builder: (context, child) =>
+            AppTheme(data: AppThemeData.light, child: child!),
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: GestureDetector(
+                onTap: () => showMobileSheet<void>(
+                  context: context,
+                  builder: (_) => MobileSheetScaffold(
+                    title: 'Select asset',
+                    expand: true,
+                    child: SwapAssetSelectorModal(
+                      assets: assets,
+                      selected: selected,
+                      loading: loading,
+                      onSelected: onSelected,
+                    ),
+                  ),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Key rowKey(SwapAsset asset) => ValueKey('swap_asset_row_${asset.identityKey}');
+
+  testWidgets('asset selector opens as a full-screen sheet with chrome', (
+    tester,
+  ) async {
+    await pumpHost(
+      tester,
+      assets: const [SwapAsset.usdc, SwapAsset.btc, SwapAsset.eth],
+      selected: SwapAsset.usdc,
+      onSelected: (_) {},
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    // Sheet chrome from MobileSheetScaffold.
+    expect(find.byKey(const ValueKey('mobile_sheet_grabber')), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('mobile_sheet_close_button')),
+      findsOneWidget,
+    );
+    expect(find.text('Select asset'), findsOneWidget);
+
+    // Asset selector body.
+    expect(
+      find.byKey(const ValueKey('swap_asset_search_field')),
+      findsOneWidget,
+    );
+    expect(find.byKey(rowKey(SwapAsset.btc)), findsOneWidget);
+  });
+
+  testWidgets('shows skeleton rows while assets are loading', (tester) async {
+    await pumpHost(
+      tester,
+      assets: const [SwapAsset.usdc, SwapAsset.btc],
+      selected: SwapAsset.usdc,
+      onSelected: (_) {},
+      loading: true,
+    );
+    await tester.tap(find.text('open'));
+    // The skeleton pulses forever, so advance with pump (not pumpAndSettle).
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      find.byKey(const ValueKey('swap_asset_selector_skeleton')),
+      findsOneWidget,
+    );
+    // Real asset rows are hidden behind the skeleton while loading.
+    expect(find.byKey(rowKey(SwapAsset.usdc)), findsNothing);
+  });
+
+  testWidgets('search filters the asset list', (tester) async {
+    await pumpHost(
+      tester,
+      assets: const [SwapAsset.usdc, SwapAsset.btc, SwapAsset.eth],
+      selected: SwapAsset.usdc,
+      onSelected: (_) {},
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('swap_asset_search_field')),
+      'btc',
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(rowKey(SwapAsset.btc)), findsOneWidget);
+    expect(find.byKey(rowKey(SwapAsset.eth)), findsNothing);
+  });
+
+  testWidgets('tapping an asset returns it', (tester) async {
+    SwapAsset? picked;
+    await pumpHost(
+      tester,
+      assets: const [SwapAsset.usdc, SwapAsset.btc, SwapAsset.eth],
+      selected: SwapAsset.usdc,
+      onSelected: (asset) => picked = asset,
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(rowKey(SwapAsset.btc)));
+    await tester.pumpAndSettle();
+
+    expect(picked, SwapAsset.btc);
+  });
+
+  testWidgets('tapping the scrim above the sheet dismisses it', (tester) async {
+    await pumpHost(
+      tester,
+      assets: const [SwapAsset.usdc, SwapAsset.btc],
+      selected: SwapAsset.usdc,
+      onSelected: (_) {},
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('Select asset'), findsOneWidget);
+
+    // The sheet stops short of the top; the gap above it is the barrier.
+    await tester.tapAt(const Offset(10, 10));
+    await tester.pumpAndSettle();
+    expect(find.text('Select asset'), findsNothing);
+  });
+
+  testWidgets('over-pulling the grabber rubber-bands up then springs back', (
+    tester,
+  ) async {
+    await pumpHost(
+      tester,
+      assets: const [SwapAsset.usdc, SwapAsset.btc],
+      selected: SwapAsset.usdc,
+      onSelected: (_) {},
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    final grabber = find.byKey(const ValueKey('mobile_sheet_grabber'));
+    final restY = tester.getTopLeft(grabber).dy;
+
+    // Pull the grabber up hard.
+    final gesture = await tester.startGesture(tester.getCenter(grabber));
+    await gesture.moveBy(const Offset(0, -20));
+    await gesture.moveBy(const Offset(0, -180));
+    await tester.pump();
+
+    final pulledY = tester.getTopLeft(grabber).dy;
+    // It follows the finger upward, but the rubber-band caps it (~30px) far
+    // short of the 200px pulled.
+    expect(pulledY, lessThan(restY));
+    expect(restY - pulledY, lessThanOrEqualTo(31));
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+    // Springs back to the original height.
+    expect(tester.getTopLeft(grabber).dy, closeTo(restY, 0.5));
+  });
+
+  testWidgets('dragging the grabber down dismisses the sheet', (tester) async {
+    await pumpHost(
+      tester,
+      assets: const [SwapAsset.usdc, SwapAsset.btc],
+      selected: SwapAsset.usdc,
+      onSelected: (_) {},
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('Select asset'), findsOneWidget);
+
+    await tester.drag(
+      find.byKey(const ValueKey('mobile_sheet_grabber')),
+      const Offset(0, 260),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Select asset'), findsNothing);
+  });
+
+  testWidgets('dragging the header (not just the pill) down dismisses', (
+    tester,
+  ) async {
+    await pumpHost(
+      tester,
+      assets: const [SwapAsset.usdc, SwapAsset.btc],
+      selected: SwapAsset.usdc,
+      onSelected: (_) {},
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('Select asset'), findsOneWidget);
+
+    // Drag starting on the title text, not the grabber pill.
+    await tester.drag(find.text('Select asset'), const Offset(0, 260));
+    await tester.pumpAndSettle();
+    expect(find.text('Select asset'), findsNothing);
+  });
+
+  testWidgets('close button dismisses the sheet', (tester) async {
+    await pumpHost(
+      tester,
+      assets: const [SwapAsset.usdc, SwapAsset.btc],
+      selected: SwapAsset.usdc,
+      onSelected: (_) {},
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('Select asset'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_sheet_close_button')));
+    await tester.pumpAndSettle();
+    expect(find.text('Select asset'), findsNothing);
+  });
+}

--- a/test/features/swap/mobile_slippage_sheet_test.dart
+++ b/test/features/swap/mobile_slippage_sheet_test.dart
@@ -1,0 +1,92 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/layout/mobile/mobile_sheet.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/swap/widgets/mobile/mobile_swap_slippage_stepper_modal.dart';
+
+void main() {
+  Future<void> pumpSheet(
+    WidgetTester tester, {
+    ValueChanged<int>? onSubmitted,
+    VoidCallback? onCancel,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        builder: (context, child) =>
+            AppTheme(data: AppThemeData.light, child: child!),
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => Center(
+              child: GestureDetector(
+                onTap: () => showMobileSheet<void>(
+                  context: context,
+                  builder: (_) => MobileSheetScaffold(
+                    title: 'Slippage',
+                    formBody: true,
+                    child: MobileSwapSlippageStepperModal(
+                      slippageBps: 50,
+                      onSubmitted: onSubmitted ?? (_) {},
+                      onCancel: onCancel ?? () {},
+                    ),
+                  ),
+                ),
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('slippage opens as a sheet with scaffold chrome + content', (
+    tester,
+  ) async {
+    await pumpSheet(tester);
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('mobile_sheet_grabber')), findsOneWidget);
+    // Scaffold supplies the single "Slippage" title (the modal's own header
+    // was removed).
+    expect(find.text('Slippage'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('mobile_swap_slippage_value')),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('swap_slippage_update_button')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('content-sized sheet hugs its form (not full-screen)', (
+    tester,
+  ) async {
+    await pumpSheet(tester);
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    final screenHeight =
+        tester.view.physicalSize.height / tester.view.devicePixelRatio;
+    final grabberTop = tester
+        .getTopLeft(find.byKey(const ValueKey('mobile_sheet_grabber')))
+        .dy;
+    // A hugging sheet sits low; a full-screen one would start near the top.
+    expect(grabberTop, greaterThan(screenHeight * 0.35));
+  });
+
+  testWidgets('close button dismisses the slippage sheet', (tester) async {
+    await pumpSheet(tester);
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+    expect(find.text('Slippage'), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_sheet_close_button')));
+    await tester.pumpAndSettle();
+    expect(find.text('Slippage'), findsNothing);
+  });
+}

--- a/test/features/swap/mobile_swap_modal_route_test.dart
+++ b/test/features/swap/mobile_swap_modal_route_test.dart
@@ -90,8 +90,8 @@ void main() {
     expect(button.right, lessThanOrEqualTo(screen.right - AppSpacing.sm));
   });
 
-  testWidgets('swap modal rides the root navigator and covers the whole '
-      'screen, tab bar included', (tester) async {
+  testWidgets('swap address sheet rides the root navigator and dismisses '
+      'from the scrim above it', (tester) async {
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
 
@@ -103,28 +103,16 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(SwapAddressEditModal), findsOneWidget);
 
-    // The dialog barrier spans the full screen — including the status
-    // bar strip at the very top and the floating tab bar at the bottom
-    // (neither was covered by the old inline overlay).
+    // The sheet rides the root navigator, so its scrim spans the whole
+    // screen — including the status-bar strip at the very top that the old
+    // inline overlay left uncovered.
     final screen = tester.getRect(find.byType(MaterialApp));
     final barrier = tester.getRect(find.byType(ModalBarrier).last);
     expect(barrier, screen);
 
-    // A tap in the top strip — which the old inline overlay left
-    // uncovered — now hits the barrier and dismisses the modal.
+    // The sheet stops below a top gap; a tap in that gap hits the scrim and
+    // dismisses it.
     await tester.tapAt(const Offset(10, 10));
-    await tester.pumpAndSettle();
-    expect(find.byType(SwapAddressEditModal), findsNothing);
-    expect(find.byType(MobileSwapScreen), findsOneWidget);
-
-    // The bottom strip — where the floating tab bar sits — is under the
-    // barrier too. The modal card is bottom-anchored with a gap beneath
-    // it, so a tap in that gap hits the barrier and dismisses the modal
-    // instead of reaching the tab bar to switch branches.
-    await tester.tap(find.text('Add recipient address'));
-    await tester.pumpAndSettle();
-    expect(find.byType(SwapAddressEditModal), findsOneWidget);
-    await tester.tapAt(Offset(screen.center.dx, screen.bottom - 4));
     await tester.pumpAndSettle();
     expect(find.byType(SwapAddressEditModal), findsNothing);
     expect(find.byType(MobileSwapScreen), findsOneWidget);
@@ -147,6 +135,43 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(SwapAddressEditModal), findsNothing);
     expect(find.byType(MobileSwapScreen), findsOneWidget);
+  });
+
+  testWidgets('contacts is a back-navigable view inside the same sheet', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.bySemanticsLabel('Swap').last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add recipient address'));
+    await tester.pumpAndSettle();
+    expect(find.byType(SwapAddressEditModal), findsOneWidget);
+    // No back chevron on the base (editor) view.
+    expect(find.byKey(const ValueKey('mobile_sheet_back_button')), findsNothing);
+
+    // Open contacts → the same sheet swaps content: the editor is replaced
+    // and a back chevron appears (no second overlapping sheet). The picker
+    // watches the address book (which stays loading in-test), so pump a few
+    // frames rather than settling.
+    await tester.tap(
+      find.byKey(const ValueKey('swap_address_contacts_button')),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(find.byType(SwapAddressEditModal), findsNothing);
+    expect(
+      find.byKey(const ValueKey('mobile_sheet_back_button')),
+      findsOneWidget,
+    );
+
+    // Back chevron returns to the editor in the same sheet.
+    await tester.tap(find.byKey(const ValueKey('mobile_sheet_back_button')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(find.byType(SwapAddressEditModal), findsOneWidget);
+    expect(find.byKey(const ValueKey('mobile_sheet_back_button')), findsNothing);
   });
 }
 


### PR DESCRIPTION
## Summary
Introduces a reusable **mobile bottom-sheet template** and migrates the swap modals onto it, replacing the fragmented per-modal presentations with one standard iOS/Android sheet.

The template lives in `lib/src/core/layout/mobile/mobile_sheet.dart`:
- **`showMobileSheet`** — root-navigator, edge-to-edge `showModalBottomSheet` wrapper (covers the floating tab bar, transparent surface, neutral scrim).
- **`MobileSheetScaffold`** — top-rounded surface with a grabber, a **centered title** flanked by absolute **back** (2nd-level views) and **close** buttons, keyboard avoidance, **drag-to-dismiss**, and a **rubber-band over-pull spring**.
- **`MobileSheetFormBody`** — adaptive form body: content above **full-width action buttons pinned to the bottom**.

### Content-driven height (3 levels)
A `formBody` sheet sizes itself to its content, clamped between a 400px floor and the top-gap cap:

| Level | Content | Height | Body |
|------|---------|--------|------|
| 1 | short | min-height floor | centered |
| 2 | medium | hugs the content | fits |
| 3 | tall | caps below the top gap | scrolls |

In every level the action buttons stay pinned to the bottom. `fillBody` keeps a fixed-min `Expanded` slot for list bodies (contacts); `expand` fills the screen for long scroll lists (asset selector).

## Migrated modals
- Swap **asset selector** (full-screen list + skeleton loading state)
- **Slippage** editor (level 1, centered)
- **Recipient / refund address** editor (level 2, hugs; morphs to contacts with a back chevron)
- Address-book **contact picker** (fills, centered empty state)

## Scope / safety
- All sheet styling is **mobile-only** via `kAppFormFactor`; **desktop layouts are unchanged** (the shared `SwapModalButtons` full-width behavior is form-factor gated, desktop keeps its original pill layout).
- DRY: over-pull/slide math and the cap-height formula are shared helpers; the back/close buttons reuse a single corner-button widget; spacing/radii/typography use existing tokens.

## Tests
- New `test/core/layout/mobile/mobile_sheet_form_body_test.dart` pins all three height levels (floor / hug / cap + scroll, actions pinned).
- New mobile-tagged sheet tests for the asset selector and slippage; updated swap modal route test (morph + back navigation).
- Verified: mobile sheet suites **19/19**, desktop swap + send + address-book **227** passing, `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)