### PR TITLE
[codex] Split mobile send flow into route steps

### DIFF
--- a/integration_test/regtest_mobile_send_screenshot_test.dart
+++ b/integration_test/regtest_mobile_send_screenshot_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+
+import 'support/mobile_regtest_flow.dart';
+
+const _mnemonic =
+    'winter shiver fetch refuse absurd mail pistol eight market lounge manual '
+    'roast miracle ethics found child scare curve congress renew salute pig '
+    'better used';
+const _screenshotDriverUrl = String.fromEnvironment(
+  'ZCASH_E2E_SCREENSHOT_DRIVER_URL',
+  defaultValue: 'http://127.0.0.1:39070',
+);
+
+/// Focused design capture for the mobile send flow. It uses the same host-side
+/// screenshot driver as the full screenshot tour, but stops at the send states
+/// needed for route-step refactors.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeZcashWalletRuntime();
+  });
+
+  testWidgets('captures the mobile send flow states', (tester) async {
+    tolerateRenderOverflows();
+    addTearDown(() async {
+      await cleanupE2eWalletState();
+    });
+    await cleanupE2eWalletState();
+
+    Future<void> shot(String name) async {
+      await settle(tester, const Duration(milliseconds: 700));
+      await postDriver('/screenshot', {
+        'name': name,
+      }, baseUrl: _screenshotDriverUrl);
+      logE2e('shot $name');
+    }
+
+    logE2e('pumping app');
+    await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+    await pumpUntil(
+      tester,
+      () =>
+          tester.any(find.byKey(const ValueKey('mobile_welcome_get_started'))),
+      description: 'welcome screen',
+      timeout: const Duration(minutes: 1),
+    );
+
+    await importWalletViaPaste(
+      tester,
+      mnemonic: _mnemonic,
+      birthdayHeight: 1,
+      isFirstWallet: true,
+    );
+    await waitForShieldedBalance(tester, '1.25 $mobileE2eTicker');
+    await pumpUntil(
+      tester,
+      () => tester.any(find.text('Vizor is synced')),
+      description: 'sync to complete',
+      timeout: const Duration(minutes: 2),
+    );
+
+    final ownAddress = await copyShieldedAddress(tester);
+    await tapWidget(tester, const ValueKey('mobile_home_send'));
+    await pumpUntil(
+      tester,
+      () => tester.any(find.text('Select Recipient')),
+      description: 'send recipient step',
+    );
+    await shot('01_send_recipient');
+
+    await enterText(
+      tester,
+      const ValueKey('mobile_send_address_field'),
+      ownAddress,
+    );
+    await shot('02_send_recipient_filled');
+
+    await tapAppButton(
+      tester,
+      const ValueKey('mobile_send_continue'),
+      timeout: const Duration(minutes: 1),
+    );
+    await pumpUntil(
+      tester,
+      () => tester.any(find.text('Enter amount')),
+      description: 'send amount step',
+    );
+    await shot('03_send_amount_empty');
+
+    await enterText(tester, const ValueKey('mobile_send_amount_input'), '0.25');
+    await pumpUntil(
+      tester,
+      () => tester.any(find.text('Finish & review')),
+      description: 'amount ready',
+      timeout: const Duration(minutes: 1),
+    );
+    await shot('04_send_amount_ready');
+
+    await tapAppButton(
+      tester,
+      const ValueKey('mobile_send_review_button'),
+      timeout: const Duration(minutes: 1),
+    );
+    await pumpUntil(
+      tester,
+      () => tester.any(find.text('Review Send')),
+      description: 'send review step',
+    );
+    await shot('05_send_review');
+
+    await tapWidget(tester, const ValueKey('mobile_send_memo_row'));
+    await pumpUntil(
+      tester,
+      () => tester.any(find.byKey(const ValueKey('mobile_send_memo_field'))),
+      description: 'memo sheet',
+    );
+    await shot('06_send_memo_sheet');
+
+    await enterText(
+      tester,
+      const ValueKey('mobile_send_memo_field'),
+      'Zcash is a privacy-focused cryptocurrency',
+    );
+    await tapAppButton(tester, const ValueKey('mobile_send_memo_save'));
+    await settle(tester, const Duration(milliseconds: 400));
+    await shot('07_send_review_with_memo');
+
+    await tapWidget(tester, const ValueKey('mobile_send_full_address'));
+    await settle(tester, const Duration(milliseconds: 400));
+    await shot('08_send_full_address');
+    await tester.tap(find.text('Cancel').last);
+    await settle(tester, const Duration(milliseconds: 400));
+
+    await tapAppButton(
+      tester,
+      const ValueKey('mobile_send_confirm'),
+      timeout: const Duration(minutes: 1),
+    );
+    await pumpUntil(
+      tester,
+      () =>
+          tester.any(find.byKey(const ValueKey('mobile_send_status_sending'))),
+      description: 'send status to start',
+      timeout: const Duration(minutes: 1),
+    );
+    await shot('09_send_sending');
+
+    await pumpUntil(
+      tester,
+      () => tester.any(
+        find.byKey(const ValueKey('mobile_send_status_succeeded')),
+      ),
+      description: 'send status to succeed',
+      timeout: const Duration(minutes: 4),
+    );
+    await shot('10_send_success');
+  });
+}

--- a/lib/src/core/navigation/app_back_resolver.dart
+++ b/lib/src/core/navigation/app_back_resolver.dart
@@ -38,6 +38,7 @@ abstract final class AppBackResolver {
   static const _routeLabels = <String, String>{
     '/home': 'Home',
     '/send': 'Send',
+    '/send/amount': 'Amount',
     '/send/review': 'Review',
     '/send/keystone/scan': 'Keystone',
     '/send/status': 'Status',

--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -111,10 +111,36 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
     ),
     GoRoute(
       path: '/send',
-      pageBuilder: (context, state) => CupertinoPage(
-        key: state.pageKey,
-        child: MobileSendScreen(initialRecipient: state.extra as String?),
-      ),
+      pageBuilder: (context, state) {
+        final extra = state.extra;
+        return CupertinoPage(
+          key: state.pageKey,
+          child: MobileSendScreen(
+            useRouteSteps: true,
+            initialRecipient: extra is String ? extra : null,
+          ),
+        );
+      },
+    ),
+    GoRoute(
+      path: '/send/amount',
+      pageBuilder: (context, state) {
+        final extra = state.extra;
+        final child = extra is MobileSendAmountArgs
+            ? MobileSendAmountScreen(args: extra)
+            : const MobileSendScreen(useRouteSteps: true);
+        return CupertinoPage(key: state.pageKey, child: child);
+      },
+    ),
+    GoRoute(
+      path: '/send/review',
+      pageBuilder: (context, state) {
+        final extra = state.extra;
+        final child = extra is MobileSendReviewDraftArgs
+            ? MobileSendReviewScreen(args: extra)
+            : const MobileSendScreen(useRouteSteps: true);
+        return CupertinoPage(key: state.pageKey, child: child);
+      },
     ),
     GoRoute(
       path: '/send/status',
@@ -126,7 +152,7 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
             keystone: extra,
           ),
           SendReviewArgs() => MobileSendStatusScreen(args: extra),
-          _ => const MobileSendScreen(),
+          _ => const MobileSendScreen(useRouteSteps: true),
         };
         return CupertinoPage(key: state.pageKey, child: child);
       },

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -805,6 +805,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   }
 
   void _handleBack() {
+    if (_isConfirmingSend) return;
     switch (_phase) {
       case _SendPhase.failed:
         setState(() => _phase = _SendPhase.compose);
@@ -967,7 +968,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
               SafeArea(
                 child: Column(
                   children: [
-                    MobileTopNav.back(title: title, onBack: _handleBack),
+                    MobileTopNav.back(
+                      title: title,
+                      onBack: _isConfirmingSend ? null : _handleBack,
+                    ),
                     Expanded(child: body),
                   ],
                 ),

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -88,6 +88,87 @@ typedef MobileSendFeeEstimator =
 
 typedef MobileSendScanner = Future<String?> Function(BuildContext context);
 
+class MobileSendAmountArgs {
+  const MobileSendAmountArgs({
+    required this.sendFlowId,
+    required this.recipient,
+    required this.addressType,
+    this.contactLabel,
+    this.contactPictureId,
+  });
+
+  final String sendFlowId;
+  final String recipient;
+  final String addressType;
+  final String? contactLabel;
+  final String? contactPictureId;
+}
+
+class MobileSendReviewDraftArgs {
+  const MobileSendReviewDraftArgs({
+    required this.sendFlowId,
+    required this.recipient,
+    required this.addressType,
+    required this.amountText,
+    this.feeZatoshi,
+    this.memo,
+    this.contactLabel,
+    this.contactPictureId,
+  });
+
+  final String sendFlowId;
+  final String recipient;
+  final String addressType;
+  final String amountText;
+  final BigInt? feeZatoshi;
+  final String? memo;
+  final String? contactLabel;
+  final String? contactPictureId;
+}
+
+class MobileSendAmountScreen extends StatelessWidget {
+  const MobileSendAmountScreen({required this.args, super.key});
+
+  final MobileSendAmountArgs args;
+
+  @override
+  Widget build(BuildContext context) {
+    return MobileSendScreen(
+      useRouteSteps: true,
+      initialAmountStep: true,
+      initialSendFlowId: args.sendFlowId,
+      initialRecipient: args.recipient,
+      initialAddressType: args.addressType,
+      initialContactLabel: args.contactLabel,
+      initialContactPictureId: args.contactPictureId,
+    );
+  }
+}
+
+class MobileSendReviewScreen extends StatelessWidget {
+  const MobileSendReviewScreen({required this.args, super.key});
+
+  final MobileSendReviewDraftArgs args;
+
+  @override
+  Widget build(BuildContext context) {
+    return MobileSendScreen(
+      useRouteSteps: true,
+      initialReview: true,
+      initialAmountReady: true,
+      initialSendFlowId: args.sendFlowId,
+      initialRecipient: args.recipient,
+      initialAddressType: args.addressType,
+      initialAmount: args.amountText,
+      initialFeeZatoshi: args.feeZatoshi,
+      refreshReviewFeeOnInit: true,
+      initialMemo: args.memo,
+      initialContactLabel: args.contactLabel,
+      initialContactPictureId: args.contactPictureId,
+    );
+  }
+}
+
 const _kMobileSendRecipientLineHeight = 17.0;
 const _kMobileSendAddressActionHeight = 36.0;
 const _kMobileSendAddressActionSlotWidth = 96.0;
@@ -127,11 +208,17 @@ class MobileSendScreen extends ConsumerStatefulWidget {
     this.validateAddress,
     this.estimateFee,
     this.openScanner = showMobileSendScanSheet,
+    this.useRouteSteps = false,
+    this.initialSendFlowId,
     this.initialRecipient,
+    this.initialAddressType,
     this.initialAmount,
     this.initialAmountError,
     this.initialAmountReady = false,
+    this.initialAmountStep = false,
     this.initialReview = false,
+    this.initialFeeZatoshi,
+    this.refreshReviewFeeOnInit = false,
     this.initialMemo,
     this.initialContactLabel,
     this.initialContactPictureId,
@@ -146,13 +233,19 @@ class MobileSendScreen extends ConsumerStatefulWidget {
   /// Pre-fills the recipient step (e.g. the accounts row menu's
   /// "Send ZEC" action passes that account's shielded address).
   final String? initialRecipient;
+  final String? initialAddressType;
 
   /// Preview/test seam for opening the amount step with a preset value.
+  final bool initialAmountStep;
   final String? initialAmount;
   final String? initialAmountError;
   final bool initialAmountReady;
   final bool initialReview;
+  final BigInt? initialFeeZatoshi;
+  final bool refreshReviewFeeOnInit;
   final String? initialMemo;
+  final String? initialSendFlowId;
+  final bool useRouteSteps;
 
   /// Preview/test seam for recipient summary states.
   final String? initialContactLabel;
@@ -177,7 +270,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   final _addressFocus = FocusNode();
   final _amountController = TextEditingController();
   final _amountFocus = FocusNode();
-  late final String _sendFlowId = newSendFlowId();
+  late final String _sendFlowId = widget.initialSendFlowId ?? newSendFlowId();
 
   var _step = _SendStep.recipient;
   var _phase = _SendPhase.compose;
@@ -209,7 +302,12 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     final initial = widget.initialRecipient;
     if (initial != null && initial.trim().isNotEmpty) {
       _addressController.text = initial.trim();
-      unawaited(_validateAddress());
+      final initialAddressType = widget.initialAddressType?.trim();
+      if (initialAddressType != null && initialAddressType.isNotEmpty) {
+        _addressType = initialAddressType;
+      } else {
+        unawaited(_validateAddress());
+      }
     }
     final initialContactLabel = widget.initialContactLabel;
     if (initialContactLabel != null && initialContactLabel.trim().isNotEmpty) {
@@ -220,20 +318,28 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     if (initialMemo != null && initialMemo.trim().isNotEmpty) {
       _memo = initialMemo.trim();
     }
-    if (widget.initialAmount != null) {
+    if (widget.initialAmountStep || widget.initialAmount != null) {
       _step = widget.initialReview ? _SendStep.review : _SendStep.amount;
-      _amountText = widget.initialAmount!.trim();
+      _amountText = widget.initialAmount?.trim() ?? '';
       _amountController.text = _amountText;
       if (widget.initialAmountError != null) {
         _amountError = widget.initialAmountError;
       } else if (widget.initialAmountReady || widget.initialReview) {
         _amountError = null;
-        _feeZatoshi = BigInt.from(10000);
+        _feeZatoshi = widget.initialFeeZatoshi;
+        if (_feeZatoshi == null && !widget.refreshReviewFeeOnInit) {
+          _feeZatoshi = BigInt.from(10000);
+        }
       } else if (_amountText.isNotEmpty) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (mounted) unawaited(_validateAmount());
         });
       }
+    }
+    if (widget.initialReview && widget.refreshReviewFeeOnInit) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) unawaited(_estimateReviewFee());
+      });
     }
     if (widget.initialRecipientFocused) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -285,7 +391,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
 
   bool get _routePopAllowed =>
       _phase == _SendPhase.compose &&
-      _step == _SendStep.recipient &&
+      (widget.useRouteSteps || _step == _SendStep.recipient) &&
       !_isConfirmingSend;
 
   bool get _isShieldedAddress =>
@@ -385,6 +491,21 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   void _continueToAmount() {
     if (!_hasValidAddress || _isHardwareTexRecipient) return;
     _addressFocus.unfocus();
+    if (widget.useRouteSteps) {
+      unawaited(
+        context.push<void>(
+          '/send/amount',
+          extra: MobileSendAmountArgs(
+            sendFlowId: _sendFlowId,
+            recipient: _addressController.text.trim(),
+            addressType: _addressType,
+            contactLabel: _contactLabel,
+            contactPictureId: _contactPictureId,
+          ),
+        ),
+      );
+      return;
+    }
     setState(() => _step = _SendStep.amount);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _amountFocus.requestFocus();
@@ -471,6 +592,24 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   void _continueToReview() {
     if (!_amountReady) return;
     _amountFocus.unfocus();
+    if (widget.useRouteSteps) {
+      unawaited(
+        context.push<void>(
+          '/send/review',
+          extra: MobileSendReviewDraftArgs(
+            sendFlowId: _sendFlowId,
+            recipient: _addressController.text.trim(),
+            addressType: _addressType,
+            amountText: _amountText,
+            feeZatoshi: _feeZatoshi,
+            memo: _memo,
+            contactLabel: _contactLabel,
+            contactPictureId: _contactPictureId,
+          ),
+        ),
+      );
+      return;
+    }
     setState(() => _step = _SendStep.review);
     // Refresh the fee for the review card (the memo may change it).
     unawaited(_estimateReviewFee());
@@ -561,6 +700,16 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     );
   }
 
+  void _openStatusRoute(Object extra) {
+    if (widget.useRouteSteps) {
+      final router = GoRouter.of(context);
+      router.go('/home');
+      unawaited(router.push<void>('/send/status', extra: extra));
+      return;
+    }
+    context.pushReplacement('/send/status', extra: extra);
+  }
+
   Future<void> _confirmAndSend() async {
     if (_phase != _SendPhase.compose || _isConfirmingSend) return;
     final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
@@ -637,15 +786,23 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         return;
       }
       if (!mounted) return;
-      context.pushReplacement('/send/status', extra: keystone);
+      _openStatusRoute(keystone);
       return;
     }
 
     if (!mounted) return;
-    context.pushReplacement('/send/status', extra: args);
+    _openStatusRoute(args);
   }
 
   // ── Navigation ─────────────────────────────────────────────────────
+
+  void _cancelSend() {
+    if (widget.useRouteSteps) {
+      context.go('/home');
+      return;
+    }
+    context.pop();
+  }
 
   void _handleBack() {
     switch (_phase) {
@@ -660,8 +817,16 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         context.pop();
       case _SendStep.amount:
         _amountFocus.unfocus();
+        if (widget.useRouteSteps) {
+          context.pop();
+          return;
+        }
         setState(() => _step = _SendStep.recipient);
       case _SendStep.review:
+        if (widget.useRouteSteps) {
+          context.pop();
+          return;
+        }
         setState(() => _step = _SendStep.amount);
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (mounted) _amountFocus.requestFocus();
@@ -1515,7 +1680,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                   key: const ValueKey('mobile_send_cancel'),
                   expand: true,
                   variant: AppButtonVariant.ghost,
-                  onPressed: () => context.pop(),
+                  onPressed: _cancelSend,
                   child: const Text('Cancel'),
                 ),
               ],

--- a/scripts/e2e/flutter-ios-regtest-mobile-send-screenshots.sh
+++ b/scripts/e2e/flutter-ios-regtest-mobile-send-screenshots.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MNEMONIC="winter shiver fetch refuse absurd mail pistol eight market lounge manual roast miracle ethics found child scare curve congress renew salute pig better used"
+SHIELDED_AMOUNT="1.25"
+CONFIRMING_BLOCKS="${E2E_CONFIRMING_BLOCKS:-10}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+SHOT_PORT="${E2E_SCREENSHOT_PORT:-39070}"
+SHOT_DIR="${E2E_SCREENSHOT_DIR:-$ROOT_DIR/.regtest-logs/send-screens}"
+SHOT_LOG="$ROOT_DIR/.regtest-logs/send-screenshot-driver.log"
+
+source "$ROOT_DIR/scripts/e2e/lib-mobile.sh"
+
+json_field() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+data = json.loads(sys.argv[1])
+print(data[sys.argv[2]])
+PY
+}
+
+require_cmd cargo
+require_cmd docker
+require_cmd fvm
+require_cmd python3
+require_cmd xcrun
+
+cd "$ROOT_DIR"
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+addresses_json="$(cd rust && cargo run --quiet --example regtest_wallet_addresses -- "$MNEMONIC")"
+unified_address="$(json_field "$addresses_json" unifiedAddress)"
+
+echo "funding shielded address with ${SHIELDED_AMOUNT} TAZ"
+scripts/regtest/fund-wallet.sh "$unified_address" "$SHIELDED_AMOUNT" "$CONFIRMING_BLOCKS" >/dev/null
+
+UDID="$(pick_simulator)"
+
+mkdir -p "$(dirname "$SHOT_LOG")" "$SHOT_DIR"
+: > "$SHOT_LOG"
+python3 -u scripts/e2e/screenshot-driver.py \
+  --udid "$UDID" \
+  --out-dir "$SHOT_DIR" \
+  --port "$SHOT_PORT" \
+  >"$SHOT_LOG" 2>&1 &
+DRIVER_PID="$!"
+cleanup() {
+  kill "$DRIVER_PID" >/dev/null 2>&1 || true
+  wait "$DRIVER_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+python3 - "http://127.0.0.1:${SHOT_PORT}" <<'PY'
+import sys
+import time
+import urllib.request
+
+url = sys.argv[1] + "/health"
+for _ in range(50):
+    try:
+        with urllib.request.urlopen(url, timeout=1) as response:
+            if response.status == 200:
+                raise SystemExit(0)
+    except Exception:
+        time.sleep(0.1)
+
+raise SystemExit("Timed out waiting for screenshot driver")
+PY
+
+run_mobile_e2e integration_test/regtest_mobile_send_screenshot_test.dart "$UDID" \
+  --dart-define=ZCASH_E2E_SCREENSHOT_DRIVER_URL="http://127.0.0.1:${SHOT_PORT}"
+
+echo "send screens captured under $SHOT_DIR"

--- a/test/core/navigation/mobile_routes_test.dart
+++ b/test/core/navigation/mobile_routes_test.dart
@@ -1,6 +1,8 @@
 @Tags(['mobile'])
 library;
 
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart' show CupertinoRouteTransitionMixin;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -131,6 +133,50 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.byType(MobileSendScreen), findsNothing);
     expect(find.byType(MobileHomeScreen), findsOneWidget);
+  });
+
+  testWidgets('send amount and review routes push Cupertino pages', (
+    tester,
+  ) async {
+    final router = _router();
+    await tester.pumpWidget(_app(router));
+    await tester.pumpAndSettle();
+
+    unawaited(
+      router.push<void>(
+        '/send/amount',
+        extra: const MobileSendAmountArgs(
+          sendFlowId: 'flow-1',
+          recipient: 'u1routeraddress',
+          addressType: 'unified',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MobileSendAmountScreen), findsOneWidget);
+    var route = ModalRoute.of(
+      tester.element(find.byType(MobileSendAmountScreen)),
+    );
+    expect(route, isA<CupertinoRouteTransitionMixin<dynamic>>());
+
+    unawaited(
+      router.push<void>(
+        '/send/review',
+        extra: MobileSendReviewDraftArgs(
+          sendFlowId: 'flow-1',
+          recipient: 'u1routeraddress',
+          addressType: 'unified',
+          amountText: '0.25',
+          feeZatoshi: BigInt.from(10000),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MobileSendReviewScreen), findsOneWidget);
+    route = ModalRoute.of(tester.element(find.byType(MobileSendReviewScreen)));
+    expect(route, isA<CupertinoRouteTransitionMixin<dynamic>>());
   });
 
   testWidgets('receive pushes over a Cupertino shell page', (tester) async {

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/formatting/zec_amount.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
@@ -192,7 +193,7 @@ Widget _app({
   );
 }
 
-Widget _sendFlowRouterApp() {
+Widget _sendFlowRouterApp({MobileSendFeeEstimator? estimateFee}) {
   final router = GoRouter(
     initialLocation: '/home',
     routes: [
@@ -207,9 +208,52 @@ Widget _sendFlowRouterApp() {
       GoRoute(
         path: '/send',
         builder: (_, _) => MobileSendScreen(
+          useRouteSteps: true,
           loadWalletDbPath: () async => '/tmp/zcash-test',
           openScanner: (_) async => null,
+          estimateFee: estimateFee,
         ),
+      ),
+      GoRoute(
+        path: '/send/amount',
+        builder: (_, state) {
+          final args = state.extra! as MobileSendAmountArgs;
+          return MobileSendScreen(
+            useRouteSteps: true,
+            initialAmountStep: true,
+            initialSendFlowId: args.sendFlowId,
+            initialRecipient: args.recipient,
+            initialAddressType: args.addressType,
+            initialContactLabel: args.contactLabel,
+            initialContactPictureId: args.contactPictureId,
+            loadWalletDbPath: () async => '/tmp/zcash-test',
+            openScanner: (_) async => null,
+            estimateFee: estimateFee,
+          );
+        },
+      ),
+      GoRoute(
+        path: '/send/review',
+        builder: (_, state) {
+          final args = state.extra! as MobileSendReviewDraftArgs;
+          return MobileSendScreen(
+            useRouteSteps: true,
+            initialReview: true,
+            initialAmountReady: true,
+            initialSendFlowId: args.sendFlowId,
+            initialRecipient: args.recipient,
+            initialAddressType: args.addressType,
+            initialAmount: args.amountText,
+            initialFeeZatoshi: args.feeZatoshi,
+            refreshReviewFeeOnInit: true,
+            initialMemo: args.memo,
+            initialContactLabel: args.contactLabel,
+            initialContactPictureId: args.contactPictureId,
+            loadWalletDbPath: () async => '/tmp/zcash-test',
+            openScanner: (_) async => null,
+            estimateFee: estimateFee,
+          );
+        },
       ),
       GoRoute(
         path: '/send/status',
@@ -456,31 +500,97 @@ void main() {
     expect(_sendRouteCanPop(tester), isFalse);
   });
 
-  testWidgets(
-    'send status replaces the send route so completed status can pop',
-    (tester) async {
-      _proposeSendSucceeds = true;
+  testWidgets('route-step mode lets amount and review pop as pages', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_sendFlowRouterApp());
+    await tester.pumpAndSettle();
 
-      await tester.pumpWidget(_sendFlowRouterApp());
-      await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('mobile_send_open_from_home')));
+    await tester.pumpAndSettle();
 
-      await tester.tap(
-        find.byKey(const ValueKey('mobile_send_open_from_home')),
-      );
-      await tester.pumpAndSettle();
+    await _toAmountStep(tester, _shieldedAddress);
+    expect(find.text('Enter amount'), findsOneWidget);
+    expect(_sendRouteCanPop(tester), isTrue);
 
-      await _toReviewStep(tester);
-      await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
-      await tester.pumpAndSettle();
+    await _enterAmount(tester, '1.5');
+    await tester.tap(find.byKey(const ValueKey('mobile_send_review_button')));
+    await tester.pumpAndSettle();
 
-      expect(find.text('status can pop'), findsOneWidget);
-      await tester.tap(find.byKey(const ValueKey('mobile_send_status_pop')));
-      await tester.pumpAndSettle();
+    expect(find.text('Review Send'), findsOneWidget);
+    expect(_sendRouteCanPop(tester), isTrue);
 
-      expect(find.text('home'), findsOneWidget);
-      expect(find.text('Review Send'), findsNothing);
-    },
-  );
+    await tester.tap(find.bySemanticsLabel('Back'));
+    await tester.pumpAndSettle();
+    expect(find.text('Enter amount'), findsOneWidget);
+
+    await tester.tap(find.bySemanticsLabel('Back'));
+    await tester.pumpAndSettle();
+    expect(find.text('Select Recipient'), findsOneWidget);
+  });
+
+  testWidgets('route-step review refreshes the fee on entry', (tester) async {
+    var feeCalls = 0;
+    final refreshedFee = BigInt.from(30000);
+
+    await tester.pumpWidget(
+      _sendFlowRouterApp(
+        estimateFee:
+            ({
+              required dbPath,
+              required network,
+              required accountUuid,
+              required toAddress,
+              required amountZatoshi,
+              memo,
+            }) async {
+              feeCalls++;
+              return feeCalls == 1 ? BigInt.from(10000) : refreshedFee;
+            },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_open_from_home')));
+    await tester.pumpAndSettle();
+
+    await _toAmountStep(tester, _shieldedAddress);
+    await _enterAmount(tester, '1.5');
+    expect(feeCalls, 1);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_review_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review Send'), findsOneWidget);
+    expect(feeCalls, greaterThanOrEqualTo(2));
+    final feeText = tester.widget<Text>(
+      find.byKey(const ValueKey('mobile_send_fee')),
+    );
+    expect(feeText.data, ZecAmount.fromZatoshi(refreshedFee).fee.toString());
+  });
+
+  testWidgets('route-step send status clears intermediate send pages', (
+    tester,
+  ) async {
+    _proposeSendSucceeds = true;
+
+    await tester.pumpWidget(_sendFlowRouterApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_open_from_home')));
+    await tester.pumpAndSettle();
+
+    await _toReviewStep(tester);
+    await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('status can pop'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('mobile_send_status_pop')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('home'), findsOneWidget);
+    expect(find.text('Review Send'), findsNothing);
+  });
 
   testWidgets('recipient step gates Continue on a valid address', (
     tester,

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -29,6 +29,7 @@ const _texAddress = 'tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte';
 const _invalidAddress = 'not-an-address';
 
 var _proposeSendSucceeds = false;
+Completer<ProposalResult>? _proposeSendCompleter;
 
 class _RustApiFake implements RustLibApi {
   @override
@@ -76,6 +77,8 @@ class _RustApiFake implements RustLibApi {
     required BigInt amountZatoshi,
     String? memo,
   }) async {
+    final completer = _proposeSendCompleter;
+    if (completer != null) return completer.future;
     if (!_proposeSendSucceeds) {
       throw StateError('proposal failed');
     }
@@ -369,6 +372,7 @@ void main() {
 
   setUp(() {
     _proposeSendSucceeds = false;
+    _proposeSendCompleter = null;
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
     binding.platformDispatcher.views.first
       ..physicalSize = const Size(520, 1100)
@@ -590,6 +594,50 @@ void main() {
 
     expect(find.text('home'), findsOneWidget);
     expect(find.text('Review Send'), findsNothing);
+  });
+
+  testWidgets('route-step review ignores back while preparing send', (
+    tester,
+  ) async {
+    final proposalCompleter = Completer<ProposalResult>();
+    _proposeSendCompleter = proposalCompleter;
+    addTearDown(() {
+      if (!proposalCompleter.isCompleted) {
+        proposalCompleter.completeError(StateError('test ended'));
+      }
+      _proposeSendCompleter = null;
+    });
+
+    await tester.pumpWidget(_sendFlowRouterApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_open_from_home')));
+    await tester.pumpAndSettle();
+
+    await _toReviewStep(tester);
+    await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+    await tester.pump();
+
+    expect(find.text('Preparing...'), findsOneWidget);
+    expect(find.bySemanticsLabel('Back'), findsNothing);
+    expect(_sendRouteCanPop(tester), isFalse);
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review Send'), findsOneWidget);
+    expect(find.text('Preparing...'), findsOneWidget);
+
+    proposalCompleter.complete(
+      ProposalResult(
+        proposalId: BigInt.from(1),
+        needsSaplingParams: false,
+        feeZatoshi: BigInt.from(10000),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('status can pop'), findsOneWidget);
   });
 
   testWidgets('recipient step gates Continue on a valid address', (


### PR DESCRIPTION
## Summary
- Split the mobile send flow into route-backed recipient, amount, and review steps.
- Preserve route pop behavior for iOS back gestures while keeping sending/status transitions guarded.
- Add focused mobile route tests and a regtest screenshot capture for the send flow.

## Validation
- fvm flutter test --reporter expanded --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/send/mobile_send_screen_test.dart --plain-name "route-step review refreshes the fee on entry"
- fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/send/mobile_send_screen_test.dart test/core/navigation/mobile_routes_test.dart
- fvm flutter analyze
- E2E_SCREENSHOT_DIR=/Users/junghwanyun/temp-screenshot/mobile-send-flow-screens/after-fee-refresh E2E_SCREENSHOT_PORT=39172 ./scripts/e2e/flutter-ios-regtest-mobile-send-screenshots.sh
- Pixel compare: previous after screenshots vs after-fee-refresh screenshots, 10/10 identical
