### PR TITLE
[codex] Remove Android foreground sync service

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
     <application
         android:label="Vizor"
@@ -11,12 +8,6 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:allowBackup="false">
-
-        <!-- flutter_foreground_task service — do not change the service name -->
-        <service
-            android:name="com.pravera.flutter_foreground_task.service.ForegroundService"
-            android:foregroundServiceType="dataSync"
-            android:exported="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,7 +1,5 @@
 PODS:
   - Flutter (1.0.0)
-  - flutter_foreground_task (0.0.1):
-    - Flutter
   - flutter_secure_storage_darwin (10.0.0):
     - Flutter
     - FlutterMacOS
@@ -22,7 +20,6 @@ PODS:
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
-  - flutter_foreground_task (from `.symlinks/plugins/flutter_foreground_task/ios`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/darwin`)
@@ -34,8 +31,6 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
-  flutter_foreground_task:
-    :path: ".symlinks/plugins/flutter_foreground_task/ios"
   flutter_secure_storage_darwin:
     :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
   integration_test:
@@ -53,14 +48,13 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_foreground_task: a159d2c2173b33699ddb3e6c2a067045d7cebb89
-  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
-  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
-  mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
-  rust_lib_zcash_wallet: 81289c417e775dee4944149f182523453083474c
-  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
-  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
-  url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
+  flutter_secure_storage_darwin: 557817588b80e60213cbecb573c45c76b788018d
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
+  mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
+  rust_lib_zcash_wallet: 19963b65fa152b920b0a2f62c640a70edd634985
+  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
+  shared_preferences_foundation: 5086985c1d43c5ba4d5e69a4e8083a389e2909e6
+  url_launcher_ios: bb13df5870e8c4234ca12609d04010a21be43dfa
 
 PODFILE CHECKSUM: 288656d4464589360115d6f81dd5d8f559352730
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -4,7 +4,6 @@ import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart' show Override;
-import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:go_router/go_router.dart';
 import 'package:desktop_window_bootstrap/desktop_window_bootstrap.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -85,7 +84,6 @@ void log(String message) => debugPrint('[zcash] $message');
 
 Future<void> initializeZcashWalletRuntime() async {
   WidgetsFlutterBinding.ensureInitialized();
-  FlutterForegroundTask.initCommunicationPort();
   log('runtime: initializing RustLib');
   await RustLib.init();
 

--- a/lib/src/services/background_sync_delegate.dart
+++ b/lib/src/services/background_sync_delegate.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/services.dart';
-import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 
 import '../../main.dart' show log;
 import '../core/config/rpc_endpoint_config.dart';
@@ -47,7 +46,6 @@ abstract class BackgroundSyncDelegate {
 
   /// Whether auto-sync polling should be suppressed while background mode is active.
   /// iOS: true (BGTask manages sync, polling would interfere).
-  /// Android: false (background mode is just a notification, polling still needed).
   bool get shouldSuppressPolling;
 
   void setupListeners({
@@ -72,92 +70,8 @@ abstract class BackgroundSyncDelegate {
   void onProgress(SyncProgressEvent event);
 
   static BackgroundSyncDelegate create() {
-    if (Platform.isAndroid) return AndroidBackgroundSyncDelegate();
     if (Platform.isIOS) return IOSBackgroundSyncDelegate();
     return NoOpBackgroundSyncDelegate();
-  }
-}
-
-// ======================== Android ========================
-
-class AndroidBackgroundSyncDelegate implements BackgroundSyncDelegate {
-  bool _active = false;
-  DataCallback? _taskDataCallback;
-
-  @override
-  bool get isActive => _active;
-
-  @override
-  bool get shouldSuppressPolling => false; // notification only, polling still needed
-
-  @override
-  void setupListeners({
-    required void Function() onStopRequested,
-    required void Function(SyncProgressEvent) onBackgroundProgress,
-  }) {
-    disposeListeners();
-    _taskDataCallback = (data) {
-      if (data == 'stop_sync') {
-        log(
-          'BackgroundSyncDelegate(Android): stop requested from notification',
-        );
-        onStopRequested();
-      }
-    };
-    FlutterForegroundTask.addTaskDataCallback(_taskDataCallback!);
-  }
-
-  @override
-  void disposeListeners() {
-    final callback = _taskDataCallback;
-    if (callback == null) return;
-    FlutterForegroundTask.removeTaskDataCallback(callback);
-    _taskDataCallback = null;
-  }
-
-  @override
-  Future<void> enable({required RpcEndpointConfig endpoint}) async {
-    _active = true;
-    await bg_sync.startBackgroundSync();
-    log('BackgroundSyncDelegate(Android): enabled');
-  }
-
-  @override
-  Future<bool> disable() async {
-    _active = false;
-    await bg_sync.stopBackgroundSync();
-    log('BackgroundSyncDelegate(Android): disabled');
-    return false; // sync never stopped, no restart needed
-  }
-
-  @override
-  Future<void> shutdownForLock() async {
-    _active = false;
-    await bg_sync.stopBackgroundSync();
-    log('BackgroundSyncDelegate(Android): shut down for lock');
-  }
-
-  @override
-  Future<bool> isAvailable() async => true;
-
-  @override
-  void onSyncDone() {
-    // Android background mode = notification only. Keep it active across
-    // sync cycles until the user explicitly disables it.
-  }
-
-  @override
-  void onResume() {}
-
-  @override
-  void onProgress(SyncProgressEvent event) {
-    if (_active) {
-      bg_sync.updateBackgroundSyncProgress(
-        percentage: event.percentage,
-        scannedHeight: event.scannedHeight,
-        chainTipHeight: event.chainTipHeight,
-      );
-    }
   }
 }
 

--- a/lib/src/services/background_sync_service.dart
+++ b/lib/src/services/background_sync_service.dart
@@ -1,41 +1,14 @@
 import 'dart:io';
 
 import 'package:flutter/services.dart';
-import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 
 import '../../main.dart' show log;
 import '../core/config/rpc_endpoint_config.dart';
 
 const _iosChannel = MethodChannel('com.zcash.wallet/background_sync');
 
-// Top-level callback required by flutter_foreground_task
-@pragma('vm:entry-point')
-void _foregroundTaskCallback() {
-  FlutterForegroundTask.setTaskHandler(_SyncTaskHandler());
-}
-
-class _SyncTaskHandler extends TaskHandler {
-  @override
-  Future<void> onStart(DateTime timestamp, TaskStarter starter) async {}
-
-  @override
-  void onRepeatEvent(DateTime timestamp) {}
-
-  @override
-  Future<void> onDestroy(DateTime timestamp, bool isAppTerminated) async {}
-
-  @override
-  void onNotificationButtonPressed(String id) {
-    if (id == 'stop') {
-      FlutterForegroundTask.sendDataToMain('stop_sync');
-      FlutterForegroundTask.stopService();
-    }
-  }
-}
-
 /// Checks if background sync is available on this platform/version.
 Future<bool> isBackgroundSyncAvailable() async {
-  if (Platform.isAndroid) return true;
   if (Platform.isIOS) {
     try {
       final available = await _iosChannel.invokeMethod<bool>('isAvailable');
@@ -48,11 +21,9 @@ Future<bool> isBackgroundSyncAvailable() async {
   return false;
 }
 
-/// Start background sync with platform notification.
+/// Start background sync with the native iOS BGTask scheduler.
 Future<void> startBackgroundSync({RpcEndpointConfig? endpoint}) async {
-  if (Platform.isAndroid) {
-    await _startAndroidForegroundService();
-  } else if (Platform.isIOS) {
+  if (Platform.isIOS) {
     try {
       final success = await _iosChannel.invokeMethod<bool>(
         'startBackgroundSync',
@@ -86,26 +57,9 @@ Future<void> updateBackgroundSyncEndpoint({
   }
 }
 
-/// Update background sync notification with progress (Android only).
-Future<void> updateBackgroundSyncProgress({
-  required double percentage,
-  required int scannedHeight,
-  required int chainTipHeight,
-}) async {
-  if (Platform.isAndroid) {
-    final pct = (percentage * 100).toStringAsFixed(1);
-    FlutterForegroundTask.updateService(
-      notificationTitle: 'Vizor — Syncing $pct%',
-      notificationText: 'Block $scannedHeight / $chainTipHeight',
-    );
-  }
-}
-
 /// Stop background sync service.
 Future<void> stopBackgroundSync() async {
-  if (Platform.isAndroid) {
-    await FlutterForegroundTask.stopService();
-  } else if (Platform.isIOS) {
+  if (Platform.isIOS) {
     try {
       final success = await _iosChannel.invokeMethod<bool>(
         'stopBackgroundSync',
@@ -115,49 +69,4 @@ Future<void> stopBackgroundSync() async {
       log('BackgroundSync: iOS BGTask cancel failed: $e');
     }
   }
-}
-
-// ======================== Android ========================
-
-Future<void> _startAndroidForegroundService() async {
-  final notifPermission =
-      await FlutterForegroundTask.checkNotificationPermission();
-  log('BackgroundSync: notification permission=$notifPermission');
-  if (notifPermission != NotificationPermission.granted) {
-    await FlutterForegroundTask.requestNotificationPermission();
-  }
-
-  FlutterForegroundTask.init(
-    androidNotificationOptions: AndroidNotificationOptions(
-      channelId: 'zcash_sync',
-      channelName: 'Vizor Sync',
-      channelDescription: 'Blockchain synchronization progress',
-      channelImportance: NotificationChannelImportance.LOW,
-      priority: NotificationPriority.LOW,
-      playSound: false,
-      showBadge: false,
-    ),
-    iosNotificationOptions: const IOSNotificationOptions(
-      showNotification: false,
-    ),
-    foregroundTaskOptions: ForegroundTaskOptions(
-      eventAction: ForegroundTaskEventAction.nothing(),
-      autoRunOnBoot: false,
-      allowWakeLock: true,
-      allowWifiLock: true,
-    ),
-  );
-
-  final result = await FlutterForegroundTask.startService(
-    notificationTitle: 'Vizor',
-    notificationText: 'Syncing blockchain...',
-    serviceId: 1001,
-    callback: _foregroundTaskCallback,
-    notificationButtons: [
-      const NotificationButton(id: 'stop', text: 'Stop Sync'),
-    ],
-  );
-
-  final success = result is ServiceRequestSuccess;
-  log('BackgroundSync: startService result: success=$success');
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -268,14 +268,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_foreground_task:
-    dependency: "direct main"
-    description:
-      name: flutter_foreground_task
-      sha256: "1903697944a31f596622e51a6af55e3a9dfb27762f9763ab2841184098c6b0ba"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.2.1"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,6 @@ dependencies:
       url: https://github.com/chainapsis/desktop_window_bootstrap.git
       ref: 16b1b30e08004e91521cc511db098f9561dfeb0a
   crypto: ^3.0.7
-  flutter_foreground_task: ^9.2.1
   window_manager: ^0.5.1
   url_launcher: ^6.3.2
   # Renders the Figma-exported icon SVGs under `assets/icons/`.


### PR DESCRIPTION
## Summary
- remove Android foreground-service permissions and service registration
- drop the unused flutter_foreground_task dependency and Android delegate path
- keep the existing iOS BGTask background sync path intact

## Validation
- fvm flutter analyze
- fvm flutter build apk --release --dart-define=VIZOR_FORM_FACTOR=mobile
- verified release merged manifest and APK permissions no longer include foreground-service permissions