### PR TITLE
Fix iOS fresh install keychain cleanup retry

### DIFF
--- a/ios/Runner/WalletPathResolver.swift
+++ b/ios/Runner/WalletPathResolver.swift
@@ -5,6 +5,7 @@ private let walletDbNameKey = "zcash_wallet_db_name"
 private let secureStoreService = "com.keplr.vizor.secure_store"
 private let biometricUnlockService = "com.zcash.wallet.biometric-unlock"
 private let installSentinelKey = "vizor_install_sentinel_v1"
+private let cleanupPendingKey = "vizor_keychain_cleanup_pending_v1"
 
 enum WalletPathResolverError: Error {
     case dbNameMissing
@@ -79,6 +80,9 @@ struct FreshInstallKeychainCleaner {
     struct Dependencies {
         var hasInstallSentinel: () -> Bool
         var markInstallSentinel: () -> Void
+        var hasCleanupPending: () -> Bool
+        var markCleanupPending: () -> Void
+        var clearCleanupPending: () -> Void
         var readWalletDbName: () -> KeychainDbNameLookup
         var walletDbExists: (String) -> Bool
         var deleteKeychainService: (String) -> OSStatus
@@ -90,6 +94,15 @@ struct FreshInstallKeychainCleaner {
             },
             markInstallSentinel: {
                 UserDefaults.standard.set(true, forKey: installSentinelKey)
+            },
+            hasCleanupPending: {
+                UserDefaults.standard.bool(forKey: cleanupPendingKey)
+            },
+            markCleanupPending: {
+                UserDefaults.standard.set(true, forKey: cleanupPendingKey)
+            },
+            clearCleanupPending: {
+                UserDefaults.standard.removeObject(forKey: cleanupPendingKey)
             },
             readWalletDbName: {
                 FreshInstallKeychainCleaner.readWalletDbNameFromKeychain()
@@ -107,29 +120,31 @@ struct FreshInstallKeychainCleaner {
     }
 
     static let servicesToClear = [
-        secureStoreService,
         biometricUnlockService,
+        // Keep this last: it holds zcash_wallet_db_name, the stale-install anchor.
+        secureStoreService,
     ]
 
     static func runIfNeeded(dependencies: Dependencies = .live) {
+        if dependencies.hasInstallSentinel() {
+            return
+        }
+
+        let cleanupPending = dependencies.hasCleanupPending()
         switch cleanupDecision(dependencies: dependencies) {
         case .sentinelPresent:
             return
         case .markInstalled:
+            dependencies.clearCleanupPending()
             dependencies.markInstallSentinel()
         case .preserveExistingInstall:
+            dependencies.clearCleanupPending()
             dependencies.markInstallSentinel()
         case .clearStaleKeychain:
-            let statuses = servicesToClear.map { dependencies.deleteKeychainService($0) }
-            let succeeded = statuses.allSatisfy { status in
-                status == errSecSuccess || status == errSecItemNotFound
+            if !cleanupPending {
+                dependencies.markCleanupPending()
             }
-            if succeeded {
-                dependencies.markInstallSentinel()
-                dependencies.log("fresh install: cleared stale iOS keychain values")
-            } else if let status = statuses.first(where: { $0 != errSecSuccess && $0 != errSecItemNotFound }) {
-                dependencies.log("fresh install: deferred keychain cleanup after delete status \(status)")
-            }
+            clearStaleKeychain(dependencies: dependencies)
         case .deferCleanupAfterReadFailure(let status):
             dependencies.log("fresh install: deferred keychain cleanup after read status \(status)")
         case .deferCleanupAfterInvalidWalletDbName:
@@ -158,6 +173,41 @@ struct FreshInstallKeychainCleaner {
             return dependencies.walletDbExists(dbName)
                 ? .preserveExistingInstall
                 : .clearStaleKeychain
+        }
+    }
+
+    private static func clearStaleKeychain(dependencies: Dependencies) {
+        var nonAnchorFailure: OSStatus?
+        var anchorStatus: OSStatus?
+
+        for service in servicesToClear {
+            let status = dependencies.deleteKeychainService(service)
+            if service == secureStoreService {
+                anchorStatus = status
+            } else if !isKeychainDeleteSuccess(status), nonAnchorFailure == nil {
+                nonAnchorFailure = status
+            }
+        }
+
+        guard let anchorStatus else {
+            dependencies.log("fresh install: deferred keychain cleanup; secure store was not attempted")
+            return
+        }
+
+        guard isKeychainDeleteSuccess(anchorStatus) else {
+            dependencies.log("fresh install: deferred keychain cleanup after delete status \(anchorStatus)")
+            return
+        }
+
+        dependencies.clearCleanupPending()
+        dependencies.markInstallSentinel()
+        if let nonAnchorFailure {
+            dependencies.log(
+                "fresh install: cleared stale iOS secure storage; "
+                    + "non-anchor keychain cleanup failed with status \(nonAnchorFailure)"
+            )
+        } else {
+            dependencies.log("fresh install: cleared stale iOS keychain values")
         }
     }
 
@@ -207,6 +257,10 @@ struct FreshInstallKeychainCleaner {
             return false
         }
         return (dbName as NSString).lastPathComponent == dbName
+    }
+
+    private static func isKeychainDeleteSuccess(_ status: OSStatus) -> Bool {
+        status == errSecSuccess || status == errSecItemNotFound
     }
 
     private static func deleteGenericPasswordService(_ service: String) -> OSStatus {

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -13,6 +13,7 @@ class RunnerTests: XCTestCase {
     FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
 
     XCTAssertTrue(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
     XCTAssertTrue(harness.deletedServices.isEmpty)
   }
 
@@ -24,6 +25,7 @@ class RunnerTests: XCTestCase {
     FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
 
     XCTAssertTrue(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
     XCTAssertTrue(harness.deletedServices.isEmpty)
   }
 
@@ -35,6 +37,7 @@ class RunnerTests: XCTestCase {
     FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
 
     XCTAssertTrue(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
     XCTAssertEqual(
       harness.deletedServices,
       FreshInstallKeychainCleaner.servicesToClear
@@ -48,6 +51,7 @@ class RunnerTests: XCTestCase {
     FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
 
     XCTAssertFalse(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
     XCTAssertTrue(harness.deletedServices.isEmpty)
   }
 
@@ -58,10 +62,11 @@ class RunnerTests: XCTestCase {
     FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
 
     XCTAssertFalse(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
     XCTAssertTrue(harness.deletedServices.isEmpty)
   }
 
-  func testFreshInstallCleanerDefersSentinelWhenDeleteFails() {
+  func testFreshInstallCleanerDefersOnlyWhenSecureStoreDeleteFails() {
     let harness = FreshInstallCleanerHarness()
     harness.lookup = .found("zcash_wallet_deleted.db")
     harness.walletDbExists = false
@@ -73,6 +78,85 @@ class RunnerTests: XCTestCase {
     FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
 
     XCTAssertFalse(harness.markedInstalled)
+    XCTAssertTrue(harness.cleanupPending)
+    XCTAssertEqual(
+      harness.deletedServices,
+      FreshInstallKeychainCleaner.servicesToClear
+    )
+  }
+
+  func testFreshInstallCleanerCompletesWhenOnlyNonAnchorDeleteFails() {
+    let harness = FreshInstallCleanerHarness()
+    harness.lookup = .found("zcash_wallet_deleted.db")
+    harness.walletDbExists = false
+    harness.deleteStatuses = [
+      FreshInstallKeychainCleaner.servicesToClear[0]: errSecAuthFailed,
+    ]
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertTrue(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
+    XCTAssertEqual(
+      harness.deletedServices,
+      FreshInstallKeychainCleaner.servicesToClear
+    )
+  }
+
+  func testFreshInstallCleanerClearsPendingWhenNoWalletKeychainExists() {
+    let harness = FreshInstallCleanerHarness()
+    harness.cleanupPending = true
+    harness.lookup = .missing
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertTrue(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
+    XCTAssertTrue(harness.deletedServices.isEmpty)
+  }
+
+  func testFreshInstallCleanerClearsPendingWhenCurrentWalletDbStillExists() {
+    let harness = FreshInstallCleanerHarness()
+    harness.cleanupPending = true
+    harness.lookup = .found("zcash_wallet_existing.db")
+    harness.walletDbExists = true
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertTrue(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
+    XCTAssertTrue(harness.deletedServices.isEmpty)
+  }
+
+  func testFreshInstallCleanerRetriesPendingCleanupWhenWalletDbIsGone() {
+    let harness = FreshInstallCleanerHarness()
+    harness.cleanupPending = true
+    harness.lookup = .found("zcash_wallet_deleted.db")
+    harness.walletDbExists = false
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertTrue(harness.markedInstalled)
+    XCTAssertFalse(harness.cleanupPending)
+    XCTAssertEqual(
+      harness.deletedServices,
+      FreshInstallKeychainCleaner.servicesToClear
+    )
+  }
+
+  func testFreshInstallCleanerKeepsPendingWhenSecureStoreDeleteFails() {
+    let harness = FreshInstallCleanerHarness()
+    harness.cleanupPending = true
+    harness.lookup = .found("zcash_wallet_deleted.db")
+    harness.walletDbExists = false
+    harness.deleteStatuses = [
+      FreshInstallKeychainCleaner.servicesToClear[1]: errSecAuthFailed,
+    ]
+
+    FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
+
+    XCTAssertFalse(harness.markedInstalled)
+    XCTAssertTrue(harness.cleanupPending)
     XCTAssertEqual(
       harness.deletedServices,
       FreshInstallKeychainCleaner.servicesToClear
@@ -82,12 +166,14 @@ class RunnerTests: XCTestCase {
   func testFreshInstallCleanerDoesNothingWhenSentinelAlreadyExists() {
     let harness = FreshInstallCleanerHarness()
     harness.hasSentinel = true
+    harness.cleanupPending = true
     harness.lookup = .found("zcash_wallet_deleted.db")
     harness.walletDbExists = false
 
     FreshInstallKeychainCleaner.runIfNeeded(dependencies: harness.dependencies())
 
     XCTAssertFalse(harness.markedInstalled)
+    XCTAssertTrue(harness.cleanupPending)
     XCTAssertTrue(harness.deletedServices.isEmpty)
   }
 
@@ -96,6 +182,7 @@ class RunnerTests: XCTestCase {
 private final class FreshInstallCleanerHarness {
   var hasSentinel = false
   var markedInstalled = false
+  var cleanupPending = false
   var lookup: KeychainDbNameLookup = .missing
   var walletDbExists = false
   var deleteStatuses: [String: OSStatus] = [:]
@@ -110,6 +197,15 @@ private final class FreshInstallCleanerHarness {
       markInstallSentinel: {
         self.markedInstalled = true
         self.hasSentinel = true
+      },
+      hasCleanupPending: {
+        self.cleanupPending
+      },
+      markCleanupPending: {
+        self.cleanupPending = true
+      },
+      clearCleanupPending: {
+        self.cleanupPending = false
       },
       readWalletDbName: {
         self.lookup


### PR DESCRIPTION
## Summary
- Add a cleanup-pending marker for iOS fresh-install Keychain cleanup retries.
- Re-check the stale wallet DB anchor before retrying so a newly valid install is preserved.
- Treat secure-store deletion as the completion gate while logging non-anchor cleanup failures.

## Why
On iOS, Keychain entries can survive app reinstall while the app-private wallet DB is removed. If cleanup partially fails, the app should retry safely without wiping a newly valid install on a later launch.

## Validation
- `xcodebuild test -quiet -workspace ios/Runner.xcworkspace -scheme Runner -destination 'id=7D86496F-3148-4531-9A89-89CE370A4A0E' -only-testing:RunnerTests/RunnerTests`
- `git diff --check origin/main...HEAD`