### PR TITLE
Polish the mobile import flow

### DIFF
--- a/lib/src/features/onboarding/mobile/mobile_import_birthday_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_birthday_screen.dart
@@ -86,6 +86,8 @@ class _MobileImportBirthdayScreenState
   @override
   void initState() {
     super.initState();
+    // Repaint the height field's focus ring when it gains/loses the keyboard.
+    _heightFocus.addListener(_onHeightFocusChanged);
     if (widget.loadChainMetadata) {
       unawaited(_loadMetadata());
     }
@@ -93,9 +95,14 @@ class _MobileImportBirthdayScreenState
 
   @override
   void dispose() {
+    _heightFocus.removeListener(_onHeightFocusChanged);
     _heightController.dispose();
     _heightFocus.dispose();
     super.dispose();
+  }
+
+  void _onHeightFocusChanged() {
+    if (mounted) setState(() {});
   }
 
   Future<void> _loadMetadata() async {
@@ -243,6 +250,15 @@ class _MobileImportBirthdayScreenState
           });
         }
     }
+  }
+
+  /// "I can't remember" — like the desktop skip, import from the Sapling
+  /// activation height so the wallet scans the whole chain rather than
+  /// guessing a birthday.
+  void _skipBirthday() {
+    if (_busy) return;
+    _heightFocus.unfocus();
+    unawaited(_submit(_minHeight));
   }
 
   Future<void> _submit(int height) async {
@@ -435,32 +451,49 @@ class _MobileImportBirthdayScreenState
       title: 'Around when did you create your wallet?',
       // Two 25 px lines like the Figma subtitle block.
       subtitle: 'An estimate is enough — sync starts\nfrom there.',
+      // Figma `Buttons Stack` (4752:26672): a full-width skip below the
+      // entry row that imports from the Sapling activation height.
+      bottomArea: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          AppButton(
+            key: const ValueKey('mobile_import_birthday_skip'),
+            variant: AppButtonVariant.secondary,
+            expand: true,
+            onPressed: _busy ? null : _skipBirthday,
+            trailing: const AppIcon(AppIcons.skip),
+            child: const Text('I can’t remember'),
+          ),
+        ],
+      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Flexible(
-                child: _ModeTab(
+          // Tabs size to their content and only scale down on very narrow
+          // screens — a 50/50 Flexible split clipped the longer label.
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _ModeTab(
                   key: const ValueKey('mobile_import_birthday_mode_date'),
                   iconName: AppIcons.calendar,
                   label: 'Enter the date',
                   selected: isDateMode,
                   onTap: () => _setMode(_BirthdayEntryMode.date),
                 ),
-              ),
-              const SizedBox(width: AppSpacing.md),
-              Flexible(
-                child: _ModeTab(
+                const SizedBox(width: AppSpacing.sm),
+                _ModeTab(
                   key: const ValueKey('mobile_import_birthday_mode_height'),
                   iconName: AppIcons.block,
                   label: 'Enter the block height',
                   selected: !isDateMode,
                   onTap: () => _setMode(_BirthdayEntryMode.blockHeight),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
           const SizedBox(height: AppSpacing.md),
           Row(
@@ -477,6 +510,7 @@ class _MobileImportBirthdayScreenState
                         onTap: () => unawaited(_pickDate()),
                       )
                     : _FieldShell(
+                        focused: _heightFocus.hasFocus,
                         child: Row(
                           children: [
                             Expanded(
@@ -526,14 +560,14 @@ class _MobileImportBirthdayScreenState
                         ),
                       ),
               ),
-              const SizedBox(width: AppSpacing.s),
+              const SizedBox(width: AppSpacing.xs),
               AppButton(
                 key: const ValueKey('mobile_import_birthday_continue'),
                 onPressed: !_canContinue || _busy ? null : _continue,
-                // 78×60 chevron pill per the Figma entry row.
+                // 70×60 chevron pill with a 20 px glyph per the Figma row.
                 height: 60,
-                minWidth: 78,
-                child: const AppIcon(AppIcons.chevronForward, size: 24),
+                minWidth: 70,
+                child: const AppIcon(AppIcons.chevronForward, size: 20),
               ),
             ],
           ),
@@ -547,11 +581,26 @@ class _MobileImportBirthdayScreenState
               ),
             )
           else if (_statusMessage != null)
-            Text(
-              _statusMessage!,
-              textAlign: TextAlign.center,
-              style: AppTypography.bodySmall.copyWith(
-                color: colors.text.secondary,
+            // Figma `Import — Estimating` (4752:27008): a spinner + Label M
+            // SemiBold in text.accent, centered, sitting ~24px (spacing/md)
+            // below the field rather than tight against it.
+            Padding(
+              padding: const EdgeInsets.only(top: AppSpacing.s),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  AppIcon(AppIcons.loader, size: 20, color: colors.icon.accent),
+                  const SizedBox(width: AppSpacing.sm),
+                  Text(
+                    _statusMessage!,
+                    textAlign: TextAlign.center,
+                    style: AppTypography.labelLarge.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: colors.text.accent,
+                    ),
+                  ),
+                ],
               ),
             )
           else if (!isDateMode)
@@ -586,7 +635,25 @@ class _ModeTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final color = selected ? colors.text.accent : colors.text.muted;
+    // Figma `Simple Tabs`: both tabs use Body M on text.accent; the
+    // inactive one is the same content at 50% opacity, and the active one
+    // is the medium weight.
+    final tab = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        AppIcon(iconName, size: AppIconSize.medium, color: colors.icon.accent),
+        const SizedBox(width: AppSpacing.xxs),
+        Text(
+          label,
+          maxLines: 1,
+          style:
+              (selected
+                      ? AppTypography.bodyMediumStrong
+                      : AppTypography.bodyMedium)
+                  .copyWith(color: colors.text.accent),
+        ),
+      ],
+    );
     return Semantics(
       button: true,
       selected: selected,
@@ -596,21 +663,7 @@ class _ModeTab extends StatelessWidget {
         onTap: onTap,
         child: SizedBox(
           height: 44,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              AppIcon(iconName, size: AppIconSize.medium, color: color),
-              const SizedBox(width: AppSpacing.xxs),
-              Flexible(
-                child: Text(
-                  label,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTypography.labelMedium.copyWith(color: color),
-                ),
-              ),
-            ],
-          ),
+          child: Opacity(opacity: selected ? 1 : 0.5, child: tab),
         ),
       ),
     );
@@ -619,19 +672,45 @@ class _ModeTab extends StatelessWidget {
 
 /// The Figma entry-row field chrome shared by both modes.
 class _FieldShell extends StatelessWidget {
-  const _FieldShell({required this.child});
+  const _FieldShell({required this.child, this.focused = false});
 
   final Widget child;
+
+  /// Shows the inverse focus ring while the field owns the keyboard. The
+  /// resting state has no visible border — the previous always-on 2px
+  /// border read as a permanent focus state.
+  final bool focused;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    // Raised white card (surface.input fill, radius 16, layered subtle
+    // shadow) with a focus-only inverse outline — mirrors MobileTextField.
     return Container(
-      height: 61,
+      height: AppInputSizing.height,
       padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s),
       decoration: BoxDecoration(
-        border: Border.all(color: colors.border.strong, width: 2),
-        borderRadius: BorderRadius.circular(AppRadii.medium),
+        color: colors.surface.input,
+        borderRadius: BorderRadius.circular(AppInputSizing.radius),
+        border: Border.all(
+          color: focused ? colors.background.inverse : const Color(0x00000000),
+          width: 1.5,
+          strokeAlign: BorderSide.strokeAlignInside,
+        ),
+        boxShadow: [
+          BoxShadow(color: colors.shadows.subtle, blurRadius: 1),
+          BoxShadow(
+            color: colors.shadows.subtle,
+            offset: const Offset(0, 2),
+            blurRadius: 4,
+          ),
+          BoxShadow(
+            color: colors.shadows.subtle,
+            offset: const Offset(0, 1),
+            blurRadius: 2,
+          ),
+          BoxShadow(color: colors.shadows.subtle, blurRadius: 1),
+        ],
       ),
       child: child,
     );
@@ -680,7 +759,7 @@ class _DateFieldButton extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: AppSpacing.xs),
-              AppIcon(AppIcons.calendar, size: 18, color: colors.icon.accent),
+              AppIcon(AppIcons.calendar, size: 24, color: colors.icon.accent),
             ],
           ),
         ),

--- a/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
@@ -207,10 +207,11 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
           extra: MobileImportReviewArgs(words: words),
         )
         .then((result) {
-          // "Clear Secret Phrase" on review — discard the typed words and
-          // pop back to the import entry to start over.
+          // "Clear Secret Phrase" on review — pop back to the import entry
+          // and forward the clear so the entry also drops any stale pasted
+          // phrase/error (manual can be opened from a rejected paste).
           if (result == ImportReviewResult.cleared && mounted) {
-            navigator.maybePop();
+            navigator.pop(ImportReviewResult.cleared);
           }
         });
   }

--- a/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
@@ -63,30 +63,43 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
     return _wordList.where((w) => w.startsWith(prefix)).take(12).toList();
   }
 
-  bool get _canReview =>
-      kMnemonicWordCounts.contains(_accepted.length) &&
-      _controller.text.trim().isEmpty;
+  String get _typed => _controller.text.trim();
+  bool get _hasTyped => _typed.isNotEmpty;
+  bool get _atMax => _accepted.length >= kMnemonicMaxWords;
 
-  /// "Continue to review" once accepting the typed word completes the
-  /// 24-word phrase, or once a valid shorter phrase sits accepted with
-  /// the field empty; otherwise the CTA accepts the next word.
-  bool get _primaryIsReview {
-    final raw = _controller.text.trim();
-    if (raw.isEmpty) return _canReview;
-    return _accepted.length + 1 == kMnemonicMaxWords;
+  /// Total word count if the currently-typed word is accepted; just the
+  /// accepted count when the field is empty.
+  int get _pendingCount => _accepted.length + (_hasTyped ? 1 : 0);
+
+  /// A valid-length phrase (12/15/18/21/24) is reachable, so offer
+  /// "Finish & Review" beside "Next Word" (Figma 4746:83516).
+  bool get _showFinish => kMnemonicWordCounts.contains(_pendingCount);
+
+  /// Accept the typed word and advance to the next slot.
+  void _acceptTyped() {
+    if (_hasTyped) _onSubmitted(_controller.text);
   }
 
-  bool get _primaryEnabled => _controller.text.trim().isNotEmpty || _canReview;
-
-  void _primaryAction() {
-    final raw = _controller.text.trim();
-    if (raw.isNotEmpty) {
-      // Accepting the 24th word auto-advances to review (see
-      // _acceptWord), so one tap covers both labels.
-      _onSubmitted(raw);
-      return;
+  /// Accept the typed word (if any), then validate the full phrase and
+  /// move to review. Validation happens here so review stays read-only.
+  void _finish() {
+    if (_hasTyped) {
+      final tokens = tokenizeMnemonicWords(_typed);
+      final word = tokens.isEmpty ? '' : tokens.first;
+      if (word.isEmpty || !_wordList.contains(word)) {
+        setState(
+          () => _error = "'$_typed' isn't in the passphrase word list.",
+        );
+        _focusNode.requestFocus();
+        return;
+      }
+      setState(() {
+        _accepted.add(word);
+        _controller.clear();
+        _error = null;
+      });
     }
-    if (_canReview) _review();
+    _review();
   }
 
   void _acceptWord(String word) {
@@ -110,7 +123,12 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
     }
     // A trailing space accepts the single word, like the keyboard's
     // suggestion flow.
-    if (value.endsWith(' ')) _onSubmitted(value);
+    if (value.endsWith(' ')) {
+      _onSubmitted(value);
+      return;
+    }
+    // Editing the word clears the invalid-word error (and its red text).
+    if (_error != null) setState(() => _error = null);
   }
 
   /// Fill consecutive slots from the current position with [tokens] (each
@@ -150,7 +168,7 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
     }
     final word = tokens.isEmpty ? '' : tokens.first;
     if (word.isEmpty) {
-      if (_canReview) _review();
+      if (kMnemonicWordCounts.contains(_accepted.length)) _review();
       return;
     }
     if (_wordList.contains(word)) {
@@ -182,7 +200,52 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
       setState(() => _error = error);
       return;
     }
-    context.push('/import/review', extra: MobileImportReviewArgs(words: words));
+    final navigator = Navigator.of(context);
+    context
+        .push<Object?>(
+          '/import/review',
+          extra: MobileImportReviewArgs(words: words),
+        )
+        .then((result) {
+          // "Clear Secret Phrase" on review — discard the typed words and
+          // pop back to the import entry to start over.
+          if (result == ImportReviewResult.cleared && mounted) {
+            navigator.maybePop();
+          }
+        });
+  }
+
+  /// The CTA row: a single "Next Word" until a valid-length phrase is
+  /// reachable, then "Next Word" (secondary) beside "Finish & Review"
+  /// (primary) — Figma 4746:83516.
+  Widget _buildButtonRow() {
+    final nextEnabled = _hasTyped && !_atMax;
+    final nextButton = AppButton(
+      key: const ValueKey('mobile_import_manual_next'),
+      variant: _showFinish
+          ? AppButtonVariant.secondary
+          : AppButtonVariant.primary,
+      expand: !_showFinish,
+      onPressed: nextEnabled ? _acceptTyped : null,
+      trailing: const AppIcon(AppIcons.chevronForward),
+      child: const Text('Next Word'),
+    );
+    if (!_showFinish) return nextButton;
+    return Row(
+      children: [
+        nextButton,
+        const SizedBox(width: AppSpacing.xs),
+        Expanded(
+          child: AppButton(
+            key: const ValueKey('mobile_import_manual_finish'),
+            expand: true,
+            onPressed: _finish,
+            trailing: const AppIcon(AppIcons.chevronForward),
+            child: const Text('Finish & Review'),
+          ),
+        ),
+      ],
+    );
   }
 
   @override
@@ -195,11 +258,29 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
       onBack: () => Navigator.of(context).maybePop(),
       title: 'Enter your Secret Passphrase',
       subtitle: 'Accept 12, 15, 18, 21 or 24 words',
-      // Only the BIP39 suggestions stay pinned above the keyboard; per
-      // the Figma frame the CTA flows directly under the word field.
-      bottomArea: _suggestions.isEmpty
-          ? null
-          : SizedBox(
+      // Only the CTA is pinned — it rides up above the keyboard (Figma
+      // 4746:83516). The autocomplete chips stay attached under the word
+      // field and scroll with the content. The stretch Column gives the
+      // expand:true button a tight width to fill.
+      bottomArea: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [_buildButtonRow()],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _WordField(
+            index: position,
+            controller: _controller,
+            focusNode: _focusNode,
+            hasError: _error != null,
+            onChanged: _onChanged,
+            onSubmitted: _onSubmitted,
+          ),
+          if (_suggestions.isNotEmpty) ...[
+            const SizedBox(height: AppSpacing.s),
+            SizedBox(
               height: 40,
               child: ListView(
                 scrollDirection: Axis.horizontal,
@@ -215,16 +296,7 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
                 ],
               ),
             ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          _WordField(
-            index: position,
-            controller: _controller,
-            focusNode: _focusNode,
-            onChanged: _onChanged,
-            onSubmitted: _onSubmitted,
-          ),
+          ],
           if (_error != null) ...[
             const SizedBox(height: AppSpacing.sm),
             Text(
@@ -235,15 +307,6 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
               ),
             ),
           ],
-          // 46 px from the field to the CTA in the Figma frame.
-          const SizedBox(height: 46),
-          AppButton(
-            key: const ValueKey('mobile_import_manual_review'),
-            expand: true,
-            onPressed: _primaryEnabled ? _primaryAction : null,
-            trailing: const AppIcon(AppIcons.chevronForward),
-            child: Text(_primaryIsReview ? 'Continue to review' : 'Next word'),
-          ),
           if (_accepted.isNotEmpty) ...[
             const SizedBox(height: AppSpacing.md),
             Text(
@@ -284,6 +347,7 @@ class _WordField extends StatelessWidget {
     required this.index,
     required this.controller,
     required this.focusNode,
+    required this.hasError,
     required this.onChanged,
     required this.onSubmitted,
   });
@@ -291,12 +355,17 @@ class _WordField extends StatelessWidget {
   final int index;
   final TextEditingController controller;
   final FocusNode focusNode;
+
+  /// When the typed word failed validation, the word renders destructive
+  /// until the user edits it (Figma invalid-word state).
+  final bool hasError;
   final ValueChanged<String> onChanged;
   final ValueChanged<String> onSubmitted;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final textColor = hasError ? colors.text.destructive : colors.text.accent;
     return Container(
       // Figma `Input` (4562:106067): 24 px padding around a 40 px serif
       // line makes the 88 px field.
@@ -322,11 +391,15 @@ class _WordField extends StatelessWidget {
               focusNode: focusNode,
               autofocus: true,
               // Full Headline XL serif per the Figma word field
-              // ("Agent |", 40 px line).
+              // ("Agent |", 40 px line). The display token's −1.35 title
+              // tracking is dropped here: on an editable field it pulls the
+              // caret into the glyph (visible on serif 'f'), so this field
+              // uses neutral tracking.
               style: AppTypography.displayLarge.copyWith(
-                color: colors.text.accent,
+                color: textColor,
+                letterSpacing: 0,
               ),
-              cursorColor: colors.text.accent,
+              cursorColor: textColor,
               decoration: null,
               keyboardType: TextInputType.visiblePassword,
               autocorrect: false,

--- a/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
@@ -72,7 +72,7 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
   int get _pendingCount => _accepted.length + (_hasTyped ? 1 : 0);
 
   /// A valid-length phrase (12/15/18/21/24) is reachable, so offer
-  /// "Finish & Review" beside "Next Word" (Figma 4746:83516).
+  /// "Finish & review" beside "Next word" (Figma 4746:83516).
   bool get _showFinish => kMnemonicWordCounts.contains(_pendingCount);
 
   /// Accept the typed word and advance to the next slot.
@@ -207,7 +207,7 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
           extra: MobileImportReviewArgs(words: words),
         )
         .then((result) {
-          // "Clear Secret Phrase" on review — pop back to the import entry
+          // "Clear secret phrase" on review — pop back to the import entry
           // and forward the clear so the entry also drops any stale pasted
           // phrase/error (manual can be opened from a rejected paste).
           if (result == ImportReviewResult.cleared && mounted) {
@@ -216,8 +216,8 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
         });
   }
 
-  /// The CTA row: a single "Next Word" until a valid-length phrase is
-  /// reachable, then "Next Word" (secondary) beside "Finish & Review"
+  /// The CTA row: a single "Next word" until a valid-length phrase is
+  /// reachable, then "Next word" (secondary) beside "Finish & review"
   /// (primary) — Figma 4746:83516.
   Widget _buildButtonRow() {
     final nextEnabled = _hasTyped && !_atMax;
@@ -229,7 +229,7 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
       expand: !_showFinish,
       onPressed: nextEnabled ? _acceptTyped : null,
       trailing: const AppIcon(AppIcons.chevronForward),
-      child: const Text('Next Word'),
+      child: const Text('Next word'),
     );
     if (!_showFinish) return nextButton;
     return Row(
@@ -242,7 +242,7 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
             expand: true,
             onPressed: _finish,
             trailing: const AppIcon(AppIcons.chevronForward),
-            child: const Text('Finish & Review'),
+            child: const Text('Finish & review'),
           ),
         ),
       ],

--- a/lib/src/features/onboarding/mobile/mobile_import_review_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_review_screen.dart
@@ -22,8 +22,8 @@ class MobileImportReviewScreen extends StatelessWidget {
     return MobileOnboardingStepScaffold(
       progress: 0.6,
       onBack: () => Navigator.of(context).maybePop(),
-      title: 'Review Secret Phrase',
-      subtitle: 'Review before the import.',
+      title: 'Review Import',
+      subtitle: 'Review your Secret Passphrase before import starts.',
       bottomArea: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -36,7 +36,7 @@ class MobileImportReviewScreen extends StatelessWidget {
               extra: ImportBirthdayArgs(mnemonic: args.mnemonic),
             ),
             trailing: const AppIcon(AppIcons.chevronForward),
-            child: const Text('Confirm & import'),
+            child: const Text('Confirm & Continue'),
           ),
           const SizedBox(height: AppSpacing.xs),
           Semantics(
@@ -44,12 +44,13 @@ class MobileImportReviewScreen extends StatelessWidget {
             child: GestureDetector(
               key: const ValueKey('mobile_import_review_edit'),
               behavior: HitTestBehavior.opaque,
-              onTap: () => Navigator.of(context).maybePop(),
+              onTap: () =>
+                  Navigator.of(context).pop(ImportReviewResult.cleared),
               child: SizedBox(
                 height: 44,
                 child: Center(
                   child: Text(
-                    'Edit secret phrase',
+                    'Clear Secret Phrase',
                     style: AppTypography.labelLarge.copyWith(
                       color: context.colors.text.primary,
                     ),

--- a/lib/src/features/onboarding/mobile/mobile_import_review_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_review_screen.dart
@@ -36,7 +36,7 @@ class MobileImportReviewScreen extends StatelessWidget {
               extra: ImportBirthdayArgs(mnemonic: args.mnemonic),
             ),
             trailing: const AppIcon(AppIcons.chevronForward),
-            child: const Text('Confirm & Continue'),
+            child: const Text('Confirm & continue'),
           ),
           const SizedBox(height: AppSpacing.xs),
           Semantics(
@@ -50,7 +50,7 @@ class MobileImportReviewScreen extends StatelessWidget {
                 height: 44,
                 child: Center(
                   child: Text(
-                    'Clear Secret Phrase',
+                    'Clear secret phrase',
                     style: AppTypography.labelLarge.copyWith(
                       color: context.colors.text.primary,
                     ),

--- a/lib/src/features/onboarding/mobile/mobile_import_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_screens.dart
@@ -123,6 +123,14 @@ class _MobileImportScreenState extends State<MobileImportScreen> {
         });
   }
 
+  void _openManual() {
+    context.push<Object?>('/import/manual').then((result) {
+      // The manual flow forwards a Clear Secret Phrase so the entry also
+      // wipes any stale pasted phrase/error and starts fresh.
+      if (result == ImportReviewResult.cleared && mounted) _clear();
+    });
+  }
+
   bool get _filled => _words.isNotEmpty && _error == null;
 
   @override
@@ -195,7 +203,7 @@ class _MobileImportScreenState extends State<MobileImportScreen> {
               child: GestureDetector(
                 key: const ValueKey('mobile_import_enter_manually'),
                 behavior: HitTestBehavior.opaque,
-                onTap: () => context.push('/import/manual'),
+                onTap: _openManual,
                 child: SizedBox(
                   height: 44,
                   child: Center(
@@ -235,7 +243,7 @@ class _MobileImportScreenState extends State<MobileImportScreen> {
               child: GestureDetector(
                 key: const ValueKey('mobile_import_slots'),
                 behavior: HitTestBehavior.opaque,
-                onTap: () => context.push('/import/manual'),
+                onTap: _openManual,
                 child: ImportSlotsCard(words: _words),
               ),
             ),

--- a/lib/src/features/onboarding/mobile/mobile_import_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_screens.dart
@@ -34,6 +34,11 @@ class MobileImportReviewArgs {
   String get mnemonic => words.join(' ');
 }
 
+/// Result a pushed review screen returns to whoever opened it. `cleared`
+/// means the user tapped "Clear Secret Phrase" — the opener drops the
+/// entered phrase and returns the user to a fresh entry.
+enum ImportReviewResult { cleared }
+
 /// Validates a candidate phrase; returns an error message or null.
 String? validateImportedMnemonic(List<String> words) {
   if (!kMnemonicWordCounts.contains(words.length)) {
@@ -106,10 +111,16 @@ class _MobileImportScreenState extends State<MobileImportScreen> {
   }
 
   void _confirm() {
-    context.push(
-      '/import/review',
-      extra: MobileImportReviewArgs(words: _words),
-    );
+    context
+        .push<Object?>(
+          '/import/review',
+          extra: MobileImportReviewArgs(words: _words),
+        )
+        .then((result) {
+          // "Clear Secret Phrase" on review wipes the pasted phrase so the
+          // entry reappears empty.
+          if (result == ImportReviewResult.cleared && mounted) _clear();
+        });
   }
 
   bool get _filled => _words.isNotEmpty && _error == null;
@@ -120,7 +131,7 @@ class _MobileImportScreenState extends State<MobileImportScreen> {
     return MobileOnboardingStepScaffold(
       progress: 0.2,
       onBack: () => Navigator.of(context).maybePop(),
-      title: 'Import Your Wallet',
+      title: 'Import Wallet',
       // Line break matches the Figma subtitle wrap.
       subtitle:
           'Paste your Secret Passphrase or\nenter it manually word by word.',

--- a/lib/src/features/onboarding/mobile/mobile_import_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_screens.dart
@@ -35,7 +35,7 @@ class MobileImportReviewArgs {
 }
 
 /// Result a pushed review screen returns to whoever opened it. `cleared`
-/// means the user tapped "Clear Secret Phrase" — the opener drops the
+/// means the user tapped "Clear secret phrase" — the opener drops the
 /// entered phrase and returns the user to a fresh entry.
 enum ImportReviewResult { cleared }
 
@@ -117,7 +117,7 @@ class _MobileImportScreenState extends State<MobileImportScreen> {
           extra: MobileImportReviewArgs(words: _words),
         )
         .then((result) {
-          // "Clear Secret Phrase" on review wipes the pasted phrase so the
+          // "Clear secret phrase" on review wipes the pasted phrase so the
           // entry reappears empty.
           if (result == ImportReviewResult.cleared && mounted) _clear();
         });
@@ -125,7 +125,7 @@ class _MobileImportScreenState extends State<MobileImportScreen> {
 
   void _openManual() {
     context.push<Object?>('/import/manual').then((result) {
-      // The manual flow forwards a Clear Secret Phrase so the entry also
+      // The manual flow forwards a Clear secret phrase so the entry also
       // wipes any stale pasted phrase/error and starts fresh.
       if (result == ImportReviewResult.cleared && mounted) _clear();
     });

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -1302,7 +1302,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
               constrainContent: true,
               onPressed: _amountReady ? _continueToReview : null,
               child: Text(
-                _amountReady ? 'Finish & Review' : 'Enter amount to continue',
+                _amountReady ? 'Finish & review' : 'Enter amount to continue',
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),

--- a/test/features/onboarding/mobile_import_review_screen_test.dart
+++ b/test/features/onboarding/mobile_import_review_screen_test.dart
@@ -1,0 +1,95 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_review_screen.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_screens.dart';
+
+const _words = [
+  'abandon', 'ability', 'able', 'about', 'above', 'absent',
+  'absorb', 'abstract', 'absurd', 'abuse', 'access', 'accident',
+];
+
+void main() {
+  setUp(() {
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.platformDispatcher.views.first
+      ..physicalSize = const Size(393, 852)
+      ..devicePixelRatio = 1.0;
+  });
+
+  testWidgets('review shows the Figma copy', (tester) async {
+    await tester.pumpWidget(_host());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review Import'), findsOneWidget);
+    expect(
+      find.text('Review your Secret Passphrase before import starts.'),
+      findsOneWidget,
+    );
+    expect(find.text('Confirm & Continue'), findsOneWidget);
+    expect(find.text('Clear Secret Phrase'), findsOneWidget);
+  });
+
+  testWidgets('Clear Secret Phrase pops with the cleared result', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host());
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_import_review_edit')));
+    await tester.pumpAndSettle();
+
+    // Back on the opener, which recorded the returned result.
+    expect(find.text('result: ImportReviewResult.cleared'), findsOneWidget);
+  });
+}
+
+Widget _host() {
+  return MaterialApp(
+    builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+    home: const _Opener(),
+  );
+}
+
+class _Opener extends StatefulWidget {
+  const _Opener();
+
+  @override
+  State<_Opener> createState() => _OpenerState();
+}
+
+class _OpenerState extends State<_Opener> {
+  Object? _result;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('result: $_result'),
+            TextButton(
+              onPressed: () async {
+                final result = await Navigator.of(context).push<Object?>(
+                  MaterialPageRoute(
+                    builder: (_) => const MobileImportReviewScreen(
+                      args: MobileImportReviewArgs(words: _words),
+                    ),
+                  ),
+                );
+                if (mounted) setState(() => _result = result);
+              },
+              child: const Text('open'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/onboarding/mobile_import_review_screen_test.dart
+++ b/test/features/onboarding/mobile_import_review_screen_test.dart
@@ -30,11 +30,11 @@ void main() {
       find.text('Review your Secret Passphrase before import starts.'),
       findsOneWidget,
     );
-    expect(find.text('Confirm & Continue'), findsOneWidget);
-    expect(find.text('Clear Secret Phrase'), findsOneWidget);
+    expect(find.text('Confirm & continue'), findsOneWidget);
+    expect(find.text('Clear secret phrase'), findsOneWidget);
   });
 
-  testWidgets('Clear Secret Phrase pops with the cleared result', (
+  testWidgets('Clear secret phrase pops with the cleared result', (
     tester,
   ) async {
     await tester.pumpWidget(_host());

--- a/test/features/onboarding/mobile_import_screens_test.dart
+++ b/test/features/onboarding/mobile_import_screens_test.dart
@@ -53,7 +53,7 @@ void main() {
     await tester.pumpWidget(_app('/import'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Import Your Wallet'), findsOneWidget);
+    expect(find.text('Import Wallet'), findsOneWidget);
     expect(find.byType(MobileImportScreen), findsOneWidget);
 
     await tester.tap(

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -830,7 +830,7 @@ void main() {
 
     await _enterAmount(tester, '1.5');
     expect(find.text('Not enough ZEC'), findsNothing);
-    expect(find.text('Finish & Review'), findsOneWidget);
+    expect(find.text('Finish & review'), findsOneWidget);
   });
 
   testWidgets('continue stays blocked while the fee check is pending', (
@@ -856,7 +856,7 @@ void main() {
 
     // Once the re-validation settles, 1.5 ZEC is spendable again.
     await tester.pumpAndSettle();
-    expect(find.text('Finish & Review'), findsOneWidget);
+    expect(find.text('Finish & review'), findsOneWidget);
   });
 
   testWidgets('review shows the receipt and the shielded memo entry', (

--- a/test/widgetbook/mobile_send_use_cases_test.dart
+++ b/test/widgetbook/mobile_send_use_cases_test.dart
@@ -204,7 +204,7 @@ void main() {
 
     expect(tester.takeException(), isNull);
     expect(find.text('24.312'), findsOneWidget);
-    expect(find.text('Finish & Review'), findsOneWidget);
+    expect(find.text('Finish & review'), findsOneWidget);
   });
 
   testWidgets('mobile send review default use case matches review layout', (


### PR DESCRIPTION
Mobile import-flow polish against the Figma `Vizor / Design System` frames. Stacked on `rowan/mobile-contacts` (retarget to the integration branch once that merges).

Reviewable commits, one per screen group:

### 1. Secret-passphrase entry (`mobile_import_screens.dart`, `mobile_import_manual_screen.dart`)
- Entry title renamed to **Import Wallet**.
- Invalid words render in the **destructive** color with the inline error, clearing as soon as the word is edited.
- Autocomplete chips now attach **directly under the word field**; only the CTA stays pinned above the keyboard.
- **Next Word** + **Finish & Review** appear side by side once a valid word count (12/15/18/21/24) is reachable. BIP39 checksum validation runs here, so the review screen stays read-only.
- Dropped the display token's negative letter-spacing on the editable field so the caret no longer cuts through serif glyphs like `f`.

### 2. Review screen (`mobile_import_review_screen.dart`)
- Copy matched to Figma: **Review Import** / *Review your Secret Passphrase before import starts.* / **Confirm & Continue** / **Clear Secret Phrase**.
- **Clear Secret Phrase** now resets the flow: the paste entry wipes its phrase and the manual flow pops back to a fresh entry (the back-to-method stack is preserved). The clear result is propagated through the manual flow so an entry opened from a rejected paste is wiped too. Added a test covering the copy and the clear-result.

### 3. Wallet-birthday screen (`mobile_import_birthday_screen.dart`)
- Estimating state shows a **spinner + "Estimating ..."** (Label M SemiBold, accent), ~24px below the field.
- The field is a raised white card with a **focus-only inverse outline** — the previous always-on 2px border read as a permanent focus state.
- Calendar icon 18 → 24; continue chevron pill is 70 wide with a 20px glyph.
- Mode tabs use Body M with the inactive tab at **50% opacity**, sized to content so the longer label isn't clipped (labels unchanged).
- Added an **"I can't remember"** skip that imports from the Sapling activation height (full chain scan), matching the desktop flow.

### Testing
- `fvm flutter analyze` clean (lib + test).
- Onboarding mobile lane green (`--tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`).
- Each screen state verified with rendered captures.
