### PR TITLE
Validate NEAR Intents quote echoes

### DIFF
--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_json.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_json.dart
@@ -158,6 +158,32 @@ BigInt _parseBaseUnits(String? value, String fieldName) {
   return parsed;
 }
 
+void _validateFormattedAmountMatchesBaseUnits({
+  required String formatted,
+  required BigInt baseUnits,
+  required int decimals,
+  required String fieldName,
+  String? operation,
+}) {
+  late final String formattedBaseUnitsText;
+  try {
+    formattedBaseUnitsText = _decimalStringToBaseUnits(formatted, decimals);
+  } on OneClickApiException catch (error) {
+    throw OneClickApiException(
+      error.message,
+      operation: operation ?? error.operation,
+      statusCode: error.statusCode,
+    );
+  }
+  final formattedBaseUnits = BigInt.parse(formattedBaseUnitsText);
+  if (formattedBaseUnits != baseUnits) {
+    throw OneClickApiException(
+      'Mismatched $fieldName formatted and base-unit amounts',
+      operation: operation,
+    );
+  }
+}
+
 String _decimalStringToBaseUnits(String value, int decimals) {
   var normalized = value.trim().toLowerCase();
   if (normalized.startsWith('+')) {

--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_models.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_models.dart
@@ -32,6 +32,10 @@ class _OneClickQuoteRequest {
     required this.destinationAsset,
     required this.mode,
     required this.appFeeBpsOrNull,
+    this.swapTypeRaw,
+    this.amount,
+    this.refundTo,
+    this.recipient,
     this.slippageToleranceBps,
     this.deadline,
   });
@@ -42,6 +46,10 @@ class _OneClickQuoteRequest {
       destinationAsset: _string(json, 'destinationAsset'),
       mode: _oneClickSwapMode(_optionalString(json, 'swapType')),
       appFeeBpsOrNull: _appFeeBpsOrNull(json['appFees']),
+      swapTypeRaw: _optionalString(json, 'swapType'),
+      amount: _optionalString(json, 'amount'),
+      refundTo: _optionalString(json, 'refundTo'),
+      recipient: _optionalString(json, 'recipient'),
       slippageToleranceBps:
           _optionalInt(json, 'slippageTolerance') ??
           _optionalInt(json, 'slippage'),
@@ -53,6 +61,10 @@ class _OneClickQuoteRequest {
   final String destinationAsset;
   final SwapQuoteMode mode;
   final int? appFeeBpsOrNull;
+  final String? swapTypeRaw;
+  final String? amount;
+  final String? refundTo;
+  final String? recipient;
   final int? slippageToleranceBps;
   final String? deadline;
 }

--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
@@ -83,18 +83,22 @@ class NearIntentsOneClickSwapAdapter
     final amountToken = request.mode == SwapQuoteMode.exactInput
         ? sellToken
         : receiveToken;
+    final amountBaseUnits = _toBaseUnits(amountText, amountToken.decimals);
+    final requestedSlippageBps = request.slippageBps ?? slippageBps;
+    final requestedRefundTo = request.refundAddress!.trim();
+    final requestedRecipient = request.destination.trim();
 
     final body = <String, Object?>{
       'dry': request.dryRun,
       'swapType': request.mode.oneClickSwapType,
-      'slippageTolerance': request.slippageBps ?? slippageBps,
+      'slippageTolerance': requestedSlippageBps,
       'originAsset': sellToken.assetId,
       'depositType': 'ORIGIN_CHAIN',
       'destinationAsset': receiveToken.assetId,
-      'amount': _toBaseUnits(amountText, amountToken.decimals),
-      'refundTo': request.refundAddress!.trim(),
+      'amount': amountBaseUnits,
+      'refundTo': requestedRefundTo,
       'refundType': 'ORIGIN_CHAIN',
-      'recipient': request.destination.trim(),
+      'recipient': requestedRecipient,
       'recipientType': 'DESTINATION_CHAIN',
       'deadline': _deadlineIso(request.deadline ?? quoteDeadline),
       'depositMode': 'SIMPLE',
@@ -115,6 +119,12 @@ class NearIntentsOneClickSwapAdapter
       expectedOriginAsset: sellToken.assetId,
       expectedDestinationAsset: receiveToken.assetId,
       expectedMode: request.mode,
+      expectedFixedAmountBaseUnits: amountBaseUnits,
+      expectedSlippageBps: requestedSlippageBps,
+      expectedRefundTo: requestedRefundTo,
+      expectedRecipient: requestedRecipient,
+      sellToken: sellToken,
+      receiveToken: receiveToken,
     );
     return _quoteFromOneClick(
       quoteResponse,
@@ -706,17 +716,79 @@ class NearIntentsOneClickSwapAdapter
     required String expectedOriginAsset,
     required String expectedDestinationAsset,
     required SwapQuoteMode expectedMode,
+    required String expectedFixedAmountBaseUnits,
+    required int expectedSlippageBps,
+    required String expectedRefundTo,
+    required String expectedRecipient,
+    required _OneClickToken sellToken,
+    required _OneClickToken receiveToken,
   }) {
     final actual = response.quoteRequest;
-    if (actual.originAsset == expectedOriginAsset &&
-        actual.destinationAsset == expectedDestinationAsset &&
-        actual.mode == expectedMode) {
-      return;
+    if (actual.originAsset != expectedOriginAsset ||
+        actual.destinationAsset != expectedDestinationAsset ||
+        actual.swapTypeRaw?.trim().toUpperCase() !=
+            expectedMode.oneClickSwapType) {
+      throw OneClickApiException(
+        '1Click quote response did not match the requested route',
+        operation: 'quote',
+      );
     }
-    throw OneClickApiException(
-      '1Click quote response did not match the requested route',
+
+    final quote = response.quote;
+    final amountField = expectedMode == SwapQuoteMode.exactInput
+        ? quote.amountIn
+        : quote.amountOut;
+    final amountFieldName = expectedMode == SwapQuoteMode.exactInput
+        ? 'amountIn'
+        : 'amountOut';
+    if (_parseQuoteResponseBaseUnits(amountField, amountFieldName) !=
+        BigInt.parse(expectedFixedAmountBaseUnits)) {
+      throw OneClickApiException(
+        '1Click quote response did not match the requested amount',
+        operation: 'quote',
+      );
+    }
+
+    _validateFormattedAmountMatchesBaseUnits(
+      formatted: quote.amountInFormatted,
+      baseUnits: _parseQuoteResponseBaseUnits(quote.amountIn, 'amountIn'),
+      decimals: sellToken.decimals,
+      fieldName: 'amountIn',
       operation: 'quote',
     );
+    _validateFormattedAmountMatchesBaseUnits(
+      formatted: quote.amountOutFormatted,
+      baseUnits: _parseQuoteResponseBaseUnits(quote.amountOut, 'amountOut'),
+      decimals: receiveToken.decimals,
+      fieldName: 'amountOut',
+      operation: 'quote',
+    );
+
+    if (actual.slippageToleranceBps != expectedSlippageBps) {
+      throw const OneClickApiException(
+        '1Click quote response did not match the requested slippage',
+        operation: 'quote',
+      );
+    }
+    if (actual.refundTo?.trim() != expectedRefundTo ||
+        actual.recipient?.trim() != expectedRecipient) {
+      throw const OneClickApiException(
+        '1Click quote response did not match the requested addresses',
+        operation: 'quote',
+      );
+    }
+  }
+
+  BigInt _parseQuoteResponseBaseUnits(String? value, String fieldName) {
+    try {
+      return _parseBaseUnits(value, fieldName);
+    } on OneClickApiException catch (error) {
+      throw OneClickApiException(
+        error.message,
+        operation: 'quote',
+        statusCode: error.statusCode,
+      );
+    }
   }
 
   _OneClickToken _requireToken(

--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
@@ -741,8 +741,11 @@ class NearIntentsOneClickSwapAdapter
     final amountFieldName = expectedMode == SwapQuoteMode.exactInput
         ? 'amountIn'
         : 'amountOut';
+    final expectedFixedAmount = BigInt.parse(expectedFixedAmountBaseUnits);
     if (_parseQuoteResponseBaseUnits(amountField, amountFieldName) !=
-        BigInt.parse(expectedFixedAmountBaseUnits)) {
+            expectedFixedAmount ||
+        _parseQuoteResponseBaseUnits(actual.amount, 'quoteRequest.amount') !=
+            expectedFixedAmount) {
       throw OneClickApiException(
         '1Click quote response did not match the requested amount',
         operation: 'quote',

--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
@@ -724,10 +724,13 @@ class NearIntentsOneClickSwapAdapter
     required _OneClickToken receiveToken,
   }) {
     final actual = response.quoteRequest;
+    final actualSwapType = actual.swapTypeRaw?.trim().toUpperCase();
+    final hasMismatchedSwapType = actualSwapType == null
+        ? actual.mode != expectedMode
+        : actualSwapType != expectedMode.oneClickSwapType;
     if (actual.originAsset != expectedOriginAsset ||
         actual.destinationAsset != expectedDestinationAsset ||
-        actual.swapTypeRaw?.trim().toUpperCase() !=
-            expectedMode.oneClickSwapType) {
+        hasMismatchedSwapType) {
       throw OneClickApiException(
         '1Click quote response did not match the requested route',
         operation: 'quote',

--- a/test/features/swap/near_intents_one_click_swap_adapter_test.dart
+++ b/test/features/swap/near_intents_one_click_swap_adapter_test.dart
@@ -224,6 +224,216 @@ void main() {
     );
   });
 
+  test('quote rejects response with an unsupported swap type echo', () async {
+    final transport = _FakeOneClickTransport([
+      _FakeResponse.get('/v0/tokens', _tokens),
+      _FakeResponse.post(
+        '/v0/quote',
+        _quoteResponse(
+          originAsset: 'nep141:zec.omft.near',
+          destinationAsset: 'nep141:usdc.example',
+          quoteRequestSwapType: 'FLEX_INPUT',
+          amountInFormatted: '1.5',
+          amountOutFormatted: '105.25',
+          minAmountOut: '104750000',
+          depositAddress: 't1deposit',
+          status: null,
+        ),
+      ),
+    ]);
+    final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+    await expectLater(
+      provider.quote(
+        const SwapQuoteRequest(
+          direction: SwapDirection.zecToExternal,
+          externalAsset: SwapAsset.usdc,
+          sellAmount: 1.5,
+          sellAmountText: '1.5',
+          destination: '0xrecipient',
+          refundAddress: 'u1refund',
+        ),
+      ),
+      throwsA(
+        isA<OneClickApiException>()
+            .having((error) => error.operation, 'operation', 'quote')
+            .having(
+              (error) => error.message,
+              'message',
+              contains('did not match the requested route'),
+            ),
+      ),
+    );
+  });
+
+  test(
+    'quote rejects mismatched sell formatted and base-unit amounts',
+    () async {
+      final transport = _FakeOneClickTransport([
+        _FakeResponse.get('/v0/tokens', _tokens),
+        _FakeResponse.post(
+          '/v0/quote',
+          _quoteResponse(
+            originAsset: 'nep141:zec.omft.near',
+            destinationAsset: 'nep141:usdc.example',
+            amountIn: '150000000',
+            amountInFormatted: '0.001',
+            amountOutFormatted: '105.25',
+            minAmountOut: '104750000',
+            depositAddress: 't1deposit',
+            status: null,
+          ),
+        ),
+      ]);
+      final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+      await expectLater(
+        provider.quote(
+          const SwapQuoteRequest(
+            direction: SwapDirection.zecToExternal,
+            externalAsset: SwapAsset.usdc,
+            sellAmount: 1.5,
+            sellAmountText: '1.5',
+            destination: '0xrecipient',
+            refundAddress: 'u1refund',
+          ),
+        ),
+        throwsA(
+          isA<OneClickApiException>()
+              .having((error) => error.operation, 'operation', 'quote')
+              .having(
+                (error) => error.message,
+                'message',
+                'Mismatched amountIn formatted and base-unit amounts',
+              ),
+        ),
+      );
+    },
+  );
+
+  test(
+    'quote rejects mismatched receive formatted and base-unit amounts',
+    () async {
+      final transport = _FakeOneClickTransport([
+        _FakeResponse.get('/v0/tokens', _tokens),
+        _FakeResponse.post(
+          '/v0/quote',
+          _quoteResponse(
+            originAsset: 'nep141:zec.omft.near',
+            destinationAsset: 'nep141:usdc.example',
+            amountInFormatted: '1',
+            amountOut: '105250000',
+            amountOutFormatted: '1',
+            minAmountOut: '995000',
+            depositAddress: 't1deposit',
+            status: null,
+          ),
+        ),
+      ]);
+      final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+      await expectLater(
+        provider.quote(
+          const SwapQuoteRequest(
+            direction: SwapDirection.zecToExternal,
+            externalAsset: SwapAsset.usdc,
+            sellAmount: 1,
+            sellAmountText: '1',
+            destination: '0xrecipient',
+            refundAddress: 'u1refund',
+          ),
+        ),
+        throwsA(
+          isA<OneClickApiException>().having(
+            (error) => error.message,
+            'message',
+            'Mismatched amountOut formatted and base-unit amounts',
+          ),
+        ),
+      );
+    },
+  );
+
+  test('quote rejects response with mismatched slippage echo', () async {
+    final transport = _FakeOneClickTransport([
+      _FakeResponse.get('/v0/tokens', _tokens),
+      _FakeResponse.post(
+        '/v0/quote',
+        _quoteResponse(
+          originAsset: 'nep141:zec.omft.near',
+          destinationAsset: 'nep141:usdc.example',
+          amountInFormatted: '1',
+          amountOutFormatted: '70',
+          minAmountOut: '69650000',
+          depositAddress: 't1deposit',
+          slippageTolerance: 500,
+          status: null,
+        ),
+      ),
+    ]);
+    final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+    await expectLater(
+      provider.quote(
+        const SwapQuoteRequest(
+          direction: SwapDirection.zecToExternal,
+          externalAsset: SwapAsset.usdc,
+          sellAmount: 1,
+          sellAmountText: '1',
+          destination: '0xrecipient',
+          refundAddress: 'u1refund',
+        ),
+      ),
+      throwsA(
+        isA<OneClickApiException>().having(
+          (error) => error.message,
+          'message',
+          '1Click quote response did not match the requested slippage',
+        ),
+      ),
+    );
+  });
+
+  test('quote rejects response with mismatched address echo', () async {
+    final transport = _FakeOneClickTransport([
+      _FakeResponse.get('/v0/tokens', _tokens),
+      _FakeResponse.post(
+        '/v0/quote',
+        _quoteResponse(
+          originAsset: 'nep141:zec.omft.near',
+          destinationAsset: 'nep141:usdc.example',
+          amountInFormatted: '1',
+          amountOutFormatted: '70',
+          minAmountOut: '69650000',
+          depositAddress: 't1deposit',
+          quoteRequestRecipient: '0xattacker',
+          status: null,
+        ),
+      ),
+    ]);
+    final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+    await expectLater(
+      provider.quote(
+        const SwapQuoteRequest(
+          direction: SwapDirection.zecToExternal,
+          externalAsset: SwapAsset.usdc,
+          sellAmount: 1,
+          sellAmountText: '1',
+          destination: '0xrecipient',
+          refundAddress: 'u1refund',
+        ),
+      ),
+      throwsA(
+        isA<OneClickApiException>().having(
+          (error) => error.message,
+          'message',
+          '1Click quote response did not match the requested addresses',
+        ),
+      ),
+    );
+  });
+
   test(
     'quote derives minimum receive from response slippage if min amount is missing',
     () async {
@@ -255,7 +465,7 @@ void main() {
           sellAmountText: '1',
           destination: '0xrecipient',
           refundAddress: 'u1refund',
-          slippageBps: 200,
+          slippageBps: 125,
         ),
       );
 
@@ -367,6 +577,8 @@ void main() {
             minAmountIn: '139650000',
             minAmountOut: '199000000',
             depositAddress: '0xexternal-deposit',
+            quoteRequestRefundTo: '0xexternal-refund',
+            quoteRequestRecipient: 'u1fresh-shielded-recipient',
             status: null,
           ),
         ),
@@ -416,6 +628,8 @@ void main() {
           amountOutFormatted: '2',
           minAmountOut: '199000000',
           depositAddress: '0xexternal-deposit',
+          quoteRequestRefundTo: '0xexternal-refund',
+          quoteRequestRecipient: 'u1fresh-shielded-recipient',
           status: null,
         ),
       ),
@@ -591,6 +805,7 @@ void main() {
             amountOutFormatted: '0.00096',
             minAmountOut: '95000',
             depositAddress: 't1deposit',
+            quoteRequestRecipient: 'bc1recipient',
             status: null,
           ),
         ),
@@ -796,6 +1011,8 @@ void main() {
             amountOutFormatted: '0.0002',
             minAmountOut: '19900',
             depositAddress: 'near-deposit',
+            quoteRequestRefundTo: 'rowan.near',
+            quoteRequestRecipient: 'u1shielded-zec-recipient',
             status: null,
           ),
         ),
@@ -835,6 +1052,8 @@ void main() {
             amountOutFormatted: '0.0002',
             minAmountOut: '19900',
             depositAddress: 'near-deposit',
+            quoteRequestRefundTo: 'rowan.near',
+            quoteRequestRecipient: 'u1shielded-zec-recipient',
             status: null,
           ),
         ),
@@ -1738,9 +1957,9 @@ Map<String, Object?> _quoteResponse({
   required String originAsset,
   required String destinationAsset,
   String swapType = 'EXACT_INPUT',
-  String amountIn = '100000000',
+  String? amountIn,
   required String amountInFormatted,
-  String amountOut = '105250000',
+  String? amountOut,
   required String amountOutFormatted,
   String? minAmountOut,
   required String depositAddress,
@@ -1754,32 +1973,42 @@ Map<String, Object?> _quoteResponse({
   String quoteDeadline = '2026-05-07T12:00:00Z',
   String timeWhenInactive = '2026-05-07T10:08:00Z',
   int? slippageTolerance = 100,
+  String? quoteRequestSwapType,
+  String quoteRequestRefundTo = 'u1refund',
+  String quoteRequestRecipient = '0xrecipient',
   Map<String, Object?>? swapDetails,
 }) {
+  final resolvedAmountIn =
+      amountIn ?? _testBaseUnitsForAsset(amountInFormatted, originAsset);
+  final resolvedAmountOut =
+      amountOut ?? _testBaseUnitsForAsset(amountOutFormatted, destinationAsset);
+  final resolvedQuoteRequestAmount = swapType == 'EXACT_OUTPUT'
+      ? resolvedAmountOut
+      : resolvedAmountIn;
   final quote = {
     if (includeNestedCorrelationId) 'correlationId': 'quote-1',
     'timestamp': '2026-05-07T10:00:00Z',
     'signature': 'quote-signature',
     'quoteRequest': {
       'dry': false,
-      'swapType': swapType,
+      'swapType': quoteRequestSwapType ?? swapType,
       'slippageTolerance': ?slippageTolerance,
       'originAsset': originAsset,
       'depositType': 'ORIGIN_CHAIN',
       'destinationAsset': destinationAsset,
-      'amount': '100000000',
-      'refundTo': 'refund-address',
+      'amount': resolvedQuoteRequestAmount,
+      'refundTo': quoteRequestRefundTo,
       'refundType': 'ORIGIN_CHAIN',
-      'recipient': 'recipient-address',
+      'recipient': quoteRequestRecipient,
       'recipientType': 'DESTINATION_CHAIN',
       'deadline': quoteRequestDeadline,
       'appFees': appFees,
     },
     'quote': {
-      'amountIn': amountIn,
+      'amountIn': resolvedAmountIn,
       'amountInFormatted': amountInFormatted,
       'minAmountIn': ?minAmountIn,
-      'amountOut': amountOut,
+      'amountOut': resolvedAmountOut,
       'amountOutFormatted': amountOutFormatted,
       'minAmountOut': ?minAmountOut,
       'timeEstimate': 120,
@@ -1802,6 +2031,32 @@ Map<String, Object?> _quoteResponse({
     'updatedAt': '2026-05-07T10:02:00Z',
     'swapDetails': swapDetails ?? <String, Object?>{},
   };
+}
+
+String _testBaseUnitsForAsset(String amount, String assetId) {
+  return _testDecimalStringToBaseUnits(amount, _testDecimalsForAsset(assetId));
+}
+
+int _testDecimalsForAsset(String assetId) {
+  if (assetId.contains('wrap.near')) return 24;
+  if (assetId.contains('usdc')) return 6;
+  if (assetId.contains('zec')) return 8;
+  if (assetId.contains('btc')) return 8;
+  return 8;
+}
+
+String _testDecimalStringToBaseUnits(String amount, int decimals) {
+  final parts = amount.trim().split('.');
+  if (parts.length > 2) {
+    throw ArgumentError.value(amount, 'amount', 'Invalid decimal amount');
+  }
+  final whole = parts.first.isEmpty ? '0' : parts.first;
+  final fraction = parts.length == 2 ? parts.last : '';
+  if (fraction.length > decimals) {
+    throw ArgumentError.value(amount, 'amount', 'Too many decimal places');
+  }
+  final raw = '$whole${fraction.padRight(decimals, '0')}';
+  return BigInt.parse(raw).toString();
 }
 
 class _FakeOneClickTransport implements OneClickApiTransport {

--- a/test/features/swap/near_intents_one_click_swap_adapter_test.dart
+++ b/test/features/swap/near_intents_one_click_swap_adapter_test.dart
@@ -267,6 +267,50 @@ void main() {
   });
 
   test(
+    'quote rejects response with mismatched quoteRequest amount echo',
+    () async {
+      final transport = _FakeOneClickTransport([
+        _FakeResponse.get('/v0/tokens', _tokens),
+        _FakeResponse.post(
+          '/v0/quote',
+          _quoteResponse(
+            originAsset: 'nep141:zec.omft.near',
+            destinationAsset: 'nep141:usdc.example',
+            amountIn: '150000000',
+            amountInFormatted: '1.5',
+            amountOutFormatted: '105.25',
+            minAmountOut: '104750000',
+            depositAddress: 't1deposit',
+            quoteRequestAmount: '100000000',
+            status: null,
+          ),
+        ),
+      ]);
+      final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+      await expectLater(
+        provider.quote(
+          const SwapQuoteRequest(
+            direction: SwapDirection.zecToExternal,
+            externalAsset: SwapAsset.usdc,
+            sellAmount: 1.5,
+            sellAmountText: '1.5',
+            destination: '0xrecipient',
+            refundAddress: 'u1refund',
+          ),
+        ),
+        throwsA(
+          isA<OneClickApiException>().having(
+            (error) => error.message,
+            'message',
+            '1Click quote response did not match the requested amount',
+          ),
+        ),
+      );
+    },
+  );
+
+  test(
     'quote rejects mismatched sell formatted and base-unit amounts',
     () async {
       final transport = _FakeOneClickTransport([
@@ -1974,6 +2018,7 @@ Map<String, Object?> _quoteResponse({
   String timeWhenInactive = '2026-05-07T10:08:00Z',
   int? slippageTolerance = 100,
   String? quoteRequestSwapType,
+  String? quoteRequestAmount,
   String quoteRequestRefundTo = 'u1refund',
   String quoteRequestRecipient = '0xrecipient',
   Map<String, Object?>? swapDetails,
@@ -1996,7 +2041,7 @@ Map<String, Object?> _quoteResponse({
       'originAsset': originAsset,
       'depositType': 'ORIGIN_CHAIN',
       'destinationAsset': destinationAsset,
-      'amount': resolvedQuoteRequestAmount,
+      'amount': quoteRequestAmount ?? resolvedQuoteRequestAmount,
       'refundTo': quoteRequestRefundTo,
       'refundType': 'ORIGIN_CHAIN',
       'recipient': quoteRequestRecipient,

--- a/test/features/swap/near_intents_one_click_swap_adapter_test.dart
+++ b/test/features/swap/near_intents_one_click_swap_adapter_test.dart
@@ -266,6 +266,39 @@ void main() {
     );
   });
 
+  test('quote accepts exact-input response without a swap type echo', () async {
+    final transport = _FakeOneClickTransport([
+      _FakeResponse.get('/v0/tokens', _tokens),
+      _FakeResponse.post(
+        '/v0/quote',
+        _quoteResponse(
+          originAsset: 'nep141:zec.omft.near',
+          destinationAsset: 'nep141:usdc.example',
+          amountInFormatted: '1.5',
+          amountOutFormatted: '105.25',
+          minAmountOut: '104750000',
+          depositAddress: 't1deposit',
+          includeQuoteRequestSwapType: false,
+          status: null,
+        ),
+      ),
+    ]);
+    final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+    final quote = await provider.quote(
+      const SwapQuoteRequest(
+        direction: SwapDirection.zecToExternal,
+        externalAsset: SwapAsset.usdc,
+        sellAmount: 1.5,
+        sellAmountText: '1.5',
+        destination: '0xrecipient',
+        refundAddress: 'u1refund',
+      ),
+    );
+
+    expect(quote.mode, SwapQuoteMode.exactInput);
+  });
+
   test(
     'quote rejects response with mismatched quoteRequest amount echo',
     () async {
@@ -2017,6 +2050,7 @@ Map<String, Object?> _quoteResponse({
   String quoteDeadline = '2026-05-07T12:00:00Z',
   String timeWhenInactive = '2026-05-07T10:08:00Z',
   int? slippageTolerance = 100,
+  bool includeQuoteRequestSwapType = true,
   String? quoteRequestSwapType,
   String? quoteRequestAmount,
   String quoteRequestRefundTo = 'u1refund',
@@ -2036,7 +2070,8 @@ Map<String, Object?> _quoteResponse({
     'signature': 'quote-signature',
     'quoteRequest': {
       'dry': false,
-      'swapType': quoteRequestSwapType ?? swapType,
+      if (includeQuoteRequestSwapType)
+        'swapType': quoteRequestSwapType ?? swapType,
       'slippageTolerance': ?slippageTolerance,
       'originAsset': originAsset,
       'depositType': 'ORIGIN_CHAIN',


### PR DESCRIPTION
## Summary

- Fail closed when a NEAR Intents 1Click quote response does not echo the requested route, swap type, fixed-side amount, slippage, refund address, or recipient address.
- Cross-check `amountIn`/`amountOut` base units against their formatted display amounts before constructing a `SwapQuote`.
- Add regression coverage for amount mismatch, unsupported swap type echo, slippage echo mismatch, and address echo mismatch.

## Why

The swap review UI displays formatted amounts from the provider response, while the executable ZEC deposit path uses base-unit amounts. A malicious or malformed quote response could otherwise make the wallet review one amount and send another. This patch keeps the quote path fail-closed unless the response is internally consistent and matches the request the wallet sent.

This does not add provider signature verification; the current integration treats the 1Click signature as support/dispute evidence rather than a locally verifiable trust boundary.

## Validation

- `fvm flutter test test/features/swap/near_intents_one_click_swap_adapter_test.dart`
- `fvm flutter analyze`
- `git diff --check`