### PR TITLE
Fix wallet sync getting stuck after deleting an old-birthday imported account (VZR-89)

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -96,6 +96,9 @@ security-framework = { version = "3.7", features = ["OSX_10_15"] }
 [dev-dependencies]
 tempfile = "3"
 hex = "0.4"
+# Integration tests inject/inspect scan_queue rows directly to exercise the
+# VZR-89 rescue path. Keep this version aligned with the [dependencies] entry.
+rusqlite = "0.37"
 vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting", rev = "38b0c738ee8773382a817a00166791210d4dcc6d", package = "vote-commitment-tree" }
 
 [lints.rust]

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -6,7 +6,7 @@ use std::{
 
 use ::transparent::keys::{IncomingViewingKey as _, NonHardenedChildIndex};
 use bip0039::{Count, English, Language, Mnemonic};
-use rusqlite::named_params;
+use rusqlite::{named_params, OptionalExtension};
 use secrecy::{ExposeSecret, SecretVec};
 use zcash_client_backend::data_api::{
     chain::ChainState, Account as _, AccountBirthday, AccountPurpose, AccountSource, WalletRead,
@@ -731,8 +731,120 @@ fn delete_account_rows(db_path: &str, account_id: AccountUuid) -> Result<(), Str
     )
     .map_err(|e| format!("Failed to delete account: {e}"))?;
 
+    // Restore the "below the wallet birthday = Ignored" invariant for any
+    // historical scan range that only the just-deleted account required. See
+    // `prune_orphaned_scan_ranges_in_conn` for the full rationale (VZR-89).
+    prune_orphaned_scan_ranges_in_conn(&tx)
+        .map_err(|e| format!("Failed to prune orphaned scan ranges after deletion: {e}"))?;
+
     tx.commit()
         .map_err(|e| format!("Failed to commit account deletion: {e}"))
+}
+
+/// Demote orphaned historical scan ranges that lie below the remaining
+/// accounts' minimum birthday back to `Ignored`.
+///
+/// librustzcash never garbage-collects `scan_queue` when an account is deleted
+/// (neither upstream `delete_account` nor our `delete_account_rows`), and
+/// importing an account with an old birthday force-rescans the whole chain,
+/// demoting already-`Scanned` history to `Historic`. When that imported account
+/// is later removed, the historical range it required is left pending in
+/// `scan_queue` even though no remaining account needs it. The sync engine's
+/// progress denominator is the sum of all pending ranges, so that orphan pins
+/// progress near 0% and wastes hours re-scanning irrelevant blocks (VZR-89).
+///
+/// This restores the normal "below the wallet birthday = `Ignored`" invariant:
+/// any pending (priority above `Scanned`) coverage strictly below
+/// `MIN(birthday_height)` is set to `Ignored`. Scan ranges are disjoint, so at
+/// most one range straddles the birthday; it is split so the portion at/above
+/// the birthday keeps its priority. `Scanned` and `Ignored` rows are left
+/// untouched, and ranges at/above the birthday (including the live chain-tip
+/// gap) are preserved.
+///
+/// Idempotent and a no-op for healthy wallets (their sub-birthday range is
+/// already `Ignored`), so it is safe to call on every sync start as a rescue
+/// for wallets already stuck by a pre-fix deletion. Returns the number of
+/// `scan_queue` rows whose pending coverage was demoted (a split counts once).
+fn prune_orphaned_scan_ranges_in_conn(conn: &rusqlite::Connection) -> rusqlite::Result<usize> {
+    // scan_queue priority codes (zcash_client_backend ScanPriority).
+    const PRIORITY_IGNORED: i64 = 0;
+    const PRIORITY_SCANNED: i64 = 10;
+
+    let min_birthday: Option<i64> =
+        conn.query_row("SELECT MIN(birthday_height) FROM accounts", [], |row| {
+            row.get(0)
+        })?;
+    let Some(min_birthday) = min_birthday else {
+        // No accounts remain (full reset handles that path); nothing to prune.
+        return Ok(0);
+    };
+
+    let mut demoted = 0usize;
+
+    // Split the single pending range (if any) that straddles the birthday:
+    // [start, min_birthday) becomes Ignored, [min_birthday, end) keeps priority.
+    let straddling_start: Option<i64> = conn
+        .query_row(
+            "SELECT block_range_start FROM scan_queue \
+             WHERE block_range_start < :b AND block_range_end > :b AND priority > :scanned \
+             LIMIT 1",
+            named_params![":b": min_birthday, ":scanned": PRIORITY_SCANNED],
+            |row| row.get(0),
+        )
+        .optional()?;
+
+    if let Some(start) = straddling_start {
+        // Shrink the existing row to [min_birthday, end), preserving its
+        // priority. Ranges are disjoint, so `min_birthday` is free as a new
+        // start bound (no other row can start at or span it).
+        conn.execute(
+            "UPDATE scan_queue SET block_range_start = :b WHERE block_range_start = :start",
+            named_params![":b": min_birthday, ":start": start],
+        )?;
+        // Insert the below-birthday remainder as Ignored. `start` was just
+        // freed, and `min_birthday` is free as an end bound (disjoint invariant).
+        conn.execute(
+            "INSERT INTO scan_queue (block_range_start, block_range_end, priority) \
+             VALUES (:start, :b, :ignored)",
+            named_params![":start": start, ":b": min_birthday, ":ignored": PRIORITY_IGNORED],
+        )?;
+        demoted += 1;
+    }
+
+    // Demote pending ranges that lie entirely below the birthday.
+    demoted += conn.execute(
+        "UPDATE scan_queue SET priority = :ignored \
+         WHERE block_range_end <= :b AND priority > :scanned",
+        named_params![
+            ":ignored": PRIORITY_IGNORED,
+            ":b": min_birthday,
+            ":scanned": PRIORITY_SCANNED,
+        ],
+    )?;
+
+    Ok(demoted)
+}
+
+/// Path-based wrapper around [`prune_orphaned_scan_ranges_in_conn`] for callers
+/// that are not already inside a wallet-DB write transaction (e.g. the sync
+/// engine's startup rescue pass). Acquires the wallet-DB write lock, runs the
+/// prune in its own transaction, and commits. Returns the number of ranges
+/// demoted.
+pub fn prune_orphaned_scan_ranges(db_path: &str) -> Result<usize, String> {
+    with_wallet_db_write_lock("keys.prune_orphaned_scan_ranges", || {
+        let mut conn = rusqlite::Connection::open(db_path)
+            .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+        conn.busy_timeout(ACCOUNT_MUTATION_DB_BUSY_TIMEOUT)
+            .map_err(|e| format!("Failed to configure wallet DB busy timeout: {e}"))?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("Failed to begin scan-queue prune transaction: {e}"))?;
+        let demoted = prune_orphaned_scan_ranges_in_conn(&tx)
+            .map_err(|e| format!("Failed to prune orphaned scan ranges: {e}"))?;
+        tx.commit()
+            .map_err(|e| format!("Failed to commit scan-queue prune: {e}"))?;
+        Ok(demoted)
+    })
 }
 
 /// Parse an account UUID string into AccountUuid.
@@ -1251,6 +1363,247 @@ mod tests {
         let accounts = list_accounts(db_path_str, WalletNetwork::Main).unwrap();
         assert_eq!(accounts.len(), 1);
         assert!(accounts.iter().all(|account| account.uuid != second_uuid));
+    }
+
+    // --- VZR-89: orphaned scan-range pruning -------------------------------
+
+    fn scan_min_birthday(db_path: &str) -> i64 {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.query_row("SELECT MIN(birthday_height) FROM accounts", [], |r| {
+            r.get(0)
+        })
+        .unwrap()
+    }
+
+    fn pending_scan_coverage_below(db_path: &str, height: i64) -> bool {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM scan_queue \
+             WHERE block_range_start < :h AND priority > 10)",
+            named_params![":h": height],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    fn pending_scan_coverage_at_or_above(db_path: &str, height: i64) -> bool {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM scan_queue \
+             WHERE block_range_end > :h AND priority > 10)",
+            named_params![":h": height],
+            |r| r.get(0),
+        )
+        .unwrap()
+    }
+
+    /// Reproduces the issue #272 / VZR-89 sequence end-to-end: an existing
+    /// recent-birthday wallet, an additional import with an old (Sapling
+    /// activation) birthday that force-rescans the whole chain, then deletion
+    /// of that import. After deletion no pending scan range may remain below the
+    /// surviving account's birthday, while its own near-tip range is preserved.
+    #[test]
+    fn test_delete_account_prunes_orphaned_scan_ranges_below_birthday() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let existing_seed = mnemonic_to_seed(&generate_mnemonic()).unwrap();
+        init_db_and_create_account(
+            db_path_str,
+            WalletNetwork::Main,
+            &existing_seed,
+            Some(2_400_000),
+            "existing",
+        )
+        .unwrap();
+        crate::wallet::sync::update_chain_tip(db_path_str, WalletNetwork::Main, 2_500_000).unwrap();
+
+        // Capture the surviving account's birthday BEFORE the import: this is
+        // the threshold the orphan must end up below. (MIN(birthday) read after
+        // the import would include the imported account's old birthday.)
+        let surviving_birthday = scan_min_birthday(db_path_str);
+
+        let imported_seed = mnemonic_to_seed(&generate_mnemonic()).unwrap();
+        let (imported_uuid, _) = add_account(
+            db_path_str,
+            WalletNetwork::Main,
+            "imported-old",
+            &imported_seed,
+            Some(419_200),
+        )
+        .unwrap();
+
+        // Sanity: importing the old-birthday account force-rescanned the chain,
+        // queuing pending (Historic) coverage below the surviving birthday.
+        assert!(
+            pending_scan_coverage_below(db_path_str, surviving_birthday),
+            "old-birthday import should queue a historical range below the existing birthday",
+        );
+
+        delete_account(db_path_str, WalletNetwork::Main, &imported_uuid).unwrap();
+
+        assert!(
+            !pending_scan_coverage_below(db_path_str, surviving_birthday),
+            "deleting the old-birthday account must prune the orphaned historical scan range",
+        );
+        assert!(
+            pending_scan_coverage_at_or_above(db_path_str, surviving_birthday),
+            "the surviving account's own near-tip scan range must be preserved",
+        );
+    }
+
+    /// Directly exercises the standalone rescue used at sync start: a wallet
+    /// already stuck by a pre-fix deletion (orphaned pending ranges injected
+    /// below the birthday, including one straddling range) is healed by
+    /// `prune_orphaned_scan_ranges`, and the pass is idempotent.
+    #[test]
+    fn test_prune_orphaned_scan_ranges_rescues_stuck_wallet_and_splits_straddling() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let seed = mnemonic_to_seed(&generate_mnemonic()).unwrap();
+        init_db_and_create_account(
+            db_path_str,
+            WalletNetwork::Main,
+            &seed,
+            Some(2_400_000),
+            "existing",
+        )
+        .unwrap();
+        crate::wallet::sync::update_chain_tip(db_path_str, WalletNetwork::Main, 2_500_000).unwrap();
+
+        let min_birthday = scan_min_birthday(db_path_str);
+        let below_start = min_birthday - 2_000_000;
+        let below_end = min_birthday - 1_000_000;
+        let straddle_end = min_birthday + 50_000;
+        let tip_end = min_birthday + 100_000;
+
+        // Simulate the leftover stuck state explicitly so the test does not
+        // depend on the on-delete pruning: a fully-below Historic orphan, a
+        // Historic range straddling the birthday, and a legitimate near-tip
+        // ChainTip range above the birthday.
+        {
+            let conn = rusqlite::Connection::open(db_path_str).unwrap();
+            conn.execute("DELETE FROM scan_queue", []).unwrap();
+            conn.execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority) \
+                 VALUES (:s, :e, 20)",
+                named_params![":s": below_start, ":e": below_end],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority) \
+                 VALUES (:s, :e, 20)",
+                named_params![":s": below_end, ":e": straddle_end],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority) \
+                 VALUES (:s, :e, 50)",
+                named_params![":s": straddle_end, ":e": tip_end],
+            )
+            .unwrap();
+        }
+
+        let demoted = prune_orphaned_scan_ranges(db_path_str).unwrap();
+        assert!(
+            demoted >= 1,
+            "expected to demote at least the straddling range"
+        );
+
+        // Rescue: nothing pending remains below the birthday.
+        assert!(!pending_scan_coverage_below(db_path_str, min_birthday));
+
+        let conn = rusqlite::Connection::open(db_path_str).unwrap();
+        // Straddling range split: [birthday, straddle_end) preserved as Historic.
+        let upper_kept: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM scan_queue \
+                 WHERE block_range_start = :b AND block_range_end = :e AND priority = 20)",
+                named_params![":b": min_birthday, ":e": straddle_end],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(upper_kept, "split must keep [birthday, end) as Historic");
+        // ...and its below-birthday remainder became Ignored.
+        let lower_ignored: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM scan_queue \
+                 WHERE block_range_start = :s AND block_range_end = :b AND priority = 0)",
+                named_params![":s": below_end, ":b": min_birthday],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            lower_ignored,
+            "split must Ignore the [start, birthday) remainder"
+        );
+        // Near-tip range above the birthday is untouched.
+        let tip_untouched: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM scan_queue \
+                 WHERE block_range_start = :s AND block_range_end = :e AND priority = 50)",
+                named_params![":s": straddle_end, ":e": tip_end],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(tip_untouched, "ranges above the birthday must be preserved");
+        drop(conn);
+
+        // Idempotent: a second pass demotes nothing.
+        assert_eq!(prune_orphaned_scan_ranges(db_path_str).unwrap(), 0);
+    }
+
+    fn scan_queue_snapshot(db_path: &str) -> Vec<(i64, i64, i64)> {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT block_range_start, block_range_end, priority \
+                 FROM scan_queue ORDER BY block_range_start",
+            )
+            .unwrap();
+        let rows = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+            .unwrap();
+        rows.map(|r| r.unwrap()).collect()
+    }
+
+    /// The prune must be a strict no-op on a healthy, librustzcash-produced
+    /// wallet (one that never imported+deleted an old-birthday account): its
+    /// sub-birthday range is already `Ignored`, so nothing is pending below the
+    /// birthday. This pins the docstring's "no-op for healthy wallets" contract
+    /// directly, since the prune runs on every sync start for every user.
+    #[test]
+    fn test_prune_orphaned_scan_ranges_is_noop_on_healthy_wallet() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let seed = mnemonic_to_seed(&generate_mnemonic()).unwrap();
+        init_db_and_create_account(
+            db_path_str,
+            WalletNetwork::Main,
+            &seed,
+            Some(2_400_000),
+            "healthy",
+        )
+        .unwrap();
+        crate::wallet::sync::update_chain_tip(db_path_str, WalletNetwork::Main, 2_500_000).unwrap();
+
+        let before = scan_queue_snapshot(db_path_str);
+        let demoted = prune_orphaned_scan_ranges(db_path_str).unwrap();
+        let after = scan_queue_snapshot(db_path_str);
+
+        assert_eq!(
+            demoted, 0,
+            "a healthy wallet has no pending coverage below its birthday to demote",
+        );
+        assert_eq!(
+            before, after,
+            "scan_queue must be byte-for-byte unchanged on a healthy wallet",
+        );
     }
 
     #[test]

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -754,21 +754,29 @@ fn delete_account_rows(db_path: &str, account_id: AccountUuid) -> Result<(), Str
 /// progress near 0% and wastes hours re-scanning irrelevant blocks (VZR-89).
 ///
 /// This restores the normal "below the wallet birthday = `Ignored`" invariant:
-/// any pending (priority above `Scanned`) coverage strictly below
-/// `MIN(birthday_height)` is set to `Ignored`. Scan ranges are disjoint, so at
-/// most one range straddles the birthday; it is split so the portion at/above
-/// the birthday keeps its priority. `Scanned` and `Ignored` rows are left
-/// untouched, and ranges at/above the birthday (including the live chain-tip
-/// gap) are preserved.
+/// EVERY non-`Ignored` range strictly below `MIN(birthday_height)` is set to
+/// `Ignored` — both leftover `Historic` (never-scanned orphan) AND leftover
+/// `Scanned` ranges. The `Scanned` case matters: a deleted old-birthday account
+/// that was only partially synced leaves a `Scanned` range below the surviving
+/// birthday, and librustzcash's `block_fully_scanned` takes the *first*
+/// `Scanned` range starting at/below the birthday and reports its end as the
+/// wallet's fully-scanned height. If that leftover `Scanned` range is left in
+/// place, an `Ignored` gap above it pins the fully-scanned height there forever
+/// and sync can never complete (`ensure_complete_scan_state` blocks it). Scan
+/// ranges are disjoint, so at most one range straddles the birthday; it is split
+/// so the portion at/above the birthday keeps its priority. Ranges at/above the
+/// birthday (including the live chain-tip gap) are never touched.
 ///
 /// Idempotent and a no-op for healthy wallets (their sub-birthday range is
 /// already `Ignored`), so it is safe to call on every sync start as a rescue
 /// for wallets already stuck by a pre-fix deletion. Returns the number of
-/// `scan_queue` rows whose pending coverage was demoted (a split counts once).
+/// `scan_queue` rows whose coverage was demoted (a split counts once).
 fn prune_orphaned_scan_ranges_in_conn(conn: &rusqlite::Connection) -> rusqlite::Result<usize> {
-    // scan_queue priority codes (zcash_client_backend ScanPriority).
+    // scan_queue priority code for `Ignored` (zcash_client_backend ScanPriority).
+    // We demote anything ABOVE this (Scanned=10, Historic=20, ...) that sits
+    // below the birthday, so the whole sub-birthday region becomes uniformly
+    // Ignored — matching the shape librustzcash produces for a fresh wallet.
     const PRIORITY_IGNORED: i64 = 0;
-    const PRIORITY_SCANNED: i64 = 10;
 
     let min_birthday: Option<i64> =
         conn.query_row("SELECT MIN(birthday_height) FROM accounts", [], |row| {
@@ -781,14 +789,14 @@ fn prune_orphaned_scan_ranges_in_conn(conn: &rusqlite::Connection) -> rusqlite::
 
     let mut demoted = 0usize;
 
-    // Split the single pending range (if any) that straddles the birthday:
+    // Split the single non-Ignored range (if any) that straddles the birthday:
     // [start, min_birthday) becomes Ignored, [min_birthday, end) keeps priority.
     let straddling_start: Option<i64> = conn
         .query_row(
             "SELECT block_range_start FROM scan_queue \
-             WHERE block_range_start < :b AND block_range_end > :b AND priority > :scanned \
+             WHERE block_range_start < :b AND block_range_end > :b AND priority > :ignored \
              LIMIT 1",
-            named_params![":b": min_birthday, ":scanned": PRIORITY_SCANNED],
+            named_params![":b": min_birthday, ":ignored": PRIORITY_IGNORED],
             |row| row.get(0),
         )
         .optional()?;
@@ -811,15 +819,14 @@ fn prune_orphaned_scan_ranges_in_conn(conn: &rusqlite::Connection) -> rusqlite::
         demoted += 1;
     }
 
-    // Demote pending ranges that lie entirely below the birthday.
+    // Demote every non-Ignored range that lies entirely below the birthday
+    // (orphaned Historic AND leftover Scanned from a deleted account's partial
+    // sync) so no Scanned range remains below the birthday to confuse
+    // `block_fully_scanned`.
     demoted += conn.execute(
         "UPDATE scan_queue SET priority = :ignored \
-         WHERE block_range_end <= :b AND priority > :scanned",
-        named_params![
-            ":ignored": PRIORITY_IGNORED,
-            ":b": min_birthday,
-            ":scanned": PRIORITY_SCANNED,
-        ],
+         WHERE block_range_end <= :b AND priority > :ignored",
+        named_params![":ignored": PRIORITY_IGNORED, ":b": min_birthday],
     )?;
 
     Ok(demoted)
@@ -1604,6 +1611,274 @@ mod tests {
             before, after,
             "scan_queue must be byte-for-byte unchanged on a healthy wallet",
         );
+    }
+
+    fn lowest_scanned_range_start(db_path: &str) -> Option<i64> {
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+        conn.query_row(
+            "SELECT block_range_start FROM scan_queue \
+             WHERE priority = 10 ORDER BY block_range_start ASC LIMIT 1",
+            [],
+            |r| r.get(0),
+        )
+        .optional()
+        .unwrap()
+    }
+
+    /// Regression for the real-device failure: a deleted old-birthday account
+    /// that was only PARTIALLY synced leaves a `Scanned` range below the
+    /// surviving account's birthday. The prune must demote that leftover
+    /// `Scanned` range to `Ignored` too — otherwise librustzcash's
+    /// `block_fully_scanned` keys off it (first Scanned range) and, with the
+    /// Ignored gap the prune creates above it, pins the fully-scanned height
+    /// there forever, blocking sync completion
+    /// ("fully scanned height N below wallet DB chain tip").
+    #[test]
+    fn test_prune_orphaned_scan_ranges_demotes_leftover_scanned_below_birthday() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let seed = mnemonic_to_seed(&generate_mnemonic()).unwrap();
+        init_db_and_create_account(
+            db_path_str,
+            WalletNetwork::Main,
+            &seed,
+            Some(2_400_000),
+            "surviving",
+        )
+        .unwrap();
+        crate::wallet::sync::update_chain_tip(db_path_str, WalletNetwork::Main, 2_500_000).unwrap();
+
+        let birthday = scan_min_birthday(db_path_str);
+
+        // Reproduce the post-delete state from a partially-synced old-birthday
+        // import: a leftover Scanned range below the birthday, plus a Historic
+        // remainder that straddles the birthday.
+        {
+            let conn = rusqlite::Connection::open(db_path_str).unwrap();
+            conn.execute("DELETE FROM scan_queue", []).unwrap();
+            conn.execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority) \
+                 VALUES (419200, 746400, 10)", // Scanned, fully below birthday
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority) \
+                 VALUES (746400, 2500001, 20)", // Historic, straddles the birthday
+                [],
+            )
+            .unwrap();
+        }
+
+        // Before the fix this leftover Scanned range was left in place.
+        assert_eq!(lowest_scanned_range_start(db_path_str), Some(419200));
+
+        let demoted = prune_orphaned_scan_ranges(db_path_str).unwrap();
+        assert!(demoted >= 1);
+
+        // KEY: no Scanned range may remain below the birthday — otherwise
+        // block_fully_scanned would pin the fully-scanned height to its end.
+        match lowest_scanned_range_start(db_path_str) {
+            None => {}
+            Some(start) => assert!(
+                start >= birthday,
+                "a Scanned range must not remain below the birthday (found start {start} < {birthday})",
+            ),
+        }
+        // The whole sub-birthday region is now Ignored; no pending coverage below.
+        assert!(!pending_scan_coverage_below(db_path_str, birthday));
+        // The straddle's at/above-birthday portion is preserved as pending.
+        assert!(pending_scan_coverage_at_or_above(db_path_str, birthday));
+
+        // Idempotent.
+        assert_eq!(prune_orphaned_scan_ranges(db_path_str).unwrap(), 0);
+    }
+
+    /// Adversarial probe for state S14: the single straddling range is a
+    /// HIGH-priority range (FoundNote=40), not Historic/Scanned. This exercises
+    /// the load-bearing split-vs-demote dispatch on the straddler: the straddle
+    /// SELECT uses `priority > Ignored`, so FoundNote must be caught by the
+    /// split (preserving the above-birthday FoundNote coverage the survivor
+    /// still needs), NOT blanket-demoted (which would Ignore a real note-bearing
+    /// range above the birthday). The below-birthday remainder — a note-discovery
+    /// hint that belonged only to the deleted account — is correctly Ignored.
+    #[test]
+    fn test_prune_splits_high_priority_foundnote_straddler_preserving_above_birthday() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let seed = mnemonic_to_seed(&generate_mnemonic()).unwrap();
+        init_db_and_create_account(
+            db_path_str,
+            WalletNetwork::Main,
+            &seed,
+            Some(2_400_000),
+            "surviving",
+        )
+        .unwrap();
+        crate::wallet::sync::update_chain_tip(db_path_str, WalletNetwork::Main, 2_500_000).unwrap();
+
+        let birthday = scan_min_birthday(db_path_str);
+        let straddle_start = birthday - 50_000;
+        let straddle_end = birthday + 50_000; // B + x, x = 50_000
+
+        // State S14: a single FoundNote (priority 40) range straddling the
+        // birthday and NO leftover Scanned range. (A note straddling B could be
+        // queued by OpenAdjacent/FoundNote propagation or a Verify lookahead
+        // belonging to the now-deleted old-birthday account.)
+        {
+            let conn = rusqlite::Connection::open(db_path_str).unwrap();
+            conn.execute("DELETE FROM scan_queue", []).unwrap();
+            conn.execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority) \
+                 VALUES (:s, :e, 40)",
+                named_params![":s": straddle_start, ":e": straddle_end],
+            )
+            .unwrap();
+        }
+
+        let demoted = prune_orphaned_scan_ranges(db_path_str).unwrap();
+        assert_eq!(demoted, 1, "the straddler split counts exactly once");
+
+        let conn = rusqlite::Connection::open(db_path_str).unwrap();
+        // EXACT post-prune scan_queue: [straddle_start, B) pri=0, [B, B+x) pri=40.
+        let rows: Vec<(i64, i64, i64)> = conn
+            .prepare(
+                "SELECT block_range_start, block_range_end, priority \
+                 FROM scan_queue ORDER BY block_range_start ASC",
+            )
+            .unwrap()
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(
+            rows,
+            vec![
+                (straddle_start, birthday, 0), // below-B remainder -> Ignored
+                (birthday, straddle_end, 40),  // at/above-B portion -> FoundNote kept
+            ],
+            "split must demote only the below-birthday remainder and preserve \
+             the high-priority FoundNote coverage at/above the birthday",
+        );
+
+        // The above-birthday FoundNote portion must NOT have been blanket-demoted:
+        // it is the survivor's real note-discovery work and must remain pending.
+        assert!(
+            pending_scan_coverage_at_or_above(db_path_str, birthday),
+            "the FoundNote portion above the birthday must survive as pending",
+        );
+        // No pending coverage below the birthday (the deleted account's hint is gone).
+        assert!(!pending_scan_coverage_below(db_path_str, birthday));
+        // No Scanned range below the birthday => block_fully_scanned will not be
+        // pinned to a stale low height (it returns None here, summary falls back
+        // to birthday-1, and the FoundNote range remains as legitimate work).
+        match lowest_scanned_range_start(db_path_str) {
+            None => {}
+            Some(start) => assert!(start >= birthday),
+        }
+
+        // Idempotent: a second pass changes nothing.
+        assert_eq!(prune_orphaned_scan_ranges(db_path_str).unwrap(), 0);
+    }
+
+    /// State S7 — the exact real-device VZR-89 shape: a deleted lower-birthday
+    /// (Imported) account that synced PAST the surviving (higher) birthday before
+    /// deletion leaves a `Scanned` range that STRADDLES the risen birthday. The
+    /// split must keep `[B, end)` as `Scanned` (real blocks back it) and Ignore
+    /// only `[start, B)`, so the lowest `Scanned` range starts at/above the
+    /// birthday and `block_fully_scanned` is not pinned below it. Distinct from
+    /// the FoundNote straddler test: here the kept upper half is `Scanned` — the
+    /// exact priority `block_fully_scanned` keys off.
+    #[test]
+    fn test_prune_splits_scanned_straddler_keeps_upper_half_scanned() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let seed = mnemonic_to_seed(&generate_mnemonic()).unwrap();
+        init_db_and_create_account(
+            db_path_str,
+            WalletNetwork::Main,
+            &seed,
+            Some(2_400_000),
+            "surviving",
+        )
+        .unwrap();
+        crate::wallet::sync::update_chain_tip(db_path_str, WalletNetwork::Main, 2_500_000).unwrap();
+
+        let birthday = scan_min_birthday(db_path_str);
+        let straddle_start = birthday - 1_000_000; // below B
+        let straddle_end = birthday + 30_000; // above B
+
+        {
+            let conn = rusqlite::Connection::open(db_path_str).unwrap();
+            conn.execute("DELETE FROM scan_queue", []).unwrap();
+            // Scanned range straddling the risen birthday.
+            conn.execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority) \
+                 VALUES (:s, :e, 10)",
+                named_params![":s": straddle_start, ":e": straddle_end],
+            )
+            .unwrap();
+            // Pending remainder up to the tip (legitimate work above the birthday).
+            conn.execute(
+                "INSERT INTO scan_queue (block_range_start, block_range_end, priority) \
+                 VALUES (:s, 2500001, 20)",
+                named_params![":s": straddle_end],
+            )
+            .unwrap();
+        }
+
+        // Before the fix the lowest Scanned range started below the birthday.
+        assert_eq!(
+            lowest_scanned_range_start(db_path_str),
+            Some(straddle_start)
+        );
+
+        let demoted = prune_orphaned_scan_ranges(db_path_str).unwrap();
+        assert!(demoted >= 1);
+
+        let conn = rusqlite::Connection::open(db_path_str).unwrap();
+        // [B, straddle_end) stays Scanned ...
+        let upper_scanned: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM scan_queue \
+                 WHERE block_range_start = :b AND block_range_end = :e AND priority = 10)",
+                named_params![":b": birthday, ":e": straddle_end],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            upper_scanned,
+            "the split must keep [birthday, end) as Scanned"
+        );
+        // ... and [start, B) became Ignored.
+        let lower_ignored: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM scan_queue \
+                 WHERE block_range_start = :s AND block_range_end = :b AND priority = 0)",
+                named_params![":s": straddle_start, ":b": birthday],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            lower_ignored,
+            "the below-birthday half of the Scanned straddler must be Ignored",
+        );
+        drop(conn);
+
+        // KEY: no Scanned range remains below the birthday, so block_fully_scanned
+        // keys off [B, end) rather than a stale low height.
+        assert!(lowest_scanned_range_start(db_path_str).unwrap() >= birthday);
+        assert!(!pending_scan_coverage_below(db_path_str, birthday));
+        assert!(pending_scan_coverage_at_or_above(db_path_str, birthday));
+
+        // Idempotent.
+        assert_eq!(prune_orphaned_scan_ranges(db_path_str).unwrap(), 0);
     }
 
     #[test]

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -1881,6 +1881,61 @@ mod tests {
         assert_eq!(prune_orphaned_scan_ranges(db_path_str).unwrap(), 0);
     }
 
+    /// Codex follow-up: proves the rescue prune must run AFTER `update_chain_tip`.
+    /// When the blocks table's `max_scanned` sits BELOW the surviving birthday
+    /// (a deleted account that synced only a low region left a scanned block
+    /// there), librustzcash's `update_chain_tip` anchors new ranges at
+    /// `max_scanned + 1` WITHOUT clamping to the birthday, so it re-creates
+    /// sub-birthday pending work. A prune that ran only before `update_chain_tip`
+    /// would miss it; the prune run afterwards demotes it.
+    #[test]
+    fn test_prune_cleans_subbirthday_range_recreated_by_update_chain_tip() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let seed = mnemonic_to_seed(&generate_mnemonic()).unwrap();
+        init_db_and_create_account(
+            db_path_str,
+            WalletNetwork::Main,
+            &seed,
+            Some(2_400_000),
+            "survivor",
+        )
+        .unwrap();
+        crate::wallet::sync::update_chain_tip(db_path_str, WalletNetwork::Main, 2_500_000).unwrap();
+        let birthday = scan_min_birthday(db_path_str);
+
+        // Simulate a deleted account's leftover scanned block BELOW the birthday:
+        // a single blocks-table row at 746399 makes max_scanned < birthday.
+        {
+            let conn = rusqlite::Connection::open(db_path_str).unwrap();
+            conn.execute(
+                "INSERT INTO blocks (height, hash, time, sapling_tree) \
+                 VALUES (746399, X'00', 0, X'')",
+                [],
+            )
+            .unwrap();
+        }
+
+        // Re-run update_chain_tip (as the sync does). With max_scanned (746399)
+        // below the birthday, it re-creates sub-birthday pending work anchored at
+        // max_scanned + 1, NOT clamped to the birthday.
+        crate::wallet::sync::update_chain_tip(db_path_str, WalletNetwork::Main, 2_500_000).unwrap();
+        assert!(
+            pending_scan_coverage_below(db_path_str, birthday),
+            "update_chain_tip should re-create sub-birthday pending work from max_scanned+1",
+        );
+
+        // The rescue prune, run AFTER update_chain_tip, must demote it.
+        prune_orphaned_scan_ranges(db_path_str).unwrap();
+        assert!(
+            !pending_scan_coverage_below(db_path_str, birthday),
+            "prune after update_chain_tip must demote the re-created sub-birthday range",
+        );
+        assert!(pending_scan_coverage_at_or_above(db_path_str, birthday));
+    }
+
     #[test]
     fn test_delete_account_handles_internal_sent_note_to_deleted_account() {
         let temp_dir = tempfile::tempdir().unwrap();

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -828,23 +828,6 @@ pub async fn run_sync_inner(
     let mut last_err = String::new();
     *SYNC_START.lock().unwrap() = Some(std::time::Instant::now());
 
-    // Rescue pass (VZR-89): demote orphaned historical scan ranges left below
-    // the remaining accounts' birthday by a pre-fix account deletion. Without
-    // this, a wallet already stuck at "0% Syncing" by such an orphan keeps
-    // re-scanning millions of irrelevant blocks on every run. No-op for healthy
-    // wallets. Best-effort: a failure here must not block sync itself.
-    match crate::wallet::keys::prune_orphaned_scan_ranges(db_data_path) {
-        Ok(demoted) if demoted > 0 => log::info!(
-            "[{}] sync: pruned {demoted} orphaned scan range(s) below the wallet birthday",
-            elapsed(),
-        ),
-        Ok(_) => {}
-        Err(e) => log::warn!(
-            "[{}] sync: failed to prune orphaned scan ranges (continuing): {e}",
-            elapsed(),
-        ),
-    }
-
     for attempt in 0..=MAX_RETRIES {
         if attempt > 0 {
             let delay_secs = 1u64 << attempt; // 2, 4, 8
@@ -1027,6 +1010,34 @@ async fn run_sync_impl(
 
     // 3. Download subtree roots (incremental)
     download_subtree_roots(&mut client, &mut db).await?;
+
+    // Rescue pass (VZR-89): demote orphaned scan ranges left below the surviving
+    // accounts' birthday by a pre-fix account deletion, so a wallet bricked by
+    // that bug heals automatically (just update + re-sync, no reinstall) and a
+    // freshly-deleted old import doesn't pin progress / block completion.
+    //
+    // This MUST run AFTER `update_chain_tip` above, not before it: that call
+    // anchors new Verify/Historic ranges at `max_scanned + 1` (read from the
+    // `blocks` table) WITHOUT clamping to the wallet birthday
+    // (zcash_client_sqlite scanning.rs::update_chain_tip / block_height_extrema).
+    // If a deleted, only-partially-synced old-birthday account left scanned
+    // blocks BELOW the surviving birthday, `max_scanned` sits below it and
+    // `update_chain_tip` re-creates sub-birthday pending work. Pruning here —
+    // after the tip update, before `initial_total` is measured — demotes both
+    // the original orphan and any such re-created range, so the orphaned history
+    // is never scanned. No-op for healthy wallets; best-effort (a failure must
+    // not block sync).
+    match crate::wallet::keys::prune_orphaned_scan_ranges(db_data_path) {
+        Ok(demoted) if demoted > 0 => log::info!(
+            "[{}] sync: pruned {demoted} orphaned scan range(s) below the wallet birthday",
+            elapsed(),
+        ),
+        Ok(_) => {}
+        Err(e) => log::warn!(
+            "[{}] sync: failed to prune orphaned scan ranges (continuing): {e}",
+            elapsed(),
+        ),
+    }
 
     // 4. Calculate initial scan target (before any scanning)
     let mut initial_total: u64 = {

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -828,6 +828,23 @@ pub async fn run_sync_inner(
     let mut last_err = String::new();
     *SYNC_START.lock().unwrap() = Some(std::time::Instant::now());
 
+    // Rescue pass (VZR-89): demote orphaned historical scan ranges left below
+    // the remaining accounts' birthday by a pre-fix account deletion. Without
+    // this, a wallet already stuck at "0% Syncing" by such an orphan keeps
+    // re-scanning millions of irrelevant blocks on every run. No-op for healthy
+    // wallets. Best-effort: a failure here must not block sync itself.
+    match crate::wallet::keys::prune_orphaned_scan_ranges(db_data_path) {
+        Ok(demoted) if demoted > 0 => log::info!(
+            "[{}] sync: pruned {demoted} orphaned scan range(s) below the wallet birthday",
+            elapsed(),
+        ),
+        Ok(_) => {}
+        Err(e) => log::warn!(
+            "[{}] sync: failed to prune orphaned scan ranges (continuing): {e}",
+            elapsed(),
+        ),
+    }
+
     for attempt in 0..=MAX_RETRIES {
         if attempt > 0 {
             let delay_secs = 1u64 << attempt; // 2, 4, 8

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -203,6 +203,35 @@ pub fn inject_orphaned_historic_below(db_path: &Path, height: i64) -> usize {
     .expect("inject orphaned historic range")
 }
 
+/// Simulate the harder pre-fix stuck state: a deleted old-birthday account that
+/// was only PARTIALLY synced leaves a `Scanned` (priority 10) range below the
+/// surviving birthday, followed by an `Ignored` gap up to the birthday. This is
+/// the configuration that pins librustzcash's `block_fully_scanned` and blocks
+/// sync completion until the rescue prune demotes the leftover Scanned range.
+pub fn inject_orphaned_scanned_below(db_path: &Path, birthday: i64) {
+    assert!(
+        birthday > 2,
+        "birthday must leave room for a sub-birthday range"
+    );
+    let mid = birthday / 2 + 1;
+    let conn = rusqlite::Connection::open(db_path).expect("open wallet db");
+    conn.execute(
+        "DELETE FROM scan_queue WHERE block_range_end <= ?1",
+        [birthday],
+    )
+    .expect("clear sub-birthday ranges");
+    conn.execute(
+        "INSERT INTO scan_queue (block_range_start, block_range_end, priority) VALUES (1, ?1, 10)",
+        [mid],
+    )
+    .expect("inject leftover scanned range");
+    conn.execute(
+        "INSERT INTO scan_queue (block_range_start, block_range_end, priority) VALUES (?1, ?2, 0)",
+        [mid, birthday],
+    )
+    .expect("inject ignored gap");
+}
+
 pub fn execute_send(
     db_path: &Path,
     sender_account_uuid: &str,

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -167,6 +167,42 @@ pub fn path_str(path: &Path) -> String {
     path.to_str().expect("utf-8 path").to_string()
 }
 
+// --- VZR-89 scan_queue helpers (orphaned-range rescue tests) --------------
+
+/// Lowest birthday across surviving accounts — the threshold below which any
+/// pending scan range is orphaned.
+pub fn min_account_birthday(db_path: &Path) -> i64 {
+    let conn = rusqlite::Connection::open(db_path).expect("open wallet db");
+    conn.query_row("SELECT MIN(birthday_height) FROM accounts", [], |r| {
+        r.get(0)
+    })
+    .expect("min birthday")
+}
+
+/// True if any pending (priority > Scanned) scan range starts below `height`.
+pub fn has_pending_scan_below(db_path: &Path, height: i64) -> bool {
+    let conn = rusqlite::Connection::open(db_path).expect("open wallet db");
+    conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM scan_queue WHERE block_range_start < ?1 AND priority > 10)",
+        [height],
+        |r| r.get(0),
+    )
+    .expect("query scan_queue")
+}
+
+/// Simulate a wallet already stuck by a PRE-FIX account deletion: demote the
+/// (normally Ignored) sub-birthday range to Historic so it looks like the
+/// orphan librustzcash leaves behind after deleting an old-birthday account.
+/// Returns the number of rows flipped to Historic.
+pub fn inject_orphaned_historic_below(db_path: &Path, height: i64) -> usize {
+    let conn = rusqlite::Connection::open(db_path).expect("open wallet db");
+    conn.execute(
+        "UPDATE scan_queue SET priority = 20 WHERE block_range_end <= ?1 AND priority = 0",
+        [height],
+    )
+    .expect("inject orphaned historic range")
+}
+
 pub fn execute_send(
     db_path: &Path,
     sender_account_uuid: &str,

--- a/rust/tests/regtest_multi_account.rs
+++ b/rust/tests/regtest_multi_account.rs
@@ -1,10 +1,74 @@
 mod common;
 
 use common::{
-    add_account_with_birthday, create_wallet, current_tip_height, ensure_regtest_up,
-    exclusive_regtest, fund_wallet, get_balance, get_transaction_history, history_txids,
-    list_accounts, mine_blocks, positive_history_count, sync_wallet, unique_account_uuids,
+    add_account_with_birthday, create_wallet, create_wallet_with_birthday, current_tip_height,
+    ensure_regtest_up, exclusive_regtest, fund_wallet, get_balance, get_transaction_history,
+    has_pending_scan_below, history_txids, inject_orphaned_historic_below, list_accounts,
+    min_account_birthday, mine_blocks, positive_history_count, sync_wallet, unique_account_uuids,
 };
+
+/// VZR-89 rescue path: a wallet already stuck by a PRE-FIX account deletion
+/// (an orphaned pending Historic range left below the surviving birthday) must
+/// be healed automatically by the sync-start rescue hook in `run_sync_inner` —
+/// the user only has to update and re-sync, no reinstall.
+///
+/// Regtest fully scans its short chain, so the orphan cannot be produced by a
+/// real import+delete here (it would all become `Scanned`); we inject the
+/// orphan directly to mimic the mainnet-scale stuck state, then drive the real
+/// sync entry point and assert it is pruned. The on-delete prevention path is
+/// covered by the in-crate unit tests.
+#[test]
+#[ignore = "requires Dockerized zcashd/lightwalletd regtest services"]
+fn sync_start_rescues_wallet_stuck_by_orphaned_historical_scan_range() {
+    let _guard = exclusive_regtest();
+    ensure_regtest_up();
+
+    // A normal, recent-birthday wallet, funded and synced to the tip.
+    let birthday = current_tip_height();
+    let (main_dir, wallet) = create_wallet_with_birthday("Primary", Some(birthday));
+    let main_db = main_dir.path().join("zcash_wallet.db");
+    fund_wallet(&wallet.unified_address, "1.0");
+    mine_blocks(10);
+    sync_wallet(&main_db);
+
+    let balance_before = get_balance(&main_db, &wallet.account_uuid);
+    assert!(
+        balance_before.spendable >= 100_000_000,
+        "primary should hold its funds before the rescue, got {}",
+        balance_before.spendable
+    );
+
+    let h = min_account_birthday(&main_db);
+    assert!(
+        h > 1,
+        "test needs a birthday above genesis to have a sub-birthday range, got {h}"
+    );
+
+    // Simulate the pre-fix stuck state: an orphaned pending Historic range below
+    // the surviving birthday that no account needs.
+    let flipped = inject_orphaned_historic_below(&main_db, h);
+    assert!(
+        flipped >= 1,
+        "expected to inject at least one orphaned historic range below birthday {h}"
+    );
+    assert!(
+        has_pending_scan_below(&main_db, h),
+        "sanity: the injected orphan must be present before the rescue sync"
+    );
+
+    // The sync-start rescue hook must demote the orphan on the next sync.
+    sync_wallet(&main_db);
+
+    assert!(
+        !has_pending_scan_below(&main_db, h),
+        "sync start must prune the orphaned historical scan range below the birthday"
+    );
+    let balance_after = get_balance(&main_db, &wallet.account_uuid);
+    assert_eq!(
+        balance_after.spendable, balance_before.spendable,
+        "the rescue prune must not disturb the wallet balance"
+    );
+}
 
 #[test]
 #[ignore = "requires Dockerized zcashd/lightwalletd regtest services"]

--- a/rust/tests/regtest_multi_account.rs
+++ b/rust/tests/regtest_multi_account.rs
@@ -3,8 +3,9 @@ mod common;
 use common::{
     add_account_with_birthday, create_wallet, create_wallet_with_birthday, current_tip_height,
     ensure_regtest_up, exclusive_regtest, fund_wallet, get_balance, get_transaction_history,
-    has_pending_scan_below, history_txids, inject_orphaned_historic_below, list_accounts,
-    min_account_birthday, mine_blocks, positive_history_count, sync_wallet, unique_account_uuids,
+    has_pending_scan_below, history_txids, inject_orphaned_historic_below,
+    inject_orphaned_scanned_below, list_accounts, min_account_birthday, mine_blocks,
+    positive_history_count, sync_wallet, unique_account_uuids,
 };
 
 /// VZR-89 rescue path: a wallet already stuck by a PRE-FIX account deletion
@@ -67,6 +68,64 @@ fn sync_start_rescues_wallet_stuck_by_orphaned_historical_scan_range() {
     assert_eq!(
         balance_after.spendable, balance_before.spendable,
         "the rescue prune must not disturb the wallet balance"
+    );
+}
+
+/// VZR-89 regression (real-device #272 retest): import an old-birthday account
+/// on a build WITHOUT the fix, partially sync, delete it, then open a build WITH
+/// the fix. The deleted account leaves a `Scanned` range below the surviving
+/// birthday; librustzcash's `block_fully_scanned` keys off that leftover Scanned
+/// range and, with the Ignored gap above it, pins the fully-scanned height there
+/// — `ensure_complete_scan_state` then blocks completion forever
+/// ("fully scanned height N below wallet DB chain tip"). The rescue prune must
+/// demote the leftover Scanned range so sync completes.
+///
+/// Regtest fully scans its short chain (so a real partial scan can't be left
+/// behind), so we inject the leftover Scanned-below-birthday state directly and
+/// then drive the real sync entry point: without the fix `sync_wallet` errors
+/// at completion and panics; with the fix it completes.
+#[test]
+#[ignore = "requires Dockerized zcashd/lightwalletd regtest services"]
+fn sync_completes_when_deleted_account_left_scanned_range_below_birthday() {
+    let _guard = exclusive_regtest();
+    ensure_regtest_up();
+
+    let birthday = current_tip_height();
+    let (main_dir, wallet) = create_wallet_with_birthday("Primary", Some(birthday));
+    let main_db = main_dir.path().join("zcash_wallet.db");
+    fund_wallet(&wallet.unified_address, "1.0");
+    mine_blocks(10);
+    sync_wallet(&main_db);
+
+    let balance_before = get_balance(&main_db, &wallet.account_uuid);
+    assert!(
+        balance_before.spendable >= 100_000_000,
+        "primary should hold its funds before the retest, got {}",
+        balance_before.spendable
+    );
+
+    let h = min_account_birthday(&main_db);
+    assert!(h > 2, "need room for a sub-birthday range, got {h}");
+
+    // Plant a leftover Scanned range below the birthday + an Ignored gap, exactly
+    // the shape a partially-synced-then-deleted old-birthday account leaves.
+    inject_orphaned_scanned_below(&main_db, h);
+
+    // Drive the real sync entry point. Without the fix this returns a
+    // "fully scanned height ... below wallet DB chain tip" error and the
+    // `.expect` inside `sync_wallet` panics, failing the test.
+    sync_wallet(&main_db);
+
+    // Sync completed cleanly, no Scanned range left below the birthday, balance
+    // intact.
+    assert!(
+        !has_pending_scan_below(&main_db, h),
+        "no pending coverage should remain below the birthday after the rescue",
+    );
+    let balance_after = get_balance(&main_db, &wallet.account_uuid);
+    assert_eq!(
+        balance_after.spendable, balance_before.spendable,
+        "the rescue prune must not disturb the wallet balance",
     );
 }
 


### PR DESCRIPTION
## TL;DR

Deleting an account never cleaned up the wallet's **shared block-scan queue**. If the deleted account had an **old birthday**, it left behind scan work that no remaining account needs — sitting *below* every surviving account's birthday. That leftover work either pinned sync at **"0% Syncing"** forever, or made sync **never report complete**. This PR makes account deletion (and every sync start, to rescue already-stuck wallets) reset the scan floor back to the surviving accounts' earliest birthday — exactly the shape a brand-new wallet has.

Tracked internally as **Linear VZR-89** (originally an external tester's sync-stuck report).

## What a user saw

1. Created a wallet, added a second account — all fine.
2. Used **Import** to add another account, set to the **oldest birthday height** (full history).
3. It was slow, so they **deleted** that imported account.
4. → Their original wallets now **won't sync**: stuck at "0% Syncing", and on a later build, sync throwing `fully scanned height 746399 below wallet DB chain tip`.

## Why it happened

Zcash scanning in this app is **wallet-wide, not per-account**: one scan queue covers *all* accounts, from the **earliest birthday among them** up to the chain tip. Importing an account with an old birthday lowers that floor and force-rescans the whole chain.

The problem: **librustzcash never prunes the scan queue when you delete an account.** So after deleting the old-birthday account, the queue still reaches all the way down to *its* birthday — even though no surviving account needs anything below *its own* (much more recent) birthday.

```
   oldBirthday (deleted account)         B = surviving accounts' earliest birthday      tip
        |──────────── orphaned, nobody needs this ───────────|────────── needed ────────|
```

That orphaned region broke sync in two ways, depending on how far the old account had scanned before deletion:

- **A) Stuck at 0%** — orphan is *unscanned* (Historic). Progress = `scanned / total-to-scan`, and the orphan (~2.6M blocks) dominates the denominator, so the bar crawls at ~0% while the app wastefully re-scans history no one needs.
- **B) Sync never completes** — orphan was *partially* scanned before deletion, leaving a `Scanned` chunk + a gap. librustzcash reports the wallet's "fully scanned height" as the **end of that leftover Scanned chunk** (far below the tip), so the completion check refuses to finish: `fully scanned height N below wallet DB chain tip`.

## The fix

On account deletion **and** at the top of every sync (so wallets already bricked by a pre-fix deletion heal automatically — just update and re-sync, no reinstall), reset the scan floor to the surviving accounts' earliest birthday: mark **everything below it as `Ignored`** — the same shape librustzcash produces for a fresh wallet.

```
before:  [ oldBirthday … Scanned / Historic (orphan) … ][ B … needed … tip ]
after:   [ oldBirthday ……………… Ignored ……………………… ][ B … needed … tip ]
                          (skipped, never re-scanned)        (kept as-is)
```

- Nothing below the birthday is re-scanned; already-scanned ranges at/above the birthday are kept untouched.
- A single range that *straddles* the birthday is split: `[start, B)` → `Ignored`, `[B, end)` keeps its priority.
- **Both `Historic` (unscanned orphan) and leftover `Scanned` ranges below the birthday are demoted** — the `Scanned` case is what fixes symptom (B): with no `Scanned` range left below the birthday, librustzcash's fully-scanned height is computed from the first range at/above the birthday, so completion works.
- No-op for healthy wallets (their sub-birthday range is already `Ignored`); idempotent.

## Why it's safe

- Touches **only** `scan_queue` priorities (plus one row split) — never notes, witnesses, the commitment tree, or block data. Demoted ranges sit below the birthday and are already excluded from the witness-stabilization views, so spendability is unaffected.
- The straddle split is `UNIQUE`/`CHECK`-safe under librustzcash's disjoint-ranges invariant (at most one range can straddle the birthday).
- Reviewed against the full space of post-delete scan-queue states (14 states × every downstream consumer: `block_fully_scanned`, `suggest_scan_ranges`, `update_chain_tip`, `scan_complete`, `get_wallet_summary`, witness stabilization, spendability) — no other breakage found.

## Tests

- **Unit** (`rust/src/wallet/keys.rs`): on-delete prune; healthy-wallet byte-for-byte no-op; orphaned-Historic split + idempotency; **leftover `Scanned` below birthday**; **`Scanned` straddler** (the exact device shape — keeps `[B, end)` Scanned); **`FoundNote` straddler**. The new tests were verified to fail without the fix.
- **Regtest E2E** (`rust/tests/regtest_multi_account.rs`): `sync_start_rescues_wallet_stuck_by_orphaned_historical_scan_range` and `sync_completes_when_deleted_account_left_scanned_range_below_birthday` drive the real sync entry point and assert the wallet recovers + balances are preserved.
- `cargo test --lib`: 180 passed. regtest `multi_account` suite: 8 passed. `cargo fmt` clean.

## Code

- Fix: `rust/src/wallet/keys.rs` — `prune_orphaned_scan_ranges_in_conn` (+ path wrapper `prune_orphaned_scan_ranges`), called from `delete_account_rows` (prevention) and `run_sync_inner` (rescue, best-effort).
- Root behavior confirmed against vendored `zcash_client_sqlite` 0.21.0 (`delete_account` never touches `scan_queue`; `block_fully_scanned` keys off the first `Scanned` range) / `zcash_client_backend` 0.23.0.

## Follow-ups (not in this PR)

- UX prevention: default the import birthday to a recent tip with an explicit "old wallet" opt-in, and keep the full-history-rescan warning (reduces how often this is triggered).

## Related Issue

- https://github.com/chainapsis/vizor-wallet/issues/272
