### PR TITLE
[codex] VZR-88 keep import keyboard focused

### DIFF
--- a/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
@@ -80,6 +80,22 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
     if (_hasTyped) _onSubmitted(_controller.text);
   }
 
+  bool _addAcceptedWord(String word) {
+    if (_accepted.length >= kMnemonicMaxWords) {
+      setState(() {
+        _controller.clear();
+        _error = null;
+      });
+      return false;
+    }
+    setState(() {
+      _accepted.add(word);
+      _controller.clear();
+      _error = null;
+    });
+    return true;
+  }
+
   /// Accept the typed word (if any), then validate the full phrase and
   /// move to review. Validation happens here so review stays read-only.
   void _finish() {
@@ -91,21 +107,19 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
         _focusNode.requestFocus();
         return;
       }
-      setState(() {
-        _accepted.add(word);
-        _controller.clear();
-        _error = null;
-      });
+      if (!_addAcceptedWord(word)) {
+        _review();
+        return;
+      }
     }
     _review();
   }
 
   void _acceptWord(String word) {
-    setState(() {
-      _accepted.add(word);
-      _controller.clear();
-      _error = null;
-    });
+    if (!_addAcceptedWord(word)) {
+      _review();
+      return;
+    }
     if (_accepted.length >= kMnemonicMaxWords) {
       _review();
     }
@@ -182,10 +196,23 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
   void _stepBack() {
     if (_accepted.isEmpty) return;
     setState(() {
-      _controller.text = _accepted.removeLast();
-      _controller.selection = TextSelection.collapsed(
-        offset: _controller.text.length,
-      );
+      _restoreLastWordToField();
+      _error = null;
+    });
+    _focusNode.requestFocus();
+  }
+
+  void _restoreLastWordToField() {
+    _controller.text = _accepted.removeLast();
+    _controller.selection = TextSelection.collapsed(
+      offset: _controller.text.length,
+    );
+  }
+
+  void _editLastWordAfterReviewBack() {
+    if (_accepted.isEmpty) return;
+    setState(() {
+      _restoreLastWordToField();
       _error = null;
     });
     _focusNode.requestFocus();
@@ -210,13 +237,15 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
           // phrase/error (manual can be opened from a rejected paste).
           if (result == ImportReviewResult.cleared && mounted) {
             navigator.pop(ImportReviewResult.cleared);
+          } else if (mounted) {
+            _editLastWordAfterReviewBack();
           }
         });
   }
 
-  /// The CTA row: a single "Next word" until a valid-length phrase is
-  /// reachable, then "Next word" (secondary) beside "Finish & review"
-  /// (primary) — Figma 4746:83516.
+  /// The CTA block: a single "Next word" until a valid-length phrase is
+  /// reachable, then a full-width "Finish & review" primary action plus a
+  /// secondary "Next word" to continue toward longer standard phrases.
   Widget _buildButtonRow() {
     final nextEnabled = _hasTyped && !_atMax;
     final nextButton = AppButton(
@@ -224,25 +253,25 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
       variant: _showFinish
           ? AppButtonVariant.secondary
           : AppButtonVariant.primary,
-      expand: !_showFinish,
+      expand: true,
       onPressed: nextEnabled ? _acceptTyped : null,
       trailing: const AppIcon(AppIcons.chevronForward),
       child: const Text('Next word'),
     );
     if (!_showFinish) return nextButton;
-    return Row(
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        nextButton,
-        const SizedBox(width: AppSpacing.xs),
-        Expanded(
-          child: AppButton(
-            key: const ValueKey('mobile_import_manual_finish'),
-            expand: true,
-            onPressed: _finish,
-            trailing: const AppIcon(AppIcons.chevronForward),
-            child: const Text('Finish & review'),
-          ),
+        AppButton(
+          key: const ValueKey('mobile_import_manual_finish'),
+          expand: true,
+          onPressed: _finish,
+          trailing: const AppIcon(AppIcons.chevronForward),
+          child: const Text('Finish & review'),
         ),
+        const SizedBox(height: AppSpacing.xs),
+        nextButton,
       ],
     );
   }

--- a/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
@@ -87,9 +87,7 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
       final tokens = tokenizeMnemonicWords(_typed);
       final word = tokens.isEmpty ? '' : tokens.first;
       if (word.isEmpty || !_wordList.contains(word)) {
-        setState(
-          () => _error = "'$_typed' isn't in the passphrase word list.",
-        );
+        setState(() => _error = "'$_typed' isn't in the passphrase word list.");
         _focusNode.requestFocus();
         return;
       }
@@ -405,6 +403,9 @@ class _WordField extends StatelessWidget {
               keyboardType: TextInputType.visiblePassword,
               autocorrect: false,
               enableSuggestions: false,
+              // Keep the keyboard open when return/check submits a word.
+              // onSubmitted still advances through the shared handler below.
+              onEditingComplete: () {},
               onSubmitted: onSubmitted,
               // The parent decides: a multi-word paste distributes across
               // slots; a single word + trailing space accepts.

--- a/test/features/onboarding/mobile_import_manual_screen_test.dart
+++ b/test/features/onboarding/mobile_import_manual_screen_test.dart
@@ -54,6 +54,33 @@ void main() {
     expect(find.textContaining('abandon'), findsOneWidget);
   });
 
+  testWidgets('keyboard action advances without dropping focus', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app());
+    await tester.pump();
+
+    final field = find.byKey(const ValueKey('mobile_import_manual_field'));
+    await tester.showKeyboard(field);
+    await tester.enterText(field, 'abandon');
+    await tester.pump();
+
+    expect(
+      tester.widget<EditableText>(find.byType(EditableText)).focusNode.hasFocus,
+      isTrue,
+    );
+
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pump();
+
+    expect(find.text('02'), findsOneWidget);
+    expect(find.textContaining('abandon'), findsOneWidget);
+    expect(
+      tester.widget<EditableText>(find.byType(EditableText)).focusNode.hasFocus,
+      isTrue,
+    );
+  });
+
   testWidgets('an unknown word is rejected with an error', (tester) async {
     await tester.pumpWidget(_app());
     await tester.pump();

--- a/test/features/onboarding/mobile_import_manual_screen_test.dart
+++ b/test/features/onboarding/mobile_import_manual_screen_test.dart
@@ -4,8 +4,12 @@ library;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_manual_screen.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_review_screen.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_screens.dart';
+import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
 const _wordList = ['abandon', 'ability', 'able', 'about', 'zebra'];
 const _wordCountSubtitle = 'Accept 12, 15, 18, 21 or 24 words';
@@ -19,7 +23,38 @@ Widget _app() {
   );
 }
 
+Widget _routedApp() {
+  final router = GoRouter(
+    initialLocation: '/import/manual',
+    routes: [
+      GoRoute(
+        path: '/import/manual',
+        builder: (_, _) =>
+            const MobileImportManualScreen(wordListOverride: _wordList),
+      ),
+      GoRoute(
+        path: '/import/review',
+        builder: (_, state) => MobileImportReviewScreen(
+          args: state.extra as MobileImportReviewArgs,
+        ),
+      ),
+    ],
+  );
+  return ProviderScope(
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, c) => AppTheme(data: AppThemeData.light, child: c!),
+    ),
+  );
+}
+
 void main() {
+  setUpAll(() {
+    RustLib.initMock(api: _RustApiFake());
+  });
+
+  tearDownAll(RustLib.dispose);
+
   setUp(() {
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
     binding.platformDispatcher.views.first
@@ -52,6 +87,38 @@ void main() {
 
     expect(find.text('02'), findsOneWidget);
     expect(find.textContaining('abandon'), findsOneWidget);
+  });
+
+  testWidgets('back from review edits the last word instead of adding a 25th', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_routedApp());
+    await tester.pumpAndSettle();
+
+    final field = find.byKey(const ValueKey('mobile_import_manual_field'));
+    await tester.enterText(
+      field,
+      List.filled(kMnemonicMaxWords, 'abandon').join(' '),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review Import'), findsOneWidget);
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Enter your Secret Passphrase'), findsOneWidget);
+    expect(tester.widget<TextField>(field).controller!.text, 'abandon');
+    expect(find.text('24'), findsOneWidget);
+
+    await tester.enterText(field, 'zebra');
+    await tester.pump();
+    await tester.testTextInput.receiveAction(TextInputAction.done);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review Import'), findsOneWidget);
+    expect(find.text('zebra'), findsOneWidget);
+    expect(find.textContaining('found 25'), findsNothing);
   });
 
   testWidgets('keyboard action advances without dropping focus', (
@@ -183,4 +250,15 @@ void main() {
     expect(find.textContaining("Stopped at 'notaword'"), findsOneWidget);
     expect(find.text('Undo last word'), findsNothing);
   });
+}
+
+class _RustApiFake implements RustLibApi {
+  @override
+  bool crateApiWalletValidateMnemonic({required String mnemonic}) {
+    final count = mnemonic.trim().split(RegExp(r'\s+')).length;
+    return count >= 12 && count <= 24 && count % 3 == 0;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => Future<void>.value();
 }


### PR DESCRIPTION
## Summary
- Keep the mobile manual import word field focused when the keyboard return/check action submits a word.
- Add a mobile widget regression test that simulates the keyboard action and verifies focus remains on the field.

## Validation
- fvm dart format --set-exit-if-changed lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart test/features/onboarding/mobile_import_manual_screen_test.dart
- fvm flutter analyze
- fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/onboarding/mobile_import_manual_screen_test.dart