### PR TITLE
[codex] Add biometric disable confirmation

### DIFF
--- a/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
@@ -303,6 +303,11 @@ class MobileSettingsScreen extends ConsumerWidget {
     if (!context.mounted) return;
     try {
       if (state.enabled) {
+        final confirmed = await showAppMobileSheet<bool>(
+          context: context,
+          builder: (_) => _DisableBiometricSheet(kind: state.availability.kind),
+        );
+        if (!context.mounted || confirmed != true) return;
         await notifier.disable();
         if (context.mounted) {
           showAppToast(
@@ -351,6 +356,78 @@ class MobileSettingsScreen extends ConsumerWidget {
     if (selected != null && selected != current) {
       await ref.read(themeModeProvider.notifier).set(selected);
     }
+  }
+}
+
+/// Compact confirmation sheet for disabling biometric unlock. Mirrors the
+/// destructive action hierarchy used by the mobile remove-account sheet.
+class _DisableBiometricSheet extends StatelessWidget {
+  const _DisableBiometricSheet({required this.kind});
+
+  final BiometricKind kind;
+
+  static const _titleStyle = TextStyle(
+    fontFamily: 'Geist',
+    fontWeight: FontWeight.w600,
+    fontSize: 16,
+    height: 24 / 16,
+    letterSpacing: -0.24,
+  );
+  static const _bodyStyle = TextStyle(
+    fontFamily: 'Geist',
+    fontWeight: FontWeight.w400,
+    fontSize: 14,
+    height: 21 / 14,
+    letterSpacing: -0.21,
+  );
+  static const _buttonLabelStyle = TextStyle(
+    fontFamily: 'Geist',
+    fontWeight: FontWeight.w500,
+    fontSize: 14,
+    height: 16 / 14,
+    letterSpacing: -0.06,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return MobileModalScaffold(
+      title: 'Turn off ${kind.inlineUnlockFeatureLabel}?',
+      onClose: () => Navigator.of(context).pop(false),
+      leading: AppIcon(AppIcons.lock, size: 20, color: colors.icon.accent),
+      titleStyle: _titleStyle.copyWith(color: colors.text.accent),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'You will use your passcode to unlock Vizor. You can turn '
+            '${kind.inlineUnlockFeatureLabel} back on in settings anytime.',
+            style: _bodyStyle.copyWith(color: colors.text.accent),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          AppButton(
+            key: const ValueKey('mobile_biometric_disable_confirm'),
+            variant: AppButtonVariant.destructive,
+            expand: true,
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(
+              'Turn off',
+              style: _buttonLabelStyle.copyWith(
+                color: colors.button.destructive.label,
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          MobileSheetCancel(
+            onTap: () => Navigator.of(context).pop(false),
+            textStyle: _buttonLabelStyle.copyWith(
+              color: colors.button.ghost.label,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/test/features/settings/mobile_settings_screen_test.dart
+++ b/test/features/settings/mobile_settings_screen_test.dart
@@ -75,21 +75,32 @@ class _FakeBiometricNotifier extends BiometricUnlockNotifier {
   _FakeBiometricNotifier(this.initialState);
 
   final BiometricUnlockState initialState;
+  int disableCount = 0;
 
   @override
   Future<BiometricUnlockState> build() async => initialState;
+
+  @override
+  Future<void> disable() async {
+    disableCount++;
+    final current = state.value ?? initialState;
+    state = AsyncData(current.copyWith(enabled: false));
+  }
 }
 
 Widget _app({
   AccountState accountState = _accountState,
   BiometricUnlockState? biometric,
+  BiometricUnlockNotifier Function()? biometricNotifier,
 }) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap(accountState)),
       syncProvider.overrideWith(() => FakeSyncNotifier(SyncState())),
       themeModeProvider.overrideWith(_FakeThemeModeNotifier.new),
-      if (biometric != null)
+      if (biometricNotifier != null)
+        biometricUnlockProvider.overrideWith(biometricNotifier)
+      else if (biometric != null)
         biometricUnlockProvider.overrideWith(
           () => _FakeBiometricNotifier(biometric),
         ),
@@ -287,6 +298,118 @@ void main() {
     expect(find.descendant(of: row, matching: find.text('On')), findsOneWidget);
   });
 
+  testWidgets('asks before turning off Face ID unlock', (tester) async {
+    final biometricNotifier = _FakeBiometricNotifier(
+      const BiometricUnlockState(
+        availability: BiometricAvailability(
+          supported: true,
+          enrolled: true,
+          kind: BiometricKind.face,
+        ),
+        enabled: true,
+      ),
+    );
+
+    await tester.pumpWidget(_app(biometricNotifier: () => biometricNotifier));
+    await tester.pump();
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_settings_biometric_row')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Turn off Face ID unlock?'), findsOneWidget);
+    expect(find.textContaining('You will use your passcode'), findsOneWidget);
+    expect(biometricNotifier.disableCount, 0);
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_biometric_disable_confirm')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(biometricNotifier.disableCount, 1);
+    expect(find.text('Turn off Face ID unlock?'), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('mobile_settings_biometric_row')),
+        matching: find.text('Off'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('cancel keeps biometric unlock enabled', (tester) async {
+    final biometricNotifier = _FakeBiometricNotifier(
+      const BiometricUnlockState(
+        availability: BiometricAvailability(
+          supported: true,
+          enrolled: true,
+          kind: BiometricKind.fingerprint,
+        ),
+        enabled: true,
+      ),
+    );
+
+    await tester.pumpWidget(_app(biometricNotifier: () => biometricNotifier));
+    await tester.pump();
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_settings_biometric_row')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Turn off fingerprint unlock?'), findsOneWidget);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(biometricNotifier.disableCount, 0);
+    expect(find.text('Turn off fingerprint unlock?'), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('mobile_settings_biometric_row')),
+        matching: find.text('On'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('close keeps biometric unlock enabled', (tester) async {
+    final biometricNotifier = _FakeBiometricNotifier(
+      const BiometricUnlockState(
+        availability: BiometricAvailability(
+          supported: true,
+          enrolled: true,
+          kind: BiometricKind.face,
+        ),
+        enabled: true,
+      ),
+    );
+
+    await tester.pumpWidget(_app(biometricNotifier: () => biometricNotifier));
+    await tester.pump();
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_settings_biometric_row')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Turn off Face ID unlock?'), findsOneWidget);
+
+    await tester.tap(_modalCloseIcon());
+    await tester.pumpAndSettle();
+
+    expect(biometricNotifier.disableCount, 0);
+    expect(find.text('Turn off Face ID unlock?'), findsNothing);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('mobile_settings_biometric_row')),
+        matching: find.text('On'),
+      ),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('labels fingerprint hardware by modality', (tester) async {
     await tester.pumpWidget(
       _app(
@@ -317,6 +440,15 @@ void main() {
       findsOneWidget,
     );
   });
+}
+
+Finder _modalCloseIcon() {
+  return find.descendant(
+    of: find.byType(MobileModalScaffold),
+    matching: find.byWidgetPredicate(
+      (widget) => widget is AppIcon && widget.name == AppIcons.cross,
+    ),
+  );
 }
 
 AppIcon _chevronIn(WidgetTester tester, ValueKey<String> rowKey) {


### PR DESCRIPTION
## Summary
- Add a mobile settings confirmation sheet before turning biometric unlock off.
- Keep the existing onboarding biometric terminology path, so iOS Face ID and Android fingerprint copy follow the current native mapping.
- Cover confirm, cancel, and close behavior in the mobile settings widget test.

## Validation
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/settings/mobile_settings_screen_test.dart`