### PR TITLE
Polish mobile contacts and Keystone QR flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,12 @@ operating-system chrome and presentation-only background layers.
 - Do not recreate, style, test, or otherwise implement the ignored OS/background
   layers unless the user explicitly asks to work on native window chrome.
 
+### Hardware Wallet QR Codes
+
+Hardware-wallet PCZT QR codes prioritize scan reliability over Figma parity.
+Use black-on-white square modules with an explicit quiet zone. Do not apply
+decorative QR treatments to codes that Keystone devices need to scan.
+
 ## UI Copy Conventions
 
 - **Sentence case is the project default for all user-facing strings**: button

--- a/lib/src/features/address_book/models/address_book_contact.dart
+++ b/lib/src/features/address_book/models/address_book_contact.dart
@@ -178,3 +178,7 @@ String? validateAddressBookAddress(String address) {
   if (trimmed.isEmpty) return 'Add an address';
   return null;
 }
+
+String addressBookQrScanTitle(AddressBookNetwork network) {
+  return 'Scan ${network.label} QR code';
+}

--- a/lib/src/features/address_book/screens/address_book_screen.dart
+++ b/lib/src/features/address_book/screens/address_book_screen.dart
@@ -1312,7 +1312,7 @@ class _ChainAddressSelector extends StatelessWidget {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  _NetworkAssetIcon(network: network, size: 16),
+                  _NetworkAssetIcon(network: network, size: 20),
                   const SizedBox(width: AppSpacing.xxs),
                   Text(
                     network.label,

--- a/lib/src/features/address_book/screens/mobile/mobile_address_book_screen.dart
+++ b/lib/src/features/address_book/screens/mobile/mobile_address_book_screen.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:flutter/material.dart' show Scaffold;
+import 'package:flutter/material.dart' show Material, MaterialType, Scaffold;
 import 'package:flutter/services.dart' show TextInputAction;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -9,6 +9,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../../main.dart' show log;
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../../core/layout/mobile/app_mobile_tab_bar.dart';
 import '../../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../../core/profile_pictures.dart';
 import '../../../../core/theme/app_theme.dart';
@@ -563,7 +564,6 @@ class _ContactRowMenuButton extends StatefulWidget {
 }
 
 class _ContactRowMenuButtonState extends State<_ContactRowMenuButton> {
-  final LayerLink _layerLink = LayerLink();
   OverlayEntry? _menuEntry;
 
   @override
@@ -581,41 +581,181 @@ class _ContactRowMenuButtonState extends State<_ContactRowMenuButton> {
   }
 
   void _showMenu() {
-    final overlay = Overlay.of(context);
-    final appTheme = AppTheme.of(context);
-    _menuEntry = OverlayEntry(
-      builder: (_) {
-        return Stack(
-          children: [
-            Positioned.fill(
-              child: GestureDetector(
-                behavior: HitTestBehavior.translucent,
-                onTap: () => _hideMenu(),
+    final overlay = Overlay.of(context, rootOverlay: true);
+    final overlayRenderObject = overlay.context.findRenderObject();
+    final anchorRenderObject = context.findRenderObject();
+    if (overlayRenderObject is! RenderBox || anchorRenderObject is! RenderBox) {
+      return;
+    }
+
+    final anchorTopLeft = anchorRenderObject.localToGlobal(
+      Offset.zero,
+      ancestor: overlayRenderObject,
+    );
+    final anchorRect = anchorTopLeft & anchorRenderObject.size;
+    final overlaySize = overlayRenderObject.size;
+    final canSend = widget.onSend != null;
+    const menuWidth = 173.0;
+    const menuPadding = EdgeInsets.symmetric(
+      horizontal: AppSpacing.xxs,
+      vertical: AppSpacing.sm,
+    );
+    final menuHeight = canSend ? 173.0 : 139.0;
+    const bottomNavClearance = kMobileTabBarHeight + AppSpacing.lg;
+    final colors = context.colors;
+    final menuMaxTop = math.max(
+      AppSpacing.sm,
+      overlaySize.height - bottomNavClearance - menuHeight,
+    );
+    final menuTop = (anchorRect.top + 34).clamp(AppSpacing.sm, menuMaxTop);
+    final menuRight =
+        (overlaySize.width - anchorRect.right).clamp(
+              AppSpacing.sm,
+              math.max(
+                AppSpacing.sm,
+                overlaySize.width - menuWidth - AppSpacing.sm,
               ),
+            )
+            as double;
+
+    void select(VoidCallback action) {
+      _hideMenu();
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        action();
+      });
+    }
+
+    Widget item({
+      required Key key,
+      required String iconName,
+      required String label,
+      required VoidCallback action,
+      Color? textColor,
+      Color? iconColor,
+    }) {
+      final itemTextColor = textColor ?? colors.text.inverse;
+      final itemIconColor = iconColor ?? colors.icon.inverse;
+      return Semantics(
+        button: true,
+        label: label,
+        excludeSemantics: true,
+        child: GestureDetector(
+          key: key,
+          behavior: HitTestBehavior.opaque,
+          onTap: () => select(action),
+          child: Container(
+            height: 26,
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.xs,
+              vertical: AppSpacing.xxs,
             ),
-            CompositedTransformFollower(
-              link: _layerLink,
-              showWhenUnlinked: false,
-              // Anchor the menu's top-right to the button's top-right so it
-              // opens down-left under the dots (Figma `right-0`, `top-22`).
-              targetAnchor: Alignment.topRight,
-              followerAnchor: Alignment.topRight,
-              offset: const Offset(0, 22),
-              child: AppTheme(
-                data: appTheme,
-                child: _ContactContextMenu(
-                  canSend: widget.onSend != null,
-                  onCopy: _handleCopy,
-                  onSend: _handleSend,
-                  onEdit: _handleEdit,
-                  onRemove: _handleRemove,
+            child: Row(
+              children: [
+                AppIcon(
+                  iconName,
+                  size: AppIconSize.medium,
+                  color: itemIconColor,
+                ),
+                const SizedBox(width: AppSpacing.xs),
+                Expanded(
+                  child: Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: itemTextColor,
+                      fontWeight: FontWeight.w400,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    final menuItems = [
+      item(
+        key: const ValueKey('mobile_contact_menu_copy'),
+        iconName: AppIcons.copy,
+        label: 'Copy address',
+        action: _handleCopy,
+      ),
+      if (canSend)
+        item(
+          key: const ValueKey('mobile_contact_menu_send'),
+          iconName: AppIcons.plane,
+          label: 'Send ZEC',
+          action: _handleSend,
+        ),
+      item(
+        key: const ValueKey('mobile_contact_menu_edit'),
+        iconName: AppIcons.edit,
+        label: 'Edit contact',
+        action: _handleEdit,
+      ),
+      const AppContextMenuDivider(),
+      item(
+        key: const ValueKey('mobile_contact_menu_remove'),
+        iconName: AppIcons.trash,
+        label: 'Remove contact',
+        action: _handleRemove,
+        textColor: colors.text.destructiveLight,
+        iconColor: colors.icon.destructiveLight,
+      ),
+    ];
+
+    final entry = OverlayEntry(
+      builder: (_) => Stack(
+        children: [
+          Positioned.fill(
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: _hideMenu,
+              child: const SizedBox.expand(),
+            ),
+          ),
+          Positioned(
+            top: menuTop,
+            right: menuRight,
+            child: Material(
+              type: MaterialType.transparency,
+              child: DefaultTextStyle.merge(
+                style: const TextStyle(decoration: TextDecoration.none),
+                child: SizedBox(
+                  key: const ValueKey('mobile_contact_menu_card'),
+                  width: menuWidth,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: colors.background.inverse,
+                      borderRadius: BorderRadius.circular(AppRadii.medium),
+                      border: Border.all(color: colors.border.inverseOpacity),
+                      boxShadow: appContextMenuShadow,
+                    ),
+                    child: Padding(
+                      padding: menuPadding,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          for (var i = 0; i < menuItems.length; i++) ...[
+                            if (i > 0) const SizedBox(height: AppSpacing.xs),
+                            menuItems[i],
+                          ],
+                        ],
+                      ),
+                    ),
+                  ),
                 ),
               ),
             ),
-          ],
-        );
-      },
+          ),
+        ],
+      ),
     );
+    _menuEntry = entry;
     overlay.insert(_menuEntry!);
     setState(() {});
   }
@@ -662,16 +802,17 @@ class _ContactRowMenuButtonState extends State<_ContactRowMenuButton> {
           width: 44,
           height: 44,
           child: Center(
-            child: CompositedTransformTarget(
-              link: _layerLink,
-              child: Container(
+            child: DecoratedBox(
+              key: ValueKey('mobile_contact_menu_button_${widget.contact.id}'),
+              decoration: BoxDecoration(
+                color: active
+                    ? context.colors.state.hover
+                    : const Color(0x00000000),
+                borderRadius: BorderRadius.circular(AppRadii.xSmall),
+              ),
+              child: SizedBox(
                 width: 20,
                 height: 20,
-                padding: const EdgeInsets.all(2),
-                decoration: BoxDecoration(
-                  color: active ? context.colors.background.base : null,
-                  borderRadius: BorderRadius.circular(AppRadii.xSmall),
-                ),
                 child: Center(
                   child: Transform.rotate(
                     angle: -math.pi / 2,
@@ -687,56 +828,6 @@ class _ContactRowMenuButtonState extends State<_ContactRowMenuButton> {
           ),
         ),
       ),
-    );
-  }
-}
-
-class _ContactContextMenu extends StatelessWidget {
-  const _ContactContextMenu({
-    required this.canSend,
-    required this.onCopy,
-    required this.onSend,
-    required this.onEdit,
-    required this.onRemove,
-  });
-
-  final bool canSend;
-  final VoidCallback onCopy;
-  final VoidCallback onSend;
-  final VoidCallback onEdit;
-  final VoidCallback onRemove;
-
-  @override
-  Widget build(BuildContext context) {
-    return AppContextMenu(
-      children: [
-        AppContextMenuItem(
-          iconName: AppIcons.copy,
-          label: 'Copy address',
-          onTap: onCopy,
-        ),
-        if (canSend) ...[
-          const SizedBox(height: AppSpacing.xxs),
-          AppContextMenuItem(
-            iconName: AppIcons.plane,
-            label: 'Send ZEC',
-            onTap: onSend,
-          ),
-        ],
-        const SizedBox(height: AppSpacing.xxs),
-        AppContextMenuItem(
-          iconName: AppIcons.scroll,
-          label: 'Edit contact',
-          onTap: onEdit,
-        ),
-        const AppContextMenuDivider(),
-        AppContextMenuItem(
-          iconName: AppIcons.trash,
-          label: 'Remove contact',
-          destructive: true,
-          onTap: onRemove,
-        ),
-      ],
     );
   }
 }

--- a/lib/src/features/address_book/screens/mobile/mobile_address_book_screen.dart
+++ b/lib/src/features/address_book/screens/mobile/mobile_address_book_screen.dart
@@ -1051,9 +1051,12 @@ class _ContactEditSheetState extends State<_ContactEditSheet> {
   }
 
   Future<void> _scanAddress() async {
+    final scanTitle = addressBookQrScanTitle(_network);
     final scanned = await showAppMobileSheet<String>(
       context: context,
       builder: (sheetContext) => MobileAddressScanCard(
+        caption: scanTitle,
+        permissionTitle: scanTitle,
         resolve: (raw) async {
           final address = normalizeAddressScanPayload(raw);
           if (address == null || address.isEmpty) {

--- a/lib/src/features/address_book/widgets/address_book_network_icon.dart
+++ b/lib/src/features/address_book/widgets/address_book_network_icon.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/widgets.dart';
 
-import '../../../core/theme/app_theme.dart';
 import '../models/address_book_contact.dart';
 
 class AddressBookNetworkIcon extends StatelessWidget {
@@ -15,21 +14,9 @@ class AddressBookNetworkIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // All networks (Zcash included) render their standard asset logo in a
-    // raised circle — no special branded crimson treatment for Zcash.
-    final padding = size <= 16 ? 0.0 : 3.0;
-    return Container(
-      width: size,
-      height: size,
-      decoration: BoxDecoration(
-        color: context.colors.background.raised,
-        shape: BoxShape.circle,
-      ),
-      clipBehavior: Clip.antiAlias,
-      child: Padding(
-        padding: EdgeInsets.all(padding),
-        child: Image.asset(network.assetPath, fit: BoxFit.cover),
-      ),
+    return SizedBox.square(
+      dimension: size,
+      child: ClipOval(child: Image.asset(network.assetPath, fit: BoxFit.cover)),
     );
   }
 }

--- a/lib/src/features/address_scan/widgets/mobile_address_scan_card.dart
+++ b/lib/src/features/address_scan/widgets/mobile_address_scan_card.dart
@@ -175,9 +175,9 @@ class _MobileQrScanCardState extends State<MobileQrScanCard>
         final status = _cameraAccessStatus(state);
         return MobileAddressScanCardContent(
           status: status,
-          // The camera preview is mounted in every state (covered by the
-          // permission card when access isn't granted) so the controller keeps
-          // running and reporting permission changes.
+          // The camera preview is mounted in every state (offstage until
+          // access is granted) so the controller keeps running and reporting
+          // permission changes.
           cameraView: QrScanner.isAvailable
               ? widget.cameraViewBuilder(context, _controller)
               : null,
@@ -213,10 +213,9 @@ class _MobileQrScanCardState extends State<MobileQrScanCard>
 ///   `_Modal Type` title, a camera-icon message and a Cancel button — and, when
 ///   denied/unavailable, a "Request again" action.
 ///
-/// The camera preview is mounted in every state (just covered by the opaque
-/// permission card when access isn't granted yet) so the single
-/// [MobileScannerController] keeps running and the requesting → active
-/// transition is seamless.
+/// The camera preview is mounted in every state (kept offstage until access is
+/// granted) so the single [MobileScannerController] keeps running and the
+/// requesting → active transition is seamless.
 class MobileAddressScanCard extends StatefulWidget {
   const MobileAddressScanCard({
     required this.resolve,
@@ -224,6 +223,7 @@ class MobileAddressScanCard extends StatefulWidget {
     required this.onClose,
     this.controller,
     this.caption = 'Scan a Zcash QR code to continue',
+    this.permissionTitle = 'Scan the address QR code',
     this.steadyHint = 'Keep the QR code steady and fully visible.',
     super.key,
   });
@@ -244,6 +244,9 @@ class MobileAddressScanCard extends StatefulWidget {
 
   /// Idle caption beneath the viewfinder.
   final String caption;
+
+  /// Title shown in the permission/requesting card state.
+  final String permissionTitle;
 
   /// Fallback message when resolution throws.
   final String steadyHint;
@@ -292,6 +295,7 @@ class _MobileAddressScanCardState extends State<MobileAddressScanCard> {
     return MobileQrScanCard(
       controller: widget.controller,
       caption: widget.caption,
+      permissionTitle: widget.permissionTitle,
       error: _error,
       unavailableDescription:
           'Address QR scanning needs a camera on this device.',
@@ -343,10 +347,10 @@ class MobileAddressScanCardContent extends StatelessWidget {
   final VoidCallback onClose;
   final VoidCallback onRetry;
 
-  /// The camera card nearly fills the screen, leaving the dimmed swap behind
+  /// The camera card nearly fills the screen, leaving the dimmed app behind
   /// visible under the top nav. `viewPadding` (not `padding`) so the status-bar
   /// inset survives the dialog's `SafeArea(top)`.
-  double _cameraCardHeight(BuildContext context) {
+  static double modalCameraHeight(BuildContext context) {
     final media = MediaQuery.of(context);
     // Figma `QR Scan` (4484:61584) on the 393x852 mobile artboard places the
     // modal at y=126 and h=694, with a 32px bottom gap. The scanner overlays
@@ -364,12 +368,15 @@ class MobileAddressScanCardContent extends StatelessWidget {
     final hasFixedHeight = showsCamera || permissionBuilder != null;
     return SizedBox(
       height: hasFixedHeight
-          ? (cameraHeight ?? _cameraCardHeight(context))
+          ? (cameraHeight ?? modalCameraHeight(context))
           : null,
       child: Stack(
         fit: hasFixedHeight ? StackFit.expand : StackFit.loose,
         children: [
-          if (cameraView != null) Positioned.fill(child: cameraView!),
+          if (cameraView != null)
+            Positioned.fill(
+              child: Offstage(offstage: !showsCamera, child: cameraView!),
+            ),
           if (status == AddressQrCameraStatus.active) ...[
             const Positioned.fill(child: _ScanViewfinder()),
             Positioned(

--- a/lib/src/features/keystone/widgets/keystone_pczt_qr_stage.dart
+++ b/lib/src/features/keystone/widgets/keystone_pczt_qr_stage.dart
@@ -8,26 +8,39 @@ import '../../../core/widgets/app_icon.dart';
 
 enum KeystonePcztQrStagePhase { preparing, ready, working, failed }
 
+const _scanOptimizedQrInk = Color(0xFF000000);
+
 class KeystonePcztQrStage extends StatelessWidget {
   const KeystonePcztQrStage({
     required this.phase,
     required this.urParts,
     required this.error,
+    this.size = 230,
+    this.scanOptimized = false,
+    this.frameInterval = const Duration(milliseconds: 250),
     super.key,
   });
 
   final KeystonePcztQrStagePhase phase;
   final List<String> urParts;
   final String? error;
+  final double size;
+  final bool scanOptimized;
+  final Duration frameInterval;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
     return SizedBox(
-      width: 230,
-      height: 230,
+      width: size,
+      height: size,
       child: switch (phase) {
-        KeystonePcztQrStagePhase.ready => _AnimatedKeystoneQr(urParts: urParts),
+        KeystonePcztQrStagePhase.ready => _AnimatedKeystoneQr(
+          urParts: urParts,
+          size: size,
+          scanOptimized: scanOptimized,
+          frameInterval: frameInterval,
+        ),
         KeystonePcztQrStagePhase.failed => Center(
           child: Text(
             error ?? 'Keystone signing could not be prepared.',
@@ -61,9 +74,17 @@ class _QrStageLoader extends StatelessWidget {
 }
 
 class _AnimatedKeystoneQr extends StatefulWidget {
-  const _AnimatedKeystoneQr({required this.urParts});
+  const _AnimatedKeystoneQr({
+    required this.urParts,
+    required this.size,
+    required this.scanOptimized,
+    required this.frameInterval,
+  });
 
   final List<String> urParts;
+  final double size;
+  final bool scanOptimized;
+  final Duration frameInterval;
 
   @override
   State<_AnimatedKeystoneQr> createState() => _AnimatedKeystoneQrState();
@@ -83,7 +104,9 @@ class _AnimatedKeystoneQrState extends State<_AnimatedKeystoneQr> {
   @override
   void didUpdateWidget(covariant _AnimatedKeystoneQr oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.urParts != widget.urParts) {
+    if (oldWidget.urParts != widget.urParts ||
+        oldWidget.scanOptimized != widget.scanOptimized ||
+        oldWidget.frameInterval != widget.frameInterval) {
       _index = 0;
       _frames.clear();
       _startTimer();
@@ -94,7 +117,9 @@ class _AnimatedKeystoneQrState extends State<_AnimatedKeystoneQr> {
     return _frames[index] ??= QrImage(
       QrCode.fromData(
         data: widget.urParts[index],
-        errorCorrectLevel: QrErrorCorrectLevel.L,
+        errorCorrectLevel: widget.scanOptimized
+            ? QrErrorCorrectLevel.M
+            : QrErrorCorrectLevel.L,
       ),
     );
   }
@@ -102,7 +127,7 @@ class _AnimatedKeystoneQrState extends State<_AnimatedKeystoneQr> {
   void _startTimer() {
     _timer?.cancel();
     if (widget.urParts.length <= 1) return;
-    _timer = Timer.periodic(const Duration(milliseconds: 250), (_) {
+    _timer = Timer.periodic(widget.frameInterval, (_) {
       if (!mounted) return;
       setState(() {
         _index = (_index + 1) % widget.urParts.length;
@@ -119,21 +144,32 @@ class _AnimatedKeystoneQrState extends State<_AnimatedKeystoneQr> {
   @override
   Widget build(BuildContext context) {
     if (widget.urParts.isEmpty) return const SizedBox.shrink();
-    // Figma (render-measured from 4654:62168 / 4654:63922): the QR ink is
-    // drawn directly on the modal panel in both themes — no backing card.
-    // Light paints #141818 modules on the #f7f7f7 panel; dark inverts the
-    // ink and paints #f7f7f7 modules on the #232828 panel. Both use the
-    // smooth symbol (adjacent modules merge into rounded runs; isolated
-    // modules render as dots) with bullseye finder eyes painted over the
-    // symbol's own eye pattern; the eye knockout matches the panel color.
-    final isDark = AppTheme.of(context) == AppThemeData.dark;
-    final moduleColor = isDark
-        ? const Color(0xFFF7F7F7)
-        : const Color(0xFF141818);
+    // Figma (render-measured from 4654:62168 / 4654:63922): the default QR
+    // ink is drawn directly on the modal panel in both themes, using the
+    // accent icon token with bullseye finder eyes painted over the symbol's
+    // own eye pattern; the eye knockout matches the panel color.
+    final colors = context.colors;
+    final moduleColor = colors.icon.accent;
     final frame = _frameAt(_index);
+    if (widget.scanOptimized) {
+      return SizedBox(
+        width: widget.size,
+        height: widget.size,
+        child: ColoredBox(
+          color: colors.surface.qrCode,
+          child: PrettyQrView(
+            qrImage: frame,
+            decoration: const PrettyQrDecoration(
+              quietZone: PrettyQrQuietZone.modules(3),
+              shape: PrettyQrSquaresSymbol(color: _scanOptimizedQrInk),
+            ),
+          ),
+        ),
+      );
+    }
     return SizedBox(
-      width: 230,
-      height: 230,
+      width: widget.size,
+      height: widget.size,
       child: Stack(
         fit: StackFit.expand,
         children: [

--- a/lib/src/features/keystone/widgets/keystone_pczt_qr_stage.dart
+++ b/lib/src/features/keystone/widgets/keystone_pczt_qr_stage.dart
@@ -16,8 +16,8 @@ class KeystonePcztQrStage extends StatelessWidget {
     required this.urParts,
     required this.error,
     this.size = 230,
-    this.scanOptimized = false,
-    this.frameInterval = const Duration(milliseconds: 250),
+    this.scanOptimized = true,
+    this.frameInterval = const Duration(milliseconds: 100),
     super.key,
   });
 
@@ -144,7 +144,10 @@ class _AnimatedKeystoneQrState extends State<_AnimatedKeystoneQr> {
   @override
   Widget build(BuildContext context) {
     if (widget.urParts.isEmpty) return const SizedBox.shrink();
-    // Figma (render-measured from 4654:62168 / 4654:63922): the default QR
+    // Hardware-wallet PCZT QR is scan-first: use high-contrast square modules
+    // on the QR surface with an explicit quiet zone. The decorative Figma
+    // treatment is retained only for explicit non-scanning previews.
+    // Figma (render-measured from 4654:62168 / 4654:63922): the decorative QR
     // ink is drawn directly on the modal panel in both themes, using the
     // accent icon token with bullseye finder eyes painted over the symbol's
     // own eye pattern; the eye knockout matches the panel color.

--- a/lib/src/features/keystone/widgets/keystone_signing_modal.dart
+++ b/lib/src/features/keystone/widgets/keystone_signing_modal.dart
@@ -8,6 +8,8 @@ import 'keystone_pczt_qr_stage.dart';
 
 enum KeystoneSigningModalPhase { preparing, ready, failed }
 
+const _desktopPcztQrSize = 264.0;
+
 class KeystoneSigningModal extends StatelessWidget {
   const KeystoneSigningModal({
     required this.phase,
@@ -102,6 +104,7 @@ class KeystoneSigningModal extends StatelessWidget {
                   },
                   urParts: urParts,
                   error: error,
+                  size: _desktopPcztQrSize,
                 ),
                 if (instruction != null && instruction.isNotEmpty) ...[
                   const SizedBox(height: AppSpacing.sm),

--- a/lib/src/features/onboarding/mobile/mobile_keystone_scan_card.dart
+++ b/lib/src/features/onboarding/mobile/mobile_keystone_scan_card.dart
@@ -9,6 +9,7 @@ import '../../address_scan/widgets/mobile_address_scan_card.dart';
 
 const _keystoneScannerCardHeight = 464.0;
 const _keystoneScannerFooterHeight = 68.0;
+const kMobileKeystoneScanCaption = 'Scan the Keystone account QR';
 
 class MobileKeystoneScanCardContent extends StatelessWidget {
   const MobileKeystoneScanCardContent({
@@ -37,7 +38,7 @@ class MobileKeystoneScanCardContent extends StatelessWidget {
     return MobileAddressScanCardContent(
       status: status,
       cameraView: cameraView,
-      caption: 'Scan a Zcash QR code to continue',
+      caption: kMobileKeystoneScanCaption,
       error: error,
       unavailableDescription: unavailableDescription,
       cameraHeight: cameraHeight ?? _keystoneScannerCardHeight,
@@ -199,7 +200,9 @@ class _KeystonePermissionMessage extends StatelessWidget {
           decoration: BoxDecoration(
             // Requesting sits on the inverse tile, denied on the neutral
             // raised tile (Figma 4654:72631 / 4654:72955) — both theme-aware.
-            color: denied ? colors.background.raised : colors.background.inverse,
+            color: denied
+                ? colors.background.raised
+                : colors.background.inverse,
             borderRadius: BorderRadius.circular(AppRadii.small),
           ),
           child: Center(

--- a/lib/src/features/onboarding/mobile/mobile_keystone_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_keystone_screens.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -7,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
@@ -205,8 +205,6 @@ class MobileKeystoneScanScreen extends ConsumerStatefulWidget {
 
 class _MobileKeystoneScanScreenState
     extends ConsumerState<MobileKeystoneScanScreen> {
-  static const _cameraMaxHeight = 464.0;
-
   bool _decoding = false;
   String? _error;
   int _scanProgress = 0;
@@ -288,54 +286,72 @@ class _MobileKeystoneScanScreenState
     return null;
   }
 
+  double _scanModalHeight(BuildContext context) {
+    return MobileAddressScanCardContent.modalCameraHeight(context);
+  }
+
+  Widget _buildScanCard(double cameraHeight) {
+    return MobileQrScanCard(
+      key: const ValueKey('mobile_keystone_scan_card'),
+      controller: widget.scannerController,
+      cameraHeight: cameraHeight,
+      caption: kMobileKeystoneScanCaption,
+      permissionTitle: 'Scan QR Code',
+      error: _scanCaptionOverride,
+      unavailableDescription:
+          'Keystone import uses camera QR scanning only. Connect a '
+          'camera and try again.',
+      onClose: () => Navigator.of(context).maybePop(),
+      permissionBuilder:
+          (context, status, unavailableDescription, onRetry, onClose) =>
+              MobileKeystoneScanPermissionCard(
+                status: status,
+                unavailableDescription: unavailableDescription,
+                onRetry: onRetry,
+                cameraHeight: cameraHeight,
+              ),
+      cameraViewBuilder: (context, controller) => AnimatedUrScannerView(
+        key: const ValueKey('mobile_keystone_scan_camera'),
+        controller: controller,
+        expectedUrType: 'zcash-accounts',
+        scanSessionResetToken: _scanSessionResetToken,
+        errorBuilder: (context, error) => const SizedBox.shrink(),
+        onProgress: _handleScanProgress,
+        onDecodeError: _handleDecodeError,
+        onComplete: (result) => unawaited(_handleScanComplete(result)),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return MobileOnboardingStepScaffold(
-      progress: 0.4,
-      onBack: () => Navigator.of(context).maybePop(),
-      title: 'Scan QR Code',
-      subtitle: 'Prepare your Keystone wallet',
-      scrollable: false,
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final availableHeight = constraints.maxHeight.isFinite
-              ? math.max(0.0, constraints.maxHeight)
-              : _cameraMaxHeight;
-          final cameraHeight = math.min(_cameraMaxHeight, availableHeight);
-          return Align(
-            alignment: Alignment.topCenter,
-            child: MobileQrScanCard(
-              key: const ValueKey('mobile_keystone_scan_card'),
-              controller: widget.scannerController,
-              cameraHeight: cameraHeight,
-              permissionTitle: 'Scan QR Code',
-              error: _scanCaptionOverride,
-              unavailableDescription:
-                  'Keystone import uses camera QR scanning only. Connect a '
-                  'camera and try again.',
-              onClose: () => Navigator.of(context).maybePop(),
-              permissionBuilder:
-                  (context, status, unavailableDescription, onRetry, onClose) =>
-                      MobileKeystoneScanPermissionCard(
-                        status: status,
-                        unavailableDescription: unavailableDescription,
-                        onRetry: onRetry,
-                        cameraHeight: cameraHeight,
-                      ),
-              cameraViewBuilder: (context, controller) => AnimatedUrScannerView(
-                key: const ValueKey('mobile_keystone_scan_camera'),
-                controller: controller,
-                expectedUrType: 'zcash-accounts',
-                scanSessionResetToken: _scanSessionResetToken,
-                errorBuilder: (context, error) => const SizedBox.shrink(),
-                onProgress: _handleScanProgress,
-                onDecodeError: _handleDecodeError,
-                onComplete: (result) => unawaited(_handleScanComplete(result)),
-              ),
-            ),
-          );
-        },
-      ),
+    final colors = context.colors;
+    final cameraHeight = _scanModalHeight(context);
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        MobileOnboardingStepScaffold(
+          progress: 0.4,
+          onBack: () => Navigator.of(context).maybePop(),
+          title: 'Scan QR Code',
+          subtitle: 'Prepare your Keystone wallet',
+          scrollable: false,
+          child: const SizedBox.shrink(),
+        ),
+        IgnorePointer(
+          child: ModalBarrier(color: colors.background.neutralScrim),
+        ),
+        SafeArea(
+          bottom: false,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              const Spacer(),
+              MobileModalCard(child: _buildScanCard(cameraHeight)),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }
@@ -488,8 +504,9 @@ class _AccountCard extends StatelessWidget {
                       name,
                       overflow: TextOverflow.ellipsis,
                       style: AppTypography.labelLarge.copyWith(
-                        fontWeight:
-                            selected ? FontWeight.w600 : FontWeight.w500,
+                        fontWeight: selected
+                            ? FontWeight.w600
+                            : FontWeight.w500,
                         color: colors.text.accent,
                       ),
                     ),

--- a/lib/src/features/send/screens/mobile/mobile_keystone_sign_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_keystone_sign_screen.dart
@@ -369,21 +369,34 @@ class _MobileKeystoneSignScreenState
               ),
             ),
             const Spacer(),
-            Container(
-              padding: const EdgeInsets.all(AppSpacing.sm),
-              decoration: BoxDecoration(
-                color: colors.background.ground,
-                borderRadius: BorderRadius.circular(AppRadii.large),
-              ),
-              child: KeystonePcztQrStage(
-                phase: switch (_stage) {
-                  _SignStage.showQr => KeystonePcztQrStagePhase.ready,
-                  _SignStage.failed => KeystonePcztQrStagePhase.failed,
-                  _ => KeystonePcztQrStagePhase.preparing,
-                },
-                urParts: _urParts,
-                error: _error,
-              ),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final availableWidth = constraints.maxWidth.isFinite
+                    ? constraints.maxWidth
+                    : 312.0;
+                final qrSize = (availableWidth - AppSpacing.sm * 2)
+                    .clamp(220.0, 280.0)
+                    .toDouble();
+                return Container(
+                  padding: const EdgeInsets.all(AppSpacing.sm),
+                  decoration: BoxDecoration(
+                    color: colors.background.ground,
+                    borderRadius: BorderRadius.circular(AppRadii.large),
+                  ),
+                  child: KeystonePcztQrStage(
+                    phase: switch (_stage) {
+                      _SignStage.showQr => KeystonePcztQrStagePhase.ready,
+                      _SignStage.failed => KeystonePcztQrStagePhase.failed,
+                      _ => KeystonePcztQrStagePhase.preparing,
+                    },
+                    urParts: _urParts,
+                    error: _error,
+                    size: qrSize,
+                    scanOptimized: true,
+                    frameInterval: const Duration(milliseconds: 100),
+                  ),
+                );
+              },
             ),
             const Spacer(),
             // Space for the bottom bar in the outer stack.

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -726,7 +726,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
 
   String _fallbackAddressTypeLabel() {
     return switch (_addressType) {
-      'unified' => 'Unified address',
+      'unified' => 'Shielded address',
       'sapling' => 'Shielded address',
       'transparent' => 'Transparent address',
       'tex' => 'TEX address',

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -209,7 +209,6 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     final initial = widget.initialRecipient;
     if (initial != null && initial.trim().isNotEmpty) {
       _addressController.text = initial.trim();
-      _addressType = 'unified';
       unawaited(_validateAddress());
     }
     final initialContactLabel = widget.initialContactLabel;

--- a/lib/widgetbook/address_book_use_cases.dart
+++ b/lib/widgetbook/address_book_use_cases.dart
@@ -1023,7 +1023,7 @@ class _ChainAddressSelector extends StatelessWidget {
               children: [
                 const _NetworkAssetIcon(
                   network: _AddressBookNetwork.zcash,
-                  size: 16,
+                  size: 20,
                 ),
                 const SizedBox(width: AppSpacing.xxs),
                 Text(
@@ -1317,19 +1317,9 @@ class _NetworkAssetIcon extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final padding = size <= 16 ? 0.0 : 3.0;
-    return Container(
-      width: size,
-      height: size,
-      decoration: BoxDecoration(
-        color: context.colors.background.raised,
-        shape: BoxShape.circle,
-      ),
-      clipBehavior: Clip.antiAlias,
-      child: Padding(
-        padding: EdgeInsets.all(padding),
-        child: Image.asset(network.assetPath, fit: BoxFit.cover),
-      ),
+    return SizedBox.square(
+      dimension: size,
+      child: ClipOval(child: Image.asset(network.assetPath, fit: BoxFit.cover)),
     );
   }
 }

--- a/lib/widgetbook/keystone_use_cases.dart
+++ b/lib/widgetbook/keystone_use_cases.dart
@@ -12,6 +12,7 @@ import '../src/app_bootstrap.dart';
 import '../src/core/config/rpc_endpoint_config.dart';
 import '../src/core/layout/mobile/app_mobile_sheet.dart';
 import '../src/core/theme/app_theme.dart';
+import '../src/features/keystone/widgets/keystone_pczt_qr_stage.dart';
 import '../src/features/address_scan/widgets/address_qr_scan_modal.dart';
 import '../src/features/onboarding/keystone/keystone_onboarding_flow.dart';
 import '../src/features/onboarding/mobile/mobile_import_birthday_screen.dart';
@@ -23,12 +24,12 @@ import '../src/providers/account_provider.dart' show AccountState;
 import '../src/rust/wallet/keystone.dart' show KeystoneAccountInfo;
 
 Widget buildMobileKeystoneScanRequestingUseCase(BuildContext context) {
-  return const _MobileKeystoneInlineScanFrame(
+  return const _MobileKeystoneModalScanFrame(
     child: MobileKeystoneScanCardContent(
       key: ValueKey('mobile_keystone_scan_widgetbook_card'),
       status: AddressQrCameraStatus.requesting,
       cameraView: _MobileKeystoneScanCameraPreview(),
-      cameraHeight: 464,
+      cameraHeight: 694,
       onTorch: _noop,
       onClose: _noop,
       onRetry: _noop,
@@ -37,12 +38,12 @@ Widget buildMobileKeystoneScanRequestingUseCase(BuildContext context) {
 }
 
 Widget buildMobileKeystoneScanDeniedUseCase(BuildContext context) {
-  return const _MobileKeystoneInlineScanFrame(
+  return const _MobileKeystoneModalScanFrame(
     child: MobileKeystoneScanCardContent(
       key: ValueKey('mobile_keystone_scan_widgetbook_card'),
       status: AddressQrCameraStatus.denied,
       cameraView: _MobileKeystoneScanCameraPreview(),
-      cameraHeight: 464,
+      cameraHeight: 694,
       onTorch: _noop,
       onClose: _noop,
       onRetry: _noop,
@@ -74,6 +75,29 @@ Widget buildMobileKeystoneScanLoadingUseCase(BuildContext context) {
       onTorch: _noop,
       onClose: _noop,
       onRetry: _noop,
+    ),
+  );
+}
+
+Widget buildMobileKeystonePcztQrDefaultUseCase(BuildContext context) {
+  return _MobileKeystonePcztQrFrame(
+    child: KeystonePcztQrStage(
+      phase: KeystonePcztQrStagePhase.ready,
+      urParts: _pcztPreviewUrParts(),
+      error: null,
+    ),
+  );
+}
+
+Widget buildMobileKeystonePcztQrOptimizedUseCase(BuildContext context) {
+  return _MobileKeystonePcztQrFrame(
+    child: KeystonePcztQrStage(
+      phase: KeystonePcztQrStagePhase.ready,
+      urParts: _pcztPreviewUrParts(),
+      error: null,
+      size: 280,
+      scanOptimized: true,
+      frameInterval: const Duration(milliseconds: 100),
     ),
   );
 }
@@ -191,34 +215,6 @@ class _SeededKeystoneOnboardingNotifier extends KeystoneOnboardingNotifier {
   }
 }
 
-class _MobileKeystoneInlineScanFrame extends StatelessWidget {
-  const _MobileKeystoneInlineScanFrame({required this.child});
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 393,
-      height: 852,
-      child: MediaQuery(
-        data: const MediaQueryData(
-          size: Size(393, 852),
-          viewPadding: EdgeInsets.only(top: 55),
-        ),
-        child: MobileOnboardingStepScaffold(
-          progress: 0.4,
-          onBack: _noop,
-          title: 'Scan QR Code',
-          subtitle: 'Prepare your Keystone wallet',
-          scrollable: false,
-          child: Align(alignment: Alignment.topCenter, child: child),
-        ),
-      ),
-    );
-  }
-}
-
 class _MobileKeystoneModalScanFrame extends StatelessWidget {
   const _MobileKeystoneModalScanFrame({required this.child});
 
@@ -244,32 +240,83 @@ class _MobileKeystoneModalScanFrame extends StatelessWidget {
               title: 'Scan QR Code',
               subtitle: 'Prepare your Keystone wallet',
               scrollable: false,
-              child: Align(
-                alignment: Alignment.topCenter,
-                child: MobileKeystoneScanCardContent(
-                  status: AddressQrCameraStatus.denied,
-                  cameraView: _MobileKeystoneScanCameraPreview(),
-                  cameraHeight: 464,
-                  onTorch: _noop,
-                  onClose: _noop,
-                  onRetry: _noop,
-                ),
-              ),
+              child: SizedBox.shrink(),
             ),
-            ColoredBox(
-              color: colors.background.neutralScrim,
-              child: SafeArea(
-                bottom: false,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    const Spacer(),
-                    MobileModalCard(child: child),
-                  ],
-                ),
+            IgnorePointer(
+              child: ModalBarrier(color: colors.background.neutralScrim),
+            ),
+            SafeArea(
+              bottom: false,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const Spacer(),
+                  MobileModalCard(child: child),
+                ],
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MobileKeystonePcztQrFrame extends StatelessWidget {
+  const _MobileKeystonePcztQrFrame({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return SizedBox(
+      width: 393,
+      height: 852,
+      child: MediaQuery(
+        data: const MediaQueryData(
+          size: Size(393, 852),
+          viewPadding: EdgeInsets.only(top: 55),
+        ),
+        child: DecoratedBox(
+          decoration: const BoxDecoration(color: Color(0xFF000000)),
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+              child: Column(
+                children: [
+                  const SizedBox(height: 72),
+                  Text(
+                    'Confirm transaction',
+                    textAlign: TextAlign.center,
+                    style: AppTypography.headlineSmall.copyWith(
+                      color: const Color(0xFFFFFFFF),
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.s),
+                  Text(
+                    'Use your Keystone wallet to scan this transaction QR '
+                    'code. Follow the steps on your device.',
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: const Color(0xCCFFFFFF),
+                    ),
+                  ),
+                  const Spacer(),
+                  Container(
+                    padding: const EdgeInsets.all(AppSpacing.sm),
+                    decoration: BoxDecoration(
+                      color: colors.background.ground,
+                      borderRadius: BorderRadius.circular(AppRadii.large),
+                    ),
+                    child: child,
+                  ),
+                  const Spacer(),
+                  const SizedBox(height: 96),
+                ],
+              ),
+            ),
+          ),
         ),
       ),
     );
@@ -301,6 +348,17 @@ class _MobileKeystoneScanCameraPreview extends StatelessWidget {
       ),
     );
   }
+}
+
+List<String> _pcztPreviewUrParts() {
+  const payload =
+      'lpadaxcsfwdmfwfwhdcxhdcxfwcxhdcxhdcxfwcxhdcxhdcxfwcxhdcxhdcxfwcx'
+      'hdcxhdcxfwcxhdcxhdcxfwcxhdcxhdcxfwcxhdcxhdcxfwcxhdcxhdcxfwcxhdcx'
+      'hdcxfwcxhdcxhdcxfwcxhdcxhdcxfwcxhdcxhdcxfwcxhdcxhdcxfwcxhdcxhdcx';
+  return [
+    for (var i = 1; i <= 12; i++)
+      'ur:zcash-pczt/$i-12/$payload${i.toString().padLeft(2, '0')}',
+  ];
 }
 
 void _noop() {}

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -179,6 +179,14 @@ class WidgetbookApp extends StatelessWidget {
                       builder: buildMobileKeystoneScanLoadingUseCase,
                     ),
                     WidgetbookUseCase(
+                      name: 'PCZT QR default',
+                      builder: buildMobileKeystonePcztQrDefaultUseCase,
+                    ),
+                    WidgetbookUseCase(
+                      name: 'PCZT QR mobile optimized',
+                      builder: buildMobileKeystonePcztQrOptimizedUseCase,
+                    ),
+                    WidgetbookUseCase(
                       name: 'Select account',
                       builder: buildMobileKeystoneSelectAccountUseCase,
                     ),

--- a/test/features/address_book/address_book_contact_test.dart
+++ b/test/features/address_book/address_book_contact_test.dart
@@ -66,4 +66,19 @@ void main() {
       isNull,
     );
   });
+
+  test('address book QR scan title follows the selected network', () {
+    expect(
+      addressBookQrScanTitle(AddressBookNetwork.zcash),
+      'Scan Zcash QR code',
+    );
+    expect(
+      addressBookQrScanTitle(AddressBookNetwork.ethereum),
+      'Scan Ethereum QR code',
+    );
+    expect(
+      addressBookQrScanTitle(AddressBookNetwork.binanceSmartChain),
+      'Scan Binance Smart Chain QR code',
+    );
+  });
 }

--- a/test/features/address_book/mobile_address_book_screen_test.dart
+++ b/test/features/address_book/mobile_address_book_screen_test.dart
@@ -95,6 +95,21 @@ void main() {
     expect(find.text('Send ZEC'), findsOneWidget);
     expect(find.text('Edit contact'), findsOneWidget);
     expect(find.text('Remove contact'), findsOneWidget);
+    final openMenuButton = tester.widget<DecoratedBox>(
+      find.byKey(const ValueKey('mobile_contact_menu_button_mike')),
+    );
+    expect(
+      (openMenuButton.decoration as BoxDecoration).color,
+      AppThemeData.light.colors.state.hover,
+    );
+    expect(
+      tester.getSize(find.byKey(const ValueKey('mobile_contact_menu_card'))),
+      const Size(173, 173),
+    );
+    expect(
+      tester.getSize(find.byKey(const ValueKey('mobile_contact_menu_copy'))),
+      const Size(165, 26),
+    );
 
     // Dismiss the menu (tap the scrim).
     await tester.tapAt(const Offset(10, 10));
@@ -107,6 +122,10 @@ void main() {
     expect(find.text('Send ZEC'), findsNothing);
     expect(find.text('Edit contact'), findsOneWidget);
     expect(find.text('Remove contact'), findsOneWidget);
+    expect(
+      tester.getSize(find.byKey(const ValueKey('mobile_contact_menu_card'))),
+      const Size(173, 139),
+    );
   });
 
   testWidgets('non-matching search shows the empty-search state', (

--- a/test/features/address_scan/mobile_address_scan_card_test.dart
+++ b/test/features/address_scan/mobile_address_scan_card_test.dart
@@ -62,11 +62,15 @@ void _useSwapViewport(WidgetTester tester) {
 
 MobileAddressScanCard _card(
   MobileScannerController controller, {
+  String? caption,
+  String? permissionTitle,
   VoidCallback? onClose,
   ValueChanged<String>? onScanned,
 }) {
   return MobileAddressScanCard(
     controller: controller,
+    caption: caption ?? 'Scan a Zcash QR code to continue',
+    permissionTitle: permissionTitle ?? 'Scan the address QR code',
     resolve: (raw) async => MobileScanOutcome.accepted(raw),
     onScanned: onScanned ?? (_) {},
     onClose: onClose ?? () {},
@@ -102,6 +106,37 @@ void main() {
       find.byKey(const ValueKey('mobile_address_scan_cancel_button')),
     );
     expect(closed, 1);
+  });
+
+  testWidgets('custom copy replaces the default Zcash scan copy', (
+    tester,
+  ) async {
+    final controller = MobileScannerController(autoStart: false);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      _host(
+        _card(
+          controller,
+          caption: 'Scan Ethereum QR code',
+          permissionTitle: 'Scan Ethereum QR code',
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Scan Ethereum QR code'), findsOneWidget);
+    expect(find.text('Scan a Zcash QR code to continue'), findsNothing);
+    expect(find.text('Scan the address QR code'), findsNothing);
+
+    controller.value = controller.value.copyWith(
+      isInitialized: true,
+      isRunning: true,
+    );
+    await tester.pump();
+
+    expect(find.text('Scan Ethereum QR code'), findsOneWidget);
+    expect(find.text('Scan a Zcash QR code to continue'), findsNothing);
   });
 
   testWidgets('denied access swaps in the retry copy and action', (
@@ -168,7 +203,10 @@ void main() {
 
     // Permission card first; the camera preview is already mounted behind it.
     expect(find.text('Scan the address QR code'), findsOneWidget);
-    final cameraElement = tester.element(find.byKey(_cameraKey));
+    expect(find.byKey(_cameraKey), findsNothing);
+    final cameraElement = tester.element(
+      find.byKey(_cameraKey, skipOffstage: false),
+    );
 
     // Granted-but-spinning-up → the camera card takes over (loading veil).
     controller.value = controller.value.copyWith(isInitialized: true);
@@ -186,8 +224,12 @@ void main() {
     controller.value = controller.value.copyWith(isInitialized: false);
     await tester.pump();
     expect(find.text('Scan the address QR code'), findsOneWidget);
+    expect(find.byKey(_cameraKey), findsNothing);
     expect(
-      identical(tester.element(find.byKey(_cameraKey)), cameraElement),
+      identical(
+        tester.element(find.byKey(_cameraKey, skipOffstage: false)),
+        cameraElement,
+      ),
       isTrue,
     );
   });

--- a/test/features/keystone/keystone_pczt_qr_stage_test.dart
+++ b/test/features/keystone/keystone_pczt_qr_stage_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pretty_qr_code/pretty_qr_code.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/keystone/widgets/keystone_pczt_qr_stage.dart';
+
+Widget _app(Widget child) {
+  return AppTheme(
+    data: AppThemeData.light,
+    child: Directionality(
+      textDirection: TextDirection.ltr,
+      child: Center(child: child),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('keeps the default desktop-sized QR treatment', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        const KeystonePcztQrStage(
+          phase: KeystonePcztQrStagePhase.ready,
+          urParts: ['ur:zcash-pczt/test'],
+          error: null,
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(PrettyQrView)), const Size(230, 230));
+    expect(find.byType(CustomPaint), findsOneWidget);
+  });
+
+  testWidgets('can render a mobile scan-optimized QR', (tester) async {
+    await tester.pumpWidget(
+      _app(
+        const KeystonePcztQrStage(
+          phase: KeystonePcztQrStagePhase.ready,
+          urParts: ['ur:zcash-pczt/test'],
+          error: null,
+          size: 280,
+          scanOptimized: true,
+          frameInterval: Duration(milliseconds: 100),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(PrettyQrView)), const Size(280, 280));
+    final qrView = tester.widget<PrettyQrView>(find.byType(PrettyQrView));
+    final decoration = (qrView as dynamic).decoration as PrettyQrDecoration;
+    expect(decoration.quietZone, const PrettyQrQuietZone.modules(3));
+    expect(find.byType(CustomPaint), findsNothing);
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is ColoredBox && widget.color == const Color(0xFFFFFFFF),
+      ),
+      findsOneWidget,
+    );
+  });
+}

--- a/test/features/keystone/keystone_pczt_qr_stage_test.dart
+++ b/test/features/keystone/keystone_pczt_qr_stage_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:pretty_qr_code/pretty_qr_code.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/keystone/widgets/keystone_pczt_qr_stage.dart';
+import 'package:zcash_wallet/src/features/keystone/widgets/keystone_signing_modal.dart';
 
 Widget _app(Widget child) {
   return AppTheme(
@@ -15,7 +16,7 @@ Widget _app(Widget child) {
 }
 
 void main() {
-  testWidgets('keeps the default desktop-sized QR treatment', (tester) async {
+  testWidgets('renders scan-optimized QR by default', (tester) async {
     await tester.pumpWidget(
       _app(
         const KeystonePcztQrStage(
@@ -27,10 +28,39 @@ void main() {
     );
 
     expect(tester.getSize(find.byType(PrettyQrView)), const Size(230, 230));
+    final qrView = tester.widget<PrettyQrView>(find.byType(PrettyQrView));
+    final decoration = (qrView as dynamic).decoration as PrettyQrDecoration;
+    expect(decoration.quietZone, const PrettyQrQuietZone.modules(3));
+    expect(find.byType(CustomPaint), findsNothing);
+    expect(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is ColoredBox && widget.color == const Color(0xFFFFFFFF),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('can render a decorative QR only when explicitly requested', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        const KeystonePcztQrStage(
+          phase: KeystonePcztQrStagePhase.ready,
+          urParts: ['ur:zcash-pczt/test'],
+          error: null,
+          scanOptimized: false,
+          frameInterval: Duration(milliseconds: 250),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(PrettyQrView)), const Size(230, 230));
     expect(find.byType(CustomPaint), findsOneWidget);
   });
 
-  testWidgets('can render a mobile scan-optimized QR', (tester) async {
+  testWidgets('can render a larger mobile scan-optimized QR', (tester) async {
     await tester.pumpWidget(
       _app(
         const KeystonePcztQrStage(
@@ -56,5 +86,32 @@ void main() {
       ),
       findsOneWidget,
     );
+  });
+
+  testWidgets('desktop signing modal uses the scan-optimized PCZT QR', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        KeystoneSigningModal(
+          phase: KeystoneSigningModalPhase.ready,
+          urParts: const ['ur:zcash-pczt/test'],
+          error: null,
+          title: 'Confirm transaction',
+          subtitle: 'Keystone required',
+          instruction: 'Scan with Keystone.',
+          primaryLabel: null,
+          onPrimary: null,
+          secondaryLabel: null,
+          onSecondary: null,
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.byType(PrettyQrView)), const Size(264, 264));
+    final qrView = tester.widget<PrettyQrView>(find.byType(PrettyQrView));
+    final decoration = (qrView as dynamic).decoration as PrettyQrDecoration;
+    expect(decoration.quietZone, const PrettyQrQuietZone.modules(3));
+    expect(find.byType(CustomPaint), findsNothing);
   });
 }

--- a/test/features/onboarding/mobile_keystone_scan_screen_test.dart
+++ b/test/features/onboarding/mobile_keystone_scan_screen_test.dart
@@ -36,14 +36,21 @@ class _RustApiFake implements RustLibApi {
 }
 
 final _rustApi = _RustApiFake();
+const _phoneViewPadding = EdgeInsets.only(top: 55);
 
 Widget _app({MobileScannerController? controller}) {
   return ProviderScope(
     child: MaterialApp(
-      home: AppTheme(
-        data: AppThemeData.dark,
-        child: MobileKeystoneScanScreen(scannerController: controller),
-      ),
+      home: MobileKeystoneScanScreen(scannerController: controller),
+      builder: (context, child) {
+        final mediaQuery = MediaQuery.of(
+          context,
+        ).copyWith(padding: _phoneViewPadding, viewPadding: _phoneViewPadding);
+        return AppTheme(
+          data: AppThemeData.dark,
+          child: MediaQuery(data: mediaQuery, child: child!),
+        );
+      },
     ),
   );
 }
@@ -74,10 +81,42 @@ Widget _routerApp({
   return ProviderScope(
     child: MaterialApp.router(
       routerConfig: router,
-      builder: (context, child) => AppTheme(
-        data: AppThemeData.dark,
-        child: child ?? const SizedBox.shrink(),
-      ),
+      builder: (context, child) {
+        final mediaQuery = MediaQuery.of(
+          context,
+        ).copyWith(padding: _phoneViewPadding, viewPadding: _phoneViewPadding);
+        return AppTheme(
+          data: AppThemeData.dark,
+          child: MediaQuery(
+            data: mediaQuery,
+            child: child ?? const SizedBox.shrink(),
+          ),
+        );
+      },
+    ),
+  );
+}
+
+Widget _stackedRouteApp({MobileScannerController? controller}) {
+  return ProviderScope(
+    child: MaterialApp(
+      initialRoute: '/scan',
+      routes: {
+        '/': (_) => const SizedBox(key: ValueKey('previous-screen')),
+        '/scan': (_) => MobileKeystoneScanScreen(scannerController: controller),
+      },
+      builder: (context, child) {
+        final mediaQuery = MediaQuery.of(
+          context,
+        ).copyWith(padding: _phoneViewPadding, viewPadding: _phoneViewPadding);
+        return AppTheme(
+          data: AppThemeData.dark,
+          child: MediaQuery(
+            data: mediaQuery,
+            child: child ?? const SizedBox.shrink(),
+          ),
+        );
+      },
     ),
   );
 }
@@ -132,7 +171,8 @@ void main() {
       find.byKey(const ValueKey('mobile_keystone_scan_explainer')),
       findsNothing,
     );
-    expect(_cameraViewportSize(tester), const Size(361, 464));
+    expect(_cameraViewportSize(tester), const Size(361, 694));
+    expect(_cameraViewportTopLeft(tester), const Offset(16, 126));
   });
 
   testWidgets('uses the Keystone permission card while access is pending', (
@@ -145,11 +185,21 @@ void main() {
     await tester.pumpWidget(_app(controller: controller));
     await tester.pump();
 
-    final cameraElement = tester.element(
-      find.byKey(const ValueKey('mobile_keystone_scan_camera')),
-    );
     expect(
       find.byKey(const ValueKey('mobile_keystone_scan_permission_card')),
+      findsOneWidget,
+    );
+    expect(_cameraViewportSize(tester), const Size(361, 694));
+    expect(_cameraViewportTopLeft(tester), const Offset(16, 126));
+    expect(
+      find.byKey(const ValueKey('mobile_keystone_scan_camera')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(
+        const ValueKey('mobile_keystone_scan_camera'),
+        skipOffstage: false,
+      ),
       findsOneWidget,
     );
     expect(find.text('Enable camera access'), findsOneWidget);
@@ -159,6 +209,7 @@ void main() {
     );
     expect(find.text('Grant access to your camera'), findsNothing);
     expect(find.text('Scan the address QR code'), findsNothing);
+    expect(find.text('Scan a Zcash QR code to continue'), findsNothing);
 
     controller.value = controller.value.copyWith(isInitialized: true);
     await tester.pump();
@@ -169,15 +220,28 @@ void main() {
       find.byKey(const ValueKey('mobile_keystone_scan_permission_card')),
       findsNothing,
     );
+    expect(find.byKey(const ValueKey('mobile_keystone_scan_camera')), findsOne);
+  });
+
+  testWidgets('keeps the onboarding back button tappable behind the scrim', (
+    tester,
+  ) async {
+    _setViewSize(tester, const Size(393, 852));
+    final controller = MobileScannerController(autoStart: false);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(_stackedRouteApp(controller: controller));
+    await tester.pump();
+
     expect(
-      identical(
-        tester.element(
-          find.byKey(const ValueKey('mobile_keystone_scan_camera')),
-        ),
-        cameraElement,
-      ),
-      isTrue,
+      find.byKey(const ValueKey('mobile_keystone_scan_permission_card')),
+      findsOneWidget,
     );
+
+    await tester.tapAt(Offset(AppSpacing.s + 22, _phoneViewPadding.top + 36));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('previous-screen')), findsOneWidget);
   });
 
   testWidgets('denied access uses the Keystone retry card', (tester) async {
@@ -203,6 +267,18 @@ void main() {
     expect(find.text("You've denied camera access"), findsOneWidget);
     expect(find.text('Request again'), findsOneWidget);
     expect(find.text('Cancel'), findsNothing);
+    expect(find.text('Scan a Zcash QR code to continue'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('mobile_keystone_scan_camera')),
+      findsNothing,
+    );
+    expect(
+      find.byKey(
+        const ValueKey('mobile_keystone_scan_camera'),
+        skipOffstage: false,
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets('shows scan card once camera permission is granted and running', (
@@ -220,7 +296,8 @@ void main() {
     await tester.pump();
 
     expect(find.byKey(const ValueKey('mobile_keystone_scan_camera')), findsOne);
-    expect(find.text('Scan a Zcash QR code to continue'), findsOneWidget);
+    expect(find.text('Scan the Keystone account QR'), findsOneWidget);
+    expect(find.text('Scan a Zcash QR code to continue'), findsNothing);
     expect(find.text('Loading...'), findsNothing);
     expect(find.text('Enable camera access'), findsNothing);
     expect(
@@ -247,9 +324,8 @@ void main() {
       find.byKey(const ValueKey('mobile_keystone_scan_explainer')),
       findsNothing,
     );
-    expect(cameraSize.width, 361);
-    expect(cameraSize.height, lessThan(464));
-    expect(cameraSize.height, greaterThan(300));
+    expect(cameraSize, const Size(361, 509));
+    expect(_cameraViewportTopLeft(tester), const Offset(16, 126));
   });
 
   testWidgets('moves to select account after a Keystone account QR scan', (
@@ -259,6 +335,10 @@ void main() {
     _rustApi.decodedAccounts = [_account(1), _account(2)];
     final controller = MobileScannerController(autoStart: false);
     addTearDown(controller.dispose);
+    controller.value = controller.value.copyWith(
+      isInitialized: true,
+      isRunning: true,
+    );
 
     await tester.pumpWidget(_routerApp(controller: controller));
     await tester.pump();
@@ -286,6 +366,10 @@ void main() {
     _rustApi.decodedAccounts = [_account(1), _account(2)];
     final controller = MobileScannerController(autoStart: false);
     addTearDown(controller.dispose);
+    controller.value = controller.value.copyWith(
+      isInitialized: true,
+      isRunning: true,
+    );
 
     await tester.pumpWidget(_routerApp(controller: controller));
     await tester.pump();
@@ -386,6 +470,12 @@ void main() {
 
 Size _cameraViewportSize(WidgetTester tester) {
   return tester.getSize(
+    find.byKey(const ValueKey('mobile_keystone_scan_card')),
+  );
+}
+
+Offset _cameraViewportTopLeft(WidgetTester tester) {
+  return tester.getTopLeft(
     find.byKey(const ValueKey('mobile_keystone_scan_card')),
   );
 }

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -953,7 +953,8 @@ void main() {
     );
     expect(reviewAmount.style?.fontSize, AppTypography.headlineLarge.fontSize);
     expect(reviewAmount.style?.height, AppTypography.headlineLarge.height);
-    expect(find.text('Unified address'), findsOneWidget);
+    expect(find.text('Shielded address'), findsOneWidget);
+    expect(find.text('Unified address'), findsNothing);
     expect(find.text('u1tests .... 0000000'), findsOneWidget);
     expect(
       tester.getSize(find.byKey(const ValueKey('mobile_send_full_address'))),

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -1,6 +1,8 @@
 @Tags(['mobile'])
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -143,6 +145,8 @@ Widget _app({
   Map<String, AccountInfo> ownAccounts = const {},
   EdgeInsets viewPadding = EdgeInsets.zero,
   MobileSendScanner? openScanner,
+  String? initialRecipient,
+  MobileSendAddressValidator? validateAddress,
 }) {
   final router = GoRouter(
     initialLocation: '/send',
@@ -152,6 +156,8 @@ Widget _app({
         builder: (_, _) => MobileSendScreen(
           loadWalletDbPath: () async => '/tmp/zcash-test',
           openScanner: openScanner ?? (_) async => null,
+          initialRecipient: initialRecipient,
+          validateAddress: validateAddress,
         ),
       ),
       GoRoute(path: '/home', builder: (_, _) => const Text('home')),
@@ -360,6 +366,55 @@ void main() {
       find.byKey(const ValueKey('mobile_send_continue')),
     );
     expect(continueButton.onPressed, isNull);
+  });
+
+  testWidgets('prefilled recipient waits for validation before Continue', (
+    tester,
+  ) async {
+    final validation = Completer<AddressValidationResult>();
+
+    await tester.pumpWidget(
+      _app(
+        initialRecipient: _texAddress,
+        validateAddress: ({required address}) => validation.future,
+        accountState: const AccountState(
+          accounts: [
+            AccountInfo(
+              uuid: 'account-1',
+              name: 'Keystone',
+              order: 0,
+              isHardware: true,
+            ),
+          ],
+          activeAccountUuid: 'account-1',
+          activeAddress: 'u1activeaddress',
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final pendingContinue = tester.widget<AppButton>(
+      find.byKey(const ValueKey('mobile_send_continue')),
+    );
+    expect(pendingContinue.onPressed, isNull);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_continue')));
+    await tester.pump();
+    expect(find.text('Enter amount'), findsNothing);
+
+    validation.complete(
+      const AddressValidationResult(isValid: true, addressType: 'tex'),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Keystone does not support TEX sends yet.'),
+      findsOneWidget,
+    );
+    final blockedContinue = tester.widget<AppButton>(
+      find.byKey(const ValueKey('mobile_send_continue')),
+    );
+    expect(blockedContinue.onPressed, isNull);
   });
 
   testWidgets('recipient step lets a software account send to a TEX address', (

--- a/test/features/send/mobile_send_status_screen_test.dart
+++ b/test/features/send/mobile_send_status_screen_test.dart
@@ -109,6 +109,9 @@ void main() {
     expect(find.text('123.12 ZEC'), findsOneWidget);
     expect(find.text(r'$8.62K'), findsOneWidget);
     expect(find.text('To'), findsOneWidget);
+    expect(find.text('Shielded'), findsOneWidget);
+    expect(find.text('Shielded address'), findsNothing);
+    expect(find.text('Unified address'), findsNothing);
 
     broadcast.complete(
       const SendBroadcastOutcome(

--- a/test/widgetbook/mobile_keystone_use_cases_test.dart
+++ b/test/widgetbook/mobile_keystone_use_cases_test.dart
@@ -4,6 +4,7 @@ library;
 import 'package:flutter/material.dart' show MaterialApp;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pretty_qr_code/pretty_qr_code.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/widgetbook/keystone_use_cases.dart';
 
@@ -28,8 +29,16 @@ void main() {
       tester.getSize(
         find.byKey(const ValueKey('mobile_keystone_scan_widgetbook_card')),
       ),
-      const Size(361, 464),
+      const Size(361, 694),
     );
+    expect(
+      tester.getTopLeft(
+        find.byKey(const ValueKey('mobile_keystone_scan_widgetbook_card')),
+      ),
+      const Offset(16, 126),
+    );
+    expect(find.byType(PrettyQrView), findsNothing);
+    expect(find.byType(PrettyQrView, skipOffstage: false), findsOneWidget);
   });
 
   testWidgets('mobile Keystone scan denied use case exposes retry action', (
@@ -44,6 +53,20 @@ void main() {
       find.byKey(const ValueKey('mobile_keystone_scan_retry_button')),
       findsOneWidget,
     );
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('mobile_keystone_scan_widgetbook_card')),
+      ),
+      const Size(361, 694),
+    );
+    expect(
+      tester.getTopLeft(
+        find.byKey(const ValueKey('mobile_keystone_scan_widgetbook_card')),
+      ),
+      const Offset(16, 126),
+    );
+    expect(find.byType(PrettyQrView), findsNothing);
+    expect(find.byType(PrettyQrView, skipOffstage: false), findsOneWidget);
   });
 
   testWidgets('mobile Keystone active scan use case renders common scan card', (
@@ -52,7 +75,8 @@ void main() {
     await _pumpUseCase(tester, buildMobileKeystoneScanActiveUseCase);
 
     expect(tester.takeException(), isNull);
-    expect(find.text('Scan a Zcash QR code to continue'), findsOneWidget);
+    expect(find.text('Scan the Keystone account QR'), findsOneWidget);
+    expect(find.text('Scan a Zcash QR code to continue'), findsNothing);
     expect(find.text('Enable camera access'), findsNothing);
     expect(
       tester.getSize(
@@ -66,6 +90,7 @@ void main() {
       ),
       const Offset(16, 126),
     );
+    expect(find.byType(PrettyQrView), findsOneWidget);
   });
 
   testWidgets('mobile Keystone loading scan use case renders loading veil', (
@@ -113,7 +138,10 @@ void main() {
     await _pumpUseCase(tester, buildMobileKeystoneBirthdayUseCase);
 
     expect(tester.takeException(), isNull);
-    expect(find.text('Around when did you create your wallet?'), findsOneWidget);
+    expect(
+      find.text('Around when did you create your wallet?'),
+      findsOneWidget,
+    );
     expect(find.text('Enter the date'), findsOneWidget);
     expect(find.text('Enter the block height'), findsOneWidget);
   });


### PR DESCRIPTION
## Summary

This PR collects the final mobile polish fixes across contacts, QR scanning, Keystone hardware-wallet QR reliability, and ZEC send review/status copy.

### Contacts

- Render address-book network icons without the extra framed circle treatment.
- Align the mobile contact row context menu with the mobile accounts-page menu behavior.
- Make Add contact / Edit contact QR scanner copy follow the selected network, e.g. `Scan Ethereum QR code` instead of hardcoded Zcash copy.

### QR scanner surfaces

- Keep the shared mobile scanner camera mounted offstage during permission/requesting states so permission transitions do not deadlock, while preventing camera preview bleed behind permission cards.
- Preserve the onboarding back affordance behind the Keystone scan scrim.
- Update Widgetbook coverage for the mobile Keystone scan states.

### Keystone / hardware wallet QR

- Present the Keystone account QR scanner as the mobile modal-style scan card instead of an inline card under the permission state.
- Update the Keystone account scan caption to `Scan the Keystone account QR`.
- Make PCZT signing QR codes scan-optimized by default: black-on-white square modules, EC level M, a 100ms animated-frame interval, and a 3-module quiet zone.
- Increase the desktop Keystone signing QR size to improve Keystone device recognition.
- Add `AGENTS.md` guidance that hardware-wallet PCZT QR codes prioritize scan reliability over Figma parity.

### Send

- Wait for prefilled recipient validation before enabling Continue.
- Label non-transparent ZEC recipients as `Shielded address` on mobile review while keeping the status badge as `Shielded`.

## Validation

- `fvm flutter test test/features/address_book/address_book_contact_test.dart test/features/keystone/keystone_pczt_qr_stage_test.dart`
- `fvm flutter test test/features/send/send_review_screen_test.dart`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/address_book/mobile_address_book_screen_test.dart test/features/address_scan/mobile_address_scan_card_test.dart test/features/onboarding/mobile_keystone_scan_screen_test.dart test/features/send/mobile_send_screen_test.dart test/features/send/mobile_send_status_screen_test.dart test/widgetbook/mobile_keystone_use_cases_test.dart`
- `fvm flutter analyze`
- `git diff --check`
- Real-device iPhone testing completed for the affected mobile QR / Keystone flows.
- Keystone device desktop PCZT QR scan verified manually after the scan-optimized QR update.
