### PR TITLE
[codex] Restore mobile accounts add account action

### DIFF
--- a/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
+++ b/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
@@ -478,6 +478,17 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
                         ],
                       ),
                     ],
+                    const SizedBox(height: AppSpacing.sm),
+                    AppButton(
+                      key: const ValueKey('mobile_accounts_add_account'),
+                      variant: AppButtonVariant.secondary,
+                      expand: true,
+                      onPressed: _busy
+                          ? null
+                          : () => context.push('/add-account'),
+                      leading: const AppIcon(AppIcons.addNew),
+                      child: const Text('Add account'),
+                    ),
                   ],
                 ),
               ),

--- a/test/features/accounts/mobile_accounts_screen_test.dart
+++ b/test/features/accounts/mobile_accounts_screen_test.dart
@@ -659,7 +659,7 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  testWidgets('does not show a page-level add account action', (tester) async {
+  testWidgets('add account routes to the add-account flow', (tester) async {
     await tester.pumpWidget(
       _app(
         AccountState(
@@ -670,11 +670,13 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(
-      find.byKey(const ValueKey('mobile_accounts_add_account')),
-      findsNothing,
-    );
-    expect(find.text('Add account'), findsNothing);
+    final button = find.byKey(const ValueKey('mobile_accounts_add_account'));
+    expect(button, findsOneWidget);
+    expect(find.text('Add account'), findsOneWidget);
+
+    await tester.tap(button);
+    await tester.pumpAndSettle();
+    expect(find.text('add account route'), findsOneWidget);
   });
 
   testWidgets('remove asks for confirmation with the design copy', (

--- a/test/widgetbook/accounts_use_cases_test.dart
+++ b/test/widgetbook/accounts_use_cases_test.dart
@@ -97,7 +97,7 @@ void main() {
     expect(find.text('Accounts'), findsOneWidget);
     expect(find.text('Current'), findsOneWidget);
     expect(find.text('Other'), findsOneWidget);
-    expect(find.text('Add account'), findsNothing);
+    expect(find.text('Add account'), findsOneWidget);
 
     await tester.tap(
       find.byKey(const ValueKey('mobile_accounts_menu_preview-account-2')),


### PR DESCRIPTION
## Summary
- Restore the page-level Add account action below the mobile accounts list.
- Route the action to the existing `/add-account` mobile onboarding entry point.
- Update mobile accounts and widgetbook coverage to expect the restored action.

## Why
The mobile accounts screen previously lost the list-level Add account affordance. This restores the expected entry point while reusing the existing add-account route used elsewhere on mobile.

## Validation
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/accounts/mobile_accounts_screen_test.dart test/widgetbook/accounts_use_cases_test.dart`
- `fvm flutter test test/widgetbook/accounts_use_cases_test.dart`
- `fvm flutter analyze`
- `git diff --check`
