### PR TITLE
Fix swap deposit copy and detail ellipsis

### DIFF
--- a/lib/src/core/widgets/review_list_row.dart
+++ b/lib/src/core/widgets/review_list_row.dart
@@ -34,6 +34,7 @@ class ReviewListRow extends StatelessWidget {
     this.trailingIconTooltip,
     this.copyText,
     this.onPressed,
+    this.scaleValueToFit = false,
     super.key,
   });
 
@@ -71,6 +72,10 @@ class ReviewListRow extends StatelessWidget {
   /// Tap handler for the value cluster (expand memo, open explorer, show
   /// fee help). The pill stays inert when null.
   final VoidCallback? onPressed;
+
+  /// Scales the value down instead of applying a second ellipsis. Use this when
+  /// callers already passed a deliberately compacted display value.
+  final bool scaleValueToFit;
 
   /// Row height pinned by the Figma `List Item` component.
   static const height = 32.0;
@@ -112,11 +117,9 @@ class ReviewListRow extends StatelessWidget {
             const SizedBox(width: AppSpacing.xxs),
           ],
           Flexible(
-            child: Text(
-              value,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.right,
+            child: _ReviewListRowValueText(
+              value: value,
+              scaleToFit: scaleValueToFit,
               style: AppTypography.bodyMediumStrong.copyWith(
                 color: resolvedValueColor,
               ),
@@ -174,6 +177,36 @@ class ReviewListRow extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _ReviewListRowValueText extends StatelessWidget {
+  const _ReviewListRowValueText({
+    required this.value,
+    required this.scaleToFit,
+    required this.style,
+  });
+
+  final String value;
+  final bool scaleToFit;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Text(
+      value,
+      maxLines: 1,
+      softWrap: false,
+      overflow: scaleToFit ? TextOverflow.visible : TextOverflow.ellipsis,
+      textAlign: TextAlign.right,
+      style: style,
+    );
+    if (!scaleToFit) return text;
+    return FittedBox(
+      fit: BoxFit.scaleDown,
+      alignment: Alignment.centerRight,
+      child: text,
     );
   }
 }

--- a/lib/src/features/swap/widgets/swap_deposit_tokens_page_content.dart
+++ b/lib/src/features/swap/widgets/swap_deposit_tokens_page_content.dart
@@ -150,6 +150,7 @@ class _SwapDepositPageShell extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.lg),
           _DepositDetailsList(
+            asset: asset,
             amountText: amountText,
             depositAddress: depositAddress,
             memo: memo,
@@ -681,11 +682,13 @@ class _DepositQrNetworkLogoFallback extends StatelessWidget {
 
 class _DepositDetailsList extends StatelessWidget {
   const _DepositDetailsList({
+    required this.asset,
     required this.amountText,
     required this.depositAddress,
     this.memo,
   });
 
+  final SwapAsset asset;
   final String amountText;
   final String depositAddress;
   final String? memo;
@@ -701,7 +704,7 @@ class _DepositDetailsList extends StatelessWidget {
           _DepositDetailRow(
             label: 'Amount',
             value: amountText,
-            copyText: amountText,
+            copyText: _depositAmountCopyText(amountText, asset),
             toastMessage: 'Amount Copied',
             copyKey: const ValueKey('swap_copy_deposit_amount'),
           ),
@@ -711,6 +714,7 @@ class _DepositDetailsList extends StatelessWidget {
             copyText: depositAddress,
             toastMessage: 'Address copied',
             copyKey: const ValueKey('swap_copy_deposit_address'),
+            scaleValueToFit: true,
           ),
           if (memo?.trim().isNotEmpty ?? false)
             _DepositDetailRow(
@@ -733,6 +737,7 @@ class _DepositDetailRow extends StatelessWidget {
     required this.copyText,
     required this.toastMessage,
     required this.copyKey,
+    this.scaleValueToFit = false,
   });
 
   final String label;
@@ -740,6 +745,7 @@ class _DepositDetailRow extends StatelessWidget {
   final String copyText;
   final String toastMessage;
   final Key copyKey;
+  final bool scaleValueToFit;
 
   @override
   Widget build(BuildContext context) {
@@ -766,11 +772,9 @@ class _DepositDetailRow extends StatelessWidget {
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Flexible(
-                    child: Text(
+                    child: _DepositDetailValueText(
                       value,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      textAlign: TextAlign.end,
+                      scaleToFit: scaleValueToFit,
                       style: AppTypography.labelLarge.copyWith(
                         color: colors.text.accent,
                       ),
@@ -806,6 +810,36 @@ class _DepositDetailRow extends StatelessWidget {
   }
 }
 
+class _DepositDetailValueText extends StatelessWidget {
+  const _DepositDetailValueText(
+    this.value, {
+    required this.scaleToFit,
+    required this.style,
+  });
+
+  final String value;
+  final bool scaleToFit;
+  final TextStyle style;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Text(
+      value,
+      maxLines: 1,
+      softWrap: false,
+      overflow: scaleToFit ? TextOverflow.visible : TextOverflow.ellipsis,
+      textAlign: TextAlign.end,
+      style: style,
+    );
+    if (!scaleToFit) return text;
+    return FittedBox(
+      fit: BoxFit.scaleDown,
+      alignment: Alignment.centerRight,
+      child: text,
+    );
+  }
+}
+
 String _formatCountdown(Duration remaining) {
   final totalSeconds = remaining.inSeconds <= 0 ? 0 : remaining.inSeconds;
   final minutes = (totalSeconds ~/ 60).toString().padLeft(2, '0');
@@ -828,4 +862,14 @@ String _formatHourLabel(int hours) {
 
 String _formatMinuteLabel(int minutes) {
   return minutes == 1 ? '1min' : '${minutes}mins';
+}
+
+String _depositAmountCopyText(String amountText, SwapAsset asset) {
+  final trimmed = amountText.trim();
+  final symbol = asset.symbol.trim();
+  if (symbol.isEmpty) return trimmed;
+
+  final symbolSuffix = ' $symbol';
+  if (!trimmed.endsWith(symbolSuffix)) return trimmed;
+  return trimmed.substring(0, trimmed.length - symbolSuffix.length).trimRight();
 }

--- a/lib/src/features/swap/widgets/swap_status_page_content.dart
+++ b/lib/src/features/swap/widgets/swap_status_page_content.dart
@@ -712,6 +712,7 @@ class _DetailRow extends StatelessWidget {
         value: row.value,
         trailingIconName: AppIcons.arrowTopRight,
         trailingIconColor: colors.icon.muted,
+        scaleValueToFit: _shouldScaleDetailValue(row),
         onPressed: () =>
             unawaited(launchUrl(linkUri, mode: LaunchMode.externalApplication)),
       );
@@ -732,6 +733,7 @@ class _DetailRow extends StatelessWidget {
       label: row.label,
       value: row.value,
       copyText: row.copyable ? (row.copyText ?? row.value) : null,
+      scaleValueToFit: _shouldScaleDetailValue(row),
     );
   }
 
@@ -837,6 +839,19 @@ class _DetailRow extends StatelessWidget {
       ),
     );
   }
+}
+
+bool _shouldScaleDetailValue(SwapStatusDetailRowData row) {
+  final source = row.copyText?.trim();
+  if (source == null || source.isEmpty || source.length <= 18) return false;
+
+  final label = row.label.toLowerCase();
+  return label.contains('address') ||
+      label.contains('recipient') ||
+      label.contains('refund') ||
+      label == 'tx id' ||
+      label.contains(' tx') ||
+      (label.startsWith('deposit ') && label.endsWith(' to'));
 }
 
 class _StatusDetailActionIcon extends StatelessWidget {

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -23,6 +23,7 @@ import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_back_link.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/core/widgets/app_toast.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/features/address_book/contact_label_generator.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
@@ -379,6 +380,75 @@ void main() {
     expect(expiryLabel(), 'Deposit within 1hr');
 
     await tester.pumpWidget(const SizedBox.shrink());
+  });
+
+  testWidgets('deposit tokens copies numeric amount and fits compact address', (
+    tester,
+  ) async {
+    final clipboardWrites = <String>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        if (call.method == 'Clipboard.setData') {
+          final args = call.arguments as Map<Object?, Object?>;
+          clipboardWrites.add(args['text']! as String);
+        }
+        return null;
+      },
+    );
+    addTearDown(() {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    });
+
+    const depositAddress =
+        '0x1111111111111111111111111111111111111111111111111111111111111111';
+    const compactDepositAddress = '0x1111111 ... 1111111';
+
+    await tester.pumpWidget(
+      _themeHarness(
+        AppToastHost(
+          child: SwapDepositTokensPageContent(
+            asset: SwapAsset.usdc,
+            amountText: '999.99 USDC',
+            depositAddress: depositAddress,
+            expiresInLabel: '16mins',
+            onDeposited: () {},
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('swap_deposit_details')),
+        matching: find.text(compactDepositAddress),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.ancestor(
+        of: find.text(compactDepositAddress),
+        matching: find.byType(FittedBox),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      tester.widget<Text>(find.text(compactDepositAddress)).overflow,
+      TextOverflow.visible,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('swap_copy_deposit_amount')));
+    await tester.pump();
+
+    expect(clipboardWrites.last, '999.99');
+
+    await tester.tap(find.byKey(const ValueKey('swap_copy_deposit_address')));
+    await tester.pump();
+
+    expect(clipboardWrites.last, depositAddress);
   });
 
   testWidgets('deposit timeout uses theme-specific failure illustration', (
@@ -1038,6 +1108,87 @@ void main() {
     );
     expect(find.text('eth account'), findsOneWidget);
     expect(find.text('Slippage tolerance'), findsOneWidget);
+  });
+
+  testWidgets('status details fit compact copyable rows without re-ellipsis', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    const fullAddress =
+        '0x1111111111111111111111111111111111111111111111111111111111111111';
+    const compactAddress = '0x1111111 ... 1111111';
+
+    await tester.pumpWidget(
+      _themeHarnessWithOverlay(
+        _statusTestPage(
+          activeTab: SwapStatusTab.details,
+          details: const [
+            SwapStatusDetailRowData(label: 'Account', value: 'John'),
+            SwapStatusDetailRowData(
+              label: 'Deposit USDC to',
+              value: compactAddress,
+              copyable: true,
+              copyText: fullAddress,
+            ),
+            SwapStatusDetailRowData(
+              label: 'Swap fee',
+              value: 'Included in shown rate',
+              help: true,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final addressText = find.text(compactAddress);
+    expect(addressText, findsOneWidget);
+    expect(tester.widget<Text>(addressText).overflow, TextOverflow.visible);
+    expect(
+      find.ancestor(of: addressText, matching: find.byType(FittedBox)),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('status details fit compact explorer rows without re-ellipsis', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+    const fullTxHash =
+        '0x2222222222222222222222222222222222222222222222222222222222222222';
+    const compactTxHash = '0x2222222 ... 2222222';
+
+    await tester.pumpWidget(
+      _themeHarnessWithOverlay(
+        _statusTestPage(
+          title: 'Swap completed',
+          statusLabel: 'Completed',
+          badgeKind: SwapStatusBadgeKind.completed,
+          showTabs: false,
+          details: [
+            SwapStatusDetailRowData(
+              label: 'USDC deposit tx',
+              value: compactTxHash,
+              copyable: true,
+              copyText: fullTxHash,
+              linkUri: Uri.parse('https://example.com/tx/$fullTxHash'),
+            ),
+            const SwapStatusDetailRowData(
+              label: 'Total fees',
+              value: 'Included',
+              help: true,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final txText = find.text(compactTxHash);
+    expect(txText, findsOneWidget);
+    expect(tester.widget<Text>(txText).overflow, TextOverflow.visible);
+    expect(
+      find.ancestor(of: txText, matching: find.byType(FittedBox)),
+      findsOneWidget,
+    );
   });
 
   testWidgets('swap tab renders composer and privacy check', (tester) async {


### PR DESCRIPTION
## Summary
- Copy only the numeric token amount from the swap deposit amount row while keeping the displayed amount with its symbol.
- Keep one-time deposit addresses and swap detail address/tx rows as a single intentional middle-ellipsis string, scaling that compact value down instead of applying a second ellipsis.
- Add regression coverage for deposit copy behavior, deposit address rendering, and swap detail compact rows including explorer-link rows.

## Root cause
- Deposit amount reused the display string as the clipboard payload, so copied values included the token symbol.
- Compact address strings could still flow through widgets that apply `TextOverflow.ellipsis`, producing a second crop on narrow detail rows.

## Validation
- `fvm dart format lib/src/core/widgets/review_list_row.dart lib/src/features/swap/widgets/swap_status_page_content.dart lib/src/features/swap/widgets/swap_deposit_tokens_page_content.dart test/features/swap/swap_screen_test.dart`
- `fvm flutter test test/features/swap/swap_screen_test.dart --plain-name 'deposit tokens'`
- `fvm flutter test test/features/swap/swap_screen_test.dart --plain-name 'status details fit compact'`
- `fvm flutter test test/features/swap/swap_screen_test.dart --plain-name 'status details'`
- `fvm flutter test test/features/swap/swap_screen_test.dart --plain-name 'activity shows direction-specific external deposit instructions'`
- `fvm flutter analyze`
- `git diff --check`