### PR TITLE
Update macOS Pod lockfile

### DIFF
--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -12,6 +12,8 @@ PODS:
     - FlutterMacOS
   - screen_retriever_macos (0.0.1):
     - FlutterMacOS
+  - share_plus (0.0.1):
+    - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -27,6 +29,7 @@ DEPENDENCIES:
   - mobile_scanner (from `Flutter/ephemeral/.symlinks/plugins/mobile_scanner/darwin`)
   - rust_lib_zcash_wallet (from `Flutter/ephemeral/.symlinks/plugins/rust_lib_zcash_wallet/macos`)
   - screen_retriever_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos`)
+  - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
   - window_manager (from `Flutter/ephemeral/.symlinks/plugins/window_manager/macos`)
@@ -44,6 +47,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/rust_lib_zcash_wallet/macos
   screen_retriever_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/screen_retriever_macos/macos
+  share_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
   url_launcher_macos:
@@ -58,6 +63,7 @@ SPEC CHECKSUMS:
   mobile_scanner: 9157936403f5a0644ca3779a38ff8404c5434a93
   rust_lib_zcash_wallet: e6239745a9c854f6b4aa85577092ca55b5e78f3b
   screen_retriever_macos: 452e51764a9e1cdb74b3c541238795849f21557f
+  share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   url_launcher_macos: f87a979182d112f911de6820aefddaf56ee9fbfd
   window_manager: b729e31d38fb04905235df9ea896128991cad99e


### PR DESCRIPTION
## Summary
- Update `macos/Podfile.lock` after resolving macOS pods with the deployment workflow environment.
- Adds the `share_plus` macOS pod entry that CocoaPods 1.16.2 now resolves for the current dependency graph.

## Validation
- From `vizor-wallet-deployment` macOS workflow: matched Ruby 3.3.7, Bundler 2.4.20, CocoaPods 1.16.2.
- `fvm flutter pub get`
- `fvm flutter precache --macos`
- `RBENV_VERSION=3.3.7 /opt/homebrew/bin/rbenv exec pod _1.16.2_ install --project-directory=macos`
- `RBENV_VERSION=3.3.7 /opt/homebrew/bin/rbenv exec bundle _2.4.20_ install --jobs 4 --retry 3`
- `cargo metadata --locked --manifest-path rust/Cargo.toml --format-version 1`