### PR TITLE
[codex] Add iOS month-year birthday picker

### DIFF
--- a/integration_test/regtest_mobile_screenshot_tour_test.dart
+++ b/integration_test/regtest_mobile_screenshot_tour_test.dart
@@ -120,10 +120,10 @@ void main() {
         description: 'import birthday',
       );
       await shot('04_import_birthday');
-      // The date "field" opens the OS-native UICalendarView sheet on
-      // iOS (the tour only runs on the iOS simulator). There are no
-      // Flutter widgets to wait on — give the present animation real
-      // time, capture, then dismiss through the picker channel since
+      // The date "field" opens the OS-native month/year picker on iOS
+      // (the tour only runs on the iOS simulator). There are no Flutter
+      // widgets to wait on — give the present animation real time,
+      // capture, then dismiss through the picker channel since
       // flutter_test cannot tap native UIKit views.
       await tapWidget(tester, const ValueKey('mobile_import_birthday_date'));
       await settle(tester, const Duration(milliseconds: 1500));

--- a/ios/Runner/DatePickerHandler.swift
+++ b/ios/Runner/DatePickerHandler.swift
@@ -1,7 +1,7 @@
 import Flutter
 import UIKit
 
-/// Presents the native iOS date picker as a sheet over the Flutter view.
+/// Presents native iOS date/month pickers as sheets over the Flutter view.
 /// Channel: `com.zcash.wallet/date_picker` (Dart side:
 /// `lib/src/services/native_date_picker.dart`).
 ///
@@ -34,6 +34,8 @@ final class DatePickerHandler: NSObject {
     switch call.method {
     case "pickDate":
       pickDate(call, result: result)
+    case "pickMonthYear":
+      pickMonthYear(call, result: result)
     case "cancel":
       dismissPresentedSheet()
       result(true)
@@ -80,6 +82,49 @@ final class DatePickerHandler: NSObject {
 
     let initialDate = (args["initial"] as? String).flatMap(Self.dayFormatter.date(from:))
     let sheet = DatePickerSheetViewController(
+      initialDate: initialDate,
+      minDate: minDate,
+      maxDate: maxDate,
+      isDarkTheme: args["isDarkTheme"] as? Bool ?? false,
+      accentColor: (args["accentColorHex"] as? String).flatMap(Self.color(fromHex:))
+    )
+    sheet.onFinish = { [weak self] date in
+      self?.finish(with: date)
+    }
+    presentedSheet = sheet
+    presenter.present(sheet, animated: true)
+  }
+
+  private func pickMonthYear(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard
+      let args = call.arguments as? [String: Any],
+      let minDate = (args["min"] as? String).flatMap(Self.dayFormatter.date(from:)),
+      let maxDate = (args["max"] as? String).flatMap(Self.dayFormatter.date(from:)),
+      minDate <= maxDate
+    else {
+      result(FlutterError(
+        code: "badArgs",
+        message: "pickMonthYear needs min/max as yyyy-MM-dd with min <= max",
+        details: nil
+      ))
+      return
+    }
+    guard let presenter = Self.topViewController() else {
+      result(FlutterError(
+        code: "noViewController",
+        message: "No view controller to present from",
+        details: nil
+      ))
+      return
+    }
+
+    // A second picker while one is showing replaces it; the first call
+    // resolves as cancelled.
+    dismissPresentedSheet()
+    pendingResult = result
+
+    let initialDate = (args["initial"] as? String).flatMap(Self.dayFormatter.date(from:))
+    let sheet = MonthYearPickerSheetViewController(
       initialDate: initialDate,
       minDate: minDate,
       maxDate: maxDate,
@@ -269,5 +314,363 @@ private final class DatePickerSheetViewController: UIViewController,
     guard !finished else { return }
     finished = true
     onFinish?(pickedDate)
+  }
+}
+
+/// Sheet for approximate wallet birthdays. iOS 17.4+ gets the native
+/// `UIDatePicker.Mode.yearAndMonth` wheels; earlier iOS versions use a
+/// two-column `UIPickerView` with the same month/year semantics.
+private final class MonthYearPickerSheetViewController: UIViewController,
+  UIPickerViewDataSource,
+  UIPickerViewDelegate
+{
+  /// Fired exactly once, after the sheet is fully gone: a day inside the
+  /// picked month, or nil for Cancel / swipe-down / programmatic dismissal.
+  var onFinish: ((Date?) -> Void)?
+
+  private let datePicker = UIDatePicker()
+  private let pickerView = UIPickerView()
+  private let minDate: Date
+  private let maxDate: Date
+  private let accentColor: UIColor?
+  private weak var contentStack: UIStackView?
+  private var calendar: Calendar
+  private var selectedYear: Int
+  private var selectedMonth: Int
+  private var selectedDate: Date
+  private var usesNativeMonthYearPicker = false
+  private var pickedDate: Date?
+  private var finished = false
+
+  private lazy var monthFormatter: DateFormatter = {
+    let formatter = DateFormatter()
+    formatter.calendar = calendar
+    formatter.locale = Locale.current
+    formatter.setLocalizedDateFormatFromTemplate("MMMM")
+    formatter.timeZone = TimeZone.current
+    return formatter
+  }()
+
+  init(
+    initialDate: Date?,
+    minDate: Date,
+    maxDate: Date,
+    isDarkTheme: Bool,
+    accentColor: UIColor?
+  ) {
+    var gregorian = Calendar(identifier: .gregorian)
+    gregorian.timeZone = TimeZone.current
+    let clampedInitial = Self.clamp(
+      initialDate ?? maxDate,
+      minDate: minDate,
+      maxDate: maxDate
+    )
+    let components = gregorian.dateComponents([.year, .month], from: clampedInitial)
+    let year = components.year ?? gregorian.component(.year, from: maxDate)
+    let month = components.month ?? gregorian.component(.month, from: maxDate)
+
+    self.minDate = minDate
+    self.maxDate = maxDate
+    self.accentColor = accentColor
+    self.calendar = gregorian
+    self.selectedYear = year
+    self.selectedMonth = month
+    self.selectedDate = Self.selectionDate(
+      year: year,
+      month: month,
+      minDate: minDate,
+      maxDate: maxDate,
+      calendar: gregorian
+    )
+    super.init(nibName: nil, bundle: nil)
+    overrideUserInterfaceStyle = isDarkTheme ? .dark : .light
+    modalPresentationStyle = .pageSheet
+  }
+
+  @available(*, unavailable)
+  required init?(coder: NSCoder) { fatalError("init(coder:) is not supported") }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemBackground
+    if let accentColor {
+      view.tintColor = accentColor
+    }
+
+    let picker = makePicker()
+    let separator = UIView()
+    separator.backgroundColor = .separator
+    separator.translatesAutoresizingMaskIntoConstraints = false
+    separator.heightAnchor.constraint(equalToConstant: 1 / UIScreen.main.scale).isActive = true
+
+    let cancelButton = UIButton(type: .system)
+    cancelButton.setTitle("Cancel", for: .normal)
+    cancelButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+
+    let doneButton = UIButton(type: .system)
+    doneButton.setTitle("Done", for: .normal)
+    doneButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+    doneButton.addTarget(self, action: #selector(doneTapped), for: .touchUpInside)
+
+    let spacer = UIView()
+    spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+    let buttonRow = UIStackView(arrangedSubviews: [cancelButton, spacer, doneButton])
+    buttonRow.axis = .horizontal
+    buttonRow.alignment = .center
+    buttonRow.spacing = 16
+
+    let stack = UIStackView(arrangedSubviews: [picker, separator, buttonRow])
+    stack.axis = .vertical
+    stack.spacing = 12
+    stack.isLayoutMarginsRelativeArrangement = true
+    stack.directionalLayoutMargins = NSDirectionalEdgeInsets(
+      top: 20,
+      leading: 20,
+      bottom: 12,
+      trailing: 20
+    )
+    stack.translatesAutoresizingMaskIntoConstraints = false
+    contentStack = stack
+    view.addSubview(stack)
+
+    NSLayoutConstraint.activate([
+      stack.topAnchor.constraint(equalTo: view.topAnchor),
+      stack.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+      stack.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+      stack.bottomAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor),
+    ])
+    configureSheet()
+  }
+
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    finishIfNeeded()
+  }
+
+  private func makePicker() -> UIView {
+    if #available(iOS 17.4, *) {
+      usesNativeMonthYearPicker = true
+      datePicker.datePickerMode = .yearAndMonth
+      datePicker.preferredDatePickerStyle = .wheels
+      datePicker.calendar = calendar
+      datePicker.timeZone = TimeZone.current
+      datePicker.minimumDate = minDate
+      datePicker.maximumDate = maxDate
+      datePicker.date = selectedDate
+      if let accentColor {
+        datePicker.tintColor = accentColor
+      }
+      datePicker.addTarget(
+        self,
+        action: #selector(datePickerChanged),
+        for: .valueChanged
+      )
+      datePicker.translatesAutoresizingMaskIntoConstraints = false
+      return datePicker
+    }
+
+    pickerView.dataSource = self
+    pickerView.delegate = self
+    pickerView.translatesAutoresizingMaskIntoConstraints = false
+    selectFallbackRows(animated: false)
+    return pickerView
+  }
+
+  private func configureSheet() {
+    guard let sheet = sheetPresentationController else { return }
+    sheet.prefersGrabberVisible = true
+    if #available(iOS 16.0, *) {
+      sheet.detents = [
+        .custom(identifier: .init("monthYearContentFit")) { [weak self] context in
+          guard let self, let contentStack = self.contentStack else {
+            return context.maximumDetentValue
+          }
+          self.view.layoutIfNeeded()
+          let targetWidth = max(
+            0,
+            self.view.bounds.width
+              - self.view.safeAreaInsets.left
+              - self.view.safeAreaInsets.right
+          )
+          let fittingSize = CGSize(
+            width: targetWidth > 0
+              ? targetWidth
+              : UIView.layoutFittingCompressedSize.width,
+            height: UIView.layoutFittingCompressedSize.height
+          )
+          return min(
+            contentStack.systemLayoutSizeFitting(
+              fittingSize,
+              withHorizontalFittingPriority: targetWidth > 0
+                ? .required
+                : .fittingSizeLevel,
+              verticalFittingPriority: .fittingSizeLevel
+            ).height,
+            context.maximumDetentValue
+          )
+        }
+      ]
+    } else {
+      sheet.detents = [.medium()]
+    }
+  }
+
+  @objc private func datePickerChanged() {
+    selectedDate = Self.selectionDate(
+      for: datePicker.date,
+      minDate: minDate,
+      maxDate: maxDate,
+      calendar: calendar
+    )
+  }
+
+  @objc private func cancelTapped() {
+    dismiss(animated: true) { [weak self] in self?.finishIfNeeded() }
+  }
+
+  @objc private func doneTapped() {
+    if usesNativeMonthYearPicker {
+      datePickerChanged()
+    }
+    pickedDate = selectedDate
+    dismiss(animated: true) { [weak self] in self?.finishIfNeeded() }
+  }
+
+  func numberOfComponents(in pickerView: UIPickerView) -> Int { 2 }
+
+  func pickerView(
+    _ pickerView: UIPickerView,
+    numberOfRowsInComponent component: Int
+  ) -> Int {
+    if component == 0 {
+      return availableMonths(for: selectedYear).count
+    }
+    return availableYears.count
+  }
+
+  func pickerView(
+    _ pickerView: UIPickerView,
+    titleForRow row: Int,
+    forComponent component: Int
+  ) -> String? {
+    if component == 0 {
+      let months = availableMonths(for: selectedYear)
+      guard months.indices.contains(row) else { return nil }
+      return monthName(months[row])
+    }
+    let years = availableYears
+    guard years.indices.contains(row) else { return nil }
+    return "\(years[row])"
+  }
+
+  func pickerView(
+    _ pickerView: UIPickerView,
+    didSelectRow row: Int,
+    inComponent component: Int
+  ) {
+    if component == 1 {
+      let years = availableYears
+      guard years.indices.contains(row) else { return }
+      selectedYear = years[row]
+      let months = availableMonths(for: selectedYear)
+      if !months.contains(selectedMonth) {
+        selectedMonth = min(
+          max(selectedMonth, months.first ?? 1),
+          months.last ?? 12
+        )
+      }
+      pickerView.reloadComponent(0)
+      if let monthIndex = months.firstIndex(of: selectedMonth) {
+        pickerView.selectRow(monthIndex, inComponent: 0, animated: true)
+      }
+    } else {
+      let months = availableMonths(for: selectedYear)
+      guard months.indices.contains(row) else { return }
+      selectedMonth = months[row]
+    }
+
+    selectedDate = Self.selectionDate(
+      year: selectedYear,
+      month: selectedMonth,
+      minDate: minDate,
+      maxDate: maxDate,
+      calendar: calendar
+    )
+  }
+
+  private var minYear: Int { calendar.component(.year, from: minDate) }
+  private var maxYear: Int { calendar.component(.year, from: maxDate) }
+  private var availableYears: [Int] { Array(minYear...maxYear) }
+
+  private func availableMonths(for year: Int) -> [Int] {
+    let minMonth = calendar.component(.month, from: minDate)
+    let maxMonth = calendar.component(.month, from: maxDate)
+    let start = year == minYear ? minMonth : 1
+    let end = year == maxYear ? maxMonth : 12
+    return Array(start...end)
+  }
+
+  private func selectFallbackRows(animated: Bool) {
+    let years = availableYears
+    if let yearIndex = years.firstIndex(of: selectedYear) {
+      pickerView.selectRow(yearIndex, inComponent: 1, animated: animated)
+    }
+    let months = availableMonths(for: selectedYear)
+    if let monthIndex = months.firstIndex(of: selectedMonth) {
+      pickerView.selectRow(monthIndex, inComponent: 0, animated: animated)
+    }
+  }
+
+  private func monthName(_ month: Int) -> String {
+    var components = DateComponents()
+    components.calendar = calendar
+    components.year = 2000
+    components.month = month
+    components.day = 1
+    guard let date = calendar.date(from: components) else { return "\(month)" }
+    return monthFormatter.string(from: date)
+  }
+
+  private func finishIfNeeded() {
+    guard !finished else { return }
+    finished = true
+    onFinish?(pickedDate)
+  }
+
+  private static func clamp(_ date: Date, minDate: Date, maxDate: Date) -> Date {
+    min(max(date, minDate), maxDate)
+  }
+
+  private static func selectionDate(
+    for date: Date,
+    minDate: Date,
+    maxDate: Date,
+    calendar: Calendar
+  ) -> Date {
+    let components = calendar.dateComponents([.year, .month], from: date)
+    return selectionDate(
+      year: components.year ?? calendar.component(.year, from: maxDate),
+      month: components.month ?? calendar.component(.month, from: maxDate),
+      minDate: minDate,
+      maxDate: maxDate,
+      calendar: calendar
+    )
+  }
+
+  private static func selectionDate(
+    year: Int,
+    month: Int,
+    minDate: Date,
+    maxDate: Date,
+    calendar: Calendar
+  ) -> Date {
+    var components = DateComponents()
+    components.calendar = calendar
+    components.year = year
+    components.month = month
+    components.day = 1
+    let monthStart = calendar.date(from: components) ?? minDate
+    return clamp(monthStart, minDate: minDate, maxDate: maxDate)
   }
 }

--- a/lib/src/features/onboarding/mobile/mobile_import_birthday_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_birthday_screen.dart
@@ -172,10 +172,10 @@ class _MobileImportBirthdayScreenState
     DateTime? candidate;
     var picked = false;
     if (Platform.isIOS) {
-      // iOS gets the OS-native calendar sheet; the Flutter sheet below
-      // stays as the fallback (handler requires iOS 16+).
+      // iOS gets an OS-native month/year picker. The Flutter calendar sheet
+      // below stays as the fallback for Android and channel failures.
       try {
-        candidate = await NativeDatePicker.pickDate(
+        candidate = await NativeDatePicker.pickMonthYear(
           initialDate: _selectedDate,
           firstDate: _firstDate,
           lastDate: _lastDate,
@@ -435,10 +435,11 @@ class _MobileImportBirthdayScreenState
     _MobileImportSubmitPhase.importing => 'Importing wallet...',
   };
 
-  String _formattedDate(DateTime date) =>
-      '${date.month.toString().padLeft(2, '0')}/'
-      '${date.day.toString().padLeft(2, '0')}/'
-      '${date.year}';
+  String _formattedDate(DateTime date) => Platform.isIOS
+      ? '${date.month.toString().padLeft(2, '0')}/${date.year}'
+      : '${date.month.toString().padLeft(2, '0')}/'
+            '${date.day.toString().padLeft(2, '0')}/'
+            '${date.year}';
 
   @override
   Widget build(BuildContext context) {
@@ -480,7 +481,7 @@ class _MobileImportBirthdayScreenState
                 _ModeTab(
                   key: const ValueKey('mobile_import_birthday_mode_date'),
                   iconName: AppIcons.calendar,
-                  label: 'Enter the date',
+                  label: Platform.isIOS ? 'Enter the month' : 'Enter the date',
                   selected: isDateMode,
                   onTap: () => _setMode(_BirthdayEntryMode.date),
                 ),
@@ -718,8 +719,7 @@ class _FieldShell extends StatelessWidget {
 }
 
 /// The date "field" — looks like the entry field but is not typeable;
-/// the calendar sheet is the only input. Tapping anywhere on it opens
-/// the sheet.
+/// tapping anywhere on it opens the native picker or fallback calendar.
 class _DateFieldButton extends StatelessWidget {
   const _DateFieldButton({
     required this.date,
@@ -738,7 +738,7 @@ class _DateFieldButton extends StatelessWidget {
     final colors = context.colors;
     return Semantics(
       button: true,
-      label: 'Pick a date',
+      label: Platform.isIOS ? 'Pick a month' : 'Pick a date',
       child: GestureDetector(
         key: const ValueKey('mobile_import_birthday_date'),
         behavior: HitTestBehavior.opaque,
@@ -748,7 +748,7 @@ class _DateFieldButton extends StatelessWidget {
             children: [
               Expanded(
                 child: Text(
-                  formatted ?? 'mm/dd/yyyy',
+                  formatted ?? (Platform.isIOS ? 'mm/yyyy' : 'mm/dd/yyyy'),
                   key: const ValueKey('mobile_import_birthday_date_text'),
                   maxLines: 1,
                   style: AppTypography.headlineSmall.copyWith(

--- a/lib/src/services/native_date_picker.dart
+++ b/lib/src/services/native_date_picker.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/services.dart';
 
-/// iOS-native date picker sheet (`UICalendarView` in a content-fit
-/// detent), presented over the Flutter view by `DatePickerHandler.swift`
-/// on the `com.zcash.wallet/date_picker` channel.
+/// iOS-native date/month picker sheets, presented over the Flutter view
+/// by `DatePickerHandler.swift` on the
+/// `com.zcash.wallet/date_picker` channel.
 ///
 /// Dates cross the channel as `yyyy-MM-dd` strings — never epoch
 /// timestamps — so a calendar day survives the Dart↔Swift hop without
@@ -10,8 +10,7 @@ import 'package:flutter/services.dart';
 ///
 /// Only iOS registers a handler. Callers branch on `Platform.isIOS`
 /// first and keep the Flutter calendar sheet as the fallback for
-/// Android and for any channel failure (e.g. the handler requires
-/// iOS 16+ and reports `unavailable` below that).
+/// Android and for any channel failure.
 abstract final class NativeDatePicker {
   static const channel = MethodChannel('com.zcash.wallet/date_picker');
 
@@ -29,6 +28,27 @@ abstract final class NativeDatePicker {
     Color? accentColor,
   }) async {
     final raw = await channel.invokeMethod<String>('pickDate', {
+      if (initialDate != null) 'initial': encodeDate(initialDate),
+      'min': encodeDate(firstDate),
+      'max': encodeDate(lastDate),
+      'isDarkTheme': isDarkTheme,
+      if (accentColor != null) 'accentColorHex': _encodeColor(accentColor),
+    });
+    return raw == null ? null : decodeDate(raw);
+  }
+
+  /// Presents an iOS month/year picker and resolves with a day inside the
+  /// chosen month. The native side clamps edge months into [firstDate] /
+  /// [lastDate], so callers can keep using the returned value as a normal
+  /// date for height estimation.
+  static Future<DateTime?> pickMonthYear({
+    DateTime? initialDate,
+    required DateTime firstDate,
+    required DateTime lastDate,
+    required bool isDarkTheme,
+    Color? accentColor,
+  }) async {
+    final raw = await channel.invokeMethod<String>('pickMonthYear', {
       if (initialDate != null) 'initial': encodeDate(initialDate),
       'min': encodeDate(firstDate),
       'max': encodeDate(lastDate),

--- a/test/services/native_date_picker_test.dart
+++ b/test/services/native_date_picker_test.dart
@@ -58,6 +58,37 @@ void main() {
     );
   });
 
+  test(
+    'pickMonthYear sends yyyy-MM-dd bounds and decodes the picked month',
+    () async {
+      MethodCall? sent;
+      messenger.setMockMethodCallHandler(NativeDatePicker.channel, (
+        call,
+      ) async {
+        sent = call;
+        return '2024-03-01';
+      });
+
+      final picked = await NativeDatePicker.pickMonthYear(
+        initialDate: DateTime(2024, 2, 20),
+        firstDate: DateTime(2018, 10, 28),
+        lastDate: DateTime(2024, 3, 12),
+        isDarkTheme: true,
+        accentColor: const Color(0xFFE5484D),
+      );
+
+      expect(sent!.method, 'pickMonthYear');
+      expect(sent!.arguments, {
+        'initial': '2024-02-20',
+        'min': '2018-10-28',
+        'max': '2024-03-12',
+        'isDarkTheme': true,
+        'accentColorHex': 'e5484d',
+      });
+      expect(picked, DateTime(2024, 3, 1));
+    },
+  );
+
   test('pickDate surfaces handler errors for the Flutter-sheet fallback', () {
     messenger.setMockMethodCallHandler(NativeDatePicker.channel, (call) async {
       throw PlatformException(code: 'unavailable');


### PR DESCRIPTION
## Summary
- Replace the iOS wallet birthday calendar with a month/year picker so users can confirm the approximate wallet creation month directly.
- Keep Android and fallback calendar behavior unchanged.
- Add native channel coverage for the new month/year picker path.

## Validation
- `git diff --check`
- Swift typecheck for `ios/Runner/DatePickerHandler.swift` against the iOS 15 simulator target
- `fvm flutter test test/services/native_date_picker_test.dart`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/onboarding/mobile_import_birthday_screen_test.dart`
