### PR TITLE
Adjust mobile slippage stepper increment

### DIFF
--- a/lib/src/features/swap/widgets/mobile/mobile_swap_slippage_stepper_modal.dart
+++ b/lib/src/features/swap/widgets/mobile/mobile_swap_slippage_stepper_modal.dart
@@ -9,7 +9,7 @@ import '../../../../core/widgets/app_button.dart';
 import '../../../../core/widgets/comma_to_dot_input_formatter.dart';
 
 /// Mobile slippage editor — Figma `Slippage` (`_Modal Type` 4755:84761): a
-/// 60px Young Serif value flanked by 60×50 minus/plus pills (0.5% steps within
+/// 60px Young Serif value flanked by 60×50 minus/plus pills (0.1% steps within
 /// 0.1–5%), or typed directly via the system keypad, capped at two decimal
 /// places. Out-of-range input turns the value and a "Slippage must be 0.1 - 5%"
 /// message destructive and disables Update. The body is a fixed 160px so the
@@ -35,7 +35,7 @@ class _MobileSwapSlippageStepperModalState
     extends State<MobileSwapSlippageStepperModal> {
   static const _minBps = 10; // 0.1%
   static const _maxBps = 500; // 5%
-  static const _stepBps = 50; // 0.5%
+  static const _stepBps = 10; // 0.1%
 
   /// Figma `Body` is a fixed 160px tall area that centers the stepper.
   static const _bodyHeight = 160.0;

--- a/test/features/swap/mobile_swap_modal_route_test.dart
+++ b/test/features/swap/mobile_swap_modal_route_test.dart
@@ -144,6 +144,52 @@ void main() {
     );
   });
 
+  testWidgets('slippage stepper changes by 0.1 percent per tap', (
+    tester,
+  ) async {
+    var submittedBps = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AppTheme(
+            data: AppThemeData.dark,
+            child: MobileSwapSlippageStepperModal(
+              slippageBps: 100,
+              onSubmitted: (value) => submittedBps = value,
+              onCancel: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    TextField field() =>
+        tester.widget(find.byKey(const ValueKey('mobile_swap_slippage_value')));
+
+    expect(field().controller!.text, '1');
+
+    await tester.tap(find.byKey(const ValueKey('mobile_swap_slippage_plus')));
+    await tester.pump();
+    expect(field().controller!.text, '1.1');
+
+    await tester.tap(find.byKey(const ValueKey('mobile_swap_slippage_minus')));
+    await tester.pump();
+    expect(field().controller!.text, '1');
+
+    await tester.tap(find.byKey(const ValueKey('swap_slippage_update_button')));
+    await tester.pump();
+    expect(submittedBps, 0);
+
+    await tester.tap(find.byKey(const ValueKey('mobile_swap_slippage_minus')));
+    await tester.pump();
+    expect(field().controller!.text, '0.9');
+
+    await tester.tap(find.byKey(const ValueKey('swap_slippage_update_button')));
+    await tester.pump();
+    expect(submittedBps, 90);
+  });
+
   testWidgets('swap composer CTA fits on narrow Android-sized screens', (
     tester,
   ) async {


### PR DESCRIPTION
## Summary
- Change the mobile swap slippage stepper from 0.5% increments to 0.1% increments.
- Add mobile widget coverage for plus/minus tap behavior and submission values.

## Impact
- Users can fine tune mobile swap slippage tolerance more precisely from the slippage modal.

## Validation
- `fvm flutter test test/features/swap/mobile_swap_modal_route_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `git diff --check`