### PR TITLE
Fix iOS biometric cold-start backdrop

### DIFF
--- a/ios/Runner/Base.lproj/LaunchScreen.storyboard
+++ b/ios/Runner/Base.lproj/LaunchScreen.storyboard
@@ -19,7 +19,7 @@
                             <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="LaunchImage" translatesAutoresizingMaskIntoConstraints="NO" id="YRO-k0-Ey4">
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="YRO-k0-Ey4" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="1a2-6s-vTC"/>
                             <constraint firstItem="YRO-k0-Ey4" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="4X2-HB-R7a"/>
@@ -33,5 +33,8 @@
     </scenes>
     <resources>
         <image name="LaunchImage" width="168" height="185"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_unlock_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart' show Icon, Icons, Scaffold;
+import 'package:flutter/scheduler.dart' show SchedulerBinding;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -32,6 +33,7 @@ const _authBackgroundImage = AssetImage(mobileBiometricSignInBackgroundAsset);
 const _welcomeBadgeImage = AssetImage(
   'assets/illustrations/welcome_badge_mobile.png',
 );
+const _biometricBackdropMaxWait = Duration(milliseconds: 350);
 
 /// Mobile unlock — Figma `Sign In Passcode` (4885:23041): "Welcome Back",
 /// crimson-filling dots, round numpad keys, a bottom biometric retry action,
@@ -65,12 +67,41 @@ class _MobileUnlockScreenState extends ConsumerState<MobileUnlockScreen> {
     super.didChangeDependencies();
     if (_didPrecacheBackdrop) return;
     _didPrecacheBackdrop = true;
-    // Warm the backdrop assets so the biometric sign-in view paints before the
-    // system Face ID sheet covers the screen. Best-effort: a decode failure
-    // must never block unlock, and this is fire-and-forget so it can't stall
-    // the prompt.
-    unawaited(precacheImage(_authBackgroundImage, context, onError: (_, _) {}));
-    unawaited(precacheImage(_welcomeBadgeImage, context, onError: (_, _) {}));
+    // Warm the backdrop assets opportunistically. The auto-prompt waits for
+    // the backdrop shell frame, but image decode must not delay Face ID.
+    unawaited(_precacheBiometricBackdrop());
+  }
+
+  Future<void> _precacheBiometricBackdrop() async {
+    await Future.wait<void>([
+      precacheImage(
+        _authBackgroundImage,
+        context,
+        onError: (_, _) {},
+      ).catchError((_) {}),
+      precacheImage(
+        _welcomeBadgeImage,
+        context,
+        onError: (_, _) {},
+      ).catchError((_) {}),
+    ]);
+  }
+
+  Future<void> _waitForBiometricBackdropFrame() async {
+    await _waitForBackdropFrame().timeout(
+      _biometricBackdropMaxWait,
+      onTimeout: () {},
+    );
+  }
+
+  Future<void> _waitForBackdropFrame() async {
+    await SchedulerBinding.instance.endOfFrame;
+    if (!mounted) return;
+
+    final binding = WidgetsBinding.instance;
+    if (!binding.firstFrameRasterized) {
+      await binding.waitUntilFirstFrameRasterized;
+    }
   }
 
   Future<void> _tryBiometricUnlock() async {
@@ -121,8 +152,24 @@ class _MobileUnlockScreenState extends ConsumerState<MobileUnlockScreen> {
     _biometricPromptShown = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      unawaited(_tryBiometricUnlock());
+      unawaited(_tryBiometricUnlockAfterBackdropFrame());
     });
+  }
+
+  Future<void> _tryBiometricUnlockAfterBackdropFrame() async {
+    await _waitForBiometricBackdropFrame();
+    if (!mounted) return;
+
+    final biometric = ref.read(biometricUnlockProvider).value;
+    if (!widget.autoPromptBiometric ||
+        _biometricFallback ||
+        _submitting ||
+        _entry.isNotEmpty ||
+        biometric == null ||
+        !biometric.usable) {
+      return;
+    }
+    await _tryBiometricUnlock();
   }
 
   void _onDigit(int digit) {
@@ -227,10 +274,9 @@ class _MobileUnlockScreenState extends ConsumerState<MobileUnlockScreen> {
       if (!mounted) return;
       setState(() {
         _submitting = false;
-        _error =
-            e.kind == DeviceOwnerAuthErrorKind.unavailable
-                ? kWalletResetDeviceAuthRequiredMessage
-                : kWalletResetDeviceAuthFailedMessage;
+        _error = e.kind == DeviceOwnerAuthErrorKind.unavailable
+            ? kWalletResetDeviceAuthRequiredMessage
+            : kWalletResetDeviceAuthFailedMessage;
       });
       return;
     } catch (e, st) {

--- a/test/features/onboarding/mobile_unlock_screen_test.dart
+++ b/test/features/onboarding/mobile_unlock_screen_test.dart
@@ -40,11 +40,16 @@ class FakeBiometricUnlock extends BiometricUnlock {
   BiometricAvailability avail;
   String? escrow;
   BiometricUnlockErrorKind? readError;
+  Completer<BiometricAvailability>? availabilityCompleter;
   Completer<String>? readCompleter;
   var reads = 0;
 
   @override
-  Future<BiometricAvailability> availability() async => avail;
+  Future<BiometricAvailability> availability() async {
+    final completer = availabilityCompleter;
+    if (completer != null) return completer.future;
+    return avail;
+  }
 
   @override
   Future<void> enable(String passcode) async => escrow = passcode;
@@ -132,6 +137,21 @@ Widget _app({
       home: MobileUnlockScreen(autoPromptBiometric: autoPromptBiometric),
     ),
   );
+}
+
+Future<void> _pumpAutoBiometricPromptWait(WidgetTester tester) async {
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 350));
+  await tester.pump();
+}
+
+Future<void> _pumpUntilBiometricRead(
+  WidgetTester tester,
+  FakeBiometricUnlock biometric,
+) async {
+  for (var i = 0; i < 4 && biometric.reads == 0; i += 1) {
+    await _pumpAutoBiometricPromptWait(tester);
+  }
 }
 
 void main() {
@@ -334,6 +354,11 @@ void main() {
       );
 
       await tester.pumpWidget(_app(biometric: biometric));
+      await tester.pump();
+
+      expect(biometric.reads, 0);
+
+      await _pumpUntilBiometricRead(tester, biometric);
       await tester.pumpAndSettle();
 
       expect(biometric.reads, 1);
@@ -369,6 +394,9 @@ void main() {
         findsOneWidget,
       );
       expect(find.byType(PasscodeNumpad), findsNothing);
+      expect(biometric.reads, 0);
+
+      await _pumpUntilBiometricRead(tester, biometric);
       expect(biometric.reads, 1);
 
       pendingRead.complete('999999');
@@ -376,6 +404,43 @@ void main() {
 
       expect(find.byType(MobileBiometricSignInView), findsNothing);
       expect(find.text('Incorrect Passcode'), findsOneWidget);
+    });
+
+    testWidgets('auto-prompt waits for a painted backdrop frame', (
+      tester,
+    ) async {
+      await AppSecureStore.instance.configurePassword('123456');
+      AppSecureStore.instance.clearSessionPassword();
+      await AppSecureStore.instance.writePlain(
+        kBiometricUnlockEnabledKey,
+        'true',
+      );
+      final availability = Completer<BiometricAvailability>();
+      final pendingRead = Completer<String>();
+      final biometric =
+          FakeBiometricUnlock(avail: faceAvailability, escrow: '999999')
+            ..availabilityCompleter = availability
+            ..readCompleter = pendingRead;
+
+      await tester.pumpWidget(
+        _app(
+          bootstrap: _bootstrap(biometricEnabled: true),
+          biometric: biometric,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(MobileBiometricSignInView), findsOneWidget);
+      expect(biometric.reads, 0);
+
+      availability.complete(faceAvailability);
+      await tester.pump();
+
+      expect(find.byType(MobileBiometricSignInView), findsOneWidget);
+      expect(biometric.reads, 0);
+
+      await _pumpUntilBiometricRead(tester, biometric);
+      expect(biometric.reads, 1);
     });
 
     testWidgets('cancel falls back to the numpad with a retry key', (
@@ -391,6 +456,7 @@ void main() {
       )..readError = BiometricUnlockErrorKind.cancelled;
 
       await tester.pumpWidget(_app(biometric: biometric));
+      await _pumpUntilBiometricRead(tester, biometric);
       await tester.pumpAndSettle();
 
       expect(biometric.reads, 1);
@@ -437,6 +503,7 @@ void main() {
         ..readError = BiometricUnlockErrorKind.invalidated;
 
       await tester.pumpWidget(_app(biometric: biometric));
+      await _pumpUntilBiometricRead(tester, biometric);
       await tester.pumpAndSettle();
 
       expect(


### PR DESCRIPTION
## Summary

- paint the mobile biometric sign-in backdrop as soon as the startup bootstrap says biometric unlock was enabled
- warm backdrop assets opportunistically while only gating Face ID on Flutter backdrop-shell frame readiness
- cap the biometric-only frame-readiness wait at 350ms so passcode unlock is not delayed
- use the iOS system launch-screen background color so cold start follows system light/dark appearance before Flutter paints
- add focused mobile regression tests for the biometric prompt timing

## Root Cause

On iOS cold start, the native Face ID prompt can appear before Flutter has painted the biometric sign-in surface. The widget tree can already be switching to the backdrop while the actual first useful Flutter frame is still blank, which made users see a plain white screen behind the Face ID prompt.

The fix renders the biometric backdrop shell early and in parallel with the biometric availability probe, but gates the native Face ID read until Flutter has had a bounded chance to finish the backdrop-shell frame. The decorative backdrop images are still warmed in the background, but image decode does not block Face ID.

## Validation

- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/onboarding/mobile_unlock_screen_test.dart`
- `fvm flutter analyze`
- `git diff --check`
- `xcrun ibtool --errors --warnings --notices --output-format human-readable-text --compile /tmp/vizor-launchscreen-test.storyboardc ios/Runner/Base.lproj/LaunchScreen.storyboard`
- `fvm flutter build ios --profile --dart-define=VIZOR_FORM_FACTOR=mobile`
- Installed the profile build on iPhone with `xcrun devicectl device install app --device 00008140-000259801444801C build/ios/iphoneos/Runner.app`, then launched with `xcrun devicectl device process launch --device 00008140-000259801444801C com.keplr.vizor`; cold-launch behavior was manually confirmed on device.
