### PR TITLE
[codex] Hide mobile onboarding legal footer

### DIFF
--- a/lib/src/features/onboarding/mobile/mobile_method_selection_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_method_selection_screen.dart
@@ -111,7 +111,17 @@ class MobileMethodSelectionScreen extends StatelessWidget {
                         ),
                       ),
                     ),
-                    const _MethodLegalFooter(),
+                    const ExcludeSemantics(
+                      key: ValueKey('mobile_method_legal_footer_semantics'),
+                      child: IgnorePointer(
+                        key: ValueKey('mobile_method_legal_footer_pointer'),
+                        child: Opacity(
+                          key: ValueKey('mobile_method_legal_footer_hidden'),
+                          opacity: 0,
+                          child: _MethodLegalFooter(),
+                        ),
+                      ),
+                    ),
                     const SizedBox(height: AppSpacing.s),
                   ],
                 ),

--- a/test/features/onboarding/mobile_welcome_screen_test.dart
+++ b/test/features/onboarding/mobile_welcome_screen_test.dart
@@ -126,7 +126,7 @@ void main() {
 
   testWidgets(
     'Get started opens method selection with the three entry points and '
-    'the legal footer',
+    'the hidden legal footer space',
     (tester) async {
       await tester.pumpWidget(_app());
       await tester.pumpAndSettle();
@@ -137,6 +137,21 @@ void main() {
       expect(find.text('Import wallet'), findsOneWidget);
       expect(find.text('Connect Keystone'), findsOneWidget);
       expect(find.textContaining('you agree to our'), findsOneWidget);
+      final hiddenFooter = find.byKey(
+        const ValueKey('mobile_method_legal_footer_hidden'),
+      );
+      expect(hiddenFooter, findsOneWidget);
+      expect(tester.widget<Opacity>(hiddenFooter).opacity, 0);
+      final semantics = find.byKey(
+        const ValueKey('mobile_method_legal_footer_semantics'),
+      );
+      final pointer = find.byKey(
+        const ValueKey('mobile_method_legal_footer_pointer'),
+      );
+      expect(semantics, findsOneWidget);
+      expect(tester.widget<ExcludeSemantics>(semantics).excluding, isTrue);
+      expect(pointer, findsOneWidget);
+      expect(tester.widget<IgnorePointer>(pointer).ignoring, isTrue);
     },
   );
 


### PR DESCRIPTION
## Summary
- Hide the mobile onboarding method-selection legal footer with opacity while preserving its layout space.
- Exclude the hidden footer from semantics and pointer handling.
- Update the mobile onboarding widget test to cover the hidden footer wrapper behavior.

## Why
Terms and privacy documents are not legally ready yet, so mobile onboarding should not expose copy that looks like legal links. The layout still needs to reserve the same bottom space to avoid visual movement.

## Validation
- `fvm dart format lib/src/features/onboarding/mobile/mobile_method_selection_screen.dart test/features/onboarding/mobile_welcome_screen_test.dart`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/onboarding/mobile_welcome_screen_test.dart`