### PR TITLE
[codex] Add mobile send max mode and fix activity overflow

### DIFF
--- a/lib/src/features/activity/screens/mobile/mobile_transaction_status_screen.dart
+++ b/lib/src/features/activity/screens/mobile/mobile_transaction_status_screen.dart
@@ -633,6 +633,7 @@ class _BottomInfoRow extends StatelessWidget {
         ],
         if (label != null)
           Expanded(
+            flex: trailing == null ? 1 : 2,
             child: Text(
               label,
               maxLines: 1,
@@ -644,7 +645,11 @@ class _BottomInfoRow extends StatelessWidget {
           )
         else
           const Spacer(),
-        ?trailing,
+        if (trailing != null)
+          Flexible(
+            flex: 3,
+            child: Align(alignment: Alignment.centerRight, child: trailing),
+          ),
       ],
     );
   }
@@ -798,7 +803,7 @@ class _GhostIconLabelButton extends StatelessWidget {
         child: Padding(
           padding: const EdgeInsets.all(AppSpacing.xxs),
           child: Row(
-            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.end,
             children: [
               AppIcon(
                 iconName,
@@ -806,10 +811,15 @@ class _GhostIconLabelButton extends StatelessWidget {
                 color: colors.button.ghost.label,
               ),
               const SizedBox(width: AppSpacing.xxs),
-              Text(
-                label,
-                style: AppTypography.labelLarge.copyWith(
-                  color: colors.button.ghost.label,
+              Flexible(
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  softWrap: false,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTypography.labelLarge.copyWith(
+                    color: colors.button.ghost.label,
+                  ),
                 ),
               ),
             ],
@@ -961,8 +971,10 @@ class _ListRow extends StatelessWidget {
               ),
             ),
           ),
-          const Spacer(),
-          value,
+          const SizedBox(width: AppSpacing.sm),
+          Expanded(
+            child: Align(alignment: Alignment.centerRight, child: value),
+          ),
         ],
       ),
     );
@@ -989,13 +1001,19 @@ class _ValueWithIcon extends StatelessWidget {
         AppSpacing.xxs,
       ),
       child: Row(
-        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.end,
         children: [
           if (text != null)
-            Text(
-              text!,
-              style: AppTypography.labelLarge.copyWith(
-                color: colors.text.accent,
+            Flexible(
+              child: Text(
+                text!,
+                maxLines: 1,
+                softWrap: false,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.right,
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.accent,
+                ),
               ),
             ),
           if (iconName != null) ...[
@@ -1055,18 +1073,23 @@ class _StatusChip extends StatelessWidget {
         AppSpacing.xxs,
       ),
       child: Row(
-        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.end,
         children: [
           if (phase == _TxPhase.pending)
             _SpinningIcon(color: color)
           else
             AppIcon(iconName, size: 20, color: color),
           const SizedBox(width: AppSpacing.xxs),
-          Text(
-            text,
-            style: AppTypography.labelLarge.copyWith(
-              fontWeight: FontWeight.w600,
-              color: color,
+          Flexible(
+            child: Text(
+              text,
+              maxLines: 1,
+              softWrap: false,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.labelLarge.copyWith(
+                fontWeight: FontWeight.w600,
+                color: color,
+              ),
             ),
           ),
         ],

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -88,6 +88,22 @@ typedef MobileSendFeeEstimator =
 
 typedef MobileSendScanner = Future<String?> Function(BuildContext context);
 
+class _MobileSendMaxQuote {
+  const _MobileSendMaxQuote({
+    required this.accountUuid,
+    required this.address,
+    required this.memo,
+    required this.amountZatoshi,
+    required this.feeZatoshi,
+  });
+
+  final String accountUuid;
+  final String address;
+  final String memo;
+  final BigInt amountZatoshi;
+  final BigInt feeZatoshi;
+}
+
 class MobileSendAmountArgs {
   const MobileSendAmountArgs({
     required this.sendFlowId,
@@ -111,6 +127,7 @@ class MobileSendReviewDraftArgs {
     required this.addressType,
     required this.amountText,
     this.feeZatoshi,
+    this.isMaxMode = false,
     this.memo,
     this.contactLabel,
     this.contactPictureId,
@@ -121,6 +138,7 @@ class MobileSendReviewDraftArgs {
   final String addressType;
   final String amountText;
   final BigInt? feeZatoshi;
+  final bool isMaxMode;
   final String? memo;
   final String? contactLabel;
   final String? contactPictureId;
@@ -162,6 +180,7 @@ class MobileSendReviewScreen extends StatelessWidget {
       initialAmount: args.amountText,
       initialFeeZatoshi: args.feeZatoshi,
       refreshReviewFeeOnInit: true,
+      initialMaxMode: args.isMaxMode,
       initialMemo: args.memo,
       initialContactLabel: args.contactLabel,
       initialContactPictureId: args.contactPictureId,
@@ -218,6 +237,7 @@ class MobileSendScreen extends ConsumerStatefulWidget {
     this.initialAmountStep = false,
     this.initialReview = false,
     this.initialFeeZatoshi,
+    this.initialMaxMode = false,
     this.refreshReviewFeeOnInit = false,
     this.initialMemo,
     this.initialContactLabel,
@@ -242,6 +262,7 @@ class MobileSendScreen extends ConsumerStatefulWidget {
   final bool initialAmountReady;
   final bool initialReview;
   final BigInt? initialFeeZatoshi;
+  final bool initialMaxMode;
   final bool refreshReviewFeeOnInit;
   final String? initialMemo;
   final String? initialSendFlowId;
@@ -286,6 +307,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   String _amountText = '';
   String? _amountError = ''; // null = valid, '' = silently incomplete
   int _validateSeq = 0;
+  bool _isMaxMode = false;
+  bool _isResolvingMax = false;
+  int _maxSeq = 0;
+  _MobileSendMaxQuote? _maxQuote;
 
   // Review state.
   String _memo = '';
@@ -322,6 +347,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       _step = widget.initialReview ? _SendStep.review : _SendStep.amount;
       _amountText = widget.initialAmount?.trim() ?? '';
       _amountController.text = _amountText;
+      _isMaxMode = widget.initialMaxMode;
       if (widget.initialAmountError != null) {
         _amountError = widget.initialAmountError;
       } else if (widget.initialAmountReady || widget.initialReview) {
@@ -330,6 +356,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         if (_feeZatoshi == null && !widget.refreshReviewFeeOnInit) {
           _feeZatoshi = BigInt.from(10000);
         }
+        _seedInitialMaxQuote();
       } else if (_amountText.isNotEmpty) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (mounted) unawaited(_validateAmount());
@@ -338,7 +365,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     }
     if (widget.initialReview && widget.refreshReviewFeeOnInit) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) unawaited(_estimateReviewFee());
+        if (mounted) unawaited(_refreshReviewQuote());
       });
     }
     if (widget.initialRecipientFocused) {
@@ -431,6 +458,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         _contactPictureId = null;
       }
       _addressType = '';
+      _clearMaxMode();
     });
     unawaited(_validateAddress());
   }
@@ -522,9 +550,168 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         .spendableBalance;
   }
 
+  String? get _activeAccountUuid =>
+      ref.read(accountProvider).value?.activeAccountUuid;
+
+  bool get _hasCurrentMaxQuote {
+    final quote = _maxQuote;
+    if (quote == null) return false;
+    return quote.accountUuid == _activeAccountUuid &&
+        quote.address == _addressController.text.trim() &&
+        quote.memo == _effectiveMemo &&
+        parseZecAmount(_amountText.trim()) == quote.amountZatoshi &&
+        _feeZatoshi == quote.feeZatoshi;
+  }
+
+  void _seedInitialMaxQuote() {
+    if (!_isMaxMode) return;
+    final accountUuid = _activeAccountUuid;
+    final amountZatoshi = parseZecAmount(_amountText.trim());
+    final feeZatoshi = _feeZatoshi;
+    if (accountUuid == null || amountZatoshi == null || feeZatoshi == null) {
+      return;
+    }
+    _maxQuote = _MobileSendMaxQuote(
+      accountUuid: accountUuid,
+      address: _addressController.text.trim(),
+      memo: _effectiveMemo,
+      amountZatoshi: amountZatoshi,
+      feeZatoshi: feeZatoshi,
+    );
+  }
+
+  void _clearMaxMode() {
+    _maxSeq++;
+    _isMaxMode = false;
+    _isResolvingMax = false;
+    _maxQuote = null;
+  }
+
   void _handleAmountChanged(String value) {
-    setState(() => _amountText = value.trim());
+    setState(() {
+      _amountText = value.trim();
+      if (_isMaxMode) {
+        _clearMaxMode();
+      }
+    });
     unawaited(_validateAmount());
+  }
+
+  void _activateMaxMode() {
+    if (_isResolvingMax) return;
+    _amountFocus.unfocus();
+    setState(() {
+      _isMaxMode = true;
+      _maxQuote = null;
+      _amountError = '';
+      _error = null;
+    });
+    unawaited(_resolveMaxEstimate());
+  }
+
+  String? _maxEstimatePreconditionError() {
+    if (_activeAccountUuid == null) return 'Max amount unavailable';
+    if (!_hasValidAddress) return 'Max amount unavailable';
+    if (_isHardwareTexRecipient) return _hardwareTexUnsupportedText;
+    if (utf8.encode(_effectiveMemo).length > 512) {
+      return 'Message is too long';
+    }
+    return null;
+  }
+
+  Future<void> _resolveMaxEstimate() async {
+    _validateSeq++;
+    final seq = ++_maxSeq;
+    final accountUuid = _activeAccountUuid;
+    final address = _addressController.text.trim();
+    final memo = _effectiveMemo;
+    final preconditionError = _maxEstimatePreconditionError();
+    setState(() {
+      _isMaxMode = true;
+      _isResolvingMax = preconditionError == null;
+      _maxQuote = null;
+      _amountError = preconditionError ?? '';
+      if (preconditionError != null) {
+        _feeZatoshi = null;
+      }
+    });
+    if (preconditionError != null || accountUuid == null) return;
+
+    try {
+      final dbPath = await widget.loadWalletDbPath();
+      final endpoint = ref.read(rpcEndpointProvider);
+      if (!_isCurrentMaxRequest(seq, accountUuid, address, memo)) return;
+
+      final estimate = await rust_sync.estimateSendMax(
+        dbPath: dbPath,
+        network: endpoint.networkName,
+        accountUuid: accountUuid,
+        toAddress: address,
+        memo: memo.isNotEmpty ? memo : null,
+      );
+      if (!_isCurrentMaxRequest(seq, accountUuid, address, memo)) return;
+
+      if (estimate.amountZatoshi <= BigInt.zero) {
+        _applyMaxEstimateError('Not enough ZEC');
+        return;
+      }
+
+      final amountText = ZecAmount.fromZatoshi(
+        estimate.amountZatoshi,
+      ).pretty().amountText;
+      _amountController.value = TextEditingValue(
+        text: amountText,
+        selection: TextSelection.collapsed(offset: amountText.length),
+      );
+
+      setState(() {
+        _amountText = amountText;
+        _amountError = null;
+        _feeZatoshi = estimate.feeZatoshi;
+        _isResolvingMax = false;
+        _maxQuote = _MobileSendMaxQuote(
+          accountUuid: accountUuid,
+          address: address,
+          memo: memo,
+          amountZatoshi: estimate.amountZatoshi,
+          feeZatoshi: estimate.feeZatoshi,
+        );
+      });
+    } catch (e) {
+      if (!_isCurrentMaxRequest(seq, accountUuid, address, memo)) return;
+      final msg = e.toString().toLowerCase();
+      _applyMaxEstimateError(
+        msg.contains('insufficient')
+            ? 'Not enough ZEC'
+            : 'Max amount unavailable',
+      );
+    }
+  }
+
+  bool _isCurrentMaxRequest(
+    int seq,
+    String accountUuid,
+    String address,
+    String memo,
+  ) {
+    return mounted &&
+        _isMaxMode &&
+        seq == _maxSeq &&
+        _activeAccountUuid == accountUuid &&
+        _addressController.text.trim() == address &&
+        _effectiveMemo == memo;
+  }
+
+  void _applyMaxEstimateError(String message) {
+    setState(() {
+      _isResolvingMax = false;
+      _maxQuote = null;
+      _feeZatoshi = null;
+      _amountError = message;
+    });
+    if (_step == _SendStep.review) {
+      showAppToast(context, message, iconName: AppIcons.warning);
+    }
   }
 
   /// Same shape as the desktop validator — quick spendable pre-check,
@@ -586,8 +773,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   }
 
   bool get _amountReady =>
+      !_isResolvingMax &&
       _amountError == null &&
-      (parseZecAmount(_amountText.trim()) ?? BigInt.zero) > BigInt.zero;
+      (parseZecAmount(_amountText.trim()) ?? BigInt.zero) > BigInt.zero &&
+      (!_isMaxMode || _hasCurrentMaxQuote);
 
   void _continueToReview() {
     if (!_amountReady) return;
@@ -602,6 +791,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
             addressType: _addressType,
             amountText: _amountText,
             feeZatoshi: _feeZatoshi,
+            isMaxMode: _isMaxMode && _hasCurrentMaxQuote,
             memo: _memo,
             contactLabel: _contactLabel,
             contactPictureId: _contactPictureId,
@@ -612,12 +802,17 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     }
     setState(() => _step = _SendStep.review);
     // Refresh the fee for the review card (the memo may change it).
-    unawaited(_estimateReviewFee());
+    unawaited(_refreshReviewQuote());
   }
 
   // ── Review step ────────────────────────────────────────────────────
 
   String get _effectiveMemo => _isShieldedAddress ? _memo.trim() : '';
+
+  Future<void> _refreshReviewQuote() {
+    if (_isMaxMode) return _resolveMaxEstimate();
+    return _estimateReviewFee();
+  }
 
   Future<void> _estimateReviewFee() async {
     final seq = ++_feeSeq;
@@ -653,7 +848,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     );
     if (next == null || !mounted) return;
     setState(() => _memo = next);
-    unawaited(_estimateReviewFee());
+    unawaited(_refreshReviewQuote());
   }
 
   Future<void> _showFeeInfo() {
@@ -712,6 +907,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
 
   Future<void> _confirmAndSend() async {
     if (_phase != _SendPhase.compose || _isConfirmingSend) return;
+    if (_isResolvingMax || (_isMaxMode && !_hasCurrentMaxQuote)) return;
     final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
     if (accountUuid == null) return;
     final isHardware = ref
@@ -1470,7 +1666,11 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
               constrainContent: true,
               onPressed: _amountReady ? _continueToReview : null,
               child: Text(
-                _amountReady ? 'Finish & review' : 'Enter amount to continue',
+                _isResolvingMax
+                    ? 'Calculating max amount'
+                    : _amountReady
+                    ? 'Finish & review'
+                    : 'Enter amount to continue',
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
               ),
@@ -1548,10 +1748,21 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
             const SizedBox(height: AppSpacing.s),
             SizedBox(
               height: _kMobileSendAmountLineHeight,
-              child: Text(
-                'Max: $spendableText',
-                style: AppTypography.labelLarge.copyWith(
-                  color: colors.text.secondary,
+              child: Center(
+                child: Semantics(
+                  button: true,
+                  label: 'Use maximum spendable balance',
+                  child: GestureDetector(
+                    key: const ValueKey('mobile_send_max_button'),
+                    behavior: HitTestBehavior.opaque,
+                    onTap: _isResolvingMax ? null : _activateMaxMode,
+                    child: Text(
+                      'Max: $spendableText',
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.text.secondary,
+                      ),
+                    ),
+                  ),
                 ),
               ),
             ),
@@ -1671,7 +1882,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                 AppButton(
                   key: const ValueKey('mobile_send_confirm'),
                   expand: true,
-                  onPressed: _isConfirmingSend
+                  onPressed:
+                      _isConfirmingSend ||
+                          _isResolvingMax ||
+                          (_isMaxMode && !_hasCurrentMaxQuote)
                       ? null
                       : () => unawaited(_confirmAndSend()),
                   leading: const AppIcon(AppIcons.plane, size: 20),

--- a/test/features/activity/mobile_transaction_status_screen_test.dart
+++ b/test/features/activity/mobile_transaction_status_screen_test.dart
@@ -297,6 +297,25 @@ void main() {
     expect(find.text(memo), findsOneWidget);
   });
 
+  testWidgets('long one-line memo preview does not overflow on mobile width', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(393, 852));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    const memo = 'ㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎ';
+    await tester.pumpWidget(_app(_tx(), detail: _detail(memo: memo)));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Message'), findsOneWidget);
+    final previewText = tester.widget<Text>(
+      find.text('${memo.substring(0, 18)}...'),
+    );
+    expect(previewText.maxLines, 1);
+    expect(previewText.overflow, TextOverflow.ellipsis);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('no memo means no message row', (tester) async {
     await tester.pumpWidget(_app(_tx()));
     await tester.pumpAndSettle();

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -30,6 +30,13 @@ const _invalidAddress = 'not-an-address';
 
 var _proposeSendSucceeds = false;
 Completer<ProposalResult>? _proposeSendCompleter;
+int _estimateSendMaxCalls = 0;
+String? _lastEstimateSendMaxToAddress;
+String? _lastEstimateSendMaxMemo;
+_SendMaxEstimateBuilder? _sendMaxEstimateBuilder;
+
+typedef _SendMaxEstimateBuilder =
+    SendMaxEstimateResult Function({required String toAddress, String? memo});
 
 class _RustApiFake implements RustLibApi {
   @override
@@ -65,6 +72,28 @@ class _RustApiFake implements RustLibApi {
     // assert Continue stays blocked until the estimate lands.
     await Future<void>.delayed(const Duration(milliseconds: 50));
     return BigInt.from(10000);
+  }
+
+  @override
+  Future<SendMaxEstimateResult> crateApiSyncEstimateSendMax({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String toAddress,
+    String? memo,
+  }) async {
+    _estimateSendMaxCalls++;
+    _lastEstimateSendMaxToAddress = toAddress;
+    _lastEstimateSendMaxMemo = memo;
+    final builder = _sendMaxEstimateBuilder;
+    if (builder != null) {
+      return builder(toAddress: toAddress, memo: memo);
+    }
+    return SendMaxEstimateResult(
+      amountZatoshi: BigInt.from(499990000),
+      feeZatoshi: BigInt.from(10000),
+      needsSaplingParams: false,
+    );
   }
 
   @override
@@ -249,6 +278,7 @@ Widget _sendFlowRouterApp({MobileSendFeeEstimator? estimateFee}) {
             initialAmount: args.amountText,
             initialFeeZatoshi: args.feeZatoshi,
             refreshReviewFeeOnInit: true,
+            initialMaxMode: args.isMaxMode,
             initialMemo: args.memo,
             initialContactLabel: args.contactLabel,
             initialContactPictureId: args.contactPictureId,
@@ -373,6 +403,10 @@ void main() {
   setUp(() {
     _proposeSendSucceeds = false;
     _proposeSendCompleter = null;
+    _estimateSendMaxCalls = 0;
+    _lastEstimateSendMaxToAddress = null;
+    _lastEstimateSendMaxMemo = null;
+    _sendMaxEstimateBuilder = null;
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
     binding.platformDispatcher.views.first
       ..physicalSize = const Size(520, 1100)
@@ -1044,6 +1078,146 @@ void main() {
     await _enterAmount(tester, '1.5');
     expect(find.text('Not enough ZEC'), findsNothing);
     expect(find.text('Finish & review'), findsOneWidget);
+  });
+
+  testWidgets('the amount step Max action fills the estimated send amount', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+    await _toAmountStep(tester, _shieldedAddress);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_max_button')));
+    await tester.pumpAndSettle();
+
+    expect(_estimateSendMaxCalls, 1);
+    expect(_lastEstimateSendMaxToAddress, _shieldedAddress);
+    expect(_lastEstimateSendMaxMemo, isNull);
+    final amountInput = tester.widget<TextField>(
+      find.byKey(const ValueKey('mobile_send_amount_input')),
+    );
+    expect(amountInput.controller?.text, '4.9999');
+    expect(find.text('Finish & review'), findsOneWidget);
+  });
+
+  testWidgets('Max ignores a stale pending amount fee validation', (
+    tester,
+  ) async {
+    final feeCompleter = Completer<BigInt>();
+    var feeCalls = 0;
+
+    await tester.pumpWidget(
+      _sendFlowRouterApp(
+        estimateFee:
+            ({
+              required dbPath,
+              required network,
+              required accountUuid,
+              required toAddress,
+              required amountZatoshi,
+              memo,
+            }) {
+              feeCalls++;
+              return feeCompleter.future;
+            },
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_open_from_home')));
+    await tester.pumpAndSettle();
+    await _toAmountStep(tester, _shieldedAddress);
+
+    await tester.enterText(
+      find.byKey(const ValueKey('mobile_send_amount_input')),
+      '1.5',
+    );
+    await tester.pump();
+    expect(feeCalls, 1);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_max_button')));
+    await tester.pumpAndSettle();
+    expect(find.text('Finish & review'), findsOneWidget);
+
+    feeCompleter.complete(BigInt.from(12345));
+    await tester.pumpAndSettle();
+
+    final amountInput = tester.widget<TextField>(
+      find.byKey(const ValueKey('mobile_send_amount_input')),
+    );
+    expect(amountInput.controller?.text, '4.9999');
+    expect(find.text('Finish & review'), findsOneWidget);
+  });
+
+  testWidgets(
+    'the amount step Max action omits memo for transparent recipients',
+    (tester) async {
+      await tester.pumpWidget(_app());
+      await tester.pumpAndSettle();
+      await _toAmountStep(tester, _transparentAddress);
+
+      await tester.tap(find.byKey(const ValueKey('mobile_send_max_button')));
+      await tester.pumpAndSettle();
+
+      expect(_estimateSendMaxCalls, 1);
+      expect(_lastEstimateSendMaxToAddress, _transparentAddress);
+      expect(_lastEstimateSendMaxMemo, isNull);
+      expect(find.text('Finish & review'), findsOneWidget);
+    },
+  );
+
+  testWidgets('route-step max mode recalculates amount when memo changes', (
+    tester,
+  ) async {
+    _sendMaxEstimateBuilder = ({required toAddress, memo}) =>
+        SendMaxEstimateResult(
+          amountZatoshi: memo == 'thanks!'
+              ? BigInt.from(499980000)
+              : BigInt.from(499990000),
+          feeZatoshi: memo == 'thanks!'
+              ? BigInt.from(20000)
+              : BigInt.from(10000),
+          needsSaplingParams: false,
+        );
+
+    await tester.pumpWidget(_sendFlowRouterApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_open_from_home')));
+    await tester.pumpAndSettle();
+    await _toAmountStep(tester, _shieldedAddress);
+    await tester.tap(find.byKey(const ValueKey('mobile_send_max_button')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_review_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Review Send'), findsOneWidget);
+    expect(find.text('4.9999 ZEC'), findsOneWidget);
+    expect(
+      find.text(ZecAmount.fromZatoshi(BigInt.from(10000)).fee.toString()),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_memo_row')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('mobile_send_memo_editable')),
+      'thanks!',
+    );
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('mobile_send_memo_save')));
+    await tester.pumpAndSettle();
+
+    expect(_lastEstimateSendMaxMemo, 'thanks!');
+    expect(find.text('4.9998 ZEC'), findsOneWidget);
+    final feeText = tester.widget<Text>(
+      find.byKey(const ValueKey('mobile_send_fee')),
+    );
+    expect(
+      feeText.data,
+      ZecAmount.fromZatoshi(BigInt.from(20000)).fee.toString(),
+    );
   });
 
   testWidgets('continue stays blocked while the fee check is pending', (


### PR DESCRIPTION
## Summary
- Add mobile send amount Max mode so tapping the Max balance label fills and maintains the estimated send-max amount.
- Keep Max mode synchronized with fee validation, memo changes, and transparent/TEX recipient memo omission.
- Fix mobile activity detail rows so long one-line memo previews and trailing address actions do not overflow on narrow mobile widths.

## Validation
- fvm flutter analyze lib/src/features/send/screens/mobile/mobile_send_screen.dart test/features/send/mobile_send_screen_test.dart lib/src/features/activity/screens/mobile/mobile_transaction_status_screen.dart test/features/activity/mobile_transaction_status_screen_test.dart
- fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/send/mobile_send_screen_test.dart test/features/activity/mobile_transaction_status_screen_test.dart
