### PR TITLE
Polish mobile Keystone onboarding

### DIFF
--- a/lib/src/features/address_scan/widgets/mobile_address_scan_card.dart
+++ b/lib/src/features/address_scan/widgets/mobile_address_scan_card.dart
@@ -18,6 +18,187 @@ import 'address_qr_scan_modal.dart' show AddressQrCameraStatus;
 import 'mobile_address_scan_view.dart'
     show MobileScanResolver, MobileScanViewfinderCorners;
 
+typedef MobileQrCameraViewBuilder =
+    Widget Function(BuildContext context, MobileScannerController controller);
+
+typedef MobileQrPermissionBuilder =
+    Widget Function(
+      BuildContext context,
+      AddressQrCameraStatus status,
+      String? unavailableDescription,
+      VoidCallback onRetry,
+      VoidCallback onClose,
+    );
+
+/// Generic live mobile QR scanner card. It owns the shared mobile camera
+/// lifecycle, permission/retry handling, and Figma scan-card visuals while the
+/// caller supplies the concrete scanner view (plain QR, animated UR, etc.).
+class MobileQrScanCard extends StatefulWidget {
+  const MobileQrScanCard({
+    required this.cameraViewBuilder,
+    required this.onClose,
+    this.controller,
+    this.caption = 'Scan a Zcash QR code to continue',
+    this.permissionTitle = 'Scan the address QR code',
+    this.error,
+    this.unavailableDescription = 'QR scanning needs a camera on this device.',
+    this.permissionBuilder,
+    this.cameraHeight,
+    super.key,
+  });
+
+  /// Optional externally-owned controller (tests inject one with
+  /// `autoStart: false` to drive camera/permission states). When null the card
+  /// creates and owns its own back-camera controller.
+  final MobileScannerController? controller;
+
+  /// Builds the scanner view mounted behind the shared scan chrome.
+  final MobileQrCameraViewBuilder cameraViewBuilder;
+
+  /// Called when the user taps close / Cancel.
+  final VoidCallback onClose;
+
+  /// Idle caption beneath the viewfinder.
+  final String caption;
+
+  /// Title shown in the permission/requesting card state.
+  final String permissionTitle;
+
+  /// Message shown beneath the viewfinder in active camera states.
+  final String? error;
+
+  /// Fallback description for no-camera / camera-open failures.
+  final String unavailableDescription;
+
+  /// Optional override for permission/requesting/denied states. The active and
+  /// loading scan chrome stays shared.
+  final MobileQrPermissionBuilder? permissionBuilder;
+
+  /// Optional height override for in-page scanner placements. The default
+  /// keeps the send/swap bottom-sheet geometry.
+  final double? cameraHeight;
+
+  @override
+  State<MobileQrScanCard> createState() => _MobileQrScanCardState();
+}
+
+class _MobileQrScanCardState extends State<MobileQrScanCard>
+    with WidgetsBindingObserver {
+  late final MobileScannerController _controller;
+  late final bool _ownsController;
+  bool _restartCameraOnResume = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _ownsController = widget.controller == null;
+    _controller =
+        widget.controller ??
+        MobileScannerController(
+          formats: QrScanner.formats,
+          detectionSpeed: QrScanner.detectionSpeed,
+        );
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+    if (!_restartCameraOnResume) return;
+    _restartCameraOnResume = false;
+    unawaited(_retryCameraStart(openSettingsOnDenied: false));
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    if (_ownsController) unawaited(_controller.dispose());
+    super.dispose();
+  }
+
+  AddressQrCameraStatus _cameraAccessStatus(MobileScannerState state) {
+    if (!QrScanner.isAvailable) return AddressQrCameraStatus.unavailable;
+    if (state.error?.errorCode == MobileScannerErrorCode.permissionDenied) {
+      return AddressQrCameraStatus.denied;
+    }
+    if (state.error != null && !state.isRunning) {
+      return AddressQrCameraStatus.unavailable;
+    }
+    if (state.hasCameraPermission && state.isRunning) {
+      return AddressQrCameraStatus.active;
+    }
+    if (state.hasCameraPermission || state.isStarting || state.isInitialized) {
+      return AddressQrCameraStatus.loading;
+    }
+    return AddressQrCameraStatus.requesting;
+  }
+
+  Future<void> _retryCameraStart({required bool openSettingsOnDenied}) async {
+    if (!QrScanner.isAvailable ||
+        _controller.value.isStarting ||
+        _controller.value.isRunning) {
+      return;
+    }
+    try {
+      await _controller.start();
+    } catch (e, st) {
+      log('MobileQrScanCard: camera start retry error: $e\n$st');
+    }
+    if (!mounted || !openSettingsOnDenied) return;
+    if (_cameraAccessStatus(_controller.value) !=
+        AddressQrCameraStatus.denied) {
+      return;
+    }
+    await _openCameraSettings();
+  }
+
+  Future<void> _openCameraSettings() async {
+    _restartCameraOnResume = true;
+    final opened = await CameraPermissionSettings.open();
+    if (!opened) {
+      _restartCameraOnResume = false;
+      log('MobileQrScanCard: failed to open camera permission settings');
+    }
+  }
+
+  String _cameraUnavailableDescription(MobileScannerState state) {
+    final message = state.error?.errorDetails?.message;
+    if (message != null && message.isNotEmpty) return message;
+    return widget.unavailableDescription;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<MobileScannerState>(
+      valueListenable: _controller,
+      builder: (context, state, _) {
+        final status = _cameraAccessStatus(state);
+        return MobileAddressScanCardContent(
+          status: status,
+          // The camera preview is mounted in every state (covered by the
+          // permission card when access isn't granted) so the controller keeps
+          // running and reporting permission changes.
+          cameraView: QrScanner.isAvailable
+              ? widget.cameraViewBuilder(context, _controller)
+              : null,
+          caption: widget.caption,
+          permissionTitle: widget.permissionTitle,
+          error: widget.error,
+          unavailableDescription: status == AddressQrCameraStatus.unavailable
+              ? _cameraUnavailableDescription(state)
+              : null,
+          permissionBuilder: widget.permissionBuilder,
+          cameraHeight: widget.cameraHeight,
+          onTorch: () => unawaited(_controller.toggleTorch()),
+          onClose: widget.onClose,
+          onRetry: () =>
+              unawaited(_retryCameraStart(openSettingsOnDenied: true)),
+        );
+      },
+    );
+  }
+}
+
 /// Card-contained mobile QR scanner — Figma `Address QR` (4697:106096 active /
 /// 4697:111341 loading / 4697:106414 requesting / 4697:111063 denied) and send
 /// `QR Scan` (4484:61584). This is the bottom-sheet/card camera surface used
@@ -71,60 +252,10 @@ class MobileAddressScanCard extends StatefulWidget {
   State<MobileAddressScanCard> createState() => _MobileAddressScanCardState();
 }
 
-class _MobileAddressScanCardState extends State<MobileAddressScanCard>
-    with WidgetsBindingObserver {
-  // Mobile only ever uses the back camera, so there is no camera picker.
-  late final MobileScannerController _controller;
-  late final bool _ownsController;
+class _MobileAddressScanCardState extends State<MobileAddressScanCard> {
   bool _validating = false;
-  bool _restartCameraOnResume = false;
   int _scanResetToken = 0;
   String? _error;
-
-  @override
-  void initState() {
-    super.initState();
-    _ownsController = widget.controller == null;
-    _controller =
-        widget.controller ??
-        MobileScannerController(
-          formats: QrScanner.formats,
-          detectionSpeed: QrScanner.detectionSpeed,
-        );
-    WidgetsBinding.instance.addObserver(this);
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state != AppLifecycleState.resumed) return;
-    if (!_restartCameraOnResume) return;
-    _restartCameraOnResume = false;
-    unawaited(_retryCameraStart(openSettingsOnDenied: false));
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    if (_ownsController) unawaited(_controller.dispose());
-    super.dispose();
-  }
-
-  AddressQrCameraStatus _cameraAccessStatus(MobileScannerState state) {
-    if (!QrScanner.isAvailable) return AddressQrCameraStatus.unavailable;
-    if (state.error?.errorCode == MobileScannerErrorCode.permissionDenied) {
-      return AddressQrCameraStatus.denied;
-    }
-    if (state.error != null && !state.isRunning) {
-      return AddressQrCameraStatus.unavailable;
-    }
-    if (state.hasCameraPermission && state.isRunning) {
-      return AddressQrCameraStatus.active;
-    }
-    if (state.hasCameraPermission || state.isStarting || state.isInitialized) {
-      return AddressQrCameraStatus.loading;
-    }
-    return AddressQrCameraStatus.requesting;
-  }
 
   Future<void> _handleScan(String raw) async {
     if (_validating || !mounted) return;
@@ -156,71 +287,22 @@ class _MobileAddressScanCardState extends State<MobileAddressScanCard>
     }
   }
 
-  Future<void> _retryCameraStart({required bool openSettingsOnDenied}) async {
-    if (!QrScanner.isAvailable ||
-        _controller.value.isStarting ||
-        _controller.value.isRunning) {
-      return;
-    }
-    try {
-      await _controller.start();
-    } catch (e, st) {
-      log('MobileAddressScanCard: camera start retry error: $e\n$st');
-    }
-    if (!mounted || !openSettingsOnDenied) return;
-    if (_cameraAccessStatus(_controller.value) !=
-        AddressQrCameraStatus.denied) {
-      return;
-    }
-    await _openCameraSettings();
-  }
-
-  Future<void> _openCameraSettings() async {
-    _restartCameraOnResume = true;
-    final opened = await CameraPermissionSettings.open();
-    if (!opened) {
-      _restartCameraOnResume = false;
-      log('MobileAddressScanCard: failed to open camera permission settings');
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<MobileScannerState>(
-      valueListenable: _controller,
-      builder: (context, state, _) {
-        final status = _cameraAccessStatus(state);
-        return MobileAddressScanCardContent(
-          status: status,
-          // The camera preview is mounted in every state (covered by the
-          // permission card when access isn't granted) so the controller keeps
-          // running and reporting permission changes.
-          cameraView: QrScanner.isAvailable
-              ? PlainQrScannerView(
-                  key: const ValueKey('mobile_address_scan_card_camera'),
-                  controller: _controller,
-                  scanSessionResetToken: _scanResetToken,
-                  onComplete: (value) => unawaited(_handleScan(value)),
-                )
-              : null,
-          caption: widget.caption,
-          error: _error,
-          unavailableDescription: status == AddressQrCameraStatus.unavailable
-              ? _cameraUnavailableDescription(state)
-              : null,
-          onTorch: () => unawaited(_controller.toggleTorch()),
-          onClose: widget.onClose,
-          onRetry: () =>
-              unawaited(_retryCameraStart(openSettingsOnDenied: true)),
-        );
-      },
+    return MobileQrScanCard(
+      controller: widget.controller,
+      caption: widget.caption,
+      error: _error,
+      unavailableDescription:
+          'Address QR scanning needs a camera on this device.',
+      onClose: widget.onClose,
+      cameraViewBuilder: (context, controller) => PlainQrScannerView(
+        key: const ValueKey('mobile_address_scan_card_camera'),
+        controller: controller,
+        scanSessionResetToken: _scanResetToken,
+        onComplete: (value) => unawaited(_handleScan(value)),
+      ),
     );
-  }
-
-  String _cameraUnavailableDescription(MobileScannerState state) {
-    final message = state.error?.errorDetails?.message;
-    if (message != null && message.isNotEmpty) return message;
-    return 'Address QR scanning needs a camera on this device.';
   }
 }
 
@@ -238,8 +320,11 @@ class MobileAddressScanCardContent extends StatelessWidget {
     required this.onRetry,
     this.cameraView,
     this.caption = 'Scan a Zcash QR code to continue',
+    this.permissionTitle = 'Scan the address QR code',
     this.error,
     this.unavailableDescription,
+    this.permissionBuilder,
+    this.cameraHeight,
     super.key,
   });
 
@@ -249,8 +334,11 @@ class MobileAddressScanCardContent extends StatelessWidget {
   /// available — the card then only ever shows the permission states.
   final Widget? cameraView;
   final String caption;
+  final String permissionTitle;
   final String? error;
   final String? unavailableDescription;
+  final MobileQrPermissionBuilder? permissionBuilder;
+  final double? cameraHeight;
   final VoidCallback onTorch;
   final VoidCallback onClose;
   final VoidCallback onRetry;
@@ -273,10 +361,13 @@ class MobileAddressScanCardContent extends StatelessWidget {
     final showsCamera =
         status == AddressQrCameraStatus.active ||
         status == AddressQrCameraStatus.loading;
+    final hasFixedHeight = showsCamera || permissionBuilder != null;
     return SizedBox(
-      height: showsCamera ? _cameraCardHeight(context) : null,
+      height: hasFixedHeight
+          ? (cameraHeight ?? _cameraCardHeight(context))
+          : null,
       child: Stack(
-        fit: showsCamera ? StackFit.expand : StackFit.loose,
+        fit: hasFixedHeight ? StackFit.expand : StackFit.loose,
         children: [
           if (cameraView != null) Positioned.fill(child: cameraView!),
           if (status == AddressQrCameraStatus.active) ...[
@@ -320,12 +411,20 @@ class MobileAddressScanCardContent extends StatelessWidget {
               ),
             ),
           if (!showsCamera)
-            _ScanPermissionCard(
-              status: status,
-              unavailableDescription: unavailableDescription,
-              onRetry: onRetry,
-              onClose: onClose,
-            ),
+            permissionBuilder?.call(
+                  context,
+                  status,
+                  unavailableDescription,
+                  onRetry,
+                  onClose,
+                ) ??
+                _ScanPermissionCard(
+                  status: status,
+                  title: permissionTitle,
+                  unavailableDescription: unavailableDescription,
+                  onRetry: onRetry,
+                  onClose: onClose,
+                ),
         ],
       ),
     );
@@ -487,12 +586,14 @@ class _ScanLoadingVeil extends StatelessWidget {
 class _ScanPermissionCard extends StatelessWidget {
   const _ScanPermissionCard({
     required this.status,
+    required this.title,
     required this.unavailableDescription,
     required this.onRetry,
     required this.onClose,
   });
 
   final AddressQrCameraStatus status;
+  final String title;
   final String? unavailableDescription;
   final VoidCallback onRetry;
   final VoidCallback onClose;
@@ -505,7 +606,7 @@ class _ScanPermissionCard extends StatelessWidget {
       color: colors.background.base,
       child: MobileModalScaffold(
         key: const ValueKey('mobile_address_scan_permission_card'),
-        title: 'Scan the address QR code',
+        title: title,
         onClose: onClose,
         bottomPadding: AppSpacing.sm,
         child: Column(

--- a/lib/src/features/onboarding/keystone/keystone_onboarding_flow.dart
+++ b/lib/src/features/onboarding/keystone/keystone_onboarding_flow.dart
@@ -98,14 +98,29 @@ class KeystoneOnboardingNotifier extends Notifier<KeystoneOnboardingState> {
   }
 
   void setAccounts(List<KeystoneAccountInfo> accounts) {
+    final normalizedAccounts = accounts
+        .map(_withFallbackAccountName)
+        .toList(growable: false);
     state = KeystoneOnboardingState(
-      accounts: List.unmodifiable(accounts),
-      selectedAccount: accounts.isEmpty ? null : accounts.first,
+      accounts: List.unmodifiable(normalizedAccounts),
+      selectedAccount: normalizedAccounts.isEmpty
+          ? null
+          : normalizedAccounts.first,
     );
   }
 
   void selectAccount(KeystoneAccountInfo account) {
-    state = state.copyWith(selectedAccount: account);
+    state = state.copyWith(selectedAccount: _withFallbackAccountName(account));
+  }
+
+  KeystoneAccountInfo _withFallbackAccountName(KeystoneAccountInfo account) {
+    if (account.name.trim().isNotEmpty) return account;
+    return KeystoneAccountInfo(
+      name: 'Account ${account.index + 1}',
+      ufvk: account.ufvk,
+      index: account.index,
+      seedFingerprint: account.seedFingerprint,
+    );
   }
 }
 

--- a/lib/src/features/onboarding/mobile/mobile_keystone_scan_card.dart
+++ b/lib/src/features/onboarding/mobile/mobile_keystone_scan_card.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/widgets.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../address_scan/widgets/address_qr_scan_modal.dart'
+    show AddressQrCameraStatus;
+import '../../address_scan/widgets/mobile_address_scan_card.dart';
+
+const _keystoneScannerCardHeight = 464.0;
+const _keystoneScannerFooterHeight = 68.0;
+
+class MobileKeystoneScanCardContent extends StatelessWidget {
+  const MobileKeystoneScanCardContent({
+    required this.status,
+    required this.onTorch,
+    required this.onClose,
+    required this.onRetry,
+    this.cameraView,
+    this.error,
+    this.unavailableDescription,
+    this.cameraHeight,
+    super.key,
+  });
+
+  final AddressQrCameraStatus status;
+  final Widget? cameraView;
+  final String? error;
+  final String? unavailableDescription;
+  final double? cameraHeight;
+  final VoidCallback onTorch;
+  final VoidCallback onClose;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return MobileAddressScanCardContent(
+      status: status,
+      cameraView: cameraView,
+      caption: 'Scan a Zcash QR code to continue',
+      error: error,
+      unavailableDescription: unavailableDescription,
+      cameraHeight: cameraHeight ?? _keystoneScannerCardHeight,
+      onTorch: onTorch,
+      onClose: onClose,
+      onRetry: onRetry,
+      permissionBuilder:
+          (context, status, unavailableDescription, onRetry, onClose) =>
+              MobileKeystoneScanPermissionCard(
+                status: status,
+                unavailableDescription: unavailableDescription,
+                onRetry: onRetry,
+                cameraHeight: cameraHeight ?? _keystoneScannerCardHeight,
+              ),
+    );
+  }
+}
+
+class MobileKeystoneScanPermissionCard extends StatelessWidget {
+  const MobileKeystoneScanPermissionCard({
+    required this.status,
+    required this.onRetry,
+    this.unavailableDescription,
+    this.cameraHeight = _keystoneScannerCardHeight,
+    super.key,
+  });
+
+  final AddressQrCameraStatus status;
+  final String? unavailableDescription;
+  final VoidCallback onRetry;
+  final double cameraHeight;
+
+  bool get _showsRetry =>
+      status == AddressQrCameraStatus.denied ||
+      status == AddressQrCameraStatus.unavailable;
+
+  String get _title {
+    switch (status) {
+      case AddressQrCameraStatus.denied:
+        return "You've denied camera access";
+      case AddressQrCameraStatus.unavailable:
+        return 'Camera unavailable';
+      case AddressQrCameraStatus.requesting:
+      case AddressQrCameraStatus.active:
+      case AddressQrCameraStatus.loading:
+        return 'Enable camera access';
+    }
+  }
+
+  String get _description {
+    switch (status) {
+      case AddressQrCameraStatus.denied:
+        return 'Request again, or enable manually\n'
+            'in the System settings.';
+      case AddressQrCameraStatus.unavailable:
+        return unavailableDescription ??
+            'Keystone import uses camera QR scanning only.\n'
+                'Connect a camera and try again.';
+      case AddressQrCameraStatus.requesting:
+      case AddressQrCameraStatus.active:
+      case AddressQrCameraStatus.loading:
+        return 'A camera is required to connect Keystone.\n'
+            'You can revert this in settings anytime later.';
+    }
+  }
+
+  String get _retryLabel => status == AddressQrCameraStatus.unavailable
+      ? 'Try again'
+      : 'Request again';
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return SizedBox(
+      key: const ValueKey('mobile_keystone_scan_permission_card'),
+      height: cameraHeight,
+      child: Column(
+        children: [
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(28),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: colors.background.ground,
+                  borderRadius: BorderRadius.circular(AppRadii.large),
+                  boxShadow: const [
+                    BoxShadow(color: Color(0x00000000), blurRadius: 1),
+                    BoxShadow(
+                      color: Color(0x00000000),
+                      blurRadius: 2,
+                      offset: Offset(0, 1),
+                    ),
+                    BoxShadow(
+                      color: Color(0x00000000),
+                      blurRadius: 4,
+                      offset: Offset(0, 2),
+                    ),
+                  ],
+                ),
+                child: Center(
+                  child: Padding(
+                    padding: const EdgeInsets.only(
+                      left: AppSpacing.s,
+                      right: AppSpacing.s,
+                      top: AppSpacing.md,
+                    ),
+                    child: _KeystonePermissionMessage(
+                      title: _title,
+                      description: _description,
+                      denied: status == AddressQrCameraStatus.denied,
+                      action: _showsRetry
+                          ? AppButton(
+                              key: const ValueKey(
+                                'mobile_keystone_scan_retry_button',
+                              ),
+                              variant: AppButtonVariant.secondary,
+                              size: AppButtonSize.medium,
+                              minWidth: 96,
+                              leading: const AppIcon(AppIcons.renew),
+                              onPressed: onRetry,
+                              child: Text(_retryLabel),
+                            )
+                          : null,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: _keystoneScannerFooterHeight),
+        ],
+      ),
+    );
+  }
+}
+
+class _KeystonePermissionMessage extends StatelessWidget {
+  const _KeystonePermissionMessage({
+    required this.title,
+    required this.description,
+    required this.denied,
+    this.action,
+  });
+
+  final String title;
+  final String description;
+  final bool denied;
+  final Widget? action;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            // Requesting sits on the inverse tile, denied on the neutral
+            // raised tile (Figma 4654:72631 / 4654:72955) — both theme-aware.
+            color: denied ? colors.background.raised : colors.background.inverse,
+            borderRadius: BorderRadius.circular(AppRadii.small),
+          ),
+          child: Center(
+            child: AppIcon(
+              AppIcons.cameraDenied,
+              size: 24,
+              color: denied ? colors.icon.accent : colors.icon.inverse,
+            ),
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        Text(
+          title,
+          textAlign: TextAlign.center,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: AppTypography.bodyLarge.copyWith(
+            color: colors.text.accent,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xxs),
+        for (final line in description.split('\n'))
+          Text(
+            line,
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            softWrap: false,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.bodyMedium.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+        if (action != null) ...[const SizedBox(height: AppSpacing.md), action!],
+      ],
+    );
+  }
+}

--- a/lib/src/features/onboarding/mobile/mobile_keystone_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_keystone_screens.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../../../../main.dart' show log;
 import '../../../core/theme/app_theme.dart';
@@ -13,9 +14,10 @@ import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
 import '../../../providers/wallet_mutation_guard.dart';
 import '../../../rust/api/keystone.dart' as rust_keystone;
-import '../../../services/qr_scanner.dart' show ScanResult;
+import '../../../services/qr_scanner.dart'
+    show AnimatedUrScannerView, ScanResult;
+import '../../address_scan/widgets/mobile_address_scan_card.dart';
 import '../../about/about_content.dart' show launchAboutUrl;
-import '../../keystone/widgets/keystone_qr_scanner_card.dart';
 import '../keystone/keystone_onboarding_flow.dart'
     show
         KeystoneOnboardingStep,
@@ -23,6 +25,7 @@ import '../keystone/keystone_onboarding_flow.dart'
         keystoneOnboardingProvider;
 import '../shared/onboarding_flow_args.dart';
 import 'mobile_import_birthday_screen.dart';
+import 'mobile_keystone_scan_card.dart';
 import 'mobile_onboarding_scaffold.dart';
 
 const _keystoneFirmwareUrl = 'https://keyst.one/firmware';
@@ -48,100 +51,116 @@ class MobileKeystoneIntroScreen extends StatelessWidget {
         trailing: const AppIcon(AppIcons.chevronForward),
         child: const Text('Continue'),
       ),
-      child: Container(
-        width: double.infinity,
-        // Same surface-card rhythm as the onboarding info cards: 20 px
-        // sides, 44 px vertical, 16 below a heading, 36 around the
-        // divider.
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 44),
-        decoration: BoxDecoration(
-          color: colors.background.ground,
-          borderRadius: BorderRadius.circular(AppRadii.large),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _SectionHeading(
-              iconName: AppIcons.importWallet,
-              title: '1. Check Keystone firmware',
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            Text(
-              'Check if your Keystone device has the latest version of the '
-              'Cypherpunk firmware, update or install if needed.',
-              style: AppTypography.bodyMedium.copyWith(
-                color: colors.text.primary,
-              ),
-            ),
-            const SizedBox(height: AppSpacing.s),
-            Semantics(
-              button: true,
-              link: true,
-              label: 'Keystone firmware link',
-              child: GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTap: () => unawaited(launchAboutUrl(_keystoneFirmwareUrl)),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    AppIcon(
-                      AppIcons.link,
-                      size: AppIconSize.medium,
-                      color: colors.icon.accent,
-                    ),
-                    const SizedBox(width: AppSpacing.xxs),
-                    Text(
-                      'Keystone firmware',
-                      style: AppTypography.labelLarge.copyWith(
-                        color: colors.text.accent,
-                      ),
-                    ),
-                  ],
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _KeystoneIntroCard(
+            key: const ValueKey('mobile_keystone_intro_firmware_card'),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _SectionHeading(
+                  iconName: AppIcons.importWallet,
+                  title: '1. Check Keystone firmware',
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.symmetric(vertical: 36),
-              child: Container(height: 1, color: colors.border.subtle),
-            ),
-            _SectionHeading(
-              iconName: AppIcons.qr,
-              title: '2. Prepare to connect',
-            ),
-            const SizedBox(height: AppSpacing.sm),
-            for (final (i, step) in const [
-              'Unlock your Keystone.',
-              'Tap the ... menu, then go to Sync.',
-              'Open the Zcash QR code in order to connect.',
-              'Allow camera access when prompted and scan the QR code '
-                  'with your phone.',
-            ].indexed) ...[
-              if (i > 0) const SizedBox(height: AppSpacing.xxs),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  SizedBox(
-                    width: 20,
-                    child: Text(
-                      '${i + 1}.',
-                      style: AppTypography.bodyMedium.copyWith(
-                        color: colors.text.primary,
-                      ),
-                    ),
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  'Check if your Keystone device has the latest version of '
+                  'the Cypherpunk firmware, update or install if needed.',
+                  style: AppTypography.bodyMedium.copyWith(
+                    color: colors.text.primary,
                   ),
-                  Expanded(
-                    child: Text(
-                      step,
-                      style: AppTypography.bodyMedium.copyWith(
-                        color: colors.text.primary,
-                      ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                Semantics(
+                  button: true,
+                  link: true,
+                  label: 'Keystone firmware link',
+                  child: AppButton(
+                    variant: AppButtonVariant.ghost,
+                    size: AppButtonSize.medium,
+                    height: 36,
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.xs,
                     ),
+                    leading: const AppIcon(AppIcons.link),
+                    onPressed: () =>
+                        unawaited(launchAboutUrl(_keystoneFirmwareUrl)),
+                    child: const Text('Keystone firmware'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          _KeystoneIntroCard(
+            key: const ValueKey('mobile_keystone_intro_prepare_card'),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _SectionHeading(
+                  iconName: AppIcons.qr,
+                  title: '2. Prepare to connect',
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                for (final (i, step) in const [
+                  'Unlock your Keystone.',
+                  'Tap the ... menu, then go to Sync.',
+                  'Open the Zcash QR code in order to connect.',
+                  'Allow camera access when prompted and scan the QR code '
+                      'with your phone.',
+                ].indexed) ...[
+                  if (i > 0) const SizedBox(height: AppSpacing.xxs),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SizedBox(
+                        width: 20,
+                        child: Text(
+                          '${i + 1}.',
+                          style: AppTypography.bodyMedium.copyWith(
+                            color: colors.text.primary,
+                          ),
+                        ),
+                      ),
+                      Expanded(
+                        child: Text(
+                          step,
+                          style: AppTypography.bodyMedium.copyWith(
+                            color: colors.text.primary,
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                 ],
-              ),
-            ],
-          ],
-        ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _KeystoneIntroCard extends StatelessWidget {
+  const _KeystoneIntroCard({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppSpacing.sm),
+      decoration: BoxDecoration(
+        color: colors.background.ground,
+        borderRadius: BorderRadius.circular(AppRadii.large),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xxs),
+        child: child,
       ),
     );
   }
@@ -175,7 +194,9 @@ class _SectionHeading extends StatelessWidget {
 /// the shared scanner card handles camera permission states and the
 /// animated-UR progress; this screen decodes the completed payload.
 class MobileKeystoneScanScreen extends ConsumerStatefulWidget {
-  const MobileKeystoneScanScreen({super.key});
+  const MobileKeystoneScanScreen({this.scannerController, super.key});
+
+  final MobileScannerController? scannerController;
 
   @override
   ConsumerState<MobileKeystoneScanScreen> createState() =>
@@ -188,12 +209,15 @@ class _MobileKeystoneScanScreenState
 
   bool _decoding = false;
   String? _error;
+  int _scanProgress = 0;
+  int _scanSessionResetToken = 0;
 
   Future<void> _handleScanComplete(ScanResult result) async {
     if (_decoding) return;
     setState(() {
       _decoding = true;
       _error = null;
+      _scanProgress = 100;
     });
 
     try {
@@ -205,6 +229,8 @@ class _MobileKeystoneScanScreenState
         setState(() {
           _decoding = false;
           _error = 'No Zcash accounts were found on this Keystone QR.';
+          _scanProgress = 0;
+          _scanSessionResetToken++;
         });
         return;
       }
@@ -217,10 +243,21 @@ class _MobileKeystoneScanScreenState
       if (!mounted) return;
       setState(() {
         _decoding = false;
+        _scanProgress = 0;
+        _scanSessionResetToken++;
         _error =
             'This QR code could not be decoded as a Keystone Zcash account.';
       });
     }
+  }
+
+  void _handleScanProgress(int progress) {
+    final clamped = progress.clamp(0, 100);
+    if (!mounted || _scanProgress == clamped) return;
+    setState(() {
+      _scanProgress = clamped;
+      if (clamped > 0) _error = null;
+    });
   }
 
   void _handleDecodeError(Object error) {
@@ -230,6 +267,15 @@ class _MobileKeystoneScanScreenState
         : 'Keep the QR code steady and fully visible.';
     if (_error == message) return;
     setState(() => _error = message);
+  }
+
+  String? get _scanCaptionOverride {
+    if (_decoding) return 'Reading accounts...';
+    if (_error != null) return _error;
+    if (_scanProgress > 0 && _scanProgress < 100) {
+      return 'Scanning... $_scanProgress%';
+    }
+    return null;
   }
 
   @override
@@ -248,29 +294,34 @@ class _MobileKeystoneScanScreenState
           final cameraHeight = math.min(_cameraMaxHeight, availableHeight);
           return Align(
             alignment: Alignment.topCenter,
-            child: KeystoneQrScannerCard(
+            child: MobileQrScanCard(
               key: const ValueKey('mobile_keystone_scan_card'),
-              expectedUrType: 'zcash-accounts',
-              decoding: _decoding,
-              error: _error,
-              // The Keystone Scan frames run the card edge-to-edge inside the
-              // 16 px content inset, as a single 464 px rounded camera card
-              // (Figma `Camera` 4654:72631 — no inner frame on mobile). Shorter
-              // phones keep the page fixed and shrink only this viewport.
-              cardWidth: double.infinity,
+              controller: widget.scannerController,
               cameraHeight: cameraHeight,
-              onProgress: (progress) {
-                if (!mounted) return;
-                setState(() {
-                  if (progress > 0) _error = null;
-                });
-              },
-              onDecodeError: _handleDecodeError,
-              onComplete: _handleScanComplete,
-              decodingLabel: 'Reading accounts...',
-              unavailableMessage:
-                  'A camera is required to connect Keystone. You can revert '
-                  'this in settings anytime later.',
+              permissionTitle: 'Scan QR Code',
+              error: _scanCaptionOverride,
+              unavailableDescription:
+                  'Keystone import uses camera QR scanning only. Connect a '
+                  'camera and try again.',
+              onClose: () => Navigator.of(context).maybePop(),
+              permissionBuilder:
+                  (context, status, unavailableDescription, onRetry, onClose) =>
+                      MobileKeystoneScanPermissionCard(
+                        status: status,
+                        unavailableDescription: unavailableDescription,
+                        onRetry: onRetry,
+                        cameraHeight: cameraHeight,
+                      ),
+              cameraViewBuilder: (context, controller) => AnimatedUrScannerView(
+                key: const ValueKey('mobile_keystone_scan_camera'),
+                controller: controller,
+                expectedUrType: 'zcash-accounts',
+                scanSessionResetToken: _scanSessionResetToken,
+                errorBuilder: (context, error) => const SizedBox.shrink(),
+                onProgress: _handleScanProgress,
+                onDecodeError: _handleDecodeError,
+                onComplete: (result) => unawaited(_handleScanComplete(result)),
+              ),
             ),
           );
         },
@@ -323,26 +374,32 @@ class MobileKeystoneSelectAccountScreen extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            '${accounts.length} account${accounts.length == 1 ? '' : 's'} '
-            'found',
-            style: AppTypography.bodyMedium.copyWith(
-              color: colors.text.secondary,
+          // Figma `List Title` (4654:74577): Label M Medium on
+          // text/secondary with a 4 px inset.
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.xxs),
+            child: Text(
+              '${accounts.length} account${accounts.length == 1 ? '' : 's'} '
+              'found',
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.secondary,
+              ),
             ),
           ),
           const SizedBox(height: AppSpacing.s),
           for (final account in accounts) ...[
             _AccountCard(
-              name: account.name,
+              name: account.name.trim().isEmpty
+                  ? 'Account ${account.index + 1}'
+                  : account.name,
               detail: _truncate(account.ufvk),
               selected: account == selected,
               onTap: () => ref
                   .read(keystoneOnboardingProvider.notifier)
                   .selectAccount(account),
             ),
-            // 10 px card gap measured from the Select Account frame
-            // (76 px row pitch with the 66 px card).
-            const SizedBox(height: 10),
+            // 12 px gap between radio cards (Figma `Radi Group` 4654:74579).
+            const SizedBox(height: AppSpacing.s),
           ],
         ],
       ),
@@ -375,37 +432,68 @@ class _AccountCard extends StatelessWidget {
         behavior: HitTestBehavior.opaque,
         onTap: onTap,
         child: Container(
-          height: 66,
-          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+          // Figma `Radio Card` (4654:74580): min-h 64, ground fill, 16 px
+          // radius, asymmetric 8/12/4 padding. Only the selected card
+          // carries a 2 px strong border; unselected cards are border-less.
+          constraints: const BoxConstraints(minHeight: 64),
+          padding: const EdgeInsets.only(
+            left: AppSpacing.xs,
+            right: AppSpacing.s,
+            top: AppSpacing.xxs,
+            bottom: AppSpacing.xxs,
+          ),
           decoration: BoxDecoration(
             color: colors.background.ground,
             borderRadius: BorderRadius.circular(AppRadii.medium),
-            border: Border.all(
-              color: selected ? colors.border.strong : colors.border.subtle,
-              width: selected ? 2 : 1,
-            ),
+            border: selected
+                ? Border.all(color: colors.border.strong, width: 2)
+                : null,
           ),
           child: Row(
             children: [
-              AppIcon(AppIcons.user, size: 20, color: colors.icon.muted),
-              const SizedBox(width: AppSpacing.s),
+              // 32 px icon cell; the user glyph dims to 50 % when the card
+              // is not selected (Figma `Card Icon`).
+              SizedBox(
+                width: 32,
+                height: 32,
+                child: Center(
+                  child: Opacity(
+                    opacity: selected ? 1 : 0.5,
+                    child: AppIcon(
+                      AppIcons.user,
+                      size: 20,
+                      color: colors.icon.accent,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xs),
               Expanded(
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
+                    // Label M; SemiBold when selected, Medium otherwise.
                     Text(
                       name,
                       overflow: TextOverflow.ellipsis,
-                      style: AppTypography.bodyMediumStrong.copyWith(
+                      style: AppTypography.labelLarge.copyWith(
+                        fontWeight:
+                            selected ? FontWeight.w600 : FontWeight.w500,
                         color: colors.text.accent,
                       ),
                     ),
+                    const SizedBox(height: 2),
+                    // Label M Regular; accent on the selected card, secondary
+                    // otherwise.
                     Text(
                       detail,
                       overflow: TextOverflow.ellipsis,
-                      style: AppTypography.labelMedium.copyWith(
-                        color: colors.text.secondary,
+                      style: AppTypography.labelLarge.copyWith(
+                        fontWeight: FontWeight.w400,
+                        color: selected
+                            ? colors.text.accent
+                            : colors.text.secondary,
                       ),
                     ),
                   ],
@@ -434,7 +522,7 @@ class _AccountCard extends StatelessWidget {
                   height: 24,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
-                    color: colors.background.raised,
+                    color: colors.background.neutralSubtleOpacity,
                   ),
                 ),
             ],

--- a/lib/src/features/onboarding/mobile/mobile_keystone_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_keystone_screens.dart
@@ -236,8 +236,18 @@ class _MobileKeystoneScanScreenState
       }
 
       ref.read(keystoneOnboardingProvider.notifier).setAccounts(accounts);
-      context.push(KeystoneOnboardingStep.selectAccount.routePath);
       if (mounted) setState(() => _decoding = false);
+      // push() resolves when select-account pops back to this still-mounted
+      // scan screen. Reset the UR session/progress on return so a second
+      // Keystone QR can be scanned — otherwise the scanner stays in its
+      // completed state and ignores new frames.
+      await context.push(KeystoneOnboardingStep.selectAccount.routePath);
+      if (!mounted) return;
+      setState(() {
+        _scanProgress = 0;
+        _scanSessionResetToken++;
+        _error = null;
+      });
     } catch (e, st) {
       log('MobileKeystoneScan: account decode error: $e\n$st');
       if (!mounted) return;

--- a/lib/widgetbook/keystone_use_cases.dart
+++ b/lib/widgetbook/keystone_use_cases.dart
@@ -1,0 +1,306 @@
+// ignore_for_file: depend_on_referenced_packages
+// widgetbook is dev-only; see `widgetbook.dart` for the boundary.
+
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart' show ThemeMode;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:pretty_qr_code/pretty_qr_code.dart';
+
+import '../src/app_bootstrap.dart';
+import '../src/core/config/rpc_endpoint_config.dart';
+import '../src/core/layout/mobile/app_mobile_sheet.dart';
+import '../src/core/theme/app_theme.dart';
+import '../src/features/address_scan/widgets/address_qr_scan_modal.dart';
+import '../src/features/onboarding/keystone/keystone_onboarding_flow.dart';
+import '../src/features/onboarding/mobile/mobile_import_birthday_screen.dart';
+import '../src/features/onboarding/mobile/mobile_keystone_scan_card.dart';
+import '../src/features/onboarding/mobile/mobile_keystone_screens.dart';
+import '../src/features/onboarding/mobile/mobile_onboarding_scaffold.dart';
+import '../src/features/onboarding/shared/onboarding_flow_args.dart';
+import '../src/providers/account_provider.dart' show AccountState;
+import '../src/rust/wallet/keystone.dart' show KeystoneAccountInfo;
+
+Widget buildMobileKeystoneScanRequestingUseCase(BuildContext context) {
+  return const _MobileKeystoneInlineScanFrame(
+    child: MobileKeystoneScanCardContent(
+      key: ValueKey('mobile_keystone_scan_widgetbook_card'),
+      status: AddressQrCameraStatus.requesting,
+      cameraView: _MobileKeystoneScanCameraPreview(),
+      cameraHeight: 464,
+      onTorch: _noop,
+      onClose: _noop,
+      onRetry: _noop,
+    ),
+  );
+}
+
+Widget buildMobileKeystoneScanDeniedUseCase(BuildContext context) {
+  return const _MobileKeystoneInlineScanFrame(
+    child: MobileKeystoneScanCardContent(
+      key: ValueKey('mobile_keystone_scan_widgetbook_card'),
+      status: AddressQrCameraStatus.denied,
+      cameraView: _MobileKeystoneScanCameraPreview(),
+      cameraHeight: 464,
+      onTorch: _noop,
+      onClose: _noop,
+      onRetry: _noop,
+    ),
+  );
+}
+
+Widget buildMobileKeystoneScanActiveUseCase(BuildContext context) {
+  return const _MobileKeystoneModalScanFrame(
+    child: MobileKeystoneScanCardContent(
+      key: ValueKey('mobile_keystone_scan_widgetbook_card'),
+      status: AddressQrCameraStatus.active,
+      cameraView: _MobileKeystoneScanCameraPreview(),
+      cameraHeight: 694,
+      onTorch: _noop,
+      onClose: _noop,
+      onRetry: _noop,
+    ),
+  );
+}
+
+Widget buildMobileKeystoneScanLoadingUseCase(BuildContext context) {
+  return const _MobileKeystoneModalScanFrame(
+    child: MobileKeystoneScanCardContent(
+      key: ValueKey('mobile_keystone_scan_widgetbook_card'),
+      status: AddressQrCameraStatus.loading,
+      cameraView: _MobileKeystoneScanCameraPreview(),
+      cameraHeight: 694,
+      onTorch: _noop,
+      onClose: _noop,
+      onRetry: _noop,
+    ),
+  );
+}
+
+Widget buildMobileKeystoneConnectUseCase(BuildContext context) {
+  return const _MobileKeystoneScreenFrame(child: MobileKeystoneIntroScreen());
+}
+
+Widget buildMobileKeystoneBirthdayUseCase(BuildContext context) {
+  // The Keystone birthday step reuses the shared import birthday screen; we
+  // render it directly with `loadChainMetadata: false` so the preview makes
+  // no network call, and seed `appBootstrapProvider` so the lazy
+  // `rpcEndpointProvider` read (block-height mode) resolves.
+  return _MobileKeystoneScreenFrame(
+    child: ProviderScope(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_widgetbookBootstrap()),
+      ],
+      child: MobileImportBirthdayScreen(
+        args: const ImportBirthdayArgs(mnemonic: ''),
+        loadChainMetadata: false,
+        onHeightConfirmed: (_) async {},
+      ),
+    ),
+  );
+}
+
+Widget buildMobileKeystoneSelectAccountUseCase(BuildContext context) {
+  return const _MobileKeystoneSelectAccountFrame();
+}
+
+/// A bare 393×852 phone frame for Keystone onboarding screens that bring
+/// their own scaffold.
+class _MobileKeystoneScreenFrame extends StatelessWidget {
+  const _MobileKeystoneScreenFrame({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 393,
+      height: 852,
+      child: MediaQuery(
+        data: const MediaQueryData(
+          size: Size(393, 852),
+          viewPadding: EdgeInsets.only(top: 55),
+        ),
+        child: child,
+      ),
+    );
+  }
+}
+
+AppBootstrapState _widgetbookBootstrap() {
+  return AppBootstrapState(
+    initialLocation: '/onboarding/keystone/birthday',
+    initialAccountState: const AccountState(accounts: []),
+    initialSyncSnapshot: AppSyncSnapshot.empty,
+    network: 'main',
+    rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+    themeMode: ThemeMode.system,
+    privacyModeEnabled: false,
+    isPasswordConfigured: false,
+    isUnlocked: true,
+    passwordRotationRecoveryFailed: false,
+  );
+}
+
+/// Renders the real [MobileKeystoneSelectAccountScreen] with the onboarding
+/// provider seeded so the radio list shows up without a live Keystone scan
+/// (the simulator cannot scan the device QR).
+class _MobileKeystoneSelectAccountFrame extends StatelessWidget {
+  const _MobileKeystoneSelectAccountFrame();
+
+  @override
+  Widget build(BuildContext context) {
+    return ProviderScope(
+      overrides: [
+        keystoneOnboardingProvider.overrideWith(
+          _SeededKeystoneOnboardingNotifier.new,
+        ),
+      ],
+      child: const SizedBox(
+        width: 393,
+        height: 852,
+        child: MediaQuery(
+          data: MediaQueryData(
+            size: Size(393, 852),
+            viewPadding: EdgeInsets.only(top: 55),
+          ),
+          child: MobileKeystoneSelectAccountScreen(),
+        ),
+      ),
+    );
+  }
+}
+
+class _SeededKeystoneOnboardingNotifier extends KeystoneOnboardingNotifier {
+  @override
+  KeystoneOnboardingState build() {
+    final accounts = <KeystoneAccountInfo>[
+      for (var i = 0; i < 4; i++)
+        KeystoneAccountInfo(
+          name: 'Account ${i + 1}',
+          ufvk: 'u1asdasdasx0qqqqqqqqqqqqqqqqqq3123llasdasd',
+          index: i,
+          seedFingerprint: Uint8List.fromList(const [0, 0, 0, 0]),
+        ),
+    ];
+    return KeystoneOnboardingState(
+      accounts: accounts,
+      selectedAccount: accounts.first,
+    );
+  }
+}
+
+class _MobileKeystoneInlineScanFrame extends StatelessWidget {
+  const _MobileKeystoneInlineScanFrame({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 393,
+      height: 852,
+      child: MediaQuery(
+        data: const MediaQueryData(
+          size: Size(393, 852),
+          viewPadding: EdgeInsets.only(top: 55),
+        ),
+        child: MobileOnboardingStepScaffold(
+          progress: 0.4,
+          onBack: _noop,
+          title: 'Scan QR Code',
+          subtitle: 'Prepare your Keystone wallet',
+          scrollable: false,
+          child: Align(alignment: Alignment.topCenter, child: child),
+        ),
+      ),
+    );
+  }
+}
+
+class _MobileKeystoneModalScanFrame extends StatelessWidget {
+  const _MobileKeystoneModalScanFrame({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return SizedBox(
+      width: 393,
+      height: 852,
+      child: MediaQuery(
+        data: const MediaQueryData(
+          size: Size(393, 852),
+          viewPadding: EdgeInsets.only(top: 55),
+        ),
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            const MobileOnboardingStepScaffold(
+              progress: 0.4,
+              onBack: _noop,
+              title: 'Scan QR Code',
+              subtitle: 'Prepare your Keystone wallet',
+              scrollable: false,
+              child: Align(
+                alignment: Alignment.topCenter,
+                child: MobileKeystoneScanCardContent(
+                  status: AddressQrCameraStatus.denied,
+                  cameraView: _MobileKeystoneScanCameraPreview(),
+                  cameraHeight: 464,
+                  onTorch: _noop,
+                  onClose: _noop,
+                  onRetry: _noop,
+                ),
+              ),
+            ),
+            ColoredBox(
+              color: colors.background.neutralScrim,
+              child: SafeArea(
+                bottom: false,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    const Spacer(),
+                    MobileModalCard(child: child),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MobileKeystoneScanCameraPreview extends StatelessWidget {
+  const _MobileKeystoneScanCameraPreview();
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: const BoxDecoration(color: Color(0xFF111515)),
+      child: Center(
+        child: SizedBox(
+          width: 320,
+          height: 320,
+          child: PrettyQrView.data(
+            data: 'ur:zcash-accounts/1-1/lftadkexamplekeystoneaccountpreview',
+            decoration: const PrettyQrDecoration(
+              quietZone: PrettyQrQuietZone.zero,
+              shape: PrettyQrSmoothSymbol(
+                roundFactor: 0,
+                color: Color(0xFFEFEDEA),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+void _noop() {}

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -15,6 +15,7 @@ import 'chip_use_cases.dart';
 import 'context_menu_use_cases.dart';
 import 'color_use_cases.dart';
 import 'icon_use_cases.dart';
+import 'keystone_use_cases.dart';
 import 'mobile_shell_use_cases.dart';
 import 'receive_use_cases.dart';
 import 'received_receipt_use_cases.dart';
@@ -151,6 +152,39 @@ class WidgetbookApp extends StatelessWidget {
                     WidgetbookUseCase(
                       name: 'Fingerprint opt-in',
                       builder: buildMobileFingerprintOptInUseCase,
+                    ),
+                  ],
+                ),
+                WidgetbookComponent(
+                  name: 'Mobile Keystone',
+                  useCases: [
+                    WidgetbookUseCase(
+                      name: 'Connect',
+                      builder: buildMobileKeystoneConnectUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Scan permission',
+                      builder: buildMobileKeystoneScanRequestingUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Scan denied',
+                      builder: buildMobileKeystoneScanDeniedUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Scan active',
+                      builder: buildMobileKeystoneScanActiveUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Scan loading',
+                      builder: buildMobileKeystoneScanLoadingUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Select account',
+                      builder: buildMobileKeystoneSelectAccountUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'Birthday height',
+                      builder: buildMobileKeystoneBirthdayUseCase,
                     ),
                   ],
                 ),

--- a/test/features/onboarding/mobile_keystone_intro_screen_test.dart
+++ b/test/features/onboarding/mobile_keystone_intro_screen_test.dart
@@ -1,0 +1,91 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_keystone_screens.dart';
+
+Widget _app(String initialLocation) {
+  final router = GoRouter(
+    initialLocation: initialLocation,
+    routes: [
+      GoRoute(
+        path: '/onboarding/keystone',
+        builder: (_, _) => const MobileKeystoneIntroScreen(),
+      ),
+      GoRoute(
+        path: '/onboarding/keystone/scan',
+        builder: (_, _) => const SizedBox(key: ValueKey('scan-screen')),
+      ),
+    ],
+  );
+  return ProviderScope(
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+    ),
+  );
+}
+
+void _setViewSize(WidgetTester tester, Size size) {
+  tester.view
+    ..physicalSize = size
+    ..devicePixelRatio = 1.0;
+}
+
+void main() {
+  tearDown(() {
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.platformDispatcher.views.first
+      ..resetPhysicalSize()
+      ..resetDevicePixelRatio();
+  });
+
+  testWidgets('intro uses two compact Figma cards', (tester) async {
+    _setViewSize(tester, const Size(393, 852));
+
+    await tester.pumpWidget(_app('/onboarding/keystone'));
+    await tester.pumpAndSettle();
+
+    const firmwareCardKey = ValueKey('mobile_keystone_intro_firmware_card');
+    const prepareCardKey = ValueKey('mobile_keystone_intro_prepare_card');
+
+    expect(find.byKey(firmwareCardKey), findsOneWidget);
+    expect(find.byKey(prepareCardKey), findsOneWidget);
+    expect(find.text('1. Check Keystone firmware'), findsOneWidget);
+    expect(find.text('2. Prepare to connect'), findsOneWidget);
+
+    expect(tester.getSize(find.byKey(firmwareCardKey)).width, 361);
+    expect(tester.getSize(find.byKey(prepareCardKey)).width, 361);
+
+    final firmwareBottom = tester.getBottomLeft(find.byKey(firmwareCardKey)).dy;
+    final prepareTop = tester.getTopLeft(find.byKey(prepareCardKey)).dy;
+    expect(prepareTop - firmwareBottom, AppSpacing.sm);
+  });
+
+  testWidgets('intro preserves the scan CTA', (tester) async {
+    _setViewSize(tester, const Size(393, 852));
+
+    await tester.pumpWidget(_app('/onboarding/keystone'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Continue'), findsOneWidget);
+    expect(find.text('Tell me how Zcash works'), findsNothing);
+    expect(
+      find.text(
+        'Allow camera access when prompted and scan the QR code with your phone.',
+      ),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_keystone_intro_continue')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('scan-screen')), findsOneWidget);
+  });
+}

--- a/test/features/onboarding/mobile_keystone_scan_screen_test.dart
+++ b/test/features/onboarding/mobile_keystone_scan_screen_test.dart
@@ -279,6 +279,47 @@ void main() {
     expect(find.text('Account 1'), findsOneWidget);
   });
 
+  testWidgets('resets the scan session when returning from select account', (
+    tester,
+  ) async {
+    _setViewSize(tester, const Size(393, 852));
+    _rustApi.decodedAccounts = [_account(1), _account(2)];
+    final controller = MobileScannerController(autoStart: false);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(_routerApp(controller: controller));
+    await tester.pump();
+
+    int token() =>
+        tester
+                .widget<AnimatedUrScannerView>(
+                  find.byKey(const ValueKey('mobile_keystone_scan_camera')),
+                )
+                .scanSessionResetToken!
+            as int;
+
+    final initial = token();
+
+    tester
+        .widget<AnimatedUrScannerView>(
+          find.byKey(const ValueKey('mobile_keystone_scan_camera')),
+        )
+        .onComplete(
+          const ScanResult(urType: 'zcash-accounts', data: [1, 2, 3]),
+        );
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(MobileKeystoneSelectAccountScreen), findsOneWidget);
+
+    // Backing out to scan a different Keystone QR must reset the scanner so
+    // it can complete again instead of staying in its finished state.
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MobileKeystoneScanScreen), findsOneWidget);
+    expect(token(), greaterThan(initial));
+  });
+
   testWidgets('stays on scan with an inline error when no accounts decode', (
     tester,
   ) async {

--- a/test/features/onboarding/mobile_keystone_scan_screen_test.dart
+++ b/test/features/onboarding/mobile_keystone_scan_screen_test.dart
@@ -7,8 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
-import 'package:zcash_wallet/src/features/keystone/widgets/keystone_qr_scanner_card.dart';
 import 'package:zcash_wallet/src/features/onboarding/keystone/keystone_onboarding_flow.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_keystone_screens.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
@@ -37,24 +37,28 @@ class _RustApiFake implements RustLibApi {
 
 final _rustApi = _RustApiFake();
 
-Widget _app() {
-  return const ProviderScope(
+Widget _app({MobileScannerController? controller}) {
+  return ProviderScope(
     child: MaterialApp(
       home: AppTheme(
         data: AppThemeData.dark,
-        child: MobileKeystoneScanScreen(),
+        child: MobileKeystoneScanScreen(scannerController: controller),
       ),
     ),
   );
 }
 
-Widget _routerApp({String initialLocation = '/onboarding/keystone/scan'}) {
+Widget _routerApp({
+  String initialLocation = '/onboarding/keystone/scan',
+  MobileScannerController? controller,
+}) {
   final router = GoRouter(
     initialLocation: initialLocation,
     routes: [
       GoRoute(
         path: KeystoneOnboardingStep.scanQrCode.routePath,
-        builder: (_, _) => const MobileKeystoneScanScreen(),
+        builder: (_, _) =>
+            MobileKeystoneScanScreen(scannerController: controller),
       ),
       GoRoute(
         path: KeystoneOnboardingStep.selectAccount.routePath,
@@ -115,8 +119,12 @@ void main() {
 
   testWidgets('keeps the Figma camera height on tall phones', (tester) async {
     _setViewSize(tester, const Size(393, 852));
+    final controller = MobileScannerController(autoStart: false);
+    addTearDown(controller.dispose);
 
-    await tester.pumpWidget(_app());
+    controller.value = controller.value.copyWith(isInitialized: true);
+
+    await tester.pumpWidget(_app(controller: controller));
     await tester.pump();
 
     expect(find.byType(SingleChildScrollView), findsNothing);
@@ -127,12 +135,110 @@ void main() {
     expect(_cameraViewportSize(tester), const Size(361, 464));
   });
 
+  testWidgets('uses the Keystone permission card while access is pending', (
+    tester,
+  ) async {
+    _setViewSize(tester, const Size(393, 852));
+    final controller = MobileScannerController(autoStart: false);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(_app(controller: controller));
+    await tester.pump();
+
+    final cameraElement = tester.element(
+      find.byKey(const ValueKey('mobile_keystone_scan_camera')),
+    );
+    expect(
+      find.byKey(const ValueKey('mobile_keystone_scan_permission_card')),
+      findsOneWidget,
+    );
+    expect(find.text('Enable camera access'), findsOneWidget);
+    expect(
+      find.text('A camera is required to connect Keystone.'),
+      findsOneWidget,
+    );
+    expect(find.text('Grant access to your camera'), findsNothing);
+    expect(find.text('Scan the address QR code'), findsNothing);
+
+    controller.value = controller.value.copyWith(isInitialized: true);
+    await tester.pump();
+
+    expect(find.text('Loading...'), findsOneWidget);
+    expect(find.text('Enable camera access'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('mobile_keystone_scan_permission_card')),
+      findsNothing,
+    );
+    expect(
+      identical(
+        tester.element(
+          find.byKey(const ValueKey('mobile_keystone_scan_camera')),
+        ),
+        cameraElement,
+      ),
+      isTrue,
+    );
+  });
+
+  testWidgets('denied access uses the Keystone retry card', (tester) async {
+    _setViewSize(tester, const Size(393, 852));
+    final controller = MobileScannerController(autoStart: false);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(_app(controller: controller));
+    await tester.pump();
+
+    controller.value = controller.value.copyWith(
+      isInitialized: true,
+      error: const MobileScannerException(
+        errorCode: MobileScannerErrorCode.permissionDenied,
+      ),
+    );
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('mobile_keystone_scan_permission_card')),
+      findsOneWidget,
+    );
+    expect(find.text("You've denied camera access"), findsOneWidget);
+    expect(find.text('Request again'), findsOneWidget);
+    expect(find.text('Cancel'), findsNothing);
+  });
+
+  testWidgets('shows scan card once camera permission is granted and running', (
+    tester,
+  ) async {
+    _setViewSize(tester, const Size(393, 852));
+    final controller = MobileScannerController(autoStart: false);
+    addTearDown(controller.dispose);
+
+    controller.value = controller.value.copyWith(
+      isInitialized: true,
+      isRunning: true,
+    );
+    await tester.pumpWidget(_app(controller: controller));
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('mobile_keystone_scan_camera')), findsOne);
+    expect(find.text('Scan a Zcash QR code to continue'), findsOneWidget);
+    expect(find.text('Loading...'), findsNothing);
+    expect(find.text('Enable camera access'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('mobile_keystone_scan_permission_card')),
+      findsNothing,
+    );
+  });
+
   testWidgets('shrinks only the camera viewport on shorter phones', (
     tester,
   ) async {
     _setViewSize(tester, const Size(393, 667));
+    final controller = MobileScannerController(autoStart: false);
+    addTearDown(controller.dispose);
 
-    await tester.pumpWidget(_app());
+    controller.value = controller.value.copyWith(isInitialized: true);
+
+    await tester.pumpWidget(_app(controller: controller));
     await tester.pump();
 
     final cameraSize = _cameraViewportSize(tester);
@@ -151,13 +257,15 @@ void main() {
   ) async {
     _setViewSize(tester, const Size(393, 852));
     _rustApi.decodedAccounts = [_account(1), _account(2)];
+    final controller = MobileScannerController(autoStart: false);
+    addTearDown(controller.dispose);
 
-    await tester.pumpWidget(_routerApp());
+    await tester.pumpWidget(_routerApp(controller: controller));
     await tester.pump();
 
     tester
-        .widget<KeystoneQrScannerCard>(
-          find.byKey(const ValueKey('mobile_keystone_scan_card')),
+        .widget<AnimatedUrScannerView>(
+          find.byKey(const ValueKey('mobile_keystone_scan_camera')),
         )
         .onComplete(
           const ScanResult(urType: 'zcash-accounts', data: [1, 2, 3]),
@@ -175,13 +283,20 @@ void main() {
     tester,
   ) async {
     _setViewSize(tester, const Size(393, 852));
+    final controller = MobileScannerController(autoStart: false);
+    addTearDown(controller.dispose);
 
-    await tester.pumpWidget(_app());
+    controller.value = controller.value.copyWith(
+      isInitialized: true,
+      isRunning: true,
+    );
+
+    await tester.pumpWidget(_app(controller: controller));
     await tester.pump();
 
     tester
-        .widget<KeystoneQrScannerCard>(
-          find.byKey(const ValueKey('mobile_keystone_scan_card')),
+        .widget<AnimatedUrScannerView>(
+          find.byKey(const ValueKey('mobile_keystone_scan_camera')),
         )
         .onComplete(
           const ScanResult(urType: 'zcash-accounts', data: [1, 2, 3]),
@@ -217,6 +332,6 @@ void main() {
 
 Size _cameraViewportSize(WidgetTester tester) {
   return tester.getSize(
-    find.byKey(const ValueKey('keystone_qr_scanner_camera_viewport')),
+    find.byKey(const ValueKey('mobile_keystone_scan_card')),
   );
 }

--- a/test/features/onboarding/mobile_keystone_scan_screen_test.dart
+++ b/test/features/onboarding/mobile_keystone_scan_screen_test.dart
@@ -82,9 +82,9 @@ Widget _routerApp({
   );
 }
 
-KeystoneAccountInfo _account(int index) {
+KeystoneAccountInfo _account(int index, {String? name}) {
   return KeystoneAccountInfo(
-    name: 'Account $index',
+    name: name ?? 'Account $index',
     ufvk: 'u1testaccount$index ... 3123llasdasd',
     index: index,
     seedFingerprint: Uint8List.fromList([index, 0, 0, 0]),
@@ -369,6 +369,19 @@ void main() {
       expect(find.byType(MobileKeystoneScanScreen), findsOneWidget);
     },
   );
+
+  test('stores the fallback name on selected Keystone accounts', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    container.read(keystoneOnboardingProvider.notifier).setAccounts([
+      _account(0, name: '   '),
+    ]);
+
+    final state = container.read(keystoneOnboardingProvider);
+    expect(state.accounts.single.name, 'Account 1');
+    expect(state.selectedAccount?.name, 'Account 1');
+  });
 }
 
 Size _cameraViewportSize(WidgetTester tester) {

--- a/test/widgetbook/mobile_keystone_use_cases_test.dart
+++ b/test/widgetbook/mobile_keystone_use_cases_test.dart
@@ -1,0 +1,141 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart' show MaterialApp;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/widgetbook/keystone_use_cases.dart';
+
+void main() {
+  testWidgets('mobile Keystone scan permission use case renders dark card', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildMobileKeystoneScanRequestingUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Scan QR Code'), findsOneWidget);
+    expect(find.text('Enable camera access'), findsOneWidget);
+    expect(
+      find.text('A camera is required to connect Keystone.'),
+      findsOneWidget,
+    );
+    expect(
+      find.byKey(const ValueKey('mobile_keystone_scan_permission_card')),
+      findsOneWidget,
+    );
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('mobile_keystone_scan_widgetbook_card')),
+      ),
+      const Size(361, 464),
+    );
+  });
+
+  testWidgets('mobile Keystone scan denied use case exposes retry action', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildMobileKeystoneScanDeniedUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text("You've denied camera access"), findsOneWidget);
+    expect(find.text('Request again'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('mobile_keystone_scan_retry_button')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('mobile Keystone active scan use case renders common scan card', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildMobileKeystoneScanActiveUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Scan a Zcash QR code to continue'), findsOneWidget);
+    expect(find.text('Enable camera access'), findsNothing);
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('mobile_keystone_scan_widgetbook_card')),
+      ),
+      const Size(361, 694),
+    );
+    expect(
+      tester.getTopLeft(
+        find.byKey(const ValueKey('mobile_keystone_scan_widgetbook_card')),
+      ),
+      const Offset(16, 126),
+    );
+  });
+
+  testWidgets('mobile Keystone loading scan use case renders loading veil', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildMobileKeystoneScanLoadingUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Loading...'), findsOneWidget);
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('mobile_keystone_scan_widgetbook_card')),
+      ),
+      const Size(361, 694),
+    );
+  });
+
+  testWidgets('mobile Keystone select account use case lists seeded accounts', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildMobileKeystoneSelectAccountUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Select account'), findsWidgets);
+    expect(find.text('4 accounts found'), findsOneWidget);
+    expect(find.text('Account 1'), findsOneWidget);
+    expect(find.text('Account 4'), findsOneWidget);
+  });
+
+  testWidgets('mobile Keystone connect use case renders the intro cards', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildMobileKeystoneConnectUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Connect Keystone'), findsOneWidget);
+    expect(find.text('1. Check Keystone firmware'), findsOneWidget);
+    expect(find.text('2. Prepare to connect'), findsOneWidget);
+    expect(find.text('Continue'), findsOneWidget);
+  });
+
+  testWidgets('mobile Keystone birthday use case renders the entry row', (
+    tester,
+  ) async {
+    await _pumpUseCase(tester, buildMobileKeystoneBirthdayUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Around when did you create your wallet?'), findsOneWidget);
+    expect(find.text('Enter the date'), findsOneWidget);
+    expect(find.text('Enter the block height'), findsOneWidget);
+  });
+}
+
+Future<void> _pumpUseCase(WidgetTester tester, WidgetBuilder builder) async {
+  tester.view
+    ..physicalSize = const Size(393, 852)
+    ..devicePixelRatio = 1.0;
+  addTearDown(() {
+    tester.view
+      ..resetPhysicalSize()
+      ..resetDevicePixelRatio();
+  });
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.dark,
+        child: Builder(builder: builder),
+      ),
+    ),
+  );
+  await tester.pump();
+}

--- a/widgetbook.sh
+++ b/widgetbook.sh
@@ -1,12 +1,65 @@
 #!/bin/bash
 # Run the Zcash design-system Widgetbook.
-# Defaults to `-d macos` when no args are given; otherwise forwards args
-# through to `flutter run` (e.g. `-d chrome`, `--release`).
+#
+# Usage:
+#   ./widgetbook.sh            # macOS host, desktop tokens (default)
+#   ./widgetbook.sh --mobile   # macOS host, mobile tokens
+#
+# --mobile adds --dart-define=VIZOR_FORM_FACTOR=mobile. Widgetbook is exempt
+# from the main.dart form-factor/platform match check, so previewing the
+# mobile token set on the desktop host is supported.
+#
+# Web (`-d chrome`) is NOT supported: the app pulls in dart:ffi (the Rust
+# bridge) and 64-bit int literals (keccak256) that cannot compile to
+# JavaScript, and the project has no web/ platform folder. Use --mobile on the
+# macOS host and a Widgetbook device frame to preview mobile dimensions.
+#
+# Any other arguments are forwarded to `flutter run`
+# (e.g. --release, -d <device>).
 
 set -e
 
-if [ $# -eq 0 ]; then
-  exec fvm flutter run -t lib/widgetbook.dart -d macos
-fi
+usage() {
+  cat <<'EOF'
+Run the Zcash design-system Widgetbook.
 
-exec fvm flutter run -t lib/widgetbook.dart "$@"
+Usage:
+  ./widgetbook.sh            macOS host, desktop tokens (default)
+  ./widgetbook.sh --mobile   macOS host, mobile tokens
+
+Flags:
+  -m, --mobile   add --dart-define=VIZOR_FORM_FACTOR=mobile
+  -h, --help     show this help
+
+Any other arguments are forwarded to `flutter run` (e.g. --release, -d <device>).
+Web (-d chrome) is unsupported — the app cannot compile to JavaScript.
+EOF
+}
+
+DEFINE=()
+DEVICE=()
+EXTRA=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -m|--mobile)
+      DEFINE=(--dart-define=VIZOR_FORM_FACTOR=mobile)
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      EXTRA+=("$1")
+      ;;
+  esac
+  shift
+done
+
+# Default to the macOS host unless the caller forwarded their own device.
+case " ${EXTRA[*]} " in
+  *" -d "*|*" --device-id "*) ;;
+  *) DEVICE=(-d macos) ;;
+esac
+
+exec fvm flutter run -t lib/widgetbook.dart "${DEVICE[@]}" "${DEFINE[@]}" "${EXTRA[@]}"


### PR DESCRIPTION
## What

Polishes the mobile Keystone hardware-wallet onboarding flow and fixes a camera-permission bug on the scan step.

### Commits
1. **Extract a shared `MobileQrScanCard`** — split the live camera / permission / retry lifecycle out of `MobileAddressScanCard` into a reusable wrapper with an optional `permissionBuilder`. Backward-compatible; send / swap / address scan are unaffected.
2. **Reuse the shared scan card and polish mobile Keystone onboarding**
   - **Scan:** drop the desktop-origin `KeystoneQrScannerCard` on mobile and mount the animated-UR scanner on the shared card. **Fixes** the TestFlight bug where entering the scan step showed a permission-blocked card even with camera access granted — the initial frame was misclassified, so `denied` now requires a real `permissionDenied`. Requesting / denied render a theme-aware Keystone card; the live scan reuses the shared black camera surface.
   - **Connect:** two-card Figma layout with the ghost-button firmware link.
   - **Select account:** Figma radio-card list (64 px min-height, 8/12/4 padding, 12 px gaps, per-state weight/colour, border only on the selected card) + `Account N` fallback when the device name is empty.
3. **Add Keystone onboarding Widgetbook previews** — Connect, scan permission/denied/active/loading, Select account, Birthday height under `Screens > Onboarding > Mobile Keystone`, so the camera-less simulator can review every state.
4. **Add a `--mobile` flag to `widgetbook.sh`** — previews the mobile token set on the macOS host.

### Heads-up
This branch also carries the pre-existing commit `8bc4c3da Gate seed screenshot warnings by route` (mobile create-wallet seed-phrase screenshot gating). It's the only branch commit not already in `mobile-activity-polish`, so it rides along in this diff. Happy to move it to a separate PR if preferred.

## Verification
- `fvm flutter analyze` — clean
- Mobile lane (`--tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`, onboarding + widgetbook + address_scan): **100 pass**
- Desktop lane (onboarding + address_scan): **53 pass / 13 skip**
- Keystone permission card colours use theme-aware semantic tokens (light + dark), mapped against Figma nodes `4654:72631` / `4654:72955`.
