### PR TITLE
Bump mobile_scanner for Android QR scanning

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -588,8 +588,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "7932282afb502abfac2f5f9fc860491372e56eda"
-      resolved-ref: "7932282afb502abfac2f5f9fc860491372e56eda"
+      ref: "2a594fd6e592fd723cf03e02337a65d83cf8aa1a"
+      resolved-ref: "2a594fd6e592fd723cf03e02337a65d83cf8aa1a"
       url: "https://github.com/chainapsis/mobile_scanner.git"
     source: git
     version: "7.2.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   mobile_scanner:
     git:
       url: https://github.com/chainapsis/mobile_scanner.git
-      ref: 7932282afb502abfac2f5f9fc860491372e56eda
+      ref: 2a594fd6e592fd723cf03e02337a65d83cf8aa1a
   desktop_window_bootstrap:
     git:
       url: https://github.com/chainapsis/desktop_window_bootstrap.git


### PR DESCRIPTION
## Summary
- Bump `mobile_scanner` to `2a594fd6e592fd723cf03e02337a65d83cf8aa1a`.
- Pulls in the Android QR scanWindow duplicate-handling fix from `chainapsis/mobile_scanner`.

## Validation
- `fvm flutter pub get`
- `fvm flutter analyze lib/src/services/qr_scanner.dart`
- In `mobile_scanner`: `./gradlew :mobile_scanner:testDebugUnitTest`