### PR TITLE
Refine mobile recipient focus styling

### DIFF
--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -56,7 +56,7 @@ List<RouteBase> buildMobileRoutes({
               GoRoute(
                 path: tab.path,
                 pageBuilder: (context, state) =>
-                    CupertinoPage(key: state.pageKey, child: tab.screen),
+                    NoTransitionPage(key: state.pageKey, child: tab.screen),
                 // Settings detail screens push over the shell (top-level
                 // routes below) so the bottom tab bar is hidden while
                 // they're open; nothing extra nests inside a branch.

--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -54,7 +54,7 @@ List<RouteBase> buildMobileRoutes({
               GoRoute(
                 path: tab.path,
                 pageBuilder: (context, state) =>
-                    NoTransitionPage(key: state.pageKey, child: tab.screen),
+                    CupertinoPage(key: state.pageKey, child: tab.screen),
                 // Settings detail screens push over the shell (top-level
                 // routes below) so the bottom tab bar is hidden while
                 // they're open; nothing extra nests inside a branch.

--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -45,8 +45,10 @@ List<RouteBase> buildMobileRoutes({
   return [
     ...entryRoutes,
     StatefulShellRoute.indexedStack(
-      builder: (context, state, navigationShell) =>
-          _MobileTabShell(navigationShell: navigationShell, tabs: tabs),
+      pageBuilder: (context, state, navigationShell) => CupertinoPage(
+        key: state.pageKey,
+        child: _MobileTabShell(navigationShell: navigationShell, tabs: tabs),
+      ),
       branches: [
         for (final tab in tabs)
           StatefulShellBranch(

--- a/lib/src/core/widgets/app_button.dart
+++ b/lib/src/core/widgets/app_button.dart
@@ -183,6 +183,8 @@ class AppButton extends StatefulWidget {
     this.minWidth,
     this.iconGap,
     this.focusRingColor,
+    this.disabledBackgroundColor,
+    this.enabledBorderColor,
     this.focusNode,
     this.autofocus = false,
     this.expand = false,
@@ -227,6 +229,12 @@ class AppButton extends StatefulWidget {
 
   /// Optional focus ring color override for one-off surface-specific cases.
   final Color? focusRingColor;
+
+  /// Optional disabled fill override for one-off surface-specific cases.
+  final Color? disabledBackgroundColor;
+
+  /// Optional border color override for enabled states.
+  final Color? enabledBorderColor;
 
   final FocusNode? focusNode;
   final bool autofocus;
@@ -282,7 +290,7 @@ class _AppButtonState extends State<AppButton> {
 
     // Fill priority: disabled > pressed > hover > default.
     final Color currentBg = !_enabled
-        ? disabled.bg
+        ? widget.disabledBackgroundColor ?? disabled.bg
         : _pressed
         ? palette.bgPressed
         : _hovered
@@ -294,13 +302,14 @@ class _AppButtonState extends State<AppButton> {
         : _pressed || _hovered
         ? palette.labelHover
         : palette.label;
-    final Color borderColor = !_enabled
-        ? palette.border
-        : _pressed
+    final Color stateBorderColor = _pressed
         ? palette.borderPressed
         : _hovered
         ? palette.borderHover
         : palette.border;
+    final Color borderColor = !_enabled
+        ? palette.border
+        : widget.enabledBorderColor ?? stateBorderColor;
     final borderWidth = _enabled ? palette.borderWidth : 0.0;
     final iconGap = widget.iconGap ?? sizing.gap;
     final contentPadding = widget.contentPadding ?? sizing.padding;

--- a/lib/src/core/widgets/app_toast.dart
+++ b/lib/src/core/widgets/app_toast.dart
@@ -77,6 +77,13 @@ class _AppToastHostState extends State<AppToastHost> {
   static final List<_AppToastHostState> _activeStates = [];
   static OverlayEntry? _fallbackOverlayEntry;
 
+  static _AppToastHostState? get _lastActiveState {
+    for (final state in _activeStates.reversed) {
+      if (state.mounted) return state;
+    }
+    return null;
+  }
+
   String? _message;
   String _iconName = AppIcons.checkCircle;
   Timer? _timer;
@@ -166,10 +173,9 @@ void showAppToast(
     return;
   }
 
-  final fallbackState = _AppToastHostState._activeStates.isEmpty
-      ? null
-      : _AppToastHostState._activeStates.last;
-  if (fallbackState != null) {
+  final fallbackState = _AppToastHostState._lastActiveState;
+  if (fallbackState != null &&
+      _canUseToastHostForContext(context, fallbackState.context)) {
     fallbackState.show(message, duration: duration, iconName: iconName);
     return;
   }
@@ -180,10 +186,25 @@ void showAppToast(
     return;
   }
 
+  if (fallbackState != null) {
+    fallbackState.show(message, duration: duration, iconName: iconName);
+    return;
+  }
+
   assert(
     fallbackState != null,
     'showAppToast called without an AppToastHost ancestor.',
   );
+}
+
+bool _canUseToastHostForContext(
+  BuildContext toastContext,
+  BuildContext hostContext,
+) {
+  final toastRoute = ModalRoute.of(toastContext);
+  final hostRoute = ModalRoute.of(hostContext);
+  if (toastRoute == null || hostRoute == null) return true;
+  return identical(toastRoute, hostRoute);
 }
 
 void _showOverlayToast(

--- a/lib/src/core/widgets/app_toast.dart
+++ b/lib/src/core/widgets/app_toast.dart
@@ -21,40 +21,43 @@ class AppToast extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: colors.background.inverse,
-        borderRadius: BorderRadius.circular(AppRadii.small),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: AppSpacing.s,
-          vertical: AppSpacing.xs,
+    return DefaultTextStyle.merge(
+      style: const TextStyle(decoration: TextDecoration.none),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: colors.background.inverse,
+          borderRadius: BorderRadius.circular(AppRadii.small),
         ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            AppIcon(
-              iconName,
-              size: AppIconSize.medium,
-              color: colors.icon.inverse,
-            ),
-            const SizedBox(width: AppSpacing.xxs),
-            // Flexible so long messages wrap inside the pill instead of
-            // overflowing the row off-screen.
-            Flexible(
-              child: Text(
-                message,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-                textAlign: TextAlign.center,
-                style: AppTypography.labelLarge.copyWith(
-                  color: colors.text.inverse,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.s,
+            vertical: AppSpacing.xs,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              AppIcon(
+                iconName,
+                size: AppIconSize.medium,
+                color: colors.icon.inverse,
+              ),
+              const SizedBox(width: AppSpacing.xxs),
+              // Flexible so long messages wrap inside the pill instead of
+              // overflowing the row off-screen.
+              Flexible(
+                child: Text(
+                  message,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                  style: AppTypography.labelLarge.copyWith(
+                    color: colors.text.inverse,
+                  ),
                 ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -163,20 +166,24 @@ void showAppToast(
     return;
   }
 
+  final fallbackState = _AppToastHostState._activeStates.isEmpty
+      ? null
+      : _AppToastHostState._activeStates.last;
+  if (fallbackState != null) {
+    fallbackState.show(message, duration: duration, iconName: iconName);
+    return;
+  }
+
   final overlay = Overlay.maybeOf(context, rootOverlay: true);
   if (overlay != null) {
     _showOverlayToast(overlay, message, duration: duration, iconName: iconName);
     return;
   }
 
-  final fallbackState = _AppToastHostState._activeStates.isEmpty
-      ? null
-      : _AppToastHostState._activeStates.last;
   assert(
     fallbackState != null,
     'showAppToast called without an AppToastHost ancestor.',
   );
-  fallbackState?.show(message, duration: duration, iconName: iconName);
 }
 
 void _showOverlayToast(

--- a/lib/src/core/widgets/mobile_text_field.dart
+++ b/lib/src/core/widgets/mobile_text_field.dart
@@ -32,6 +32,7 @@ class MobileTextField extends StatefulWidget {
     this.backgroundColor,
     this.restingBorderColor,
     this.focusedBorderColor,
+    this.focusedBoxShadow,
     this.textStyle,
     this.hintStyle,
     this.height,
@@ -67,6 +68,9 @@ class MobileTextField extends StatefulWidget {
 
   /// Optional border shown when focused. Defaults to the inverse focus ring.
   final Color? focusedBorderColor;
+
+  /// Optional shadow shown only when focused.
+  final List<BoxShadow>? focusedBoxShadow;
 
   /// Optional text style override. Color is not injected automatically.
   final TextStyle? textStyle;
@@ -124,6 +128,20 @@ class _MobileTextFieldState extends State<MobileTextField> {
     final hintStyle =
         widget.hintStyle ??
         AppTypography.labelMedium.copyWith(color: colors.text.muted);
+    final surfaceShadow = [
+      BoxShadow(color: colors.shadows.subtle, blurRadius: 1),
+      BoxShadow(
+        color: colors.shadows.subtle,
+        offset: const Offset(0, 2),
+        blurRadius: 4,
+      ),
+      BoxShadow(
+        color: colors.shadows.subtle,
+        offset: const Offset(0, 1),
+        blurRadius: 2,
+      ),
+      BoxShadow(color: colors.shadows.subtle, blurRadius: 1),
+    ];
     return Container(
       // Mobile input metrics (AppInputSizing → 60px tall, radius 16); desktop
       // resolves these to 46 / 12. The surface fill, the focus-only inverse
@@ -142,20 +160,9 @@ class _MobileTextFieldState extends State<MobileTextField> {
           width: 1.5,
           strokeAlign: BorderSide.strokeAlignInside,
         ),
-        boxShadow: [
-          BoxShadow(color: colors.shadows.subtle, blurRadius: 1),
-          BoxShadow(
-            color: colors.shadows.subtle,
-            offset: const Offset(0, 2),
-            blurRadius: 4,
-          ),
-          BoxShadow(
-            color: colors.shadows.subtle,
-            offset: const Offset(0, 1),
-            blurRadius: 2,
-          ),
-          BoxShadow(color: colors.shadows.subtle, blurRadius: 1),
-        ],
+        boxShadow: focused
+            ? widget.focusedBoxShadow ?? surfaceShadow
+            : surfaceShadow,
       ),
       child: Row(
         children: [

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -270,6 +270,11 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       _step == _SendStep.recipient &&
       _addressFocus.hasFocus;
 
+  bool get _routePopAllowed =>
+      _phase == _SendPhase.compose &&
+      _step == _SendStep.recipient &&
+      !_isConfirmingSend;
+
   bool get _isShieldedAddress =>
       _addressType == 'unified' || _addressType == 'sapling';
 
@@ -768,7 +773,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     };
 
     return PopScope<void>(
-      canPop: false,
+      canPop: _routePopAllowed,
       onPopInvokedWithResult: (didPop, _) {
         if (!didPop) _handleBack();
       },

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -98,7 +98,8 @@ const _kMobileSendAddressFieldGroupHeight =
     AppInputSizing.height +
     _kMobileSendAddressErrorGap +
     _kMobileSendRecipientLineHeight;
-const _kMobileSendRecipientFocusFieldTop = kMobileTopNavHeight + AppSpacing.sm;
+const _kMobileSendRecipientFocusScrimTop =
+    kMobileTopNavHeight + AppSpacing.s + _kMobileSendAddressFieldGroupHeight;
 const _kMobileSendAmountFieldHeight = 178.0;
 const _kMobileSendAmountInputHeight = 64.0;
 const _kMobileSendAmountLineHeight = 17.0;
@@ -764,7 +765,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       _SendPhase.compose => switch (_step) {
         _SendStep.recipient => _buildRecipientStep(
           context,
-          elevateFocusedControls: showRecipientFocusOverlay,
+          hasFocusedRecipient: showRecipientFocusOverlay,
         ),
         _SendStep.amount => _buildAmountStep(context),
         _SendStep.review => _buildReviewStep(context),
@@ -792,24 +793,19 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                 ),
               ),
               if (showRecipientFocusOverlay) ...[
-                Positioned.fill(
+                Positioned(
+                  top:
+                      MediaQuery.paddingOf(context).top +
+                      _kMobileSendRecipientFocusScrimTop,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
                   child: GestureDetector(
                     key: const ValueKey('mobile_send_recipient_focus_scrim'),
                     behavior: HitTestBehavior.opaque,
                     onTap: _addressFocus.unfocus,
                     child: ColoredBox(color: colors.background.neutralScrim),
                   ),
-                ),
-                Positioned(
-                  key: const ValueKey(
-                    'mobile_send_recipient_focus_address_layer',
-                  ),
-                  top:
-                      MediaQuery.paddingOf(context).top +
-                      _kMobileSendRecipientFocusFieldTop,
-                  left: AppSpacing.sm,
-                  right: AppSpacing.sm,
-                  child: _buildAddressFieldGroup(context),
                 ),
                 if (_showRecipientContinue)
                   Positioned(
@@ -833,7 +829,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
 
   Widget _buildRecipientStep(
     BuildContext context, {
-    required bool elevateFocusedControls,
+    required bool hasFocusedRecipient,
   }) {
     final colors = context.colors;
     final contacts = [
@@ -854,13 +850,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
               AppSpacing.md,
             ),
             children: [
-              if (elevateFocusedControls)
-                const SizedBox(
-                  key: ValueKey('mobile_send_address_field_placeholder'),
-                  height: _kMobileSendAddressFieldGroupHeight,
-                )
-              else
-                _buildAddressFieldGroup(context),
+              _buildAddressFieldGroup(context),
               const SizedBox(height: AppSpacing.md),
               Semantics(
                 button: true,
@@ -999,7 +989,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
             ],
           ),
         ),
-        if (_showRecipientContinue && !elevateFocusedControls)
+        if (_showRecipientContinue && !hasFocusedRecipient)
           Padding(
             padding: const EdgeInsets.fromLTRB(
               AppSpacing.sm,

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -624,12 +624,12 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         return;
       }
       if (!mounted) return;
-      context.go('/send/status', extra: keystone);
+      context.pushReplacement('/send/status', extra: keystone);
       return;
     }
 
     if (!mounted) return;
-    context.go('/send/status', extra: args);
+    context.pushReplacement('/send/status', extra: args);
   }
 
   // ── Navigation ─────────────────────────────────────────────────────

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -98,8 +98,6 @@ const _kMobileSendAddressFieldGroupHeight =
     AppInputSizing.height +
     _kMobileSendAddressErrorGap +
     _kMobileSendRecipientLineHeight;
-const _kMobileSendRecipientFocusScrimTop =
-    kMobileTopNavHeight + AppSpacing.s + _kMobileSendAddressFieldGroupHeight;
 const _kMobileSendAmountFieldHeight = 178.0;
 const _kMobileSendAmountInputHeight = 64.0;
 const _kMobileSendAmountLineHeight = 17.0;
@@ -751,6 +749,8 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final showRecipientFocusOverlay = _showRecipientFocusOverlay;
+    final showRecipientFieldLayer =
+        _phase == _SendPhase.compose && _step == _SendStep.recipient;
 
     final title = switch (_phase) {
       _SendPhase.compose => switch (_step) {
@@ -793,13 +793,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                 ),
               ),
               if (showRecipientFocusOverlay) ...[
-                Positioned(
-                  top:
-                      MediaQuery.paddingOf(context).top +
-                      _kMobileSendRecipientFocusScrimTop,
-                  left: 0,
-                  right: 0,
-                  bottom: 0,
+                Positioned.fill(
+                  key: const ValueKey(
+                    'mobile_send_recipient_focus_scrim_layer',
+                  ),
                   child: GestureDetector(
                     key: const ValueKey('mobile_send_recipient_focus_scrim'),
                     behavior: HitTestBehavior.opaque,
@@ -807,6 +804,19 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                     child: ColoredBox(color: colors.background.neutralScrim),
                   ),
                 ),
+              ],
+              if (showRecipientFieldLayer)
+                Positioned(
+                  key: const ValueKey('mobile_send_recipient_field_layer'),
+                  top:
+                      MediaQuery.paddingOf(context).top +
+                      kMobileTopNavHeight +
+                      AppSpacing.s,
+                  left: AppSpacing.sm,
+                  right: AppSpacing.sm,
+                  child: _buildAddressFieldGroup(context),
+                ),
+              if (showRecipientFocusOverlay) ...[
                 if (_showRecipientContinue)
                   Positioned(
                     key: const ValueKey(
@@ -845,13 +855,13 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
           child: ListView(
             padding: const EdgeInsets.fromLTRB(
               AppSpacing.sm,
-              AppSpacing.s,
+              AppSpacing.s +
+                  _kMobileSendAddressFieldGroupHeight +
+                  AppSpacing.md,
               AppSpacing.sm,
               AppSpacing.md,
             ),
             children: [
-              _buildAddressFieldGroup(context),
-              const SizedBox(height: AppSpacing.md),
               Semantics(
                 button: true,
                 child: GestureDetector(
@@ -1005,6 +1015,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
 
   Widget _buildAddressFieldGroup(BuildContext context) {
     return Column(
+      key: const ValueKey('mobile_send_address_field_group'),
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [_buildAddressField(context), _buildAddressErrorSpace(context)],

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -801,7 +801,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                     key: const ValueKey('mobile_send_recipient_focus_scrim'),
                     behavior: HitTestBehavior.opaque,
                     onTap: _addressFocus.unfocus,
-                    child: ColoredBox(color: colors.background.neutralScrim),
+                    child: const SizedBox.expand(),
                   ),
                 ),
               ],
@@ -825,7 +825,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                     left: AppSpacing.sm,
                     right: AppSpacing.sm,
                     bottom: MediaQuery.paddingOf(context).bottom + AppSpacing.s,
-                    child: _buildRecipientContinueButton(context),
+                    child: _buildRecipientContinueButton(
+                      context,
+                      useBackdropColors: true,
+                    ),
                   ),
               ],
             ],
@@ -1025,6 +1028,8 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   Widget _buildAddressField(BuildContext context) {
     final colors = context.colors;
     final showAction = _addressFocus.hasFocus;
+    final hasAddressError =
+        _addressType == 'invalid' || _addressType == 'error';
     return MobileTextField(
       key: const ValueKey('mobile_send_address_field'),
       fieldKey: const ValueKey('mobile_send_address_input'),
@@ -1045,11 +1050,21 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
           ),
         ),
       ),
-      restingBorderColor: _addressType == 'invalid' || _addressType == 'error'
+      restingBorderColor: hasAddressError
           ? colors.border.utilityDestructive
           : null,
-      focusedBorderColor: _addressType == 'invalid' || _addressType == 'error'
+      focusedBorderColor: hasAddressError
           ? colors.border.utilityDestructive
+          : const Color(0x00000000),
+      focusedBoxShadow: showAction
+          ? [
+              BoxShadow(
+                color: colors.background.neutralScrim,
+                offset: const Offset(0, 4),
+                blurRadius: 4,
+                spreadRadius: 1000,
+              ),
+            ]
           : null,
       trailing: showAction
           ? SizedBox(
@@ -1097,13 +1112,23 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     );
   }
 
-  Widget _buildRecipientContinueButton(BuildContext context) {
+  Widget _buildRecipientContinueButton(
+    BuildContext context, {
+    bool useBackdropColors = false,
+  }) {
+    final colors = context.colors;
     return SizedBox(
       width: double.infinity,
       child: AppButton(
         key: const ValueKey('mobile_send_continue'),
         expand: true,
         constrainContent: true,
+        disabledBackgroundColor: useBackdropColors
+            ? Color.alphaBlend(colors.button.disabled.bg, colors.surface.input)
+            : null,
+        enabledBorderColor: useBackdropColors
+            ? colors.border.subtleOpacity
+            : null,
         onPressed: _hasValidAddress ? _continueToAmount : null,
         child: Text(
           _addressController.text.trim().isEmpty

--- a/lib/src/features/send/screens/mobile/mobile_send_status_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_status_screen.dart
@@ -138,8 +138,14 @@ class _MobileSendStatusScreenState
 
   void _handleBack() {
     if (_phase == _MobileSendStatusPhase.sending) return;
+    if (context.canPop()) {
+      context.pop();
+      return;
+    }
     context.go('/home');
   }
+
+  bool get _routePopAllowed => _phase != _MobileSendStatusPhase.sending;
 
   Future<void> _openExplorer() async {
     final txid = _displayTxid;
@@ -171,7 +177,7 @@ class _MobileSendStatusScreenState
     );
 
     return PopScope<void>(
-      canPop: false,
+      canPop: _routePopAllowed,
       onPopInvokedWithResult: (didPop, _) {
         if (!didPop) _handleBack();
       },
@@ -675,11 +681,15 @@ class _StatusChip extends StatelessWidget {
         children: [
           AppIcon(iconName, size: 20, color: color),
           const SizedBox(width: AppSpacing.xxs),
-          Text(
-            text,
-            style: AppTypography.labelLarge.copyWith(
-              fontWeight: FontWeight.w600,
-              color: color,
+          Flexible(
+            child: Text(
+              text,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.labelLarge.copyWith(
+                fontWeight: FontWeight.w600,
+                color: color,
+              ),
             ),
           ),
         ],

--- a/test/core/navigation/mobile_routes_test.dart
+++ b/test/core/navigation/mobile_routes_test.dart
@@ -8,11 +8,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/layout/mobile/app_mobile_shell.dart';
 import 'package:zcash_wallet/src/core/navigation/mobile_routes.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/activity/screens/mobile/mobile_activity_screen.dart';
 import 'package:zcash_wallet/src/features/home/screens/mobile/mobile_home_screen.dart';
+import 'package:zcash_wallet/src/features/receive/screens/mobile/mobile_receive_screen.dart';
 import 'package:zcash_wallet/src/features/send/screens/mobile/mobile_send_screen.dart';
 import 'package:zcash_wallet/src/features/swap/screens/mobile/mobile_swap_screen.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
@@ -83,6 +85,10 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(MobileHomeScreen), findsOneWidget);
+    final shellRoute = ModalRoute.of(
+      tester.element(find.byType(AppMobileShell)),
+    );
+    expect(shellRoute, isA<CupertinoRouteTransitionMixin<dynamic>>());
     for (final label in ['Home', 'Swap', 'Activity', 'Settings']) {
       expect(find.bySemanticsLabel(label), findsWidgets);
     }
@@ -125,6 +131,27 @@ void main() {
     await tester.tap(find.bySemanticsLabel('Back'));
     await tester.pumpAndSettle();
     expect(find.byType(MobileSendScreen), findsNothing);
+    expect(find.byType(MobileHomeScreen), findsOneWidget);
+  });
+
+  testWidgets('receive pushes over a Cupertino shell page', (tester) async {
+    await tester.pumpWidget(_app(_router()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Receive'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+
+    expect(find.byType(MobileReceiveScreen), findsOneWidget);
+    final route = ModalRoute.of(
+      tester.element(find.byType(MobileReceiveScreen)),
+    );
+    expect(route, isA<CupertinoRouteTransitionMixin<dynamic>>());
+
+    await tester.tap(find.bySemanticsLabel('Back'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
+    expect(find.byType(MobileReceiveScreen), findsNothing);
     expect(find.byType(MobileHomeScreen), findsOneWidget);
   });
 }

--- a/test/core/widgets/app_toast_test.dart
+++ b/test/core/widgets/app_toast_test.dart
@@ -53,6 +53,27 @@ void main() {
     expect(icon.color, AppThemeData.light.colors.icon.inverse);
   });
 
+  testWidgets('AppToast clears inherited text decoration', (tester) async {
+    await tester.pumpWidget(
+      const _ThemedHarness(
+        theme: AppThemeData.light,
+        child: DefaultTextStyle(
+          style: TextStyle(
+            decoration: TextDecoration.underline,
+            decorationColor: Colors.yellow,
+          ),
+          child: Center(child: AppToast(message: 'Address copied')),
+        ),
+      ),
+    );
+
+    final textContext = tester.element(find.text('Address copied'));
+    expect(
+      DefaultTextStyle.of(textContext).style.decoration,
+      TextDecoration.none,
+    );
+  });
+
   testWidgets('showAppToast displays a top-centered transient toast', (
     tester,
   ) async {

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -273,6 +273,33 @@ bool _sendRouteCanPop(WidgetTester tester) {
   return popScope.canPop;
 }
 
+BoxDecoration _fieldDecoration(WidgetTester tester, Finder fieldFinder) {
+  final containers = tester.widgetList<Container>(
+    find.descendant(of: fieldFinder, matching: find.byType(Container)),
+  );
+  return containers
+      .map((container) => container.decoration)
+      .whereType<BoxDecoration>()
+      .firstWhere(
+        (decoration) =>
+            decoration.borderRadius ==
+            BorderRadius.circular(AppInputSizing.radius),
+      );
+}
+
+ShapeDecoration _continueButtonDecoration(WidgetTester tester) {
+  final containers = tester.widgetList<AnimatedContainer>(
+    find.descendant(
+      of: find.byKey(const ValueKey('mobile_send_continue')),
+      matching: find.byType(AnimatedContainer),
+    ),
+  );
+  return containers
+      .map((container) => container.decoration)
+      .whereType<ShapeDecoration>()
+      .firstWhere((decoration) => decoration.shape is StadiumBorder);
+}
+
 void main() {
   setUpAll(() {
     RustLib.initMock(api: _RustApiFake());
@@ -445,6 +472,17 @@ void main() {
         tester.widget<EditableText>(inputFinder).focusNode.hasFocus,
         isTrue,
       );
+      final focusedDecoration = _fieldDecoration(tester, fieldFinder);
+      final focusedBorder = focusedDecoration.border as Border;
+      expect(focusedBorder.top.color, const Color(0x00000000));
+      final focusedShadow = focusedDecoration.boxShadow!.single;
+      expect(
+        focusedShadow.color,
+        AppThemeData.light.colors.background.neutralScrim,
+      );
+      expect(focusedShadow.offset, const Offset(0, 4));
+      expect(focusedShadow.blurRadius, 4);
+      expect(focusedShadow.spreadRadius, 1000);
       expect(tester.getRect(fieldFinder), rectBeforeFocus);
       expect(tester.getRect(groupFinder), groupRectBeforeFocus);
       expect(tester.getRect(scanRowFinder), scanRowRectBeforeFocus);
@@ -467,6 +505,54 @@ void main() {
       expect(scrimRect.bottom, greaterThan(fieldRect.bottom));
     },
   );
+
+  testWidgets('recipient focus applies backdrop-only Continue colors', (
+    tester,
+  ) async {
+    final colors = AppThemeData.light.colors;
+    final fieldFinder = find.byKey(const ValueKey('mobile_send_address_field'));
+    final scrimFinder = find.byKey(
+      const ValueKey('mobile_send_recipient_focus_scrim'),
+    );
+
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+
+    await tester.tap(fieldFinder);
+    await tester.pumpAndSettle();
+
+    var decoration = _continueButtonDecoration(tester);
+    expect(
+      decoration.color,
+      Color.alphaBlend(colors.button.disabled.bg, colors.surface.input),
+    );
+
+    await _enterAddress(tester, _invalidAddress);
+    await tester.tap(scrimFinder);
+    await tester.pumpAndSettle();
+
+    decoration = _continueButtonDecoration(tester);
+    expect(decoration.color, colors.button.disabled.bg);
+
+    await tester.tap(fieldFinder);
+    await tester.pumpAndSettle();
+    await _enterAddress(tester, _shieldedAddress);
+
+    decoration = _continueButtonDecoration(tester);
+    final focusedEnabledBorder = decoration.shape as StadiumBorder;
+    expect(decoration.color, colors.button.primary.bg);
+    expect(focusedEnabledBorder.side.color, colors.border.subtleOpacity);
+    expect(focusedEnabledBorder.side.width, 1.5);
+
+    await tester.tap(scrimFinder);
+    await tester.pumpAndSettle();
+
+    decoration = _continueButtonDecoration(tester);
+    final normalEnabledBorder = decoration.shape as StadiumBorder;
+    expect(decoration.color, colors.button.primary.bg);
+    expect(normalEnabledBorder.side.color, colors.button.primary.border);
+    expect(normalEnabledBorder.side.width, 1.5);
+  });
 
   testWidgets('tapping a contact fills its address', (tester) async {
     await tester.pumpWidget(

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -399,32 +399,54 @@ void main() {
     expect(find.text('Continue'), findsOneWidget);
   });
 
-  testWidgets('recipient focus scrim covers the full safe-area frame', (
-    tester,
-  ) async {
-    await tester.pumpWidget(
-      _app(viewPadding: const EdgeInsets.only(top: 55, bottom: 34)),
-    );
-    await tester.pumpAndSettle();
+  testWidgets(
+    'recipient focus keeps the address field mounted and stationary',
+    (tester) async {
+      await tester.pumpWidget(
+        _app(viewPadding: const EdgeInsets.only(top: 55, bottom: 34)),
+      );
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(const ValueKey('mobile_send_address_field')));
-    await tester.pumpAndSettle();
+      final fieldFinder = find.byKey(
+        const ValueKey('mobile_send_address_field'),
+      );
+      final inputFinder = find.descendant(
+        of: fieldFinder,
+        matching: find.byType(EditableText),
+      );
+      final rectBeforeFocus = tester.getRect(fieldFinder);
+      expect(
+        tester.widget<EditableText>(inputFinder).focusNode.hasFocus,
+        isFalse,
+      );
 
-    final scrimRect = tester.getRect(
-      find.byKey(const ValueKey('mobile_send_recipient_focus_scrim')),
-    );
-    expect(scrimRect, Offset.zero & const Size(520, 1100));
-    expect(
-      tester
-          .getRect(
-            find.byKey(
-              const ValueKey('mobile_send_recipient_focus_address_layer'),
-            ),
-          )
-          .top,
-      143,
-    );
-  });
+      await tester.tap(find.byKey(const ValueKey('mobile_send_address_field')));
+      await tester.pumpAndSettle();
+
+      expect(fieldFinder, findsOneWidget);
+      expect(inputFinder, findsOneWidget);
+      expect(
+        tester.widget<EditableText>(inputFinder).focusNode.hasFocus,
+        isTrue,
+      );
+      expect(tester.getRect(fieldFinder), rectBeforeFocus);
+      expect(tester.getSize(fieldFinder).height, AppInputSizing.height);
+      expect(
+        find.byKey(const ValueKey('mobile_send_recipient_focus_address_layer')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey('mobile_send_address_field_placeholder')),
+        findsNothing,
+      );
+
+      final fieldRect = tester.getRect(fieldFinder);
+      final scrimRect = tester.getRect(
+        find.byKey(const ValueKey('mobile_send_recipient_focus_scrim')),
+      );
+      expect(scrimRect.top, greaterThanOrEqualTo(fieldRect.bottom));
+    },
+  );
 
   testWidgets('tapping a contact fills its address', (tester) async {
     await tester.pumpWidget(

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -196,6 +196,11 @@ Future<void> _toReviewStep(
   await tester.pumpAndSettle();
 }
 
+bool _sendRouteCanPop(WidgetTester tester) {
+  final popScope = tester.widget<PopScope<void>>(find.byType(PopScope<void>));
+  return popScope.canPop;
+}
+
 void main() {
   setUpAll(() {
     RustLib.initMock(api: _RustApiFake());
@@ -207,6 +212,27 @@ void main() {
     binding.platformDispatcher.views.first
       ..physicalSize = const Size(520, 1100)
       ..devicePixelRatio = 1.0;
+  });
+
+  testWidgets('route pop is allowed only on the first recipient step', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Select Recipient'), findsOneWidget);
+    expect(_sendRouteCanPop(tester), isTrue);
+
+    await _toAmountStep(tester, _shieldedAddress);
+    expect(find.text('Enter amount'), findsOneWidget);
+    expect(_sendRouteCanPop(tester), isFalse);
+
+    await _enterAmount(tester, '1.5');
+    await tester.tap(find.byKey(const ValueKey('mobile_send_review_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review Send'), findsOneWidget);
+    expect(_sendRouteCanPop(tester), isFalse);
   });
 
   testWidgets('recipient step gates Continue on a valid address', (
@@ -713,6 +739,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Send failed'), findsNWidgets(2)); // nav title + headline
+    expect(_sendRouteCanPop(tester), isFalse);
     await tester.tap(find.byKey(const ValueKey('mobile_send_try_again')));
     await tester.pumpAndSettle();
     expect(find.text('Review Send'), findsOneWidget);

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -410,11 +410,22 @@ void main() {
       final fieldFinder = find.byKey(
         const ValueKey('mobile_send_address_field'),
       );
+      final fieldLayerFinder = find.byKey(
+        const ValueKey('mobile_send_recipient_field_layer'),
+      );
+      final groupFinder = find.byKey(
+        const ValueKey('mobile_send_address_field_group'),
+      );
+      final scanRowFinder = find.byKey(const ValueKey('mobile_send_scan_row'));
       final inputFinder = find.descendant(
         of: fieldFinder,
         matching: find.byType(EditableText),
       );
+      final fieldLayerElementBeforeFocus = tester.element(fieldLayerFinder);
+      final inputElementBeforeFocus = tester.element(inputFinder);
       final rectBeforeFocus = tester.getRect(fieldFinder);
+      final groupRectBeforeFocus = tester.getRect(groupFinder);
+      final scanRowRectBeforeFocus = tester.getRect(scanRowFinder);
       expect(
         tester.widget<EditableText>(inputFinder).focusNode.hasFocus,
         isFalse,
@@ -426,10 +437,17 @@ void main() {
       expect(fieldFinder, findsOneWidget);
       expect(inputFinder, findsOneWidget);
       expect(
+        tester.element(fieldLayerFinder),
+        same(fieldLayerElementBeforeFocus),
+      );
+      expect(tester.element(inputFinder), same(inputElementBeforeFocus));
+      expect(
         tester.widget<EditableText>(inputFinder).focusNode.hasFocus,
         isTrue,
       );
       expect(tester.getRect(fieldFinder), rectBeforeFocus);
+      expect(tester.getRect(groupFinder), groupRectBeforeFocus);
+      expect(tester.getRect(scanRowFinder), scanRowRectBeforeFocus);
       expect(tester.getSize(fieldFinder).height, AppInputSizing.height);
       expect(
         find.byKey(const ValueKey('mobile_send_recipient_focus_address_layer')),
@@ -444,7 +462,9 @@ void main() {
       final scrimRect = tester.getRect(
         find.byKey(const ValueKey('mobile_send_recipient_focus_scrim')),
       );
-      expect(scrimRect.top, greaterThanOrEqualTo(fieldRect.bottom));
+      expect(scrimRect, Offset.zero & const Size(520, 1100));
+      expect(scrimRect.top, lessThan(fieldRect.top));
+      expect(scrimRect.bottom, greaterThan(fieldRect.bottom));
     },
   );
 

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -24,6 +24,8 @@ const _shieldedAddress =
 const _transparentAddress = 't1transparentdestination0000000000000000000';
 const _invalidAddress = 'not-an-address';
 
+var _proposeSendSucceeds = false;
+
 class _RustApiFake implements RustLibApi {
   @override
   Future<AddressValidationResult> crateApiSyncValidateAddress({
@@ -55,6 +57,26 @@ class _RustApiFake implements RustLibApi {
     // assert Continue stays blocked until the estimate lands.
     await Future<void>.delayed(const Duration(milliseconds: 50));
     return BigInt.from(10000);
+  }
+
+  @override
+  Future<ProposalResult> crateApiSyncProposeSend({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String sendFlowId,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+  }) async {
+    if (!_proposeSendSucceeds) {
+      throw StateError('proposal failed');
+    }
+    return ProposalResult(
+      proposalId: BigInt.from(1),
+      needsSaplingParams: false,
+      feeZatoshi: BigInt.from(10000),
+    );
   }
 
   @override
@@ -160,6 +182,56 @@ Widget _app({
   );
 }
 
+Widget _sendFlowRouterApp() {
+  final router = GoRouter(
+    initialLocation: '/home',
+    routes: [
+      GoRoute(
+        path: '/home',
+        builder: (context, _) => TextButton(
+          key: const ValueKey('mobile_send_open_from_home'),
+          onPressed: () => context.push('/send'),
+          child: const Text('home'),
+        ),
+      ),
+      GoRoute(
+        path: '/send',
+        builder: (_, _) => MobileSendScreen(
+          loadWalletDbPath: () async => '/tmp/zcash-test',
+          openScanner: (_) async => null,
+        ),
+      ),
+      GoRoute(
+        path: '/send/status',
+        builder: (context, _) => TextButton(
+          key: const ValueKey('mobile_send_status_pop'),
+          onPressed: context.canPop() ? () => context.pop() : null,
+          child: Text(
+            context.canPop() ? 'status can pop' : 'status cannot pop',
+          ),
+        ),
+      ),
+    ],
+  );
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap()),
+      syncProvider.overrideWith(_FakeSyncNotifier.new),
+      zecMarketDataSourceProvider.overrideWithValue(
+        const _FakeMarketDataSource(),
+      ),
+      addressBookRepositoryProvider.overrideWithValue(
+        _FakeAddressBookRepository(const []),
+      ),
+      ownAccountAddressesProvider.overrideWith((ref) async => const {}),
+    ],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (context, c) => AppTheme(data: AppThemeData.light, child: c!),
+    ),
+  );
+}
+
 Future<void> _enterAddress(WidgetTester tester, String address) async {
   await tester.enterText(
     find.descendant(
@@ -208,6 +280,7 @@ void main() {
   tearDownAll(RustLib.dispose);
 
   setUp(() {
+    _proposeSendSucceeds = false;
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
     binding.platformDispatcher.views.first
       ..physicalSize = const Size(520, 1100)
@@ -234,6 +307,32 @@ void main() {
     expect(find.text('Review Send'), findsOneWidget);
     expect(_sendRouteCanPop(tester), isFalse);
   });
+
+  testWidgets(
+    'send status replaces the send route so completed status can pop',
+    (tester) async {
+      _proposeSendSucceeds = true;
+
+      await tester.pumpWidget(_sendFlowRouterApp());
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.byKey(const ValueKey('mobile_send_open_from_home')),
+      );
+      await tester.pumpAndSettle();
+
+      await _toReviewStep(tester);
+      await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('status can pop'), findsOneWidget);
+      await tester.tap(find.byKey(const ValueKey('mobile_send_status_pop')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('home'), findsOneWidget);
+      expect(find.text('Review Send'), findsNothing);
+    },
+  );
 
   testWidgets('recipient step gates Continue on a valid address', (
     tester,

--- a/test/features/send/mobile_send_status_screen_test.dart
+++ b/test/features/send/mobile_send_status_screen_test.dart
@@ -59,7 +59,19 @@ Widget _app({required MobileSendBroadcastRunner broadcastRunner}) {
   );
 }
 
+bool _statusRouteCanPop(WidgetTester tester) {
+  final popScope = tester.widget<PopScope<void>>(find.byType(PopScope<void>));
+  return popScope.canPop;
+}
+
 void main() {
+  setUp(() {
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.platformDispatcher.views.first
+      ..physicalSize = const Size(520, 1100)
+      ..devicePixelRatio = 1.0;
+  });
+
   testWidgets('broadcast success updates the integrated send status screen', (
     tester,
   ) async {
@@ -79,6 +91,7 @@ void main() {
     await tester.pump();
 
     expect(find.byKey(const ValueKey('mobile_send_status_sending')), findsOne);
+    expect(_statusRouteCanPop(tester), isFalse);
     expect(find.text('Sending...'), findsOneWidget);
     expect(find.text('In progress'), findsOneWidget);
     expect(find.text('123.12 ZEC'), findsOneWidget);
@@ -100,8 +113,44 @@ void main() {
       findsOne,
     );
     expect(find.text('Sent successfully'), findsOneWidget);
+    expect(_statusRouteCanPop(tester), isTrue);
     expect(find.text('Completed'), findsOneWidget);
     expect(find.byKey(const ValueKey('mobile_send_status_txid')), findsOne);
     expect(find.text('0.00015 ZEC'), findsOneWidget);
+  });
+
+  testWidgets('failed status allows route pop after broadcast finishes', (
+    tester,
+  ) async {
+    final broadcast = Completer<SendBroadcastOutcome>();
+    await tester.pumpWidget(
+      _app(
+        broadcastRunner:
+            ({
+              required ref,
+              required args,
+              keystone,
+              required confirmSaplingParamsDownload,
+              shouldAbort,
+            }) => broadcast.future,
+      ),
+    );
+    await tester.pump();
+
+    expect(_statusRouteCanPop(tester), isFalse);
+
+    broadcast.complete(
+      const SendBroadcastOutcome(
+        phase: SendBroadcastPhase.failed,
+        proposalConsumed: true,
+        error: 'failed',
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('mobile_send_status_failed')), findsOne);
+    expect(find.text('Send failed'), findsOneWidget);
+    expect(_statusRouteCanPop(tester), isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- Keep the mobile send recipient field mounted while focused and apply the focused field styling.
- Move the recipient focus backdrop visual onto the field shadow while keeping the tap-dismiss layer non-visual.
- Apply the Figma-specific Continue button colors only while the recipient focus backdrop is visible.

## Validation
- fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/send/mobile_send_screen_test.dart
- fvm flutter analyze
- git diff --check