### PR TITLE
[VZR-82] Rotate transparent receive addresses

### DIFF
--- a/integration_test/regtest_shield_transparent_retry_test.dart
+++ b/integration_test/regtest_shield_transparent_retry_test.dart
@@ -247,7 +247,7 @@ Future<void> _createFirstWallet(WidgetTester tester) async {
 
 Future<String> _transparentAddressForAccount(String accountUuid) async {
   final dbPath = await getWalletDbPath();
-  return rust_wallet.getTransparentAddress(
+  return rust_wallet.getTransparentReceiveAddress(
     dbPath: dbPath,
     network: _network,
     accountUuid: accountUuid,
@@ -327,7 +327,9 @@ Future<void> _waitForHome(
 }) async {
   await _pumpUntil(
     tester,
-    () => tester.any(find.byKey(const ValueKey('home_desktop_balance_amount_text'))),
+    () => tester.any(
+      find.byKey(const ValueKey('home_desktop_balance_amount_text')),
+    ),
     description: 'home balance card to render',
     timeout: timeout,
   );

--- a/integration_test/regtest_shield_transparent_test.dart
+++ b/integration_test/regtest_shield_transparent_test.dart
@@ -174,7 +174,7 @@ Future<void> _createFirstWallet(WidgetTester tester) async {
 
 Future<String> _transparentAddressForAccount(String accountUuid) async {
   final dbPath = await getWalletDbPath();
-  return rust_wallet.getTransparentAddress(
+  return rust_wallet.getTransparentReceiveAddress(
     dbPath: dbPath,
     network: _network,
     accountUuid: accountUuid,
@@ -254,7 +254,9 @@ Future<void> _waitForHome(
 }) async {
   await _pumpUntil(
     tester,
-    () => tester.any(find.byKey(const ValueKey('home_desktop_balance_amount_text'))),
+    () => tester.any(
+      find.byKey(const ValueKey('home_desktop_balance_amount_text')),
+    ),
     description: 'home balance card to render',
     timeout: timeout,
   );

--- a/lib/src/features/receive/screens/mobile/mobile_receive_screen.dart
+++ b/lib/src/features/receive/screens/mobile/mobile_receive_screen.dart
@@ -86,7 +86,7 @@ class _MobileReceiveScreenState extends ConsumerState<MobileReceiveScreen> {
       setState(() => _shieldedAddress = '');
     }
     try {
-      final transparent = await service.loadTransparentAddress(
+      final transparent = await service.loadTransparentReceiveAddress(
         accountUuid: accountUuid,
       );
       if (!mounted) return;

--- a/lib/src/features/receive/screens/mobile/mobile_receive_screen.dart
+++ b/lib/src/features/receive/screens/mobile/mobile_receive_screen.dart
@@ -24,6 +24,14 @@ import '../../widgets/receive_address_widgets.dart';
 const _renewShieldedAddressErrorMessage =
     "We couldn't refresh your shielded address. Try again, or use your current one.";
 
+bool _didSyncAttemptEnd(SyncState previous, SyncState next) {
+  final completedAt = next.lastSyncCompletedAt;
+  final failedAt = next.lastSyncFailedAt;
+
+  return (completedAt != null && completedAt != previous.lastSyncCompletedAt) ||
+      (failedAt != null && failedAt != previous.lastSyncFailedAt);
+}
+
 /// Mobile receive screen — Figma `Receive` (4514:110524): pool tabs,
 /// QR with the renew control on its bottom edge, compact address line,
 /// and share/copy actions, composed from the shared receive widgets.
@@ -190,10 +198,9 @@ class _MobileReceiveScreenState extends ConsumerState<MobileReceiveScreen> {
     ref.listen(syncProvider, (previous, next) {
       final previousState = previous?.asData?.value;
       final nextState = next.asData?.value;
-      final completedAt = nextState?.lastSyncCompletedAt;
       if (previousState != null &&
-          completedAt != null &&
-          completedAt != previousState.lastSyncCompletedAt) {
+          nextState != null &&
+          _didSyncAttemptEnd(previousState, nextState)) {
         unawaited(_refreshTransparentReceiveAddressAfterSync());
       }
     });

--- a/lib/src/features/receive/screens/mobile/mobile_receive_screen.dart
+++ b/lib/src/features/receive/screens/mobile/mobile_receive_screen.dart
@@ -24,11 +24,15 @@ import '../../widgets/receive_address_widgets.dart';
 const _renewShieldedAddressErrorMessage =
     "We couldn't refresh your shielded address. Try again, or use your current one.";
 
-bool _didSyncAttemptEnd(SyncState previous, SyncState next) {
+bool _shouldRefreshTransparentAddressAfterSyncUpdate(
+  SyncState previous,
+  SyncState next,
+) {
   final completedAt = next.lastSyncCompletedAt;
   final failedAt = next.lastSyncFailedAt;
 
-  return (completedAt != null && completedAt != previous.lastSyncCompletedAt) ||
+  return (previous.isSyncing && !next.isSyncing) ||
+      (completedAt != null && completedAt != previous.lastSyncCompletedAt) ||
       (failedAt != null && failedAt != previous.lastSyncFailedAt);
 }
 
@@ -200,7 +204,10 @@ class _MobileReceiveScreenState extends ConsumerState<MobileReceiveScreen> {
       final nextState = next.asData?.value;
       if (previousState != null &&
           nextState != null &&
-          _didSyncAttemptEnd(previousState, nextState)) {
+          _shouldRefreshTransparentAddressAfterSyncUpdate(
+            previousState,
+            nextState,
+          )) {
         unawaited(_refreshTransparentReceiveAddressAfterSync());
       }
     });

--- a/lib/src/features/receive/screens/mobile/mobile_receive_screen.dart
+++ b/lib/src/features/receive/screens/mobile/mobile_receive_screen.dart
@@ -17,6 +17,7 @@ import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/app_toast.dart';
 import '../../../../providers/account_provider.dart';
 import '../../../../providers/receive_address_provider.dart';
+import '../../../../providers/sync_provider.dart';
 import '../../widgets/mobile/receive_address_info_sheet.dart';
 import '../../widgets/receive_address_widgets.dart';
 
@@ -98,6 +99,26 @@ class _MobileReceiveScreenState extends ConsumerState<MobileReceiveScreen> {
     }
   }
 
+  Future<void> _refreshTransparentReceiveAddressAfterSync() async {
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    if (accountUuid == null) return;
+
+    try {
+      final address = await ref
+          .read(receiveAddressServiceProvider)
+          .loadTransparentReceiveAddress(accountUuid: accountUuid);
+      if (!mounted) return;
+      if (ref.read(accountProvider).value?.activeAccountUuid != accountUuid) {
+        return;
+      }
+      if (_transparentAddress == address) return;
+
+      setState(() => _transparentAddress = address);
+    } catch (e) {
+      log('MobileReceive: ERROR refreshing transparent address after sync: $e');
+    }
+  }
+
   String get _selectedAddress => switch (_selectedType) {
     ReceiveAddressType.shielded => _shieldedAddress ?? '',
     ReceiveAddressType.transparent => _transparentAddress ?? '',
@@ -166,6 +187,17 @@ class _MobileReceiveScreenState extends ConsumerState<MobileReceiveScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen(syncProvider, (previous, next) {
+      final previousState = previous?.asData?.value;
+      final nextState = next.asData?.value;
+      final completedAt = nextState?.lastSyncCompletedAt;
+      if (previousState != null &&
+          completedAt != null &&
+          completedAt != previousState.lastSyncCompletedAt) {
+        unawaited(_refreshTransparentReceiveAddressAfterSync());
+      }
+    });
+
     final colors = context.colors;
     final accountName =
         ref.watch(accountProvider).value?.activeAccount?.name ?? '';

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -133,8 +133,6 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
       setState(() {
         _transparentAddress = cachedAddress;
         _transparentErrorText = null;
-        _isLoadingTransparent = false;
-        _transparentLoadingAccountUuid = null;
       });
     }
 
@@ -143,7 +141,7 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
     }
 
     setState(() {
-      _isLoadingTransparent = cachedAddress == null;
+      _isLoadingTransparent = true;
       _transparentLoadingAccountUuid = targetAccountUuid;
       _transparentErrorText = null;
     });

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -26,11 +26,15 @@ import '../widgets/receive_address_widgets.dart';
 const _renewShieldedAddressErrorMessage =
     "We couldn't refresh your shielded address. Try again, or use your current one.";
 
-bool _didSyncAttemptEnd(SyncState previous, SyncState next) {
+bool _shouldRefreshTransparentAddressAfterSyncUpdate(
+  SyncState previous,
+  SyncState next,
+) {
   final completedAt = next.lastSyncCompletedAt;
   final failedAt = next.lastSyncFailedAt;
 
-  return (completedAt != null && completedAt != previous.lastSyncCompletedAt) ||
+  return (previous.isSyncing && !next.isSyncing) ||
+      (completedAt != null && completedAt != previous.lastSyncCompletedAt) ||
       (failedAt != null && failedAt != previous.lastSyncFailedAt);
 }
 
@@ -295,7 +299,10 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
       final nextState = next.asData?.value;
       if (previousState != null &&
           nextState != null &&
-          _didSyncAttemptEnd(previousState, nextState)) {
+          _shouldRefreshTransparentAddressAfterSyncUpdate(
+            previousState,
+            nextState,
+          )) {
         unawaited(_refreshTransparentReceiveAddressAfterSync());
       }
     });

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -614,7 +614,7 @@ class _ReceiveInfoDialog extends StatelessWidget {
     final infoItems = receiveAddressInfoItems(type, touchUi: false);
     final heights = _isShielded
         ? const [63.0, 63.0, 63.0]
-        : const [42.0, 84.0, 105.0];
+        : const [42.0, 84.0, 105.0, 105.0];
     final items = [
       for (var i = 0; i < infoItems.length; i++)
         _InfoItemData(
@@ -631,7 +631,7 @@ class _ReceiveInfoDialog extends StatelessWidget {
             : 'receive_transparent_info_modal',
       ),
       width: 312,
-      height: _isShielded ? 382 : 403,
+      height: _isShielded ? 382 : 516,
       padding: const EdgeInsets.fromLTRB(16, 24, 16, 24),
       decoration: BoxDecoration(
         color: colors.background.ground,
@@ -681,7 +681,7 @@ class _ReceiveInfoDialog extends StatelessWidget {
           const SizedBox(height: AppSpacing.md),
           SizedBox(
             width: 280,
-            height: _isShielded ? 205 : 247,
+            height: _isShielded ? 205 : 360,
             child: Column(
               children: [
                 for (var i = 0; i < items.length; i++) ...[

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -19,6 +19,7 @@ import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/receive_address_provider.dart';
+import '../../../providers/sync_provider.dart';
 import '../../../providers/wallet_provider.dart';
 import '../widgets/receive_address_widgets.dart';
 
@@ -175,6 +176,32 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
     }
   }
 
+  Future<void> _refreshTransparentReceiveAddressAfterSync() async {
+    if (_selectedType != ReceiveAddressType.transparent) return;
+
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    if (accountUuid == null) return;
+
+    try {
+      final address = await ref
+          .read(receiveAddressServiceProvider)
+          .loadTransparentReceiveAddress(accountUuid: accountUuid);
+      if (!mounted) return;
+      if (ref.read(accountProvider).value?.activeAccountUuid != accountUuid) {
+        return;
+      }
+      if (_selectedType != ReceiveAddressType.transparent) return;
+      if (_transparentAddress == address) return;
+
+      setState(() {
+        _transparentAddress = address;
+        _transparentErrorText = null;
+      });
+    } catch (e) {
+      log('Receive: ERROR refreshing transparent address after sync: $e');
+    }
+  }
+
   Future<void> _renewShieldedAddress() async {
     if (_isRenewingShielded) return;
 
@@ -253,6 +280,16 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
       final nextUuid = next.value?.activeAccountUuid;
       if (nextUuid != null && nextUuid != _activeAccountUuid) {
         unawaited(_loadAddresses());
+      }
+    });
+    ref.listen(syncProvider, (previous, next) {
+      final previousState = previous?.asData?.value;
+      final nextState = next.asData?.value;
+      final completedAt = nextState?.lastSyncCompletedAt;
+      if (previousState != null &&
+          completedAt != null &&
+          completedAt != previousState.lastSyncCompletedAt) {
+        unawaited(_refreshTransparentReceiveAddressAfterSync());
       }
     });
 

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -85,7 +85,7 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
     });
 
     if (_selectedType == ReceiveAddressType.transparent) {
-      unawaited(_loadTransparentAddress(accountUuid: accountUuid));
+      unawaited(_loadTransparentReceiveAddress(accountUuid: accountUuid));
     }
 
     try {
@@ -115,7 +115,7 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
     }
   }
 
-  Future<void> _loadTransparentAddress({String? accountUuid}) async {
+  Future<void> _loadTransparentReceiveAddress({String? accountUuid}) async {
     final targetAccountUuid =
         accountUuid ?? ref.read(accountProvider).value?.activeAccountUuid;
     if (targetAccountUuid == null) return;
@@ -229,7 +229,7 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
 
     setState(() => _selectedType = type);
     if (type == ReceiveAddressType.transparent) {
-      unawaited(_loadTransparentAddress());
+      unawaited(_loadTransparentReceiveAddress());
     }
   }
 

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -26,6 +26,14 @@ import '../widgets/receive_address_widgets.dart';
 const _renewShieldedAddressErrorMessage =
     "We couldn't refresh your shielded address. Try again, or use your current one.";
 
+bool _didSyncAttemptEnd(SyncState previous, SyncState next) {
+  final completedAt = next.lastSyncCompletedAt;
+  final failedAt = next.lastSyncFailedAt;
+
+  return (completedAt != null && completedAt != previous.lastSyncCompletedAt) ||
+      (failedAt != null && failedAt != previous.lastSyncFailedAt);
+}
+
 class ReceiveScreen extends ConsumerStatefulWidget {
   const ReceiveScreen({super.key});
 
@@ -285,10 +293,9 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
     ref.listen(syncProvider, (previous, next) {
       final previousState = previous?.asData?.value;
       final nextState = next.asData?.value;
-      final completedAt = nextState?.lastSyncCompletedAt;
       if (previousState != null &&
-          completedAt != null &&
-          completedAt != previousState.lastSyncCompletedAt) {
+          nextState != null &&
+          _didSyncAttemptEnd(previousState, nextState)) {
         unawaited(_refreshTransparentReceiveAddressAfterSync());
       }
     });

--- a/lib/src/features/receive/screens/receive_screen.dart
+++ b/lib/src/features/receive/screens/receive_screen.dart
@@ -84,8 +84,7 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
       _transparentAddress = cachedTransparentAddress;
     });
 
-    if (_selectedType == ReceiveAddressType.transparent &&
-        cachedTransparentAddress == null) {
+    if (_selectedType == ReceiveAddressType.transparent) {
       unawaited(_loadTransparentAddress(accountUuid: accountUuid));
     }
 
@@ -137,22 +136,20 @@ class _ReceiveScreenState extends ConsumerState<ReceiveScreen> {
         _isLoadingTransparent = false;
         _transparentLoadingAccountUuid = null;
       });
-      return;
     }
 
-    if (_isLoadingTransparent &&
-        _transparentLoadingAccountUuid == targetAccountUuid) {
+    if (_transparentLoadingAccountUuid == targetAccountUuid) {
       return;
     }
 
     setState(() {
-      _isLoadingTransparent = true;
+      _isLoadingTransparent = cachedAddress == null;
       _transparentLoadingAccountUuid = targetAccountUuid;
       _transparentErrorText = null;
     });
 
     try {
-      final address = await service.loadTransparentAddress(
+      final address = await service.loadTransparentReceiveAddress(
         accountUuid: targetAccountUuid,
       );
       if (!mounted) return;

--- a/lib/src/features/receive/widgets/mobile/receive_address_info_sheet.dart
+++ b/lib/src/features/receive/widgets/mobile/receive_address_info_sheet.dart
@@ -31,7 +31,7 @@ class ReceiveAddressInfoSheet extends StatelessWidget {
     final colors = context.colors;
     final items = receiveAddressInfoItems(type, touchUi: true);
     final isShielded = type == ReceiveAddressType.shielded;
-    final itemMaxLines = isShielded ? const [3, 3, 3] : const [2, 4, 4];
+    final itemMaxLines = isShielded ? const [3, 3, 3] : const [2, 4, 4, 4];
 
     return Stack(
       children: [

--- a/lib/src/features/receive/widgets/mobile/receive_address_info_sheet.dart
+++ b/lib/src/features/receive/widgets/mobile/receive_address_info_sheet.dart
@@ -31,7 +31,7 @@ class ReceiveAddressInfoSheet extends StatelessWidget {
     final colors = context.colors;
     final items = receiveAddressInfoItems(type, touchUi: true);
     final isShielded = type == ReceiveAddressType.shielded;
-    final itemMaxLines = isShielded ? const [3, 3, 3] : const [2, 4, 4, 4];
+    final itemMaxLines = isShielded ? const [3, 3, 3] : const [2, 4, 5, 4];
 
     return Stack(
       children: [

--- a/lib/src/features/receive/widgets/receive_address_widgets.dart
+++ b/lib/src/features/receive/widgets/receive_address_widgets.dart
@@ -843,6 +843,11 @@ List<ReceiveAddressInfoItem> receiveAddressInfoItems(
       text:
           'Commonly used by exchanges that require transparency or regulatory clarity. Also the default for compatibility across many wallets.',
     ),
+    const ReceiveAddressInfoItem(
+      iconName: AppIcons.renew,
+      text:
+          'After this address receives ZEC and Vizor syncs, your next transparent address will automatically change. Previous addresses still belong to this wallet.',
+    ),
     ReceiveAddressInfoItem(
       iconName: touchUi ? AppIcons.shieldKeyholeOutline : AppIcons.shieldAsset,
       text:

--- a/lib/src/features/receive/widgets/receive_desktop_preview.dart
+++ b/lib/src/features/receive/widgets/receive_desktop_preview.dart
@@ -1012,6 +1012,12 @@ class _ReceiveInfoModal extends StatelessWidget {
                   'Commonly used by exchanges that require transparency or regulatory clarity. Also the default for compatibility across many wallets.',
             ),
             _InfoItemData(
+              iconName: AppIcons.renew,
+              height: 105,
+              text:
+                  'After this address receives ZEC and Vizor syncs, your next transparent address will automatically change. Previous addresses still belong to this wallet.',
+            ),
+            _InfoItemData(
               iconName: AppIcons.shieldAsset,
               height: 105,
               text:
@@ -1026,7 +1032,7 @@ class _ReceiveInfoModal extends StatelessWidget {
             : 'receive_preview_transparent_info_modal',
       ),
       width: 312,
-      height: isShielded ? 382 : 403,
+      height: isShielded ? 382 : 516,
       padding: const EdgeInsets.fromLTRB(16, 24, 16, 24),
       decoration: BoxDecoration(
         color: colors.background.ground,
@@ -1076,7 +1082,7 @@ class _ReceiveInfoModal extends StatelessWidget {
           const SizedBox(height: AppSpacing.md),
           SizedBox(
             width: 280,
-            height: isShielded ? 205 : 247,
+            height: isShielded ? 205 : 360,
             child: Column(
               children: [
                 for (var i = 0; i < items.length; i++) ...[

--- a/lib/src/features/send/widgets/send_recipient_resolver.dart
+++ b/lib/src/features/send/widgets/send_recipient_resolver.dart
@@ -9,12 +9,12 @@ import '../../address_book/models/address_book_contact.dart';
 import '../../address_book/models/address_book_label_lookup.dart';
 import 'send_review_layout.dart';
 
-/// Current unified and transparent address of every local account, keyed by the
-/// trimmed address. Used by send review surfaces to recognize a recipient as
-/// one of the user's own accounts without persisting addresses in [AccountInfo].
-///
-/// Address rotation caveat: only each account's CURRENT addresses are matched;
-/// an older rotated address of the same account is not recognized.
+const _selfSendTransparentLookbackLimit = 20;
+
+/// Current unified address and recent transparent receive addresses of every
+/// local account, keyed by the trimmed address. Used by send review surfaces to
+/// recognize a recipient as one of the user's own accounts without persisting
+/// addresses in [AccountInfo].
 final ownAccountAddressesProvider = FutureProvider<Map<String, AccountInfo>>((
   ref,
 ) async {
@@ -37,15 +37,16 @@ final ownAccountAddressesProvider = FutureProvider<Map<String, AccountInfo>>((
       ),
       addressKind: 'unified',
     );
-    await _addOwnAccountAddress(
+    await _addOwnAccountAddresses(
       byAddress: byAddress,
       account: account,
-      loadAddress: () => rust_wallet.getTransparentAddress(
+      loadAddresses: () => rust_wallet.getRecentTransparentReceiveAddresses(
         dbPath: dbPath,
         network: network,
         accountUuid: account.uuid,
+        limit: _selfSendTransparentLookbackLimit,
       ),
-      addressKind: 'transparent',
+      addressKind: 'transparent receive',
     );
   }
   return byAddress;
@@ -67,6 +68,29 @@ Future<void> _addOwnAccountAddress({
     // recognized as a self-transfer target for that address kind.
     log(
       'ownAccountAddresses: $addressKind address load failed for '
+      '${account.uuid}: $e',
+    );
+  }
+}
+
+Future<void> _addOwnAccountAddresses({
+  required Map<String, AccountInfo> byAddress,
+  required AccountInfo account,
+  required Future<List<String>> Function() loadAddresses,
+  required String addressKind,
+}) async {
+  try {
+    for (final rawAddress in await loadAddresses()) {
+      final address = rawAddress.trim();
+      if (address.isNotEmpty) {
+        byAddress[address] = account;
+      }
+    }
+  } catch (e) {
+    // Best-effort: an account whose address fails to load simply is not
+    // recognized as a self-transfer target for that address kind.
+    log(
+      'ownAccountAddresses: $addressKind addresses load failed for '
       '${account.uuid}: $e',
     );
   }

--- a/lib/src/features/swap/providers/swap_max_amount_estimator.dart
+++ b/lib/src/features/swap/providers/swap_max_amount_estimator.dart
@@ -31,7 +31,7 @@ class RustSwapMaxAmountEstimator implements SwapMaxAmountEstimator {
     final spendableZatoshi = sync.spendableBalance;
     final estimateAddress = await _ref
         .read(receiveAddressServiceProvider)
-        .loadTransparentAddress(accountUuid: accountUuid);
+        .loadTransparentReceiveAddress(accountUuid: accountUuid);
 
     log(
       'SwapMaxAmount: estimate begin account=$accountUuid '

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -31,6 +31,8 @@ const _networkKey = 'zcash_wallet_network';
 // Keep in sync with zcash_voting::storage::VotingDb::wallet_sidecar_path,
 // which appends ".voting" to the wallet DB path for sidecar persistence.
 const _votingSidecarSuffix = '.voting';
+// Keep in sync with wallet::transparent_receive_cache::RECEIVE_CACHE_SIDECAR_SUFFIX.
+const _receiveCacheSidecarSuffix = '.receive.redb';
 const _sqliteCompanionSuffixes = ['', '-journal', '-wal', '-shm'];
 
 const kWalletCreationCurrentBlockHeightErrorMessage =
@@ -900,5 +902,6 @@ List<String> walletDbCleanupPaths(String dbPath) {
   return [
     for (final target in targets)
       for (final suffix in _sqliteCompanionSuffixes) '$target$suffix',
+    '$dbPath$_receiveCacheSidecarSuffix',
   ];
 }

--- a/lib/src/providers/receive_address_provider.dart
+++ b/lib/src/providers/receive_address_provider.dart
@@ -71,26 +71,6 @@ class ReceiveAddressService {
     return _transparentAddressCache[accountUuid];
   }
 
-  Future<String> loadTransparentAddress({required String accountUuid}) async {
-    final cached = _transparentAddressCache[accountUuid];
-    if (cached != null) return cached;
-
-    final dbPath = await getWalletDbPath();
-    final network = _network;
-
-    final transparentAddress = await _withDatabaseLockRetry(
-      operationName: 'load transparent address',
-      operation: () => rust_wallet.getTransparentAddress(
-        dbPath: dbPath,
-        network: network,
-        accountUuid: accountUuid,
-      ),
-    );
-
-    _transparentAddressCache[accountUuid] = transparentAddress;
-    return transparentAddress;
-  }
-
   Future<String> loadTransparentReceiveAddress({
     required String accountUuid,
   }) async {

--- a/lib/src/providers/receive_address_provider.dart
+++ b/lib/src/providers/receive_address_provider.dart
@@ -79,8 +79,27 @@ class ReceiveAddressService {
     final network = _network;
 
     final transparentAddress = await _withDatabaseLockRetry(
-      operationName: 'load transparent receive address',
+      operationName: 'load transparent address',
       operation: () => rust_wallet.getTransparentAddress(
+        dbPath: dbPath,
+        network: network,
+        accountUuid: accountUuid,
+      ),
+    );
+
+    _transparentAddressCache[accountUuid] = transparentAddress;
+    return transparentAddress;
+  }
+
+  Future<String> loadTransparentReceiveAddress({
+    required String accountUuid,
+  }) async {
+    final dbPath = await getWalletDbPath();
+    final network = _network;
+
+    final transparentAddress = await _withDatabaseLockRetry(
+      operationName: 'load transparent receive address',
+      operation: () => rust_wallet.getTransparentReceiveAddress(
         dbPath: dbPath,
         network: network,
         accountUuid: accountUuid,

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -225,6 +225,18 @@ Future<String> getTransparentReceiveAddress({
   accountUuid: accountUuid,
 );
 
+Future<List<String>> getRecentTransparentReceiveAddresses({
+  required String dbPath,
+  required String network,
+  String? accountUuid,
+  required int limit,
+}) => RustLib.instance.api.crateApiWalletGetRecentTransparentReceiveAddresses(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+  limit: limit,
+);
+
 /// Result of adding an account to an existing wallet.
 class AccountCreationResult {
   final String accountUuid;

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -200,17 +200,6 @@ Future<void> ensureWalletDbMigrated({
 bool validateMnemonic({required String mnemonic}) =>
     RustLib.instance.api.crateApiWalletValidateMnemonic(mnemonic: mnemonic);
 
-/// Get the transparent address for a specific account (or first account if uuid is None).
-Future<String> getTransparentAddress({
-  required String dbPath,
-  required String network,
-  String? accountUuid,
-}) => RustLib.instance.api.crateApiWalletGetTransparentAddress(
-  dbPath: dbPath,
-  network: network,
-  accountUuid: accountUuid,
-);
-
 /// Get the next transparent receive address for a specific account.
 ///
 /// This is read-only: it returns the first tracked external transparent address

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -211,6 +211,20 @@ Future<String> getTransparentAddress({
   accountUuid: accountUuid,
 );
 
+/// Get the next transparent receive address for a specific account.
+///
+/// This is read-only: it returns the first tracked external transparent address
+/// that has not received a transparent output.
+Future<String> getTransparentReceiveAddress({
+  required String dbPath,
+  required String network,
+  String? accountUuid,
+}) => RustLib.instance.api.crateApiWalletGetTransparentReceiveAddress(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+);
+
 /// Result of adding an account to an existing wallet.
 class AccountCreationResult {
   final String accountUuid;

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -413437861;
+  int get rustContentHash => -1052771162;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -458,12 +458,6 @@ abstract class RustLibApi extends BaseApi {
     required String network,
     int? limit,
     required String accountUuid,
-  });
-
-  Future<String> crateApiWalletGetTransparentAddress({
-    required String dbPath,
-    required String network,
-    String? accountUuid,
   });
 
   Future<String> crateApiWalletGetTransparentReceiveAddress({
@@ -3243,43 +3237,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<String> crateApiWalletGetTransparentAddress({
-    required String dbPath,
-    required String network,
-    String? accountUuid,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(dbPath, serializer);
-          sse_encode_String(network, serializer);
-          sse_encode_opt_String(accountUuid, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 61,
-            port: port_,
-          );
-        },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_String,
-          decodeErrorData: sse_decode_String,
-        ),
-        constMeta: kCrateApiWalletGetTransparentAddressConstMeta,
-        argValues: [dbPath, network, accountUuid],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiWalletGetTransparentAddressConstMeta =>
-      const TaskConstMeta(
-        debugName: "get_transparent_address",
-        argNames: ["dbPath", "network", "accountUuid"],
-      );
-
-  @override
   Future<String> crateApiWalletGetTransparentReceiveAddress({
     required String dbPath,
     required String network,
@@ -3295,7 +3252,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 61,
             port: port_,
           );
         },
@@ -3332,7 +3289,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 62,
             port: port_,
           );
         },
@@ -3360,7 +3317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3400,7 +3357,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 64,
             port: port_,
           );
         },
@@ -3464,7 +3421,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 65,
             port: port_,
           );
         },
@@ -3526,7 +3483,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 66,
             port: port_,
           );
         },
@@ -3561,7 +3518,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 67,
             port: port_,
           );
         },
@@ -3592,7 +3549,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_64(nowSeconds, serializer);
           sse_encode_u_64(ceremonyStartSeconds, serializer);
           sse_encode_u_64(voteEndTimeSeconds, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3616,7 +3573,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3641,7 +3598,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3663,7 +3620,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3690,7 +3647,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_64(ceremonyStartSeconds, serializer);
           sse_encode_u_64(voteEndTimeSeconds, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_u_64,
@@ -3723,7 +3680,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 73,
             port: port_,
           );
         },
@@ -3763,7 +3720,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 74,
             port: port_,
           );
         },
@@ -3806,7 +3763,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 75,
             port: port_,
           );
         },
@@ -3863,7 +3820,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 76,
             port: port_,
           );
         },
@@ -3904,7 +3861,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 78)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 77)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -3934,7 +3891,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 78,
             port: port_,
           );
         },
@@ -3969,7 +3926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 79,
             port: port_,
           );
         },
@@ -4012,7 +3969,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 80,
             port: port_,
           );
         },
@@ -4066,7 +4023,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 81,
             port: port_,
           );
         },
@@ -4105,7 +4062,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 82,
             port: port_,
           );
         },
@@ -4157,7 +4114,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 83,
             port: port_,
           );
         },
@@ -4215,7 +4172,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 84,
             port: port_,
           );
         },
@@ -4276,7 +4233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 85,
             port: port_,
           );
         },
@@ -4335,7 +4292,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 86,
             port: port_,
           );
         },
@@ -4382,7 +4339,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 87,
             port: port_,
           );
         },
@@ -4427,7 +4384,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 88,
             port: port_,
           );
         },
@@ -4454,7 +4411,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4486,7 +4443,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 90,
             port: port_,
           );
         },
@@ -4523,7 +4480,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4558,7 +4515,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 92,
             port: port_,
           );
         },
@@ -4600,7 +4557,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 93,
             port: port_,
           );
         },
@@ -4637,7 +4594,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 94,
             port: port_,
           );
         },
@@ -4675,7 +4632,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 95,
             port: port_,
           );
         },
@@ -4728,7 +4685,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 96,
             port: port_,
           );
         },
@@ -4796,7 +4753,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 97,
             port: port_,
           );
         },
@@ -4840,7 +4797,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 98)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4874,7 +4831,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 99,
             port: port_,
           );
         },
@@ -4907,7 +4864,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 100,
             port: port_,
           );
         },
@@ -4947,7 +4904,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 101,
             port: port_,
           );
         },
@@ -4988,7 +4945,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 102,
             port: port_,
           );
         },
@@ -5042,7 +4999,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 103,
             port: port_,
           );
         },
@@ -5092,7 +5049,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 105,
+              funcId: 104,
               port: port_,
             );
           },
@@ -5133,7 +5090,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 106,
+              funcId: 105,
               port: port_,
             );
           },
@@ -5165,7 +5122,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 106,
           )!;
         },
         codec: SseCodec(
@@ -5206,7 +5163,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 107,
             port: port_,
           );
         },
@@ -5257,7 +5214,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 108,
             port: port_,
           );
         },
@@ -5296,7 +5253,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 109,
             port: port_,
           );
         },
@@ -5339,7 +5296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 110,
             port: port_,
           );
         },
@@ -5389,7 +5346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5421,7 +5378,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5449,7 +5406,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 113,
           )!;
         },
         codec: SseCodec(
@@ -5481,7 +5438,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 114,
             port: port_,
           );
         },
@@ -5518,7 +5475,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 115,
             port: port_,
           );
         },
@@ -5549,7 +5506,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 116,
           )!;
         },
         codec: SseCodec(
@@ -5580,7 +5537,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 117,
             port: port_,
           );
         },

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 2006318776;
+  int get rustContentHash => -413437861;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -405,6 +405,13 @@ abstract class RustLibApi extends BaseApi {
     required String network,
     required String accountUuid,
     required String address,
+  });
+
+  Future<List<String>> crateApiWalletGetRecentTransparentReceiveAddresses({
+    required String dbPath,
+    required String network,
+    String? accountUuid,
+    required int limit,
   });
 
   Future<RoundPlanView> crateApiVotingGetRoundPlan({
@@ -2918,6 +2925,46 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<List<String>> crateApiWalletGetRecentTransparentReceiveAddresses({
+    required String dbPath,
+    required String network,
+    String? accountUuid,
+    required int limit,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_opt_String(accountUuid, serializer);
+          sse_encode_u_32(limit, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 52,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_String,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletGetRecentTransparentReceiveAddressesConstMeta,
+        argValues: [dbPath, network, accountUuid, limit],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiWalletGetRecentTransparentReceiveAddressesConstMeta =>
+      const TaskConstMeta(
+        debugName: "get_recent_transparent_receive_addresses",
+        argNames: ["dbPath", "network", "accountUuid", "limit"],
+      );
+
+  @override
   Future<RoundPlanView> crateApiVotingGetRoundPlan({
     required String dbPath,
     required String accountUuid,
@@ -2935,7 +2982,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 52,
+            funcId: 53,
             port: port_,
           );
         },
@@ -2971,7 +3018,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 53,
+            funcId: 54,
             port: port_,
           );
         },
@@ -3008,7 +3055,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 54,
+            funcId: 55,
             port: port_,
           );
         },
@@ -3035,7 +3082,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_u_8,
@@ -3065,7 +3112,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 56,
+            funcId: 57,
             port: port_,
           );
         },
@@ -3099,7 +3146,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 57,
+            funcId: 58,
             port: port_,
           );
         },
@@ -3137,7 +3184,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(txidHex, serializer);
           sse_encode_String(txKind, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_transaction_detail,
@@ -3174,7 +3221,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 59,
+            funcId: 60,
             port: port_,
           );
         },
@@ -3211,7 +3258,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 61,
             port: port_,
           );
         },
@@ -3248,7 +3295,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 62,
             port: port_,
           );
         },
@@ -3285,7 +3332,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 63,
             port: port_,
           );
         },
@@ -3313,7 +3360,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 64)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3353,7 +3400,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 65,
             port: port_,
           );
         },
@@ -3417,7 +3464,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 66,
             port: port_,
           );
         },
@@ -3479,7 +3526,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 67,
             port: port_,
           );
         },
@@ -3514,7 +3561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 68,
             port: port_,
           );
         },
@@ -3545,7 +3592,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_64(nowSeconds, serializer);
           sse_encode_u_64(ceremonyStartSeconds, serializer);
           sse_encode_u_64(voteEndTimeSeconds, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3569,7 +3616,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3594,7 +3641,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3616,7 +3663,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3643,7 +3690,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_64(ceremonyStartSeconds, serializer);
           sse_encode_u_64(voteEndTimeSeconds, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_u_64,
@@ -3676,7 +3723,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 74,
             port: port_,
           );
         },
@@ -3716,7 +3763,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 75,
             port: port_,
           );
         },
@@ -3759,7 +3806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 76,
             port: port_,
           );
         },
@@ -3816,7 +3863,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 77,
             port: port_,
           );
         },
@@ -3857,7 +3904,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 77)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 78)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -3887,7 +3934,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 79,
             port: port_,
           );
         },
@@ -3922,7 +3969,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 80,
             port: port_,
           );
         },
@@ -3965,7 +4012,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 81,
             port: port_,
           );
         },
@@ -4019,7 +4066,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 82,
             port: port_,
           );
         },
@@ -4058,7 +4105,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 83,
             port: port_,
           );
         },
@@ -4110,7 +4157,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 84,
             port: port_,
           );
         },
@@ -4168,7 +4215,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 85,
             port: port_,
           );
         },
@@ -4229,7 +4276,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 86,
             port: port_,
           );
         },
@@ -4288,7 +4335,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 87,
             port: port_,
           );
         },
@@ -4335,7 +4382,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 88,
             port: port_,
           );
         },
@@ -4380,7 +4427,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 89,
             port: port_,
           );
         },
@@ -4407,7 +4454,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4439,7 +4486,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4476,7 +4523,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 92,
             port: port_,
           );
         },
@@ -4511,7 +4558,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -4553,7 +4600,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 94,
             port: port_,
           );
         },
@@ -4590,7 +4637,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 95,
             port: port_,
           );
         },
@@ -4628,7 +4675,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 96,
             port: port_,
           );
         },
@@ -4681,7 +4728,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -4749,7 +4796,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 98,
             port: port_,
           );
         },
@@ -4793,7 +4840,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 98)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 99)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4827,7 +4874,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 100,
             port: port_,
           );
         },
@@ -4860,7 +4907,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 101,
             port: port_,
           );
         },
@@ -4900,7 +4947,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 102,
             port: port_,
           );
         },
@@ -4941,7 +4988,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 103,
             port: port_,
           );
         },
@@ -4995,7 +5042,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 104,
             port: port_,
           );
         },
@@ -5045,7 +5092,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 104,
+              funcId: 105,
               port: port_,
             );
           },
@@ -5086,7 +5133,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 105,
+              funcId: 106,
               port: port_,
             );
           },
@@ -5118,7 +5165,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 107,
           )!;
         },
         codec: SseCodec(
@@ -5159,7 +5206,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 108,
             port: port_,
           );
         },
@@ -5210,7 +5257,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 109,
             port: port_,
           );
         },
@@ -5249,7 +5296,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
             port: port_,
           );
         },
@@ -5292,7 +5339,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5342,7 +5389,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5374,7 +5421,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
             port: port_,
           );
         },
@@ -5402,7 +5449,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
           )!;
         },
         codec: SseCodec(
@@ -5434,7 +5481,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },
@@ -5471,7 +5518,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
             port: port_,
           );
         },
@@ -5502,7 +5549,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
           )!;
         },
         codec: SseCodec(
@@ -5533,7 +5580,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 118,
             port: port_,
           );
         },

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 724045055;
+  int get rustContentHash => 2006318776;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -454,6 +454,12 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<String> crateApiWalletGetTransparentAddress({
+    required String dbPath,
+    required String network,
+    String? accountUuid,
+  });
+
+  Future<String> crateApiWalletGetTransparentReceiveAddress({
     required String dbPath,
     required String network,
     String? accountUuid,
@@ -3227,7 +3233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Future<String> crateApiWalletGetUnifiedAddress({
+  Future<String> crateApiWalletGetTransparentReceiveAddress({
     required String dbPath,
     required String network,
     String? accountUuid,
@@ -3243,6 +3249,43 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             generalizedFrbRustBinding,
             serializer,
             funcId: 61,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_String,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletGetTransparentReceiveAddressConstMeta,
+        argValues: [dbPath, network, accountUuid],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiWalletGetTransparentReceiveAddressConstMeta =>
+      const TaskConstMeta(
+        debugName: "get_transparent_receive_address",
+        argNames: ["dbPath", "network", "accountUuid"],
+      );
+
+  @override
+  Future<String> crateApiWalletGetUnifiedAddress({
+    required String dbPath,
+    required String network,
+    String? accountUuid,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_opt_String(accountUuid, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 62,
             port: port_,
           );
         },
@@ -3270,7 +3313,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(name, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 62)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 63)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3310,7 +3353,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 64,
             port: port_,
           );
         },
@@ -3374,7 +3417,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 65,
             port: port_,
           );
         },
@@ -3436,7 +3479,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 66,
             port: port_,
           );
         },
@@ -3471,7 +3514,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 67,
             port: port_,
           );
         },
@@ -3502,7 +3545,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_u_64(nowSeconds, serializer);
           sse_encode_u_64(ceremonyStartSeconds, serializer);
           sse_encode_u_64(voteEndTimeSeconds, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 67)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3526,7 +3569,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 68)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3551,7 +3594,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 69)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3573,7 +3616,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3600,7 +3643,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_64(ceremonyStartSeconds, serializer);
           sse_encode_u_64(voteEndTimeSeconds, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_u_64,
@@ -3633,7 +3676,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 73,
             port: port_,
           );
         },
@@ -3673,7 +3716,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 74,
             port: port_,
           );
         },
@@ -3716,7 +3759,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 75,
             port: port_,
           );
         },
@@ -3773,7 +3816,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 76,
             port: port_,
           );
         },
@@ -3814,7 +3857,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 76)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 77)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -3844,7 +3887,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 78,
             port: port_,
           );
         },
@@ -3879,7 +3922,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 79,
             port: port_,
           );
         },
@@ -3922,7 +3965,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 80,
             port: port_,
           );
         },
@@ -3976,7 +4019,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 81,
             port: port_,
           );
         },
@@ -4015,7 +4058,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 82,
             port: port_,
           );
         },
@@ -4067,7 +4110,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 83,
             port: port_,
           );
         },
@@ -4125,7 +4168,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 84,
             port: port_,
           );
         },
@@ -4186,7 +4229,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 85,
             port: port_,
           );
         },
@@ -4245,7 +4288,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 86,
             port: port_,
           );
         },
@@ -4292,7 +4335,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 87,
             port: port_,
           );
         },
@@ -4337,7 +4380,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 88,
             port: port_,
           );
         },
@@ -4364,7 +4407,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4396,7 +4439,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 90,
             port: port_,
           );
         },
@@ -4433,7 +4476,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4468,7 +4511,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 92,
             port: port_,
           );
         },
@@ -4510,7 +4553,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -4547,7 +4590,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 94,
             port: port_,
           );
         },
@@ -4585,7 +4628,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 95,
             port: port_,
           );
         },
@@ -4638,7 +4681,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 96,
             port: port_,
           );
         },
@@ -4706,7 +4749,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -4750,7 +4793,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_8(mode, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 97)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 98)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4784,7 +4827,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 99,
             port: port_,
           );
         },
@@ -4817,7 +4860,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 100,
             port: port_,
           );
         },
@@ -4857,7 +4900,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 101,
             port: port_,
           );
         },
@@ -4898,7 +4941,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 102,
             port: port_,
           );
         },
@@ -4952,7 +4995,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 103,
             port: port_,
           );
         },
@@ -5002,7 +5045,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 103,
+              funcId: 104,
               port: port_,
             );
           },
@@ -5043,7 +5086,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 104,
+              funcId: 105,
               port: port_,
             );
           },
@@ -5075,7 +5118,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 106,
           )!;
         },
         codec: SseCodec(
@@ -5116,7 +5159,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 107,
             port: port_,
           );
         },
@@ -5167,7 +5210,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 108,
             port: port_,
           );
         },
@@ -5206,7 +5249,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 109,
             port: port_,
           );
         },
@@ -5249,7 +5292,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
             port: port_,
           );
         },
@@ -5299,7 +5342,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5331,7 +5374,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5359,7 +5402,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
           )!;
         },
         codec: SseCodec(
@@ -5391,7 +5434,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
             port: port_,
           );
         },
@@ -5428,7 +5471,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },
@@ -5459,7 +5502,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
           )!;
         },
         codec: SseCodec(
@@ -5490,7 +5533,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
             port: port_,
           );
         },

--- a/lib/widgetbook/receive_use_cases.dart
+++ b/lib/widgetbook/receive_use_cases.dart
@@ -208,10 +208,6 @@ class _WidgetbookReceiveAddressService implements ReceiveAddressService {
   }) async => currentShieldedAddress ?? _mobileShieldedAddress;
 
   @override
-  Future<String> loadTransparentAddress({required String accountUuid}) async =>
-      _mobileTransparentAddress;
-
-  @override
   Future<String> loadTransparentReceiveAddress({
     required String accountUuid,
   }) async => _mobileTransparentAddress;

--- a/lib/widgetbook/receive_use_cases.dart
+++ b/lib/widgetbook/receive_use_cases.dart
@@ -72,14 +72,12 @@ class _ReceiveDesktopHarness extends StatelessWidget {
       color: colors.background.window,
       child: LayoutBuilder(
         builder: (context, constraints) {
-          final maxWidth =
-              constraints.maxWidth.isFinite
-                  ? constraints.maxWidth
-                  : ReceiveDesktopPreview.size.width;
-          final maxHeight =
-              constraints.maxHeight.isFinite
-                  ? constraints.maxHeight
-                  : ReceiveDesktopPreview.size.height;
+          final maxWidth = constraints.maxWidth.isFinite
+              ? constraints.maxWidth
+              : ReceiveDesktopPreview.size.width;
+          final maxHeight = constraints.maxHeight.isFinite
+              ? constraints.maxHeight
+              : ReceiveDesktopPreview.size.height;
           final contentWidth = math.max(320.0, maxWidth);
           final contentHeight = math.max(240.0, maxHeight);
           final scale = math.min(
@@ -212,6 +210,11 @@ class _WidgetbookReceiveAddressService implements ReceiveAddressService {
   @override
   Future<String> loadTransparentAddress({required String accountUuid}) async =>
       _mobileTransparentAddress;
+
+  @override
+  Future<String> loadTransparentReceiveAddress({
+    required String accountUuid,
+  }) async => _mobileTransparentAddress;
 
   @override
   Future<String> renewShieldedAddress({required String accountUuid}) async =>

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -1556,11 +1556,6 @@ class _PreviewReceiveAddressService implements ReceiveAddressService {
   }
 
   @override
-  Future<String> loadTransparentAddress({required String accountUuid}) async {
-    return 't1WidgetbookTransparentAddress';
-  }
-
-  @override
   Future<String> loadTransparentReceiveAddress({
     required String accountUuid,
   }) async {

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -1561,6 +1561,13 @@ class _PreviewReceiveAddressService implements ReceiveAddressService {
   }
 
   @override
+  Future<String> loadTransparentReceiveAddress({
+    required String accountUuid,
+  }) async {
+    return 't1WidgetbookTransparentAddress';
+  }
+
+  @override
   Future<String> renewShieldedAddress({required String accountUuid}) async {
     return 'u1widgetbookaccountsrenewedaddress';
   }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2801,6 +2801,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "reddsa"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,6 +2956,7 @@ dependencies = [
  "prost 0.14.3",
  "rand",
  "rand_core",
+ "redb",
  "rusqlite",
  "rustls",
  "sapling-crypto",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -76,6 +76,7 @@ rustls = "0.23"
 
 # SQLite (re-exported by zcash_client_sqlite but needed for Connection type)
 rusqlite = "0.37"
+redb = "4.1.0"
 
 # Logging (FRB forwards to Dart console via setup_default_user_utils)
 log = "0.4"

--- a/rust/examples/regtest_wallet_addresses.rs
+++ b/rust/examples/regtest_wallet_addresses.rs
@@ -34,7 +34,7 @@ fn main() {
     )
     .expect("import regtest wallet");
 
-    let transparent_address = wallet::get_transparent_address(
+    let transparent_address = wallet::get_transparent_receive_address(
         db_path,
         "regtest".to_string(),
         Some(result.account_uuid.clone()),

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -734,18 +734,6 @@ pub fn validate_mnemonic(mnemonic: String) -> bool {
     keys::mnemonic_to_seed(&mnemonic).is_ok()
 }
 
-/// Get the transparent address for a specific account (or first account if uuid is None).
-pub fn get_transparent_address(
-    db_path: String,
-    network: String,
-    account_uuid: Option<String>,
-) -> Result<String, String> {
-    catch(|| {
-        let network = parse_network_and_migrate(&db_path, &network)?;
-        keys::get_transparent_address_from_db(&db_path, network, account_uuid.as_deref())
-    })
-}
-
 /// Get the next transparent receive address for a specific account.
 ///
 /// This is read-only: it returns the first tracked external transparent address

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -738,6 +738,21 @@ pub fn get_transparent_address(
     })
 }
 
+/// Get the next transparent receive address for a specific account.
+///
+/// This is read-only: it returns the first tracked external transparent address
+/// that has not received a transparent output.
+pub fn get_transparent_receive_address(
+    db_path: String,
+    network: String,
+    account_uuid: Option<String>,
+) -> Result<String, String> {
+    catch(|| {
+        let network = parse_network_and_migrate(&db_path, &network)?;
+        keys::get_transparent_receive_address_from_db(&db_path, network, account_uuid.as_deref())
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -1,6 +1,6 @@
 use std::panic;
 
-use crate::wallet::{keys, network::WalletNetwork};
+use crate::wallet::{keys, network::WalletNetwork, transparent_receive_cache};
 use tonic::{transport::Channel, Request};
 use zcash_client_backend::proto::service::{
     self, compact_tx_streamer_client::CompactTxStreamerClient,
@@ -678,7 +678,15 @@ pub fn delete_account(
 ) -> Result<(), String> {
     catch(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
-        keys::delete_account(&db_path, network, &account_uuid)
+        keys::delete_account(&db_path, network, &account_uuid)?;
+        if let Err(e) = transparent_receive_cache::delete_account(&db_path, &account_uuid) {
+            log::warn!(
+                "transparent receive cache: failed to delete account {}: {}",
+                account_uuid,
+                e
+            );
+        }
+        Ok(())
     })
 }
 
@@ -748,8 +756,83 @@ pub fn get_transparent_receive_address(
     account_uuid: Option<String>,
 ) -> Result<String, String> {
     catch(|| {
-        let network = parse_network_and_migrate(&db_path, &network)?;
-        keys::get_transparent_receive_address_from_db(&db_path, network, account_uuid.as_deref())
+        let network = keys::parse_network(&network)?;
+        if let Some(account_uuid) = account_uuid.as_deref() {
+            match transparent_receive_cache::get_clean_address(&db_path, network, account_uuid) {
+                Ok(Some(address)) => return Ok(address),
+                Ok(None) => {}
+                Err(e) => log::warn!("transparent receive cache: read failed: {e}"),
+            }
+        }
+
+        keys::ensure_db_migrated_once(&db_path, network)?;
+        match account_uuid.as_deref() {
+            Some(account_uuid) => transparent_receive_cache::refresh_account_from_wallet_db(
+                &db_path,
+                network,
+                account_uuid,
+                None,
+            ),
+            None => keys::get_transparent_receive_address_from_db(&db_path, network, None),
+        }
+    })
+}
+
+pub fn get_recent_transparent_receive_addresses(
+    db_path: String,
+    network: String,
+    account_uuid: Option<String>,
+    limit: u32,
+) -> Result<Vec<String>, String> {
+    catch(|| {
+        let network = keys::parse_network(&network)?;
+        if let Some(account_uuid) = account_uuid.as_deref() {
+            match transparent_receive_cache::get_recent_addresses(
+                &db_path,
+                network,
+                account_uuid,
+                limit,
+            ) {
+                Ok(Some(addresses)) => return Ok(addresses),
+                Ok(None) => {}
+                Err(e) => log::warn!("transparent receive cache: recent read failed: {e}"),
+            }
+        }
+
+        keys::ensure_db_migrated_once(&db_path, network)?;
+        if let Some(account_uuid) = account_uuid.as_deref() {
+            match transparent_receive_cache::refresh_account_cache_from_wallet_db(
+                &db_path,
+                network,
+                account_uuid,
+                None,
+            ) {
+                Ok(()) => match transparent_receive_cache::get_recent_addresses(
+                    &db_path,
+                    network,
+                    account_uuid,
+                    limit,
+                ) {
+                    Ok(Some(addresses)) => return Ok(addresses),
+                    Ok(None) => {}
+                    Err(e) => log::warn!(
+                        "transparent receive cache: recent read after refresh failed: {e}"
+                    ),
+                },
+                Err(e) => log::warn!(
+                    "transparent receive cache: recent refresh failed for account {}: {}",
+                    account_uuid,
+                    e
+                ),
+            }
+        }
+
+        keys::get_recent_transparent_receive_addresses_from_db(
+            &db_path,
+            network,
+            account_uuid.as_deref(),
+            limit,
+        )
     })
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -413437861;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1052771162;
 
 // Section: executor
 
@@ -2334,45 +2334,6 @@ fn wire__crate__api__sync__get_transaction_history_impl(
                         api_db_path,
                         api_network,
                         api_limit,
-                        api_account_uuid,
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
-fn wire__crate__api__wallet__get_transparent_address_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "get_transparent_address",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_db_path = <String>::sse_decode(&mut deserializer);
-            let api_network = <String>::sse_decode(&mut deserializer);
-            let api_account_uuid = <Option<String>>::sse_decode(&mut deserializer);
-            deserializer.end();
-            move |context| {
-                transform_result_sse::<_, String>((move || {
-                    let output_ok = crate::api::wallet::get_transparent_address(
-                        api_db_path,
-                        api_network,
                         api_account_uuid,
                     )?;
                     Ok(output_ok)
@@ -6952,52 +6913,51 @@ fn pde_ffi_dispatcher_primary_impl(
 57 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
 58 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
 60 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
-61 => wire__crate__api__wallet__get_transparent_address_impl(port, ptr, rust_vec_len, data_len),
-62 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
-63 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-65 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
-66 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
-67 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-68 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-74 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-75 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-76 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
-77 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-79 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-80 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
-81 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
-82 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-83 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-86 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-91 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-92 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-93 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-94 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
-95 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-97 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-100 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-103 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-104 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-105 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-106 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-108 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-109 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-116 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+61 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
+62 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+64 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
+65 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
+66 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+67 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+73 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+74 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+75 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
+76 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+78 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
+80 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+82 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+88 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+92 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+96 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+99 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+101 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+102 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+104 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+105 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+107 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+108 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+109 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+117 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -7015,20 +6975,20 @@ fn pde_ffi_dispatcher_sync_impl(
         44 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
         56 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
         59 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
-        64 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
-        71 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        72 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        73 => {
+        63 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        68 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        71 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        72 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        78 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        90 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        99 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        107 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        114 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        117 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        77 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        89 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        98 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        106 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        113 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        116 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2006318776;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -413437861;
 
 // Section: executor
 
@@ -1996,6 +1996,47 @@ fn wire__crate__api__sync__get_previous_transaction_count_for_address_impl(
                         api_network,
                         api_account_uuid,
                         api_address,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet__get_recent_transparent_receive_addresses_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_recent_transparent_receive_addresses",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <Option<String>>::sse_decode(&mut deserializer);
+            let api_limit = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::wallet::get_recent_transparent_receive_addresses(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                        api_limit,
                     )?;
                     Ok(output_ok)
                 })())
@@ -6904,58 +6945,59 @@ fn pde_ffi_dispatcher_primary_impl(
 49 => wire__crate__api__sync__get_next_available_address_impl(port, ptr, rust_vec_len, data_len),
 50 => wire__crate__api__sync__get_next_subtree_indices_impl(port, ptr, rust_vec_len, data_len),
 51 => wire__crate__api__sync__get_previous_transaction_count_for_address_impl(port, ptr, rust_vec_len, data_len),
-52 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
-53 => wire__crate__api__voting__get_round_recovery_state_impl(port, ptr, rust_vec_len, data_len),
-54 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
-56 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
-57 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
-59 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
-60 => wire__crate__api__wallet__get_transparent_address_impl(port, ptr, rust_vec_len, data_len),
-61 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
-62 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-64 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
-65 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
-66 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-67 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-73 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-74 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-75 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
-76 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-78 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-79 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
-80 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
-81 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-82 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-83 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-86 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-90 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-91 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-92 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-93 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
-94 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-95 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-97 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-99 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-100 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-103 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-104 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-105 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-107 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-108 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-109 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-117 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+52 => wire__crate__api__wallet__get_recent_transparent_receive_addresses_impl(port, ptr, rust_vec_len, data_len),
+53 => wire__crate__api__voting__get_round_plan_impl(port, ptr, rust_vec_len, data_len),
+54 => wire__crate__api__voting__get_round_recovery_state_impl(port, ptr, rust_vec_len, data_len),
+55 => wire__crate__api__sync__get_shield_transparent_status_impl(port, ptr, rust_vec_len, data_len),
+57 => wire__crate__api__sync__get_sync_status_impl(port, ptr, rust_vec_len, data_len),
+58 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
+60 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
+61 => wire__crate__api__wallet__get_transparent_address_impl(port, ptr, rust_vec_len, data_len),
+62 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
+63 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+65 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
+66 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
+67 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+68 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+74 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+75 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+76 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
+77 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+80 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
+82 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+88 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+92 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+96 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+101 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+102 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+104 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+105 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+106 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+108 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+109 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+116 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+118 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -6971,22 +7013,22 @@ fn pde_ffi_dispatcher_sync_impl(
         8 => wire__crate__api__sync__cancel_full_sync_impl(ptr, rust_vec_len, data_len),
         39 => wire__crate__api__wallet__generate_mnemonic_impl(ptr, rust_vec_len, data_len),
         44 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
-        63 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        71 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        72 => {
+        56 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
+        64 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
+        71 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        72 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        73 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        77 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        89 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        98 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        106 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        113 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        116 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        78 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        90 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        99 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        107 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        114 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        117 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 724045055;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2006318776;
 
 // Section: executor
 
@@ -2330,6 +2330,45 @@ fn wire__crate__api__wallet__get_transparent_address_impl(
             move |context| {
                 transform_result_sse::<_, String>((move || {
                     let output_ok = crate::api::wallet::get_transparent_address(
+                        api_db_path,
+                        api_network,
+                        api_account_uuid,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__wallet__get_transparent_receive_address_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_transparent_receive_address",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_account_uuid = <Option<String>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::wallet::get_transparent_receive_address(
                         api_db_path,
                         api_network,
                         api_account_uuid,
@@ -6872,50 +6911,51 @@ fn pde_ffi_dispatcher_primary_impl(
 57 => wire__crate__api__sync__get_transaction_data_requests_impl(port, ptr, rust_vec_len, data_len),
 59 => wire__crate__api__sync__get_transaction_history_impl(port, ptr, rust_vec_len, data_len),
 60 => wire__crate__api__wallet__get_transparent_address_impl(port, ptr, rust_vec_len, data_len),
-61 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
-63 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
-64 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
-65 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
-66 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-72 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-73 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-74 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
-75 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-77 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-78 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
-79 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
-80 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-81 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-82 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-83 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-86 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-90 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-91 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-92 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
-93 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-94 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-95 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-99 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-100 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-103 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-104 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-106 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-107 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-108 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-109 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-116 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+61 => wire__crate__api__wallet__get_transparent_receive_address_impl(port, ptr, rust_vec_len, data_len),
+62 => wire__crate__api__wallet__get_unified_address_impl(port, ptr, rust_vec_len, data_len),
+64 => wire__crate__api__wallet__import_hardware_account_impl(port, ptr, rust_vec_len, data_len),
+65 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
+66 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
+67 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
+73 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+74 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+75 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
+76 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+78 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
+80 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+82 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+88 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+92 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+96 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+99 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+101 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+102 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+104 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+105 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+107 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+108 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+109 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+117 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -6933,20 +6973,20 @@ fn pde_ffi_dispatcher_sync_impl(
         44 => wire__crate__api__sync__get_blocks_dir_impl(ptr, rust_vec_len, data_len),
         55 => wire__crate__api__sync__get_sync_mode_impl(ptr, rust_vec_len, data_len),
         58 => wire__crate__api__sync__get_transaction_detail_impl(ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
-        68 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        71 => {
+        63 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
+        68 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
+        69 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        71 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        72 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        76 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        88 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        97 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        105 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        112 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        115 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        77 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        89 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        98 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        106 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        113 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        116 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -885,31 +885,6 @@ fn orchard_address_request() -> UnifiedAddressRequest {
     .expect("valid receiver requirements")
 }
 
-/// Get the transparent address from an existing wallet database.
-pub fn get_transparent_address_from_db(
-    db_path: &str,
-    network: WalletNetwork,
-    account_uuid: Option<&str>,
-) -> Result<String, String> {
-    let db = open_wallet_db_for_read(db_path, network)?;
-
-    let account_id = resolve_account_id(&db, account_uuid)?;
-
-    let current_ua = db
-        .get_last_generated_address_matching(account_id, UnifiedAddressRequest::AllAvailableKeys)
-        .map_err(|e| format!("Failed to get current generated address: {e}"))?
-        .ok_or_else(|| "No tracked transparent address available".to_string())?;
-    let taddr = current_ua.transparent().ok_or_else(|| {
-        "Current generated address does not include a transparent receiver".to_string()
-    })?;
-
-    Ok(encode_transparent_address(
-        &network.b58_pubkey_address_prefix(),
-        &network.b58_script_address_prefix(),
-        taddr,
-    ))
-}
-
 /// Get the first external transparent receive address that has no received output.
 ///
 /// zcash_client_sqlite pre-generates external transparent gap-limit rows for

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -39,6 +39,13 @@ const MAX_MNEMONIC_WORD_COUNT: usize = 24;
 const MNEMONIC_WORD_COUNT_STEP: usize = 3;
 const TRANSPARENT_EXTERNAL_KEY_SCOPE: i64 = 0;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ExternalTransparentAddress {
+    pub child_index: u32,
+    pub address: String,
+    pub has_received: bool,
+}
+
 fn map_account_import_error(
     error: SqliteClientError,
     duplicate_message: &str,
@@ -575,6 +582,25 @@ pub fn list_accounts(db_path: &str, network: WalletNetwork) -> Result<Vec<Accoun
     Ok(accounts)
 }
 
+pub fn list_account_uuids_from_db(db_path: &str) -> Result<Vec<String>, String> {
+    let conn = open_readonly_conn_with_timeout(db_path, Some(READ_DB_BUSY_TIMEOUT))?;
+    let mut stmt = conn
+        .prepare("SELECT uuid FROM accounts ORDER BY id ASC")
+        .map_err(|e| format!("Failed to prepare account UUID query: {e}"))?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, Vec<u8>>(0))
+        .map_err(|e| format!("Failed to list account UUIDs: {e}"))?;
+
+    let mut uuids = Vec::new();
+    for row in rows {
+        let bytes = row.map_err(|e| format!("Failed to read account UUID: {e}"))?;
+        let uuid = uuid::Uuid::from_slice(&bytes)
+            .map_err(|e| format!("Invalid account UUID bytes in DB: {e}"))?;
+        uuids.push(uuid.to_string());
+    }
+    Ok(uuids)
+}
+
 /// Delete an account from the wallet database.
 pub fn delete_account(
     db_path: &str,
@@ -892,38 +918,131 @@ pub fn get_transparent_address_from_db(
 /// expose a new address.
 pub fn get_transparent_receive_address_from_db(
     db_path: &str,
-    _network: WalletNetwork,
+    network: WalletNetwork,
     account_uuid: Option<&str>,
 ) -> Result<String, String> {
+    let addresses =
+        get_external_transparent_receive_addresses_from_db(db_path, network, account_uuid)?;
+    first_unused_external_transparent_address(&addresses)
+        .ok_or_else(|| "No unused external transparent receive address available".to_string())
+}
+
+pub(crate) fn get_external_transparent_receive_addresses_from_db(
+    db_path: &str,
+    _network: WalletNetwork,
+    account_uuid: Option<&str>,
+) -> Result<Vec<ExternalTransparentAddress>, String> {
     let conn = open_readonly_conn_with_timeout(db_path, Some(READ_DB_BUSY_TIMEOUT))?;
     let account_uuid_bytes = resolve_account_uuid_bytes_for_read(&conn, account_uuid)?;
 
-    conn.query_row(
-        r#"
-        SELECT a.cached_transparent_receiver_address
-        FROM addresses a
-        JOIN accounts acct ON acct.id = a.account_id
-        WHERE acct.uuid = :account_uuid
-          AND a.key_scope = :external_scope
-          AND a.transparent_child_index IS NOT NULL
-          AND a.cached_transparent_receiver_address IS NOT NULL
-          AND NOT EXISTS (
-              SELECT 1
-              FROM transparent_received_outputs tro
-              WHERE tro.address_id = a.id
-          )
-        ORDER BY a.transparent_child_index ASC
-        LIMIT 1
-        "#,
-        named_params! {
-            ":account_uuid": account_uuid_bytes.as_slice(),
-            ":external_scope": TRANSPARENT_EXTERNAL_KEY_SCOPE,
-        },
-        |row| row.get::<_, String>(0),
-    )
-    .optional()
-    .map_err(|e| format!("Failed to get transparent receive address: {e}"))?
-    .ok_or_else(|| "No unused external transparent receive address available".to_string())
+    let mut stmt = conn
+        .prepare(
+            r#"
+            SELECT a.transparent_child_index,
+                   a.cached_transparent_receiver_address,
+                   EXISTS (
+                       SELECT 1
+                       FROM transparent_received_outputs tro
+                       WHERE tro.address_id = a.id
+                   ) AS has_received
+            FROM addresses a
+            JOIN accounts acct ON acct.id = a.account_id
+            WHERE acct.uuid = :account_uuid
+              AND a.key_scope = :external_scope
+              AND a.transparent_child_index IS NOT NULL
+              AND a.cached_transparent_receiver_address IS NOT NULL
+            ORDER BY a.transparent_child_index ASC
+            "#,
+        )
+        .map_err(|e| format!("Failed to prepare external transparent address query: {e}"))?;
+
+    let rows = stmt
+        .query_map(
+            named_params! {
+                ":account_uuid": account_uuid_bytes.as_slice(),
+                ":external_scope": TRANSPARENT_EXTERNAL_KEY_SCOPE,
+            },
+            |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, i64>(2)? != 0,
+                ))
+            },
+        )
+        .map_err(|e| format!("Failed to get external transparent addresses: {e}"))?;
+
+    let mut addresses = Vec::new();
+    for row in rows {
+        let (child_index, address, has_received) =
+            row.map_err(|e| format!("Failed to read external transparent address: {e}"))?;
+        let child_index = u32::try_from(child_index)
+            .map_err(|e| format!("Invalid transparent child index {child_index}: {e}"))?;
+        addresses.push(ExternalTransparentAddress {
+            child_index,
+            address,
+            has_received,
+        });
+    }
+
+    Ok(addresses)
+}
+
+pub fn get_recent_transparent_receive_addresses_from_db(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: Option<&str>,
+    limit: u32,
+) -> Result<Vec<String>, String> {
+    if limit == 0 {
+        return Ok(Vec::new());
+    }
+    let addresses =
+        get_external_transparent_receive_addresses_from_db(db_path, network, account_uuid)?;
+    Ok(recent_external_transparent_addresses(
+        &addresses,
+        limit.min(100) as usize,
+    ))
+}
+
+pub(crate) fn first_unused_external_transparent_address(
+    addresses: &[ExternalTransparentAddress],
+) -> Option<String> {
+    addresses
+        .iter()
+        .filter(|address| !address.has_received)
+        .min_by_key(|address| address.child_index)
+        .map(|address| address.address.clone())
+}
+
+pub(crate) fn recent_external_transparent_addresses(
+    addresses: &[ExternalTransparentAddress],
+    limit: usize,
+) -> Vec<String> {
+    if limit == 0 {
+        return Vec::new();
+    }
+
+    let Some(latest_index) = addresses
+        .iter()
+        .filter(|address| !address.has_received)
+        .map(|address| address.child_index)
+        .min()
+        .or_else(|| addresses.iter().map(|address| address.child_index).max())
+    else {
+        return Vec::new();
+    };
+
+    let mut recent = addresses
+        .iter()
+        .filter(|address| address.child_index <= latest_index)
+        .collect::<Vec<_>>();
+    recent.sort_by_key(|address| std::cmp::Reverse(address.child_index));
+    recent
+        .into_iter()
+        .take(limit)
+        .map(|address| address.address.clone())
+        .collect()
 }
 
 /// Validate that a wallet database exists and has at least one account.
@@ -1180,6 +1299,71 @@ mod tests {
 
         assert_eq!(receive_address, second_external);
         assert_eq!(second_exposed_after, second_exposed_before);
+    }
+
+    #[test]
+    fn test_get_recent_transparent_receive_addresses_walks_down_from_current_receive() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let phrase = generate_mnemonic();
+        let seed = mnemonic_to_seed(&phrase).unwrap();
+        let (uuid, _) =
+            init_db_and_create_account(db_path_str, WalletNetwork::Main, &seed, None, "test")
+                .unwrap();
+
+        let conn = rusqlite::Connection::open(db_path_str).unwrap();
+        conn.execute("PRAGMA foreign_keys = ON", []).unwrap();
+        let rows = external_transparent_address_rows(&conn, &uuid);
+        assert!(rows.len() >= 4);
+
+        mark_transparent_address_received(&conn, &uuid, rows[0].0, &rows[0].1, 1);
+        mark_transparent_address_received(&conn, &uuid, rows[1].0, &rows[1].1, 2);
+
+        let recent = get_recent_transparent_receive_addresses_from_db(
+            db_path_str,
+            WalletNetwork::Main,
+            Some(&uuid),
+            3,
+        )
+        .unwrap();
+
+        assert_eq!(
+            recent,
+            vec![rows[2].1.clone(), rows[1].1.clone(), rows[0].1.clone()]
+        );
+    }
+
+    #[test]
+    fn test_get_recent_transparent_receive_addresses_honors_limit() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let phrase = generate_mnemonic();
+        let seed = mnemonic_to_seed(&phrase).unwrap();
+        let (uuid, _) =
+            init_db_and_create_account(db_path_str, WalletNetwork::Main, &seed, None, "test")
+                .unwrap();
+
+        let conn = rusqlite::Connection::open(db_path_str).unwrap();
+        conn.execute("PRAGMA foreign_keys = ON", []).unwrap();
+        let rows = external_transparent_address_rows(&conn, &uuid);
+        assert!(rows.len() >= 4);
+        mark_transparent_address_received(&conn, &uuid, rows[0].0, &rows[0].1, 1);
+        mark_transparent_address_received(&conn, &uuid, rows[1].0, &rows[1].1, 2);
+        mark_transparent_address_received(&conn, &uuid, rows[2].0, &rows[2].1, 3);
+
+        let recent = get_recent_transparent_receive_addresses_from_db(
+            db_path_str,
+            WalletNetwork::Main,
+            Some(&uuid),
+            2,
+        )
+        .unwrap();
+
+        assert_eq!(recent, vec![rows[3].1.clone(), rows[2].1.clone()]);
     }
 
     #[test]

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -6,7 +6,7 @@ use std::{
 
 use ::transparent::keys::{IncomingViewingKey as _, NonHardenedChildIndex};
 use bip0039::{Count, English, Language, Mnemonic};
-use rusqlite::named_params;
+use rusqlite::{named_params, OptionalExtension};
 use secrecy::{ExposeSecret, SecretVec};
 use zcash_client_backend::data_api::{
     chain::ChainState, Account as _, AccountBirthday, AccountPurpose, AccountSource, WalletRead,
@@ -24,9 +24,9 @@ use zip32::fingerprint::SeedFingerprint;
 
 use crate::wallet::{
     db::{
-        open_wallet_db_for_read_with_timeout, open_wallet_db_with_timeout,
-        with_wallet_db_write_lock, WalletDatabase, ACCOUNT_MUTATION_DB_BUSY_TIMEOUT,
-        READ_DB_BUSY_TIMEOUT, WALLET_DB_BUSY_TIMEOUT,
+        open_readonly_conn_with_timeout, open_wallet_db_for_read_with_timeout,
+        open_wallet_db_with_timeout, with_wallet_db_write_lock, WalletDatabase,
+        ACCOUNT_MUTATION_DB_BUSY_TIMEOUT, READ_DB_BUSY_TIMEOUT, WALLET_DB_BUSY_TIMEOUT,
     },
     network::WalletNetwork,
 };
@@ -37,6 +37,7 @@ const DUPLICATE_KEYSTONE_ACCOUNT_MESSAGE: &str = "This Keystone account is alrea
 const MIN_MNEMONIC_WORD_COUNT: usize = 12;
 const MAX_MNEMONIC_WORD_COUNT: usize = 24;
 const MNEMONIC_WORD_COUNT_STEP: usize = 3;
+const TRANSPARENT_EXTERNAL_KEY_SCOPE: i64 = 0;
 
 fn map_account_import_error(
     error: SqliteClientError,
@@ -759,6 +760,27 @@ fn resolve_account_id(
     }
 }
 
+fn resolve_account_uuid_bytes_for_read(
+    conn: &rusqlite::Connection,
+    account_uuid: Option<&str>,
+) -> Result<Vec<u8>, String> {
+    match account_uuid {
+        Some(uuid_str) => {
+            let account_id = parse_account_uuid(uuid_str)?;
+            Ok(account_id.expose_uuid().as_bytes().to_vec())
+        }
+        None => conn
+            .query_row(
+                "SELECT uuid FROM accounts ORDER BY id ASC LIMIT 1",
+                [],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .optional()
+            .map_err(|e| format!("Failed to resolve first account: {e}"))?
+            .ok_or_else(|| "No accounts found in wallet".to_string()),
+    }
+}
+
 /// Get the Unified Address from an existing wallet database.
 pub fn get_address_from_db(
     db_path: &str,
@@ -860,6 +882,48 @@ pub fn get_transparent_address_from_db(
         &network.b58_script_address_prefix(),
         taddr,
     ))
+}
+
+/// Get the first external transparent receive address that has no received output.
+///
+/// zcash_client_sqlite pre-generates external transparent gap-limit rows for
+/// each account. This function intentionally reads those rows without calling
+/// get_next_available_address, so displaying receive UI does not reserve or
+/// expose a new address.
+pub fn get_transparent_receive_address_from_db(
+    db_path: &str,
+    _network: WalletNetwork,
+    account_uuid: Option<&str>,
+) -> Result<String, String> {
+    let conn = open_readonly_conn_with_timeout(db_path, Some(READ_DB_BUSY_TIMEOUT))?;
+    let account_uuid_bytes = resolve_account_uuid_bytes_for_read(&conn, account_uuid)?;
+
+    conn.query_row(
+        r#"
+        SELECT a.cached_transparent_receiver_address
+        FROM addresses a
+        JOIN accounts acct ON acct.id = a.account_id
+        WHERE acct.uuid = :account_uuid
+          AND a.key_scope = :external_scope
+          AND a.transparent_child_index IS NOT NULL
+          AND a.cached_transparent_receiver_address IS NOT NULL
+          AND NOT EXISTS (
+              SELECT 1
+              FROM transparent_received_outputs tro
+              WHERE tro.address_id = a.id
+          )
+        ORDER BY a.transparent_child_index ASC
+        LIMIT 1
+        "#,
+        named_params! {
+            ":account_uuid": account_uuid_bytes.as_slice(),
+            ":external_scope": TRANSPARENT_EXTERNAL_KEY_SCOPE,
+        },
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .map_err(|e| format!("Failed to get transparent receive address: {e}"))?
+    .ok_or_else(|| "No unused external transparent receive address available".to_string())
 }
 
 /// Validate that a wallet database exists and has at least one account.
@@ -1063,6 +1127,101 @@ mod tests {
                 .unwrap()
                 .unified_address
         );
+    }
+
+    #[test]
+    fn test_get_transparent_receive_address_returns_first_unused_external_address() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let phrase = generate_mnemonic();
+        let seed = mnemonic_to_seed(&phrase).unwrap();
+        let (uuid, _) =
+            init_db_and_create_account(db_path_str, WalletNetwork::Main, &seed, None, "test")
+                .unwrap();
+
+        let conn = rusqlite::Connection::open(db_path_str).unwrap();
+        let (_, first_external, exposed_before) = external_transparent_address_row(&conn, &uuid, 0);
+
+        let receive_address =
+            get_transparent_receive_address_from_db(db_path_str, WalletNetwork::Main, Some(&uuid))
+                .unwrap();
+        let (_, _, exposed_after) = external_transparent_address_row(&conn, &uuid, 0);
+
+        assert_eq!(receive_address, first_external);
+        assert_eq!(exposed_after, exposed_before);
+    }
+
+    #[test]
+    fn test_get_transparent_receive_address_skips_received_external_address() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let phrase = generate_mnemonic();
+        let seed = mnemonic_to_seed(&phrase).unwrap();
+        let (uuid, _) =
+            init_db_and_create_account(db_path_str, WalletNetwork::Main, &seed, None, "test")
+                .unwrap();
+
+        let conn = rusqlite::Connection::open(db_path_str).unwrap();
+        conn.execute("PRAGMA foreign_keys = ON", []).unwrap();
+        let (first_id, first_external, _) = external_transparent_address_row(&conn, &uuid, 0);
+        let (_, second_external, second_exposed_before) =
+            external_transparent_address_row(&conn, &uuid, 1);
+
+        mark_transparent_address_received(&conn, &uuid, first_id, &first_external, 1);
+
+        let receive_address =
+            get_transparent_receive_address_from_db(db_path_str, WalletNetwork::Main, Some(&uuid))
+                .unwrap();
+        let (_, _, second_exposed_after) = external_transparent_address_row(&conn, &uuid, 1);
+
+        assert_eq!(receive_address, second_external);
+        assert_eq!(second_exposed_after, second_exposed_before);
+    }
+
+    #[test]
+    fn test_get_transparent_receive_address_does_not_return_internal_or_ephemeral() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+
+        let phrase = generate_mnemonic();
+        let seed = mnemonic_to_seed(&phrase).unwrap();
+        let (uuid, _) =
+            init_db_and_create_account(db_path_str, WalletNetwork::Main, &seed, None, "test")
+                .unwrap();
+
+        let conn = rusqlite::Connection::open(db_path_str).unwrap();
+        conn.execute("PRAGMA foreign_keys = ON", []).unwrap();
+        let account_id = account_row_id(&conn, &uuid);
+        let non_external_count: i64 = conn
+            .query_row(
+                r#"
+                SELECT COUNT(*)
+                FROM addresses
+                WHERE account_id = ?1
+                  AND key_scope IN (1, 2)
+                  AND cached_transparent_receiver_address IS NOT NULL
+                "#,
+                rusqlite::params![account_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(non_external_count > 0);
+
+        let external_rows = external_transparent_address_rows(&conn, &uuid);
+        assert!(!external_rows.is_empty());
+        for (index, (address_id, address)) in external_rows.iter().enumerate() {
+            mark_transparent_address_received(&conn, &uuid, *address_id, address, index as u32);
+        }
+
+        let error =
+            get_transparent_receive_address_from_db(db_path_str, WalletNetwork::Main, Some(&uuid))
+                .unwrap_err();
+        assert!(error.contains("No unused external transparent receive address available"));
     }
 
     #[test]
@@ -1422,6 +1581,85 @@ mod tests {
             |row| row.get(0),
         )
         .unwrap()
+    }
+
+    fn external_transparent_address_row(
+        conn: &rusqlite::Connection,
+        account_uuid: &str,
+        child_index: i64,
+    ) -> (i64, String, Option<i64>) {
+        let account_id = account_row_id(conn, account_uuid);
+        conn.query_row(
+            r#"
+            SELECT id, cached_transparent_receiver_address, exposed_at_height
+            FROM addresses
+            WHERE account_id = ?1
+              AND key_scope = ?2
+              AND transparent_child_index = ?3
+              AND cached_transparent_receiver_address IS NOT NULL
+            "#,
+            rusqlite::params![account_id, TRANSPARENT_EXTERNAL_KEY_SCOPE, child_index],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap()
+    }
+
+    fn external_transparent_address_rows(
+        conn: &rusqlite::Connection,
+        account_uuid: &str,
+    ) -> Vec<(i64, String)> {
+        let account_id = account_row_id(conn, account_uuid);
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT id, cached_transparent_receiver_address
+                FROM addresses
+                WHERE account_id = ?1
+                  AND key_scope = ?2
+                  AND transparent_child_index IS NOT NULL
+                  AND cached_transparent_receiver_address IS NOT NULL
+                ORDER BY transparent_child_index ASC
+                "#,
+            )
+            .unwrap();
+        stmt.query_map(
+            rusqlite::params![account_id, TRANSPARENT_EXTERNAL_KEY_SCOPE],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap()
+        .map(Result::unwrap)
+        .collect()
+    }
+
+    fn mark_transparent_address_received(
+        conn: &rusqlite::Connection,
+        account_uuid: &str,
+        address_id: i64,
+        address: &str,
+        tx_suffix: u32,
+    ) {
+        let account_id = account_row_id(conn, account_uuid);
+        let mut txid = vec![0_u8; 32];
+        txid[0] = 0xAB;
+        txid[28..32].copy_from_slice(&tx_suffix.to_be_bytes());
+        let height = 10_i64 + i64::from(tx_suffix);
+
+        conn.execute(
+            "INSERT INTO transactions (txid, mined_height, min_observed_height)
+             VALUES (?1, ?2, ?2)",
+            rusqlite::params![txid, height],
+        )
+        .unwrap();
+        let transaction_id = conn.last_insert_rowid();
+
+        conn.execute(
+            "INSERT INTO transparent_received_outputs (
+                 transaction_id, output_index, account_id, address, script,
+                 value_zat, max_observed_unspent_height, address_id
+             ) VALUES (?1, 0, ?2, ?3, x'51', 1000, ?4, ?5)",
+            rusqlite::params![transaction_id, account_id, address, height, address_id],
+        )
+        .unwrap();
     }
 
     #[test]

--- a/rust/src/wallet/mod.rs
+++ b/rust/src/wallet/mod.rs
@@ -6,4 +6,5 @@ pub mod secret_payload;
 pub mod secret_store;
 pub mod sync;
 pub mod sync_engine;
+pub(crate) mod transparent_receive_cache;
 pub mod voting;

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -25,6 +25,7 @@ use crate::wallet::{
         SYNC_DB_BUSY_TIMEOUT,
     },
     network::WalletNetwork,
+    transparent_receive_cache,
 };
 
 use {
@@ -715,6 +716,7 @@ async fn repair_anchor_root_mismatch_if_needed(
 
 async fn refresh_utxos(
     client: &mut CompactTxStreamerClient<Channel>,
+    db_data_path: &str,
     db: &mut WalletDatabase,
     network: WalletNetwork,
 ) -> Result<(), SyncError> {
@@ -733,8 +735,26 @@ async fn refresh_utxos(
             .collect();
 
         if !addresses.is_empty() {
-            refresh_transparent_addresses(client, db, addresses, start_height, "transparent UTXOs")
-                .await?;
+            let received_any = refresh_transparent_addresses(
+                client,
+                db,
+                addresses,
+                start_height,
+                "transparent UTXOs",
+            )
+            .await?;
+            if received_any {
+                let account_uuid = account_id.expose_uuid().to_string();
+                if let Err(e) =
+                    transparent_receive_cache::mark_account_dirty(db_data_path, &account_uuid)
+                {
+                    log::warn!(
+                        "transparent receive cache: failed to mark account {} dirty: {}",
+                        account_uuid,
+                        e
+                    );
+                }
+            }
         }
     }
 
@@ -747,9 +767,9 @@ async fn refresh_transparent_addresses(
     addresses: Vec<String>,
     start_height: BlockHeight,
     label: &str,
-) -> Result<(), SyncError> {
+) -> Result<bool, SyncError> {
     if addresses.is_empty() {
-        return Ok(());
+        return Ok(false);
     }
 
     log::info!(
@@ -770,6 +790,7 @@ async fn refresh_transparent_addresses(
         .map_err(|e| SyncError::net(format!("get_address_utxos_stream: {e}")))?
         .into_inner();
 
+    let mut received_any = false;
     while let Some(reply) = stream
         .message()
         .await
@@ -805,9 +826,10 @@ async fn refresh_transparent_addresses(
             db.put_received_transparent_utxo(&output)
                 .map_err(|e| SyncError::db(format!("put_received_transparent_utxo: {e}")))
         })?;
+        received_any = true;
     }
 
-    Ok(())
+    Ok(received_any)
 }
 
 // ==================== Main sync ====================
@@ -967,7 +989,7 @@ async fn run_sync_impl(
         return Ok(());
     }
 
-    refresh_utxos(&mut client, &mut db, network).await?;
+    refresh_utxos(&mut client, db_data_path, &mut db, network).await?;
 
     if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode {
         log::info!(
@@ -1744,6 +1766,22 @@ async fn run_sync_impl(
         final_scanned_height,
         final_tip_height,
     );
+    match transparent_receive_cache::refresh_all_from_wallet_db(
+        db_data_path,
+        network,
+        Some(final_scanned_height),
+    ) {
+        Ok(refreshed) => log::info!(
+            "[{}] sync: refreshed transparent receive cache ({} accounts)",
+            elapsed(),
+            refreshed
+        ),
+        Err(e) => log::warn!(
+            "[{}] sync: transparent receive cache refresh failed: {}",
+            elapsed(),
+            e
+        ),
+    }
     // Final progress
     let final_progress = SyncProgressEvent {
         scanned_height: final_scanned_height,

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 
@@ -14,7 +15,7 @@ use zcash_client_backend::{
     },
     proto::service,
 };
-use zcash_client_sqlite::error::SqliteClientError;
+use zcash_client_sqlite::{error::SqliteClientError, AccountUuid};
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::{BlockHeight, NetworkUpgrade, Parameters};
 
@@ -24,6 +25,7 @@ use crate::wallet::{
         open_wallet_raw_conn_with_timeout, with_wallet_db_write_lock, WalletDatabase,
         SYNC_DB_BUSY_TIMEOUT,
     },
+    keys,
     network::WalletNetwork,
     transparent_receive_cache,
 };
@@ -32,6 +34,7 @@ use {
     ::transparent::{
         address::Script,
         bundle::{OutPoint, TxOut},
+        keys::TransparentKeyScope,
     },
     zcash_client_backend::{
         proto::service::compact_tx_streamer_client::CompactTxStreamerClient,
@@ -81,6 +84,8 @@ const BATCH_SIZE_FOREGROUND: u32 = 2000;
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 const BATCH_SIZE_FOREGROUND: u32 = 1000;
 const BATCH_SIZE_BACKGROUND: u32 = 300;
+const TRANSPARENT_UTXO_RECENT_EXTERNAL_LIMIT: usize = 20;
+const TRANSPARENT_UTXO_SWEEP_EXTERNAL_LIMIT: usize = 20;
 
 /// Sandblasting attack range (Zcash mainnet). Blocks in this range
 /// contain a very large number of outputs from a sustained spam
@@ -719,46 +724,153 @@ async fn refresh_utxos(
     db_data_path: &str,
     db: &mut WalletDatabase,
     network: WalletNetwork,
+    tip_height: BlockHeight,
 ) -> Result<(), SyncError> {
     for account_id in db
         .get_account_ids()
         .map_err(|e| SyncError::db(format!("get_account_ids: {e}")))?
     {
-        let start_height = db
+        let account_uuid = account_id.expose_uuid().to_string();
+        let safety_start_height = db
             .utxo_query_height(account_id)
             .map_err(|e| SyncError::db(format!("utxo_query_height: {e}")))?;
-        let addresses: Vec<String> = db
+        let account_birthday_height = account_birthday_height(db_data_path, account_id)
+            .unwrap_or_else(|e| {
+                log::warn!(
+                    "sync: failed to read account {} birthday for transparent UTXO sweep: {}",
+                    account_uuid,
+                    e
+                );
+                u64::from(u32::from(safety_start_height))
+            });
+
+        let external_addresses = keys::get_external_transparent_receive_addresses_from_db(
+            db_data_path,
+            network,
+            Some(&account_uuid),
+        )
+        .map_err(|e| SyncError::db(format!("external transparent receive addresses: {e}")))?;
+        let external_batches = match transparent_receive_cache::plan_external_utxo_refresh(
+            db_data_path,
+            network,
+            &account_uuid,
+            &external_addresses,
+            account_birthday_height,
+            u64::from(u32::from(safety_start_height)),
+            TRANSPARENT_UTXO_RECENT_EXTERNAL_LIMIT,
+            TRANSPARENT_UTXO_SWEEP_EXTERNAL_LIMIT,
+        ) {
+            Ok(batches) => batches,
+            Err(e) => {
+                log::warn!(
+                    "transparent receive cache: failed to plan bounded UTXO refresh for account {}; falling back to full external refresh: {}",
+                    account_uuid,
+                    e
+                );
+                vec![transparent_receive_cache::TransparentUtxoRefreshBatch {
+                    addresses: external_addresses
+                        .iter()
+                        .filter(|address| !address.address.is_empty())
+                        .map(|address| address.address.clone())
+                        .collect(),
+                    child_indices: Vec::new(),
+                    start_height: u64::from(u32::from(safety_start_height)),
+                    next_sweep_offset: None,
+                }]
+            }
+        };
+
+        for (batch_index, batch) in external_batches.into_iter().enumerate() {
+            let start_height = block_height_from_u64(
+                batch.start_height,
+                "transparent receive UTXO batch start height",
+            )?;
+            let label = if batch.next_sweep_offset.is_some() {
+                format!("transparent external UTXOs sweep batch {}", batch_index + 1)
+            } else {
+                "transparent external UTXOs recent batch".to_string()
+            };
+            let received_any =
+                refresh_transparent_addresses(client, db, batch.addresses, start_height, &label)
+                    .await?;
+            if received_any {
+                mark_transparent_receive_cache_dirty(db_data_path, &account_uuid);
+            }
+            if let Err(e) = transparent_receive_cache::mark_utxo_refresh_batch_complete(
+                db_data_path,
+                network,
+                &account_uuid,
+                &batch.child_indices,
+                u64::from(u32::from(tip_height)) + 1,
+                batch.next_sweep_offset,
+            ) {
+                log::warn!(
+                    "transparent receive cache: failed to mark UTXO batch complete for account {}: {}",
+                    account_uuid,
+                    e
+                );
+            }
+        }
+
+        let external_selected = external_addresses
+            .iter()
+            .map(|address| address.address.as_str())
+            .collect::<BTreeSet<_>>();
+        let non_external_addresses: Vec<String> = db
             .get_transparent_receivers(account_id, true, true)
             .map_err(|e| SyncError::db(format!("get_transparent_receivers: {e}")))?
-            .into_keys()
-            .map(|addr| addr.encode(&network))
+            .into_iter()
+            .filter(|(_, metadata)| metadata.scope() != Some(TransparentKeyScope::EXTERNAL))
+            .map(|(addr, _)| addr.encode(&network))
+            .filter(|addr| !external_selected.contains(addr.as_str()))
             .collect();
 
-        if !addresses.is_empty() {
+        if !non_external_addresses.is_empty() {
             let received_any = refresh_transparent_addresses(
                 client,
                 db,
-                addresses,
-                start_height,
-                "transparent UTXOs",
+                non_external_addresses,
+                safety_start_height,
+                "transparent non-external UTXOs",
             )
             .await?;
             if received_any {
-                let account_uuid = account_id.expose_uuid().to_string();
-                if let Err(e) =
-                    transparent_receive_cache::mark_account_dirty(db_data_path, &account_uuid)
-                {
-                    log::warn!(
-                        "transparent receive cache: failed to mark account {} dirty: {}",
-                        account_uuid,
-                        e
-                    );
-                }
+                mark_transparent_receive_cache_dirty(db_data_path, &account_uuid);
             }
         }
     }
 
     Ok(())
+}
+
+fn mark_transparent_receive_cache_dirty(db_data_path: &str, account_uuid: &str) {
+    if let Err(e) = transparent_receive_cache::mark_account_dirty(db_data_path, account_uuid) {
+        log::warn!(
+            "transparent receive cache: failed to mark account {} dirty: {}",
+            account_uuid,
+            e
+        );
+    }
+}
+
+fn account_birthday_height(db_path: &str, account_id: AccountUuid) -> Result<u64, SyncError> {
+    let conn = open_readonly_conn_with_timeout(db_path, Some(SYNC_DB_BUSY_TIMEOUT))
+        .map_err(|e| SyncError::db(format!("open DB for account birthday: {e}")))?;
+    let birthday: i64 = conn
+        .query_row(
+            "SELECT birthday_height FROM accounts WHERE uuid = ?1",
+            params![account_id.expose_uuid().as_bytes().as_slice()],
+            |row| row.get(0),
+        )
+        .map_err(|e| SyncError::db(format!("account birthday query: {e}")))?;
+    u64::try_from(birthday)
+        .map_err(|_| SyncError::parse(format!("invalid account birthday height: {birthday}")))
+}
+
+fn block_height_from_u64(height: u64, label: &str) -> Result<BlockHeight, SyncError> {
+    let height = u32::try_from(height)
+        .map_err(|_| SyncError::parse(format!("{label} exceeded u32: {height}")))?;
+    Ok(BlockHeight::from_u32(height))
 }
 
 async fn refresh_transparent_addresses(
@@ -989,7 +1101,7 @@ async fn run_sync_impl(
         return Ok(());
     }
 
-    refresh_utxos(&mut client, db_data_path, &mut db, network).await?;
+    refresh_utxos(&mut client, db_data_path, &mut db, network, tip_height).await?;
 
     if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode {
         log::info!(

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -790,12 +790,15 @@ async fn refresh_utxos(
             } else {
                 "transparent external UTXOs recent batch".to_string()
             };
-            let received_any =
-                refresh_transparent_addresses(client, db, batch.addresses, start_height, &label)
-                    .await?;
-            if received_any {
-                mark_transparent_receive_cache_dirty(db_data_path, &account_uuid);
-            }
+            refresh_transparent_addresses(
+                client,
+                db,
+                batch.addresses,
+                start_height,
+                &label,
+                || mark_transparent_receive_cache_dirty(db_data_path, &account_uuid),
+            )
+            .await?;
             if let Err(e) = transparent_receive_cache::mark_utxo_refresh_batch_complete(
                 db_data_path,
                 network,
@@ -826,17 +829,15 @@ async fn refresh_utxos(
             .collect();
 
         if !non_external_addresses.is_empty() {
-            let received_any = refresh_transparent_addresses(
+            refresh_transparent_addresses(
                 client,
                 db,
                 non_external_addresses,
                 safety_start_height,
                 "transparent non-external UTXOs",
+                || mark_transparent_receive_cache_dirty(db_data_path, &account_uuid),
             )
             .await?;
-            if received_any {
-                mark_transparent_receive_cache_dirty(db_data_path, &account_uuid);
-            }
         }
     }
 
@@ -879,6 +880,7 @@ async fn refresh_transparent_addresses(
     addresses: Vec<String>,
     start_height: BlockHeight,
     label: &str,
+    mut mark_cache_dirty: impl FnMut(),
 ) -> Result<bool, SyncError> {
     if addresses.is_empty() {
         return Ok(false);
@@ -938,6 +940,9 @@ async fn refresh_transparent_addresses(
             db.put_received_transparent_utxo(&output)
                 .map_err(|e| SyncError::db(format!("put_received_transparent_utxo: {e}")))
         })?;
+        if !received_any {
+            mark_cache_dirty();
+        }
         received_any = true;
     }
 

--- a/rust/src/wallet/transparent_receive_cache.rs
+++ b/rust/src/wallet/transparent_receive_cache.rs
@@ -271,17 +271,20 @@ pub(crate) fn plan_external_utxo_refresh(
     recent_limit: usize,
     sweep_limit: usize,
 ) -> Result<Vec<TransparentUtxoRefreshBatch>, String> {
-    let external_addresses = projected_external_addresses(addresses);
+    let discovery_addresses = all_external_addresses(addresses);
+    let cached_external_addresses = projected_external_addresses(addresses);
     let mut record = read_compatible_record(db_path, network, account_uuid)?
         .unwrap_or_else(|| empty_record(network, None));
     record.version = CACHE_VERSION;
     record.network = network_cache_key(network).to_string();
     record.dirty = false;
-    record.utxo_checked_heights = preserved_utxo_checked_heights(&record, &external_addresses);
-    record.external_addresses = external_addresses;
+    record.utxo_checked_heights = preserved_utxo_checked_heights(&record, &discovery_addresses);
+    record.external_addresses = cached_external_addresses;
 
     let batches = external_utxo_refresh_batches(
-        &record,
+        &discovery_addresses,
+        &record.utxo_checked_heights,
+        record.utxo_sweep_next_offset,
         account_birthday_height,
         safety_start_height,
         recent_limit,
@@ -307,22 +310,13 @@ pub(crate) fn mark_utxo_refresh_batch_complete(
         Some(record) => record,
         None => return Ok(()),
     };
-    let selected = child_indices.iter().copied().collect::<HashSet<_>>();
-    let known = record
-        .external_addresses
-        .iter()
-        .map(|address| address.child_index)
-        .collect::<HashSet<_>>();
     let mut checked = record
         .utxo_checked_heights
         .iter()
-        .filter(|entry| known.contains(&entry.child_index))
         .map(|entry| (entry.child_index, entry.next_start_height))
         .collect::<BTreeMap<_, _>>();
-    for child_index in selected {
-        if known.contains(&child_index) {
-            checked.insert(child_index, next_start_height);
-        }
+    for child_index in child_indices.iter().copied() {
+        checked.insert(child_index, next_start_height);
     }
     record.utxo_checked_heights = checked
         .into_iter()
@@ -345,6 +339,7 @@ fn write_clean_addresses(
     addresses: &[keys::ExternalTransparentAddress],
     scanned_height: Option<u64>,
 ) -> Result<(), String> {
+    let full_external_addresses = all_external_addresses(addresses);
     let external_addresses = projected_external_addresses(addresses);
     let existing = read_compatible_record(db_path, network, account_uuid)?;
     let (utxo_sweep_next_offset, utxo_checked_heights) = existing
@@ -352,7 +347,7 @@ fn write_clean_addresses(
         .map(|record| {
             (
                 record.utxo_sweep_next_offset,
-                preserved_utxo_checked_heights(record, &external_addresses),
+                preserved_utxo_checked_heights(record, &full_external_addresses),
             )
         })
         .unwrap_or_default();
@@ -370,6 +365,22 @@ fn write_clean_addresses(
             utxo_checked_heights,
         },
     )
+}
+
+fn all_external_addresses(
+    addresses: &[keys::ExternalTransparentAddress],
+) -> Vec<CachedExternalAddress> {
+    let mut external_addresses = addresses
+        .iter()
+        .filter(|address| !address.address.is_empty())
+        .map(|address| CachedExternalAddress {
+            child_index: address.child_index,
+            address: address.address.clone(),
+            has_received: address.has_received,
+        })
+        .collect::<Vec<_>>();
+    external_addresses.sort_by_key(|address| address.child_index);
+    external_addresses
 }
 
 fn projected_external_addresses(
@@ -398,30 +409,19 @@ fn projected_external_addresses(
 }
 
 fn external_utxo_refresh_batches(
-    record: &CacheRecord,
+    addresses: &[CachedExternalAddress],
+    utxo_checked_heights: &[CachedUtxoCheck],
+    utxo_sweep_next_offset: usize,
     account_birthday_height: u64,
     safety_start_height: u64,
     recent_limit: usize,
     sweep_limit: usize,
 ) -> Vec<TransparentUtxoRefreshBatch> {
-    if record.external_addresses.is_empty() {
+    if addresses.is_empty() {
         return Vec::new();
     }
 
-    let latest_index = first_unused_child_index(&record.external_addresses).unwrap_or_else(|| {
-        record
-            .external_addresses
-            .iter()
-            .map(|address| address.child_index)
-            .max()
-            .unwrap_or(0)
-    });
-    let mut eligible = record
-        .external_addresses
-        .iter()
-        .filter(|address| address.child_index <= latest_index)
-        .cloned()
-        .collect::<Vec<_>>();
+    let mut eligible = addresses.to_vec();
     eligible.sort_by_key(|address| std::cmp::Reverse(address.child_index));
 
     let recent = eligible
@@ -435,8 +435,7 @@ fn external_utxo_refresh_batches(
         .cloned()
         .collect::<Vec<_>>();
 
-    let checked_heights = record
-        .utxo_checked_heights
+    let checked_heights = utxo_checked_heights
         .iter()
         .map(|entry| (entry.child_index, entry.next_start_height))
         .collect::<BTreeMap<_, _>>();
@@ -452,7 +451,7 @@ fn external_utxo_refresh_batches(
     }
 
     if !old.is_empty() && sweep_limit > 0 {
-        let offset = record.utxo_sweep_next_offset % old.len();
+        let offset = utxo_sweep_next_offset % old.len();
         let take = sweep_limit.min(old.len());
         let selected = (0..take)
             .map(|i| old[(offset + i) % old.len()].clone())
@@ -511,14 +510,6 @@ fn refresh_batch(
         start_height,
         next_sweep_offset,
     })
-}
-
-fn first_unused_child_index(addresses: &[CachedExternalAddress]) -> Option<u32> {
-    addresses
-        .iter()
-        .filter(|address| !address.has_received)
-        .map(|address| address.child_index)
-        .min()
 }
 
 fn preserved_utxo_checked_heights(
@@ -846,6 +837,91 @@ mod tests {
                 (1, "t1child1", true),
                 (2, "t1child2", false),
             ]
+        );
+    }
+
+    #[test]
+    fn external_utxo_plan_uses_full_gap_window_but_stores_compact_receive_cache() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+        let addresses = (0..5)
+            .map(|child_index| keys::ExternalTransparentAddress {
+                child_index,
+                address: format!("t1child{child_index}"),
+                has_received: false,
+            })
+            .collect::<Vec<_>>();
+
+        let batches = plan_external_utxo_refresh(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &addresses,
+            100,
+            150,
+            20,
+            20,
+        )
+        .unwrap();
+
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].child_indices, vec![4, 3, 2, 1, 0]);
+        let record = read_cached_record(db_path, "account-1");
+        let cached = record
+            .external_addresses
+            .iter()
+            .map(|address| {
+                (
+                    address.child_index,
+                    address.address.as_str(),
+                    address.has_received,
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(cached, vec![(0, "t1child0", false)]);
+
+        mark_utxo_refresh_batch_complete(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &batches[0].child_indices,
+            1_000,
+            batches[0].next_sweep_offset,
+        )
+        .unwrap();
+        write_clean_addresses(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &addresses,
+            Some(42),
+        )
+        .unwrap();
+        let record = read_cached_record(db_path, "account-1");
+        assert_eq!(
+            record
+                .utxo_checked_heights
+                .iter()
+                .map(|entry| (entry.child_index, entry.next_start_height))
+                .collect::<Vec<_>>(),
+            vec![(0, 1_000), (1, 1_000), (2, 1_000), (3, 1_000), (4, 1_000),]
+        );
+
+        let batches = plan_external_utxo_refresh(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &addresses,
+            100,
+            150,
+            20,
+            20,
+        )
+        .unwrap();
+        assert_eq!(
+            batches[0].start_height,
+            1_000 - TRANSPARENT_UTXO_REQUERY_LOOKBACK
         );
     }
 

--- a/rust/src/wallet/transparent_receive_cache.rs
+++ b/rust/src/wallet/transparent_receive_cache.rs
@@ -1,0 +1,597 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::{Mutex, OnceLock},
+};
+
+use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
+use serde::{Deserialize, Serialize};
+
+use crate::wallet::{keys, network::WalletNetwork};
+
+pub(crate) const RECEIVE_CACHE_SIDECAR_SUFFIX: &str = ".receive.redb";
+const CACHE_VERSION: u32 = 2;
+const CACHE_TABLE: TableDefinition<&str, &str> = TableDefinition::new("transparent_receive");
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
+const REDB_CACHE_SIZE_BYTES: usize = 256 * 1024;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+const REDB_CACHE_SIZE_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct CacheRecord {
+    version: u32,
+    network: String,
+    dirty: bool,
+    refreshed_scanned_height: Option<u64>,
+    external_addresses: Vec<CachedExternalAddress>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct CachedExternalAddress {
+    child_index: u32,
+    address: String,
+    has_received: bool,
+}
+
+pub(crate) fn sidecar_path(db_path: &str) -> PathBuf {
+    PathBuf::from(format!("{db_path}{RECEIVE_CACHE_SIDECAR_SUFFIX}"))
+}
+
+pub(crate) fn get_clean_address(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+) -> Result<Option<String>, String> {
+    with_cache_lock(|| {
+        let path = sidecar_path(db_path);
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let db = open_existing_db(&path)?;
+        let read_txn = db
+            .begin_read()
+            .map_err(|e| format!("transparent receive cache read txn: {e}"))?;
+        let table = match read_txn.open_table(CACHE_TABLE) {
+            Ok(table) => table,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => return Err(format!("transparent receive cache open table: {e}")),
+        };
+        let Some(value) = table
+            .get(account_uuid)
+            .map_err(|e| format!("transparent receive cache get: {e}"))?
+        else {
+            return Ok(None);
+        };
+
+        let Some(record) = clean_record_from_json(value.value(), network)? else {
+            return Ok(None);
+        };
+
+        Ok(keys::first_unused_external_transparent_address(
+            &record.as_external_transparent_addresses(),
+        ))
+    })
+}
+
+pub(crate) fn get_recent_addresses(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    limit: u32,
+) -> Result<Option<Vec<String>>, String> {
+    if limit == 0 {
+        return Ok(Some(Vec::new()));
+    }
+
+    with_cache_lock(|| {
+        let path = sidecar_path(db_path);
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let db = open_existing_db(&path)?;
+        let read_txn = db
+            .begin_read()
+            .map_err(|e| format!("transparent receive cache read txn: {e}"))?;
+        let table = match read_txn.open_table(CACHE_TABLE) {
+            Ok(table) => table,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => return Err(format!("transparent receive cache open table: {e}")),
+        };
+        let Some(value) = table
+            .get(account_uuid)
+            .map_err(|e| format!("transparent receive cache get: {e}"))?
+        else {
+            return Ok(None);
+        };
+
+        let Some(record) = clean_record_from_json(value.value(), network)? else {
+            return Ok(None);
+        };
+        Ok(Some(keys::recent_external_transparent_addresses(
+            &record.as_external_transparent_addresses(),
+            limit.min(100) as usize,
+        )))
+    })
+}
+
+pub(crate) fn mark_account_dirty(db_path: &str, account_uuid: &str) -> Result<(), String> {
+    with_cache_lock(|| {
+        let path = sidecar_path(db_path);
+        if !path.exists() {
+            return Ok(());
+        }
+
+        let db = open_existing_db(&path)?;
+        let write_txn = db
+            .begin_write()
+            .map_err(|e| format!("transparent receive cache write txn: {e}"))?;
+        {
+            let mut table = write_txn
+                .open_table(CACHE_TABLE)
+                .map_err(|e| format!("transparent receive cache open table: {e}"))?;
+            let encoded_record = {
+                let Some(value) = table
+                    .get(account_uuid)
+                    .map_err(|e| format!("transparent receive cache get: {e}"))?
+                else {
+                    return Ok(());
+                };
+                value.value().to_string()
+            };
+            let mut record: CacheRecord = serde_json::from_str(&encoded_record)
+                .map_err(|e| format!("transparent receive cache decode: {e}"))?;
+            record.dirty = true;
+            let encoded = serde_json::to_string(&record)
+                .map_err(|e| format!("transparent receive cache encode: {e}"))?;
+            table
+                .insert(account_uuid, encoded.as_str())
+                .map_err(|e| format!("transparent receive cache insert: {e}"))?;
+        }
+        write_txn
+            .commit()
+            .map_err(|e| format!("transparent receive cache commit: {e}"))
+    })
+}
+
+pub(crate) fn delete_account(db_path: &str, account_uuid: &str) -> Result<(), String> {
+    with_cache_lock(|| {
+        let path = sidecar_path(db_path);
+        if !path.exists() {
+            return Ok(());
+        }
+
+        let db = open_existing_db(&path)?;
+        let write_txn = db
+            .begin_write()
+            .map_err(|e| format!("transparent receive cache write txn: {e}"))?;
+        {
+            let mut table = match write_txn.open_table(CACHE_TABLE) {
+                Ok(table) => table,
+                Err(redb::TableError::TableDoesNotExist(_)) => return Ok(()),
+                Err(e) => return Err(format!("transparent receive cache open table: {e}")),
+            };
+            table
+                .remove(account_uuid)
+                .map_err(|e| format!("transparent receive cache remove: {e}"))?;
+        }
+        write_txn
+            .commit()
+            .map_err(|e| format!("transparent receive cache commit: {e}"))
+    })
+}
+
+pub(crate) fn refresh_account_from_wallet_db(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    scanned_height: Option<u64>,
+) -> Result<String, String> {
+    let addresses = keys::get_external_transparent_receive_addresses_from_db(
+        db_path,
+        network,
+        Some(account_uuid),
+    )?;
+    if let Err(e) =
+        write_clean_addresses(db_path, network, account_uuid, &addresses, scanned_height)
+    {
+        log::warn!(
+            "transparent receive cache: failed to write clean addresses for account {}: {}",
+            account_uuid,
+            e
+        );
+    }
+    keys::first_unused_external_transparent_address(&addresses)
+        .ok_or_else(|| "No unused external transparent receive address available".to_string())
+}
+
+pub(crate) fn refresh_all_from_wallet_db(
+    db_path: &str,
+    network: WalletNetwork,
+    scanned_height: Option<u64>,
+) -> Result<usize, String> {
+    let account_uuids = keys::list_account_uuids_from_db(db_path)?;
+    let mut refreshed = 0;
+    for account_uuid in account_uuids {
+        match refresh_account_cache_from_wallet_db(db_path, network, &account_uuid, scanned_height)
+        {
+            Ok(()) => refreshed += 1,
+            Err(e) => log::warn!(
+                "transparent receive cache: refresh failed for account {}: {}",
+                account_uuid,
+                e
+            ),
+        }
+    }
+    Ok(refreshed)
+}
+
+pub(crate) fn refresh_account_cache_from_wallet_db(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    scanned_height: Option<u64>,
+) -> Result<(), String> {
+    let addresses = keys::get_external_transparent_receive_addresses_from_db(
+        db_path,
+        network,
+        Some(account_uuid),
+    )?;
+    write_clean_addresses(db_path, network, account_uuid, &addresses, scanned_height)
+}
+
+fn write_clean_addresses(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    addresses: &[keys::ExternalTransparentAddress],
+    scanned_height: Option<u64>,
+) -> Result<(), String> {
+    let external_addresses = projected_external_addresses(addresses);
+
+    write_record(
+        db_path,
+        account_uuid,
+        &CacheRecord {
+            version: CACHE_VERSION,
+            network: network_cache_key(network).to_string(),
+            dirty: false,
+            refreshed_scanned_height: scanned_height,
+            external_addresses,
+        },
+    )
+}
+
+fn projected_external_addresses(
+    addresses: &[keys::ExternalTransparentAddress],
+) -> Vec<CachedExternalAddress> {
+    let first_unused_index = addresses
+        .iter()
+        .filter(|address| !address.address.is_empty() && !address.has_received)
+        .map(|address| address.child_index)
+        .min();
+
+    let mut external_addresses = addresses
+        .iter()
+        .filter(|address| {
+            !address.address.is_empty()
+                && (address.has_received || Some(address.child_index) == first_unused_index)
+        })
+        .map(|address| CachedExternalAddress {
+            child_index: address.child_index,
+            address: address.address.clone(),
+            has_received: address.has_received,
+        })
+        .collect::<Vec<_>>();
+    external_addresses.sort_by_key(|address| address.child_index);
+    external_addresses
+}
+
+fn write_record(db_path: &str, account_uuid: &str, record: &CacheRecord) -> Result<(), String> {
+    let encoded = serde_json::to_string(record)
+        .map_err(|e| format!("transparent receive cache encode: {e}"))?;
+    with_cache_lock(|| {
+        let path = sidecar_path(db_path);
+        let db = open_or_create_db(&path)?;
+        let write_txn = db
+            .begin_write()
+            .map_err(|e| format!("transparent receive cache write txn: {e}"))?;
+        {
+            let mut table = write_txn
+                .open_table(CACHE_TABLE)
+                .map_err(|e| format!("transparent receive cache open table: {e}"))?;
+            table
+                .insert(account_uuid, encoded.as_str())
+                .map_err(|e| format!("transparent receive cache insert: {e}"))?;
+        }
+        write_txn
+            .commit()
+            .map_err(|e| format!("transparent receive cache commit: {e}"))
+    })
+}
+
+fn open_existing_db(path: &Path) -> Result<Database, String> {
+    let mut builder = Database::builder();
+    builder.set_cache_size(REDB_CACHE_SIZE_BYTES);
+    builder
+        .open(path)
+        .map_err(|e| format!("transparent receive cache open: {e}"))
+}
+
+fn open_or_create_db(path: &Path) -> Result<Database, String> {
+    let mut builder = Database::builder();
+    builder.set_cache_size(REDB_CACHE_SIZE_BYTES);
+    builder
+        .create(path)
+        .map_err(|e| format!("transparent receive cache create/open: {e}"))
+}
+
+fn network_cache_key(network: WalletNetwork) -> &'static str {
+    match network {
+        WalletNetwork::Main => "main",
+        WalletNetwork::Test => "test",
+        WalletNetwork::Regtest => "regtest",
+    }
+}
+
+fn clean_record_from_json(
+    json: &str,
+    network: WalletNetwork,
+) -> Result<Option<CacheRecord>, String> {
+    let record: CacheRecord =
+        serde_json::from_str(json).map_err(|e| format!("transparent receive cache decode: {e}"))?;
+    if record.version != CACHE_VERSION
+        || record.network != network_cache_key(network)
+        || record.dirty
+    {
+        return Ok(None);
+    }
+    Ok(Some(record))
+}
+
+impl CacheRecord {
+    fn as_external_transparent_addresses(&self) -> Vec<keys::ExternalTransparentAddress> {
+        self.external_addresses
+            .iter()
+            .map(|address| keys::ExternalTransparentAddress {
+                child_index: address.child_index,
+                address: address.address.clone(),
+                has_received: address.has_received,
+            })
+            .collect()
+    }
+}
+
+fn with_cache_lock<T>(operation: impl FnOnce() -> Result<T, String>) -> Result<T, String> {
+    static CACHE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    let lock = CACHE_LOCK.get_or_init(|| Mutex::new(()));
+    let _guard = match lock.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => {
+            log::error!("transparent receive cache lock poisoned; continuing");
+            poisoned.into_inner()
+        }
+    };
+    operation()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_cached_record(db_path: &str, account_uuid: &str) -> CacheRecord {
+        let db = open_existing_db(&sidecar_path(db_path)).unwrap();
+        let read_txn = db.begin_read().unwrap();
+        let table = read_txn.open_table(CACHE_TABLE).unwrap();
+        let value = table.get(account_uuid).unwrap().unwrap();
+        serde_json::from_str(value.value()).unwrap()
+    }
+
+    #[test]
+    fn clean_cache_roundtrip() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+
+        assert_eq!(
+            get_clean_address(db_path, WalletNetwork::Main, "account-1").unwrap(),
+            None
+        );
+
+        write_clean_addresses(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &[
+                keys::ExternalTransparentAddress {
+                    child_index: 0,
+                    address: "t1used".to_string(),
+                    has_received: true,
+                },
+                keys::ExternalTransparentAddress {
+                    child_index: 1,
+                    address: "t1exampleaddress".to_string(),
+                    has_received: false,
+                },
+            ],
+            Some(42),
+        )
+        .unwrap();
+
+        assert_eq!(
+            get_clean_address(db_path, WalletNetwork::Main, "account-1").unwrap(),
+            Some("t1exampleaddress".to_string())
+        );
+        assert_eq!(
+            get_clean_address(db_path, WalletNetwork::Test, "account-1").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn recent_cache_returns_current_and_lower_external_addresses() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+
+        write_clean_addresses(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &[
+                keys::ExternalTransparentAddress {
+                    child_index: 0,
+                    address: "t1child0".to_string(),
+                    has_received: true,
+                },
+                keys::ExternalTransparentAddress {
+                    child_index: 1,
+                    address: "t1child1".to_string(),
+                    has_received: true,
+                },
+                keys::ExternalTransparentAddress {
+                    child_index: 2,
+                    address: "t1child2".to_string(),
+                    has_received: false,
+                },
+                keys::ExternalTransparentAddress {
+                    child_index: 3,
+                    address: "t1child3".to_string(),
+                    has_received: false,
+                },
+            ],
+            Some(42),
+        )
+        .unwrap();
+
+        assert_eq!(
+            get_recent_addresses(db_path, WalletNetwork::Main, "account-1", 3).unwrap(),
+            Some(vec![
+                "t1child2".to_string(),
+                "t1child1".to_string(),
+                "t1child0".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn clean_cache_stores_used_addresses_and_only_the_first_unused_address() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+
+        write_clean_addresses(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &[
+                keys::ExternalTransparentAddress {
+                    child_index: 0,
+                    address: "t1child0".to_string(),
+                    has_received: true,
+                },
+                keys::ExternalTransparentAddress {
+                    child_index: 1,
+                    address: "t1child1".to_string(),
+                    has_received: true,
+                },
+                keys::ExternalTransparentAddress {
+                    child_index: 2,
+                    address: "t1child2".to_string(),
+                    has_received: false,
+                },
+                keys::ExternalTransparentAddress {
+                    child_index: 3,
+                    address: "t1child3".to_string(),
+                    has_received: false,
+                },
+                keys::ExternalTransparentAddress {
+                    child_index: 4,
+                    address: "t1child4".to_string(),
+                    has_received: false,
+                },
+            ],
+            Some(42),
+        )
+        .unwrap();
+
+        let record = read_cached_record(db_path, "account-1");
+        let cached = record
+            .external_addresses
+            .iter()
+            .map(|address| {
+                (
+                    address.child_index,
+                    address.address.as_str(),
+                    address.has_received,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            cached,
+            vec![
+                (0, "t1child0", true),
+                (1, "t1child1", true),
+                (2, "t1child2", false),
+            ]
+        );
+    }
+
+    #[test]
+    fn dirty_cache_is_not_returned() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+
+        write_clean_addresses(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &[keys::ExternalTransparentAddress {
+                child_index: 0,
+                address: "t1example".to_string(),
+                has_received: false,
+            }],
+            None,
+        )
+        .unwrap();
+        mark_account_dirty(db_path, "account-1").unwrap();
+
+        assert_eq!(
+            get_clean_address(db_path, WalletNetwork::Main, "account-1").unwrap(),
+            None
+        );
+        assert_eq!(
+            get_recent_addresses(db_path, WalletNetwork::Main, "account-1", 20).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn delete_account_removes_cached_record() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+
+        write_clean_addresses(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &[keys::ExternalTransparentAddress {
+                child_index: 0,
+                address: "t1example".to_string(),
+                has_received: false,
+            }],
+            None,
+        )
+        .unwrap();
+        delete_account(db_path, "account-1").unwrap();
+
+        assert_eq!(
+            get_clean_address(db_path, WalletNetwork::Main, "account-1").unwrap(),
+            None
+        );
+    }
+}

--- a/rust/src/wallet/transparent_receive_cache.rs
+++ b/rust/src/wallet/transparent_receive_cache.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::{BTreeMap, HashSet},
     path::{Path, PathBuf},
     sync::{Mutex, OnceLock},
 };
@@ -9,8 +10,9 @@ use serde::{Deserialize, Serialize};
 use crate::wallet::{keys, network::WalletNetwork};
 
 pub(crate) const RECEIVE_CACHE_SIDECAR_SUFFIX: &str = ".receive.redb";
-const CACHE_VERSION: u32 = 2;
+const CACHE_VERSION: u32 = 3;
 const CACHE_TABLE: TableDefinition<&str, &str> = TableDefinition::new("transparent_receive");
+const TRANSPARENT_UTXO_REQUERY_LOOKBACK: u64 = 100;
 
 #[cfg(any(target_os = "android", target_os = "ios"))]
 const REDB_CACHE_SIZE_BYTES: usize = 256 * 1024;
@@ -24,6 +26,10 @@ struct CacheRecord {
     dirty: bool,
     refreshed_scanned_height: Option<u64>,
     external_addresses: Vec<CachedExternalAddress>,
+    #[serde(default)]
+    utxo_sweep_next_offset: usize,
+    #[serde(default)]
+    utxo_checked_heights: Vec<CachedUtxoCheck>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -31,6 +37,20 @@ struct CachedExternalAddress {
     child_index: u32,
     address: String,
     has_received: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct CachedUtxoCheck {
+    child_index: u32,
+    next_start_height: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TransparentUtxoRefreshBatch {
+    pub addresses: Vec<String>,
+    pub child_indices: Vec<u32>,
+    pub start_height: u64,
+    pub next_sweep_offset: Option<usize>,
 }
 
 pub(crate) fn sidecar_path(db_path: &str) -> PathBuf {
@@ -241,6 +261,83 @@ pub(crate) fn refresh_account_cache_from_wallet_db(
     write_clean_addresses(db_path, network, account_uuid, &addresses, scanned_height)
 }
 
+pub(crate) fn plan_external_utxo_refresh(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    addresses: &[keys::ExternalTransparentAddress],
+    account_birthday_height: u64,
+    safety_start_height: u64,
+    recent_limit: usize,
+    sweep_limit: usize,
+) -> Result<Vec<TransparentUtxoRefreshBatch>, String> {
+    let external_addresses = projected_external_addresses(addresses);
+    let mut record = read_compatible_record(db_path, network, account_uuid)?
+        .unwrap_or_else(|| empty_record(network, None));
+    record.version = CACHE_VERSION;
+    record.network = network_cache_key(network).to_string();
+    record.dirty = false;
+    record.utxo_checked_heights = preserved_utxo_checked_heights(&record, &external_addresses);
+    record.external_addresses = external_addresses;
+
+    let batches = external_utxo_refresh_batches(
+        &record,
+        account_birthday_height,
+        safety_start_height,
+        recent_limit,
+        sweep_limit,
+    );
+    write_record(db_path, account_uuid, &record)?;
+    Ok(batches)
+}
+
+pub(crate) fn mark_utxo_refresh_batch_complete(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    child_indices: &[u32],
+    next_start_height: u64,
+    next_sweep_offset: Option<usize>,
+) -> Result<(), String> {
+    if child_indices.is_empty() {
+        return Ok(());
+    }
+
+    let mut record = match read_compatible_record(db_path, network, account_uuid)? {
+        Some(record) => record,
+        None => return Ok(()),
+    };
+    let selected = child_indices.iter().copied().collect::<HashSet<_>>();
+    let known = record
+        .external_addresses
+        .iter()
+        .map(|address| address.child_index)
+        .collect::<HashSet<_>>();
+    let mut checked = record
+        .utxo_checked_heights
+        .iter()
+        .filter(|entry| known.contains(&entry.child_index))
+        .map(|entry| (entry.child_index, entry.next_start_height))
+        .collect::<BTreeMap<_, _>>();
+    for child_index in selected {
+        if known.contains(&child_index) {
+            checked.insert(child_index, next_start_height);
+        }
+    }
+    record.utxo_checked_heights = checked
+        .into_iter()
+        .map(|(child_index, next_start_height)| CachedUtxoCheck {
+            child_index,
+            next_start_height,
+        })
+        .collect();
+    if let Some(next_sweep_offset) = next_sweep_offset {
+        record.utxo_sweep_next_offset = next_sweep_offset;
+    }
+
+    write_record(db_path, account_uuid, &record)
+}
+
 fn write_clean_addresses(
     db_path: &str,
     network: WalletNetwork,
@@ -249,6 +346,16 @@ fn write_clean_addresses(
     scanned_height: Option<u64>,
 ) -> Result<(), String> {
     let external_addresses = projected_external_addresses(addresses);
+    let existing = read_compatible_record(db_path, network, account_uuid)?;
+    let (utxo_sweep_next_offset, utxo_checked_heights) = existing
+        .as_ref()
+        .map(|record| {
+            (
+                record.utxo_sweep_next_offset,
+                preserved_utxo_checked_heights(record, &external_addresses),
+            )
+        })
+        .unwrap_or_default();
 
     write_record(
         db_path,
@@ -259,6 +366,8 @@ fn write_clean_addresses(
             dirty: false,
             refreshed_scanned_height: scanned_height,
             external_addresses,
+            utxo_sweep_next_offset,
+            utxo_checked_heights,
         },
     )
 }
@@ -286,6 +395,164 @@ fn projected_external_addresses(
         .collect::<Vec<_>>();
     external_addresses.sort_by_key(|address| address.child_index);
     external_addresses
+}
+
+fn external_utxo_refresh_batches(
+    record: &CacheRecord,
+    account_birthday_height: u64,
+    safety_start_height: u64,
+    recent_limit: usize,
+    sweep_limit: usize,
+) -> Vec<TransparentUtxoRefreshBatch> {
+    if record.external_addresses.is_empty() {
+        return Vec::new();
+    }
+
+    let latest_index = first_unused_child_index(&record.external_addresses).unwrap_or_else(|| {
+        record
+            .external_addresses
+            .iter()
+            .map(|address| address.child_index)
+            .max()
+            .unwrap_or(0)
+    });
+    let mut eligible = record
+        .external_addresses
+        .iter()
+        .filter(|address| address.child_index <= latest_index)
+        .cloned()
+        .collect::<Vec<_>>();
+    eligible.sort_by_key(|address| std::cmp::Reverse(address.child_index));
+
+    let recent = eligible
+        .iter()
+        .take(recent_limit)
+        .cloned()
+        .collect::<Vec<_>>();
+    let old = eligible
+        .iter()
+        .skip(recent.len())
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let checked_heights = record
+        .utxo_checked_heights
+        .iter()
+        .map(|entry| (entry.child_index, entry.next_start_height))
+        .collect::<BTreeMap<_, _>>();
+    let mut batches = Vec::new();
+    if let Some(batch) = refresh_batch(
+        recent,
+        &checked_heights,
+        account_birthday_height,
+        safety_start_height,
+        None,
+    ) {
+        batches.push(batch);
+    }
+
+    if !old.is_empty() && sweep_limit > 0 {
+        let offset = record.utxo_sweep_next_offset % old.len();
+        let take = sweep_limit.min(old.len());
+        let selected = (0..take)
+            .map(|i| old[(offset + i) % old.len()].clone())
+            .collect::<Vec<_>>();
+        let next_offset = (offset + take) % old.len();
+        if let Some(batch) = refresh_batch(
+            selected,
+            &checked_heights,
+            account_birthday_height,
+            safety_start_height,
+            Some(next_offset),
+        ) {
+            batches.push(batch);
+        }
+    }
+
+    batches
+}
+
+fn refresh_batch(
+    addresses: Vec<CachedExternalAddress>,
+    checked_heights: &BTreeMap<u32, u64>,
+    account_birthday_height: u64,
+    safety_start_height: u64,
+    next_sweep_offset: Option<usize>,
+) -> Option<TransparentUtxoRefreshBatch> {
+    if addresses.is_empty() {
+        return None;
+    }
+
+    let initial_start_height = account_birthday_height.min(safety_start_height);
+    let start_height = addresses
+        .iter()
+        .map(|address| {
+            checked_heights
+                .get(&address.child_index)
+                .copied()
+                .map(|height| {
+                    height
+                        .saturating_sub(TRANSPARENT_UTXO_REQUERY_LOOKBACK)
+                        .max(initial_start_height)
+                })
+                .unwrap_or(initial_start_height)
+        })
+        .min()
+        .unwrap_or(initial_start_height);
+    Some(TransparentUtxoRefreshBatch {
+        addresses: addresses
+            .iter()
+            .map(|address| address.address.clone())
+            .collect(),
+        child_indices: addresses
+            .iter()
+            .map(|address| address.child_index)
+            .collect(),
+        start_height,
+        next_sweep_offset,
+    })
+}
+
+fn first_unused_child_index(addresses: &[CachedExternalAddress]) -> Option<u32> {
+    addresses
+        .iter()
+        .filter(|address| !address.has_received)
+        .map(|address| address.child_index)
+        .min()
+}
+
+fn preserved_utxo_checked_heights(
+    record: &CacheRecord,
+    external_addresses: &[CachedExternalAddress],
+) -> Vec<CachedUtxoCheck> {
+    let known = external_addresses
+        .iter()
+        .map(|address| address.child_index)
+        .collect::<HashSet<_>>();
+    record
+        .utxo_checked_heights
+        .iter()
+        .filter(|entry| known.contains(&entry.child_index))
+        .map(|entry| (entry.child_index, entry.next_start_height))
+        .collect::<BTreeMap<_, _>>()
+        .into_iter()
+        .map(|(child_index, next_start_height)| CachedUtxoCheck {
+            child_index,
+            next_start_height,
+        })
+        .collect()
+}
+
+fn empty_record(network: WalletNetwork, scanned_height: Option<u64>) -> CacheRecord {
+    CacheRecord {
+        version: CACHE_VERSION,
+        network: network_cache_key(network).to_string(),
+        dirty: false,
+        refreshed_scanned_height: scanned_height,
+        external_addresses: Vec::new(),
+        utxo_sweep_next_offset: 0,
+        utxo_checked_heights: Vec::new(),
+    }
 }
 
 fn write_record(db_path: &str, account_uuid: &str, record: &CacheRecord) -> Result<(), String> {
@@ -333,6 +600,49 @@ fn network_cache_key(network: WalletNetwork) -> &'static str {
         WalletNetwork::Test => "test",
         WalletNetwork::Regtest => "regtest",
     }
+}
+
+fn read_compatible_record(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+) -> Result<Option<CacheRecord>, String> {
+    let Some(record) = read_record(db_path, account_uuid)? else {
+        return Ok(None);
+    };
+    if record.version == CACHE_VERSION && record.network == network_cache_key(network) {
+        Ok(Some(record))
+    } else {
+        Ok(None)
+    }
+}
+
+fn read_record(db_path: &str, account_uuid: &str) -> Result<Option<CacheRecord>, String> {
+    with_cache_lock(|| {
+        let path = sidecar_path(db_path);
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let db = open_existing_db(&path)?;
+        let read_txn = db
+            .begin_read()
+            .map_err(|e| format!("transparent receive cache read txn: {e}"))?;
+        let table = match read_txn.open_table(CACHE_TABLE) {
+            Ok(table) => table,
+            Err(redb::TableError::TableDoesNotExist(_)) => return Ok(None),
+            Err(e) => return Err(format!("transparent receive cache open table: {e}")),
+        };
+        let Some(value) = table
+            .get(account_uuid)
+            .map_err(|e| format!("transparent receive cache get: {e}"))?
+        else {
+            return Ok(None);
+        };
+        serde_json::from_str(value.value())
+            .map(Some)
+            .map_err(|e| format!("transparent receive cache decode: {e}"))
+    })
 }
 
 fn clean_record_from_json(
@@ -537,6 +847,166 @@ mod tests {
                 (2, "t1child2", false),
             ]
         );
+    }
+
+    #[test]
+    fn external_utxo_plan_refreshes_recent_and_sweeps_old_addresses() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+        let addresses = (0..45)
+            .map(|child_index| keys::ExternalTransparentAddress {
+                child_index,
+                address: format!("t1child{child_index}"),
+                has_received: child_index < 44,
+            })
+            .collect::<Vec<_>>();
+
+        let batches = plan_external_utxo_refresh(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &addresses,
+            100,
+            150,
+            20,
+            20,
+        )
+        .unwrap();
+
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].child_indices.first().copied(), Some(44));
+        assert_eq!(batches[0].child_indices.last().copied(), Some(25));
+        assert_eq!(batches[0].start_height, 100);
+        assert_eq!(batches[1].child_indices.first().copied(), Some(24));
+        assert_eq!(batches[1].child_indices.last().copied(), Some(5));
+        assert_eq!(batches[1].next_sweep_offset, Some(20));
+
+        mark_utxo_refresh_batch_complete(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &batches[1].child_indices,
+            201,
+            batches[1].next_sweep_offset,
+        )
+        .unwrap();
+
+        let batches = plan_external_utxo_refresh(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &addresses,
+            100,
+            150,
+            20,
+            20,
+        )
+        .unwrap();
+        assert_eq!(batches[1].child_indices.first().copied(), Some(4));
+        assert_eq!(batches[1].child_indices.last().copied(), Some(10));
+        assert!(batches[1].child_indices.contains(&24));
+    }
+
+    #[test]
+    fn external_utxo_plan_uses_checked_height_with_lookback() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+        let addresses = (0..3)
+            .map(|child_index| keys::ExternalTransparentAddress {
+                child_index,
+                address: format!("t1child{child_index}"),
+                has_received: child_index < 2,
+            })
+            .collect::<Vec<_>>();
+
+        let batches = plan_external_utxo_refresh(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &addresses,
+            100,
+            150,
+            20,
+            20,
+        )
+        .unwrap();
+        mark_utxo_refresh_batch_complete(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &batches[0].child_indices,
+            1_000,
+            batches[0].next_sweep_offset,
+        )
+        .unwrap();
+
+        let batches = plan_external_utxo_refresh(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &addresses,
+            100,
+            150,
+            20,
+            20,
+        )
+        .unwrap();
+
+        assert_eq!(
+            batches[0].start_height,
+            1_000 - TRANSPARENT_UTXO_REQUERY_LOOKBACK
+        );
+    }
+
+    #[test]
+    fn external_utxo_plan_does_not_rewind_checked_height_below_initial_start() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+        let addresses = (0..2)
+            .map(|child_index| keys::ExternalTransparentAddress {
+                child_index,
+                address: format!("t1child{child_index}"),
+                has_received: child_index == 0,
+            })
+            .collect::<Vec<_>>();
+
+        let batches = plan_external_utxo_refresh(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &addresses,
+            100,
+            150,
+            20,
+            20,
+        )
+        .unwrap();
+        mark_utxo_refresh_batch_complete(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &batches[0].child_indices,
+            120,
+            batches[0].next_sweep_offset,
+        )
+        .unwrap();
+
+        let batches = plan_external_utxo_refresh(
+            db_path,
+            WalletNetwork::Main,
+            "account-1",
+            &addresses,
+            100,
+            150,
+            20,
+            20,
+        )
+        .unwrap();
+
+        assert_eq!(batches[0].start_height, 100);
     }
 
     #[test]

--- a/test/fakes/fake_sync_notifier.dart
+++ b/test/fakes/fake_sync_notifier.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 
 class FakeSyncNotifier extends SyncNotifier {
@@ -7,4 +8,8 @@ class FakeSyncNotifier extends SyncNotifier {
 
   @override
   Future<SyncState> build() async => initialState ?? SyncState();
+
+  void emit(SyncState next) {
+    state = AsyncData(next);
+  }
 }

--- a/test/features/accounts/mobile_accounts_sheet_test.dart
+++ b/test/features/accounts/mobile_accounts_sheet_test.dart
@@ -95,6 +95,11 @@ class _FakeReceiveAddressService implements ReceiveAddressService {
   }
 
   @override
+  Future<String> loadTransparentReceiveAddress({
+    required String accountUuid,
+  }) async => address;
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 

--- a/test/features/receive/mobile_receive_screen_test.dart
+++ b/test/features/receive/mobile_receive_screen_test.dart
@@ -21,6 +21,7 @@ import '../../fakes/fake_sync_notifier.dart';
 
 const _shielded = 'u1tvg2412a23kshieldedaddressk64123hhq6d';
 const _transparent = 't1aWwWwqk3jYGkZc7nLGuTvuM8hDywMZCo';
+const _freshTransparent = 't1freshWwqk3jYGkZc7nLGuTvuM8hDywMZCo';
 
 const _accountState = AccountState(
   accounts: [
@@ -50,6 +51,8 @@ AppBootstrapState _bootstrap() => AppBootstrapState(
 
 class _FakeReceiveAddressService implements ReceiveAddressService {
   var renewals = 0;
+  var transparentLoads = 0;
+  var transparentAddress = _transparent;
 
   @override
   Future<String> loadShieldedAddress({
@@ -60,7 +63,10 @@ class _FakeReceiveAddressService implements ReceiveAddressService {
   @override
   Future<String> loadTransparentReceiveAddress({
     required String accountUuid,
-  }) async => _transparent;
+  }) async {
+    transparentLoads++;
+    return transparentAddress;
+  }
 
   @override
   Future<String> renewShieldedAddress({required String accountUuid}) async {
@@ -204,6 +210,50 @@ void main() {
       find.text('Copy transparent address'),
     );
     expect(copyLabel.style?.fontSize, AppTypography.labelMedium.fontSize);
+  });
+
+  testWidgets('updates hidden transparent address after sync completes', (
+    tester,
+  ) async {
+    final service = _FakeReceiveAddressService();
+    await _pumpReceive(tester, service);
+
+    expect(
+      find.textContaining(_shielded.substring(0, 13), findRichText: true),
+      findsOneWidget,
+    );
+    expect(service.transparentLoads, 1);
+
+    service.transparentAddress = _freshTransparent;
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(MobileReceiveScreen)),
+      listen: false,
+    );
+    final syncNotifier =
+        container.read(syncProvider.notifier) as FakeSyncNotifier;
+    syncNotifier.emit(
+      SyncState(
+        accountUuid: _accountState.activeAccountUuid,
+        hasAccountScopedData: true,
+        lastSyncCompletedAt: DateTime.utc(2026, 6, 24, 12),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(service.transparentLoads, 2);
+
+    await tester.tap(find.text('Transparent'));
+    await _settle(tester);
+
+    expect(
+      find.textContaining(
+        _freshTransparent.substring(0, 13),
+        findRichText: true,
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Copy transparent address'), findsOneWidget);
   });
 
   testWidgets('swipes between shielded and transparent receive codes', (

--- a/test/features/receive/mobile_receive_screen_test.dart
+++ b/test/features/receive/mobile_receive_screen_test.dart
@@ -299,6 +299,58 @@ void main() {
     );
   });
 
+  testWidgets('updates hidden transparent address after sync stops', (
+    tester,
+  ) async {
+    final service = _FakeReceiveAddressService();
+    await _pumpReceive(tester, service);
+
+    expect(
+      find.textContaining(_shielded.substring(0, 13), findRichText: true),
+      findsOneWidget,
+    );
+    expect(service.transparentLoads, 1);
+
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(MobileReceiveScreen)),
+      listen: false,
+    );
+    final syncNotifier =
+        container.read(syncProvider.notifier) as FakeSyncNotifier;
+    syncNotifier.emit(
+      SyncState(
+        accountUuid: _accountState.activeAccountUuid,
+        hasAccountScopedData: true,
+        isSyncing: true,
+      ),
+    );
+    await tester.pump();
+
+    service.transparentAddress = _freshTransparent;
+    syncNotifier.emit(
+      SyncState(
+        accountUuid: _accountState.activeAccountUuid,
+        hasAccountScopedData: true,
+        isSyncing: false,
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(service.transparentLoads, 2);
+
+    await tester.tap(find.text('Transparent'));
+    await _settle(tester);
+
+    expect(
+      find.textContaining(
+        _freshTransparent.substring(0, 13),
+        findRichText: true,
+      ),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('swipes between shielded and transparent receive codes', (
     tester,
   ) async {

--- a/test/features/receive/mobile_receive_screen_test.dart
+++ b/test/features/receive/mobile_receive_screen_test.dart
@@ -58,10 +58,6 @@ class _FakeReceiveAddressService implements ReceiveAddressService {
   }) async => currentShieldedAddress ?? _shielded;
 
   @override
-  Future<String> loadTransparentAddress({required String accountUuid}) async =>
-      _transparent;
-
-  @override
   Future<String> loadTransparentReceiveAddress({
     required String accountUuid,
   }) async => _transparent;

--- a/test/features/receive/mobile_receive_screen_test.dart
+++ b/test/features/receive/mobile_receive_screen_test.dart
@@ -317,11 +317,31 @@ void main() {
       findsOneWidget,
     );
     expect(
+      find.textContaining(
+        'next transparent address will automatically change',
+        findRichText: true,
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining(
+        'Vizor will guide you to shield the balance',
+        findRichText: true,
+      ),
+      findsOneWidget,
+    );
+    expect(
       find.byWidgetPredicate(
         (widget) =>
             widget is AppIcon && widget.name == AppIcons.shieldKeyholeOutline,
       ),
       findsOneWidget,
+    );
+    expect(
+      find.byWidgetPredicate(
+        (widget) => widget is AppIcon && widget.name == AppIcons.renew,
+      ),
+      findsAtLeastNWidgets(1),
     );
   });
 

--- a/test/features/receive/mobile_receive_screen_test.dart
+++ b/test/features/receive/mobile_receive_screen_test.dart
@@ -62,6 +62,11 @@ class _FakeReceiveAddressService implements ReceiveAddressService {
       _transparent;
 
   @override
+  Future<String> loadTransparentReceiveAddress({
+    required String accountUuid,
+  }) async => _transparent;
+
+  @override
   Future<String> renewShieldedAddress({required String accountUuid}) async {
     renewals++;
     return 'u1renewedaddress9876543210abcdefghij';

--- a/test/features/receive/mobile_receive_screen_test.dart
+++ b/test/features/receive/mobile_receive_screen_test.dart
@@ -256,6 +256,49 @@ void main() {
     expect(find.text('Copy transparent address'), findsOneWidget);
   });
 
+  testWidgets('updates hidden transparent address after sync fails', (
+    tester,
+  ) async {
+    final service = _FakeReceiveAddressService();
+    await _pumpReceive(tester, service);
+
+    expect(
+      find.textContaining(_shielded.substring(0, 13), findRichText: true),
+      findsOneWidget,
+    );
+    expect(service.transparentLoads, 1);
+
+    service.transparentAddress = _freshTransparent;
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(MobileReceiveScreen)),
+      listen: false,
+    );
+    final syncNotifier =
+        container.read(syncProvider.notifier) as FakeSyncNotifier;
+    syncNotifier.emit(
+      SyncState(
+        accountUuid: _accountState.activeAccountUuid,
+        hasAccountScopedData: true,
+        lastSyncFailedAt: DateTime.utc(2026, 6, 24, 12),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(service.transparentLoads, 2);
+
+    await tester.tap(find.text('Transparent'));
+    await _settle(tester);
+
+    expect(
+      find.textContaining(
+        _freshTransparent.substring(0, 13),
+        findRichText: true,
+      ),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('swipes between shielded and transparent receive codes', (
     tester,
   ) async {

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -208,6 +208,68 @@ void main() {
     );
   });
 
+  testWidgets('silently updates transparent address after sync completes', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    late _FakeReceiveAddressService service;
+    await tester.pumpWidget(
+      _receiveHarness(
+        receiveAddressService: (ref) {
+          service = _FakeReceiveAddressService(ref);
+          return service;
+        },
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.text('Transparent'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      _findAddressRichText('t1testtranspa ... 11111111111'),
+      findsOneWidget,
+    );
+    expect(service.transparentReceiveLoads, 1);
+
+    service.transparentReceiveAddress = _freshTransparentAddress;
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ReceiveScreen)),
+      listen: false,
+    );
+    final syncNotifier =
+        container.read(syncProvider.notifier) as FakeSyncNotifier;
+    syncNotifier.emit(
+      _syncedStateFor(
+        _bootstrap.initialAccountState,
+      ).copyWith(lastSyncCompletedAt: DateTime.utc(2026, 6, 24, 12)),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(service.transparentReceiveLoads, 2);
+    expect(
+      _findAddressRichText('t1freshtransp ... 22222222222'),
+      findsOneWidget,
+    );
+    expect(
+      tester
+          .widget<ReceiveCopyAddressButton>(
+            find.byKey(
+              const ValueKey('receive_copy_transparent_address_button'),
+            ),
+          )
+          .enabled,
+      isTrue,
+    );
+  });
+
   testWidgets('uses dark receive color for renew icon and address text', (
     tester,
   ) async {

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -127,6 +127,35 @@ void main() {
     );
   });
 
+  testWidgets('refreshes transparent receive address even when cached', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    late _FakeReceiveAddressService service;
+    await tester.pumpWidget(
+      _receiveHarness(
+        receiveAddressService: (ref) {
+          service = _FakeReceiveAddressService(ref);
+          return service;
+        },
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(service.transparentReceiveLoads, 0);
+
+    await tester.tap(find.text('Transparent'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(service.transparentReceiveLoads, 1);
+  });
+
   testWidgets('uses dark receive color for renew icon and address text', (
     tester,
   ) async {
@@ -473,6 +502,9 @@ const _accountTwoAddress = 'u1accounttwo-current';
 class _FakeReceiveAddressService extends ReceiveAddressService {
   _FakeReceiveAddressService(super.ref);
 
+  int transparentReceiveLoads = 0;
+  String transparentReceiveAddress = _transparentAddress;
+
   @override
   Future<String> loadShieldedAddress({
     required String accountUuid,
@@ -489,6 +521,14 @@ class _FakeReceiveAddressService extends ReceiveAddressService {
   @override
   Future<String> loadTransparentAddress({required String accountUuid}) async {
     return _transparentAddress;
+  }
+
+  @override
+  Future<String> loadTransparentReceiveAddress({
+    required String accountUuid,
+  }) async {
+    transparentReceiveLoads++;
+    return transparentReceiveAddress;
   }
 
   @override
@@ -537,6 +577,13 @@ class _RacyReceiveAddressService extends ReceiveAddressService {
 
   @override
   Future<String> loadTransparentAddress({required String accountUuid}) async {
+    return 't1transparent-$accountUuid';
+  }
+
+  @override
+  Future<String> loadTransparentReceiveAddress({
+    required String accountUuid,
+  }) async {
     return 't1transparent-$accountUuid';
   }
 

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -249,6 +249,42 @@ void main() {
     );
   });
 
+  testWidgets('explains transparent address rotation and shielding', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(_receiveHarness());
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.text('Transparent'));
+    await tester.pump();
+    await tester.pump();
+    await tester.tap(_findAppIcon(AppIcons.help));
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(find.text('Transparent address'), findsOneWidget);
+    expect(
+      find.textContaining('next transparent address will automatically change'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('Vizor will guide you to shield the balance'),
+      findsOneWidget,
+    );
+    expect(_findAppIcon(AppIcons.renew), findsOneWidget);
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('receive_transparent_info_modal')),
+      ),
+      const Size(312, 516),
+    );
+  });
+
   testWidgets('receive info modal does not block sidebar navigation', (
     tester,
   ) async {

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -555,11 +555,6 @@ class _FakeReceiveAddressService extends ReceiveAddressService {
   }
 
   @override
-  Future<String> loadTransparentAddress({required String accountUuid}) async {
-    return _transparentAddress;
-  }
-
-  @override
   Future<String> loadTransparentReceiveAddress({
     required String accountUuid,
   }) async {
@@ -610,11 +605,6 @@ class _RacyReceiveAddressService extends ReceiveAddressService {
 
   @override
   String? getCachedTransparentAddress(String accountUuid) => null;
-
-  @override
-  Future<String> loadTransparentAddress({required String accountUuid}) async {
-    return 't1transparent-$accountUuid';
-  }
 
   @override
   Future<String> loadTransparentReceiveAddress({

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -270,6 +270,58 @@ void main() {
     );
   });
 
+  testWidgets('silently updates transparent address after sync fails', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    late _FakeReceiveAddressService service;
+    await tester.pumpWidget(
+      _receiveHarness(
+        receiveAddressService: (ref) {
+          service = _FakeReceiveAddressService(ref);
+          return service;
+        },
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.text('Transparent'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      _findAddressRichText('t1testtranspa ... 11111111111'),
+      findsOneWidget,
+    );
+    expect(service.transparentReceiveLoads, 1);
+
+    service.transparentReceiveAddress = _freshTransparentAddress;
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(ReceiveScreen)),
+      listen: false,
+    );
+    final syncNotifier =
+        container.read(syncProvider.notifier) as FakeSyncNotifier;
+    syncNotifier.emit(
+      _syncedStateFor(
+        _bootstrap.initialAccountState,
+      ).copyWith(lastSyncFailedAt: DateTime.utc(2026, 6, 24, 12)),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(service.transparentReceiveLoads, 2);
+    expect(
+      _findAddressRichText('t1freshtransp ... 22222222222'),
+      findsOneWidget,
+    );
+  });
+
   testWidgets('uses dark receive color for renew icon and address text', (
     tester,
   ) async {

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:zcash_wallet/src/core/layout/app_desktop_shell.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/receive/screens/receive_screen.dart';
+import 'package:zcash_wallet/src/features/receive/widgets/receive_address_widgets.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/receive_address_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
@@ -154,6 +155,57 @@ void main() {
     await tester.pump();
 
     expect(service.transparentReceiveLoads, 1);
+  });
+
+  testWidgets('disables transparent copy while cached address refreshes', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    late _DelayedTransparentReceiveAddressService service;
+    await tester.pumpWidget(
+      _receiveHarness(
+        receiveAddressService: (ref) {
+          service = _DelayedTransparentReceiveAddressService(ref);
+          return service;
+        },
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    await tester.tap(find.text('Transparent'));
+    await tester.pump();
+
+    expect(service.transparentReceiveLoads, 1);
+    expect(
+      tester
+          .widget<ReceiveCopyAddressButton>(
+            find.byKey(
+              const ValueKey('receive_copy_transparent_address_button'),
+            ),
+          )
+          .enabled,
+      isFalse,
+    );
+
+    service.completeTransparentRefresh();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 200));
+
+    expect(
+      tester
+          .widget<ReceiveCopyAddressButton>(
+            find.byKey(
+              const ValueKey('receive_copy_transparent_address_button'),
+            ),
+          )
+          .enabled,
+      isTrue,
+    );
   });
 
   testWidgets('uses dark receive color for renew icon and address text', (
@@ -532,6 +584,8 @@ const _renewedShieldedAddress =
     'u1testrenewedshieldedaddress0000000000000000000000000000000000000000000';
 const _transparentAddress =
     't1testtransparentaddress111111111111111111111111111111111111';
+const _freshTransparentAddress =
+    't1freshtransparentaddress222222222222222222222222222222222222';
 const _accountOneAddress = 'u1accountone-stale';
 const _accountTwoAddress = 'u1accounttwo-current';
 
@@ -577,6 +631,23 @@ class _RecordingReceiveAddressService extends _FakeReceiveAddressService {
   Future<String> renewShieldedAddress({required String accountUuid}) async {
     renewedAccountUuid = accountUuid;
     return _renewedShieldedAddress;
+  }
+}
+
+class _DelayedTransparentReceiveAddressService
+    extends _FakeReceiveAddressService {
+  _DelayedTransparentReceiveAddressService(super.ref);
+
+  final _transparentRefresh = Completer<String>();
+
+  @override
+  Future<String> loadTransparentReceiveAddress({required String accountUuid}) {
+    transparentReceiveLoads++;
+    return _transparentRefresh.future;
+  }
+
+  void completeTransparentRefresh() {
+    _transparentRefresh.complete(_freshTransparentAddress);
   }
 }
 

--- a/test/features/receive/receive_screen_test.dart
+++ b/test/features/receive/receive_screen_test.dart
@@ -322,6 +322,66 @@ void main() {
     );
   });
 
+  testWidgets(
+    'silently updates transparent address after sync stops without result',
+    (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1512, 982));
+      addTearDown(() async {
+        await tester.binding.setSurfaceSize(null);
+      });
+
+      late _FakeReceiveAddressService service;
+      await tester.pumpWidget(
+        _receiveHarness(
+          receiveAddressService: (ref) {
+            service = _FakeReceiveAddressService(ref);
+            return service;
+          },
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Transparent'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(
+        _findAddressRichText('t1testtranspa ... 11111111111'),
+        findsOneWidget,
+      );
+      expect(service.transparentReceiveLoads, 1);
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ReceiveScreen)),
+        listen: false,
+      );
+      final syncNotifier =
+          container.read(syncProvider.notifier) as FakeSyncNotifier;
+      syncNotifier.emit(
+        _syncedStateFor(
+          _bootstrap.initialAccountState,
+        ).copyWith(isSyncing: true),
+      );
+      await tester.pump();
+
+      service.transparentReceiveAddress = _freshTransparentAddress;
+      syncNotifier.emit(
+        _syncedStateFor(
+          _bootstrap.initialAccountState,
+        ).copyWith(isSyncing: false),
+      );
+      await tester.pump();
+      await tester.pump();
+
+      expect(service.transparentReceiveLoads, 2);
+      expect(
+        _findAddressRichText('t1freshtransp ... 22222222222'),
+        findsOneWidget,
+      );
+    },
+  );
+
   testWidgets('uses dark receive color for renew icon and address text', (
     tester,
   ) async {

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -744,6 +744,16 @@ class _RustApiFake implements RustLibApi {
   }
 
   @override
+  Future<List<String>> crateApiWalletGetRecentTransparentReceiveAddresses({
+    required String dbPath,
+    required String network,
+    String? accountUuid,
+    required int limit,
+  }) async {
+    return [transparentAddress];
+  }
+
+  @override
   Future<Uint8List> crateApiSyncCreatePcztFromProposal({
     required String dbPath,
     required String network,

--- a/test/features/send/send_review_screen_test.dart
+++ b/test/features/send/send_review_screen_test.dart
@@ -735,7 +735,7 @@ class _RustApiFake implements RustLibApi {
   }
 
   @override
-  Future<String> crateApiWalletGetTransparentAddress({
+  Future<String> crateApiWalletGetTransparentReceiveAddress({
     required String dbPath,
     required String network,
     String? accountUuid,

--- a/test/features/send/send_status_screen_test.dart
+++ b/test/features/send/send_status_screen_test.dart
@@ -508,5 +508,15 @@ class _RustApiFake implements RustLibApi {
   }
 
   @override
+  Future<List<String>> crateApiWalletGetRecentTransparentReceiveAddresses({
+    required String dbPath,
+    required String network,
+    String? accountUuid,
+    required int limit,
+  }) async {
+    return [transparentAddress];
+  }
+
+  @override
   dynamic noSuchMethod(Invocation invocation) => Future<void>.value();
 }

--- a/test/features/send/send_status_screen_test.dart
+++ b/test/features/send/send_status_screen_test.dart
@@ -499,7 +499,7 @@ class _RustApiFake implements RustLibApi {
   }
 
   @override
-  Future<String> crateApiWalletGetTransparentAddress({
+  Future<String> crateApiWalletGetTransparentReceiveAddress({
     required String dbPath,
     required String network,
     String? accountUuid,

--- a/test/providers/account_provider_test.dart
+++ b/test/providers/account_provider_test.dart
@@ -24,6 +24,7 @@ void main() {
       '/tmp/zcash_wallet.db.voting-journal',
       '/tmp/zcash_wallet.db.voting-wal',
       '/tmp/zcash_wallet.db.voting-shm',
+      '/tmp/zcash_wallet.db.receive.redb',
     ]);
   });
 
@@ -39,6 +40,7 @@ void main() {
       '.voting-journal',
       '.voting-wal',
       '.voting-shm',
+      '.receive.redb',
     ]);
   });
 


### PR DESCRIPTION
## Summary
- rotate transparent receive addresses by returning the first external address without a received output
- keep transparent receive lookup read-only for receive UI and swap fee probing
- add a redb-backed transparent receive cache to reduce SQLite read contention during sync
- update receive copy on desktop/mobile and remove the legacy transparent address API

## Validation
- fvm flutter analyze
- fvm flutter test test/features/send/send_review_screen_test.dart test/features/send/send_status_screen_test.dart test/features/receive/receive_screen_test.dart test/features/receive/mobile_receive_screen_test.dart
- fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/receive/mobile_receive_screen_test.dart
- cd rust && cargo test --lib
- cd rust && cargo build --examples
