### PR TITLE
Allow transparent source sends

### DIFF
--- a/integration_test/regtest_transparent_source_send_test.dart
+++ b/integration_test/regtest_transparent_source_send_test.dart
@@ -1,0 +1,688 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zcash_wallet/app.dart';
+import 'package:zcash_wallet/src/core/config/network_config.dart';
+import 'package:zcash_wallet/src/core/formatting/zec_amount.dart';
+import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
+import 'package:zcash_wallet/src/core/storage/wallet_paths.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
+import 'package:zcash_wallet/src/rust/api/wallet.dart' as rust_wallet;
+
+final _network = kZcashDefaultNetworkName;
+const _driverUrl = String.fromEnvironment(
+  'ZCASH_E2E_DRIVER_URL',
+  defaultValue: 'http://127.0.0.1:39068',
+);
+const _receiverAddress = String.fromEnvironment(
+  'ZCASH_E2E_TRANSPARENT_SOURCE_RECIPIENT',
+);
+const _password = 'Vizor123!';
+const _transparentFundingAmount = '0.75';
+const _sendAmount = '0.25';
+final _transparentFundingZatoshi = BigInt.from(75_000_000);
+final _sendZatoshi = BigInt.from(25_000_000);
+final _currencyTicker = kZcashDefaultCurrencyTicker;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await initializeZcashWalletRuntime();
+  });
+
+  testWidgets(
+    'requires confirmations before a transparent-source send is available',
+    (tester) async {
+      if (_receiverAddress.isEmpty) {
+        fail(
+          'Set ZCASH_E2E_TRANSPARENT_SOURCE_RECIPIENT for the '
+          'transparent-source send test.',
+        );
+      }
+
+      addTearDown(() async {
+        await _cleanupE2eWalletState();
+      });
+
+      await _cleanupE2eWalletState();
+
+      _log('pumping app');
+      await tester.pumpWidget(await buildBootstrappedZcashWalletApp());
+
+      await _createFirstWallet(tester);
+      final accountUuid = await _accountUuidAtOrder(0);
+      final transparentAddress = await _transparentAddressForAccount(
+        accountUuid,
+      );
+      expect(transparentAddress, startsWith('t'));
+      _log('created account $accountUuid transparent=$transparentAddress');
+
+      final fundingTxid = await _fundTransparent(
+        transparentAddress,
+        _transparentFundingAmount,
+        confirmations: 1,
+      );
+      _log('external 1-conf transparent funding txid=$fundingTxid');
+
+      await _waitForTransparentBalance(
+        tester,
+        accountUuid: accountUuid,
+        spendable: BigInt.zero,
+        pending: _transparentFundingZatoshi,
+        timeout: const Duration(minutes: 5),
+      );
+      await _expectHomeTransparentBalanceHidden(tester);
+      await _expectSendSourceTransparentBalance(
+        tester,
+        _formatSendBalance(BigInt.zero),
+      );
+
+      await _openWallet(tester);
+      await _mineRegtestBlocks(9);
+      await _waitForTransparentBalance(
+        tester,
+        accountUuid: accountUuid,
+        spendable: _transparentFundingZatoshi,
+        pending: BigInt.zero,
+        timeout: const Duration(minutes: 5),
+      );
+      await _waitForHomeTransparentBalance(
+        tester,
+        'Transparent: ${_formatHomeBalance(_transparentFundingZatoshi)} '
+        '$_currencyTicker',
+        timeout: const Duration(minutes: 5),
+      );
+
+      await _sendTransparentSourceToAddress(
+        tester,
+        _receiverAddress,
+        _sendAmount,
+      );
+      await _waitForHistoryEntry(
+        tester,
+        accountUuid: accountUuid,
+        txKind: 'sent',
+        displayAmount: _sendZatoshi,
+        pending: true,
+        timeout: const Duration(minutes: 4),
+      );
+      await _openWallet(tester);
+      await _expectActivityRow(
+        tester,
+        const ValueKey('home_desktop_activity_row_0'),
+        title: 'Sending',
+        amount: '-$_sendAmount $_currencyTicker',
+        status: 'In progress',
+      );
+
+      await _mineRegtestBlocks(10);
+      await _waitForHistoryEntry(
+        tester,
+        accountUuid: accountUuid,
+        txKind: 'sent',
+        displayAmount: _sendZatoshi,
+        pending: false,
+        timeout: const Duration(minutes: 5),
+      );
+      await _expectActivityRow(
+        tester,
+        const ValueKey('home_desktop_activity_row_0'),
+        title: 'Sent',
+        amount: '-$_sendAmount $_currencyTicker',
+        status: 'Completed',
+        timeout: const Duration(minutes: 3),
+      );
+      _log('transparent-source send activity matched');
+    },
+    timeout: const Timeout(Duration(minutes: 15)),
+  );
+}
+
+Future<void> _createFirstWallet(WidgetTester tester) async {
+  _log('creating first wallet');
+  await _tapAppButton(tester, const ValueKey('welcome_create_wallet_button'));
+  await _tapText(tester, 'I know how to use Zcash');
+  await _tapAppButton(
+    tester,
+    const ValueKey('create_secret_phrase_primary_button'),
+    timeout: const Duration(minutes: 1),
+  );
+  await _tapAppButton(
+    tester,
+    const ValueKey('create_secret_phrase_primary_button'),
+  );
+  await _enterText(
+    tester,
+    const ValueKey('set_password_password_field'),
+    _password,
+  );
+  await _enterText(
+    tester,
+    const ValueKey('set_password_confirm_field'),
+    _password,
+  );
+  await _tapAppButton(
+    tester,
+    const ValueKey('set_password_submit_button'),
+    timeout: const Duration(minutes: 4),
+  );
+  await _waitForHome(tester, timeout: const Duration(minutes: 4));
+  _log('first wallet created');
+}
+
+Future<String> _transparentAddressForAccount(String accountUuid) async {
+  final dbPath = await getWalletDbPath();
+  return rust_wallet.getTransparentReceiveAddress(
+    dbPath: dbPath,
+    network: _network,
+    accountUuid: accountUuid,
+  );
+}
+
+Future<String> _fundTransparent(
+  String address,
+  String amount, {
+  required int confirmations,
+}) async {
+  _log(
+    'requesting transparent funding of $amount $_currencyTicker '
+    'confirmations=$confirmations',
+  );
+  final response = await _postDriver('/fund-confirmed', {
+    'address': address,
+    'amount': amount,
+    'confirmations': confirmations,
+  }, timeout: const Duration(minutes: 10));
+  final txid = response['txid'] as String? ?? '';
+  if (txid.isEmpty) fail('E2E driver did not return a txid.');
+  return txid;
+}
+
+Future<void> _mineRegtestBlocks(int blocks) async {
+  _log('requesting external mining of $blocks regtest blocks');
+  await _postDriver('/mine', {'blocks': blocks});
+}
+
+Future<Map<String, Object?>> _postDriver(
+  String path,
+  Map<String, Object?> payload, {
+  Duration timeout = const Duration(minutes: 2),
+}) async {
+  final client = HttpClient();
+  try {
+    final request = await client
+        .postUrl(Uri.parse('$_driverUrl$path'))
+        .timeout(timeout);
+    final bodyBytes = utf8.encode(jsonEncode(payload));
+    request.headers.contentType = ContentType.json;
+    request.contentLength = bodyBytes.length;
+    request.add(bodyBytes);
+
+    final response = await request.close().timeout(timeout);
+    final body = await utf8.decoder.bind(response).join().timeout(timeout);
+    if (response.statusCode != HttpStatus.ok) {
+      throw StateError(
+        'E2E driver $path failed: HTTP ${response.statusCode}\n$body',
+      );
+    }
+    return jsonDecode(body) as Map<String, Object?>;
+  } finally {
+    client.close(force: true);
+  }
+}
+
+Future<String> _accountUuidAtOrder(int order) async {
+  final dbPath = await getWalletDbPath();
+  final accounts = await rust_wallet.listAccounts(
+    dbPath: dbPath,
+    network: _network,
+  );
+  if (order >= accounts.length) {
+    fail('Expected account order $order, got ${accounts.length} accounts.');
+  }
+  return accounts[order].uuid;
+}
+
+Future<void> _openWallet(WidgetTester tester) async {
+  if (tester.any(
+    find.byKey(const ValueKey('home_desktop_balance_amount_text')),
+  )) {
+    return;
+  }
+  await _tapWidget(tester, const ValueKey('sidebar_home_button'));
+  await _waitForHome(tester);
+}
+
+Future<void> _waitForHome(
+  WidgetTester tester, {
+  Duration timeout = const Duration(minutes: 1),
+}) async {
+  await _pumpUntil(
+    tester,
+    () => tester.any(
+      find.byKey(const ValueKey('home_desktop_balance_amount_text')),
+    ),
+    description: 'home balance card to render',
+    timeout: timeout,
+  );
+}
+
+Future<void> _waitForTransparentBalance(
+  WidgetTester tester, {
+  required String accountUuid,
+  required BigInt spendable,
+  required BigInt pending,
+  Duration timeout = const Duration(minutes: 2),
+}) async {
+  final dbPath = await getWalletDbPath();
+  final deadline = DateTime.now().add(timeout);
+  Object? lastError;
+  var lastBalance = '<not read>';
+
+  while (DateTime.now().isBefore(deadline)) {
+    try {
+      final balance = await rust_sync.getBalance(
+        dbPath: dbPath,
+        network: _network,
+        accountUuid: accountUuid,
+      );
+      lastBalance =
+          'transparent=${balance.transparent}, '
+          'transparentPending=${balance.transparentPending}';
+      if (balance.transparent == spendable &&
+          balance.transparentPending == pending) {
+        _log('transparent balance matched: $lastBalance');
+        return;
+      }
+    } catch (e) {
+      lastError = e;
+    }
+
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail(
+    'Timed out waiting for transparent balance spendable=$spendable '
+    'pending=$pending. Last balance: $lastBalance.$error',
+  );
+}
+
+Future<void> _expectHomeTransparentBalanceHidden(WidgetTester tester) async {
+  await _pumpUntil(
+    tester,
+    () => !tester.any(
+      find.byKey(const ValueKey('home_desktop_transparent_balance_strip')),
+    ),
+    description: 'home transparent balance strip to stay hidden',
+    timeout: const Duration(minutes: 1),
+  );
+  _log('home transparent balance strip hidden');
+}
+
+Future<void> _waitForHomeTransparentBalance(
+  WidgetTester tester,
+  String expected, {
+  Duration timeout = const Duration(minutes: 4),
+}) async {
+  await _pumpUntil(
+    tester,
+    () => _keyedTextEquals(
+      tester,
+      const ValueKey('home_transparent_balance_text'),
+      expected,
+    ),
+    description: 'home transparent balance to show $expected',
+    timeout: timeout,
+  );
+  _log('home transparent balance matched: $expected');
+}
+
+Future<void> _expectSendSourceTransparentBalance(
+  WidgetTester tester,
+  String expected,
+) async {
+  await _tapWidget(tester, const ValueKey('home_desktop_send_button'));
+  await _openSourcePicker(tester);
+  await _pumpUntil(
+    tester,
+    () => _textSetIn(
+      tester,
+      find.byKey(const ValueKey('send_source_option_transparent')),
+    ).contains(expected),
+    description: 'send transparent source row to show $expected',
+    timeout: const Duration(minutes: 1),
+  );
+  _log('send transparent source row matched: $expected');
+  await _dismissSourcePicker(tester);
+}
+
+Future<void> _sendTransparentSourceToAddress(
+  WidgetTester tester,
+  String address,
+  String amount,
+) async {
+  _log('sending $amount $_currencyTicker from transparent source');
+  await _tapWidget(tester, const ValueKey('home_desktop_send_button'));
+  await _enterText(tester, const ValueKey('send_address_field'), address);
+  await _openSourcePicker(tester);
+  await _tapWidget(tester, const ValueKey('send_source_option_transparent'));
+  await _enterText(tester, const ValueKey('send_amount_field'), amount);
+  await _pumpUntil(
+    tester,
+    () => tester.any(
+      find.text('Max: ${_formatSendBalance(_transparentFundingZatoshi)}'),
+    ),
+    description: 'transparent source max label',
+    timeout: const Duration(minutes: 1),
+  );
+  await _tapAppButton(
+    tester,
+    const ValueKey('send_review_button'),
+    timeout: const Duration(minutes: 1),
+  );
+  await _tapAppButton(
+    tester,
+    const ValueKey('send_confirm_button'),
+    timeout: const Duration(minutes: 1),
+  );
+  await _pumpUntil(
+    tester,
+    () => tester.any(find.byKey(const ValueKey('send_status_completed'))),
+    description: 'transparent-source send status to succeed',
+    timeout: const Duration(minutes: 4),
+  );
+  _log('transparent-source send succeeded');
+}
+
+Future<void> _openSourcePicker(WidgetTester tester) async {
+  final picker = find.byKey(const ValueKey('send_source_picker'));
+  if (tester.any(picker)) return;
+  await _tapWidget(tester, const ValueKey('send_source_toggle_button'));
+  await _pumpUntil(
+    tester,
+    () => tester.any(picker),
+    description: 'send source picker to render',
+    timeout: const Duration(minutes: 1),
+  );
+}
+
+Future<void> _dismissSourcePicker(WidgetTester tester) async {
+  if (!tester.any(find.byKey(const ValueKey('send_source_picker')))) return;
+  await tester.tapAt(const Offset(8, 8));
+  await tester.pump(const Duration(milliseconds: 250));
+}
+
+Future<void> _waitForHistoryEntry(
+  WidgetTester tester, {
+  required String accountUuid,
+  required String txKind,
+  required BigInt displayAmount,
+  required bool pending,
+  Duration timeout = const Duration(minutes: 2),
+}) async {
+  final dbPath = await getWalletDbPath();
+  final deadline = DateTime.now().add(timeout);
+  Object? lastError;
+  var lastHistorySummary = '<not read>';
+
+  while (DateTime.now().isBefore(deadline)) {
+    try {
+      final history = await rust_sync.getTransactionHistory(
+        dbPath: dbPath,
+        network: _network,
+        limit: 20,
+        accountUuid: accountUuid,
+      );
+      lastHistorySummary = history
+          .map(
+            (tx) =>
+                '${tx.txidHex}:${tx.txKind}:${tx.displayAmount}:'
+                'mined=${tx.minedHeight}:expired=${tx.expiredUnmined}',
+          )
+          .join(', ');
+      if (history.any(
+        (tx) =>
+            tx.txKind == txKind &&
+            tx.displayAmount == displayAmount &&
+            (tx.minedHeight == BigInt.zero) == pending &&
+            !tx.expiredUnmined,
+      )) {
+        _log('history matched $txKind tx amount=$displayAmount');
+        return;
+      }
+    } catch (e) {
+      lastError = e;
+    }
+
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail(
+    'Timed out waiting for history $txKind amount=$displayAmount '
+    'pending=$pending. Observed history: $lastHistorySummary.$error',
+  );
+}
+
+Future<void> _expectActivityRow(
+  WidgetTester tester,
+  Key key, {
+  required String title,
+  required String amount,
+  required String status,
+  Duration timeout = const Duration(minutes: 2),
+}) async {
+  await _pumpUntil(
+    tester,
+    () => _activityRowMatches(
+      _textSetIn(tester, find.byKey(key)),
+      title,
+      amount,
+      status,
+    ),
+    description: '$key activity row to show $title $amount $status',
+    timeout: timeout,
+  );
+  _log('activity row matched: $title $amount $status');
+}
+
+bool _activityRowMatches(
+  Set<String> texts,
+  String title,
+  String amount,
+  String status,
+) {
+  if (!texts.contains(amount)) return false;
+  final titleOk = texts.contains(title) || texts.contains('$title ...');
+  if (!titleOk) return false;
+  const knownStatuses = {'In progress', 'Completed', 'Failed', 'Refunded'};
+  final rendered = texts.where(knownStatuses.contains);
+  return rendered.isEmpty || rendered.contains(status);
+}
+
+Future<void> _tapAppButton(
+  WidgetTester tester,
+  Key key, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () =>
+        tester.any(finder) &&
+        tester.widget<AppButton>(finder).onPressed != null,
+    description: '$key button to be enabled',
+    timeout: timeout,
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _tapWidget(
+  WidgetTester tester,
+  Key key, {
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final finder = find.byKey(key);
+  await _pumpUntil(
+    tester,
+    () => tester.any(finder),
+    description: '$key widget to render',
+    timeout: timeout,
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped $key');
+}
+
+Future<void> _tapText(WidgetTester tester, String text) async {
+  final finder = find.text(text);
+  await _pumpUntil(
+    tester,
+    () => tester.any(finder),
+    description: '$text text to render',
+  );
+  await tester.ensureVisible(finder);
+  await tester.pump(const Duration(milliseconds: 50));
+  await tester.tap(finder);
+  await tester.pump(const Duration(milliseconds: 250));
+  _log('tapped text "$text"');
+}
+
+Future<void> _enterText(WidgetTester tester, Key key, String text) async {
+  final editable = find.descendant(
+    of: find.byKey(key),
+    matching: find.byType(EditableText),
+  );
+  await _pumpUntil(
+    tester,
+    () => tester.any(editable),
+    description: '$key editable text field',
+  );
+  await tester.tap(editable);
+  await tester.enterText(editable, text);
+  await tester.pump(const Duration(milliseconds: 100));
+  _log('entered text into $key');
+}
+
+bool _keyedTextEquals(WidgetTester tester, Key key, String expected) {
+  return _textForKey(tester, key) == expected;
+}
+
+String? _textForKey(WidgetTester tester, Key key) {
+  final finder = find.byKey(key);
+  if (!tester.any(finder)) return null;
+  final widget = tester.widget<Text>(finder);
+  return widget.data;
+}
+
+Set<String> _textSetIn(WidgetTester tester, Finder root) {
+  if (!tester.any(root)) return const {};
+  final texts = <String>{};
+  for (final element
+      in find.descendant(of: root, matching: find.byType(Text)).evaluate()) {
+    final widget = element.widget;
+    if (widget is Text) {
+      final value = widget.data ?? widget.textSpan?.toPlainText();
+      if (value != null) texts.add(value);
+    }
+  }
+  return texts;
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester,
+  bool Function() condition, {
+  required String description,
+  Duration timeout = const Duration(seconds: 20),
+}) async {
+  final end = DateTime.now().add(timeout);
+  Object? lastError;
+  var polls = 0;
+  while (DateTime.now().isBefore(end)) {
+    try {
+      if (condition()) return;
+    } catch (e) {
+      lastError = e;
+    }
+    await tester.pump(const Duration(milliseconds: 100));
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+    polls++;
+    if (polls % 25 == 0) {
+      _log('still waiting for $description');
+    }
+  }
+
+  final error = lastError == null ? '' : ' Last error: $lastError';
+  fail('Timed out waiting for $description.$error');
+}
+
+String _formatHomeBalance(BigInt zatoshi) {
+  return ZecAmount.fromZatoshi(zatoshi).balance.amountText;
+}
+
+String _formatSendBalance(BigInt zatoshi) {
+  return ZecAmount.fromZatoshi(
+    zatoshi,
+  ).pretty(denomStyle: ZecDenomStyle.upper).toString();
+}
+
+Future<void> _cleanupE2eWalletState() async {
+  if (kZcashDefaultNetworkName != ZcashNetwork.regtest.name) {
+    throw StateError(
+      'Refusing to clean wallet state without ZCASH_DEFAULT_NETWORK=regtest.',
+    );
+  }
+
+  final storage = AppSecureStore.instance;
+  final dbName = await getWalletDbName();
+
+  _log('cleaning regtest wallet state');
+  await _stopRustWorkForCleanup();
+
+  await storage.deleteAll();
+
+  final supportDir = await getWalletSupportDirectory();
+  if (!supportDir.existsSync()) return;
+
+  for (final name in [dbName, '$dbName-shm', '$dbName-wal']) {
+    final file = File('${supportDir.path}${Platform.pathSeparator}$name');
+    if (file.existsSync()) file.deleteSync();
+  }
+}
+
+Future<void> _stopRustWorkForCleanup() async {
+  rust_sync.setSyncMode(mode: 0);
+  rust_sync.cancelFullSync();
+  rust_sync.stopMempoolObserver();
+
+  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  while ((rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) &&
+      DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+
+  if (rust_sync.isSyncRunning() || rust_sync.isMempoolObserverRunning()) {
+    _log(
+      'timed out waiting for Rust work to stop; continuing E2E storage cleanup',
+    );
+  }
+}
+
+void _log(String message) {
+  // ignore: avoid_print
+  print('[regtest_transparent_source_send_test] $message');
+}

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -544,7 +544,8 @@ Future<AppSyncSnapshot> _loadInitialSyncSnapshot({
     var canShieldTransparentBalance = false;
     var shieldTransparentFee = BigInt.zero;
     var shieldTransparentAmount = BigInt.zero;
-    if (balance.transparent > BigInt.zero) {
+    final transparentTotal = balance.transparent + balance.transparentPending;
+    if (transparentTotal > BigInt.zero) {
       try {
         final shieldStatus = await rust_sync.getShieldTransparentStatus(
           dbPath: dbPath,

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -195,8 +195,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       privacyModeEnabled: privacyModeEnabled,
     );
     final priceChange24hPct = ref.watch(zecPriceChange24hPctProvider);
-    final transparentBalance =
-        sync.transparentBalance + sync.transparentPendingBalance;
+    final transparentBalance = sync.transparentBalance;
     final canShieldTransparentBalance = sync.canShieldTransparentBalance;
     final isImportingForBackground =
         activeAccountUuid != null &&

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -231,10 +231,11 @@ class _HomeContentState extends ConsumerState<_HomeContent> {
         sync.orchardBalance +
         sync.saplingPendingBalance +
         sync.orchardPendingBalance;
-    final transparentBalance =
+    final transparentBalance = sync.transparentBalance;
+    final transparentTotalBalance =
         sync.transparentBalance + sync.transparentPendingBalance;
     final hasBalance =
-        shieldedBalance > BigInt.zero || transparentBalance > BigInt.zero;
+        shieldedBalance > BigInt.zero || transparentTotalBalance > BigInt.zero;
     final zecUsdUnitPrice = ref.watch(zecHomeUsdUnitPriceProvider);
     final fiatBalanceText = fiatTextForZatoshi(
       shieldedBalance,

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -55,12 +55,13 @@ class _ReviewRecipientPresentation {
   Widget buildReviewLeading() {
     return KeyedSubtree(
       key: const ValueKey('mobile_send_review_recipient_picture'),
-      child: useZecIcon
-          ? const _ReviewWalletIcon()
-          : AppProfilePicture(
-              profilePictureId: profilePictureId ?? '',
-              size: AppProfilePictureSize.navLarge,
-            ),
+      child:
+          useZecIcon
+              ? const _ReviewWalletIcon()
+              : AppProfilePicture(
+                profilePictureId: profilePictureId ?? '',
+                size: AppProfilePictureSize.navLarge,
+              ),
     );
   }
 
@@ -86,6 +87,7 @@ typedef MobileSendFeeEstimator =
       required String toAddress,
       required BigInt amountZatoshi,
       String? memo,
+      String? sendSource,
     });
 
 typedef MobileSendScanner = Future<String?> Function(BuildContext context);
@@ -97,6 +99,7 @@ class _MobileSendMaxQuote {
     required this.memo,
     required this.amountZatoshi,
     required this.feeZatoshi,
+    required this.sendSource,
   });
 
   final String accountUuid;
@@ -104,6 +107,7 @@ class _MobileSendMaxQuote {
   final String memo;
   final BigInt amountZatoshi;
   final BigInt feeZatoshi;
+  final SendSource sendSource;
 }
 
 class MobileSendAmountArgs {
@@ -111,6 +115,7 @@ class MobileSendAmountArgs {
     required this.sendFlowId,
     required this.recipient,
     required this.addressType,
+    this.sendSource = SendSource.shielded,
     this.contactLabel,
     this.contactPictureId,
   });
@@ -118,6 +123,7 @@ class MobileSendAmountArgs {
   final String sendFlowId;
   final String recipient;
   final String addressType;
+  final SendSource sendSource;
   final String? contactLabel;
   final String? contactPictureId;
 }
@@ -130,6 +136,7 @@ class MobileSendReviewDraftArgs {
     required this.amountText,
     this.feeZatoshi,
     this.isMaxMode = false,
+    this.sendSource = SendSource.shielded,
     this.memo,
     this.contactLabel,
     this.contactPictureId,
@@ -141,6 +148,7 @@ class MobileSendReviewDraftArgs {
   final String amountText;
   final BigInt? feeZatoshi;
   final bool isMaxMode;
+  final SendSource sendSource;
   final String? memo;
   final String? contactLabel;
   final String? contactPictureId;
@@ -159,6 +167,7 @@ class MobileSendAmountScreen extends StatelessWidget {
       initialSendFlowId: args.sendFlowId,
       initialRecipient: args.recipient,
       initialAddressType: args.addressType,
+      initialSendSource: args.sendSource,
       initialContactLabel: args.contactLabel,
       initialContactPictureId: args.contactPictureId,
     );
@@ -183,6 +192,7 @@ class MobileSendReviewScreen extends StatelessWidget {
       initialFeeZatoshi: args.feeZatoshi,
       refreshReviewFeeOnInit: true,
       initialMaxMode: args.isMaxMode,
+      initialSendSource: args.sendSource,
       initialMemo: args.memo,
       initialContactLabel: args.contactLabel,
       initialContactPictureId: args.contactPictureId,
@@ -240,6 +250,7 @@ class MobileSendScreen extends ConsumerStatefulWidget {
     this.initialReview = false,
     this.initialFeeZatoshi,
     this.initialMaxMode = false,
+    this.initialSendSource = SendSource.shielded,
     this.refreshReviewFeeOnInit = false,
     this.initialMemo,
     this.initialContactLabel,
@@ -265,6 +276,7 @@ class MobileSendScreen extends ConsumerStatefulWidget {
   final bool initialReview;
   final BigInt? initialFeeZatoshi;
   final bool initialMaxMode;
+  final SendSource initialSendSource;
   final bool refreshReviewFeeOnInit;
   final String? initialMemo;
   final String? initialSendFlowId;
@@ -311,6 +323,8 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   int _validateSeq = 0;
   bool _isMaxMode = false;
   bool _isResolvingMax = false;
+  bool _isSourceSheetOpen = false;
+  late SendSource _sendSource = widget.initialSendSource;
   int _maxSeq = 0;
   _MobileSendMaxQuote? _maxQuote;
 
@@ -438,10 +452,8 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       return;
     }
     try {
-      final result =
-          await (widget.validateAddress ?? rust_sync.validateAddress)(
-            address: address,
-          );
+      final result = await (widget.validateAddress ??
+          rust_sync.validateAddress)(address: address);
       if (!mounted || seq != _addressSeq) return;
       setState(
         () => _addressType = result.isValid ? result.addressType : 'invalid',
@@ -472,9 +484,8 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       selection: TextSelection.collapsed(offset: address.length),
     );
     setState(() {
-      _contactLabel = contact.label.trim().isEmpty
-          ? null
-          : contact.label.trim();
+      _contactLabel =
+          contact.label.trim().isEmpty ? null : contact.label.trim();
       _contactPictureId = contact.profilePictureId;
     });
     _handleAddressChanged(clearContact: false);
@@ -529,6 +540,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
             sendFlowId: _sendFlowId,
             recipient: _addressController.text.trim(),
             addressType: _addressType,
+            sendSource: _sendSource,
             contactLabel: _contactLabel,
             contactPictureId: _contactPictureId,
           ),
@@ -547,13 +559,31 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
 
   BigInt get _spendable {
     final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
-    return (ref.read(syncProvider).value ?? SyncState())
-        .scopedToAccount(accountUuid)
-        .spendableBalance;
+    final sync = (ref.read(syncProvider).value ?? SyncState()).scopedToAccount(
+      accountUuid,
+    );
+    return _sendSource.isTransparent
+        ? sync.transparentBalance
+        : sync.spendableBalance;
+  }
+
+  SyncState get _scopedSyncState {
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    return (ref.read(syncProvider).value ?? SyncState()).scopedToAccount(
+      accountUuid,
+    );
   }
 
   String? get _activeAccountUuid =>
       ref.read(accountProvider).value?.activeAccountUuid;
+
+  bool get _isTransparentSource => _sendSource.isTransparent;
+
+  bool get _isHardwareTransparentSourceSend =>
+      _isTransparentSource && _activeAccountIsHardware;
+
+  static const _hardwareTransparentSourceUnsupportedText =
+      'Keystone does not support transparent source sends yet.';
 
   bool get _hasCurrentMaxQuote {
     final quote = _maxQuote;
@@ -561,6 +591,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     return quote.accountUuid == _activeAccountUuid &&
         quote.address == _addressController.text.trim() &&
         quote.memo == _effectiveMemo &&
+        quote.sendSource == _sendSource &&
         parseZecAmount(_amountText.trim()) == quote.amountZatoshi &&
         _feeZatoshi == quote.feeZatoshi;
   }
@@ -579,6 +610,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       memo: _effectiveMemo,
       amountZatoshi: amountZatoshi,
       feeZatoshi: feeZatoshi,
+      sendSource: _sendSource,
     );
   }
 
@@ -611,10 +643,53 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     unawaited(_resolveMaxEstimate());
   }
 
+  void _selectSendSource(SendSource next) {
+    if (_sendSource == next) return;
+    setState(() {
+      _sendSource = next;
+      _clearMaxMode();
+      _feeZatoshi = null;
+      _amountError = '';
+      _error = null;
+    });
+    unawaited(_validateAmount());
+  }
+
+  Future<void> _showSendSourceSheet() async {
+    if (_isSourceSheetOpen) return;
+    _amountFocus.unfocus();
+    setState(() => _isSourceSheetOpen = true);
+    final sync = _scopedSyncState;
+    final next = await showAppMobileSheet<SendSource>(
+      context: context,
+      builder:
+          (sheetContext) => _MobileSendSourceSheet(
+            totalText: _formatSourceBalance(sync.totalBalance),
+            shieldedText: _formatSourceBalance(sync.spendableBalance),
+            transparentText: _formatSourceBalance(sync.transparentBalance),
+            selectedSource: _sendSource,
+          ),
+    );
+    if (!mounted) return;
+    setState(() => _isSourceSheetOpen = false);
+    if (next != null) {
+      _selectSendSource(next);
+    }
+  }
+
+  String _formatSourceBalance(BigInt zatoshi) {
+    return ZecAmount.fromZatoshi(
+      zatoshi,
+    ).pretty(denomStyle: ZecDenomStyle.upper).toString();
+  }
+
   String? _maxEstimatePreconditionError() {
     if (_activeAccountUuid == null) return 'Max amount unavailable';
     if (!_hasValidAddress) return 'Max amount unavailable';
     if (_isHardwareTexRecipient) return _hardwareTexUnsupportedText;
+    if (_isHardwareTransparentSourceSend) {
+      return _hardwareTransparentSourceUnsupportedText;
+    }
     if (utf8.encode(_effectiveMemo).length > 512) {
       return 'Message is too long';
     }
@@ -627,6 +702,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     final accountUuid = _activeAccountUuid;
     final address = _addressController.text.trim();
     final memo = _effectiveMemo;
+    final sendSource = _sendSource;
     final preconditionError = _maxEstimatePreconditionError();
     setState(() {
       _isMaxMode = true;
@@ -642,7 +718,9 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     try {
       final dbPath = await widget.loadWalletDbPath();
       final endpoint = ref.read(rpcEndpointProvider);
-      if (!_isCurrentMaxRequest(seq, accountUuid, address, memo)) return;
+      if (!_isCurrentMaxRequest(seq, accountUuid, address, memo, sendSource)) {
+        return;
+      }
 
       final estimate = await rust_sync.estimateSendMax(
         dbPath: dbPath,
@@ -650,17 +728,19 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         accountUuid: accountUuid,
         toAddress: address,
         memo: memo.isNotEmpty ? memo : null,
+        sendSource: sendSource.wireName,
       );
-      if (!_isCurrentMaxRequest(seq, accountUuid, address, memo)) return;
+      if (!_isCurrentMaxRequest(seq, accountUuid, address, memo, sendSource)) {
+        return;
+      }
 
       if (estimate.amountZatoshi <= BigInt.zero) {
         _applyMaxEstimateError('Not enough ZEC');
         return;
       }
 
-      final amountText = ZecAmount.fromZatoshi(
-        estimate.amountZatoshi,
-      ).pretty().amountText;
+      final amountText =
+          ZecAmount.fromZatoshi(estimate.amountZatoshi).pretty().amountText;
       _amountController.value = TextEditingValue(
         text: amountText,
         selection: TextSelection.collapsed(offset: amountText.length),
@@ -677,10 +757,13 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
           memo: memo,
           amountZatoshi: estimate.amountZatoshi,
           feeZatoshi: estimate.feeZatoshi,
+          sendSource: sendSource,
         );
       });
     } catch (e) {
-      if (!_isCurrentMaxRequest(seq, accountUuid, address, memo)) return;
+      if (!_isCurrentMaxRequest(seq, accountUuid, address, memo, sendSource)) {
+        return;
+      }
       final msg = e.toString().toLowerCase();
       _applyMaxEstimateError(
         msg.contains('insufficient')
@@ -695,13 +778,15 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     String accountUuid,
     String address,
     String memo,
+    SendSource sendSource,
   ) {
     return mounted &&
         _isMaxMode &&
         seq == _maxSeq &&
         _activeAccountUuid == accountUuid &&
         _addressController.text.trim() == address &&
-        _effectiveMemo == memo;
+        _effectiveMemo == memo &&
+        _sendSource == sendSource;
   }
 
   void _applyMaxEstimateError(String message) {
@@ -735,6 +820,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       setState(() => _amountError = 'Not enough ZEC');
       return;
     }
+    if (_isHardwareTransparentSourceSend) {
+      setState(() => _amountError = _hardwareTransparentSourceUnsupportedText);
+      return;
+    }
     // Block Continue until the fee estimate confirms the total fits —
     // otherwise a quick Continue tap right after typing rides on the
     // previous amount's validation result.
@@ -752,6 +841,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         toAddress: _addressController.text.trim(),
         amountZatoshi: zatoshi,
         memo: _effectiveMemo.isNotEmpty ? _effectiveMemo : null,
+        sendSource: _sendSource.wireName,
       );
       if (!mounted || seq != _validateSeq) return;
       if (zatoshi + fee > _spendable) {
@@ -794,6 +884,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
             amountText: _amountText,
             feeZatoshi: _feeZatoshi,
             isMaxMode: _isMaxMode && _hasCurrentMaxQuote,
+            sendSource: _sendSource,
             memo: _memo,
             contactLabel: _contactLabel,
             contactPictureId: _contactPictureId,
@@ -832,6 +923,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         toAddress: _addressController.text.trim(),
         amountZatoshi: zatoshi,
         memo: _effectiveMemo.isNotEmpty ? _effectiveMemo : null,
+        sendSource: _sendSource.wireName,
       );
       if (!mounted || seq != _feeSeq) return;
       setState(() => _feeZatoshi = fee);
@@ -868,6 +960,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
   Future<void> _confirmAndSend() async {
     if (_phase != _SendPhase.compose || _isConfirmingSend) return;
     if (_isResolvingMax || (_isMaxMode && !_hasCurrentMaxQuote)) return;
+    if (_isHardwareTransparentSourceSend) return;
     final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
     if (accountUuid == null) return;
     final isHardware = ref
@@ -892,6 +985,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         addressType: _addressType,
         amountZatoshi: amountZatoshi,
         memo: _effectiveMemo.isNotEmpty ? _effectiveMemo : null,
+        sendSource: _sendSource,
       );
     } catch (e) {
       log('MobileSend: propose error: $e');
@@ -1384,45 +1478,50 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
           child: AppIcon(
             AppIcons.plane,
             size: 20,
-            color: _addressController.text.trim().isEmpty
-                ? colors.icon.regular
-                : colors.icon.accent,
+            color:
+                _addressController.text.trim().isEmpty
+                    ? colors.icon.regular
+                    : colors.icon.accent,
           ),
         ),
       ),
-      restingBorderColor: hasAddressError
-          ? colors.border.utilityDestructive
-          : null,
-      focusedBorderColor: hasAddressError
-          ? colors.border.utilityDestructive
-          : const Color(0x00000000),
-      focusedBoxShadow: showAction
-          ? [
-              BoxShadow(
-                color: colors.background.neutralScrim,
-                offset: const Offset(0, 4),
-                blurRadius: 4,
-                spreadRadius: 1000,
-              ),
-            ]
-          : null,
-      trailing: showAction
-          ? SizedBox(
-              key: const ValueKey('mobile_send_address_action_slot'),
-              width: _kMobileSendAddressActionSlotWidth,
-              height: AppInputSizing.height,
-              child: Center(
-                child: _AddressFieldActionButton(
-                  label: _addressController.text.trim().isEmpty
-                      ? 'Paste'
-                      : 'Clear',
-                  onTap: _addressController.text.trim().isEmpty
-                      ? () => unawaited(_pasteAddress())
-                      : _clearAddress,
+      restingBorderColor:
+          hasAddressError ? colors.border.utilityDestructive : null,
+      focusedBorderColor:
+          hasAddressError
+              ? colors.border.utilityDestructive
+              : const Color(0x00000000),
+      focusedBoxShadow:
+          showAction
+              ? [
+                BoxShadow(
+                  color: colors.background.neutralScrim,
+                  offset: const Offset(0, 4),
+                  blurRadius: 4,
+                  spreadRadius: 1000,
                 ),
-              ),
-            )
-          : null,
+              ]
+              : null,
+      trailing:
+          showAction
+              ? SizedBox(
+                key: const ValueKey('mobile_send_address_action_slot'),
+                width: _kMobileSendAddressActionSlotWidth,
+                height: AppInputSizing.height,
+                child: Center(
+                  child: _AddressFieldActionButton(
+                    label:
+                        _addressController.text.trim().isEmpty
+                            ? 'Paste'
+                            : 'Clear',
+                    onTap:
+                        _addressController.text.trim().isEmpty
+                            ? () => unawaited(_pasteAddress())
+                            : _clearAddress,
+                  ),
+                ),
+              )
+              : null,
       onChanged: (_) => _handleAddressChanged(),
       keyboardType: TextInputType.text,
     );
@@ -1435,24 +1534,27 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         _addressType == 'invalid' || _addressType == 'error' || hardwareTex;
     return SizedBox(
       height: _kMobileSendAddressErrorGap + _kMobileSendRecipientLineHeight,
-      child: showError
-          ? Padding(
-              padding: const EdgeInsets.only(top: _kMobileSendAddressErrorGap),
-              child: Align(
-                alignment: Alignment.topLeft,
-                child: Text(
-                  hardwareTex
-                      ? _hardwareTexUnsupportedText
-                      : (_addressType == 'invalid'
+      child:
+          showError
+              ? Padding(
+                padding: const EdgeInsets.only(
+                  top: _kMobileSendAddressErrorGap,
+                ),
+                child: Align(
+                  alignment: Alignment.topLeft,
+                  child: Text(
+                    hardwareTex
+                        ? _hardwareTexUnsupportedText
+                        : (_addressType == 'invalid'
                             ? 'Invalid address'
                             : 'Address validation failed'),
-                  style: AppTypography.labelLarge.copyWith(
-                    color: colors.text.destructive,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: colors.text.destructive,
+                    ),
                   ),
                 ),
-              ),
-            )
-          : null,
+              )
+              : null,
     );
   }
 
@@ -1467,15 +1569,19 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         key: const ValueKey('mobile_send_continue'),
         expand: true,
         constrainContent: true,
-        disabledBackgroundColor: useBackdropColors
-            ? Color.alphaBlend(colors.button.disabled.bg, colors.surface.input)
-            : null,
-        enabledBorderColor: useBackdropColors
-            ? colors.border.subtleOpacity
-            : null,
-        onPressed: _hasValidAddress && !_isHardwareTexRecipient
-            ? _continueToAmount
-            : null,
+        disabledBackgroundColor:
+            useBackdropColors
+                ? Color.alphaBlend(
+                  colors.button.disabled.bg,
+                  colors.surface.input,
+                )
+                : null,
+        enabledBorderColor:
+            useBackdropColors ? colors.border.subtleOpacity : null,
+        onPressed:
+            _hasValidAddress && !_isHardwareTexRecipient
+                ? _continueToAmount
+                : null,
         child: Text(
           _addressController.text.trim().isEmpty
               ? 'Enter address to continue'
@@ -1489,9 +1595,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
 
   Widget _buildAmountStep(BuildContext context) {
     final colors = context.colors;
-    final spendableText = ZecAmount.fromZatoshi(
-      _spendable,
-    ).pretty(denomStyle: ZecDenomStyle.upper).toString();
+    final spendableText =
+        ZecAmount.fromZatoshi(
+          _spendable,
+        ).pretty(denomStyle: ZecDenomStyle.upper).toString();
     final showError = _amountError != null && _amountError!.isNotEmpty;
     final amountStyle = AppTypography.displayLarge.copyWith(
       color: showError ? colors.text.destructive : colors.text.accent,
@@ -1571,30 +1678,31 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                                           MainAxisAlignment.center,
                                       crossAxisAlignment:
                                           CrossAxisAlignment.start,
-                                      children: _contactLabel == null
-                                          ? [
-                                              _RecipientLineText(
-                                                _truncateAddress(
-                                                  _addressController.text,
+                                      children:
+                                          _contactLabel == null
+                                              ? [
+                                                _RecipientLineText(
+                                                  _truncateAddress(
+                                                    _addressController.text,
+                                                  ),
+                                                  color: colors.text.accent,
                                                 ),
-                                                color: colors.text.accent,
-                                              ),
-                                            ]
-                                          : [
-                                              _RecipientLineText(
-                                                _contactLabel!,
-                                                color: colors.text.accent,
-                                              ),
-                                              const SizedBox(
-                                                height: AppSpacing.xxs,
-                                              ),
-                                              _RecipientLineText(
-                                                _truncateAddress(
-                                                  _addressController.text,
+                                              ]
+                                              : [
+                                                _RecipientLineText(
+                                                  _contactLabel!,
+                                                  color: colors.text.accent,
                                                 ),
-                                                color: colors.text.secondary,
-                                              ),
-                                            ],
+                                                const SizedBox(
+                                                  height: AppSpacing.xxs,
+                                                ),
+                                                _RecipientLineText(
+                                                  _truncateAddress(
+                                                    _addressController.text,
+                                                  ),
+                                                  color: colors.text.secondary,
+                                                ),
+                                              ],
                                     ),
                                   ),
                                 ],
@@ -1659,16 +1767,17 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
           children: [
             SizedBox(
               height: _kMobileSendAmountLineHeight,
-              child: showError
-                  ? Center(
-                      child: Text(
-                        _amountError!,
-                        style: AppTypography.labelLarge.copyWith(
-                          color: colors.text.destructive,
+              child:
+                  showError
+                      ? Center(
+                        child: Text(
+                          _amountError!,
+                          style: AppTypography.labelLarge.copyWith(
+                            color: colors.text.destructive,
+                          ),
                         ),
-                      ),
-                    )
-                  : const SizedBox.shrink(),
+                      )
+                      : const SizedBox.shrink(),
             ),
             const SizedBox(height: AppSpacing.s),
             SizedBox(
@@ -1693,9 +1802,8 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                 ],
                 maxLines: 1,
                 style: amountStyle,
-                cursorColor: showError
-                    ? colors.text.destructive
-                    : colors.text.accent,
+                cursorColor:
+                    showError ? colors.text.destructive : colors.text.accent,
                 cursorWidth: _kMobileSendAmountCaretWidth,
                 cursorHeight: _kMobileSendAmountCaretHeight,
                 cursorRadius: const Radius.circular(AppRadii.full),
@@ -1709,20 +1817,12 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
             SizedBox(
               height: _kMobileSendAmountLineHeight,
               child: Center(
-                child: Semantics(
-                  button: true,
-                  label: 'Use maximum spendable balance',
-                  child: GestureDetector(
-                    key: const ValueKey('mobile_send_max_button'),
-                    behavior: HitTestBehavior.opaque,
-                    onTap: _isResolvingMax ? null : _activateMaxMode,
-                    child: Text(
-                      'Max: $spendableText',
-                      style: AppTypography.labelLarge.copyWith(
-                        color: colors.text.secondary,
-                      ),
-                    ),
-                  ),
+                child: _MobileSendMaxBalanceControl(
+                  spendableText: spendableText,
+                  isTransparentSource: _isTransparentSource,
+                  sourceSheetOpen: _isSourceSheetOpen,
+                  onMaxTap: _isResolvingMax ? null : _activateMaxMode,
+                  onSourceTap: () => unawaited(_showSendSourceSheet()),
                 ),
               ),
             ),
@@ -1738,15 +1838,17 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         ZecAmount.tryParse(_amountText)?.activityDetail.toString() ??
         '$_amountText ZEC';
     final amountZatoshi = parseZecAmount(_amountText.trim());
-    final amountFiatText = amountZatoshi == null
-        ? null
-        : fiatTextForZatoshi(
-            amountZatoshi,
-            zecUsdUnitPrice: ref.watch(zecHomeUsdUnitPriceProvider),
-          );
-    final feeText = _feeZatoshi == null
-        ? '—'
-        : ZecAmount.fromZatoshi(_feeZatoshi!).fee.toString();
+    final amountFiatText =
+        amountZatoshi == null
+            ? null
+            : fiatTextForZatoshi(
+              amountZatoshi,
+              zecUsdUnitPrice: ref.watch(zecHomeUsdUnitPriceProvider),
+            );
+    final feeText =
+        _feeZatoshi == null
+            ? '—'
+            : ZecAmount.fromZatoshi(_feeZatoshi!).fee.toString();
     final address = _addressController.text.trim();
     final addressBookContacts =
         ref.watch(addressBookProvider).value?.contacts ??
@@ -1811,9 +1913,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                               address: _compactReviewAddress(address),
                               addressType: _addressType,
                               isShielded: _isShieldedAddress,
-                              onFullAddress: () => unawaited(
-                                _showFullAddressSheet(address, recipient),
-                              ),
+                              onFullAddress:
+                                  () => unawaited(
+                                    _showFullAddressSheet(address, recipient),
+                                  ),
                             ),
                           ),
                         ],
@@ -1844,10 +1947,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                   expand: true,
                   onPressed:
                       _isConfirmingSend ||
-                          _isResolvingMax ||
-                          (_isMaxMode && !_hasCurrentMaxQuote)
-                      ? null
-                      : () => unawaited(_confirmAndSend()),
+                              _isResolvingMax ||
+                              (_isMaxMode && !_hasCurrentMaxQuote)
+                          ? null
+                          : () => unawaited(_confirmAndSend()),
                   leading: const AppIcon(AppIcons.plane, size: 20),
                   child: Text(
                     _isConfirmingSend ? 'Preparing...' : 'Confirm & Send',
@@ -2002,6 +2105,314 @@ class _ZecAmountInputFormatter extends TextInputFormatter {
   }
 }
 
+class _MobileSendMaxBalanceControl extends StatelessWidget {
+  const _MobileSendMaxBalanceControl({
+    required this.spendableText,
+    required this.isTransparentSource,
+    required this.sourceSheetOpen,
+    required this.onMaxTap,
+    required this.onSourceTap,
+  });
+
+  final String spendableText;
+  final bool isTransparentSource;
+  final bool sourceSheetOpen;
+  final VoidCallback? onMaxTap;
+  final VoidCallback onSourceTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final labelStyle = AppTypography.labelLarge.copyWith(
+      color: colors.text.secondary,
+    );
+    final chevronColor =
+        isTransparentSource ? colors.icon.brandCrimson : colors.icon.accent;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Semantics(
+          button: true,
+          label: 'Use maximum spendable balance',
+          child: GestureDetector(
+            key: const ValueKey('mobile_send_max_button'),
+            behavior: HitTestBehavior.opaque,
+            onTap: onMaxTap,
+            child: Text('Max: $spendableText', style: labelStyle),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.xxs),
+        Semantics(
+          button: true,
+          label: 'Choose send source balance',
+          child: GestureDetector(
+            key: const ValueKey('mobile_send_source_button'),
+            behavior: HitTestBehavior.opaque,
+            onTap: onSourceTap,
+            child: SizedBox(
+              width: 24,
+              height: 22,
+              child: Center(
+                child: RotatedBox(
+                  quarterTurns: sourceSheetOpen ? 3 : 1,
+                  child: AppIcon(
+                    AppIcons.chevronForward,
+                    size: 18,
+                    color: chevronColor,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _MobileSendSourceSheet extends StatelessWidget {
+  const _MobileSendSourceSheet({
+    required this.totalText,
+    required this.shieldedText,
+    required this.transparentText,
+    required this.selectedSource,
+  });
+
+  final String totalText;
+  final String shieldedText;
+  final String transparentText;
+  final SendSource selectedSource;
+
+  static const _helpText =
+      'Spendable balance can be lower than total balance while funds wait for '
+      'confirmations or scanning.';
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return MobileModalScaffold(
+      title: 'Send source',
+      onClose: () => Navigator.of(context).pop(),
+      bottomPadding: AppSpacing.base,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _MobileSendSourceSummaryRow(
+            iconName: AppIcons.zcash,
+            label: 'Total',
+            value: totalText,
+          ),
+          const _MobileSendSourceDivider(),
+          _MobileSendSourceOptionRow(
+            key: const ValueKey('mobile_send_source_option_shielded'),
+            iconName: AppIcons.shieldKeyhole,
+            label: 'Shielded',
+            value: shieldedText,
+            selected: selectedSource == SendSource.shielded,
+            selectedColor: colors.text.brandCrimson,
+            onTap: () => Navigator.of(context).pop(SendSource.shielded),
+          ),
+          _MobileSendSourceOptionRow(
+            key: const ValueKey('mobile_send_source_option_transparent'),
+            iconName: AppIcons.transparentBalance,
+            label: 'Transparent',
+            value: transparentText,
+            selected: selectedSource == SendSource.transparent,
+            onTap: () => Navigator.of(context).pop(SendSource.transparent),
+          ),
+          const SizedBox(height: AppSpacing.xs),
+          const _MobileSendSourceHelpRow(text: _helpText),
+        ],
+      ),
+    );
+  }
+}
+
+class _MobileSendSourceSummaryRow extends StatelessWidget {
+  const _MobileSendSourceSummaryRow({
+    required this.iconName,
+    required this.label,
+    required this.value,
+  });
+
+  final String iconName;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: AppSpacing.xxs,
+      ),
+      child: _MobileSendSourceRowContent(
+        iconName: iconName,
+        label: label,
+        value: value,
+        iconColor: colors.icon.muted,
+        labelColor: colors.text.secondary,
+        valueColor: colors.text.accent,
+      ),
+    );
+  }
+}
+
+class _MobileSendSourceDivider extends StatelessWidget {
+  const _MobileSendSourceDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: AppSpacing.xs,
+      ),
+      child: Container(
+        key: const ValueKey('mobile_send_source_total_divider'),
+        height: 1,
+        color: context.colors.border.subtleOpacity,
+      ),
+    );
+  }
+}
+
+class _MobileSendSourceOptionRow extends StatelessWidget {
+  const _MobileSendSourceOptionRow({
+    super.key,
+    required this.iconName,
+    required this.label,
+    required this.value,
+    required this.selected,
+    required this.onTap,
+    this.selectedColor,
+  });
+
+  final String iconName;
+  final String label;
+  final String value;
+  final bool selected;
+  final VoidCallback onTap;
+  final Color? selectedColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final accentColor =
+        selectedColor ?? (selected ? colors.text.accent : colors.icon.regular);
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: Container(
+        height: 40,
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+        decoration: BoxDecoration(
+          color: selected ? colors.background.brandCrimsonAlpha : null,
+          borderRadius: BorderRadius.circular(AppRadii.medium),
+        ),
+        child: _MobileSendSourceRowContent(
+          iconName: iconName,
+          label: label,
+          value: value,
+          iconColor: selected ? accentColor : colors.icon.regular,
+          labelColor: selected ? accentColor : colors.text.accent,
+          valueColor: colors.text.secondary,
+        ),
+      ),
+    );
+  }
+}
+
+class _MobileSendSourceRowContent extends StatelessWidget {
+  const _MobileSendSourceRowContent({
+    required this.iconName,
+    required this.label,
+    required this.value,
+    required this.iconColor,
+    required this.labelColor,
+    required this.valueColor,
+  });
+
+  final String iconName;
+  final String label;
+  final String value;
+  final Color iconColor;
+  final Color labelColor;
+  final Color valueColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 20,
+          height: 20,
+          child: Center(
+            child: AppIcon(
+              iconName,
+              size: AppIconSize.medium,
+              color: iconColor,
+            ),
+          ),
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            label,
+            style: AppTypography.labelLarge.copyWith(color: labelColor),
+          ),
+        ),
+        Text(
+          value,
+          style: AppTypography.labelLarge.copyWith(color: valueColor),
+        ),
+      ],
+    );
+  }
+}
+
+class _MobileSendSourceHelpRow extends StatelessWidget {
+  const _MobileSendSourceHelpRow({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 20,
+            height: 20,
+            child: Center(
+              child: AppIcon(
+                AppIcons.help,
+                size: AppIconSize.medium,
+                color: colors.icon.muted,
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              text,
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _ReviewZecIcon extends StatelessWidget {
   const _ReviewZecIcon();
 
@@ -2116,17 +2527,18 @@ class _ReviewInfoRow extends StatelessWidget {
                         bottom ??
                         Align(
                           alignment: Alignment.centerLeft,
-                          child: detailText == null
-                              ? const SizedBox.shrink()
-                              : Text(
-                                  detailText,
-                                  key: detailKey,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: AppTypography.labelLarge.copyWith(
-                                    color: colors.text.secondary,
+                          child:
+                              detailText == null
+                                  ? const SizedBox.shrink()
+                                  : Text(
+                                    detailText,
+                                    key: detailKey,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: AppTypography.labelLarge.copyWith(
+                                      color: colors.text.secondary,
+                                    ),
                                   ),
-                                ),
                         ),
                   ),
                 ],
@@ -2167,9 +2579,8 @@ class _ReviewAddressLine extends StatelessWidget {
                     ? AppIcons.shieldKeyhole
                     : AppIcons.transparentBalance,
                 size: 16,
-                color: isShielded
-                    ? colors.icon.brandCrimson
-                    : colors.icon.muted,
+                color:
+                    isShielded ? colors.icon.brandCrimson : colors.icon.muted,
               ),
               const SizedBox(width: AppSpacing.xxs),
               Expanded(
@@ -2277,9 +2688,8 @@ class _ReviewWrap extends StatelessWidget {
                 onTap: onMemoTap,
                 leftLabel: memo.isEmpty ? null : 'Message',
                 rightLabel: memo.isEmpty ? 'Add short encrypted message' : memo,
-                rightIcon: memo.isEmpty
-                    ? AppIcons.edit
-                    : AppIcons.doubleArrowVertical,
+                rightIcon:
+                    memo.isEmpty ? AppIcons.edit : AppIcons.doubleArrowVertical,
                 centered: memo.isEmpty,
               ),
               const SizedBox(height: AppSpacing.sm),
@@ -2329,9 +2739,8 @@ class _ReviewListRow extends StatelessWidget {
     final colors = context.colors;
     final right = Row(
       mainAxisSize: centered ? MainAxisSize.min : MainAxisSize.max,
-      mainAxisAlignment: centered
-          ? MainAxisAlignment.center
-          : MainAxisAlignment.end,
+      mainAxisAlignment:
+          centered ? MainAxisAlignment.center : MainAxisAlignment.end,
       children: [
         if (rightIcon != null && centered) ...[
           AppIcon(rightIcon!, size: 20, color: colors.icon.muted),
@@ -2346,9 +2755,10 @@ class _ReviewListRow extends StatelessWidget {
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
             style: AppTypography.bodyMediumStrong.copyWith(
-              color: centered && leftLabel == null
-                  ? colors.text.secondary
-                  : colors.text.accent,
+              color:
+                  centered && leftLabel == null
+                      ? colors.text.secondary
+                      : colors.text.accent,
             ),
           ),
         ),
@@ -2363,21 +2773,22 @@ class _ReviewListRow extends StatelessWidget {
       height: _kMobileSendReviewRowHeight,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
-        child: centered
-            ? Center(child: right)
-            : Row(
-                children: [
-                  if (leftLabel != null)
-                    Text(
-                      leftLabel!,
-                      style: AppTypography.bodyMediumStrong.copyWith(
-                        color: colors.text.secondary,
+        child:
+            centered
+                ? Center(child: right)
+                : Row(
+                  children: [
+                    if (leftLabel != null)
+                      Text(
+                        leftLabel!,
+                        style: AppTypography.bodyMediumStrong.copyWith(
+                          color: colors.text.secondary,
+                        ),
                       ),
-                    ),
-                  const SizedBox(width: AppSpacing.sm),
-                  Expanded(child: right),
-                ],
-              ),
+                    const SizedBox(width: AppSpacing.sm),
+                    Expanded(child: right),
+                  ],
+                ),
       ),
     );
 
@@ -2472,9 +2883,10 @@ class _MemoSheetState extends State<_MemoSheet> {
                           // "51/512".
                           '$_usedBytes/$_memoByteLimit',
                           style: labelStyle.copyWith(
-                            color: overLimit
-                                ? colors.text.destructive
-                                : colors.text.secondary,
+                            color:
+                                overLimit
+                                    ? colors.text.destructive
+                                    : colors.text.secondary,
                           ),
                         ),
                       ],
@@ -2493,14 +2905,15 @@ class _MemoSheetState extends State<_MemoSheet> {
                     height: _kMobileSendRecipientLineHeight,
                     child: Align(
                       alignment: Alignment.centerLeft,
-                      child: overLimit
-                          ? Text(
-                              'Message is too long',
-                              style: labelStyle.copyWith(
-                                color: colors.text.destructive,
-                              ),
-                            )
-                          : const SizedBox.shrink(),
+                      child:
+                          overLimit
+                              ? Text(
+                                'Message is too long',
+                                style: labelStyle.copyWith(
+                                  color: colors.text.destructive,
+                                ),
+                              )
+                              : const SizedBox.shrink(),
                     ),
                   ),
                 ],
@@ -2521,14 +2934,14 @@ class _MemoSheetState extends State<_MemoSheet> {
                         : 'mobile_send_memo_save',
                   ),
                   expand: true,
-                  leading: primaryIsClear
-                      ? const AppIcon(AppIcons.trash)
-                      : null,
-                  onPressed: primaryDisabled
-                      ? null
-                      : () => Navigator.of(
-                          context,
-                        ).pop(primaryIsClear ? '' : _currentMemo),
+                  leading:
+                      primaryIsClear ? const AppIcon(AppIcons.trash) : null,
+                  onPressed:
+                      primaryDisabled
+                          ? null
+                          : () => Navigator.of(
+                            context,
+                          ).pop(primaryIsClear ? '' : _currentMemo),
                   child: Text(primaryIsClear ? 'Clear memo' : 'Add Memo'),
                 ),
                 const SizedBox(height: AppSpacing.s),
@@ -2621,9 +3034,10 @@ class _MemoTextAreaState extends State<_MemoTextArea> {
         color: colors.background.ground,
         borderRadius: BorderRadius.circular(AppRadii.small),
         border: Border.all(
-          color: focused
-              ? colors.background.inverse
-              : colors.background.ground.withValues(alpha: 0),
+          color:
+              focused
+                  ? colors.background.inverse
+                  : colors.background.ground.withValues(alpha: 0),
           width: 1.5,
           strokeAlign: BorderSide.strokeAlignInside,
         ),
@@ -2773,17 +3187,18 @@ class _MemoTextAreaScrollbarState extends State<_MemoTextAreaScrollbar> {
       return null;
     }
 
-    final maxThumbHeight = trackHeight < _maxThumbHeight
-        ? trackHeight
-        : _maxThumbHeight;
+    final maxThumbHeight =
+        trackHeight < _maxThumbHeight ? trackHeight : _maxThumbHeight;
     if (maxThumbHeight <= 0) return null;
-    final thumbHeight = (trackHeight * viewportExtent / contentExtent)
-        .clamp(_minThumbHeight, maxThumbHeight)
-        .toDouble();
+    final thumbHeight =
+        (trackHeight * viewportExtent / contentExtent)
+            .clamp(_minThumbHeight, maxThumbHeight)
+            .toDouble();
     final thumbTravel = trackHeight - thumbHeight;
-    final scrollFraction = thumbTravel <= 0
-        ? 0.0
-        : (position.pixels / maxScrollExtent).clamp(0.0, 1.0).toDouble();
+    final scrollFraction =
+        thumbTravel <= 0
+            ? 0.0
+            : (position.pixels / maxScrollExtent).clamp(0.0, 1.0).toDouble();
     final thumbTop = _topInset + scrollFraction * thumbTravel;
 
     return _MemoScrollbarGeometry(
@@ -2799,9 +3214,10 @@ class _MemoTextAreaScrollbarState extends State<_MemoTextAreaScrollbar> {
     if (geometry.thumbTravel <= 0) return;
     final dragOffset = _dragThumbOffset ?? geometry.thumbHeight / 2;
     final targetThumbTop = localY - dragOffset;
-    final scrollFraction = ((targetThumbTop - _topInset) / geometry.thumbTravel)
-        .clamp(0.0, 1.0)
-        .toDouble();
+    final scrollFraction =
+        ((targetThumbTop - _topInset) / geometry.thumbTravel)
+            .clamp(0.0, 1.0)
+            .toDouble();
     widget.controller.jumpTo(scrollFraction * geometry.maxScrollExtent);
   }
 
@@ -2812,9 +3228,8 @@ class _MemoTextAreaScrollbarState extends State<_MemoTextAreaScrollbar> {
     final hitThumb =
         localY >= geometry.thumbTop &&
         localY <= geometry.thumbTop + geometry.thumbHeight;
-    _dragThumbOffset = hitThumb
-        ? localY - geometry.thumbTop
-        : geometry.thumbHeight / 2;
+    _dragThumbOffset =
+        hitThumb ? localY - geometry.thumbTop : geometry.thumbHeight / 2;
     _jumpToLocalY(localY, geometry);
   }
 

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -975,6 +975,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
     });
 
     SendReviewArgs args;
+    final sendSource = _sendSource;
     try {
       args = await proposeSendTransfer(
         ref: ref,
@@ -985,7 +986,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         addressType: _addressType,
         amountZatoshi: amountZatoshi,
         memo: _effectiveMemo.isNotEmpty ? _effectiveMemo : null,
-        sendSource: _sendSource,
+        sendSource: sendSource,
       );
     } catch (e) {
       log('MobileSend: propose error: $e');
@@ -993,7 +994,7 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
       setState(() {
         _isConfirmingSend = false;
         _phase = _SendPhase.failed;
-        _error = friendlyProposeSendError(e.toString());
+        _error = friendlyProposeSendError(e.toString(), sendSource: sendSource);
       });
       return;
     }

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -16,10 +16,10 @@ import '../../../core/storage/wallet_paths.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_back_link.dart';
 import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_context_menu.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_pane_modal_overlay.dart';
 import '../../../core/widgets/app_text_field.dart';
-import '../../../core/widgets/app_tooltip.dart';
 import '../../../providers/account_provider.dart';
 import '../../../providers/privacy_mode_provider.dart';
 import '../../../providers/rpc_endpoint_provider.dart';
@@ -59,6 +59,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       ),
     );
     final spendableBalance = sync.spendableBalance;
+    final transparentBalance = sync.transparentBalance;
 
     return _SendComposeBody(
       key: ValueKey('$activeAccountUuid:${widget.prefill?.fingerprint ?? ''}'),
@@ -66,6 +67,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       activeAccountUuid: activeAccountUuid,
       activeAccountIsHardware: activeAccountIsHardware,
       spendableBalance: spendableBalance,
+      transparentBalance: transparentBalance,
       prefill: widget.prefill,
     );
   }
@@ -78,6 +80,7 @@ class _SendComposeBody extends ConsumerStatefulWidget {
     required this.activeAccountUuid,
     required this.activeAccountIsHardware,
     required this.spendableBalance,
+    required this.transparentBalance,
     this.prefill,
   });
 
@@ -85,6 +88,7 @@ class _SendComposeBody extends ConsumerStatefulWidget {
   final String? activeAccountUuid;
   final bool activeAccountIsHardware;
   final BigInt spendableBalance;
+  final BigInt transparentBalance;
   final SendPrefillArgs? prefill;
 
   @override
@@ -94,12 +98,14 @@ class _SendComposeBody extends ConsumerStatefulWidget {
 class _MaxQuote {
   const _MaxQuote({
     required this.accountUuid,
+    required this.sendSource,
     required this.address,
     required this.memo,
     required this.amountZatoshi,
   });
 
   final String accountUuid;
+  final SendSource sendSource;
   final String address;
   final String memo;
   final BigInt amountZatoshi;
@@ -158,6 +164,8 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   static const _maxDebounceDuration = Duration(milliseconds: 300);
   static const _hardwareTexUnsupportedText =
       'Keystone does not support TEX sends yet.';
+  static const _hardwareTransparentSourceUnsupportedText =
+      'Keystone does not support transparent source sends yet.';
   final _addressController = _AddressTextEditingController();
   final _amountController = TextEditingController();
   final _memoController = TextEditingController();
@@ -176,6 +184,8 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   bool _isMaxMode = false;
   bool _isResolvingMax = false;
   bool _programmaticAmountEdit = false;
+  bool _sourcePickerOpen = false;
+  SendSource _sendSource = SendSource.shielded;
   _MaxQuote? _maxQuote;
   Timer? _maxDebounceTimer;
   int _addressSeq = 0;
@@ -247,7 +257,10 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   }
 
   void _openContactPicker() {
-    setState(() => _contactPickerOpen = true);
+    setState(() {
+      _contactPickerOpen = true;
+      _sourcePickerOpen = false;
+    });
   }
 
   void _closeContactPicker() {
@@ -267,7 +280,13 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   @override
   void didUpdateWidget(covariant _SendComposeBody oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.spendableBalance != widget.spendableBalance) {
+    final selectedBalanceChanged = switch (_sendSource) {
+      SendSource.shielded =>
+        oldWidget.spendableBalance != widget.spendableBalance,
+      SendSource.transparent =>
+        oldWidget.transparentBalance != widget.transparentBalance,
+    };
+    if (selectedBalanceChanged) {
       if (_isMaxMode) {
         _scheduleMaxEstimate(immediate: true);
       } else if (_amountController.text.trim().isNotEmpty) {
@@ -372,9 +391,17 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
   String get _effectiveMemo =>
       _isTransparentLikeAddress ? '' : _memoController.text.trim();
 
-  BigInt get _availableBalanceForCurrentAddress => widget.spendableBalance;
-  String get _insufficientBalanceText =>
-      _isTexAddress ? 'Insufficient balance' : 'Insufficient shielded balance';
+  bool get _isTransparentSource => _sendSource.isTransparent;
+  BigInt get _availableBalanceForCurrentAddress => _isTransparentSource
+      ? widget.transparentBalance
+      : widget.spendableBalance;
+  String get _insufficientBalanceText {
+    if (_isTransparentSource) return 'Insufficient transparent balance';
+    return _isTexAddress
+        ? 'Insufficient balance'
+        : 'Insufficient shielded balance';
+  }
+
   String get _insufficientBalanceToCoverFeeText =>
       '$_insufficientBalanceText to cover fee';
   String get _insufficientBalanceIncludingFeeText =>
@@ -383,18 +410,27 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       '$_insufficientBalanceText (fee: $feeText)';
   bool get _isHardwareTexSend =>
       _isTexAddress && widget.activeAccountIsHardware;
+  bool get _isHardwareTransparentSourceSend =>
+      _isTransparentSource && widget.activeAccountIsHardware;
 
   bool get _showAmountError =>
       _amountError != null &&
       _amountError!.trim().isNotEmpty &&
-      _amountError != _hardwareTexUnsupportedText;
-  String? get _ctaWarningText =>
-      _isHardwareTexSend ? _hardwareTexUnsupportedText : null;
+      _amountError != _hardwareTexUnsupportedText &&
+      _amountError != _hardwareTransparentSourceUnsupportedText;
+  String? get _ctaWarningText {
+    if (_isHardwareTexSend) return _hardwareTexUnsupportedText;
+    if (_isHardwareTransparentSourceSend) {
+      return _hardwareTransparentSourceUnsupportedText;
+    }
+    return null;
+  }
 
   bool get _hasCurrentMaxQuote {
     final quote = _maxQuote;
     if (quote == null) return false;
     return quote.accountUuid == widget.activeAccountUuid &&
+        quote.sendSource == _sendSource &&
         quote.address == _addressController.text.trim() &&
         quote.memo == _effectiveMemo &&
         parseZecAmount(_amountController.text.trim()) == quote.amountZatoshi;
@@ -417,6 +453,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       _hasValidAddress &&
       _isAmountValid &&
       !_isHardwareTexSend &&
+      !_isHardwareTransparentSourceSend &&
       (!_isMaxMode || _hasCurrentMaxQuote) &&
       _memoError == null &&
       (_isShieldedAddress || _effectiveMemo.isEmpty);
@@ -435,7 +472,43 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     if (widget.activeAccountUuid == null) return 'No active account';
     if (!_hasValidAddress) return 'Enter a valid address to use Max';
     if (_isHardwareTexSend) return _hardwareTexUnsupportedText;
+    if (_isHardwareTransparentSourceSend) {
+      return _hardwareTransparentSourceUnsupportedText;
+    }
     return _memoError;
+  }
+
+  void _toggleSourcePicker() {
+    setState(() => _sourcePickerOpen = !_sourcePickerOpen);
+  }
+
+  void _closeSourcePicker() {
+    if (!_sourcePickerOpen) return;
+    setState(() => _sourcePickerOpen = false);
+  }
+
+  void _selectSendSource(SendSource next) {
+    if (next == _sendSource) {
+      _closeSourcePicker();
+      return;
+    }
+
+    setState(() {
+      _sourcePickerOpen = false;
+      _sendSource = next;
+      _maxQuote = null;
+      _error = null;
+      _isResolvingMax = false;
+      _amountError = _isMaxMode ? '' : null;
+      _validateSeq++;
+      _maxSeq++;
+    });
+
+    if (_isMaxMode) {
+      _scheduleMaxEstimate(immediate: true);
+    } else if (_amountController.text.trim().isNotEmpty) {
+      _validateAmount();
+    }
   }
 
   void _scheduleMaxEstimate({bool immediate = false}) {
@@ -468,12 +541,18 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     final accountUuid = widget.activeAccountUuid;
     final address = _addressController.text.trim();
     final memo = _effectiveMemo;
+    final sendSource = _sendSource;
     if (accountUuid == null || !_isMaxMode || seq != _maxSeq) return;
 
     try {
       final dbPath = await ref.read(sendWalletDbPathProvider).call();
       final endpoint = ref.read(rpcEndpointProvider);
-      if (!mounted || !_isMaxMode || seq != _maxSeq) return;
+      if (!mounted ||
+          !_isMaxMode ||
+          seq != _maxSeq ||
+          sendSource != _sendSource) {
+        return;
+      }
 
       final estimate = await rust_sync.estimateSendMax(
         dbPath: dbPath,
@@ -481,9 +560,15 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         accountUuid: accountUuid,
         toAddress: address,
         memo: memo.isNotEmpty ? memo : null,
+        sendSource: sendSource.wireName,
       );
 
-      if (!mounted || !_isMaxMode || seq != _maxSeq) return;
+      if (!mounted ||
+          !_isMaxMode ||
+          seq != _maxSeq ||
+          sendSource != _sendSource) {
+        return;
+      }
 
       if (estimate.amountZatoshi <= BigInt.zero) {
         setState(() {
@@ -509,13 +594,19 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         _amountError = null;
         _maxQuote = _MaxQuote(
           accountUuid: accountUuid,
+          sendSource: sendSource,
           address: address,
           memo: memo,
           amountZatoshi: estimate.amountZatoshi,
         );
       });
     } catch (e) {
-      if (!mounted || !_isMaxMode || seq != _maxSeq) return;
+      if (!mounted ||
+          !_isMaxMode ||
+          seq != _maxSeq ||
+          sendSource != _sendSource) {
+        return;
+      }
       final msg = e.toString().toLowerCase();
       setState(() {
         _isResolvingMax = false;
@@ -560,6 +651,11 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       setState(() => _amountError = _hardwareTexUnsupportedText);
       return;
     }
+    if (_isHardwareTransparentSourceSend) {
+      setState(() => _amountError = _hardwareTransparentSourceUnsupportedText);
+      return;
+    }
+    final sendSource = _sendSource;
     final available = _availableBalanceForCurrentAddress;
     if (zatoshi > available) {
       setState(() => _amountError = _insufficientBalanceText);
@@ -569,7 +665,9 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     try {
       final dbPath = await ref.read(sendWalletDbPathProvider).call();
       final endpoint = ref.read(rpcEndpointProvider);
-      if (!mounted || seq != _validateSeq) return;
+      if (!mounted || seq != _validateSeq || sendSource != _sendSource) {
+        return;
+      }
       final memo = _effectiveMemo;
       final accountUuid = widget.activeAccountUuid;
       if (accountUuid == null) {
@@ -583,10 +681,13 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         toAddress: address,
         amountZatoshi: zatoshi,
         memo: memo.isNotEmpty ? memo : null,
+        sendSource: sendSource.wireName,
       );
 
       // Stale check — new input arrived while awaiting
-      if (!mounted || seq != _validateSeq) return;
+      if (!mounted || seq != _validateSeq || sendSource != _sendSource) {
+        return;
+      }
 
       final totalNeeded = zatoshi + fee;
       if (totalNeeded > available) {
@@ -596,7 +697,9 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         setState(() => _amountError = null);
       }
     } catch (e) {
-      if (!mounted || seq != _validateSeq) return;
+      if (!mounted || seq != _validateSeq || sendSource != _sendSource) {
+        return;
+      }
       final msg = e.toString();
       if (msg.contains('InsufficientFunds') || msg.contains('insufficient')) {
         setState(() => _amountError = _insufficientBalanceIncludingFeeText);
@@ -645,6 +748,13 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         });
         return;
       }
+      if (_isHardwareTransparentSourceSend) {
+        setState(() {
+          _error = _hardwareTransparentSourceUnsupportedText;
+          _isSending = false;
+        });
+        return;
+      }
       if (amountZatoshi == null || amountZatoshi <= BigInt.zero) {
         setState(() {
           _error = 'Invalid amount';
@@ -672,6 +782,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       }
 
       final memo = _effectiveMemo;
+      final sendSource = _sendSource;
 
       // Step 1: Propose transfer
       log('Send: proposing transfer');
@@ -691,6 +802,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
         address: address,
         addressType: _addressType,
         amountZatoshi: amountZatoshi,
+        sendSource: sendSource,
         memo: memo.isNotEmpty ? memo : null,
       );
       activeProposalId = reviewArgs.proposalId;
@@ -705,7 +817,10 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
       log('Send: review preparation error: $e');
       if (!mounted) return;
       setState(() {
-        _error = friendlyProposeSendError(e.toString());
+        _error = friendlyProposeSendError(
+          e.toString(),
+          sendSource: _sendSource,
+        );
         _isSending = false;
       });
     } finally {
@@ -725,9 +840,28 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     final visibleSpendableText = ZecAmount.fromZatoshi(
       available,
     ).pretty(denomStyle: ZecDenomStyle.upper).toString();
+    final privacyModeEnabled = ref.watch(privacyModeProvider);
     final spendableText = hideAmountIfPrivacyMode(
       visibleSpendableText,
-      privacyModeEnabled: ref.watch(privacyModeProvider),
+      privacyModeEnabled: privacyModeEnabled,
+    );
+    final totalText = hideAmountIfPrivacyMode(
+      ZecAmount.fromZatoshi(
+        widget.spendableBalance + widget.transparentBalance,
+      ).pretty(denomStyle: ZecDenomStyle.upper).toString(),
+      privacyModeEnabled: privacyModeEnabled,
+    );
+    final shieldedText = hideAmountIfPrivacyMode(
+      ZecAmount.fromZatoshi(
+        widget.spendableBalance,
+      ).pretty(denomStyle: ZecDenomStyle.upper).toString(),
+      privacyModeEnabled: privacyModeEnabled,
+    );
+    final transparentText = hideAmountIfPrivacyMode(
+      ZecAmount.fromZatoshi(
+        widget.transparentBalance,
+      ).pretty(denomStyle: ZecDenomStyle.upper).toString(),
+      privacyModeEnabled: privacyModeEnabled,
     );
     final colors = context.colors;
 
@@ -886,9 +1020,17 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
                             ),
                             rightSlot: _SendMaxBalanceControl(
                               spendableText: spendableText,
+                              totalText: totalText,
+                              shieldedText: shieldedText,
+                              transparentText: transparentText,
+                              isTransparentSource: _isTransparentSource,
+                              pickerOpen: _sourcePickerOpen,
                               onMaxPressed: _isResolvingMax
                                   ? null
                                   : _activateMaxMode,
+                              onSourceToggle: _toggleSourcePicker,
+                              onSourceSelected: _selectSendSource,
+                              onPickerDismissed: _closeSourcePicker,
                             ),
                             messageText: _showAmountError ? _amountError : null,
                             messageIcon: _showAmountError
@@ -1166,27 +1308,126 @@ class _SendContactsLabelButtonState extends State<_SendContactsLabelButton> {
   }
 }
 
-class _SendMaxBalanceControl extends StatelessWidget {
+class _SendMaxBalanceControl extends StatefulWidget {
   const _SendMaxBalanceControl({
     required this.spendableText,
+    required this.totalText,
+    required this.shieldedText,
+    required this.transparentText,
+    required this.isTransparentSource,
+    required this.pickerOpen,
     required this.onMaxPressed,
+    required this.onSourceToggle,
+    required this.onSourceSelected,
+    required this.onPickerDismissed,
   });
 
-  static const _tooltipTitle =
-      'Your spendable balance may be lower than your total balance.';
-  static const _tooltipBody =
-      'Funds need confirmations before they can be spent: 3 for change from '
-      'your own wallet, 10 for funds received from others. Shielded notes also '
-      "need to be fully scanned. They'll become available shortly.";
-
   final String spendableText;
+  final String totalText;
+  final String shieldedText;
+  final String transparentText;
+  final bool isTransparentSource;
+  final bool pickerOpen;
   final VoidCallback? onMaxPressed;
+  final VoidCallback onSourceToggle;
+  final ValueChanged<SendSource> onSourceSelected;
+  final VoidCallback onPickerDismissed;
+
+  @override
+  State<_SendMaxBalanceControl> createState() => _SendMaxBalanceControlState();
+}
+
+class _SendMaxBalanceControlState extends State<_SendMaxBalanceControl> {
+  final LayerLink _sourceMenuLink = LayerLink();
+  OverlayEntry? _sourceMenuEntry;
+  bool _overlaySyncScheduled = false;
+
+  @override
+  void didUpdateWidget(covariant _SendMaxBalanceControl oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.pickerOpen && _sourceMenuEntry == null) {
+      _syncMenuAfterFrame();
+    } else if (!widget.pickerOpen && _sourceMenuEntry != null) {
+      _syncMenuAfterFrame();
+    } else if (widget.pickerOpen) {
+      _syncMenuAfterFrame();
+    }
+  }
+
+  @override
+  void dispose() {
+    _hideMenu();
+    super.dispose();
+  }
+
+  void _syncMenuAfterFrame() {
+    if (_overlaySyncScheduled) return;
+    _overlaySyncScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _overlaySyncScheduled = false;
+      if (!mounted) {
+        _hideMenu();
+        return;
+      }
+      if (widget.pickerOpen) {
+        if (_sourceMenuEntry == null) {
+          _showMenu();
+        } else {
+          _sourceMenuEntry?.markNeedsBuild();
+        }
+      } else {
+        _hideMenu();
+      }
+    });
+  }
+
+  void _showMenu() {
+    final overlay = Overlay.of(context);
+    final appTheme = AppTheme.of(context);
+    _sourceMenuEntry = OverlayEntry(
+      builder: (_) => AppTheme(
+        data: appTheme,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.translucent,
+                onTap: widget.onPickerDismissed,
+              ),
+            ),
+            CompositedTransformFollower(
+              link: _sourceMenuLink,
+              showWhenUnlinked: false,
+              targetAnchor: Alignment.topRight,
+              followerAnchor: Alignment.topRight,
+              offset: const Offset(0, 24),
+              child: _SendSourcePicker(
+                totalText: widget.totalText,
+                shieldedText: widget.shieldedText,
+                transparentText: widget.transparentText,
+                selectedSource: widget.isTransparentSource
+                    ? SendSource.transparent
+                    : SendSource.shielded,
+                onSourceSelected: widget.onSourceSelected,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+    overlay.insert(_sourceMenuEntry!);
+  }
+
+  void _hideMenu() {
+    _sourceMenuEntry?.remove();
+    _sourceMenuEntry = null;
+  }
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
     final maxLabel = Text(
-      'Max: $spendableText',
+      'Max: ${widget.spendableText}',
       style: AppTypography.labelMedium.copyWith(color: colors.text.secondary),
     );
 
@@ -1197,41 +1438,330 @@ class _SendMaxBalanceControl extends StatelessWidget {
           button: true,
           label: 'Use maximum spendable balance',
           child: MouseRegion(
-            cursor: onMaxPressed == null
+            cursor: widget.onMaxPressed == null
                 ? SystemMouseCursors.basic
                 : SystemMouseCursors.click,
             child: GestureDetector(
               behavior: HitTestBehavior.opaque,
-              onTap: onMaxPressed,
+              onTap: widget.onMaxPressed,
               child: maxLabel,
             ),
           ),
         ),
         const SizedBox(width: AppSpacing.xxs),
-        AppTooltip(
-          richMessage: TextSpan(
-            children: [
-              TextSpan(
-                text: _tooltipTitle,
-                style: const TextStyle(fontWeight: FontWeight.bold),
-              ),
-              const TextSpan(text: '\n\n$_tooltipBody'),
-            ],
-          ),
-          child: SizedBox(
-            width: 18,
-            height: 18,
-            child: Center(
-              child: AppIcon(
-                AppIcons.help,
-                size: 14,
-                color: colors.icon.muted,
-                semanticLabel: 'Spendable balance info',
+        CompositedTransformTarget(
+          link: _sourceMenuLink,
+          child: Semantics(
+            button: true,
+            label: 'Choose send source balance',
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: GestureDetector(
+                key: const ValueKey('send_source_toggle_button'),
+                behavior: HitTestBehavior.opaque,
+                onTap: widget.onSourceToggle,
+                child: SizedBox(
+                  width: 24,
+                  height: 22,
+                  child: Center(
+                    child: RotatedBox(
+                      quarterTurns: widget.pickerOpen ? 3 : 1,
+                      child: AppIcon(
+                        AppIcons.chevronForward,
+                        size: 20,
+                        color: widget.isTransparentSource
+                            ? colors.icon.brandCrimson
+                            : colors.icon.accent,
+                      ),
+                    ),
+                  ),
+                ),
               ),
             ),
           ),
         ),
       ],
+    );
+  }
+}
+
+class _SendSourcePicker extends StatelessWidget {
+  const _SendSourcePicker({
+    required this.totalText,
+    required this.shieldedText,
+    required this.transparentText,
+    required this.selectedSource,
+    required this.onSourceSelected,
+  });
+
+  final String totalText;
+  final String shieldedText;
+  final String transparentText;
+  final SendSource selectedSource;
+  final ValueChanged<SendSource> onSourceSelected;
+
+  static const _helpText =
+      'Spendable balance can be lower than total balance while funds wait for '
+      'confirmations or scanning.';
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return DefaultTextStyle.merge(
+      style: const TextStyle(decoration: TextDecoration.none),
+      child: Container(
+        key: const ValueKey('send_source_picker'),
+        width: 236,
+        padding: const EdgeInsets.fromLTRB(6, 10, 6, AppSpacing.xs),
+        decoration: BoxDecoration(
+          color: colors.surface.nav,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: colors.border.subtleOpacity),
+          boxShadow: appContextMenuShadow,
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            _SendSourceSummaryRow(
+              iconName: AppIcons.zcash,
+              label: 'Total',
+              value: totalText,
+            ),
+            const _SendSourceDivider(),
+            _SendSourceOptionRow(
+              key: const ValueKey('send_source_option_shielded'),
+              iconName: AppIcons.shieldKeyhole,
+              label: 'Shielded',
+              value: shieldedText,
+              selected: selectedSource == SendSource.shielded,
+              selectedColor: colors.text.brandCrimson,
+              onTap: () => onSourceSelected(SendSource.shielded),
+            ),
+            _SendSourceOptionRow(
+              key: const ValueKey('send_source_option_transparent'),
+              iconName: AppIcons.transparentBalance,
+              label: 'Transparent',
+              value: transparentText,
+              selected: selectedSource == SendSource.transparent,
+              onTap: () => onSourceSelected(SendSource.transparent),
+            ),
+            const SizedBox(height: 2),
+            const _SendSourceHelpRow(text: _helpText),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SendSourceSummaryRow extends StatelessWidget {
+  const _SendSourceSummaryRow({
+    required this.iconName,
+    required this.label,
+    required this.value,
+  });
+
+  final String iconName;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: 1,
+      ),
+      child: _SendSourceRowContent(
+        iconName: iconName,
+        label: label,
+        value: value,
+        iconColor: colors.icon.muted,
+        labelColor: colors.text.secondary,
+        valueColor: colors.text.accent,
+      ),
+    );
+  }
+}
+
+class _SendSourceDivider extends StatelessWidget {
+  const _SendSourceDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.xs,
+        vertical: AppSpacing.xxs,
+      ),
+      child: Container(
+        key: const ValueKey('send_source_total_divider'),
+        height: 1,
+        color: context.colors.border.subtleOpacity,
+      ),
+    );
+  }
+}
+
+class _SendSourceOptionRow extends StatefulWidget {
+  const _SendSourceOptionRow({
+    super.key,
+    required this.iconName,
+    required this.label,
+    required this.value,
+    required this.selected,
+    required this.onTap,
+    this.selectedColor,
+  });
+
+  final String iconName;
+  final String label;
+  final String value;
+  final bool selected;
+  final VoidCallback onTap;
+  final Color? selectedColor;
+
+  @override
+  State<_SendSourceOptionRow> createState() => _SendSourceOptionRowState();
+}
+
+class _SendSourceOptionRowState extends State<_SendSourceOptionRow> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final accentColor =
+        widget.selectedColor ??
+        (widget.selected ? colors.text.accent : colors.icon.regular);
+    final rowColor = widget.selected
+        ? colors.background.brandCrimsonAlpha
+        : _hovered
+        ? colors.state.hoverOpacity
+        : null;
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => _setHovered(true),
+      onExit: (_) => _setHovered(false),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: widget.onTap,
+        child: Container(
+          height: 34,
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
+          decoration: BoxDecoration(
+            color: rowColor,
+            borderRadius: BorderRadius.circular(AppRadii.medium),
+          ),
+          child: _SendSourceRowContent(
+            iconName: widget.iconName,
+            label: widget.label,
+            value: widget.value,
+            iconColor: widget.selected ? accentColor : colors.icon.regular,
+            labelColor: widget.selected ? accentColor : colors.text.accent,
+            valueColor: colors.text.secondary,
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _setHovered(bool value) {
+    if (_hovered == value) return;
+    setState(() => _hovered = value);
+  }
+}
+
+class _SendSourceRowContent extends StatelessWidget {
+  const _SendSourceRowContent({
+    required this.iconName,
+    required this.label,
+    required this.value,
+    required this.iconColor,
+    required this.labelColor,
+    required this.valueColor,
+  });
+
+  final String iconName;
+  final String label;
+  final String value;
+  final Color iconColor;
+  final Color labelColor;
+  final Color valueColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 20,
+          height: 20,
+          child: Center(
+            child: AppIcon(
+              iconName,
+              size: AppIconSize.medium,
+              color: iconColor,
+            ),
+          ),
+        ),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            label,
+            style: AppTypography.labelMedium.copyWith(color: labelColor),
+          ),
+        ),
+        Text(
+          value,
+          style: AppTypography.labelMedium.copyWith(color: valueColor),
+        ),
+      ],
+    );
+  }
+}
+
+class _SendSourceHelpRow extends StatelessWidget {
+  const _SendSourceHelpRow({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.xs,
+        AppSpacing.xxs,
+        AppSpacing.xs,
+        2,
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 20,
+            height: 20,
+            child: Center(
+              child: AppIcon(
+                AppIcons.help,
+                size: AppIconSize.medium,
+                color: colors.icon.muted,
+              ),
+            ),
+          ),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              text,
+              style: AppTypography.labelMedium.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -59,7 +59,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       ),
     );
     final spendableBalance = sync.spendableBalance;
-    final transparentBalance = sync.transparentBalance;
+    final transparentBalance = sync.transparentSpendableBalance;
     final totalBalance = sync.totalBalance;
 
     return _SendComposeBody(

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -60,6 +60,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
     );
     final spendableBalance = sync.spendableBalance;
     final transparentBalance = sync.transparentBalance;
+    final totalBalance = sync.totalBalance;
 
     return _SendComposeBody(
       key: ValueKey('$activeAccountUuid:${widget.prefill?.fingerprint ?? ''}'),
@@ -68,6 +69,7 @@ class _SendScreenState extends ConsumerState<SendScreen> {
       activeAccountIsHardware: activeAccountIsHardware,
       spendableBalance: spendableBalance,
       transparentBalance: transparentBalance,
+      totalBalance: totalBalance,
       prefill: widget.prefill,
     );
   }
@@ -81,6 +83,7 @@ class _SendComposeBody extends ConsumerStatefulWidget {
     required this.activeAccountIsHardware,
     required this.spendableBalance,
     required this.transparentBalance,
+    required this.totalBalance,
     this.prefill,
   });
 
@@ -89,6 +92,7 @@ class _SendComposeBody extends ConsumerStatefulWidget {
   final bool activeAccountIsHardware;
   final BigInt spendableBalance;
   final BigInt transparentBalance;
+  final BigInt totalBalance;
   final SendPrefillArgs? prefill;
 
   @override
@@ -847,7 +851,7 @@ class _SendComposeBodyState extends ConsumerState<_SendComposeBody> {
     );
     final totalText = hideAmountIfPrivacyMode(
       ZecAmount.fromZatoshi(
-        widget.spendableBalance + widget.transparentBalance,
+        widget.totalBalance,
       ).pretty(denomStyle: ZecDenomStyle.upper).toString(),
       privacyModeEnabled: privacyModeEnabled,
     );

--- a/lib/src/features/send/services/send_flow.dart
+++ b/lib/src/features/send/services/send_flow.dart
@@ -22,6 +22,17 @@ import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
 import 'sapling_params.dart';
 
+enum SendSource {
+  shielded('shielded'),
+  transparent('transparent');
+
+  const SendSource(this.wireName);
+
+  final String wireName;
+
+  bool get isTransparent => this == SendSource.transparent;
+}
+
 /// Route-extra payload for the review/status legs of the send flow.
 class SendReviewArgs {
   const SendReviewArgs({
@@ -33,6 +44,8 @@ class SendReviewArgs {
     required this.amountZatoshi,
     required this.feeZatoshi,
     required this.needsSaplingParams,
+    this.sendSource = SendSource.shielded,
+    this.sourceAddress,
     this.memo,
   });
 
@@ -44,9 +57,12 @@ class SendReviewArgs {
   final BigInt amountZatoshi;
   final BigInt feeZatoshi;
   final bool needsSaplingParams;
+  final SendSource sendSource;
+  final String? sourceAddress;
   final String? memo;
 
   bool get isShielded => addressType == 'unified' || addressType == 'sapling';
+  bool get isTransparentSource => sendSource.isTransparent;
 }
 
 /// Hardware-wallet handoff payload: the phone-side proof clone plus the
@@ -81,6 +97,7 @@ Future<SendReviewArgs> proposeSendTransfer({
   required String address,
   required String addressType,
   required BigInt amountZatoshi,
+  SendSource sendSource = SendSource.shielded,
   String? memo,
   Future<String> Function() loadDbPath = getWalletDbPath,
 }) async {
@@ -94,6 +111,7 @@ Future<SendReviewArgs> proposeSendTransfer({
     toAddress: address,
     amountZatoshi: amountZatoshi,
     memo: (memo != null && memo.isNotEmpty) ? memo : null,
+    sendSource: sendSource.wireName,
   );
   return SendReviewArgs(
     proposalId: proposal.proposalId,
@@ -103,6 +121,8 @@ Future<SendReviewArgs> proposeSendTransfer({
     addressType: addressType,
     amountZatoshi: amountZatoshi,
     feeZatoshi: proposal.feeZatoshi,
+    sendSource: sendSource,
+    sourceAddress: proposal.sourceAddress,
     memo: (memo != null && memo.isNotEmpty) ? memo : null,
     needsSaplingParams: proposal.needsSaplingParams,
   );
@@ -125,10 +145,15 @@ Future<void> discardSendProposal({
   }
 }
 
-String friendlyProposeSendError(String raw) {
+String friendlyProposeSendError(
+  String raw, {
+  SendSource sendSource = SendSource.shielded,
+}) {
   final lower = raw.toLowerCase();
   if (lower.contains('insufficientfunds') || lower.contains('insufficient')) {
-    return 'Insufficient shielded balance to cover amount and fee.';
+    return sendSource.isTransparent
+        ? 'Insufficient transparent balance to cover amount and fee.'
+        : 'Insufficient shielded balance to cover amount and fee.';
   }
   if (lower.contains('grpc connect failed') ||
       lower.contains('connection refused') ||
@@ -405,7 +430,9 @@ Future<SendBroadcastOutcome> runSendBroadcast({
           .switchToFallbackFor(
             broadcastMessageForFallback,
             endpoint: endpoint,
-            operation: isHardware ? 'keystone send broadcast' : 'send broadcast',
+            operation: isHardware
+                ? 'keystone send broadcast'
+                : 'send broadcast',
           );
       if (switched) {
         unawaited(ref.read(syncProvider.notifier).restartSync());

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -36,6 +36,9 @@ class SyncState {
   final double displayPercentage;
   final int scannedHeight;
   final int chainTipHeight;
+
+  /// Transparent balance that is spendable for ordinary transparent-source sends.
+  /// Zero-conf transparent outputs may still be shieldable, but stay pending here.
   final BigInt transparentBalance;
   final BigInt saplingBalance;
   final BigInt orchardBalance;
@@ -70,6 +73,8 @@ class SyncState {
   /// Amount waiting for confirmations (e.g. change from a recently sent tx).
   BigInt get pendingBalance =>
       transparentPendingBalance + saplingPendingBalance + orchardPendingBalance;
+
+  BigInt get transparentSpendableBalance => transparentBalance;
 
   SyncState({
     this.accountUuid,
@@ -1371,8 +1376,11 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         dbPath: dbPath,
         network: network,
         accountUuid: accountUuid,
-        transparentBalance:
-            transparent ?? scopedPrev?.transparentBalance ?? BigInt.zero,
+        transparentTotalBalance:
+            (transparent ?? scopedPrev?.transparentBalance ?? BigInt.zero) +
+            (transparentPending ??
+                scopedPrev?.transparentPendingBalance ??
+                BigInt.zero),
       );
       if (shieldStatus != null) {
         canShieldTransparentBalance = shieldStatus.canShield;
@@ -1578,8 +1586,11 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       dbPath: dbPath,
       network: network,
       accountUuid: accountUuid,
-      transparentBalance:
-          transparent ?? scopedPrev?.transparentBalance ?? BigInt.zero,
+      transparentTotalBalance:
+          (transparent ?? scopedPrev?.transparentBalance ?? BigInt.zero) +
+          (transparentPending ??
+              scopedPrev?.transparentPendingBalance ??
+              BigInt.zero),
     );
     if (shieldStatus != null) {
       canShieldTransparentBalance = shieldStatus.canShield;
@@ -1659,9 +1670,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     required String dbPath,
     required String network,
     required String accountUuid,
-    required BigInt transparentBalance,
+    required BigInt transparentTotalBalance,
   }) async {
-    if (transparentBalance <= BigInt.zero) {
+    if (transparentTotalBalance <= BigInt.zero) {
       return (canShield: false, fee: BigInt.zero, amount: BigInt.zero);
     }
 

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -209,6 +209,7 @@ Future<ProposalResult> proposeSend({
   required String toAddress,
   required BigInt amountZatoshi,
   String? memo,
+  String? sendSource,
 }) => RustLib.instance.api.crateApiSyncProposeSend(
   dbPath: dbPath,
   network: network,
@@ -217,6 +218,7 @@ Future<ProposalResult> proposeSend({
   toAddress: toAddress,
   amountZatoshi: amountZatoshi,
   memo: memo,
+  sendSource: sendSource,
 );
 
 /// Estimate the fee for a transfer without storing a proposal.
@@ -227,6 +229,7 @@ Future<BigInt> estimateFee({
   required String toAddress,
   required BigInt amountZatoshi,
   String? memo,
+  String? sendSource,
 }) => RustLib.instance.api.crateApiSyncEstimateFee(
   dbPath: dbPath,
   network: network,
@@ -234,6 +237,7 @@ Future<BigInt> estimateFee({
   toAddress: toAddress,
   amountZatoshi: amountZatoshi,
   memo: memo,
+  sendSource: sendSource,
 );
 
 /// Estimate the maximum recipient amount for the current recipient and memo.
@@ -243,12 +247,14 @@ Future<SendMaxEstimateResult> estimateSendMax({
   required String accountUuid,
   required String toAddress,
   String? memo,
+  String? sendSource,
 }) => RustLib.instance.api.crateApiSyncEstimateSendMax(
   dbPath: dbPath,
   network: network,
   accountUuid: accountUuid,
   toAddress: toAddress,
   memo: memo,
+  sendSource: sendSource,
 );
 
 /// Step 2: Execute a previously proposed transfer and broadcast to the network.
@@ -750,16 +756,21 @@ class ProposalResult {
   final BigInt proposalId;
   final bool needsSaplingParams;
   final BigInt feeZatoshi;
+  final String? sourceAddress;
 
   const ProposalResult({
     required this.proposalId,
     required this.needsSaplingParams,
     required this.feeZatoshi,
+    this.sourceAddress,
   });
 
   @override
   int get hashCode =>
-      proposalId.hashCode ^ needsSaplingParams.hashCode ^ feeZatoshi.hashCode;
+      proposalId.hashCode ^
+      needsSaplingParams.hashCode ^
+      feeZatoshi.hashCode ^
+      sourceAddress.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -768,7 +779,8 @@ class ProposalResult {
           runtimeType == other.runtimeType &&
           proposalId == other.proposalId &&
           needsSaplingParams == other.needsSaplingParams &&
-          feeZatoshi == other.feeZatoshi;
+          feeZatoshi == other.feeZatoshi &&
+          sourceAddress == other.sourceAddress;
 }
 
 class ScanRangeInfo {

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -300,6 +300,7 @@ abstract class RustLibApi extends BaseApi {
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
+    String? sendSource,
   });
 
   Future<SendMaxEstimateResult> crateApiSyncEstimateSendMax({
@@ -308,6 +309,7 @@ abstract class RustLibApi extends BaseApi {
     required String accountUuid,
     required String toAddress,
     String? memo,
+    String? sendSource,
   });
 
   Future<ExecuteProposalResult> crateApiSyncExecuteProposal({
@@ -598,6 +600,7 @@ abstract class RustLibApi extends BaseApi {
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
+    String? sendSource,
   });
 
   Future<void> crateApiSyncPutSubtreeRoots({
@@ -2195,6 +2198,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
+    String? sendSource,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -2206,6 +2210,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(toAddress, serializer);
           sse_encode_u_64(amountZatoshi, serializer);
           sse_encode_opt_String(memo, serializer);
+          sse_encode_opt_String(sendSource, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -2225,6 +2230,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           toAddress,
           amountZatoshi,
           memo,
+          sendSource,
         ],
         apiImpl: this,
       ),
@@ -2240,6 +2246,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       "toAddress",
       "amountZatoshi",
       "memo",
+      "sendSource",
     ],
   );
 
@@ -2250,6 +2257,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String accountUuid,
     required String toAddress,
     String? memo,
+    String? sendSource,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -2260,6 +2268,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(accountUuid, serializer);
           sse_encode_String(toAddress, serializer);
           sse_encode_opt_String(memo, serializer);
+          sse_encode_opt_String(sendSource, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -2272,7 +2281,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncEstimateSendMaxConstMeta,
-        argValues: [dbPath, network, accountUuid, toAddress, memo],
+        argValues: [dbPath, network, accountUuid, toAddress, memo, sendSource],
         apiImpl: this,
       ),
     );
@@ -2281,7 +2290,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiSyncEstimateSendMaxConstMeta =>
       const TaskConstMeta(
         debugName: "estimate_send_max",
-        argNames: ["dbPath", "network", "accountUuid", "toAddress", "memo"],
+        argNames: [
+          "dbPath",
+          "network",
+          "accountUuid",
+          "toAddress",
+          "memo",
+          "sendSource",
+        ],
       );
 
   @override
@@ -4099,6 +4115,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
+    String? sendSource,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -4111,6 +4128,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(toAddress, serializer);
           sse_encode_u_64(amountZatoshi, serializer);
           sse_encode_opt_String(memo, serializer);
+          sse_encode_opt_String(sendSource, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -4131,6 +4149,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           toAddress,
           amountZatoshi,
           memo,
+          sendSource,
         ],
         apiImpl: this,
       ),
@@ -4147,6 +4166,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       "toAddress",
       "amountZatoshi",
       "memo",
+      "sendSource",
     ],
   );
 
@@ -6469,12 +6489,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ProposalResult dco_decode_proposal_result(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3)
-      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 4)
+      throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return ProposalResult(
       proposalId: dco_decode_u_64(arr[0]),
       needsSaplingParams: dco_decode_bool(arr[1]),
       feeZatoshi: dco_decode_u_64(arr[2]),
+      sourceAddress: dco_decode_opt_String(arr[3]),
     );
   }
 
@@ -8392,10 +8413,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     var var_proposalId = sse_decode_u_64(deserializer);
     var var_needsSaplingParams = sse_decode_bool(deserializer);
     var var_feeZatoshi = sse_decode_u_64(deserializer);
+    var var_sourceAddress = sse_decode_opt_String(deserializer);
     return ProposalResult(
       proposalId: var_proposalId,
       needsSaplingParams: var_needsSaplingParams,
       feeZatoshi: var_feeZatoshi,
+      sourceAddress: var_sourceAddress,
     );
   }
 
@@ -10300,6 +10323,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_u_64(self.proposalId, serializer);
     sse_encode_bool(self.needsSaplingParams, serializer);
     sse_encode_u_64(self.feeZatoshi, serializer);
+    sse_encode_opt_String(self.sourceAddress, serializer);
   }
 
   @protected

--- a/lib/widgetbook/send_use_cases.dart
+++ b/lib/widgetbook/send_use_cases.dart
@@ -495,6 +495,7 @@ Future<BigInt> _widgetbookEstimateFee({
   required String toAddress,
   required BigInt amountZatoshi,
   String? memo,
+  String? sendSource,
 }) async {
   return BigInt.from(10000);
 }

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -585,6 +585,7 @@ pub struct ProposalResult {
     pub proposal_id: u64,
     pub needs_sapling_params: bool,
     pub fee_zatoshi: u64,
+    pub source_address: Option<String>,
 }
 
 pub struct ExecuteProposalResult {
@@ -640,9 +641,11 @@ pub fn propose_send(
     to_address: String,
     amount_zatoshi: u64,
     memo: Option<String>,
+    send_source: Option<String>,
 ) -> Result<ProposalResult, String> {
     catch(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
+        let send_source = wallet_sync::SendSource::parse(send_source.as_deref())?;
         let r = wallet_sync::propose_send(
             &db_path,
             network,
@@ -651,11 +654,13 @@ pub fn propose_send(
             &to_address,
             amount_zatoshi,
             memo.as_deref(),
+            send_source,
         )?;
         Ok(ProposalResult {
             proposal_id: r.proposal_id,
             needs_sapling_params: r.needs_sapling_params,
             fee_zatoshi: r.fee_zatoshi,
+            source_address: r.source_address,
         })
     })
 }
@@ -668,9 +673,11 @@ pub fn estimate_fee(
     to_address: String,
     amount_zatoshi: u64,
     memo: Option<String>,
+    send_source: Option<String>,
 ) -> Result<u64, String> {
     catch(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
+        let send_source = wallet_sync::SendSource::parse(send_source.as_deref())?;
         wallet_sync::estimate_fee(
             &db_path,
             network,
@@ -678,6 +685,7 @@ pub fn estimate_fee(
             &to_address,
             amount_zatoshi,
             memo.as_deref(),
+            send_source,
         )
     })
 }
@@ -689,15 +697,18 @@ pub fn estimate_send_max(
     account_uuid: String,
     to_address: String,
     memo: Option<String>,
+    send_source: Option<String>,
 ) -> Result<SendMaxEstimateResult, String> {
     catch(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
+        let send_source = wallet_sync::SendSource::parse(send_source.as_deref())?;
         let r = wallet_sync::estimate_send_max(
             &db_path,
             network,
             &account_uuid,
             &to_address,
             memo.as_deref(),
+            send_source,
         )?;
         Ok(SendMaxEstimateResult {
             amount_zatoshi: r.amount_zatoshi,

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -1328,6 +1328,7 @@ fn wire__crate__api__sync__estimate_fee_impl(
             let api_to_address = <String>::sse_decode(&mut deserializer);
             let api_amount_zatoshi = <u64>::sse_decode(&mut deserializer);
             let api_memo = <Option<String>>::sse_decode(&mut deserializer);
+            let api_send_source = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -1338,6 +1339,7 @@ fn wire__crate__api__sync__estimate_fee_impl(
                         api_to_address,
                         api_amount_zatoshi,
                         api_memo,
+                        api_send_source,
                     )?;
                     Ok(output_ok)
                 })())
@@ -1372,6 +1374,7 @@ fn wire__crate__api__sync__estimate_send_max_impl(
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_to_address = <String>::sse_decode(&mut deserializer);
             let api_memo = <Option<String>>::sse_decode(&mut deserializer);
+            let api_send_source = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -1381,6 +1384,7 @@ fn wire__crate__api__sync__estimate_send_max_impl(
                         api_account_uuid,
                         api_to_address,
                         api_memo,
+                        api_send_source,
                     )?;
                     Ok(output_ok)
                 })())
@@ -3216,6 +3220,7 @@ fn wire__crate__api__sync__propose_send_impl(
             let api_to_address = <String>::sse_decode(&mut deserializer);
             let api_amount_zatoshi = <u64>::sse_decode(&mut deserializer);
             let api_memo = <Option<String>>::sse_decode(&mut deserializer);
+            let api_send_source = <Option<String>>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -3227,6 +3232,7 @@ fn wire__crate__api__sync__propose_send_impl(
                         api_to_address,
                         api_amount_zatoshi,
                         api_memo,
+                        api_send_source,
                     )?;
                     Ok(output_ok)
                 })())
@@ -6043,10 +6049,12 @@ impl SseDecode for crate::api::sync::ProposalResult {
         let mut var_proposalId = <u64>::sse_decode(deserializer);
         let mut var_needsSaplingParams = <bool>::sse_decode(deserializer);
         let mut var_feeZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_sourceAddress = <Option<String>>::sse_decode(deserializer);
         return crate::api::sync::ProposalResult {
             proposal_id: var_proposalId,
             needs_sapling_params: var_needsSaplingParams,
             fee_zatoshi: var_feeZatoshi,
+            source_address: var_sourceAddress,
         };
     }
 }
@@ -7726,6 +7734,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::sync::ProposalResult {
             self.proposal_id.into_into_dart().into_dart(),
             self.needs_sapling_params.into_into_dart().into_dart(),
             self.fee_zatoshi.into_into_dart().into_dart(),
+            self.source_address.into_into_dart().into_dart(),
         ]
         .into_dart()
     }
@@ -9601,6 +9610,7 @@ impl SseEncode for crate::api::sync::ProposalResult {
         <u64>::sse_encode(self.proposal_id, serializer);
         <bool>::sse_encode(self.needs_sapling_params, serializer);
         <u64>::sse_encode(self.fee_zatoshi, serializer);
+        <Option<String>>::sse_encode(self.source_address, serializer);
     }
 }
 

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -26,6 +26,7 @@ use crate::wallet::{
 mod pczt;
 mod send;
 mod transactions;
+mod transparent_send;
 
 // Re-export the split submodules at the `wallet::sync` path so every
 // `crate::wallet::sync::propose_send` / `::get_wallet_balance` /

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -56,6 +56,8 @@ pub(crate) use send::ProposalResult;
 #[allow(unused_imports)] // names reachable via `crate::wallet::sync::*`; pre-refactor surface
 pub(crate) use send::SendMaxEstimateResult;
 #[allow(unused_imports)] // names reachable via `crate::wallet::sync::*`; pre-refactor surface
+pub(crate) use send::SendSource;
+#[allow(unused_imports)] // names reachable via `crate::wallet::sync::*`; pre-refactor surface
 pub(crate) use send::ShieldTransparentPcztResult;
 #[allow(unused_imports)] // names reachable via `crate::wallet::sync::*`; pre-refactor surface
 pub(crate) use send::ShieldTransparentResult;

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -255,6 +255,7 @@ pub fn propose_send(
             None,
         ),
         SendSource::Transparent => build_transparent_source_send_proposal(
+            db_path,
             &mut db,
             network,
             account_id,
@@ -324,6 +325,7 @@ pub fn estimate_fee(
         )?,
         SendSource::Transparent => {
             build_transparent_source_send_proposal(
+                db_path,
                 &mut db,
                 network,
                 account_id,
@@ -365,7 +367,7 @@ pub(crate) fn estimate_send_max(
             build_send_max_proposal(&mut db, network, account_id, to_address, memo_str)?
         }
         SendSource::Transparent => build_transparent_source_send_max_proposal(
-            &mut db, network, account_id, to_address, memo_str,
+            db_path, &mut db, network, account_id, to_address, memo_str,
         )?,
     };
     summarize_send_max_proposal(&proposal)
@@ -404,6 +406,7 @@ fn build_shielded_source_send_proposal(
 }
 
 fn build_transparent_source_send_proposal(
+    db_path: &str,
     db: &mut WalletDatabase,
     network: WalletNetwork,
     account_id: AccountUuid,
@@ -419,18 +422,13 @@ fn build_transparent_source_send_proposal(
 > {
     let value = Zatoshis::from_u64(amount_zatoshi).map_err(|_| "Bad amount")?;
     let memo_bytes = parse_memo(memo_str)?;
-    let confirmations_policy = ConfirmationsPolicy::default();
+    let confirmations_policy = super::transparent_send::transparent_send_confirmations_policy();
     let (target_height, _) = db
         .get_target_and_anchor_heights(confirmations_policy.trusted())
         .map_err(|e| format!("Failed to read target height: {e}"))?
         .ok_or("Wallet must sync before sending transparent funds")?;
-    let (transparent_inputs, source_address, _) = select_transparent_source_inputs(
-        db,
-        network,
-        account_id,
-        target_height,
-        confirmations_policy,
-    )?;
+    let (transparent_inputs, source_address, _) =
+        select_transparent_source_inputs(db_path, network, account_id, target_height)?;
 
     let proposal = build_transparent_source_proposal_from_inputs(
         db,
@@ -447,6 +445,7 @@ fn build_transparent_source_send_proposal(
 }
 
 fn build_transparent_source_send_max_proposal(
+    db_path: &str,
     db: &mut WalletDatabase,
     network: WalletNetwork,
     account_id: AccountUuid,
@@ -454,18 +453,13 @@ fn build_transparent_source_send_max_proposal(
     memo_str: Option<&str>,
 ) -> Result<Proposal<WalletFeeRule, <WalletDatabase as InputSource>::NoteRef>, String> {
     let memo_bytes = parse_memo(memo_str)?;
-    let confirmations_policy = ConfirmationsPolicy::default();
+    let confirmations_policy = super::transparent_send::transparent_send_confirmations_policy();
     let (target_height, _) = db
         .get_target_and_anchor_heights(confirmations_policy.trusted())
         .map_err(|e| format!("Failed to read target height: {e}"))?
         .ok_or("Wallet must sync before sending transparent funds")?;
-    let (transparent_inputs, _, input_total) = select_transparent_source_inputs(
-        db,
-        network,
-        account_id,
-        target_height,
-        confirmations_policy,
-    )?;
+    let (transparent_inputs, _, input_total) =
+        select_transparent_source_inputs(db_path, network, account_id, target_height)?;
     let fee = transparent_source_send_max_fee(
         network,
         target_height,
@@ -689,32 +683,33 @@ fn transparent_source_send_max_fee(
 }
 
 fn select_transparent_source_inputs(
-    db: &WalletDatabase,
+    db_path: &str,
     network: WalletNetwork,
     account_id: AccountUuid,
     target_height: TargetHeight,
-    confirmations_policy: ConfirmationsPolicy,
 ) -> Result<(Vec<WalletTransparentOutput>, Option<String>, Zatoshis), String> {
-    let balances = db
-        .get_transparent_balances(account_id, target_height, confirmations_policy)
-        .map_err(|e| format!("Failed to get transparent balances: {e}"))?;
+    let balances = super::transparent_send::get_transparent_send_balances_by_address(
+        db_path,
+        network,
+        account_id,
+        target_height,
+    )?;
     let (source_addrs, _) = select_transparent_sources(balances)?;
     let mut source_addrs_with_inputs = Vec::new();
     let mut transparent_inputs = Vec::new();
 
     for source_addr in source_addrs {
-        let utxos = db
-            .get_spendable_transparent_outputs(
-                &source_addr,
-                target_height,
-                confirmations_policy,
-                TransparentOutputFilter::All,
-            )
-            .map_err(|e| format!("Failed to get transparent UTXOs: {e}"))?;
+        let utxos = super::transparent_send::get_spendable_transparent_outputs_for_address(
+            db_path,
+            network,
+            account_id,
+            target_height,
+            &source_addr,
+        )?;
         if !utxos.is_empty() {
             source_addrs_with_inputs.push(source_addr);
         }
-        transparent_inputs.extend(utxos.into_iter().map(|utxo| utxo.into_wallet_output()));
+        transparent_inputs.extend(utxos);
     }
 
     let total = transparent_inputs

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -34,7 +34,7 @@
 //! components) and the provers log+fail loudly rather than produce a
 //! silently-invalid proof.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::Infallible;
 use std::num::NonZeroUsize;
 
@@ -50,19 +50,21 @@ use zcash_client_backend::{
         Account as _, Balance, InputSource, MaxSpendMode, NoteRetention, ReceivedNotes,
         TargetValue, TransparentKeyOrigin, TransparentOutputFilter, WalletRead,
     },
+    encoding::AddressCodec,
     fees::{
         zip317::{MultiOutputChangeStrategy, Zip317FeeRule},
-        DustOutputPolicy, SplitPolicy, StandardFeeRule, TransactionBalance,
+        ChangeError, ChangeStrategy, DustOutputPolicy, SplitPolicy, StandardFeeRule,
+        TransactionBalance,
     },
     proposal::{Proposal, ShieldedInputs},
-    wallet::{OvkPolicy, ReceivedNote},
+    wallet::{OvkPolicy, ReceivedNote, WalletTransparentOutput},
     zip321::{Payment, TransactionRequest},
 };
 use zcash_client_sqlite::AccountUuid;
 use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
 use zcash_primitives::transaction::{
     fees::{
-        transparent::InputSize as TransparentInputSize,
+        transparent::{InputSize as TransparentInputSize, InputView as TransparentInputView},
         zip317::{P2PKH_STANDARD_INPUT_SIZE, P2PKH_STANDARD_OUTPUT_SIZE},
         FeeRule,
     },
@@ -95,6 +97,7 @@ pub(crate) struct ProposalResult {
     pub proposal_id: u64,
     pub needs_sapling_params: bool,
     pub fee_zatoshi: u64,
+    pub source_address: Option<String>,
 }
 
 pub struct ExecuteProposalResult {
@@ -109,6 +112,27 @@ pub(crate) struct SendMaxEstimateResult {
     pub amount_zatoshi: u64,
     pub fee_zatoshi: u64,
     pub needs_sapling_params: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SendSource {
+    Shielded,
+    Transparent,
+}
+
+impl SendSource {
+    pub(crate) fn parse(raw: Option<&str>) -> Result<Self, String> {
+        match raw
+            .unwrap_or("shielded")
+            .trim()
+            .to_ascii_lowercase()
+            .as_str()
+        {
+            "" | "shielded" => Ok(Self::Shielded),
+            "transparent" => Ok(Self::Transparent),
+            other => Err(format!("Unsupported send source: {other}")),
+        }
+    }
 }
 
 pub(crate) struct ShieldTransparentResult {
@@ -208,6 +232,7 @@ pub fn propose_send(
     to_address: &str,
     amount_zatoshi: u64,
     memo_str: Option<&str>,
+    send_source: SendSource,
 ) -> Result<ProposalResult, String> {
     use zcash_protocol::{PoolType, ShieldedProtocol as SP};
 
@@ -217,37 +242,27 @@ pub fn propose_send(
 
     let mut db = open_wallet_db_for_read(db_path, network)?;
     let account_id = parse_account_uuid(account_uuid)?;
-
-    let to: zcash_address::ZcashAddress = to_address
-        .parse()
-        .map_err(|e| format!("Bad address: {e}"))?;
-    let value = Zatoshis::from_u64(amount_zatoshi).map_err(|_| "Bad amount")?;
-    let memo_bytes = match memo_str {
-        Some(m) => {
-            let bytes = MemoBytes::from(
-                Memo::from_bytes(m.as_bytes()).map_err(|e| format!("Bad memo: {e}"))?,
-            );
-            Some(bytes)
-        }
-        None => None,
+    let (proposal, source_address) = match send_source {
+        SendSource::Shielded => (
+            build_shielded_source_send_proposal(
+                &mut db,
+                network,
+                account_id,
+                to_address,
+                amount_zatoshi,
+                memo_str,
+            )?,
+            None,
+        ),
+        SendSource::Transparent => build_transparent_source_send_proposal(
+            &mut db,
+            network,
+            account_id,
+            to_address,
+            amount_zatoshi,
+            memo_str,
+        )?,
     };
-
-    let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None);
-    let payment = Payment::new(to, Some(value), memo_bytes, None, None, vec![])
-        .map_err(|e| format!("Cannot create payment: {e:?}"))?;
-    let request = TransactionRequest::new(vec![payment]).map_err(|e| format!("{e:?}"))?;
-
-    let proposal = propose_transfer::<_, _, _, _, Infallible>(
-        &mut db,
-        &network,
-        account_id,
-        &input_selector,
-        &change_strategy,
-        request,
-        ConfirmationsPolicy::default(),
-        None,
-    )
-    .map_err(|e| format!("Propose failed: {e}"))?;
 
     let needs_sapling = proposal
         .steps()
@@ -280,6 +295,7 @@ pub fn propose_send(
         proposal_id: id,
         needs_sapling_params: needs_sapling,
         fee_zatoshi: fee,
+        source_address,
     })
 }
 
@@ -293,40 +309,31 @@ pub fn estimate_fee(
     to_address: &str,
     amount_zatoshi: u64,
     memo_str: Option<&str>,
+    send_source: SendSource,
 ) -> Result<u64, String> {
     let mut db = open_wallet_db_for_read(db_path, network)?;
     let account_id = parse_account_uuid(account_uuid)?;
-
-    let to: zcash_address::ZcashAddress = to_address
-        .parse()
-        .map_err(|e| format!("Bad address: {e}"))?;
-    let value = Zatoshis::from_u64(amount_zatoshi).map_err(|_| "Bad amount")?;
-    let memo_bytes = match memo_str {
-        Some(m) => {
-            let bytes = MemoBytes::from(
-                Memo::from_bytes(m.as_bytes()).map_err(|e| format!("Bad memo: {e}"))?,
-            );
-            Some(bytes)
+    let proposal = match send_source {
+        SendSource::Shielded => build_shielded_source_send_proposal(
+            &mut db,
+            network,
+            account_id,
+            to_address,
+            amount_zatoshi,
+            memo_str,
+        )?,
+        SendSource::Transparent => {
+            build_transparent_source_send_proposal(
+                &mut db,
+                network,
+                account_id,
+                to_address,
+                amount_zatoshi,
+                memo_str,
+            )?
+            .0
         }
-        None => None,
     };
-
-    let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None);
-    let payment = Payment::new(to, Some(value), memo_bytes, None, None, vec![])
-        .map_err(|e| format!("Cannot create payment: {e:?}"))?;
-    let request = TransactionRequest::new(vec![payment]).map_err(|e| format!("{e:?}"))?;
-
-    let proposal = propose_transfer::<_, _, _, _, Infallible>(
-        &mut db,
-        &network,
-        account_id,
-        &input_selector,
-        &change_strategy,
-        request,
-        ConfirmationsPolicy::default(),
-        None,
-    )
-    .map_err(|e| format!("Propose failed: {e}"))?;
 
     let fee: u64 = proposal
         .steps()
@@ -349,11 +356,382 @@ pub(crate) fn estimate_send_max(
     account_uuid: &str,
     to_address: &str,
     memo_str: Option<&str>,
+    send_source: SendSource,
 ) -> Result<SendMaxEstimateResult, String> {
     let mut db = open_wallet_db_for_read(db_path, network)?;
     let account_id = parse_account_uuid(account_uuid)?;
-    let proposal = build_send_max_proposal(&mut db, network, account_id, to_address, memo_str)?;
+    let proposal = match send_source {
+        SendSource::Shielded => {
+            build_send_max_proposal(&mut db, network, account_id, to_address, memo_str)?
+        }
+        SendSource::Transparent => build_transparent_source_send_max_proposal(
+            &mut db, network, account_id, to_address, memo_str,
+        )?,
+    };
     summarize_send_max_proposal(&proposal)
+}
+
+fn build_shielded_source_send_proposal(
+    db: &mut WalletDatabase,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    to_address: &str,
+    amount_zatoshi: u64,
+    memo_str: Option<&str>,
+) -> Result<Proposal<WalletFeeRule, <WalletDatabase as InputSource>::NoteRef>, String> {
+    let to: zcash_address::ZcashAddress = to_address
+        .parse()
+        .map_err(|e| format!("Bad address: {e}"))?;
+    let value = Zatoshis::from_u64(amount_zatoshi).map_err(|_| "Bad amount")?;
+    let memo_bytes = parse_memo(memo_str)?;
+
+    let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None);
+    let payment = Payment::new(to, Some(value), memo_bytes, None, None, vec![])
+        .map_err(|e| format!("Cannot create payment: {e:?}"))?;
+    let request = TransactionRequest::new(vec![payment]).map_err(|e| format!("{e:?}"))?;
+
+    propose_transfer::<_, _, _, _, Infallible>(
+        db,
+        &network,
+        account_id,
+        &input_selector,
+        &change_strategy,
+        request,
+        ConfirmationsPolicy::default(),
+        None,
+    )
+    .map_err(|e| format!("Propose failed: {e}"))
+}
+
+fn build_transparent_source_send_proposal(
+    db: &mut WalletDatabase,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    to_address: &str,
+    amount_zatoshi: u64,
+    memo_str: Option<&str>,
+) -> Result<
+    (
+        Proposal<WalletFeeRule, <WalletDatabase as InputSource>::NoteRef>,
+        Option<String>,
+    ),
+    String,
+> {
+    let value = Zatoshis::from_u64(amount_zatoshi).map_err(|_| "Bad amount")?;
+    let memo_bytes = parse_memo(memo_str)?;
+    let confirmations_policy = ConfirmationsPolicy::default();
+    let (target_height, _) = db
+        .get_target_and_anchor_heights(confirmations_policy.trusted())
+        .map_err(|e| format!("Failed to read target height: {e}"))?
+        .ok_or("Wallet must sync before sending transparent funds")?;
+    let (transparent_inputs, source_address, _) = select_transparent_source_inputs(
+        db,
+        network,
+        account_id,
+        target_height,
+        confirmations_policy,
+    )?;
+
+    let proposal = build_transparent_source_proposal_from_inputs(
+        db,
+        network,
+        account_id,
+        target_height,
+        transparent_inputs,
+        to_address,
+        value,
+        memo_bytes,
+    )?;
+
+    Ok((proposal, source_address))
+}
+
+fn build_transparent_source_send_max_proposal(
+    db: &mut WalletDatabase,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    to_address: &str,
+    memo_str: Option<&str>,
+) -> Result<Proposal<WalletFeeRule, <WalletDatabase as InputSource>::NoteRef>, String> {
+    let memo_bytes = parse_memo(memo_str)?;
+    let confirmations_policy = ConfirmationsPolicy::default();
+    let (target_height, _) = db
+        .get_target_and_anchor_heights(confirmations_policy.trusted())
+        .map_err(|e| format!("Failed to read target height: {e}"))?
+        .ok_or("Wallet must sync before sending transparent funds")?;
+    let (transparent_inputs, _, input_total) = select_transparent_source_inputs(
+        db,
+        network,
+        account_id,
+        target_height,
+        confirmations_policy,
+    )?;
+    let fee = transparent_source_send_max_fee(
+        network,
+        target_height,
+        &transparent_inputs,
+        to_address,
+        memo_bytes.as_ref(),
+    )?;
+    let value = (input_total - fee).ok_or("Insufficient transparent balance to cover fee")?;
+    if value == Zatoshis::ZERO {
+        return Err("Insufficient transparent balance to cover fee".to_string());
+    }
+
+    build_transparent_source_proposal_from_inputs(
+        db,
+        network,
+        account_id,
+        target_height,
+        transparent_inputs,
+        to_address,
+        value,
+        memo_bytes,
+    )
+}
+
+fn parse_memo(memo_str: Option<&str>) -> Result<Option<MemoBytes>, String> {
+    match memo_str {
+        Some(m) => Ok(Some(MemoBytes::from(
+            Memo::from_bytes(m.as_bytes()).map_err(|e| format!("Bad memo: {e}"))?,
+        ))),
+        None => Ok(None),
+    }
+}
+
+struct RecipientOutputPlan {
+    request: TransactionRequest,
+    payment_pools: BTreeMap<usize, PoolType>,
+    transparent_outputs: Vec<transparent::bundle::TxOut>,
+    sapling_outputs: Vec<Zatoshis>,
+    orchard_outputs: Vec<Zatoshis>,
+}
+
+fn recipient_output_plan(
+    network: WalletNetwork,
+    to_address: &str,
+    value: Zatoshis,
+    memo_bytes: Option<MemoBytes>,
+) -> Result<RecipientOutputPlan, String> {
+    let to: zcash_address::ZcashAddress = to_address
+        .parse()
+        .map_err(|e| format!("Bad address: {e}"))?;
+    let recipient_address: Address = to
+        .clone()
+        .convert_if_network(network.network_type())
+        .map_err(|e| format!("Bad address: {e:?}"))?;
+    let payment = Payment::new(to, Some(value), memo_bytes, None, None, vec![])
+        .map_err(|e| format!("Cannot create payment: {e:?}"))?;
+    let request = TransactionRequest::new(vec![payment]).map_err(|e| format!("{e:?}"))?;
+
+    let mut payment_pools = BTreeMap::new();
+    let mut transparent_outputs = Vec::new();
+    let mut sapling_outputs = Vec::new();
+    let mut orchard_outputs = Vec::new();
+
+    match recipient_address {
+        Address::Transparent(addr) => {
+            payment_pools.insert(0, PoolType::TRANSPARENT);
+            transparent_outputs.push(transparent::bundle::TxOut::new(value, addr.script().into()));
+        }
+        Address::Tex(data) => {
+            let addr = TransparentAddress::PublicKeyHash(data);
+            payment_pools.insert(0, PoolType::TRANSPARENT);
+            transparent_outputs.push(transparent::bundle::TxOut::new(value, addr.script().into()));
+        }
+        Address::Sapling(_) => {
+            payment_pools.insert(0, PoolType::SAPLING);
+            sapling_outputs.push(value);
+        }
+        Address::Unified(addr) => {
+            if addr.has_orchard() {
+                payment_pools.insert(0, PoolType::ORCHARD);
+                orchard_outputs.push(value);
+            } else if addr.has_sapling() {
+                payment_pools.insert(0, PoolType::SAPLING);
+                sapling_outputs.push(value);
+            } else if let Some(taddr) = addr.transparent() {
+                payment_pools.insert(0, PoolType::TRANSPARENT);
+                transparent_outputs.push(transparent::bundle::TxOut::new(
+                    value,
+                    taddr.script().into(),
+                ));
+            } else {
+                return Err("Unsupported recipient address".to_string());
+            }
+        }
+    }
+
+    Ok(RecipientOutputPlan {
+        request,
+        payment_pools,
+        transparent_outputs,
+        sapling_outputs,
+        orchard_outputs,
+    })
+}
+
+fn build_transparent_source_proposal_from_inputs(
+    db: &mut WalletDatabase,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    target_height: TargetHeight,
+    mut transparent_inputs: Vec<WalletTransparentOutput>,
+    to_address: &str,
+    value: Zatoshis,
+    memo_bytes: Option<MemoBytes>,
+) -> Result<Proposal<WalletFeeRule, <WalletDatabase as InputSource>::NoteRef>, String> {
+    if transparent_inputs.is_empty() {
+        return Err("No transparent funds available to send".to_string());
+    }
+
+    let plan = recipient_output_plan(network, to_address, value, memo_bytes)?;
+    let (change_strategy, _) = zip317_helper::<WalletDatabase>(None);
+    let wallet_meta = change_strategy
+        .fetch_wallet_meta(db, account_id, target_height, &[])
+        .map_err(|e| format!("Failed to fetch wallet metadata: {e}"))?;
+    let no_sapling_inputs: [Infallible; 0] = [];
+    let no_orchard_inputs: [Infallible; 0] = [];
+
+    loop {
+        let balance = change_strategy
+            .compute_balance::<_, <WalletDatabase as InputSource>::NoteRef>(
+                &network,
+                target_height,
+                &transparent_inputs,
+                &plan.transparent_outputs,
+                &(
+                    sapling_crypto::builder::BundleType::DEFAULT,
+                    &no_sapling_inputs[..],
+                    &plan.sapling_outputs[..],
+                ),
+                &(
+                    orchard::builder::BundleType::DEFAULT,
+                    &no_orchard_inputs[..],
+                    &plan.orchard_outputs[..],
+                ),
+                None,
+                &wallet_meta,
+            );
+
+        match balance {
+            Ok(balance) => {
+                return Proposal::single_step(
+                    plan.request,
+                    plan.payment_pools,
+                    transparent_inputs,
+                    None,
+                    balance,
+                    ConservativeZip317FeeRule,
+                    target_height,
+                    false,
+                )
+                .map_err(|e| format!("Propose transparent source failed: {e}"));
+            }
+            Err(ChangeError::DustInputs { transparent, .. }) => {
+                let exclusions = transparent.into_iter().collect::<BTreeSet<_>>();
+                let before = transparent_inputs.len();
+                transparent_inputs.retain(|input| !exclusions.contains(input.outpoint()));
+                if transparent_inputs.is_empty() || transparent_inputs.len() == before {
+                    return Err("No economic transparent funds available to send".to_string());
+                }
+            }
+            Err(ChangeError::InsufficientFunds {
+                required,
+                available,
+            }) => {
+                return Err(format!(
+                    "Insufficient transparent balance (have {}, need {} including fee)",
+                    u64::from(available),
+                    u64::from(required)
+                ));
+            }
+            Err(other) => return Err(format!("Transparent source balance failed: {other}")),
+        }
+    }
+}
+
+fn transparent_source_send_max_fee(
+    network: WalletNetwork,
+    target_height: TargetHeight,
+    transparent_inputs: &[WalletTransparentOutput],
+    to_address: &str,
+    memo_bytes: Option<&MemoBytes>,
+) -> Result<Zatoshis, String> {
+    let plan = recipient_output_plan(
+        network,
+        to_address,
+        Zatoshis::const_from_u64(1),
+        memo_bytes.cloned(),
+    )?;
+    let sapling_output_count = sapling_crypto::builder::BundleType::DEFAULT
+        .num_outputs(0, plan.sapling_outputs.len())
+        .map_err(|e| format!("Sapling bundle size failed: {e:?}"))?;
+    let orchard_action_count = orchard::builder::BundleType::DEFAULT
+        .num_actions(0, plan.orchard_outputs.len())
+        .map_err(|e| format!("Orchard bundle size failed: {e:?}"))?;
+
+    ConservativeZip317FeeRule
+        .fee_required(
+            &network,
+            BlockHeight::from(target_height),
+            transparent_inputs
+                .iter()
+                .map(|input| input.serialized_size()),
+            plan.transparent_outputs
+                .iter()
+                .map(|_| P2PKH_STANDARD_OUTPUT_SIZE),
+            0,
+            sapling_output_count,
+            orchard_action_count,
+        )
+        .map_err(|e| format!("Transparent max fee calculation failed: {e}"))
+}
+
+fn select_transparent_source_inputs(
+    db: &WalletDatabase,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    target_height: TargetHeight,
+    confirmations_policy: ConfirmationsPolicy,
+) -> Result<(Vec<WalletTransparentOutput>, Option<String>, Zatoshis), String> {
+    let balances = db
+        .get_transparent_balances(account_id, target_height, confirmations_policy)
+        .map_err(|e| format!("Failed to get transparent balances: {e}"))?;
+    let (source_addrs, _) = select_transparent_sources(balances)?;
+    let mut source_addrs_with_inputs = Vec::new();
+    let mut transparent_inputs = Vec::new();
+
+    for source_addr in source_addrs {
+        let utxos = db
+            .get_spendable_transparent_outputs(
+                &source_addr,
+                target_height,
+                confirmations_policy,
+                TransparentOutputFilter::All,
+            )
+            .map_err(|e| format!("Failed to get transparent UTXOs: {e}"))?;
+        if !utxos.is_empty() {
+            source_addrs_with_inputs.push(source_addr);
+        }
+        transparent_inputs.extend(utxos.into_iter().map(|utxo| utxo.into_wallet_output()));
+    }
+
+    let total = transparent_inputs
+        .iter()
+        .try_fold(Zatoshis::ZERO, |acc, input| {
+            (acc + input.value()).ok_or("Selected transparent balance overflow")
+        })?;
+    if total == Zatoshis::ZERO {
+        return Err("No transparent funds available to send".to_string());
+    }
+
+    let source_address = match source_addrs_with_inputs.as_slice() {
+        [addr] => Some(addr.encode(&network)),
+        _ => None,
+    };
+
+    Ok((transparent_inputs, source_address, total))
 }
 
 /// Dry-run the transparent shielding proposal path without creating or
@@ -835,6 +1213,16 @@ fn select_shielding_sources(
     account_receivers: HashMap<TransparentAddress, (TransparentKeyOrigin, Balance)>,
     shielding_threshold: Zatoshis,
 ) -> Result<(Vec<TransparentAddress>, Zatoshis), String> {
+    let (addresses, total) = select_transparent_sources(account_receivers)?;
+    if total < shielding_threshold {
+        return Err("No transparent funds available to shield above the fee threshold".to_string());
+    }
+    Ok((addresses, total))
+}
+
+fn select_transparent_sources(
+    account_receivers: HashMap<TransparentAddress, (TransparentKeyOrigin, Balance)>,
+) -> Result<(Vec<TransparentAddress>, Zatoshis), String> {
     let mut ephemeral = Vec::new();
     let mut non_ephemeral = Vec::new();
 
@@ -874,8 +1262,8 @@ fn select_shielding_sources(
         addresses.push(address);
     }
 
-    if addresses.is_empty() || total < shielding_threshold {
-        return Err("No transparent funds available to shield above the fee threshold".to_string());
+    if addresses.is_empty() {
+        return Err("No transparent funds available to send".to_string());
     }
 
     Ok((addresses, total))
@@ -1378,6 +1766,75 @@ mod tests {
 
     fn receiver(value: u64, scope: TransparentKeyScope) -> (TransparentKeyOrigin, Balance) {
         (TransparentKeyOrigin::Derived { scope }, balance(value))
+    }
+
+    #[test]
+    fn send_source_parse_defaults_to_shielded() {
+        assert_eq!(SendSource::parse(None).unwrap(), SendSource::Shielded);
+        assert_eq!(SendSource::parse(Some("")).unwrap(), SendSource::Shielded);
+        assert_eq!(
+            SendSource::parse(Some(" SHIELDED ")).unwrap(),
+            SendSource::Shielded
+        );
+        assert_eq!(
+            SendSource::parse(Some(" Transparent ")).unwrap(),
+            SendSource::Transparent
+        );
+        assert!(SendSource::parse(Some("orchard")).is_err());
+    }
+
+    #[test]
+    fn transparent_source_selection_rejects_empty_or_unspendable_receivers() {
+        assert!(select_transparent_sources(HashMap::new())
+            .unwrap_err()
+            .contains("No transparent funds available"));
+
+        let selected = HashMap::from([(taddr(1), receiver(0, TransparentKeyScope::EXTERNAL))]);
+
+        assert!(select_transparent_sources(selected)
+            .unwrap_err()
+            .contains("No transparent funds available"));
+    }
+
+    #[test]
+    fn transparent_source_selection_prefers_non_ephemeral_receivers() {
+        let non_ephemeral_a = taddr(1);
+        let non_ephemeral_b = taddr(2);
+        let ephemeral = taddr(3);
+        let selected = HashMap::from([
+            (
+                non_ephemeral_a,
+                receiver(100_000, TransparentKeyScope::EXTERNAL),
+            ),
+            (
+                non_ephemeral_b,
+                receiver(200_000, TransparentKeyScope::EXTERNAL),
+            ),
+            (ephemeral, receiver(900_000, TransparentKeyScope::EPHEMERAL)),
+        ]);
+
+        let (addresses, total) = select_transparent_sources(selected).unwrap();
+
+        assert_eq!(total, Zatoshis::from_u64(300_000).unwrap());
+        assert_eq!(addresses.len(), 2);
+        assert!(addresses.contains(&non_ephemeral_a));
+        assert!(addresses.contains(&non_ephemeral_b));
+        assert!(!addresses.contains(&ephemeral));
+    }
+
+    #[test]
+    fn transparent_source_selection_uses_largest_single_ephemeral_receiver() {
+        let smaller = taddr(1);
+        let larger = taddr(2);
+        let selected = HashMap::from([
+            (smaller, receiver(100_000, TransparentKeyScope::EPHEMERAL)),
+            (larger, receiver(200_000, TransparentKeyScope::EPHEMERAL)),
+        ]);
+
+        let (addresses, total) = select_transparent_sources(selected).unwrap();
+
+        assert_eq!(total, Zatoshis::from_u64(200_000).unwrap());
+        assert_eq!(addresses, vec![larger]);
     }
 
     #[test]

--- a/rust/src/wallet/sync/transactions.rs
+++ b/rust/src/wallet/sync/transactions.rs
@@ -58,30 +58,34 @@ pub fn get_wallet_balance(
         .get_wallet_summary(ConfirmationsPolicy::default())
         .map_err(|e| format!("{e}"))?
     {
-        Some(s) => match s.account_balances().get(&target_id) {
-            Some(b) => Ok(WalletBalance {
-                transparent: u64::from(b.unshielded_balance().spendable_value()),
-                sapling: u64::from(b.sapling_balance().spendable_value()),
-                orchard: u64::from(b.orchard_balance().spendable_value()),
-                transparent_pending: u64::from(
-                    b.unshielded_balance().change_pending_confirmation(),
-                ) + u64::from(
-                    b.unshielded_balance().value_pending_spendability(),
-                ),
-                sapling_pending: u64::from(b.sapling_balance().change_pending_confirmation())
-                    + u64::from(b.sapling_balance().value_pending_spendability()),
-                orchard_pending: u64::from(b.orchard_balance().change_pending_confirmation())
-                    + u64::from(b.orchard_balance().value_pending_spendability()),
-            }),
-            None => Ok(WalletBalance {
-                transparent: 0,
-                sapling: 0,
-                orchard: 0,
-                transparent_pending: 0,
-                sapling_pending: 0,
-                orchard_pending: 0,
-            }),
-        },
+        Some(s) => {
+            let transparent_send_balance = super::transparent_send::get_transparent_send_balance(
+                db_path,
+                network,
+                target_id,
+                (s.chain_tip_height() + 1).into(),
+            )?;
+            match s.account_balances().get(&target_id) {
+                Some(b) => Ok(WalletBalance {
+                    transparent: transparent_send_balance.spendable,
+                    sapling: u64::from(b.sapling_balance().spendable_value()),
+                    orchard: u64::from(b.orchard_balance().spendable_value()),
+                    transparent_pending: transparent_send_balance.pending,
+                    sapling_pending: u64::from(b.sapling_balance().change_pending_confirmation())
+                        + u64::from(b.sapling_balance().value_pending_spendability()),
+                    orchard_pending: u64::from(b.orchard_balance().change_pending_confirmation())
+                        + u64::from(b.orchard_balance().value_pending_spendability()),
+                }),
+                None => Ok(WalletBalance {
+                    transparent: transparent_send_balance.spendable,
+                    sapling: 0,
+                    orchard: 0,
+                    transparent_pending: transparent_send_balance.pending,
+                    sapling_pending: 0,
+                    orchard_pending: 0,
+                }),
+            }
+        }
         None => Ok(WalletBalance {
             transparent: 0,
             sapling: 0,
@@ -3520,12 +3524,7 @@ mod tests {
             Some("u-my-receiver"),
             Some(0),
         );
-        set_cached_transparent_receiver_address(
-            &db,
-            account,
-            "u-my-receiver",
-            "t-my-receiver",
-        );
+        set_cached_transparent_receiver_address(&db, account, "u-my-receiver", "t-my-receiver");
 
         let got = get_transaction_detail(
             db.path().to_str().unwrap(),

--- a/rust/src/wallet/sync/transparent_send.rs
+++ b/rust/src/wallet/sync/transparent_send.rs
@@ -1,0 +1,379 @@
+use std::collections::HashMap;
+use std::num::NonZeroU32;
+
+use rusqlite::{named_params, Row};
+use transparent::{
+    address::{Script, TransparentAddress},
+    bundle::{OutPoint, TxOut},
+    keys::TransparentKeyScope,
+};
+use zcash_client_backend::{
+    data_api::{
+        wallet::{ConfirmationsPolicy, TargetHeight},
+        Balance, TransparentKeyOrigin,
+    },
+    encoding::AddressCodec,
+    wallet::WalletTransparentOutput,
+};
+use zcash_client_sqlite::AccountUuid;
+use zcash_primitives::transaction::{builder::DEFAULT_TX_EXPIRY_DELTA, fees::zip317};
+use zcash_protocol::{
+    consensus::{BlockHeight, COINBASE_MATURITY_BLOCKS},
+    value::Zatoshis,
+    PoolType,
+};
+use zcash_script::script;
+
+use crate::wallet::network::WalletNetwork;
+
+use super::open_readonly_conn;
+
+pub(crate) struct TransparentSendBalance {
+    pub spendable: u64,
+    pub pending: u64,
+}
+
+struct TransparentCandidate {
+    address: TransparentAddress,
+    output: WalletTransparentOutput,
+    key_origin: TransparentKeyOrigin,
+    spendable: bool,
+}
+
+pub(crate) fn transparent_send_confirmations_policy() -> ConfirmationsPolicy {
+    ConfirmationsPolicy::new(
+        NonZeroU32::new(3).expect("nonzero trusted confirmations"),
+        NonZeroU32::new(10).expect("nonzero untrusted confirmations"),
+        false,
+    )
+    .expect("trusted confirmations must be <= untrusted confirmations")
+}
+
+pub(crate) fn get_transparent_send_balance(
+    db_path: &str,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    target_height: TargetHeight,
+) -> Result<TransparentSendBalance, String> {
+    let mut spendable = Zatoshis::ZERO;
+    let mut pending = Zatoshis::ZERO;
+
+    for candidate in query_transparent_candidates(db_path, network, account_id, target_height)? {
+        if candidate.spendable {
+            spendable = (spendable + candidate.output.value())
+                .ok_or("Transparent spendable balance overflow")?;
+        } else {
+            pending = (pending + candidate.output.value())
+                .ok_or("Transparent pending balance overflow")?;
+        }
+    }
+
+    Ok(TransparentSendBalance {
+        spendable: u64::from(spendable),
+        pending: u64::from(pending),
+    })
+}
+
+pub(crate) fn get_transparent_send_balances_by_address(
+    db_path: &str,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    target_height: TargetHeight,
+) -> Result<HashMap<TransparentAddress, (TransparentKeyOrigin, Balance)>, String> {
+    let mut result = HashMap::new();
+
+    for candidate in query_transparent_candidates(db_path, network, account_id, target_height)? {
+        if !candidate.spendable {
+            continue;
+        }
+
+        let entry = result
+            .entry(candidate.address)
+            .or_insert((candidate.key_origin, Balance::ZERO));
+        entry
+            .1
+            .add_spendable_value(candidate.output.value())
+            .map_err(|e| format!("Transparent address balance overflow: {e}"))?;
+    }
+
+    Ok(result)
+}
+
+pub(crate) fn get_spendable_transparent_outputs_for_address(
+    db_path: &str,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    target_height: TargetHeight,
+    address: &TransparentAddress,
+) -> Result<Vec<WalletTransparentOutput>, String> {
+    let candidates = query_transparent_candidates_for_address(
+        db_path,
+        network,
+        account_id,
+        target_height,
+        address,
+    )?;
+    Ok(candidates
+        .into_iter()
+        .filter(|candidate| candidate.spendable)
+        .map(|candidate| candidate.output)
+        .collect())
+}
+
+fn query_transparent_candidates(
+    db_path: &str,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    target_height: TargetHeight,
+) -> Result<Vec<TransparentCandidate>, String> {
+    query_transparent_candidates_inner(db_path, network, account_id, target_height, None)
+}
+
+fn query_transparent_candidates_for_address(
+    db_path: &str,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    target_height: TargetHeight,
+    address: &TransparentAddress,
+) -> Result<Vec<TransparentCandidate>, String> {
+    query_transparent_candidates_inner(db_path, network, account_id, target_height, Some(address))
+}
+
+fn query_transparent_candidates_inner(
+    db_path: &str,
+    network: WalletNetwork,
+    account_id: AccountUuid,
+    target_height: TargetHeight,
+    address: Option<&TransparentAddress>,
+) -> Result<Vec<TransparentCandidate>, String> {
+    let conn = open_readonly_conn(db_path)?;
+    let policy = transparent_send_confirmations_policy();
+    let account_uuid = account_id.expose_uuid();
+    let address_filter = address.map(|addr| addr.encode(&network));
+    let mut stmt = conn
+        .prepare(&format!(
+            "SELECT u.address,
+                    t.txid,
+                    u.output_index,
+                    u.script,
+                    u.value_zat,
+                    addresses.key_scope,
+                    addresses.imported_transparent_receiver_script,
+                    t.mined_height AS received_height,
+                    t.tx_index,
+                    IFNULL(t.trust_status, 0) AS trust_status
+             FROM transparent_received_outputs u
+             JOIN accounts ON accounts.id = u.account_id
+             JOIN transactions t ON t.id_tx = u.transaction_id
+             JOIN addresses ON addresses.id = u.address_id
+             WHERE accounts.uuid = :account_uuid
+             AND (:address IS NULL OR u.address = :address)
+             AND u.value_zat > :min_value
+             AND ({})
+             AND u.id NOT IN ({})
+             AND ({})
+             ORDER BY IFNULL(t.mined_height, :target_height), u.output_index",
+            tx_unexpired_condition("t"),
+            spent_utxos_clause(),
+            excluding_wallet_internal_ephemeral_outputs("u", "addresses", "t", "accounts"),
+        ))
+        .map_err(|e| format!("Failed to prepare transparent balance query: {e}"))?;
+
+    let mut rows = stmt
+        .query(named_params![
+            ":account_uuid": account_uuid.as_bytes(),
+            ":address": address_filter,
+            ":target_height": u32::from(target_height),
+            ":min_value": u64::from(zip317::MARGINAL_FEE),
+        ])
+        .map_err(|e| format!("Failed to query transparent balance: {e}"))?;
+
+    let mut candidates = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .map_err(|e| format!("Failed to read transparent balance row: {e}"))?
+    {
+        candidates.push(row_to_candidate(row, &network, target_height, policy)?);
+    }
+
+    Ok(candidates)
+}
+
+fn row_to_candidate(
+    row: &Row,
+    network: &WalletNetwork,
+    target_height: TargetHeight,
+    policy: ConfirmationsPolicy,
+) -> Result<TransparentCandidate, String> {
+    let address_str: String = row
+        .get("address")
+        .map_err(|e| format!("Failed to read transparent address: {e}"))?;
+    let address = TransparentAddress::decode(network, &address_str)
+        .map_err(|e| format!("Failed to decode transparent address: {e}"))?;
+
+    let key_scope_code: i64 = row
+        .get("key_scope")
+        .map_err(|e| format!("Failed to read transparent key scope: {e}"))?;
+    let key_origin = transparent_key_origin(key_scope_code)?;
+    let receiving_key_scope = receiving_zip32_scope(key_scope_code);
+    let received_height_raw: Option<u32> = row
+        .get("received_height")
+        .map_err(|e| format!("Failed to read transparent received height: {e}"))?;
+    let received_height = received_height_raw.map(BlockHeight::from);
+    let tx_trusted: bool = row
+        .get("trust_status")
+        .map_err(|e| format!("Failed to read transparent trust status: {e}"))?;
+    let tx_index: Option<u32> = row
+        .get("tx_index")
+        .map_err(|e| format!("Failed to read transparent tx index: {e}"))?;
+    let output = row_to_wallet_output(row)?;
+    let confirmations_remaining = policy.confirmations_until_spendable(
+        target_height,
+        PoolType::TRANSPARENT,
+        receiving_key_scope,
+        received_height,
+        tx_trusted,
+        None,
+        false,
+    );
+    let spendable = confirmations_remaining == 0
+        && !is_immature_coinbase(target_height, received_height_raw, tx_index);
+
+    Ok(TransparentCandidate {
+        address,
+        output,
+        key_origin,
+        spendable,
+    })
+}
+
+fn row_to_wallet_output(row: &Row) -> Result<WalletTransparentOutput, String> {
+    let txid: Vec<u8> = row
+        .get("txid")
+        .map_err(|e| format!("Failed to read transparent txid: {e}"))?;
+    let txid_bytes: [u8; 32] = txid
+        .try_into()
+        .map_err(|_| "Transparent txid must be 32 bytes".to_string())?;
+    let index: u32 = row
+        .get("output_index")
+        .map_err(|e| format!("Failed to read transparent output index: {e}"))?;
+    let script_pubkey =
+        Script(script::Code(row.get("script").map_err(|e| {
+            format!("Failed to read transparent script: {e}")
+        })?));
+    let raw_value: i64 = row
+        .get("value_zat")
+        .map_err(|e| format!("Failed to read transparent value: {e}"))?;
+    let value = Zatoshis::from_nonnegative_i64(raw_value)
+        .map_err(|_| format!("Invalid transparent UTXO value: {raw_value}"))?;
+    let received_height: Option<u32> = row
+        .get("received_height")
+        .map_err(|e| format!("Failed to read transparent received height: {e}"))?;
+    let mut output = WalletTransparentOutput::from_parts(
+        OutPoint::new(txid_bytes, index),
+        TxOut::new(value, script_pubkey),
+        received_height.map(BlockHeight::from),
+    )
+    .ok_or_else(|| "Transparent UTXO script does not map to a supported address".to_string())?;
+
+    let redeem_script: Option<Vec<u8>> = row
+        .get("imported_transparent_receiver_script")
+        .map_err(|e| format!("Failed to read transparent redeem script: {e}"))?;
+    if let Some(redeem_script) = redeem_script {
+        if let Ok(from_chain) = script::FromChain::parse(&script::Code(redeem_script)) {
+            if let Some(input_size) = transparent::builder::p2sh_input_serialized_len(&from_chain) {
+                output = output.with_known_input_size(input_size);
+            }
+        }
+    }
+
+    Ok(output)
+}
+
+fn receiving_zip32_scope(key_scope: i64) -> Option<zip32::Scope> {
+    match key_scope {
+        0 => Some(zip32::Scope::External),
+        1 => Some(zip32::Scope::Internal),
+        _ => None,
+    }
+}
+
+fn transparent_key_origin(key_scope: i64) -> Result<TransparentKeyOrigin, String> {
+    match key_scope {
+        0 => Ok(TransparentKeyOrigin::Derived {
+            scope: TransparentKeyScope::EXTERNAL,
+        }),
+        1 => Ok(TransparentKeyOrigin::Derived {
+            scope: TransparentKeyScope::INTERNAL,
+        }),
+        2 => Ok(TransparentKeyOrigin::Derived {
+            scope: TransparentKeyScope::custom(2).expect("valid transparent key scope"),
+        }),
+        -1 => Ok(TransparentKeyOrigin::Imported),
+        other => Err(format!("Invalid transparent key scope code: {other}")),
+    }
+}
+
+fn is_immature_coinbase(
+    target_height: TargetHeight,
+    received_height: Option<u32>,
+    tx_index: Option<u32>,
+) -> bool {
+    tx_index == Some(0)
+        && match received_height {
+            Some(height) => {
+                u32::from(target_height).saturating_sub(height) < COINBASE_MATURITY_BLOCKS
+            }
+            None => true,
+        }
+}
+
+fn tx_unexpired_condition(tx: &str) -> String {
+    format!(
+        r#"
+        {tx}.mined_height < :target_height
+        OR {tx}.expiry_height = 0
+        OR {tx}.expiry_height >= :target_height
+        OR (
+            {tx}.expiry_height IS NULL
+            AND {tx}.min_observed_height + {DEFAULT_TX_EXPIRY_DELTA} >= :target_height
+        )
+        "#
+    )
+}
+
+fn spent_utxos_clause() -> String {
+    format!(
+        r#"
+        SELECT txo_spends.transparent_received_output_id
+        FROM transparent_received_output_spends txo_spends
+        JOIN transactions stx ON stx.id_tx = txo_spends.transaction_id
+        WHERE {}
+        "#,
+        tx_unexpired_condition("stx")
+    )
+}
+
+fn excluding_wallet_internal_ephemeral_outputs(
+    transparent_received_outputs: &str,
+    addresses: &str,
+    tx: &str,
+    accounts: &str,
+) -> String {
+    r#"
+        {addresses}.key_scope != 2
+        OR {tx}.id_tx NOT IN (
+            SELECT transaction_id
+            FROM v_received_output_spends
+            WHERE v_received_output_spends.account_id = {accounts}.id
+        )
+        OR {transparent_received_outputs}.max_observed_unspent_height > {tx}.expiry_height
+        "#
+    .replace("{addresses}", addresses)
+    .replace("{tx}", tx)
+    .replace("{accounts}", accounts)
+    .replace(
+        "{transparent_received_outputs}",
+        transparent_received_outputs,
+    )
+}

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -150,6 +150,15 @@ pub fn get_balance(db_path: &Path, account_uuid: &str) -> sync_api::WalletBalanc
     .expect("get_balance")
 }
 
+pub fn transparent_receive_address(db_path: &Path, account_uuid: &str) -> String {
+    wallet_api::get_transparent_receive_address(
+        path_str(db_path),
+        REGTEST_NETWORK.into(),
+        Some(account_uuid.into()),
+    )
+    .expect("get_transparent_receive_address")
+}
+
 pub fn get_transaction_history(
     db_path: &Path,
     account_uuid: &str,
@@ -239,6 +248,24 @@ pub fn execute_send(
     to_address: &str,
     amount_zatoshi: u64,
 ) -> String {
+    execute_send_with_source(
+        db_path,
+        sender_account_uuid,
+        sender_mnemonic,
+        to_address,
+        amount_zatoshi,
+        None,
+    )
+}
+
+pub fn execute_send_with_source(
+    db_path: &Path,
+    sender_account_uuid: &str,
+    sender_mnemonic: &str,
+    to_address: &str,
+    amount_zatoshi: u64,
+    send_source: Option<&str>,
+) -> String {
     let send_flow_id = "regtest-send-flow";
     let proposal = sync_api::propose_send(
         path_str(db_path),
@@ -248,6 +275,7 @@ pub fn execute_send(
         to_address.into(),
         amount_zatoshi,
         None,
+        send_source.map(str::to_string),
     )
     .expect("propose_send");
 

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -65,7 +65,18 @@ pub fn mine_blocks(blocks: u32) {
 }
 
 pub fn fund_wallet(unified_address: &str, amount_zec: &str) -> String {
-    run_script("fund-wallet.sh", &[unified_address, amount_zec, "10"])
+    fund_wallet_with_confirmations(unified_address, amount_zec, 10)
+}
+
+pub fn fund_wallet_with_confirmations(
+    unified_address: &str,
+    amount_zec: &str,
+    confirming_blocks: u32,
+) -> String {
+    run_script(
+        "fund-wallet.sh",
+        &[unified_address, amount_zec, &confirming_blocks.to_string()],
+    )
 }
 
 pub fn current_tip_height() -> u64 {
@@ -267,15 +278,13 @@ pub fn execute_send_with_source(
     send_source: Option<&str>,
 ) -> String {
     let send_flow_id = "regtest-send-flow";
-    let proposal = sync_api::propose_send(
-        path_str(db_path),
-        REGTEST_NETWORK.into(),
-        sender_account_uuid.into(),
-        send_flow_id.into(),
-        to_address.into(),
+    let proposal = propose_send_with_source(
+        db_path,
+        sender_account_uuid,
+        send_flow_id,
+        to_address,
         amount_zatoshi,
-        None,
-        send_source.map(str::to_string),
+        send_source,
     )
     .expect("propose_send");
 
@@ -300,6 +309,26 @@ pub fn execute_send_with_source(
     )
     .expect("execute_proposal")
     .txids
+}
+
+pub fn propose_send_with_source(
+    db_path: &Path,
+    sender_account_uuid: &str,
+    send_flow_id: &str,
+    to_address: &str,
+    amount_zatoshi: u64,
+    send_source: Option<&str>,
+) -> Result<sync_api::ProposalResult, String> {
+    sync_api::propose_send(
+        path_str(db_path),
+        REGTEST_NETWORK.into(),
+        sender_account_uuid.into(),
+        send_flow_id.into(),
+        to_address.into(),
+        amount_zatoshi,
+        None,
+        send_source.map(str::to_string),
+    )
 }
 
 pub fn positive_history_count(history: &[sync_api::TransactionInfo]) -> usize {

--- a/rust/tests/regtest_send.rs
+++ b/rust/tests/regtest_send.rs
@@ -2,7 +2,8 @@ mod common;
 
 use common::{
     add_account_with_birthday, create_wallet, ensure_regtest_up, exclusive_regtest, execute_send,
-    fund_wallet, get_balance, get_transaction_history, mine_blocks, sync_wallet,
+    execute_send_with_source, fund_wallet, get_balance, get_transaction_history, mine_blocks,
+    sync_wallet, transparent_receive_address,
 };
 
 #[test]
@@ -124,5 +125,66 @@ fn imported_second_account_can_send_using_its_own_seed() {
         receiver_after.spendable >= 60_000_000,
         "receiver should see at least 0.6 ZEC after imported-account send, got {}",
         receiver_after.spendable
+    );
+}
+
+#[test]
+#[ignore = "requires Dockerized zcashd/lightwalletd regtest services"]
+fn transparent_source_can_send_to_shielded_recipient() {
+    let _guard = exclusive_regtest();
+    ensure_regtest_up();
+
+    let (sender_dir, sender_wallet) = create_wallet("Transparent Sender");
+    let sender_db = sender_dir.path().join("zcash_wallet.db");
+    let (receiver_dir, receiver_wallet) = create_wallet("Shielded Receiver");
+    let receiver_db = receiver_dir.path().join("zcash_wallet.db");
+
+    let sender_taddr = transparent_receive_address(&sender_db, &sender_wallet.account_uuid);
+    fund_wallet(&sender_taddr, "1.1");
+    sync_wallet(&sender_db);
+
+    let sender_before = get_balance(&sender_db, &sender_wallet.account_uuid);
+    assert!(
+        sender_before.transparent >= 110_000_000,
+        "expected sender to have at least 1.1 transparent ZEC before send, got {}",
+        sender_before.transparent
+    );
+
+    let txid = execute_send_with_source(
+        &sender_db,
+        &sender_wallet.account_uuid,
+        &sender_wallet.mnemonic,
+        &receiver_wallet.unified_address,
+        40_000_000,
+        Some("transparent"),
+    );
+    assert!(
+        !txid.is_empty(),
+        "transparent-source send should return a txid"
+    );
+
+    mine_blocks(10);
+    sync_wallet(&sender_db);
+    sync_wallet(&receiver_db);
+
+    let sender_after = get_balance(&sender_db, &sender_wallet.account_uuid);
+    let receiver_after = get_balance(&receiver_db, &receiver_wallet.account_uuid);
+
+    assert!(
+        sender_after.transparent < sender_before.transparent,
+        "sender transparent balance should decrease after transparent-source send"
+    );
+    assert!(
+        receiver_after.spendable >= 40_000_000,
+        "receiver should see at least 0.4 ZEC after transparent-source send, got {}",
+        receiver_after.spendable
+    );
+
+    let receiver_history = get_transaction_history(&receiver_db, &receiver_wallet.account_uuid);
+    assert!(
+        receiver_history
+            .iter()
+            .any(|tx| tx.account_balance_delta > 0),
+        "receiver should record an inbound transparent-source transaction"
     );
 }

--- a/rust/tests/regtest_send.rs
+++ b/rust/tests/regtest_send.rs
@@ -2,8 +2,9 @@ mod common;
 
 use common::{
     add_account_with_birthday, create_wallet, ensure_regtest_up, exclusive_regtest, execute_send,
-    execute_send_with_source, fund_wallet, get_balance, get_transaction_history, mine_blocks,
-    sync_wallet, transparent_receive_address,
+    execute_send_with_source, fund_wallet, fund_wallet_with_confirmations, get_balance,
+    get_transaction_history, mine_blocks, propose_send_with_source, sync_wallet,
+    transparent_receive_address,
 };
 
 #[test]
@@ -186,5 +187,71 @@ fn transparent_source_can_send_to_shielded_recipient() {
             .iter()
             .any(|tx| tx.account_balance_delta > 0),
         "receiver should record an inbound transparent-source transaction"
+    );
+}
+
+#[test]
+#[ignore = "requires Dockerized zcashd/lightwalletd regtest services"]
+fn transparent_source_send_requires_untrusted_confirmations() {
+    let _guard = exclusive_regtest();
+    ensure_regtest_up();
+
+    let (sender_dir, sender_wallet) = create_wallet("Pending Transparent Sender");
+    let sender_db = sender_dir.path().join("zcash_wallet.db");
+    let (_receiver_dir, receiver_wallet) = create_wallet("Confirmed Shielded Receiver");
+
+    let sender_taddr = transparent_receive_address(&sender_db, &sender_wallet.account_uuid);
+    fund_wallet_with_confirmations(&sender_taddr, "1.1", 1);
+    sync_wallet(&sender_db);
+
+    let pending_balance = get_balance(&sender_db, &sender_wallet.account_uuid);
+    assert_eq!(
+        pending_balance.transparent, 0,
+        "1-conf external transparent funds must not be ordinary-send spendable"
+    );
+    assert!(
+        pending_balance.transparent_pending >= 110_000_000,
+        "1-conf external transparent funds should be pending, got {}",
+        pending_balance.transparent_pending
+    );
+
+    let pending_send = propose_send_with_source(
+        &sender_db,
+        &sender_wallet.account_uuid,
+        "pending-transparent-send",
+        &receiver_wallet.unified_address,
+        40_000_000,
+        Some("transparent"),
+    );
+    let err = match pending_send {
+        Ok(_) => panic!("1-conf transparent source send should fail"),
+        Err(err) => err,
+    };
+    assert!(
+        err.contains("No transparent funds available"),
+        "unexpected pending transparent send error: {err}"
+    );
+
+    mine_blocks(9);
+    sync_wallet(&sender_db);
+
+    let confirmed_balance = get_balance(&sender_db, &sender_wallet.account_uuid);
+    assert!(
+        confirmed_balance.transparent >= 110_000_000,
+        "10-conf external transparent funds should be spendable, got {}",
+        confirmed_balance.transparent
+    );
+
+    let txid = execute_send_with_source(
+        &sender_db,
+        &sender_wallet.account_uuid,
+        &sender_wallet.mnemonic,
+        &receiver_wallet.unified_address,
+        40_000_000,
+        Some("transparent"),
+    );
+    assert!(
+        !txid.is_empty(),
+        "10-conf transparent-source send should return a txid"
     );
 }

--- a/scripts/e2e/flutter-macos-regtest-full.sh
+++ b/scripts/e2e/flutter-macos-regtest-full.sh
@@ -27,34 +27,37 @@ require_cmd python3
 cd "$ROOT_DIR"
 
 # Keep this ordered from the narrowest smoke test to broader user flows.
-run_test "1/10 import funded wallet and sync balances" \
+run_test "1/11 import funded wallet and sync balances" \
   "scripts/e2e/flutter-macos-regtest-import-sync.sh"
 
-run_test "2/10 fallback from unavailable endpoint and sync balances" \
+run_test "2/11 fallback from unavailable endpoint and sync balances" \
   "scripts/e2e/flutter-macos-regtest-fallback-endpoint.sh"
 
-run_test "3/10 keep custom endpoint failures private" \
+run_test "3/11 keep custom endpoint failures private" \
   "scripts/e2e/flutter-macos-regtest-custom-endpoint-no-fallback.sh"
 
-run_test "4/10 fallback from slow-height primary and recover" \
+run_test "4/11 fallback from slow-height primary and recover" \
   "scripts/e2e/flutter-macos-regtest-slow-height-fallback.sh"
 
-run_test "5/10 create wallet and shield transparent funds" \
+run_test "5/11 create wallet and shield transparent funds" \
   "scripts/e2e/flutter-macos-regtest-shield-transparent.sh"
 
-run_test "6/10 retry shield transparent broadcast failure" \
+run_test "6/11 retry shield transparent broadcast failure" \
   "scripts/e2e/flutter-macos-regtest-shield-transparent-retry.sh"
 
-run_test "7/10 import two accounts and send shielded funds" \
+run_test "7/11 create wallet and send from transparent source" \
+  "scripts/e2e/flutter-macos-regtest-transparent-source-send.sh"
+
+run_test "8/11 import two accounts and send shielded funds" \
   "scripts/e2e/flutter-macos-regtest-multi-account-send.sh"
 
-run_test "8/10 show mempool receives in activity history" \
+run_test "9/11 show mempool receives in activity history" \
   "scripts/e2e/flutter-macos-regtest-mempool-receive-history.sh"
 
-run_test "9/10 show mempool receives while sync is running" \
+run_test "10/11 show mempool receives while sync is running" \
   "scripts/e2e/flutter-macos-regtest-mempool-during-sync.sh"
 
-run_test "10/10 expire unmined mempool receives" \
+run_test "11/11 expire unmined mempool receives" \
   "scripts/e2e/flutter-macos-regtest-mempool-expiry.sh"
 
 echo

--- a/scripts/e2e/flutter-macos-regtest-transparent-source-send.sh
+++ b/scripts/e2e/flutter-macos-regtest-transparent-source-send.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RECEIVER_MNEMONIC="return try reason flat civil wolf dwarf announce toddler uphold equip range neck proof gauge east rifle swim tray twin venue fossil will version"
+LIGHTWALLETD_URL="${E2E_LIGHTWALLETD_URL:-http://127.0.0.1:9067}"
+FLUTTER_DEVICE="${FLUTTER_DEVICE:-macos}"
+RESET_REGTEST="${RESET_REGTEST:-1}"
+DRIVER_PORT="${E2E_DRIVER_PORT:-39068}"
+DRIVER_URL="http://127.0.0.1:${DRIVER_PORT}"
+DRIVER_LOG="$ROOT_DIR/.regtest/transparent-source-send-driver.log"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+json_field() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+data = json.loads(sys.argv[1])
+print(data[sys.argv[2]])
+PY
+}
+
+require_cmd cargo
+require_cmd docker
+require_cmd fvm
+require_cmd python3
+
+cd "$ROOT_DIR"
+
+if [[ "$RESET_REGTEST" == "1" ]]; then
+  scripts/regtest/reset.sh
+fi
+scripts/regtest/up.sh
+
+addresses_json="$(cd rust && cargo run --quiet --example regtest_wallet_addresses -- "$RECEIVER_MNEMONIC")"
+receiver_unified_address="$(json_field "$addresses_json" unifiedAddress)"
+
+mkdir -p "$ROOT_DIR/.regtest"
+: > "$DRIVER_LOG"
+
+python3 -u scripts/e2e/mempool-receive-history-driver.py \
+  --repo-root "$ROOT_DIR" \
+  --port "$DRIVER_PORT" \
+  >"$DRIVER_LOG" 2>&1 &
+driver_pid="$!"
+
+cleanup() {
+  kill "$driver_pid" >/dev/null 2>&1 || true
+  wait "$driver_pid" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+python3 - "$DRIVER_URL" <<'PY'
+import sys
+import time
+import urllib.request
+
+url = sys.argv[1] + "/health"
+for _ in range(50):
+    try:
+        with urllib.request.urlopen(url, timeout=1) as response:
+            if response.status == 200:
+                raise SystemExit(0)
+    except Exception:
+        time.sleep(0.1)
+
+raise SystemExit("Timed out waiting for transparent-source send E2E driver")
+PY
+
+echo "running Flutter macOS transparent-source send integration test"
+set +e
+fvm flutter test \
+  integration_test/regtest_transparent_source_send_test.dart \
+  -d "$FLUTTER_DEVICE" \
+  --dart-define=ZCASH_DEFAULT_NETWORK=regtest \
+  --dart-define=ZCASH_E2E_LIGHTWALLETD_URL="$LIGHTWALLETD_URL" \
+  --dart-define=ZCASH_E2E_DRIVER_URL="$DRIVER_URL" \
+  --dart-define=ZCASH_E2E_TRANSPARENT_SOURCE_RECIPIENT="$receiver_unified_address"
+status="$?"
+set -e
+
+if [[ "$status" -ne 0 ]]; then
+  echo "transparent-source send driver log:" >&2
+  sed -n '1,220p' "$DRIVER_LOG" >&2 || true
+fi
+
+exit "$status"

--- a/test/features/home/home_desktop_screen_test.dart
+++ b/test/features/home/home_desktop_screen_test.dart
@@ -394,9 +394,10 @@ void main() {
           hasAccountScopedData: true,
           orchardBalance: BigInt.from(14_312_000_000),
           transparentBalance: BigInt.from(242_000_000),
+          transparentPendingBalance: BigInt.from(100_000_000),
           canShieldTransparentBalance: true,
           spendableBalance: BigInt.from(14_312_000_000),
-          totalBalance: BigInt.from(14_554_000_000),
+          totalBalance: BigInt.from(14_654_000_000),
         ),
       ),
     );
@@ -407,6 +408,7 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Transparent: 2.42 ZEC'), findsOneWidget);
+    expect(find.text('Transparent: 3.42 ZEC'), findsNothing);
     expect(
       find.byKey(const ValueKey('home_shield_balance_button')),
       findsOneWidget,

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -112,6 +112,7 @@ Widget _app(
 SyncState _syncedState({
   BigInt? orchardBalance,
   BigInt? transparentBalance,
+  BigInt? transparentPendingBalance,
   bool canShieldTransparentBalance = false,
 }) => SyncState(
   accountUuid: 'account-1',
@@ -120,6 +121,7 @@ SyncState _syncedState({
   displayPercentage: 1.0,
   orchardBalance: orchardBalance ?? BigInt.zero,
   transparentBalance: transparentBalance ?? BigInt.zero,
+  transparentPendingBalance: transparentPendingBalance ?? BigInt.zero,
   canShieldTransparentBalance: canShieldTransparentBalance,
 );
 
@@ -201,6 +203,7 @@ void main() {
         _syncedState(
           orchardBalance: BigInt.from(14312000000),
           transparentBalance: BigInt.from(242000000),
+          transparentPendingBalance: BigInt.from(100000000),
           canShieldTransparentBalance: true,
         ),
       ),
@@ -213,6 +216,7 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Transparent: 2.42 ZEC'), findsOneWidget);
+    expect(find.text('Transparent: 3.42 ZEC'), findsNothing);
     expect(
       find.byKey(const ValueKey('mobile_home_shield_balance_button')),
       findsOneWidget,

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -34,11 +34,17 @@ Completer<ProposalResult>? _proposeSendCompleter;
 int _estimateSendMaxCalls = 0;
 String? _lastEstimateSendMaxToAddress;
 String? _lastEstimateSendMaxMemo;
+String? _lastEstimateSendMaxSource;
+String? _lastEstimateFeeSendSource;
 String? _lastProposeSendSource;
 _SendMaxEstimateBuilder? _sendMaxEstimateBuilder;
 
 typedef _SendMaxEstimateBuilder =
-    SendMaxEstimateResult Function({required String toAddress, String? memo});
+    SendMaxEstimateResult Function({
+      required String toAddress,
+      String? memo,
+      String? sendSource,
+    });
 
 class _RustApiFake implements RustLibApi {
   @override
@@ -70,6 +76,7 @@ class _RustApiFake implements RustLibApi {
     String? memo,
     String? sendSource,
   }) async {
+    _lastEstimateFeeSendSource = sendSource;
     // Real fee estimation crosses the FFI boundary and takes real time;
     // the timer keeps an in-flight validation window open so tests can
     // assert Continue stays blocked until the estimate lands.
@@ -89,9 +96,10 @@ class _RustApiFake implements RustLibApi {
     _estimateSendMaxCalls++;
     _lastEstimateSendMaxToAddress = toAddress;
     _lastEstimateSendMaxMemo = memo;
+    _lastEstimateSendMaxSource = sendSource;
     final builder = _sendMaxEstimateBuilder;
     if (builder != null) {
-      return builder(toAddress: toAddress, memo: memo);
+      return builder(toAddress: toAddress, memo: memo, sendSource: sendSource);
     }
     return SendMaxEstimateResult(
       amountZatoshi: BigInt.from(499990000),
@@ -161,8 +169,9 @@ class _FakeSyncNotifier extends SyncNotifier {
   Future<SyncState> build() async => SyncState(
     accountUuid: 'account-1',
     hasAccountScopedData: true,
+    transparentBalance: BigInt.from(220000000), // 2.2 ZEC
     spendableBalance: BigInt.from(500000000), // 5 ZEC
-    totalBalance: BigInt.from(500000000),
+    totalBalance: BigInt.from(720000000),
   );
 }
 
@@ -265,6 +274,7 @@ Widget _sendFlowRouterApp({MobileSendFeeEstimator? estimateFee}) {
             initialSendFlowId: args.sendFlowId,
             initialRecipient: args.recipient,
             initialAddressType: args.addressType,
+            initialSendSource: args.sendSource,
             initialContactLabel: args.contactLabel,
             initialContactPictureId: args.contactPictureId,
             loadWalletDbPath: () async => '/tmp/zcash-test',
@@ -288,6 +298,7 @@ Widget _sendFlowRouterApp({MobileSendFeeEstimator? estimateFee}) {
             initialFeeZatoshi: args.feeZatoshi,
             refreshReviewFeeOnInit: true,
             initialMaxMode: args.isMaxMode,
+            initialSendSource: args.sendSource,
             initialMemo: args.memo,
             initialContactLabel: args.contactLabel,
             initialContactPictureId: args.contactPictureId,
@@ -416,6 +427,8 @@ void main() {
     _estimateSendMaxCalls = 0;
     _lastEstimateSendMaxToAddress = null;
     _lastEstimateSendMaxMemo = null;
+    _lastEstimateSendMaxSource = null;
+    _lastEstimateFeeSendSource = null;
     _lastProposeSendSource = null;
     _sendMaxEstimateBuilder = null;
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
@@ -591,6 +604,7 @@ void main() {
           required toAddress,
           required amountZatoshi,
           memo,
+          sendSource,
         }) async {
           feeCalls++;
           return feeCalls == 1 ? BigInt.from(10000) : refreshedFee;
@@ -1111,6 +1125,53 @@ void main() {
     expect(find.text('Finish & review'), findsOneWidget);
   });
 
+  testWidgets('the amount step source picker sends transparent Max source', (
+    tester,
+  ) async {
+    _sendMaxEstimateBuilder =
+        ({required toAddress, memo, sendSource}) => SendMaxEstimateResult(
+          amountZatoshi:
+              sendSource == 'transparent'
+                  ? BigInt.from(219990000)
+                  : BigInt.from(499990000),
+          feeZatoshi: BigInt.from(10000),
+          needsSaplingParams: false,
+        );
+
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+    await _toAmountStep(tester, _shieldedAddress);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_source_button')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('mobile_send_source_total_divider')),
+      findsOneWidget,
+    );
+    expect(find.text('Send source'), findsOneWidget);
+    expect(find.text('Total'), findsOneWidget);
+    expect(find.text('Shielded'), findsOneWidget);
+    expect(find.text('Transparent'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_send_source_option_transparent')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Max: 2.2 ZEC'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('mobile_send_max_button')));
+    await tester.pumpAndSettle();
+
+    expect(_estimateSendMaxCalls, 1);
+    expect(_lastEstimateSendMaxSource, 'transparent');
+    final amountInput = tester.widget<TextField>(
+      find.byKey(const ValueKey('mobile_send_amount_input')),
+    );
+    expect(amountInput.controller?.text, '2.1999');
+    expect(find.text('Finish & review'), findsOneWidget);
+  });
+
   testWidgets('Max ignores a stale pending amount fee validation', (
     tester,
   ) async {
@@ -1126,6 +1187,7 @@ void main() {
           required toAddress,
           required amountZatoshi,
           memo,
+          sendSource,
         }) {
           feeCalls++;
           return feeCompleter.future;
@@ -1176,11 +1238,42 @@ void main() {
     },
   );
 
+  testWidgets('route-step source picker sends transparent source on confirm', (
+    tester,
+  ) async {
+    _proposeSendSucceeds = true;
+
+    await tester.pumpWidget(_sendFlowRouterApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_open_from_home')));
+    await tester.pumpAndSettle();
+    await _toAmountStep(tester, _shieldedAddress);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_source_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_send_source_option_transparent')),
+    );
+    await tester.pumpAndSettle();
+
+    await _enterAmount(tester, '1.2');
+    expect(_lastEstimateFeeSendSource, 'transparent');
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_review_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+    await tester.pumpAndSettle();
+
+    expect(_lastProposeSendSource, 'transparent');
+    expect(find.text('status can pop'), findsOneWidget);
+  });
+
   testWidgets('route-step max mode recalculates amount when memo changes', (
     tester,
   ) async {
     _sendMaxEstimateBuilder =
-        ({required toAddress, memo}) => SendMaxEstimateResult(
+        ({required toAddress, memo, sendSource}) => SendMaxEstimateResult(
           amountZatoshi:
               memo == 'thanks!'
                   ? BigInt.from(499980000)

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -123,7 +123,7 @@ class _RustApiFake implements RustLibApi {
     final completer = _proposeSendCompleter;
     if (completer != null) return completer.future;
     if (!_proposeSendSucceeds) {
-      throw StateError('proposal failed');
+      throw StateError('insufficient funds');
     }
     return ProposalResult(
       proposalId: BigInt.from(1),
@@ -1267,6 +1267,40 @@ void main() {
 
     expect(_lastProposeSendSource, 'transparent');
     expect(find.text('status can pop'), findsOneWidget);
+  });
+
+  testWidgets('transparent source propose failure uses transparent copy', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_sendFlowRouterApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_open_from_home')));
+    await tester.pumpAndSettle();
+    await _toAmountStep(tester, _shieldedAddress);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_send_source_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_send_source_option_transparent')),
+    );
+    await tester.pumpAndSettle();
+
+    await _enterAmount(tester, '1.2');
+    await tester.tap(find.byKey(const ValueKey('mobile_send_review_button')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('mobile_send_confirm')));
+    await tester.pumpAndSettle();
+
+    expect(_lastProposeSendSource, 'transparent');
+    expect(
+      find.text('Insufficient transparent balance to cover amount and fee.'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Insufficient shielded balance to cover amount and fee.'),
+      findsNothing,
+    );
   });
 
   testWidgets('route-step max mode recalculates amount when memo changes', (

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -34,6 +34,7 @@ Completer<ProposalResult>? _proposeSendCompleter;
 int _estimateSendMaxCalls = 0;
 String? _lastEstimateSendMaxToAddress;
 String? _lastEstimateSendMaxMemo;
+String? _lastProposeSendSource;
 _SendMaxEstimateBuilder? _sendMaxEstimateBuilder;
 
 typedef _SendMaxEstimateBuilder =
@@ -67,6 +68,7 @@ class _RustApiFake implements RustLibApi {
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
+    String? sendSource,
   }) async {
     // Real fee estimation crosses the FFI boundary and takes real time;
     // the timer keeps an in-flight validation window open so tests can
@@ -82,6 +84,7 @@ class _RustApiFake implements RustLibApi {
     required String accountUuid,
     required String toAddress,
     String? memo,
+    String? sendSource,
   }) async {
     _estimateSendMaxCalls++;
     _lastEstimateSendMaxToAddress = toAddress;
@@ -106,7 +109,9 @@ class _RustApiFake implements RustLibApi {
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
+    String? sendSource,
   }) async {
+    _lastProposeSendSource = sendSource;
     final completer = _proposeSendCompleter;
     if (completer != null) return completer.future;
     if (!_proposeSendSucceeds) {
@@ -187,12 +192,13 @@ Widget _app({
     routes: [
       GoRoute(
         path: '/send',
-        builder: (_, _) => MobileSendScreen(
-          loadWalletDbPath: () async => '/tmp/zcash-test',
-          openScanner: openScanner ?? (_) async => null,
-          initialRecipient: initialRecipient,
-          validateAddress: validateAddress,
-        ),
+        builder:
+            (_, _) => MobileSendScreen(
+              loadWalletDbPath: () async => '/tmp/zcash-test',
+              openScanner: openScanner ?? (_) async => null,
+              initialRecipient: initialRecipient,
+              validateAddress: validateAddress,
+            ),
       ),
       GoRoute(path: '/home', builder: (_, _) => const Text('home')),
     ],
@@ -232,20 +238,22 @@ Widget _sendFlowRouterApp({MobileSendFeeEstimator? estimateFee}) {
     routes: [
       GoRoute(
         path: '/home',
-        builder: (context, _) => TextButton(
-          key: const ValueKey('mobile_send_open_from_home'),
-          onPressed: () => context.push('/send'),
-          child: const Text('home'),
-        ),
+        builder:
+            (context, _) => TextButton(
+              key: const ValueKey('mobile_send_open_from_home'),
+              onPressed: () => context.push('/send'),
+              child: const Text('home'),
+            ),
       ),
       GoRoute(
         path: '/send',
-        builder: (_, _) => MobileSendScreen(
-          useRouteSteps: true,
-          loadWalletDbPath: () async => '/tmp/zcash-test',
-          openScanner: (_) async => null,
-          estimateFee: estimateFee,
-        ),
+        builder:
+            (_, _) => MobileSendScreen(
+              useRouteSteps: true,
+              loadWalletDbPath: () async => '/tmp/zcash-test',
+              openScanner: (_) async => null,
+              estimateFee: estimateFee,
+            ),
       ),
       GoRoute(
         path: '/send/amount',
@@ -291,13 +299,14 @@ Widget _sendFlowRouterApp({MobileSendFeeEstimator? estimateFee}) {
       ),
       GoRoute(
         path: '/send/status',
-        builder: (context, _) => TextButton(
-          key: const ValueKey('mobile_send_status_pop'),
-          onPressed: context.canPop() ? () => context.pop() : null,
-          child: Text(
-            context.canPop() ? 'status can pop' : 'status cannot pop',
-          ),
-        ),
+        builder:
+            (context, _) => TextButton(
+              key: const ValueKey('mobile_send_status_pop'),
+              onPressed: context.canPop() ? () => context.pop() : null,
+              child: Text(
+                context.canPop() ? 'status can pop' : 'status cannot pop',
+              ),
+            ),
       ),
     ],
   );
@@ -407,6 +416,7 @@ void main() {
     _estimateSendMaxCalls = 0;
     _lastEstimateSendMaxToAddress = null;
     _lastEstimateSendMaxMemo = null;
+    _lastProposeSendSource = null;
     _sendMaxEstimateBuilder = null;
     final binding = TestWidgetsFlutterBinding.ensureInitialized();
     binding.platformDispatcher.views.first
@@ -574,18 +584,17 @@ void main() {
 
     await tester.pumpWidget(
       _sendFlowRouterApp(
-        estimateFee:
-            ({
-              required dbPath,
-              required network,
-              required accountUuid,
-              required toAddress,
-              required amountZatoshi,
-              memo,
-            }) async {
-              feeCalls++;
-              return feeCalls == 1 ? BigInt.from(10000) : refreshedFee;
-            },
+        estimateFee: ({
+          required dbPath,
+          required network,
+          required accountUuid,
+          required toAddress,
+          required amountZatoshi,
+          memo,
+        }) async {
+          feeCalls++;
+          return feeCalls == 1 ? BigInt.from(10000) : refreshedFee;
+        },
       ),
     );
     await tester.pumpAndSettle();
@@ -624,6 +633,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('status can pop'), findsOneWidget);
+    expect(_lastProposeSendSource, 'shielded');
     await tester.tap(find.byKey(const ValueKey('mobile_send_status_pop')));
     await tester.pumpAndSettle();
 
@@ -1109,18 +1119,17 @@ void main() {
 
     await tester.pumpWidget(
       _sendFlowRouterApp(
-        estimateFee:
-            ({
-              required dbPath,
-              required network,
-              required accountUuid,
-              required toAddress,
-              required amountZatoshi,
-              memo,
-            }) {
-              feeCalls++;
-              return feeCompleter.future;
-            },
+        estimateFee: ({
+          required dbPath,
+          required network,
+          required accountUuid,
+          required toAddress,
+          required amountZatoshi,
+          memo,
+        }) {
+          feeCalls++;
+          return feeCompleter.future;
+        },
       ),
     );
     await tester.pumpAndSettle();
@@ -1170,14 +1179,14 @@ void main() {
   testWidgets('route-step max mode recalculates amount when memo changes', (
     tester,
   ) async {
-    _sendMaxEstimateBuilder = ({required toAddress, memo}) =>
-        SendMaxEstimateResult(
-          amountZatoshi: memo == 'thanks!'
-              ? BigInt.from(499980000)
-              : BigInt.from(499990000),
-          feeZatoshi: memo == 'thanks!'
-              ? BigInt.from(20000)
-              : BigInt.from(10000),
+    _sendMaxEstimateBuilder =
+        ({required toAddress, memo}) => SendMaxEstimateResult(
+          amountZatoshi:
+              memo == 'thanks!'
+                  ? BigInt.from(499980000)
+                  : BigInt.from(499990000),
+          feeZatoshi:
+              memo == 'thanks!' ? BigInt.from(20000) : BigInt.from(10000),
           needsSaplingParams: false,
         );
 

--- a/test/features/send/send_review_content_view_test.dart
+++ b/test/features/send/send_review_content_view_test.dart
@@ -44,6 +44,7 @@ void main() {
     expect(find.text('Amount'), findsOneWidget);
     expect(find.text('123.12 ZEC'), findsOneWidget);
     expect(find.text(r'$250.12'), findsOneWidget);
+    expect(find.text('From'), findsNothing);
     expect(find.text('To'), findsOneWidget);
     expect(find.text(truncatedAddress(_address)), findsOneWidget);
     expect(find.text('Shielded'), findsOneWidget);

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -338,6 +338,7 @@ void main() {
       _sendHarness(
         spendableBalance: BigInt.from(500000000),
         transparentBalance: BigInt.from(242000000),
+        totalBalance: BigInt.from(842000000),
       ),
     );
     await tester.pumpAndSettle();
@@ -377,6 +378,13 @@ void main() {
     );
     expect(openChevron.quarterTurns, 3);
     expect(find.text('Total'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('send_source_picker')),
+        matching: find.text('8.42 ZEC'),
+      ),
+      findsOneWidget,
+    );
     expect(
       find.byKey(const ValueKey('send_source_total_divider')),
       findsOneWidget,
@@ -599,6 +607,7 @@ Widget _sendHarness({
   AppBootstrapState? bootstrap,
   BigInt? spendableBalance,
   BigInt? transparentBalance,
+  BigInt? totalBalance,
 }) {
   final router = GoRouter(
     initialLocation: '/send',
@@ -619,6 +628,7 @@ Widget _sendHarness({
         () => _FakeSyncNotifier(
           spendableBalance: spendableBalance ?? BigInt.from(500000000),
           transparentBalance: transparentBalance ?? BigInt.zero,
+          totalBalance: totalBalance,
         ),
       ),
       if (addressBookRepository != null)
@@ -729,10 +739,12 @@ class _FakeSyncNotifier extends SyncNotifier {
   _FakeSyncNotifier({
     required this.spendableBalance,
     required this.transparentBalance,
+    this.totalBalance,
   });
 
   final BigInt spendableBalance;
   final BigInt transparentBalance;
+  final BigInt? totalBalance;
 
   @override
   Future<SyncState> build() async => SyncState(
@@ -740,7 +752,7 @@ class _FakeSyncNotifier extends SyncNotifier {
     hasAccountScopedData: true,
     spendableBalance: spendableBalance,
     transparentBalance: transparentBalance,
-    totalBalance: spendableBalance + transparentBalance,
+    totalBalance: totalBalance ?? spendableBalance + transparentBalance,
   );
 }
 

--- a/test/features/send/send_screen_test.dart
+++ b/test/features/send/send_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
 import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
 import 'package:zcash_wallet/src/features/send/models/send_prefill_args.dart';
@@ -328,6 +329,106 @@ void main() {
     expect(find.text('Max amount unavailable'), findsNothing);
   });
 
+  testWidgets('source picker sends transparent source through desktop send', (
+    tester,
+  ) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _sendHarness(
+        spendableBalance: BigInt.from(500000000),
+        transparentBalance: BigInt.from(242000000),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Max: 5 ZEC'), findsOneWidget);
+    expect(find.text('Transparent'), findsNothing);
+
+    final sourceIcon = tester.widget<AppIcon>(
+      find.descendant(
+        of: find.byKey(const ValueKey('send_source_toggle_button')),
+        matching: find.byType(AppIcon),
+      ),
+    );
+    final closedChevron = tester.widget<RotatedBox>(
+      find.descendant(
+        of: find.byKey(const ValueKey('send_source_toggle_button')),
+        matching: find.byType(RotatedBox),
+      ),
+    );
+    expect(sourceIcon.name, AppIcons.chevronForward);
+    expect(sourceIcon.size, 20);
+    expect(closedChevron.quarterTurns, 1);
+
+    await tester.tap(find.byKey(const ValueKey('send_source_toggle_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('send_source_picker')), findsOneWidget);
+    expect(
+      tester.getSize(find.byKey(const ValueKey('send_source_picker'))).width,
+      236,
+    );
+    final openChevron = tester.widget<RotatedBox>(
+      find.descendant(
+        of: find.byKey(const ValueKey('send_source_toggle_button')),
+        matching: find.byType(RotatedBox),
+      ),
+    );
+    expect(openChevron.quarterTurns, 3);
+    expect(find.text('Total'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('send_source_total_divider')),
+      findsOneWidget,
+    );
+    expect(find.text('Shielded'), findsOneWidget);
+    expect(find.text('Transparent'), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey('send_source_picker')),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is AppIcon && widget.name == AppIcons.check,
+        ),
+      ),
+      findsNothing,
+    );
+    final helpIcon = tester.widget<AppIcon>(
+      find.descendant(
+        of: find.byKey(const ValueKey('send_source_picker')),
+        matching: find.byWidgetPredicate(
+          (widget) => widget is AppIcon && widget.name == AppIcons.help,
+        ),
+      ),
+    );
+    expect(helpIcon.size, AppIconSize.medium);
+    expect(
+      find.textContaining('Spendable balance can be lower'),
+      findsOneWidget,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('send_source_option_transparent')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const ValueKey('send_source_picker')), findsNothing);
+    expect(find.textContaining('Max: 2.42 ZEC'), findsOneWidget);
+
+    await tester.enterText(_editableIn('send_address_field'), _shieldedAddress);
+    await tester.pumpAndSettle();
+    await tester.tap(find.textContaining('Max:'));
+    await tester.pumpAndSettle();
+
+    expect(rustApi.estimateSendMaxCalls, 1);
+    expect(rustApi.lastEstimateSendMaxSource, 'transparent');
+
+    await tester.tap(find.text('Review'));
+    await tester.pumpAndSettle();
+
+    expect(rustApi.proposeSendCalls, 1);
+    expect(rustApi.lastProposeSendSource, 'transparent');
+  });
+
   testWidgets('hides imported memo controls for TEX recipients', (
     tester,
   ) async {
@@ -648,16 +749,20 @@ class _RustApiFake implements RustLibApi {
   int estimateSendMaxCalls = 0;
   String? lastProposeToAddress;
   String? lastProposeMemo;
+  String? lastProposeSendSource;
   String? lastEstimateSendMaxToAddress;
   String? lastEstimateSendMaxMemo;
+  String? lastEstimateSendMaxSource;
 
   void reset() {
     proposeSendCalls = 0;
     estimateSendMaxCalls = 0;
     lastProposeToAddress = null;
     lastProposeMemo = null;
+    lastProposeSendSource = null;
     lastEstimateSendMaxToAddress = null;
     lastEstimateSendMaxMemo = null;
+    lastEstimateSendMaxSource = null;
   }
 
   @override
@@ -684,6 +789,7 @@ class _RustApiFake implements RustLibApi {
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
+    String? sendSource,
   }) async {
     return BigInt.from(10000);
   }
@@ -695,12 +801,16 @@ class _RustApiFake implements RustLibApi {
     required String accountUuid,
     required String toAddress,
     String? memo,
+    String? sendSource,
   }) async {
     estimateSendMaxCalls++;
     lastEstimateSendMaxToAddress = toAddress;
     lastEstimateSendMaxMemo = memo;
+    lastEstimateSendMaxSource = sendSource;
     return SendMaxEstimateResult(
-      amountZatoshi: BigInt.from(499990000),
+      amountZatoshi: sendSource == 'transparent'
+          ? BigInt.from(241990000)
+          : BigInt.from(499990000),
       feeZatoshi: BigInt.from(10000),
       needsSaplingParams: false,
     );
@@ -715,10 +825,12 @@ class _RustApiFake implements RustLibApi {
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
+    String? sendSource,
   }) async {
     proposeSendCalls++;
     lastProposeToAddress = toAddress;
     lastProposeMemo = memo;
+    lastProposeSendSource = sendSource;
     return ProposalResult(
       proposalId: BigInt.one,
       needsSaplingParams: false,

--- a/test/features/swap/swap_deposit_amount_test.dart
+++ b/test/features/swap/swap_deposit_amount_test.dart
@@ -1,5 +1,13 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_deposit_sender.dart';
 import 'package:zcash_wallet/src/features/swap/providers/swap_hardware_signing_service.dart';
@@ -14,8 +22,22 @@ void main() {
     RustLib.initMock(api: rustApi);
   });
 
-  setUp(() {
+  setUp(() async {
     rustApi.reset();
+    FlutterSecureStorage.setMockInitialValues({
+      'zcash_wallet_db_name': 'zcash_wallet_test.db',
+    });
+    final previousPathProvider = PathProviderPlatform.instance;
+    final tempDir = await Directory.systemTemp.createTemp(
+      'swap_deposit_amount_test',
+    );
+    PathProviderPlatform.instance = _FakePathProviderPlatform(tempDir.path);
+    addTearDown(() async {
+      PathProviderPlatform.instance = previousPathProvider;
+      try {
+        await tempDir.delete(recursive: true);
+      } catch (_) {}
+    });
   });
 
   tearDownAll(RustLib.dispose);
@@ -37,6 +59,30 @@ void main() {
       throwsA(isA<StateError>()),
     );
   });
+
+  test(
+    'software ZEC deposit fee preflight does not select send source',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final sender = container.read(swapDepositSenderProvider);
+      final fee = await sender.estimateZecDepositFee(
+        accountUuid: 'account-1',
+        quote: _quote(sellAmountBaseUnits: BigInt.from(150000000)),
+      );
+
+      expect(fee, BigInt.from(10000));
+      expect(rustApi.estimateFeeCalls, 1);
+      expect(rustApi.lastEstimateFeeToAddress, 't1deposit');
+      expect(rustApi.lastEstimateFeeAmountZatoshi, BigInt.from(150000000));
+      expect(rustApi.lastEstimateFeeSendSource, isNull);
+    },
+  );
 
   test('hardware ZEC deposit uses intent base units, not display text', () {
     final intent = _intent(
@@ -131,9 +177,17 @@ SwapIntent _intent({
 
 class _RustApiFake implements RustLibApi {
   int proposeSendCalls = 0;
+  int estimateFeeCalls = 0;
+  String? lastEstimateFeeToAddress;
+  BigInt? lastEstimateFeeAmountZatoshi;
+  String? lastEstimateFeeSendSource;
 
   void reset() {
     proposeSendCalls = 0;
+    estimateFeeCalls = 0;
+    lastEstimateFeeToAddress = null;
+    lastEstimateFeeAmountZatoshi = null;
+    lastEstimateFeeSendSource = null;
   }
 
   @override
@@ -150,6 +204,23 @@ class _RustApiFake implements RustLibApi {
   }
 
   @override
+  Future<BigInt> crateApiSyncEstimateFee({
+    required String dbPath,
+    required String network,
+    required String accountUuid,
+    required String toAddress,
+    required BigInt amountZatoshi,
+    String? memo,
+    String? sendSource,
+  }) async {
+    estimateFeeCalls++;
+    lastEstimateFeeToAddress = toAddress;
+    lastEstimateFeeAmountZatoshi = amountZatoshi;
+    lastEstimateFeeSendSource = sendSource;
+    return BigInt.from(10000);
+  }
+
+  @override
   Future<ProposalResult> crateApiSyncProposeSend({
     required String dbPath,
     required String network,
@@ -158,6 +229,7 @@ class _RustApiFake implements RustLibApi {
     required String toAddress,
     required BigInt amountZatoshi,
     String? memo,
+    String? sendSource,
   }) async {
     proposeSendCalls++;
     return ProposalResult(
@@ -169,6 +241,16 @@ class _RustApiFake implements RustLibApi {
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakePathProviderPlatform extends PathProviderPlatform
+    with MockPlatformInterfaceMixin {
+  _FakePathProviderPlatform(this.root);
+
+  final String root;
+
+  @override
+  Future<String?> getApplicationSupportPath() async => root;
 }
 
 const _texAddress = 'tex1s2rt77ggv6q989lr49rkgzmh5slsksa9khdgte';

--- a/test/sync_state_test.dart
+++ b/test/sync_state_test.dart
@@ -18,6 +18,19 @@ void main() {
     expect(state.pendingBalance, BigInt.from(12));
   });
 
+  test(
+    'transparentSpendableBalance aliases ordinary-send transparent balance',
+    () {
+      final state = SyncState(
+        transparentBalance: BigInt.from(100),
+        transparentPendingBalance: BigInt.from(300),
+      );
+
+      expect(state.transparentSpendableBalance, BigInt.from(100));
+      expect(state.pendingBalance, BigInt.from(300));
+    },
+  );
+
   test('displayPercentage defaults to actual percentage', () {
     final state = SyncState(percentage: 0.25);
 


### PR DESCRIPTION
## Summary

- Adds an explicit `SendSource` path for shielded vs transparent sends across Dart and Rust.
- Adds compact desktop and mobile send source pickers next to Max, keeping shielded as the default and requiring explicit transparent selection.
- Carries the selected source through proposal, fee, send-max, review/status, and Rust proposal construction.
- Adds regression coverage for desktop selection, mobile source picker routing, swap preflight isolation, Rust source selection, and a regtest transparent-source send.

## Impact

Users can intentionally send from transparent funds from the desktop and mobile send screens without changing the default send behavior. Existing send surfaces continue to default to shielded source unless a source is explicitly selected.

## Screenshots

| Desktop source picker open | Mobile source picker open |
| --- | --- |
| <img width="1192" height="832" alt="스크린샷 2026-06-30 오후 3 09 18" src="https://github.com/user-attachments/assets/10aa936a-feb5-4b4c-8892-7c8c0727fa7d" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-30 at 15 23 23" src="https://github.com/user-attachments/assets/ea2fb4a2-a396-4455-bf56-9663390c00f8" />|

## Validation

- `fvm flutter analyze`
- `fvm flutter test --reporter compact test/features/send/send_screen_test.dart test/features/send/send_review_content_view_test.dart`
- `fvm flutter test --reporter compact --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/send/mobile_send_screen_test.dart`
- `fvm flutter test --reporter compact test/features/swap/swap_deposit_amount_test.dart`
- `cd rust && cargo test -q send_source_parse`
- `cd rust && cargo test -q transparent_source_selection`
- `cd rust && RUSTFLAGS="${RUSTFLAGS:-} -Awarnings" cargo test --test regtest_send transparent_source_can_send_to_shielded_recipient --no-run`
- Docker regtest: `REGTEST_SAPLING_PARAMS_DIR="$HOME/.zcash-params" RUSTFLAGS="${RUSTFLAGS:-} -Awarnings" cargo test --test regtest_send transparent_source_can_send_to_shielded_recipient -- --ignored --nocapture --test-threads=1`
- `git diff --check`

## Notes

- The current UI composition is provisional and still needs design/product alignment before it is treated as final.
- Excluded local-only artifacts from the PR: `design_suggestion/vzr-83-transparent-source-picker.html` and `macos/Podfile.lock`.
