### PR TITLE
[codex] Add iOS fresh install keychain cleanup

### DIFF
--- a/integration_test/mainnet_mobile_create_wallet_state_test.dart
+++ b/integration_test/mainnet_mobile_create_wallet_state_test.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+
+import 'support/mobile_regtest_flow.dart';
+
+const _accountsKey = 'zcash_accounts';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeZcashWalletRuntime();
+  });
+
+  testWidgets(
+    'creates mainnet wallet state for fresh-install keychain cleanup E2E',
+    (tester) async {
+      tolerateRenderOverflows();
+      expect(kZcashDefaultNetworkName, ZcashNetwork.mainnet.name);
+
+      logE2e('pumping mainnet app');
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+
+      await createWalletWithPasscode(tester);
+
+      final storage = AppSecureStore.instance;
+      final accountsJson = await storage.readString(_accountsKey);
+      expect(accountsJson, isNotNull);
+      expect(accountsJson, isNotEmpty);
+
+      final dbName = await storage.readPlain(kWalletDbNameKey);
+      expect(dbName, isNotNull);
+      expect(dbName!, startsWith('zcash_wallet_'));
+      expect(dbName, endsWith('.db'));
+
+      final dbPath = await getWalletDbPath();
+      expect(File(dbPath).existsSync(), isTrue);
+      logE2e('mainnet wallet state created with DB $dbName');
+    },
+    timeout: const Timeout(Duration(minutes: 5)),
+  );
+}

--- a/integration_test/mainnet_mobile_create_wallet_state_test.dart
+++ b/integration_test/mainnet_mobile_create_wallet_state_test.dart
@@ -10,6 +10,7 @@ import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
 import 'support/mobile_regtest_flow.dart';
 
 const _accountsKey = 'zcash_accounts';
+const _holdAfterCreate = bool.fromEnvironment('ZCASH_E2E_HOLD_AFTER_CREATE');
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -42,6 +43,10 @@ void main() {
       final dbPath = await getWalletDbPath();
       expect(File(dbPath).existsSync(), isTrue);
       logE2e('mainnet wallet state created with DB $dbName');
+
+      while (_holdAfterCreate) {
+        await Future<void>.delayed(const Duration(seconds: 1));
+      }
     },
     timeout: const Timeout(Duration(minutes: 5)),
   );

--- a/integration_test/mainnet_mobile_fresh_install_keychain_cleanup_test.dart
+++ b/integration_test/mainnet_mobile_fresh_install_keychain_cleanup_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+
+import 'support/mobile_regtest_flow.dart';
+
+const _accountsKey = 'zcash_accounts';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeZcashWalletRuntime();
+  });
+
+  testWidgets(
+    'clears stale mainnet keychain values after app uninstall',
+    (tester) async {
+      tolerateRenderOverflows();
+      expect(kZcashDefaultNetworkName, ZcashNetwork.mainnet.name);
+
+      logE2e('pumping mainnet app after host-side uninstall');
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+
+      await pumpUntil(
+        tester,
+        () => tester.any(
+          find.byKey(const ValueKey('mobile_welcome_get_started')),
+        ),
+        description: 'fresh install welcome screen',
+        timeout: const Duration(minutes: 1),
+      );
+
+      final storage = AppSecureStore.instance;
+      expect(await storage.readString(_accountsKey), isNull);
+      expect(await storage.isPasswordConfigured(), isFalse);
+      logE2e('stale mainnet keychain values were cleared');
+    },
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+}

--- a/integration_test/support/mobile_regtest_flow.dart
+++ b/integration_test/support/mobile_regtest_flow.dart
@@ -40,7 +40,7 @@ const _zcashdRpcPassword = 'zcash';
 const _accountsKey = 'zcash_accounts';
 
 void logE2e(String message) {
-  debugPrint('[mobile-regtest-e2e] $message');
+  debugPrint('[mobile-$mobileE2eNetwork-e2e] $message');
 }
 
 /// Keeps cosmetic RenderFlex overflows (a few px on the 393pt frame

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -7,6 +7,8 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    FreshInstallKeychainCleaner.runIfNeeded()
+
     if #available(iOS 26.0, *) {
       BackgroundSyncManager.shared.registerBackgroundTask()
       TxTrackManager.shared.registerTask()

--- a/ios/Runner/WalletPathResolver.swift
+++ b/ios/Runner/WalletPathResolver.swift
@@ -3,6 +3,8 @@ import Security
 
 private let walletDbNameKey = "zcash_wallet_db_name"
 private let secureStoreService = "com.keplr.vizor.secure_store"
+private let biometricUnlockService = "com.zcash.wallet.biometric-unlock"
+private let installSentinelKey = "vizor_install_sentinel_v1"
 
 enum WalletPathResolverError: Error {
     case dbNameMissing
@@ -54,5 +56,175 @@ private func resolveWalletDbName() throws -> String {
         throw WalletPathResolverError.dbNameMissing
     default:
         throw WalletPathResolverError.keychainStatus(status)
+    }
+}
+
+enum KeychainDbNameLookup: Equatable {
+    case found(String)
+    case missing
+    case invalid
+    case failed(OSStatus)
+}
+
+enum FreshInstallKeychainCleanupDecision: Equatable {
+    case sentinelPresent
+    case markInstalled
+    case preserveExistingInstall
+    case clearStaleKeychain
+    case deferCleanupAfterReadFailure(OSStatus)
+    case deferCleanupAfterInvalidWalletDbName
+}
+
+struct FreshInstallKeychainCleaner {
+    struct Dependencies {
+        var hasInstallSentinel: () -> Bool
+        var markInstallSentinel: () -> Void
+        var readWalletDbName: () -> KeychainDbNameLookup
+        var walletDbExists: (String) -> Bool
+        var deleteKeychainService: (String) -> OSStatus
+        var log: (String) -> Void
+
+        static let live = Dependencies(
+            hasInstallSentinel: {
+                UserDefaults.standard.bool(forKey: installSentinelKey)
+            },
+            markInstallSentinel: {
+                UserDefaults.standard.set(true, forKey: installSentinelKey)
+            },
+            readWalletDbName: {
+                FreshInstallKeychainCleaner.readWalletDbNameFromKeychain()
+            },
+            walletDbExists: { dbName in
+                FreshInstallKeychainCleaner.walletDbExists(dbName)
+            },
+            deleteKeychainService: { service in
+                FreshInstallKeychainCleaner.deleteGenericPasswordService(service)
+            },
+            log: { message in
+                NSLog("[zcash] %@", message)
+            }
+        )
+    }
+
+    static let servicesToClear = [
+        secureStoreService,
+        biometricUnlockService,
+    ]
+
+    static func runIfNeeded(dependencies: Dependencies = .live) {
+        switch cleanupDecision(dependencies: dependencies) {
+        case .sentinelPresent:
+            return
+        case .markInstalled:
+            dependencies.markInstallSentinel()
+        case .preserveExistingInstall:
+            dependencies.markInstallSentinel()
+        case .clearStaleKeychain:
+            let statuses = servicesToClear.map { dependencies.deleteKeychainService($0) }
+            let succeeded = statuses.allSatisfy { status in
+                status == errSecSuccess || status == errSecItemNotFound
+            }
+            if succeeded {
+                dependencies.markInstallSentinel()
+                dependencies.log("fresh install: cleared stale iOS keychain values")
+            } else if let status = statuses.first(where: { $0 != errSecSuccess && $0 != errSecItemNotFound }) {
+                dependencies.log("fresh install: deferred keychain cleanup after delete status \(status)")
+            }
+        case .deferCleanupAfterReadFailure(let status):
+            dependencies.log("fresh install: deferred keychain cleanup after read status \(status)")
+        case .deferCleanupAfterInvalidWalletDbName:
+            dependencies.log("fresh install: deferred keychain cleanup after invalid wallet DB name")
+        }
+    }
+
+    static func cleanupDecision(
+        dependencies: Dependencies = .live
+    ) -> FreshInstallKeychainCleanupDecision {
+        if dependencies.hasInstallSentinel() {
+            return .sentinelPresent
+        }
+
+        switch dependencies.readWalletDbName() {
+        case .missing:
+            return .markInstalled
+        case .invalid:
+            return .deferCleanupAfterInvalidWalletDbName
+        case .failed(let status):
+            return .deferCleanupAfterReadFailure(status)
+        case .found(let dbName):
+            // Existing users from before this install sentinel existed can have a
+            // Keychain wallet DB name without the sentinel. If the app-private DB
+            // still exists, preserve their Keychain values and write the sentinel.
+            return dependencies.walletDbExists(dbName)
+                ? .preserveExistingInstall
+                : .clearStaleKeychain
+        }
+    }
+
+    private static func readWalletDbNameFromKeychain() -> KeychainDbNameLookup {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: walletDbNameKey,
+            kSecAttrService: secureStoreService,
+            kSecReturnData: true,
+            kSecMatchLimit: kSecMatchLimitOne,
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        switch status {
+        case errSecSuccess:
+            guard let data = item as? Data else {
+                return .invalid
+            }
+            guard let dbName = String(data: data, encoding: .utf8), isSafeDbName(dbName) else {
+                return .invalid
+            }
+            return .found(dbName)
+        case errSecItemNotFound:
+            return .missing
+        default:
+            return .failed(status)
+        }
+    }
+
+    private static func walletDbExists(_ dbName: String) -> Bool {
+        guard isSafeDbName(dbName) else {
+            return true
+        }
+        guard let supportDir = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return false
+        }
+        let dbUrl = supportDir.appendingPathComponent(dbName, isDirectory: false)
+        return FileManager.default.fileExists(atPath: dbUrl.path)
+    }
+
+    private static func isSafeDbName(_ dbName: String) -> Bool {
+        if dbName.isEmpty {
+            return false
+        }
+        return (dbName as NSString).lastPathComponent == dbName
+    }
+
+    private static func deleteGenericPasswordService(_ service: String) -> OSStatus {
+        let statuses = [kCFBooleanTrue, kCFBooleanFalse].map { synchronizable in
+            let query: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: service,
+                kSecAttrSynchronizable: synchronizable as Any,
+            ]
+            return SecItemDelete(query as CFDictionary)
+        }
+
+        if statuses.contains(errSecSuccess) {
+            return errSecSuccess
+        }
+        if statuses.allSatisfy({ $0 == errSecItemNotFound }) {
+            return errSecSuccess
+        }
+        return statuses.first { $0 != errSecItemNotFound } ?? errSecSuccess
     }
 }

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -1,12 +1,129 @@
 import Flutter
+@testable import Runner
+import Security
 import UIKit
 import XCTest
 
 class RunnerTests: XCTestCase {
 
-  func testExample() {
-    // If you add code to the Runner application, consider adding tests here.
-    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+  func testFreshInstallCleanerMarksInstallWhenNoWalletKeychainExists() {
+    let harness = FreshInstallCleanerHarness()
+    harness.lookup = .missing
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertTrue(harness.markedInstalled)
+    XCTAssertTrue(harness.deletedServices.isEmpty)
   }
 
+  func testFreshInstallCleanerPreservesExistingInstallWhenWalletDbStillExists() {
+    let harness = FreshInstallCleanerHarness()
+    harness.lookup = .found("zcash_wallet_existing.db")
+    harness.walletDbExists = true
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertTrue(harness.markedInstalled)
+    XCTAssertTrue(harness.deletedServices.isEmpty)
+  }
+
+  func testFreshInstallCleanerClearsStaleKeychainWhenWalletDbIsGone() {
+    let harness = FreshInstallCleanerHarness()
+    harness.lookup = .found("zcash_wallet_deleted.db")
+    harness.walletDbExists = false
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertTrue(harness.markedInstalled)
+    XCTAssertEqual(
+      harness.deletedServices,
+      FreshInstallKeychainCleaner.servicesToClear
+    )
+  }
+
+  func testFreshInstallCleanerDefersSentinelWhenKeychainReadFails() {
+    let harness = FreshInstallCleanerHarness()
+    harness.lookup = .failed(errSecInteractionNotAllowed)
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertFalse(harness.markedInstalled)
+    XCTAssertTrue(harness.deletedServices.isEmpty)
+  }
+
+  func testFreshInstallCleanerDefersSentinelWhenWalletDbNameIsInvalid() {
+    let harness = FreshInstallCleanerHarness()
+    harness.lookup = .invalid
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertFalse(harness.markedInstalled)
+    XCTAssertTrue(harness.deletedServices.isEmpty)
+  }
+
+  func testFreshInstallCleanerDefersSentinelWhenDeleteFails() {
+    let harness = FreshInstallCleanerHarness()
+    harness.lookup = .found("zcash_wallet_deleted.db")
+    harness.walletDbExists = false
+    harness.deleteStatuses = [
+      FreshInstallKeychainCleaner.servicesToClear[0]: errSecSuccess,
+      FreshInstallKeychainCleaner.servicesToClear[1]: errSecAuthFailed,
+    ]
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertFalse(harness.markedInstalled)
+    XCTAssertEqual(
+      harness.deletedServices,
+      FreshInstallKeychainCleaner.servicesToClear
+    )
+  }
+
+  func testFreshInstallCleanerDoesNothingWhenSentinelAlreadyExists() {
+    let harness = FreshInstallCleanerHarness()
+    harness.hasSentinel = true
+    harness.lookup = .found("zcash_wallet_deleted.db")
+    harness.walletDbExists = false
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertFalse(harness.markedInstalled)
+    XCTAssertTrue(harness.deletedServices.isEmpty)
+  }
+
+}
+
+private final class FreshInstallCleanerHarness {
+  var hasSentinel = false
+  var markedInstalled = false
+  var lookup: KeychainDbNameLookup = .missing
+  var walletDbExists = false
+  var deleteStatuses: [String: OSStatus] = [:]
+  var deletedServices: [String] = []
+  var logs: [String] = []
+
+  func dependencies() -> FreshInstallKeychainCleaner.Dependencies {
+    FreshInstallKeychainCleaner.Dependencies(
+      hasInstallSentinel: {
+        self.hasSentinel
+      },
+      markInstallSentinel: {
+        self.markedInstalled = true
+        self.hasSentinel = true
+      },
+      readWalletDbName: {
+        self.lookup
+      },
+      walletDbExists: { _ in
+        self.walletDbExists
+      },
+      deleteKeychainService: { service in
+        self.deletedServices.append(service)
+        return self.deleteStatuses[service] ?? errSecSuccess
+      },
+      log: { message in
+        self.logs.append(message)
+      }
+    )
+  }
 }

--- a/scripts/e2e/flutter-ios-mainnet-mobile-fresh-install-keychain-cleanup.sh
+++ b/scripts/e2e/flutter-ios-mainnet-mobile-fresh-install-keychain-cleanup.sh
@@ -6,21 +6,119 @@ APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.keplr.vizor}"
 
 source "$ROOT_DIR/scripts/e2e/lib-mobile.sh"
 
+read_install_sentinel() {
+  /usr/libexec/PlistBuddy -c 'Print :vizor_install_sentinel_v1' "$1" \
+    2>/dev/null || true
+}
+
+install_sentinel_is_true() {
+  local value
+  value="$(read_install_sentinel "$1")"
+  [[ "$value" == "true" || "$value" == "1" ]]
+}
+
 require_cmd fvm
 require_cmd xcrun
 
 cd "$ROOT_DIR"
 
 UDID="$(pick_simulator)"
+LEGACY_LOG_DIR="$ROOT_DIR/.regtest-logs"
+CREATE_LOG="$LEGACY_LOG_DIR/mainnet-create-wallet-state.log"
+LEGACY_LOG="$LEGACY_LOG_DIR/mainnet-legacy-launch.log"
 
 echo "resetting simulator keychain and app state on ${UDID}"
 xcrun simctl terminate "$UDID" "$APP_BUNDLE_ID" >/dev/null 2>&1 || true
 xcrun simctl uninstall "$UDID" "$APP_BUNDLE_ID" >/dev/null 2>&1 || true
 xcrun simctl keychain "$UDID" reset
 
+mkdir -p "$LEGACY_LOG_DIR"
+: > "$CREATE_LOG"
 run_mobile_mainnet_e2e \
   integration_test/mainnet_mobile_create_wallet_state_test.dart \
-  "$UDID"
+  "$UDID" \
+  --dart-define=ZCASH_E2E_HOLD_AFTER_CREATE=true \
+  >"$CREATE_LOG" 2>&1 &
+CREATE_PID="$!"
+
+create_ok=0
+for _ in {1..300}; do
+  if grep -q "mainnet wallet state created with DB" "$CREATE_LOG"; then
+    create_ok=1
+    break
+  fi
+  if ! kill -0 "$CREATE_PID" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$create_ok" != "1" ]]; then
+  echo "mainnet wallet state setup did not complete; log follows:" >&2
+  cat "$CREATE_LOG" >&2
+  exit 1
+fi
+
+kill "$CREATE_PID" >/dev/null 2>&1 || true
+wait "$CREATE_PID" >/dev/null 2>&1 || true
+
+echo "removing install sentinel while preserving app data and keychain"
+xcrun simctl terminate "$UDID" "$APP_BUNDLE_ID" >/dev/null 2>&1 || true
+data_container="$(xcrun simctl get_app_container "$UDID" "$APP_BUNDLE_ID" data)"
+sentinel_plist="$data_container/Library/Preferences/${APP_BUNDLE_ID}.plist"
+/usr/libexec/PlistBuddy -c 'Delete :vizor_install_sentinel_v1' \
+  "$sentinel_plist" >/dev/null 2>&1 || true
+if [[ -n "$(read_install_sentinel "$sentinel_plist")" ]]; then
+  echo "failed to remove install sentinel from ${APP_BUNDLE_ID}" >&2
+  exit 1
+fi
+
+wallet_db_count="$(find "$data_container/Library/Application Support" \
+  -maxdepth 1 -name 'zcash_wallet_*.db' 2>/dev/null | wc -l | tr -d ' ')"
+if [[ "$wallet_db_count" == "0" ]]; then
+  echo "expected an existing wallet DB before legacy launch" >&2
+  exit 1
+fi
+
+echo "launching app to verify legacy data is preserved"
+: > "$LEGACY_LOG"
+xcrun simctl terminate "$UDID" "$APP_BUNDLE_ID" >/dev/null 2>&1 || true
+xcrun simctl launch --console "$UDID" "$APP_BUNDLE_ID" \
+  >"$LEGACY_LOG" 2>&1 &
+LAUNCH_PID="$!"
+
+legacy_ok=0
+for _ in {1..30}; do
+  if grep -q "fresh install: cleared stale iOS keychain values" "$LEGACY_LOG"; then
+    break
+  fi
+  if install_sentinel_is_true "$sentinel_plist"; then
+    legacy_ok=1
+    break
+  fi
+  sleep 1
+done
+
+kill "$LAUNCH_PID" >/dev/null 2>&1 || true
+xcrun simctl terminate "$UDID" "$APP_BUNDLE_ID" >/dev/null 2>&1 || true
+
+if [[ "$legacy_ok" != "1" ]]; then
+  echo "legacy launch did not preserve wallet state; log follows:" >&2
+  cat "$LEGACY_LOG" >&2
+  exit 1
+fi
+
+if grep -q "fresh install: cleared stale iOS keychain values" "$LEGACY_LOG"; then
+  echo "legacy launch unexpectedly cleared keychain values; log follows:" >&2
+  cat "$LEGACY_LOG" >&2
+  exit 1
+fi
+
+sentinel_value="$(read_install_sentinel "$sentinel_plist")"
+if [[ "$sentinel_value" != "true" && "$sentinel_value" != "1" ]]; then
+  echo "expected legacy launch to restore install sentinel, got: ${sentinel_value}" >&2
+  exit 1
+fi
 
 echo "uninstalling ${APP_BUNDLE_ID} without resetting keychain"
 xcrun simctl terminate "$UDID" "$APP_BUNDLE_ID" >/dev/null 2>&1 || true
@@ -30,4 +128,4 @@ run_mobile_mainnet_e2e \
   integration_test/mainnet_mobile_fresh_install_keychain_cleanup_test.dart \
   "$UDID"
 
-echo "mainnet iOS fresh-install keychain cleanup E2E passed"
+echo "mainnet iOS keychain cleanup E2E passed"

--- a/scripts/e2e/flutter-ios-mainnet-mobile-fresh-install-keychain-cleanup.sh
+++ b/scripts/e2e/flutter-ios-mainnet-mobile-fresh-install-keychain-cleanup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.keplr.vizor}"
+
+source "$ROOT_DIR/scripts/e2e/lib-mobile.sh"
+
+require_cmd fvm
+require_cmd xcrun
+
+cd "$ROOT_DIR"
+
+UDID="$(pick_simulator)"
+
+echo "resetting simulator keychain and app state on ${UDID}"
+xcrun simctl terminate "$UDID" "$APP_BUNDLE_ID" >/dev/null 2>&1 || true
+xcrun simctl uninstall "$UDID" "$APP_BUNDLE_ID" >/dev/null 2>&1 || true
+xcrun simctl keychain "$UDID" reset
+
+run_mobile_mainnet_e2e \
+  integration_test/mainnet_mobile_create_wallet_state_test.dart \
+  "$UDID"
+
+echo "uninstalling ${APP_BUNDLE_ID} without resetting keychain"
+xcrun simctl terminate "$UDID" "$APP_BUNDLE_ID" >/dev/null 2>&1 || true
+xcrun simctl uninstall "$UDID" "$APP_BUNDLE_ID"
+
+run_mobile_mainnet_e2e \
+  integration_test/mainnet_mobile_fresh_install_keychain_cleanup_test.dart \
+  "$UDID"
+
+echo "mainnet iOS fresh-install keychain cleanup E2E passed"

--- a/scripts/e2e/lib-mobile.sh
+++ b/scripts/e2e/lib-mobile.sh
@@ -60,6 +60,23 @@ run_mobile_e2e() {
     "$@"
 }
 
+# Runs one mobile integration test file against the public mainnet endpoint.
+# Extra --dart-define flags can be passed as additional arguments.
+run_mobile_mainnet_e2e() {
+  local test_file="$1"
+  local udid="$2"
+  shift 2
+
+  echo "running mobile mainnet E2E ${test_file} on ${udid}"
+  fvm flutter test \
+    "$test_file" \
+    -d "$udid" \
+    --dart-define=VIZOR_FORM_FACTOR=mobile \
+    --dart-define=ZCASH_DEFAULT_NETWORK=main \
+    --dart-define=ZCASH_E2E_NETWORK=mainnet \
+    "$@"
+}
+
 # Starts the python E2E driver on $1 (port), logging to $2. Sets
 # DRIVER_PID; callers must trap and kill it. Extra args pass through to
 # the driver (e.g. --prepared-faucet-zaddr).


### PR DESCRIPTION
## Summary
- Add an iOS startup cleaner that uses an app-container install sentinel to identify fresh installs.
- Preserve existing users when the Keychain wallet DB name points to an existing app-private DB file.
- Clear stale mainnet secure storage and biometric-unlock Keychain services after uninstall/reinstall when the DB file is gone.
- Defer without writing the sentinel on Keychain read failures, invalid DB names, or delete failures so a later launch can retry safely.

## Validation
- `git diff --check`
- `xcodebuild test -workspace ios/Runner.xcworkspace -scheme Runner -destination 'platform=iOS Simulator,id=C406F64F-8A4D-4AAE-B4ED-0D4063BAC61D' -parallel-testing-enabled NO -destination-timeout 60`