### PR TITLE
[codex] Add mobile transparent shielding

### DIFF
--- a/lib/src/core/layout/mobile/app_mobile_sheet.dart
+++ b/lib/src/core/layout/mobile/app_mobile_sheet.dart
@@ -216,6 +216,7 @@ class MobileModalScaffold extends StatelessWidget {
     required this.child,
     this.leading,
     this.titleStyle,
+    this.titleMaxLines = 1,
     this.showTitle = true,
     this.showClose = true,
     this.bodyGap = AppSpacing.sm,
@@ -228,6 +229,7 @@ class MobileModalScaffold extends StatelessWidget {
   final Widget child;
   final Widget? leading;
   final TextStyle? titleStyle;
+  final int titleMaxLines;
   final bool showTitle;
   final bool showClose;
 
@@ -261,8 +263,8 @@ class MobileModalScaffold extends StatelessWidget {
                 ConstrainedBox(
                   constraints: const BoxConstraints(minHeight: 26),
                   child: Padding(
-                    // Clear the absolute 32px close (+ an 8px gap) so a long title
-                    // ellipsizes instead of sliding under it.
+                    // Clear the absolute 32px close (+ an 8px gap) so long
+                    // titles wrap/ellipsize instead of sliding under it.
                     padding: const EdgeInsets.only(right: 40),
                     child: Row(
                       children: [
@@ -273,7 +275,7 @@ class MobileModalScaffold extends StatelessWidget {
                         Expanded(
                           child: Text(
                             title,
-                            maxLines: 1,
+                            maxLines: titleMaxLines,
                             overflow: TextOverflow.ellipsis,
                             style:
                                 titleStyle ??

--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import '../../features/accounts/screens/mobile/mobile_accounts_screen.dart';
 import '../../features/activity/screens/mobile/mobile_activity_screen.dart';
 import '../../features/home/screens/mobile/mobile_home_screen.dart';
+import '../../features/home/screens/mobile/mobile_keystone_shield_screen.dart';
 import '../../features/receive/screens/mobile/mobile_receive_screen.dart';
 import '../../features/address_book/screens/mobile/mobile_address_book_screen.dart';
 import '../../features/activity/screens/mobile/mobile_swap_activity_detail_screen.dart';
@@ -205,6 +206,13 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
       pageBuilder: (context, state) => CupertinoPage(
         key: state.pageKey,
         child: MobileKeystoneSignScreen(args: state.extra! as SendReviewArgs),
+      ),
+    ),
+    GoRoute(
+      path: '/home/keystone-shield',
+      pageBuilder: (context, state) => CupertinoPage(
+        key: state.pageKey,
+        child: const MobileKeystoneShieldScreen(),
       ),
     ),
     GoRoute(

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -1,7 +1,6 @@
 // ignore_for_file: unused_element, unused_field
 
 import 'dart:async';
-import 'dart:io' show Platform;
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart'
@@ -13,7 +12,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
 import '../../../app_bootstrap.dart';
-import '../../../core/config/rpc_endpoint_config.dart';
+import '../../../core/config/network_config.dart';
 import '../../../core/config/swap_feature_config.dart';
 import '../../../core/formatting/zec_amount.dart';
 import '../../../core/layout/app_main_sidebar.dart';
@@ -27,7 +26,6 @@ import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../providers/zec_price_change_provider.dart';
 import '../../../providers/account_provider.dart';
-import '../../../providers/app_security_provider.dart';
 import '../../../providers/privacy_mode_provider.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
@@ -41,6 +39,7 @@ import '../../activity/swap_activity_row_mapper.dart';
 import '../../swap/models/swap_activity_navigation.dart';
 import '../../swap/models/swap_fiat_value_formatting.dart';
 import '../../swap/providers/swap_activity_tracker.dart';
+import '../services/transparent_shielding_service.dart';
 import '../widgets/keystone_shield_signing_overlay.dart';
 
 const _shieldErrorTooltipIconSize = 14.0;
@@ -49,15 +48,6 @@ const _homeDesktopActivationShortcuts = <ShortcutActivator, Intent>{
   SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
   SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
 };
-const shieldBalancePendingBroadcastMessage =
-    'Shielding queued for retry. Check Activity.';
-
-String? shieldBalanceBroadcastStatusMessage(
-  rust_sync.ShieldTransparentResult result,
-) {
-  if (result.status == 'broadcasted') return null;
-  return shieldBalancePendingBroadcastMessage;
-}
 
 class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
@@ -113,9 +103,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   Future<void> _shieldTransparentBalance() async {
     if (_isShieldingBalance) return;
 
-    final wallet = ref.read(walletProvider).value;
-    final accountUuid = wallet?.activeAccountUuid;
-    if (accountUuid == null) {
+    late final String accountUuid;
+    try {
+      accountUuid = activeShieldingAccountUuid(ref);
+    } catch (_) {
       setState(() {
         _shieldBalanceError = 'No active account.';
       });
@@ -138,88 +129,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       _shieldBalanceErrorDetail = null;
     });
 
-    RpcEndpointConfig? attemptedEndpoint;
     try {
-      final sync = (ref.read(syncProvider).value ?? SyncState())
-          .scopedToAccount(accountUuid);
-      if (!sync.canShieldTransparentBalance) {
-        throw Exception(
-          'Transparent balance is too small to shield after fees.',
-        );
-      }
-
-      final dbPath = await getWalletDbPath();
-      final endpoint = ref.read(rpcEndpointFailoverProvider).current;
-      attemptedEndpoint = endpoint;
-
-      late final rust_sync.ShieldTransparentResult result;
-      late final Future<rust_sync.ShieldTransparentResult> resultFuture;
-
-      if (Platform.isMacOS) {
-        final password = ref
-            .read(appSecurityProvider.notifier)
-            .requireSessionPasswordForNativeSecretUse();
-        resultFuture = rust_sync
-            .shieldTransparentBalanceWithMacosStoredMnemonic(
-              dbPath: dbPath,
-              lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-              network: endpoint.networkName,
-              accountUuid: accountUuid,
-              password: password,
-            );
-      } else {
-        final mnemonicBytes = await accountNotifier.getMnemonicBytesForAccount(
-          accountUuid,
-        );
-        if (mnemonicBytes == null || mnemonicBytes.isEmpty) {
-          throw Exception('Mnemonic not found for the active account.');
-        }
-
-        try {
-          resultFuture = rust_sync.shieldTransparentBalance(
-            dbPath: dbPath,
-            lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
-            network: endpoint.networkName,
-            accountUuid: accountUuid,
-            mnemonicBytes: mnemonicBytes,
-          );
-        } finally {
-          mnemonicBytes.fillRange(0, mnemonicBytes.length, 0);
-        }
-      }
-      result = await resultFuture;
-      log(
-        'HomeScreen: shielded transparent balance txids=${result.txids} '
-        'status=${result.status} '
-        'broadcasted=${result.broadcastedCount}/${result.totalCount} '
-        'fee=${result.feeZatoshi} shielded=${result.shieldedZatoshi}',
+      final result = await shieldTransparentSoftwareBalance(
+        ref: ref,
+        accountUuid: accountUuid,
+        logContext: 'HomeScreen',
       );
-
       final broadcastStatusMessage = shieldBalanceBroadcastStatusMessage(
         result,
       );
-      final broadcastDetailMessage = result.message?.trim();
-      if (broadcastStatusMessage != null &&
-          broadcastDetailMessage != null &&
-          broadcastDetailMessage.isNotEmpty) {
-        final switched = await ref
-            .read(rpcEndpointFailoverProvider.notifier)
-            .switchToFallbackFor(
-              broadcastDetailMessage,
-              endpoint: attemptedEndpoint,
-              operation: 'shield transparent balance broadcast',
-            );
-        if (switched) {
-          unawaited(ref.read(syncProvider.notifier).restartSync());
-        }
-      }
-
-      try {
-        await ref.read(syncProvider.notifier).refreshAfterSend();
-      } catch (e) {
-        log('HomeScreen: refreshAfterSend after shielding failed: $e');
-      }
-
       if (broadcastStatusMessage != null) {
         if (!mounted) return;
         setState(() {
@@ -227,22 +145,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           _shieldBalanceErrorDetail = null;
         });
       }
-    } catch (e, st) {
-      log('HomeScreen: shield transparent balance failed: $e\n$st');
-      final switched = await ref
-          .read(rpcEndpointFailoverProvider.notifier)
-          .switchToFallbackFor(
-            e,
-            endpoint: attemptedEndpoint,
-            operation: 'shield transparent balance',
-          );
-      if (switched) {
-        unawaited(ref.read(syncProvider.notifier).restartSync());
-      }
+    } catch (e) {
       if (!mounted) return;
       setState(() {
-        _shieldBalanceError = _friendlyShieldBalanceError(e);
-        _shieldBalanceErrorDetail = _shieldBalanceErrorDetails(e);
+        _shieldBalanceError = friendlyShieldBalanceError(e);
+        _shieldBalanceErrorDetail = shieldBalanceErrorDetails(e);
       });
     } finally {
       if (mounted) {
@@ -251,36 +158,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         });
       }
     }
-  }
-
-  String _friendlyShieldBalanceError(Object error) {
-    final message = error.toString();
-    final lower = message.toLowerCase();
-    if (lower.contains('mnemonic')) {
-      return "Secret Passphrase isn't available for this account.";
-    }
-    if (lower.contains('sync')) {
-      return 'Wait for sync to finish, then shield.';
-    }
-    if (lower.contains('insufficient') ||
-        lower.contains('threshold') ||
-        lower.contains('too small') ||
-        lower.contains('no transparent funds')) {
-      return 'Transparent balance is too small to shield after fees.';
-    }
-    if (lower.contains('broadcast') || lower.contains('sendtransaction')) {
-      return "Couldn't broadcast your shielding transaction. Try again.";
-    }
-    return "Couldn't shield your balance. Try again.";
-  }
-
-  String? _shieldBalanceErrorDetails(Object error) {
-    final message = error.toString().trim();
-    final lower = message.toLowerCase();
-    if (lower.contains('broadcast') || lower.contains('sendtransaction')) {
-      return null;
-    }
-    return message.isEmpty ? null : message;
   }
 
   void _closeKeystoneShieldSigning() {

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -15,6 +15,7 @@ import '../../../../core/privacy/privacy_mask.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/app_button.dart';
 import '../../../../core/widgets/app_icon.dart';
+import '../../../../core/widgets/app_toast.dart';
 import '../../../../providers/account_provider.dart';
 import '../../../../providers/privacy_mode_provider.dart';
 import '../../../../providers/sync_provider.dart';
@@ -28,6 +29,8 @@ import '../../../activity/swap_activity_row_mapper.dart';
 import '../../../activity/widgets/activity_feed.dart';
 import '../../../swap/models/swap_activity_navigation.dart';
 import '../../../swap/widgets/swap_activity_status_auto_refresh.dart';
+import '../../services/transparent_shielding_service.dart';
+import 'mobile_keystone_shield_screen.dart';
 
 /// Mobile home tab: shielded balance card, send/receive actions, and
 /// up to ten recent activity rows — Figma `HOME` section frames
@@ -144,7 +147,7 @@ class _ImportingBackground extends StatelessWidget {
   }
 }
 
-class _HomeContent extends ConsumerWidget {
+class _HomeContent extends ConsumerStatefulWidget {
   const _HomeContent({
     required this.sync,
     required this.activeAccountUuid,
@@ -158,13 +161,80 @@ class _HomeContent extends ConsumerWidget {
   final VoidCallback onTogglePrivacyMode;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_HomeContent> createState() => _HomeContentState();
+}
+
+class _HomeContentState extends ConsumerState<_HomeContent> {
+  bool _isShieldingBalance = false;
+
+  Future<void> _shieldTransparentBalance() async {
+    if (_isShieldingBalance) return;
+
+    late final String accountUuid;
+    try {
+      accountUuid = activeShieldingAccountUuid(ref);
+    } catch (_) {
+      _showShieldToast('No active account.');
+      return;
+    }
+
+    final accountNotifier = ref.read(accountProvider.notifier);
+    if (accountNotifier.isHardwareAccount(accountUuid)) {
+      final result = await context.push<MobileKeystoneShieldResult>(
+        '/home/keystone-shield',
+      );
+      if (!mounted || result == null) return;
+      final message = result.message;
+      if (message != null && message.isNotEmpty) {
+        _showShieldToast(message);
+      } else if (result.succeeded) {
+        showAppToast(context, 'Shielding complete');
+      }
+      return;
+    }
+
+    setState(() => _isShieldingBalance = true);
+    try {
+      final result = await shieldTransparentSoftwareBalance(
+        ref: ref,
+        accountUuid: accountUuid,
+        logContext: 'MobileHome',
+      );
+      if (!mounted) return;
+      final warning = shieldBalanceBroadcastStatusMessage(result);
+      if (warning != null) {
+        _showShieldToast(warning);
+      } else {
+        showAppToast(context, 'Shielding complete');
+      }
+    } catch (e) {
+      if (!mounted) return;
+      _showShieldToast(friendlyShieldBalanceError(e));
+    } finally {
+      if (mounted) {
+        setState(() => _isShieldingBalance = false);
+      }
+    }
+  }
+
+  void _showShieldToast(String message) {
+    showAppToast(context, message, iconName: AppIcons.warning);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final sync = widget.sync;
+    final activeAccountUuid = widget.activeAccountUuid;
+    final privacyModeEnabled = widget.privacyModeEnabled;
     final shieldedBalance =
         sync.saplingBalance +
         sync.orchardBalance +
         sync.saplingPendingBalance +
         sync.orchardPendingBalance;
-    final hasBalance = shieldedBalance > BigInt.zero;
+    final transparentBalance =
+        sync.transparentBalance + sync.transparentPendingBalance;
+    final hasBalance =
+        shieldedBalance > BigInt.zero || transparentBalance > BigInt.zero;
     final zecUsdUnitPrice = ref.watch(zecHomeUsdUnitPriceProvider);
     final fiatBalanceText = fiatTextForZatoshi(
       shieldedBalance,
@@ -239,8 +309,15 @@ class _HomeContent extends ConsumerWidget {
               : ZecAmount.fromZatoshi(shieldedBalance).balance.amountText,
           fiatBalanceText: shieldedFiatBalanceText,
           priceChange24hPct: priceChange24hPct,
+          transparentBalanceText: ZecAmount.fromZatoshi(
+            transparentBalance,
+          ).balance.amountText,
+          hasTransparentBalance: transparentBalance > BigInt.zero,
+          canShieldBalance: sync.canShieldTransparentBalance,
+          isShieldingBalance: _isShieldingBalance,
           privacyModeEnabled: privacyModeEnabled,
-          onTogglePrivacyMode: onTogglePrivacyMode,
+          onTogglePrivacyMode: widget.onTogglePrivacyMode,
+          onShieldBalancePressed: () => unawaited(_shieldTransparentBalance()),
         ),
         const SizedBox(height: AppSpacing.s),
         if (hasBalance)
@@ -323,20 +400,31 @@ class _BalanceCard extends StatelessWidget {
     required this.balanceText,
     required this.fiatBalanceText,
     required this.priceChange24hPct,
+    required this.transparentBalanceText,
+    required this.hasTransparentBalance,
+    required this.canShieldBalance,
+    required this.isShieldingBalance,
     required this.privacyModeEnabled,
     required this.onTogglePrivacyMode,
+    required this.onShieldBalancePressed,
   });
 
   final String balanceText;
   final String? fiatBalanceText;
   final double? priceChange24hPct;
+  final String transparentBalanceText;
+  final bool hasTransparentBalance;
+  final bool canShieldBalance;
+  final bool isShieldingBalance;
   final bool privacyModeEnabled;
   final VoidCallback onTogglePrivacyMode;
+  final VoidCallback onShieldBalancePressed;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
     final cardText = colors.text.homeCard;
+    final cardRadius = BorderRadius.circular(AppRadii.large);
     final roundedPriceChangePct = priceChange24hPct == null
         ? null
         : roundZecPriceChange24hPct(priceChange24hPct!);
@@ -349,88 +437,245 @@ class _BalanceCard extends StatelessWidget {
         : cardText;
 
     return Container(
-      height: 200,
-      padding: const EdgeInsets.all(AppSpacing.sm),
       decoration: BoxDecoration(
-        color: colors.background.homeCard,
-        borderRadius: BorderRadius.circular(AppRadii.large),
-        border: Border.all(
-          color: const Color(0xFFFFFFFF).withValues(alpha: 0.07),
-          width: 1.5,
-        ),
+        color: colors.background.ground,
+        borderRadius: cardRadius,
+        boxShadow: appSurfaceShadow(colors),
       ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            children: [
-              AppIcon(AppIcons.shieldKeyhole, size: 20, color: cardText),
-              const SizedBox(width: AppSpacing.xs),
-              Expanded(
-                child: Text(
-                  'Shielded balance',
-                  style: _mobileHomeLabelMStyle.copyWith(color: cardText),
+      child: ClipRRect(
+        borderRadius: cardRadius,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              height: 200,
+              padding: const EdgeInsets.all(AppSpacing.sm),
+              decoration: BoxDecoration(
+                color: colors.background.homeCard,
+                borderRadius: cardRadius,
+                border: Border.all(
+                  color: const Color(0xFFFFFFFF).withValues(alpha: 0.07),
+                  width: 1.5,
                 ),
               ),
-              _PrivacyEyeButton(
-                enabled: privacyModeEnabled,
-                onTap: onTogglePrivacyMode,
-              ),
-            ],
-          ),
-          const Spacer(),
-          if (fiatBalanceText != null) ...[
-            Row(
-              children: [
-                Flexible(
-                  child: Text(
-                    fiatBalanceText!,
-                    key: const ValueKey('mobile_home_balance_fiat_text'),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      AppIcon(
+                        AppIcons.shieldKeyhole,
+                        size: 20,
+                        color: cardText,
+                      ),
+                      const SizedBox(width: AppSpacing.xs),
+                      Expanded(
+                        child: Text(
+                          'Shielded balance',
+                          style: _mobileHomeLabelMStyle.copyWith(
+                            color: cardText,
+                          ),
+                        ),
+                      ),
+                      _PrivacyEyeButton(
+                        enabled: privacyModeEnabled,
+                        onTap: onTogglePrivacyMode,
+                      ),
+                    ],
+                  ),
+                  const Spacer(),
+                  if (fiatBalanceText != null) ...[
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            fiatBalanceText!,
+                            key: const ValueKey(
+                              'mobile_home_balance_fiat_text',
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: _mobileHomeLabelMStyle.copyWith(
+                              color: cardText.withValues(alpha: 0.8),
+                            ),
+                          ),
+                        ),
+                        if (priceChangeColor != null) ...[
+                          const SizedBox(width: AppSpacing.xs),
+                          Text(
+                            formatZecPriceChange24hPct(priceChange24hPct!),
+                            key: const ValueKey(
+                              'mobile_home_balance_price_change_text',
+                            ),
+                            style: _mobileHomeLabelMStyle.copyWith(
+                              color: priceChangeColor,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                  ],
+                  Text.rich(
+                    key: const ValueKey('mobile_home_shielded_balance'),
+                    TextSpan(
+                      children: [
+                        TextSpan(
+                          text: '$balanceText ',
+                          style: _mobileHomeBalanceAmountStyle.copyWith(
+                            color: cardText,
+                          ),
+                        ),
+                        TextSpan(
+                          text: kZcashDefaultCurrencyTicker,
+                          style: _mobileHomeBalanceTickerStyle.copyWith(
+                            color: cardText,
+                          ),
+                        ),
+                      ],
+                    ),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: _mobileHomeLabelMStyle.copyWith(
-                      color: cardText.withValues(alpha: 0.8),
-                    ),
                   ),
-                ),
-                if (priceChangeColor != null) ...[
+                ],
+              ),
+            ),
+            if (hasTransparentBalance)
+              _MobileTransparentBalanceStrip(
+                key: const ValueKey('mobile_home_transparent_balance_strip'),
+                balanceText: transparentBalanceText,
+                canShieldBalance: canShieldBalance,
+                isShieldingBalance: isShieldingBalance,
+                privacyModeEnabled: privacyModeEnabled,
+                onShieldBalancePressed: onShieldBalancePressed,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MobileTransparentBalanceStrip extends StatelessWidget {
+  const _MobileTransparentBalanceStrip({
+    required this.balanceText,
+    required this.canShieldBalance,
+    required this.isShieldingBalance,
+    required this.privacyModeEnabled,
+    required this.onShieldBalancePressed,
+    super.key,
+  });
+
+  final String balanceText;
+  final bool canShieldBalance;
+  final bool isShieldingBalance;
+  final bool privacyModeEnabled;
+  final VoidCallback onShieldBalancePressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final displayedBalance = hideAmountIfPrivacyMode(
+      '$balanceText $kZcashDefaultCurrencyTicker',
+      privacyModeEnabled: privacyModeEnabled,
+    );
+
+    return SizedBox(
+      height: 57,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.sm,
+          vertical: AppSpacing.xs,
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  AppIcon(
+                    AppIcons.transparentBalance,
+                    size: 20,
+                    color: colors.text.primary,
+                  ),
                   const SizedBox(width: AppSpacing.xs),
-                  Text(
-                    formatZecPriceChange24hPct(priceChange24hPct!),
-                    key: const ValueKey(
-                      'mobile_home_balance_price_change_text',
-                    ),
-                    style: _mobileHomeLabelMStyle.copyWith(
-                      color: priceChangeColor,
+                  Flexible(
+                    child: Text(
+                      'Transparent: $displayedBalance',
+                      key: const ValueKey(
+                        'mobile_home_transparent_balance_text',
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: _mobileHomeLabelMStyle.copyWith(
+                        color: colors.text.primary,
+                        fontWeight: FontWeight.w500,
+                      ),
                     ),
                   ),
                 ],
-              ],
+              ),
             ),
-            const SizedBox(height: AppSpacing.xs),
+            if (canShieldBalance || isShieldingBalance)
+              _MobileShieldBalanceButton(
+                enabled: canShieldBalance,
+                isLoading: isShieldingBalance,
+                onPressed: onShieldBalancePressed,
+              ),
           ],
-          Text.rich(
-            key: const ValueKey('mobile_home_shielded_balance'),
-            TextSpan(
-              children: [
-                TextSpan(
-                  text: '$balanceText ',
-                  style: _mobileHomeBalanceAmountStyle.copyWith(
-                    color: cardText,
-                  ),
-                ),
-                TextSpan(
-                  text: kZcashDefaultCurrencyTicker,
-                  style: _mobileHomeBalanceTickerStyle.copyWith(
-                    color: cardText,
-                  ),
-                ),
-              ],
-            ),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
+        ),
+      ),
+    );
+  }
+}
+
+class _MobileShieldBalanceButton extends StatelessWidget {
+  const _MobileShieldBalanceButton({
+    required this.enabled,
+    required this.isLoading,
+    required this.onPressed,
+  });
+
+  final bool enabled;
+  final bool isLoading;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final isInteractive = enabled && !isLoading;
+    final contentColor = isLoading || enabled
+        ? colors.text.accent
+        : colors.text.secondary.withValues(alpha: 0.64);
+
+    return Semantics(
+      key: const ValueKey('mobile_home_shield_balance_button'),
+      button: true,
+      enabled: isInteractive,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: isInteractive ? onPressed : null,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.xxs,
+            vertical: AppSpacing.s,
           ),
-        ],
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                isLoading ? 'Shielding...' : 'Shield',
+                style: _mobileHomeLabelMStyle.copyWith(color: contentColor),
+              ),
+              const SizedBox(width: AppSpacing.xxs),
+              AppIcon(
+                isLoading ? AppIcons.loader : AppIcons.chevronForward,
+                size: 16,
+                color: contentColor,
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -540,16 +540,164 @@ class _BalanceCard extends StatelessWidget {
                 ],
               ),
             ),
-            if (hasTransparentBalance)
-              _MobileTransparentBalanceStrip(
-                key: const ValueKey('mobile_home_transparent_balance_strip'),
-                balanceText: transparentBalanceText,
-                canShieldBalance: canShieldBalance,
-                isShieldingBalance: isShieldingBalance,
-                privacyModeEnabled: privacyModeEnabled,
-                onShieldBalancePressed: onShieldBalancePressed,
-              ),
+            _AnimatedMobileTransparentBalanceStrip(
+              visible: hasTransparentBalance,
+              balanceText: transparentBalanceText,
+              canShieldBalance: canShieldBalance,
+              isShieldingBalance: isShieldingBalance,
+              privacyModeEnabled: privacyModeEnabled,
+              onShieldBalancePressed: onShieldBalancePressed,
+            ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+const _mobileTransparentBalanceStripHeight = 57.0;
+const _mobileTransparentBalanceMotionDuration = Duration(milliseconds: 280);
+const _mobileTransparentBalanceMotionReverseDuration = Duration(
+  milliseconds: 240,
+);
+
+class _AnimatedMobileTransparentBalanceStrip extends StatefulWidget {
+  const _AnimatedMobileTransparentBalanceStrip({
+    required this.visible,
+    required this.balanceText,
+    required this.canShieldBalance,
+    required this.isShieldingBalance,
+    required this.privacyModeEnabled,
+    required this.onShieldBalancePressed,
+  });
+
+  final bool visible;
+  final String balanceText;
+  final bool canShieldBalance;
+  final bool isShieldingBalance;
+  final bool privacyModeEnabled;
+  final VoidCallback onShieldBalancePressed;
+
+  @override
+  State<_AnimatedMobileTransparentBalanceStrip> createState() =>
+      _AnimatedMobileTransparentBalanceStripState();
+}
+
+class _AnimatedMobileTransparentBalanceStripState
+    extends State<_AnimatedMobileTransparentBalanceStrip>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _sizeFactor;
+  late final Animation<double> _opacity;
+  late final Animation<Offset> _offset;
+
+  late String _balanceText;
+  late bool _canShieldBalance;
+  late bool _isShieldingBalance;
+  late bool _privacyModeEnabled;
+  late VoidCallback _onShieldBalancePressed;
+  var _hasCachedStrip = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: _mobileTransparentBalanceMotionDuration,
+      reverseDuration: _mobileTransparentBalanceMotionReverseDuration,
+      value: widget.visible ? 1.0 : 0.0,
+    )..addStatusListener(_handleAnimationStatus);
+    final curve = CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOutCubic,
+      reverseCurve: Curves.easeInCubic,
+    );
+    _sizeFactor = curve;
+    _opacity = CurvedAnimation(
+      parent: _controller,
+      curve: const Interval(0.2, 1.0, curve: Curves.easeOut),
+      reverseCurve: Curves.easeIn,
+    );
+    _offset = Tween<Offset>(
+      begin: const Offset(0, -0.14),
+      end: Offset.zero,
+    ).animate(curve);
+    if (widget.visible) {
+      _cacheVisibleStrip();
+      _hasCachedStrip = true;
+    }
+  }
+
+  @override
+  void didUpdateWidget(
+    covariant _AnimatedMobileTransparentBalanceStrip oldWidget,
+  ) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.visible) {
+      setState(() {
+        _cacheVisibleStrip();
+        _hasCachedStrip = true;
+      });
+      unawaited(_controller.forward());
+      return;
+    }
+
+    if (oldWidget.visible && !widget.visible) {
+      unawaited(_controller.reverse());
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller
+      ..removeStatusListener(_handleAnimationStatus)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _cacheVisibleStrip() {
+    _balanceText = widget.balanceText;
+    _canShieldBalance = widget.canShieldBalance;
+    _isShieldingBalance = widget.isShieldingBalance;
+    _privacyModeEnabled = widget.privacyModeEnabled;
+    _onShieldBalancePressed = widget.onShieldBalancePressed;
+  }
+
+  void _handleAnimationStatus(AnimationStatus status) {
+    if (status != AnimationStatus.dismissed ||
+        widget.visible ||
+        !_hasCachedStrip) {
+      return;
+    }
+    setState(() => _hasCachedStrip = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_hasCachedStrip && !widget.visible && _controller.isDismissed) {
+      return const SizedBox.shrink();
+    }
+
+    return ClipRect(
+      key: const ValueKey('mobile_home_transparent_balance_strip'),
+      child: SizeTransition(
+        sizeFactor: _sizeFactor,
+        axisAlignment: -1,
+        child: FadeTransition(
+          opacity: _opacity,
+          child: SlideTransition(
+            position: _offset,
+            child: IgnorePointer(
+              ignoring: !widget.visible,
+              child: _MobileTransparentBalanceStrip(
+                balanceText: _balanceText,
+                canShieldBalance: _canShieldBalance,
+                isShieldingBalance: _isShieldingBalance,
+                privacyModeEnabled: _privacyModeEnabled,
+                onShieldBalancePressed: _onShieldBalancePressed,
+              ),
+            ),
+          ),
         ),
       ),
     );
@@ -563,7 +711,6 @@ class _MobileTransparentBalanceStrip extends StatelessWidget {
     required this.isShieldingBalance,
     required this.privacyModeEnabled,
     required this.onShieldBalancePressed,
-    super.key,
   });
 
   final String balanceText;
@@ -581,7 +728,7 @@ class _MobileTransparentBalanceStrip extends StatelessWidget {
     );
 
     return SizedBox(
-      height: 57,
+      height: _mobileTransparentBalanceStripHeight,
       child: Padding(
         padding: const EdgeInsets.symmetric(
           horizontal: AppSpacing.sm,

--- a/lib/src/features/home/screens/mobile/mobile_keystone_shield_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_keystone_shield_screen.dart
@@ -1,0 +1,686 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart' show Colors, Icons, Scaffold;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+import '../../../../../main.dart' show log;
+import '../../../../core/config/rpc_endpoint_config.dart';
+import '../../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../../core/storage/wallet_paths.dart';
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/app_button.dart';
+import '../../../../core/widgets/app_icon.dart';
+import '../../../../providers/rpc_endpoint_failover_provider.dart';
+import '../../../../providers/sync_provider.dart';
+import '../../../../rust/api/keystone.dart' as rust_keystone;
+import '../../../../rust/api/sync.dart' as rust_sync;
+import '../../../../services/camera_permission_settings.dart';
+import '../../../../services/qr_scanner.dart';
+import '../../../address_scan/widgets/mobile_address_scan_view.dart'
+    show MobileScanCameraErrorOverlay, MobileScanViewfinderCorners;
+import '../../../keystone/widgets/keystone_pczt_qr_stage.dart';
+import '../../../send/screens/mobile/mobile_send_screen.dart'
+    show MobileSaplingParamsSheet;
+import '../../../send/services/sapling_params.dart';
+import '../../services/transparent_shielding_service.dart';
+
+enum _ShieldSignStage {
+  preparing,
+  showQr,
+  scanning,
+  broadcasting,
+  failed,
+  broadcastWarning,
+}
+
+class MobileKeystoneShieldResult {
+  const MobileKeystoneShieldResult._({required this.succeeded, this.message});
+
+  const MobileKeystoneShieldResult.succeeded() : this._(succeeded: true);
+
+  const MobileKeystoneShieldResult.warning(String message)
+    : this._(succeeded: false, message: message);
+
+  final bool succeeded;
+  final String? message;
+}
+
+class MobileKeystoneShieldScreen extends ConsumerStatefulWidget {
+  const MobileKeystoneShieldScreen({super.key});
+
+  @override
+  ConsumerState<MobileKeystoneShieldScreen> createState() =>
+      _MobileKeystoneShieldScreenState();
+}
+
+class _MobileKeystoneShieldScreenState
+    extends ConsumerState<MobileKeystoneShieldScreen>
+    with WidgetsBindingObserver {
+  var _stage = _ShieldSignStage.preparing;
+  String? _error;
+  String? _statusMessage;
+  List<String> _urParts = const [];
+  Uint8List? _pcztWithProofs;
+  SaplingParamsStatus? _saplingParams;
+  bool _needsSaplingParams = false;
+  bool _proofsFailed = false;
+  bool _decoding = false;
+  bool _restartCameraOnResume = false;
+  int _scanProgress = 0;
+  String? _scanHint;
+
+  MobileScannerController? _scanController;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    unawaited(_preparePczt());
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+    if (!_restartCameraOnResume) return;
+    _restartCameraOnResume = false;
+    unawaited(_restartCameraAfterSettings());
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    unawaited(_scanController?.dispose());
+    super.dispose();
+  }
+
+  Future<void> _preparePczt() async {
+    try {
+      final accountUuid = activeShieldingAccountUuid(ref);
+      final dbPath = await getWalletDbPath();
+      final endpoint = ref.read(rpcEndpointFailoverProvider).current;
+      final shieldPczt = await rust_sync.createShieldTransparentPczt(
+        dbPath: dbPath,
+        network: endpoint.networkName,
+        accountUuid: accountUuid,
+      );
+
+      var saplingParams = await loadSaplingParamsStatus();
+      if (shieldPczt.needsSaplingParams && !saplingParams.complete) {
+        final confirmed = await _confirmSaplingParamsDownload();
+        if (!confirmed) {
+          if (!mounted) return;
+          context.pop();
+          return;
+        }
+        await downloadMissingSaplingParams(
+          saplingParams,
+          log: (message) => log('MobileKeystoneShield: $message'),
+        );
+        saplingParams = await loadSaplingParamsStatus();
+      }
+
+      final redactedPczt = await rust_sync.redactPcztForSigner(
+        pcztBytes: shieldPczt.pcztBytes,
+      );
+      final urParts = await rust_keystone.encodePcztUrParts(
+        pcztBytes: redactedPczt,
+        maxFragmentLen: BigInt.from(140),
+      );
+
+      if (!mounted) return;
+      setState(() {
+        _stage = _ShieldSignStage.showQr;
+        _saplingParams = saplingParams;
+        _needsSaplingParams = shieldPczt.needsSaplingParams;
+        _urParts = urParts;
+      });
+
+      final pcztWithProofs = await rust_sync.addProofsToPczt(
+        pcztBytes: shieldPczt.pcztBytes,
+        spendParamsPath: shieldPczt.needsSaplingParams
+            ? saplingParams.spendPath
+            : null,
+        outputParamsPath: shieldPczt.needsSaplingParams
+            ? saplingParams.outputPath
+            : null,
+      );
+      if (!mounted) return;
+      setState(() => _pcztWithProofs = pcztWithProofs);
+    } catch (e, st) {
+      log('MobileKeystoneShield._preparePczt: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        if (_stage == _ShieldSignStage.showQr) {
+          _proofsFailed = true;
+        }
+        _stage = _ShieldSignStage.failed;
+        _error = _friendlyError(e);
+      });
+    }
+  }
+
+  Future<bool> _confirmSaplingParamsDownload() async {
+    if (!mounted) return false;
+    final confirmed = await showAppMobileSheet<bool>(
+      context: context,
+      isDismissible: false,
+      builder: (_) => const MobileSaplingParamsSheet(),
+    );
+    return confirmed == true;
+  }
+
+  String _friendlyError(Object error) {
+    final lower = error.toString().toLowerCase();
+    if (lower.contains('sapling') || lower.contains('download')) {
+      return 'Required proving parameters could not be prepared.';
+    }
+    if (lower.contains('pczt') || lower.contains('signature')) {
+      return 'Keystone signature could not be applied.';
+    }
+    if (lower.contains('extract')) {
+      return 'Shield transaction could not be finalized.';
+    }
+    return friendlyShieldBalanceError(error);
+  }
+
+  void _startScanning() {
+    _scanController ??= MobileScannerController(
+      facing: CameraFacing.back,
+      formats: QrScanner.formats,
+      detectionSpeed: QrScanner.detectionSpeed,
+    );
+    setState(() {
+      _stage = _ShieldSignStage.scanning;
+      _scanHint = null;
+      _scanProgress = 0;
+    });
+  }
+
+  void _backToQr() {
+    setState(() {
+      _stage = _ShieldSignStage.showQr;
+      _scanHint = null;
+      _scanProgress = 0;
+    });
+  }
+
+  Future<void> _openCameraSettings() async {
+    _restartCameraOnResume = true;
+    final opened = await CameraPermissionSettings.open();
+    if (!opened) {
+      _restartCameraOnResume = false;
+      log('MobileKeystoneShield: failed to open camera permission settings');
+    }
+  }
+
+  Future<void> _restartCameraAfterSettings() async {
+    final scanController = _scanController;
+    if (scanController == null ||
+        scanController.value.isStarting ||
+        scanController.value.isRunning) {
+      return;
+    }
+
+    try {
+      await scanController.start();
+    } catch (e, st) {
+      log('MobileKeystoneShield: camera settings return retry error: $e\n$st');
+    }
+  }
+
+  Future<void> _handleScanComplete(ScanResult result) async {
+    if (_decoding) return;
+    setState(() {
+      _decoding = true;
+      _scanHint = null;
+    });
+    try {
+      final signedPczt = await rust_keystone.decodePcztFromCbor(
+        cbor: result.data,
+      );
+      while (mounted && _pcztWithProofs == null && !_proofsFailed) {
+        if (_stage == _ShieldSignStage.failed) break;
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      }
+      final pcztWithProofs = _pcztWithProofs;
+      final saplingParams = _saplingParams;
+      if (!mounted) return;
+      if (pcztWithProofs == null || saplingParams == null) {
+        setState(() {
+          _decoding = false;
+          _stage = _ShieldSignStage.failed;
+          _error ??= 'Keystone signing could not be prepared.';
+        });
+        return;
+      }
+      await _broadcast(
+        pcztWithProofs: pcztWithProofs,
+        signatures: Uint8List.fromList(signedPczt),
+        saplingParams: saplingParams,
+      );
+    } catch (e, st) {
+      log('MobileKeystoneShield: signed PCZT decode error: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _decoding = false;
+        _scanHint =
+            'This QR code could not be decoded as a Keystone signature.';
+      });
+    }
+  }
+
+  void _handleDecodeError(Object error) {
+    if (!mounted || _decoding) return;
+    final message = error.toString().contains('Unexpected UR type')
+        ? 'Open the signed shield QR on Keystone, then scan again.'
+        : 'Keep the QR code steady and fully visible.';
+    if (_scanHint == message) return;
+    setState(() => _scanHint = message);
+  }
+
+  Future<void> _broadcast({
+    required Uint8List pcztWithProofs,
+    required Uint8List signatures,
+    required SaplingParamsStatus saplingParams,
+  }) async {
+    setState(() {
+      _stage = _ShieldSignStage.broadcasting;
+      _error = null;
+      _statusMessage = null;
+    });
+
+    RpcEndpointConfig? attemptedEndpoint;
+    try {
+      final dbPath = await getWalletDbPath();
+      final endpoint = ref.read(rpcEndpointFailoverProvider).current;
+      attemptedEndpoint = endpoint;
+      final result = await rust_sync.extractAndBroadcastPczt(
+        dbPath: dbPath,
+        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+        network: endpoint.networkName,
+        pcztWithProofsBytes: pcztWithProofs,
+        pcztWithSignaturesBytes: signatures,
+        spendParamsPath: _needsSaplingParams ? saplingParams.spendPath : null,
+        outputParamsPath: _needsSaplingParams ? saplingParams.outputPath : null,
+      );
+      log(
+        'MobileKeystoneShield: broadcast shield txid=${result.txid} '
+        'status=${result.status}',
+      );
+
+      if (result.status != 'broadcasted' && result.message != null) {
+        await _maybeSwitchBroadcastEndpoint(result.message!, attemptedEndpoint);
+      }
+
+      try {
+        await ref.read(syncProvider.notifier).refreshAfterSend();
+      } catch (e) {
+        log('MobileKeystoneShield: refreshAfterSend failed: $e');
+      }
+      if (!mounted) return;
+      if (result.status != 'broadcasted') {
+        setState(() {
+          _stage = _ShieldSignStage.broadcastWarning;
+          _statusMessage = shieldPcztBroadcastStatusMessage(result);
+        });
+        return;
+      }
+      context.pop(const MobileKeystoneShieldResult.succeeded());
+    } catch (e, st) {
+      log('MobileKeystoneShield._broadcast: ERROR: $e\n$st');
+      await _maybeSwitchBroadcastEndpoint(e, attemptedEndpoint);
+      if (!mounted) return;
+      final postBroadcastMessage = postBroadcastShieldErrorMessage(e);
+      if (postBroadcastMessage != null) {
+        setState(() {
+          _stage = _ShieldSignStage.broadcastWarning;
+          _statusMessage = postBroadcastMessage;
+        });
+        return;
+      }
+      setState(() {
+        _stage = _ShieldSignStage.failed;
+        _error = _friendlyError(e);
+      });
+    }
+  }
+
+  Future<void> _maybeSwitchBroadcastEndpoint(
+    Object error,
+    RpcEndpointConfig? attemptedEndpoint,
+  ) async {
+    final switched = await ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .switchToFallbackFor(
+          error,
+          endpoint: attemptedEndpoint,
+          operation: 'mobile keystone shield broadcast',
+        );
+    if (switched) {
+      unawaited(ref.read(syncProvider.notifier).restartSync());
+    }
+  }
+
+  void _cancel() {
+    if (_stage == _ShieldSignStage.broadcasting) return;
+    context.pop();
+  }
+
+  void _finishWarningOrFailure() {
+    final message = _statusMessage;
+    if (_stage == _ShieldSignStage.broadcastWarning &&
+        message != null &&
+        message.isNotEmpty) {
+      context.pop(MobileKeystoneShieldResult.warning(message));
+      return;
+    }
+    context.pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scanning = _stage == _ShieldSignStage.scanning;
+    return PopScope<void>(
+      canPop: _stage != _ShieldSignStage.broadcasting,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) _cancel();
+      },
+      child: Scaffold(
+        backgroundColor: Colors.black,
+        body: Stack(
+          fit: StackFit.expand,
+          children: [
+            if (scanning) _buildScanner() else _buildQrStage(),
+            SafeArea(
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.sm,
+                      vertical: AppSpacing.s,
+                    ),
+                    child: Row(
+                      children: [
+                        if (scanning)
+                          Semantics(
+                            button: true,
+                            label: 'Toggle flashlight',
+                            excludeSemantics: true,
+                            child: GestureDetector(
+                              behavior: HitTestBehavior.opaque,
+                              onTap: () =>
+                                  unawaited(_scanController?.toggleTorch()),
+                              child: const SizedBox(
+                                width: 44,
+                                height: 44,
+                                child: Icon(
+                                  Icons.flashlight_on_outlined,
+                                  color: Colors.white,
+                                  size: 24,
+                                ),
+                              ),
+                            ),
+                          ),
+                        const Spacer(),
+                        Semantics(
+                          button: true,
+                          label: 'Cancel signing',
+                          excludeSemantics: true,
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.opaque,
+                            onTap: _cancel,
+                            child: const SizedBox(
+                              width: 44,
+                              height: 44,
+                              child: Center(
+                                child: AppIcon(
+                                  AppIcons.cross,
+                                  size: 24,
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const Spacer(),
+                  _buildBottomBar(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildQrStage() {
+    final colors = context.colors;
+    final error = _stage == _ShieldSignStage.broadcastWarning
+        ? _statusMessage ??
+              'The shield transaction status is uncertain. Check activity before trying again.'
+        : _error;
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+        child: Column(
+          children: [
+            const SizedBox(height: 72),
+            Text(
+              _stage == _ShieldSignStage.broadcasting
+                  ? 'Broadcasting shield tx'
+                  : 'Shield transparent balance',
+              textAlign: TextAlign.center,
+              style: AppTypography.headlineSmall.copyWith(color: Colors.white),
+            ),
+            const SizedBox(height: AppSpacing.s),
+            Text(
+              _stage == _ShieldSignStage.broadcasting
+                  ? 'Keep Vizor open while the transaction is sent.'
+                  : 'Use your Keystone wallet to scan this shielding QR code. Follow the steps on your device.',
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMedium.copyWith(
+                color: const Color(0xCCFFFFFF),
+              ),
+            ),
+            const Spacer(),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final availableWidth = constraints.maxWidth.isFinite
+                    ? constraints.maxWidth
+                    : 312.0;
+                final qrSize = (availableWidth - AppSpacing.sm * 2)
+                    .clamp(220.0, 280.0)
+                    .toDouble();
+                return Container(
+                  padding: const EdgeInsets.all(AppSpacing.sm),
+                  decoration: BoxDecoration(
+                    color: colors.background.ground,
+                    borderRadius: BorderRadius.circular(AppRadii.large),
+                  ),
+                  child: KeystonePcztQrStage(
+                    phase: switch (_stage) {
+                      _ShieldSignStage.showQr => KeystonePcztQrStagePhase.ready,
+                      _ShieldSignStage.failed ||
+                      _ShieldSignStage.broadcastWarning =>
+                        KeystonePcztQrStagePhase.failed,
+                      _ => KeystonePcztQrStagePhase.preparing,
+                    },
+                    urParts: _urParts,
+                    error: error,
+                    size: qrSize,
+                    scanOptimized: true,
+                    frameInterval: const Duration(milliseconds: 100),
+                  ),
+                );
+              },
+            ),
+            const Spacer(),
+            const SizedBox(height: 96),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScanner() {
+    const viewfinderSize = 260.0;
+    final scanController = _scanController;
+    if (scanController == null) return const SizedBox.shrink();
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        AnimatedUrScannerView(
+          controller: scanController,
+          expectedUrType: 'zcash-pczt',
+          scanSessionResetToken: _stage,
+          errorBuilder: (context, error) => const SizedBox.shrink(),
+          onProgress: (progress) {
+            if (!mounted || _scanProgress == progress) return;
+            setState(() => _scanProgress = progress);
+          },
+          onDecodeError: _handleDecodeError,
+          onComplete: (result) => unawaited(_handleScanComplete(result)),
+        ),
+        ColorFiltered(
+          colorFilter: const ColorFilter.mode(
+            Color(0x99000000),
+            BlendMode.srcOut,
+          ),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              Container(
+                decoration: const BoxDecoration(
+                  color: Colors.black,
+                  backgroundBlendMode: BlendMode.dstOut,
+                ),
+              ),
+              Center(
+                child: Container(
+                  width: viewfinderSize,
+                  height: viewfinderSize,
+                  decoration: BoxDecoration(
+                    color: Colors.black,
+                    borderRadius: BorderRadius.circular(AppRadii.large),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Center(
+          child: SizedBox(
+            width: viewfinderSize,
+            height: viewfinderSize,
+            child: const MobileScanViewfinderCorners(),
+          ),
+        ),
+        MobileScanCameraErrorOverlay(
+          controller: scanController,
+          maxWidth: viewfinderSize,
+          permissionDeniedMessage:
+              'Camera access is off. Allow it in Settings to scan Keystone signatures.',
+          unavailableMessage: 'The camera is unavailable right now.',
+          onOpenSettings: _openCameraSettings,
+        ),
+        Align(
+          alignment: Alignment.center,
+          child: Padding(
+            padding: const EdgeInsets.only(top: viewfinderSize + 96),
+            child: Text(
+              _decoding
+                  ? 'Reading signature...'
+                  : _scanHint ??
+                        (_scanProgress > 0
+                            ? 'Scanning... $_scanProgress%'
+                            : 'Scan the signed QR on your Keystone'),
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMedium.copyWith(color: Colors.white),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBottomBar() {
+    final scanning = _stage == _ShieldSignStage.scanning;
+    final terminal =
+        _stage == _ShieldSignStage.failed ||
+        _stage == _ShieldSignStage.broadcastWarning;
+    if (terminal) {
+      return Padding(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.md,
+          AppSpacing.s,
+          AppSpacing.md,
+          AppSpacing.md,
+        ),
+        child: AppButton(
+          expand: true,
+          onPressed: _finishWarningOrFailure,
+          child: const Text('Back to wallet'),
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.s,
+        AppSpacing.md,
+        AppSpacing.md,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: AppButton(
+              expand: true,
+              variant: AppButtonVariant.ghost,
+              onPressed: _stage == _ShieldSignStage.broadcasting
+                  ? null
+                  : _cancel,
+              child: const Text(
+                'Cancel',
+                style: TextStyle(color: Colors.white),
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(
+            child: scanning
+                ? AppButton(
+                    expand: true,
+                    variant: AppButtonVariant.secondary,
+                    onPressed: _decoding ? null : _backToQr,
+                    child: const Text('Show QR'),
+                  )
+                : AppButton(
+                    expand: true,
+                    onPressed: _stage == _ShieldSignStage.showQr
+                        ? _startScanning
+                        : null,
+                    trailing: _stage == _ShieldSignStage.broadcasting
+                        ? const AppIcon(AppIcons.loader)
+                        : const AppIcon(AppIcons.chevronForward),
+                    child: Text(
+                      _stage == _ShieldSignStage.broadcasting
+                          ? 'Broadcasting...'
+                          : 'Next step',
+                    ),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/home/services/transparent_shielding_service.dart
+++ b/lib/src/features/home/services/transparent_shielding_service.dart
@@ -1,0 +1,186 @@
+import 'dart:async';
+import 'dart:io' show Platform;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/config/rpc_endpoint_config.dart';
+import '../../../core/storage/wallet_paths.dart';
+import '../../../providers/account_provider.dart';
+import '../../../providers/app_security_provider.dart';
+import '../../../providers/rpc_endpoint_failover_provider.dart';
+import '../../../providers/sync_provider.dart';
+import '../../../providers/wallet_provider.dart';
+import '../../../rust/api/sync.dart' as rust_sync;
+
+const shieldBalancePendingBroadcastMessage =
+    'Shielding queued for retry. Check Activity.';
+
+String? shieldBalanceBroadcastStatusMessage(
+  rust_sync.ShieldTransparentResult result,
+) {
+  if (result.status == 'broadcasted') return null;
+  return shieldBalancePendingBroadcastMessage;
+}
+
+String friendlyShieldBalanceError(Object error) {
+  final message = error.toString();
+  final lower = message.toLowerCase();
+  if (lower.contains('mnemonic')) {
+    return "Secret Passphrase isn't available for this account.";
+  }
+  if (lower.contains('sync')) {
+    return 'Wait for sync to finish, then shield.';
+  }
+  if (lower.contains('insufficient') ||
+      lower.contains('threshold') ||
+      lower.contains('too small') ||
+      lower.contains('no transparent funds')) {
+    return 'Transparent balance is too small to shield after fees.';
+  }
+  if (lower.contains('broadcast') || lower.contains('sendtransaction')) {
+    return "Couldn't broadcast your shielding transaction. Try again.";
+  }
+  return "Couldn't shield your balance. Try again.";
+}
+
+String? shieldBalanceErrorDetails(Object error) {
+  final message = error.toString().trim();
+  final lower = message.toLowerCase();
+  if (lower.contains('broadcast') || lower.contains('sendtransaction')) {
+    return null;
+  }
+  return message.isEmpty ? null : message;
+}
+
+Future<rust_sync.ShieldTransparentResult> shieldTransparentSoftwareBalance({
+  required WidgetRef ref,
+  required String accountUuid,
+  String logContext = 'TransparentShielding',
+}) async {
+  RpcEndpointConfig? attemptedEndpoint;
+  try {
+    final sync = (ref.read(syncProvider).value ?? SyncState()).scopedToAccount(
+      accountUuid,
+    );
+    if (!sync.canShieldTransparentBalance) {
+      throw Exception('Transparent balance is too small to shield after fees.');
+    }
+
+    final dbPath = await getWalletDbPath();
+    final endpoint = ref.read(rpcEndpointFailoverProvider).current;
+    attemptedEndpoint = endpoint;
+
+    late final rust_sync.ShieldTransparentResult result;
+    late final Future<rust_sync.ShieldTransparentResult> resultFuture;
+
+    if (Platform.isMacOS) {
+      final password = ref
+          .read(appSecurityProvider.notifier)
+          .requireSessionPasswordForNativeSecretUse();
+      resultFuture = rust_sync.shieldTransparentBalanceWithMacosStoredMnemonic(
+        dbPath: dbPath,
+        lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+        network: endpoint.networkName,
+        accountUuid: accountUuid,
+        password: password,
+      );
+    } else {
+      final accountNotifier = ref.read(accountProvider.notifier);
+      final mnemonicBytes = await accountNotifier.getMnemonicBytesForAccount(
+        accountUuid,
+      );
+      if (mnemonicBytes == null || mnemonicBytes.isEmpty) {
+        throw Exception('Mnemonic not found for the active account.');
+      }
+
+      try {
+        resultFuture = rust_sync.shieldTransparentBalance(
+          dbPath: dbPath,
+          lightwalletdUrl: endpoint.normalizedLightwalletdUrl,
+          network: endpoint.networkName,
+          accountUuid: accountUuid,
+          mnemonicBytes: mnemonicBytes,
+        );
+      } finally {
+        mnemonicBytes.fillRange(0, mnemonicBytes.length, 0);
+      }
+    }
+
+    result = await resultFuture;
+    log(
+      '$logContext: shielded transparent balance txids=${result.txids} '
+      'status=${result.status} '
+      'broadcasted=${result.broadcastedCount}/${result.totalCount} '
+      'fee=${result.feeZatoshi} shielded=${result.shieldedZatoshi}',
+    );
+
+    final broadcastStatusMessage = shieldBalanceBroadcastStatusMessage(result);
+    final broadcastDetailMessage = result.message?.trim();
+    if (broadcastStatusMessage != null &&
+        broadcastDetailMessage != null &&
+        broadcastDetailMessage.isNotEmpty) {
+      final switched = await ref
+          .read(rpcEndpointFailoverProvider.notifier)
+          .switchToFallbackFor(
+            broadcastDetailMessage,
+            endpoint: attemptedEndpoint,
+            operation: 'shield transparent balance broadcast',
+          );
+      if (switched) {
+        unawaited(ref.read(syncProvider.notifier).restartSync());
+      }
+    }
+
+    try {
+      await ref.read(syncProvider.notifier).refreshAfterSend();
+    } catch (e) {
+      log('$logContext: refreshAfterSend after shielding failed: $e');
+    }
+
+    return result;
+  } catch (e, st) {
+    log('$logContext: shield transparent balance failed: $e\n$st');
+    final switched = await ref
+        .read(rpcEndpointFailoverProvider.notifier)
+        .switchToFallbackFor(
+          e,
+          endpoint: attemptedEndpoint,
+          operation: 'shield transparent balance',
+        );
+    if (switched) {
+      unawaited(ref.read(syncProvider.notifier).restartSync());
+    }
+    rethrow;
+  }
+}
+
+String shieldPcztBroadcastStatusMessage(
+  rust_sync.ExtractAndBroadcastPcztResult result,
+) {
+  if (result.status == 'broadcast_unknown') {
+    return result.message ??
+        'The shield transaction may have reached the network, but confirmation timed out. Check activity before trying again.';
+  }
+  if (result.status == 'broadcasted_storage_failed') {
+    return result.message ??
+        'The shield transaction reached the network, but Vizor could not store it locally. Do not try again until sync or an explorer confirms the latest status.';
+  }
+  return result.message ??
+      'The shield transaction status is uncertain. Check activity before trying again.';
+}
+
+String? postBroadcastShieldErrorMessage(Object error) {
+  final raw = error.toString();
+  if (!raw.toLowerCase().contains('broadcast succeeded')) return null;
+  return raw.replaceFirst(RegExp(r'^Exception:\s*'), '');
+}
+
+String activeShieldingAccountUuid(WidgetRef ref) {
+  final wallet = ref.read(walletProvider).value;
+  final accountUuid = wallet?.activeAccountUuid;
+  if (accountUuid == null) {
+    throw Exception('No active account.');
+  }
+  return accountUuid;
+}

--- a/lib/src/features/onboarding/mobile/mobile_import_birthday_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_birthday_screen.dart
@@ -24,6 +24,7 @@ import '../import/import_birthday_estimator.dart';
 import '../shared/onboarding_error_messages.dart';
 import '../shared/onboarding_flow_args.dart';
 import 'mobile_import_account_discovery_sheet.dart';
+import 'mobile_import_birthday_unknown_height_sheet.dart';
 import 'mobile_onboarding_scaffold.dart';
 
 enum _BirthdayEntryMode { date, blockHeight }
@@ -255,10 +256,12 @@ class _MobileImportBirthdayScreenState
   /// "I can't remember" — like the desktop skip, import from the Sapling
   /// activation height so the wallet scans the whole chain rather than
   /// guessing a birthday.
-  void _skipBirthday() {
+  Future<void> _skipBirthday() async {
     if (_busy) return;
     _heightFocus.unfocus();
-    unawaited(_submit(_minHeight));
+    final confirmed = await showMobileImportBirthdayUnknownHeightSheet(context);
+    if (!mounted || !confirmed) return;
+    await _submit(_minHeight);
   }
 
   Future<void> _submit(int height) async {
@@ -462,7 +465,7 @@ class _MobileImportBirthdayScreenState
             key: const ValueKey('mobile_import_birthday_skip'),
             variant: AppButtonVariant.secondary,
             expand: true,
-            onPressed: _busy ? null : _skipBirthday,
+            onPressed: _busy ? null : () => unawaited(_skipBirthday()),
             trailing: const AppIcon(AppIcons.skip),
             child: const Text('I can’t remember'),
           ),

--- a/lib/src/features/onboarding/mobile/mobile_import_birthday_unknown_height_sheet.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_birthday_unknown_height_sheet.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/widgets.dart';
+
+import '../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+
+Future<bool> showMobileImportBirthdayUnknownHeightSheet(
+  BuildContext context,
+) async {
+  final confirmed = await showAppMobileSheet<bool>(
+    context: context,
+    builder: (sheetContext) => MobileImportBirthdayUnknownHeightSheet(
+      onConfirm: () => Navigator.of(sheetContext).pop(true),
+      onCancel: () => Navigator.of(sheetContext).pop(false),
+    ),
+  );
+  return confirmed == true;
+}
+
+class MobileImportBirthdayUnknownHeightSheet extends StatelessWidget {
+  const MobileImportBirthdayUnknownHeightSheet({
+    required this.onConfirm,
+    required this.onCancel,
+    super.key,
+  });
+
+  final VoidCallback onConfirm;
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return MobileModalScaffold(
+      key: const ValueKey('mobile_import_birthday_unknown_height_sheet'),
+      title: 'Import from the earliest height?',
+      titleMaxLines: 2,
+      leading: Container(
+        width: 32,
+        height: 32,
+        decoration: BoxDecoration(
+          color: colors.background.neutralSubtleOpacity,
+          shape: BoxShape.circle,
+        ),
+        child: Center(
+          child: AppIcon(
+            AppIcons.warning,
+            size: AppIconSize.medium,
+            color: colors.icon.regular,
+          ),
+        ),
+      ),
+      onClose: onCancel,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'If you continue without a wallet birthday, Vizor will scan from '
+            'the earliest supported shielded height. This is safe, but the '
+            'first sync can take a very long time.',
+            style: AppTypography.bodyMedium.copyWith(color: colors.text.accent),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          Text(
+            'Choosing even an approximate date will be much faster.',
+            style: AppTypography.bodyMedium.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          AppButton(
+            key: const ValueKey(
+              'mobile_import_birthday_unknown_height_confirm',
+            ),
+            variant: AppButtonVariant.ghost,
+            expand: true,
+            onPressed: onConfirm,
+            child: const Text('Continue anyway'),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          AppButton(
+            key: const ValueKey('mobile_import_birthday_unknown_height_cancel'),
+            expand: true,
+            onPressed: onCancel,
+            child: const Text('Go back'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/fakes/fake_sync_notifier.dart
+++ b/test/fakes/fake_sync_notifier.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 
 class FakeSyncNotifier extends SyncNotifier {
@@ -7,4 +8,8 @@ class FakeSyncNotifier extends SyncNotifier {
 
   @override
   Future<SyncState> build() async => initialState ?? SyncState();
+
+  void setSyncState(SyncState nextState) {
+    state = AsyncData(nextState);
+  }
 }

--- a/test/features/home/home_shield_balance_message_test.dart
+++ b/test/features/home/home_shield_balance_message_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:zcash_wallet/src/features/home/screens/home_screen.dart';
+import 'package:zcash_wallet/src/features/home/services/transparent_shielding_service.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 void main() {

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -107,12 +107,18 @@ Widget _app(
   );
 }
 
-SyncState _syncedState({BigInt? orchardBalance}) => SyncState(
+SyncState _syncedState({
+  BigInt? orchardBalance,
+  BigInt? transparentBalance,
+  bool canShieldTransparentBalance = false,
+}) => SyncState(
   accountUuid: 'account-1',
   hasAccountScopedData: true,
   percentage: 1.0,
   displayPercentage: 1.0,
   orchardBalance: orchardBalance ?? BigInt.zero,
+  transparentBalance: transparentBalance ?? BigInt.zero,
+  canShieldTransparentBalance: canShieldTransparentBalance,
 );
 
 rust_sync.TransactionInfo _tx(int index) {
@@ -183,6 +189,33 @@ void main() {
     expect(find.text('Send'), findsOneWidget);
     expect(find.text('Receive'), findsOneWidget);
     expect(find.text('No activity, yet...'), findsOneWidget);
+  });
+
+  testWidgets('shows transparent balance tray with shield action', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        _syncedState(
+          orchardBalance: BigInt.from(14312000000),
+          transparentBalance: BigInt.from(242000000),
+          canShieldTransparentBalance: true,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('mobile_home_transparent_balance_strip')),
+      findsOneWidget,
+    );
+    expect(find.text('Transparent: 2.42 ZEC'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('mobile_home_shield_balance_button')),
+      findsOneWidget,
+    );
+    expect(find.text('Shield'), findsOneWidget);
   });
 
   testWidgets('matches the Figma balance card controls and action labels', (

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -77,7 +77,9 @@ Widget _app(
     usdPrice: 70,
     change24hPct: 13.12,
   ),
+  FakeSyncNotifier? syncNotifier,
 }) {
+  final effectiveSyncNotifier = syncNotifier ?? FakeSyncNotifier(syncState);
   final router = GoRouter(
     initialLocation: '/home',
     routes: [
@@ -94,7 +96,7 @@ Widget _app(
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
-      syncProvider.overrideWith(() => FakeSyncNotifier(syncState)),
+      syncProvider.overrideWith(() => effectiveSyncNotifier),
       privacyModeProvider.overrideWith(_FakePrivacyModeNotifier.new),
       zecMarketDataSourceProvider.overrideWithValue(
         _FakeMarketDataSource(marketData),
@@ -216,6 +218,42 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Shield'), findsOneWidget);
+  });
+
+  testWidgets('animates transparent balance tray away before removal', (
+    tester,
+  ) async {
+    final syncNotifier = FakeSyncNotifier(
+      _syncedState(
+        orchardBalance: BigInt.from(14312000000),
+        transparentBalance: BigInt.from(242000000),
+        canShieldTransparentBalance: true,
+      ),
+    );
+    await tester.pumpWidget(
+      _app(syncNotifier.initialState!, syncNotifier: syncNotifier),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    final stripFinder = find.byKey(
+      const ValueKey('mobile_home_transparent_balance_strip'),
+    );
+    expect(stripFinder, findsOneWidget);
+    final expandedHeight = tester.getSize(stripFinder).height;
+    expect(expandedHeight, moreOrLessEquals(57));
+
+    syncNotifier.setSyncState(
+      _syncedState(orchardBalance: BigInt.from(14312000000)),
+    );
+    await tester.pump();
+    expect(stripFinder, findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 70));
+    expect(tester.getSize(stripFinder).height, lessThan(expandedHeight));
+
+    await tester.pumpAndSettle();
+    expect(stripFinder, findsNothing);
   });
 
   testWidgets('matches the Figma balance card controls and action labels', (

--- a/test/features/onboarding/mobile_import_birthday_screen_test.dart
+++ b/test/features/onboarding/mobile_import_birthday_screen_test.dart
@@ -33,13 +33,14 @@ AppBootstrapState _bootstrap() => AppBootstrapState(
   passwordRotationRecoveryFailed: false,
 );
 
-Widget _app() {
+Widget _app({Future<void> Function(int height)? onHeightConfirmed}) {
   return ProviderScope(
     overrides: [appBootstrapProvider.overrideWithValue(_bootstrap())],
     child: MaterialApp(
       builder: (_, c) => AppTheme(data: AppThemeData.light, child: c!),
-      home: const MobileImportBirthdayScreen(
-        args: ImportBirthdayArgs(mnemonic: 'stub mnemonic'),
+      home: MobileImportBirthdayScreen(
+        args: const ImportBirthdayArgs(mnemonic: 'stub mnemonic'),
+        onHeightConfirmed: onHeightConfirmed,
         loadChainMetadata: false,
       ),
     ),
@@ -174,6 +175,87 @@ void main() {
     await tester.enterText(heightField, '25a.b00');
     await tester.pump();
     expect(tester.widget<TextField>(heightField).controller!.text, '2500');
+  });
+
+  testWidgets('skip asks before importing from the earliest supported height', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(393, 852);
+
+    int? confirmedHeight;
+    final expectedHeight = defaultRpcEndpointConfig(
+      'main',
+    ).network.saplingActivationHeight;
+
+    await tester.pumpWidget(
+      _app(onHeightConfirmed: (height) async => confirmedHeight = height),
+    );
+    await tester.pump();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_import_birthday_skip')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('mobile_import_birthday_unknown_height_sheet')),
+      findsOneWidget,
+    );
+    expect(find.text('Import from the earliest height?'), findsOneWidget);
+    expect(
+      tester
+          .widget<Text>(find.text('Import from the earliest height?'))
+          .maxLines,
+      2,
+    );
+    expect(
+      tester
+          .widget<AppButton>(
+            find.byKey(
+              const ValueKey('mobile_import_birthday_unknown_height_confirm'),
+            ),
+          )
+          .variant,
+      AppButtonVariant.ghost,
+    );
+    expect(
+      tester
+          .widget<AppButton>(
+            find.byKey(
+              const ValueKey('mobile_import_birthday_unknown_height_cancel'),
+            ),
+          )
+          .variant,
+      AppButtonVariant.primary,
+    );
+    expect(confirmedHeight, isNull);
+
+    await tester.tap(
+      find.byKey(
+        const ValueKey('mobile_import_birthday_unknown_height_cancel'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('mobile_import_birthday_unknown_height_sheet')),
+      findsNothing,
+    );
+    expect(confirmedHeight, isNull);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_import_birthday_skip')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(
+        const ValueKey('mobile_import_birthday_unknown_height_confirm'),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      find.byKey(const ValueKey('mobile_import_birthday_unknown_height_sheet')),
+      findsNothing,
+    );
+    expect(confirmedHeight, expectedHeight);
   });
 
   testWidgets('the date field is not typeable and opens the calendar', (


### PR DESCRIPTION
## Summary

- Adds mobile transparent asset shielding on the home screen, reusing the desktop shielding flow and routing.
- Adds the mobile Keystone transparent shield flow with QR signing screens and Sapling parameter confirmation.
- Animates the mobile transparent balance strip below the home card.
- Adds a mobile warning sheet before importing from the earliest birthday height.

## Validation

- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/home/mobile_home_screen_test.dart`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/onboarding/mobile_import_birthday_screen_test.dart`
- `fvm flutter analyze`

Note: local `fvm` commands emitted the existing Pub/Dart cache warning `Can't load Kernel binary...`, but the validation commands completed successfully.