### PR TITLE
Force-disable iOS mobile swap for stable releases

### DIFF
--- a/fastlane/android/Fastfile
+++ b/fastlane/android/Fastfile
@@ -86,6 +86,7 @@ platform :android do
         # Store builds must compile the mobile token set — release
         # builds have no form-factor guard (see AGENTS.md).
         "--dart-define=VIZOR_FORM_FACTOR=mobile",
+        "--dart-define=#{shell_escape("VIZOR_RELEASE_VERSION=#{metadata.fetch(:asset_version)}")}",
         "--dart-define=#{shell_escape("VIZOR_COINGECKO_PRICE_BASE_URL=#{coingecko_price_base_url}")}",
         "--build-name", shell_escape(metadata.fetch(:version)),
         "--build-number", shell_escape(metadata.fetch(:build_number))

--- a/fastlane/ios/Fastfile
+++ b/fastlane/ios/Fastfile
@@ -226,6 +226,10 @@ platform :ios do
   lane :build do
     metadata = ios_release_metadata
     coingecko_price_base_url = ENV.fetch("VIZOR_COINGECKO_PRICE_BASE_URL", "https://api.coingecko.com/api/v3")
+    force_disable_swap = ENV.fetch("VIZOR_FORCE_DISABLE_IOS_MOBILE_SWAP", "false").strip
+    unless ["true", "false"].include?(force_disable_swap)
+      UI.user_error!("VIZOR_FORCE_DISABLE_IOS_MOBILE_SWAP must be true or false")
+    end
     keychain = setup_ios_signing_keychain
     profile_mapping = sync_ios_match!(keychain)
     configure_ios_code_signing!(profile_mapping)
@@ -239,6 +243,7 @@ platform :ios do
           # Store builds must compile the mobile token set — release
           # builds have no form-factor guard (see AGENTS.md).
           "--dart-define=VIZOR_FORM_FACTOR=mobile",
+          "--dart-define=VIZOR_FORCE_DISABLE_IOS_MOBILE_SWAP=#{force_disable_swap}",
           "--dart-define=#{shell_escape("VIZOR_COINGECKO_PRICE_BASE_URL=#{coingecko_price_base_url}")}",
           "--build-name", shell_escape(metadata.fetch(:version)),
           "--build-number", shell_escape(metadata.fetch(:build_number)),

--- a/fastlane/ios/Fastfile
+++ b/fastlane/ios/Fastfile
@@ -243,6 +243,7 @@ platform :ios do
           # Store builds must compile the mobile token set — release
           # builds have no form-factor guard (see AGENTS.md).
           "--dart-define=VIZOR_FORM_FACTOR=mobile",
+          "--dart-define=#{shell_escape("VIZOR_RELEASE_VERSION=#{metadata.fetch(:asset_version)}")}",
           "--dart-define=VIZOR_FORCE_DISABLE_IOS_MOBILE_SWAP=#{force_disable_swap}",
           "--dart-define=#{shell_escape("VIZOR_COINGECKO_PRICE_BASE_URL=#{coingecko_price_base_url}")}",
           "--build-name", shell_escape(metadata.fetch(:version)),

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -188,11 +188,13 @@ Future<void> runZcashWalletApp() async {
 final _routerProvider = Provider<GoRouter>((ref) {
   final bootstrap = ref.watch(appBootstrapProvider);
   final refresh = ref.watch(routerRefreshProvider);
-  final swapFeatureEnabled = ref.watch(swapFeatureEnabledProvider);
   ref.listen(walletProvider, (_, _) {
     refresh.requestRefresh();
   });
   ref.listen(appSecurityProvider, (_, _) {
+    refresh.requestRefresh();
+  });
+  ref.listen(swapFeatureEnabledProvider, (_, _) {
     refresh.requestRefresh();
   });
   log('router: initialized');
@@ -200,12 +202,8 @@ final _routerProvider = Provider<GoRouter>((ref) {
   return GoRouter(
     initialLocation: bootstrap.initialLocation,
     refreshListenable: refresh,
-    redirect: (context, state) => appRedirect(
-      ref: ref,
-      bootstrap: bootstrap,
-      swapFeatureEnabled: swapFeatureEnabled,
-      state: state,
-    ),
+    redirect: (context, state) =>
+        appRedirect(ref: ref, bootstrap: bootstrap, state: state),
     // The mobile tree only carries the routes that exist on mobile so
     // far; anything else (desktop-only paths, stale deep links) falls
     // back to home instead of the error screen.
@@ -225,7 +223,6 @@ final _routerProvider = Provider<GoRouter>((ref) {
               ),
               ...mobileOnboardingRoutes(),
             ],
-            swapFeatureEnabled: swapFeatureEnabled,
           )
         : [
             ...appAuthRoutes(
@@ -234,7 +231,7 @@ final _routerProvider = Provider<GoRouter>((ref) {
               unlockScreen: const UnlockScreen(),
             ),
             ...appDesktopOnboardingRoutes(ref),
-            ..._desktopRoutes(swapFeatureEnabled),
+            ..._desktopRoutes(),
           ],
   );
 });
@@ -245,7 +242,6 @@ final _routerProvider = Provider<GoRouter>((ref) {
 String? appRedirect({
   required Ref ref,
   required AppBootstrapState bootstrap,
-  required bool swapFeatureEnabled,
   required GoRouterState state,
 }) {
   final walletAsync = ref.read(walletProvider);
@@ -279,6 +275,7 @@ String? appRedirect({
   final isSwap =
       state.matchedLocation.startsWith('/swap') ||
       state.matchedLocation.startsWith('/activity/swap');
+  final swapFeatureEnabled = ref.read(swapFeatureEnabledProvider);
 
   log(
     'router redirect: location=${state.matchedLocation}, hasWallet=$hasWallet, '
@@ -639,7 +636,7 @@ List<RouteBase> appDesktopOnboardingRoutes(Ref ref) => [
 ];
 
 /// Main application routes for the desktop (large-form-factor) tree.
-List<RouteBase> _desktopRoutes(bool swapFeatureEnabled) => [
+List<RouteBase> _desktopRoutes() => [
   GoRoute(path: '/home', builder: (_, _) => const HomeScreen()),
   GoRoute(path: '/about', builder: (_, _) => const AboutScreen()),
   GoRoute(path: '/address-book', builder: (_, _) => const AddressBookScreen()),
@@ -694,16 +691,8 @@ List<RouteBase> _desktopRoutes(bool swapFeatureEnabled) => [
       return SendScreen(prefill: extra is SendPrefillArgs ? extra : null);
     },
   ),
-  GoRoute(
-    path: '/swap',
-    redirect: (_, _) => swapFeatureEnabled ? null : '/home',
-    builder: (_, _) => const SwapScreen(),
-  ),
-  GoRoute(
-    path: '/swap/review',
-    redirect: (_, _) => swapFeatureEnabled ? null : '/home',
-    builder: (_, _) => const SwapReviewScreen(),
-  ),
+  GoRoute(path: '/swap', builder: (_, _) => const SwapScreen()),
+  GoRoute(path: '/swap/review', builder: (_, _) => const SwapReviewScreen()),
   GoRoute(
     path: '/send/review',
     builder: (_, state) {

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -5,10 +5,13 @@ import 'package:flutter/foundation.dart' show kDebugMode, visibleForTesting;
 import 'package:flutter/material.dart' show ThemeMode;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../main.dart' show log;
 import 'core/profile_pictures.dart';
+import 'core/config/app_version_config.dart';
 import 'core/config/rpc_endpoint_config.dart';
+import 'core/config/swap_remote_enable_config.dart';
 import 'core/storage/app_secure_store.dart';
 import 'core/storage/wallet_paths.dart';
 import 'providers/account_models.dart';
@@ -56,6 +59,7 @@ class AppBootstrapState {
     required this.isPasswordConfigured,
     required this.isUnlocked,
     required this.passwordRotationRecoveryFailed,
+    this.swapEnabledOverrideCachedForRelease = false,
     this.biometricUnlockEnabled = false,
     this.failureKind,
     this.failureMessage,
@@ -68,6 +72,7 @@ class AppBootstrapState {
   final RpcEndpointConfig rpcEndpointConfig;
   final ThemeMode themeMode;
   final bool privacyModeEnabled;
+  final bool swapEnabledOverrideCachedForRelease;
 
   /// Whether biometric unlock was enabled at startup, read synchronously from
   /// secure storage. The unlock screen uses this to paint the biometric
@@ -219,6 +224,8 @@ Future<AppBootstrapState> loadAppBootstrap() async {
     await _seedNativeRpcEndpointMirror(rpcEndpointConfig);
     final themeMode = await _readThemeMode(storage);
     final privacyModeEnabled = await _readPrivacyModeEnabled(storage);
+    final swapEnabledOverrideCachedForRelease =
+        await _readSwapEnabledOverrideCachedForRelease();
     final biometricUnlockEnabled = await _readBiometricUnlockEnabled(storage);
     final isPasswordConfigured = await storage.isPasswordConfigured();
     final isUnlocked = storage.hasSessionPassword;
@@ -316,6 +323,7 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       rpcEndpointConfig: rpcEndpointConfig,
       themeMode: themeMode,
       privacyModeEnabled: privacyModeEnabled,
+      swapEnabledOverrideCachedForRelease: swapEnabledOverrideCachedForRelease,
       biometricUnlockEnabled: biometricUnlockEnabled,
       isPasswordConfigured: isPasswordConfigured,
       isUnlocked: isUnlocked,
@@ -471,6 +479,17 @@ Future<bool> _readBiometricUnlockEnabled(AppSecureStore storage) async {
     rethrow;
   } catch (e) {
     log('bootstrap: failed to read biometric unlock flag: $e');
+    return false;
+  }
+}
+
+Future<bool> _readSwapEnabledOverrideCachedForRelease() async {
+  try {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(swapEnabledOverrideStorageKey(kVizorReleaseVersion)) ??
+        false;
+  } catch (e) {
+    log('bootstrap: failed to read swap override cache: $e');
     return false;
   }
 }

--- a/lib/src/core/config/swap_feature_config.dart
+++ b/lib/src/core/config/swap_feature_config.dart
@@ -1,13 +1,156 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' show HttpClient, HttpHeaders, Platform;
 
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../main.dart' show log;
 import '../../app_bootstrap.dart';
+import '../layout/app_form_factor.dart';
+import 'app_version_config.dart';
 import 'network_config.dart';
+import 'swap_remote_enable_config.dart';
 
 final swapFeatureEnabledProvider = Provider<bool>((ref) {
   final networkName = ref.watch(appBootstrapProvider).network;
-  return isSwapFeatureEnabledForNetwork(networkName);
+  final networkEnabled = isSwapFeatureEnabledForNetwork(networkName);
+  if (!networkEnabled) return false;
+  if (!ref.watch(swapForceDisabledForCurrentBuildProvider)) return true;
+  return ref.watch(swapEnabledRemoteOverrideProvider);
 });
 
 bool isSwapFeatureEnabledForNetwork(String networkName) {
   return zcashNetworkFromName(networkName) == ZcashNetwork.mainnet;
+}
+
+final swapFeatureIsIosProvider = Provider<bool>((_) => Platform.isIOS);
+
+final swapForceDisabledForCurrentBuildProvider = Provider<bool>((ref) {
+  return shouldForceDisableSwapForCurrentBuild(
+    forceDisableDefine: kVizorForceDisableIosMobileSwap,
+    formFactor: kAppFormFactor,
+    isIOS: ref.watch(swapFeatureIsIosProvider),
+  );
+});
+
+@visibleForTesting
+bool shouldForceDisableSwapForCurrentBuild({
+  required bool forceDisableDefine,
+  required AppFormFactor formFactor,
+  required bool isIOS,
+}) {
+  return forceDisableDefine && formFactor == AppFormFactor.mobile && isIOS;
+}
+
+abstract interface class SwapEnabledOverrideSource {
+  Future<bool> isEnabledForVersion(String version);
+}
+
+class HttpSwapEnabledOverrideSource implements SwapEnabledOverrideSource {
+  HttpSwapEnabledOverrideSource({
+    HttpClient? client,
+    Uri? endpoint,
+    this.timeout = const Duration(seconds: 8),
+  }) : _client = client ?? HttpClient(),
+       _endpoint = endpoint ?? Uri.parse(kSwapEnabledOverrideUrl);
+
+  final HttpClient _client;
+  final Uri _endpoint;
+  final Duration timeout;
+
+  @override
+  Future<bool> isEnabledForVersion(String version) async {
+    try {
+      final request = await _client.getUrl(_endpoint).timeout(timeout);
+      request.headers.set(HttpHeaders.acceptHeader, 'application/json');
+      final response = await request.close().timeout(timeout);
+      final body = await utf8.decoder.bind(response).join().timeout(timeout);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        log('swapFeature: override returned ${response.statusCode}');
+        return false;
+      }
+      return parseSwapEnabledOverrideForVersion(body, version);
+    } catch (e) {
+      log('swapFeature: override fetch failed: $e');
+      return false;
+    }
+  }
+
+  void close({bool force = false}) {
+    _client.close(force: force);
+  }
+}
+
+abstract interface class SwapEnabledOverrideStore {
+  Future<void> cacheEnabledForVersion(String version);
+}
+
+class SharedPreferencesSwapEnabledOverrideStore
+    implements SwapEnabledOverrideStore {
+  const SharedPreferencesSwapEnabledOverrideStore();
+
+  @override
+  Future<void> cacheEnabledForVersion(String version) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(swapEnabledOverrideStorageKey(version), true);
+  }
+}
+
+final swapEnabledOverrideSourceProvider = Provider<SwapEnabledOverrideSource>((
+  ref,
+) {
+  final source = HttpSwapEnabledOverrideSource();
+  ref.onDispose(() => source.close());
+  return source;
+});
+
+final swapEnabledOverrideStoreProvider = Provider<SwapEnabledOverrideStore>((
+  ref,
+) {
+  return const SharedPreferencesSwapEnabledOverrideStore();
+});
+
+final swapEnabledRemoteOverrideProvider =
+    NotifierProvider<SwapEnabledRemoteOverrideNotifier, bool>(
+      SwapEnabledRemoteOverrideNotifier.new,
+    );
+
+class SwapEnabledRemoteOverrideNotifier extends Notifier<bool> {
+  var _fetchStarted = false;
+  var _disposed = false;
+
+  @override
+  bool build() {
+    ref.onDispose(() {
+      _disposed = true;
+    });
+    final bootstrap = ref.watch(appBootstrapProvider);
+    if (bootstrap.swapEnabledOverrideCachedForRelease) return true;
+    if (!ref.watch(swapForceDisabledForCurrentBuildProvider)) return false;
+    if (!isSwapFeatureEnabledForNetwork(bootstrap.network)) return false;
+
+    if (!_fetchStarted) {
+      _fetchStarted = true;
+      scheduleMicrotask(() => unawaited(_fetchOverride()));
+    }
+    return false;
+  }
+
+  Future<void> _fetchOverride() async {
+    final source = ref.read(swapEnabledOverrideSourceProvider);
+    final enabled = await source.isEnabledForVersion(kVizorReleaseVersion);
+    if (_disposed) return;
+    if (!enabled) return;
+    try {
+      await ref
+          .read(swapEnabledOverrideStoreProvider)
+          .cacheEnabledForVersion(kVizorReleaseVersion);
+    } catch (e) {
+      log('swapFeature: failed to cache override: $e');
+    }
+    if (_disposed) return;
+    state = true;
+  }
 }

--- a/lib/src/core/config/swap_remote_enable_config.dart
+++ b/lib/src/core/config/swap_remote_enable_config.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+
+const kVizorForceDisableIosMobileSwapEnvKey =
+    'VIZOR_FORCE_DISABLE_IOS_MOBILE_SWAP';
+const kVizorForceDisableIosMobileSwap = bool.fromEnvironment(
+  kVizorForceDisableIosMobileSwapEnvKey,
+  defaultValue: false,
+);
+
+const kSwapEnabledOverrideUrl =
+    'https://functions.vizor.cash/static/swap-enabled.json';
+
+const _swapEnabledOverrideStorageKeyPrefix = 'vizor_swap_enabled_override_';
+
+String swapEnabledOverrideStorageKey(String version) {
+  return '$_swapEnabledOverrideStorageKeyPrefix$version';
+}
+
+bool parseSwapEnabledOverrideForVersion(String body, String version) {
+  try {
+    final decoded = jsonDecode(body);
+    if (decoded is Map<String, dynamic>) {
+      return decoded[version] == true;
+    }
+    if (decoded is Map) {
+      return decoded[version] == true;
+    }
+  } catch (_) {
+    return false;
+  }
+  return false;
+}

--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -23,6 +23,7 @@ import '../../features/settings/screens/mobile/mobile_endpoint_screen.dart';
 import '../../features/settings/screens/mobile/mobile_seed_phrase_screen.dart';
 import '../../features/settings/screens/mobile/mobile_settings_screen.dart';
 import '../../features/swap/screens/mobile/mobile_swap_screen.dart';
+import '../config/swap_feature_config.dart';
 import '../layout/mobile/app_mobile_shell.dart';
 import '../layout/mobile/app_mobile_tab_bar.dart';
 import '../widgets/app_icon.dart';
@@ -37,20 +38,19 @@ import 'mobile_tab_history.dart';
 /// redirect guard, deep links, and `bootstrap.initialLocation` work
 /// unchanged. The shared entry routes are passed in (rather than
 /// imported from `app.dart`) to keep the import graph acyclic.
-List<RouteBase> buildMobileRoutes({
-  required List<RouteBase> entryRoutes,
-  required bool swapFeatureEnabled,
-}) {
-  final tabs = _mobileTabs(swapFeatureEnabled: swapFeatureEnabled);
+List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
   return [
     ...entryRoutes,
     StatefulShellRoute.indexedStack(
       pageBuilder: (context, state, navigationShell) => CupertinoPage(
         key: state.pageKey,
-        child: _MobileTabShell(navigationShell: navigationShell, tabs: tabs),
+        child: _MobileTabShell(
+          navigationShell: navigationShell,
+          tabs: _allMobileTabs,
+        ),
       ),
       branches: [
-        for (final tab in tabs)
+        for (final tab in _allMobileTabs)
           StatefulShellBranch(
             routes: [
               GoRoute(
@@ -208,24 +208,23 @@ class _MobileTab {
 
 /// Branch order and tab-bar order derive from this single list so their
 /// indices can never drift apart.
-List<_MobileTab> _mobileTabs({required bool swapFeatureEnabled}) => [
-  const _MobileTab(
+const List<_MobileTab> _allMobileTabs = [
+  _MobileTab(
     path: '/home',
     item: AppMobileTabItem(iconName: AppIcons.home, label: 'Home'),
     screen: MobileHomeScreen(),
   ),
-  if (swapFeatureEnabled)
-    const _MobileTab(
-      path: '/swap',
-      item: AppMobileTabItem(iconName: AppIcons.swapArrows, label: 'Swap'),
-      screen: MobileSwapScreen(),
-    ),
-  const _MobileTab(
+  _MobileTab(
+    path: '/swap',
+    item: AppMobileTabItem(iconName: AppIcons.swapArrows, label: 'Swap'),
+    screen: MobileSwapScreen(),
+  ),
+  _MobileTab(
     path: '/activity',
     item: AppMobileTabItem(iconName: AppIcons.history, label: 'Activity'),
     screen: MobileActivityScreen(),
   ),
-  const _MobileTab(
+  _MobileTab(
     path: '/settings',
     item: AppMobileTabItem(iconName: AppIcons.cog, label: 'Settings'),
     screen: MobileSettingsScreen(),
@@ -240,26 +239,43 @@ class _MobileTabShell extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final swapFeatureEnabled = ref.watch(swapFeatureEnabledProvider);
+    final visibleTabs = [
+      for (final tab in tabs)
+        if (swapFeatureEnabled || tab.path != '/swap') tab,
+    ];
+    final currentBranchIndex = navigationShell.currentIndex;
+    final currentTab =
+        currentBranchIndex >= 0 && currentBranchIndex < tabs.length
+        ? tabs[currentBranchIndex]
+        : tabs.first;
+    final currentVisibleIndex = visibleTabs.indexOf(currentTab);
+    final tabBarCurrentIndex = currentVisibleIndex < 0
+        ? 0
+        : currentVisibleIndex;
+
     return AppMobileShell(
       body: navigationShell,
       tabBar: AppMobileTabBar(
-        items: [for (final tab in tabs) tab.item],
-        currentIndex: navigationShell.currentIndex,
+        items: [for (final tab in visibleTabs) tab.item],
+        currentIndex: tabBarCurrentIndex,
         onSelect: (index) {
+          final targetTab = visibleTabs[index];
+          final targetBranchIndex = tabs.indexOf(targetTab);
           // Record the outgoing tab path so a tab root can offer a
           // "back to where you came from" affordance (the indexedStack
           // shell keeps no tab history of its own). Skip when re-selecting
           // the active tab — that just resets it to root.
-          if (index != navigationShell.currentIndex) {
+          if (targetBranchIndex != currentBranchIndex) {
             ref
                 .read(mobilePreviousTabPathProvider.notifier)
-                .record(tabs[navigationShell.currentIndex].path);
+                .record(currentTab.path);
           }
           navigationShell.goBranch(
-            index,
+            targetBranchIndex,
             // Re-selecting the active tab resets that tab to its root,
             // the platform-conventional behavior.
-            initialLocation: index == navigationShell.currentIndex,
+            initialLocation: targetBranchIndex == currentBranchIndex,
           );
         },
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -873,7 +873,7 @@ packages:
     source: hosted
     version: "6.1.0"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: c3025c5534b01739267eb7d76959bbc25a6d10f6988e1c2a3036940133dd10bf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   pretty_qr_code: ^3.6.0
   # Platform share sheet for the receive screen's share action.
   share_plus: ^12.0.1
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   flutter_test:

--- a/test/app_swap_feature_test.dart
+++ b/test/app_swap_feature_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/app.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
@@ -16,6 +17,11 @@ import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 
 import 'fakes/fake_sync_notifier.dart';
+
+final _swapFeatureToggleProvider =
+    NotifierProvider<_SwapFeatureToggleNotifier, bool>(
+      _SwapFeatureToggleNotifier.new,
+    );
 
 void main() {
   testWidgets('disabled swap route redirects to home', (tester) async {
@@ -42,6 +48,33 @@ void main() {
 
     expect(find.byType(SwapActivityDetailScreen), findsNothing);
     expect(find.byType(HomeScreen), findsOneWidget);
+  });
+
+  testWidgets('enabling swap preserves the current route', (tester) async {
+    await tester.pumpWidget(
+      _appHarness(
+        '/home',
+        swapFeatureOverride: swapFeatureEnabledProvider.overrideWith(
+          (ref) => ref.watch(_swapFeatureToggleProvider),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Activity').first);
+    await tester.pumpAndSettle();
+    expect(find.byType(ActivityScreen), findsOneWidget);
+    expect(find.byType(HomeScreen), findsNothing);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ZcashWalletApp)),
+      listen: false,
+    );
+    container.read(_swapFeatureToggleProvider.notifier).setEnabled(true);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ActivityScreen), findsOneWidget);
+    expect(find.byType(HomeScreen), findsNothing);
   });
 
   testWidgets('disabled swap hides home swap activity surface', (tester) async {
@@ -172,6 +205,7 @@ SwapIntentRecord _swapActivityRecord({required String id}) {
 Widget _appHarness(
   String initialLocation, {
   bool? swapEnabled,
+  Override? swapFeatureOverride,
   String network = 'main',
   SwapActivityStore? swapActivityStore,
 }) {
@@ -181,7 +215,9 @@ Widget _appHarness(
         _bootstrap(initialLocation, network: network),
       ),
       syncProvider.overrideWith(() => FakeSyncNotifier(_syncedSyncState)),
-      if (swapEnabled != null)
+      if (swapFeatureOverride != null)
+        swapFeatureOverride
+      else if (swapEnabled != null)
         swapFeatureEnabledProvider.overrideWithValue(swapEnabled),
       swapIntentProvider.overrideWithValue(const _FakeSwapProvider()),
       if (swapActivityStore != null)
@@ -189,6 +225,15 @@ Widget _appHarness(
     ],
     child: const ZcashWalletApp(),
   );
+}
+
+class _SwapFeatureToggleNotifier extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  void setEnabled(bool enabled) {
+    state = enabled;
+  }
 }
 
 Future<void> _pumpUntilPresent(WidgetTester tester, Finder finder) async {

--- a/test/core/config/swap_feature_config_test.dart
+++ b/test/core/config/swap_feature_config_test.dart
@@ -1,9 +1,13 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' show ThemeMode;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/app_version_config.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/config/swap_feature_config.dart';
+import 'package:zcash_wallet/src/core/config/swap_remote_enable_config.dart';
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 
 void main() {
@@ -19,7 +23,10 @@ void main() {
     for (final entry in cases.entries) {
       final container = ProviderContainer(
         overrides: [
-          appBootstrapProvider.overrideWithValue(_bootstrap(entry.key)),
+          appBootstrapProvider.overrideWithValue(
+            _bootstrap(network: entry.key),
+          ),
+          swapForceDisabledForCurrentBuildProvider.overrideWithValue(false),
         ],
       );
       addTearDown(container.dispose);
@@ -31,19 +38,225 @@ void main() {
       );
     }
   });
+
+  group('parseSwapEnabledOverrideForVersion', () {
+    test('requires an exact true value for the current version', () {
+      expect(
+        parseSwapEnabledOverrideForVersion('{"1.2.3":true}', '1.2.3'),
+        true,
+      );
+      expect(
+        parseSwapEnabledOverrideForVersion('{"1.2.3":false}', '1.2.3'),
+        false,
+      );
+      expect(
+        parseSwapEnabledOverrideForVersion('{"1.2.4":true}', '1.2.3'),
+        false,
+      );
+      expect(
+        parseSwapEnabledOverrideForVersion('{"1.2.3":"true"}', '1.2.3'),
+        false,
+      );
+      expect(parseSwapEnabledOverrideForVersion('[]', '1.2.3'), false);
+      expect(parseSwapEnabledOverrideForVersion('not json', '1.2.3'), false);
+    });
+  });
+
+  group('shouldForceDisableSwapForCurrentBuild', () {
+    test('only applies to explicitly forced iOS mobile builds', () {
+      expect(
+        shouldForceDisableSwapForCurrentBuild(
+          forceDisableDefine: true,
+          formFactor: AppFormFactor.mobile,
+          isIOS: true,
+        ),
+        true,
+      );
+      expect(
+        shouldForceDisableSwapForCurrentBuild(
+          forceDisableDefine: false,
+          formFactor: AppFormFactor.mobile,
+          isIOS: true,
+        ),
+        false,
+      );
+      expect(
+        shouldForceDisableSwapForCurrentBuild(
+          forceDisableDefine: true,
+          formFactor: AppFormFactor.desktop,
+          isIOS: true,
+        ),
+        false,
+      );
+      expect(
+        shouldForceDisableSwapForCurrentBuild(
+          forceDisableDefine: true,
+          formFactor: AppFormFactor.mobile,
+          isIOS: false,
+        ),
+        false,
+      );
+    });
+  });
+
+  group('swapFeatureEnabledProvider', () {
+    test('keeps current mainnet behavior when not force disabled', () async {
+      final source = _FakeSwapEnabledOverrideSource(enabled: true);
+      final container = _container(
+        forceDisabled: false,
+        source: source,
+        store: _FakeSwapEnabledOverrideStore(),
+      );
+      final sub = container.listen(swapFeatureEnabledProvider, (_, _) {});
+
+      expect(sub.read(), true);
+      await _pumpAsync();
+      expect(source.fetchCount, 0);
+    });
+
+    test('does not enable swap on non-mainnet networks', () async {
+      final source = _FakeSwapEnabledOverrideSource(enabled: true);
+      final container = _container(
+        bootstrap: _bootstrap(network: 'test'),
+        forceDisabled: true,
+        source: source,
+        store: _FakeSwapEnabledOverrideStore(),
+      );
+      final sub = container.listen(swapFeatureEnabledProvider, (_, _) {});
+
+      expect(sub.read(), false);
+      await _pumpAsync();
+      expect(source.fetchCount, 0);
+    });
+
+    test('uses cached remote enablement immediately and skips fetch', () async {
+      final source = _FakeSwapEnabledOverrideSource(enabled: true);
+      final container = _container(
+        bootstrap: _bootstrap(swapOverrideCached: true),
+        forceDisabled: true,
+        source: source,
+        store: _FakeSwapEnabledOverrideStore(),
+      );
+      final sub = container.listen(swapFeatureEnabledProvider, (_, _) {});
+
+      expect(sub.read(), true);
+      await _pumpAsync();
+      expect(source.fetchCount, 0);
+    });
+
+    test('stays disabled when remote override is missing or false', () async {
+      final source = _FakeSwapEnabledOverrideSource(enabled: false);
+      final store = _FakeSwapEnabledOverrideStore();
+      final container = _container(
+        forceDisabled: true,
+        source: source,
+        store: store,
+      );
+      final sub = container.listen(swapFeatureEnabledProvider, (_, _) {});
+
+      expect(sub.read(), false);
+      await _pumpAsync();
+
+      expect(sub.read(), false);
+      expect(source.fetchCount, 1);
+      expect(store.cachedVersions, isEmpty);
+    });
+
+    test('remote true enables swap and caches the release version', () async {
+      final source = _FakeSwapEnabledOverrideSource(enabled: true);
+      final store = _FakeSwapEnabledOverrideStore();
+      final container = _container(
+        forceDisabled: true,
+        source: source,
+        store: store,
+      );
+      final sub = container.listen(swapFeatureEnabledProvider, (_, _) {});
+
+      expect(sub.read(), false);
+      await _pumpAsync();
+
+      expect(sub.read(), true);
+      expect(source.fetchCount, 1);
+      expect(source.requestedVersions, [kVizorReleaseVersion]);
+      expect(store.cachedVersions, [kVizorReleaseVersion]);
+    });
+  });
+
+  group('SharedPreferencesSwapEnabledOverrideStore', () {
+    test('stores the release override as a bool keyed by version', () async {
+      SharedPreferences.setMockInitialValues({});
+      const store = SharedPreferencesSwapEnabledOverrideStore();
+
+      await store.cacheEnabledForVersion('9.9.9');
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(swapEnabledOverrideStorageKey('9.9.9')), true);
+    });
+  });
 }
 
-AppBootstrapState _bootstrap(String network) {
+ProviderContainer _container({
+  AppBootstrapState? bootstrap,
+  required bool forceDisabled,
+  required _FakeSwapEnabledOverrideSource source,
+  required _FakeSwapEnabledOverrideStore store,
+}) {
+  final container = ProviderContainer(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(bootstrap ?? _bootstrap()),
+      swapForceDisabledForCurrentBuildProvider.overrideWithValue(forceDisabled),
+      swapEnabledOverrideSourceProvider.overrideWithValue(source),
+      swapEnabledOverrideStoreProvider.overrideWithValue(store),
+    ],
+  );
+  addTearDown(container.dispose);
+  return container;
+}
+
+AppBootstrapState _bootstrap({
+  String network = 'main',
+  bool swapOverrideCached = false,
+}) {
   return AppBootstrapState(
-    initialLocation: '/home',
+    initialLocation: '/welcome',
     initialAccountState: AccountState(),
     initialSyncSnapshot: AppSyncSnapshot.empty,
     network: network,
     rpcEndpointConfig: defaultRpcEndpointConfig(network),
     themeMode: ThemeMode.system,
     privacyModeEnabled: false,
+    swapEnabledOverrideCachedForRelease: swapOverrideCached,
     isPasswordConfigured: false,
     isUnlocked: false,
     passwordRotationRecoveryFailed: false,
   );
+}
+
+Future<void> _pumpAsync() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}
+
+class _FakeSwapEnabledOverrideSource implements SwapEnabledOverrideSource {
+  _FakeSwapEnabledOverrideSource({required this.enabled});
+
+  final bool enabled;
+  var fetchCount = 0;
+  final requestedVersions = <String>[];
+
+  @override
+  Future<bool> isEnabledForVersion(String version) async {
+    fetchCount++;
+    requestedVersions.add(version);
+    return enabled;
+  }
+}
+
+class _FakeSwapEnabledOverrideStore implements SwapEnabledOverrideStore {
+  final cachedVersions = <String>[];
+
+  @override
+  Future<void> cacheEnabledForVersion(String version) async {
+    cachedVersions.add(version);
+  }
 }

--- a/test/core/navigation/mobile_routes_test.dart
+++ b/test/core/navigation/mobile_routes_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/config/swap_feature_config.dart';
 import 'package:zcash_wallet/src/core/layout/mobile/app_mobile_shell.dart';
 import 'package:zcash_wallet/src/core/navigation/mobile_routes.dart';
 import 'package:zcash_wallet/src/core/profile_pictures.dart';
@@ -48,17 +49,15 @@ AppBootstrapState _bootstrap() => AppBootstrapState(
   passwordRotationRecoveryFailed: false,
 );
 
-GoRouter _router({bool swapFeatureEnabled = true}) => GoRouter(
+GoRouter _router() => GoRouter(
   initialLocation: '/home',
-  routes: buildMobileRoutes(
-    entryRoutes: const [],
-    swapFeatureEnabled: swapFeatureEnabled,
-  ),
+  routes: buildMobileRoutes(entryRoutes: const []),
 );
 
-Widget _app(GoRouter router) => ProviderScope(
+Widget _app(GoRouter router, {bool swapFeatureEnabled = true}) => ProviderScope(
   overrides: [
     appBootstrapProvider.overrideWithValue(_bootstrap()),
+    swapFeatureEnabledProvider.overrideWithValue(swapFeatureEnabled),
     // Funded so the home tab shows the Send action used by the push
     // test.
     syncProvider.overrideWith(
@@ -106,7 +105,7 @@ void main() {
   testWidgets('swap tab is hidden when the swap feature is disabled', (
     tester,
   ) async {
-    await tester.pumpWidget(_app(_router(swapFeatureEnabled: false)));
+    await tester.pumpWidget(_app(_router(), swapFeatureEnabled: false));
     await tester.pumpAndSettle();
 
     expect(find.bySemanticsLabel('Swap'), findsNothing);

--- a/test/features/swap/mobile_swap_modal_route_test.dart
+++ b/test/features/swap/mobile_swap_modal_route_test.dart
@@ -72,10 +72,7 @@ Widget _app({_MobileDelayedQuoteSwapProvider? swapProvider}) => ProviderScope(
   child: MaterialApp.router(
     routerConfig: GoRouter(
       initialLocation: '/home',
-      routes: buildMobileRoutes(
-        entryRoutes: const [],
-        swapFeatureEnabled: true,
-      ),
+      routes: buildMobileRoutes(entryRoutes: const []),
     ),
     builder: (_, child) => AppTheme(data: AppThemeData.dark, child: child!),
   ),


### PR DESCRIPTION
## Summary
- add an iOS mobile swap force-disable dart define with a remote version override and SharedPreferences true-cache
- pass VIZOR_FORCE_DISABLE_IOS_MOBILE_SWAP through the iOS Fastfile into flutter build ipa
- cover the force-disable, remote override, and cache behavior with config tests

## Validation
- fvm flutter test test/core/config/swap_feature_config_test.dart
- fvm flutter test test/app_swap_feature_test.dart
- fvm flutter analyze
- ruby -c fastlane/ios/Fastfile
- git diff --check

## Notes
- Deployment workflow wiring lives in the separate vizor-wallet-deployment repository and is not part of this PR.