### PR TITLE
Fix mobile swap Keystone signing flow

### DIFF
--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -28,6 +28,7 @@ import '../../features/swap/screens/mobile/mobile_swap_screen.dart';
 import '../config/swap_feature_config.dart';
 import '../layout/mobile/app_mobile_shell.dart';
 import '../layout/mobile/app_mobile_tab_bar.dart';
+import '../theme/app_theme.dart';
 import '../widgets/app_icon.dart';
 import 'mobile_tab_history.dart';
 
@@ -173,7 +174,7 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
         final child = extra is MobileSwapKeystoneSignArgs
             ? MobileSwapKeystoneSignScreen(args: extra)
             : const MobileSwapScreen();
-        return CupertinoPage(key: state.pageKey, child: child);
+        return _mobileModalPage(context: context, state: state, child: child);
       },
     ),
     // Same path as the desktop transaction status route so the shared
@@ -214,8 +215,9 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
     ),
     GoRoute(
       path: '/send/keystone-sign',
-      pageBuilder: (context, state) => CupertinoPage(
-        key: state.pageKey,
+      pageBuilder: (context, state) => _mobileModalPage(
+        context: context,
+        state: state,
         child: MobileKeystoneSignScreen(args: state.extra! as SendReviewArgs),
       ),
     ),
@@ -237,6 +239,23 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
           CupertinoPage(key: state.pageKey, child: const MobileAboutScreen()),
     ),
   ];
+}
+
+CustomTransitionPage<T> _mobileModalPage<T>({
+  required BuildContext context,
+  required GoRouterState state,
+  required Widget child,
+}) {
+  return CustomTransitionPage<T>(
+    key: state.pageKey,
+    opaque: false,
+    barrierDismissible: false,
+    barrierColor: context.colors.background.neutralScrim,
+    transitionDuration: Duration.zero,
+    reverseTransitionDuration: Duration.zero,
+    transitionsBuilder: (_, _, _, child) => child,
+    child: child,
+  );
 }
 
 class _MobileTab {

--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -13,6 +13,7 @@ import '../../features/activity/screens/mobile/mobile_swap_activity_detail_scree
 import '../../features/activity/screens/mobile/mobile_transaction_status_screen.dart';
 import '../../features/send/screens/mobile/mobile_keystone_sign_screen.dart';
 import '../../features/swap/models/swap_activity_navigation.dart';
+import '../../features/swap/screens/mobile/mobile_swap_keystone_sign_screen.dart';
 import '../../features/swap/screens/mobile/mobile_swap_review_screen.dart';
 import '../../features/send/services/send_flow.dart'
     show KeystoneBroadcastArgs, SendReviewArgs;
@@ -164,6 +165,16 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
         key: state.pageKey,
         child: const MobileSwapReviewScreen(),
       ),
+    ),
+    GoRoute(
+      path: '/swap/keystone-sign',
+      pageBuilder: (context, state) {
+        final extra = state.extra;
+        final child = extra is MobileSwapKeystoneSignArgs
+            ? MobileSwapKeystoneSignScreen(args: extra)
+            : const MobileSwapScreen();
+        return CupertinoPage(key: state.pageKey, child: child);
+      },
     ),
     // Same path as the desktop transaction status route so the shared
     // redirect guard and deep links treat them identically.

--- a/lib/src/features/address_scan/widgets/mobile_address_scan_card.dart
+++ b/lib/src/features/address_scan/widgets/mobile_address_scan_card.dart
@@ -38,6 +38,8 @@ class MobileQrScanCard extends StatefulWidget {
     required this.cameraViewBuilder,
     required this.onClose,
     this.controller,
+    this.closeEnabled = true,
+    this.forceActiveForTesting = false,
     this.caption = 'Scan a Zcash QR code to continue',
     this.permissionTitle = 'Scan the address QR code',
     this.error,
@@ -57,6 +59,13 @@ class MobileQrScanCard extends StatefulWidget {
 
   /// Called when the user taps close / Cancel.
   final VoidCallback onClose;
+
+  /// Whether the camera close control is interactive. Permission states keep
+  /// their existing Cancel action; this is for in-flight scan finalization
+  /// where leaving the route would drop a result.
+  final bool closeEnabled;
+
+  final bool forceActiveForTesting;
 
   /// Idle caption beneath the viewfinder.
   final String caption;
@@ -172,7 +181,9 @@ class _MobileQrScanCardState extends State<MobileQrScanCard>
     return ValueListenableBuilder<MobileScannerState>(
       valueListenable: _controller,
       builder: (context, state, _) {
-        final status = _cameraAccessStatus(state);
+        final status = widget.forceActiveForTesting
+            ? AddressQrCameraStatus.active
+            : _cameraAccessStatus(state);
         return MobileAddressScanCardContent(
           status: status,
           // The camera preview is mounted in every state (offstage until
@@ -189,6 +200,7 @@ class _MobileQrScanCardState extends State<MobileQrScanCard>
               : null,
           permissionBuilder: widget.permissionBuilder,
           cameraHeight: widget.cameraHeight,
+          closeEnabled: widget.closeEnabled,
           onTorch: () => unawaited(_controller.toggleTorch()),
           onClose: widget.onClose,
           onRetry: () =>
@@ -329,6 +341,7 @@ class MobileAddressScanCardContent extends StatelessWidget {
     this.unavailableDescription,
     this.permissionBuilder,
     this.cameraHeight,
+    this.closeEnabled = true,
     super.key,
   });
 
@@ -343,6 +356,7 @@ class MobileAddressScanCardContent extends StatelessWidget {
   final String? unavailableDescription;
   final MobileQrPermissionBuilder? permissionBuilder;
   final double? cameraHeight;
+  final bool closeEnabled;
   final VoidCallback onTorch;
   final VoidCallback onClose;
   final VoidCallback onRetry;
@@ -409,10 +423,13 @@ class MobileAddressScanCardContent extends StatelessWidget {
               right: AppSpacing.base,
               child: _CameraGlyphButton(
                 semanticLabel: 'Close scanner',
-                icon: const AppIcon(
+                enabled: closeEnabled,
+                icon: AppIcon(
                   AppIcons.cross,
                   size: 30,
-                  color: Color(0xFFFFFFFF),
+                  color: closeEnabled
+                      ? const Color(0xFFFFFFFF)
+                      : const Color(0x61FFFFFF),
                 ),
                 onTap: onClose,
               ),
@@ -445,21 +462,24 @@ class _CameraGlyphButton extends StatelessWidget {
     required this.semanticLabel,
     required this.icon,
     required this.onTap,
+    this.enabled = true,
   });
 
   final String semanticLabel;
   final Widget icon;
   final VoidCallback onTap;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
     return Semantics(
       button: true,
+      enabled: enabled,
       label: semanticLabel,
       excludeSemantics: true,
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
-        onTap: onTap,
+        onTap: enabled ? onTap : null,
         child: SizedBox(width: 40, height: 40, child: Center(child: icon)),
       ),
     );

--- a/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
+++ b/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
@@ -301,7 +301,7 @@ class _MobileKeystonePcztSigningFlowState
         ? 'Loading the QR code ...'
         : isFailed
         ? _error ?? widget.friendlyError(StateError('Keystone signing failed.'))
-        : 'After you scanned, click Get Signature.';
+        : 'After you scanned, click Get signature.';
 
     final surface = Stack(
       key: _key('modal_surface'),
@@ -370,7 +370,7 @@ class _MobileKeystonePcztSigningFlowState
                     key: _key('get_signature'),
                     expand: true,
                     onPressed: actionEnabled ? _startScanning : null,
-                    child: const Text('Get Signature'),
+                    child: const Text('Get signature'),
                   ),
                   const SizedBox(height: AppSpacing.s),
                   AppButton(

--- a/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
+++ b/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
@@ -1,0 +1,559 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart' show Colors, Icons, Scaffold;
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../rust/api/keystone.dart' as rust_keystone;
+import '../../../services/camera_permission_settings.dart';
+import '../../../services/qr_scanner.dart';
+import '../../address_scan/widgets/mobile_address_scan_view.dart'
+    show MobileScanCameraErrorOverlay, MobileScanViewfinderCorners;
+import 'keystone_pczt_qr_stage.dart';
+
+class MobileKeystonePcztSigningAborted implements Exception {
+  const MobileKeystonePcztSigningAborted();
+}
+
+class MobileKeystonePcztSigningPayload {
+  const MobileKeystonePcztSigningPayload({
+    required this.urParts,
+    required this.pcztWithProofs,
+  });
+
+  final List<String> urParts;
+  final Future<List<int>> pcztWithProofs;
+}
+
+typedef MobileKeystonePcztPrepare =
+    Future<MobileKeystonePcztSigningPayload> Function(
+      BuildContext context,
+      WidgetRef ref,
+    );
+
+typedef MobileKeystonePcztSigned =
+    Future<void> Function(
+      BuildContext context,
+      WidgetRef ref,
+      List<int> pcztWithProofs,
+      Uint8List signedPczt,
+    );
+
+typedef MobileKeystonePcztFriendlyError = String Function(Object error);
+
+enum _SignStage { preparing, showQr, scanning, failed }
+
+/// Shared mobile Keystone PCZT round trip.
+///
+/// Callers own domain-specific PCZT creation and broadcast; this widget owns the
+/// common mobile UX: animated transaction QR, camera scan for the signed PCZT,
+/// decode, and waiting for the locally-proved PCZT clone.
+class MobileKeystonePcztSigningFlow extends ConsumerStatefulWidget {
+  const MobileKeystonePcztSigningFlow({
+    required this.title,
+    required this.description,
+    required this.preparePczt,
+    required this.onSigned,
+    required this.friendlyError,
+    this.failedTitle,
+    this.keyPrefix = 'mobile_keystone_sign',
+    this.readingSignatureLabel = 'Reading signature...',
+    this.finalizingSignatureLabel,
+    this.logTag = 'MobileKeystonePcztSigningFlow',
+    super.key,
+  });
+
+  final String title;
+  final String? failedTitle;
+  final String description;
+  final String keyPrefix;
+  final String readingSignatureLabel;
+  final String? finalizingSignatureLabel;
+  final String logTag;
+  final MobileKeystonePcztPrepare preparePczt;
+  final MobileKeystonePcztSigned onSigned;
+  final MobileKeystonePcztFriendlyError friendlyError;
+
+  @override
+  ConsumerState<MobileKeystonePcztSigningFlow> createState() =>
+      _MobileKeystonePcztSigningFlowState();
+}
+
+class _MobileKeystonePcztSigningFlowState
+    extends ConsumerState<MobileKeystonePcztSigningFlow>
+    with WidgetsBindingObserver {
+  var _stage = _SignStage.preparing;
+  String? _error;
+  List<String> _urParts = const [];
+  List<int>? _pcztWithProofs;
+  bool _proofsFailed = false;
+  bool _decoding = false;
+  bool _restartCameraOnResume = false;
+  int _scanProgress = 0;
+  String? _scanHint;
+
+  MobileScannerController? _scanController;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    unawaited(_preparePczt());
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) return;
+    if (!_restartCameraOnResume) return;
+    _restartCameraOnResume = false;
+    unawaited(_restartCameraAfterSettings());
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    unawaited(_scanController?.dispose());
+    super.dispose();
+  }
+
+  Future<void> _preparePczt() async {
+    try {
+      final payload = await widget.preparePczt(context, ref);
+      if (!mounted) return;
+      setState(() {
+        _stage = _SignStage.showQr;
+        _urParts = payload.urParts;
+        _error = null;
+      });
+      unawaited(_waitForProofs(payload.pcztWithProofs));
+    } on MobileKeystonePcztSigningAborted {
+      if (!mounted) return;
+      context.pop();
+    } catch (e, st) {
+      log('${widget.logTag}._preparePczt: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _stage = _SignStage.failed;
+        _error = widget.friendlyError(e);
+      });
+    }
+  }
+
+  Future<void> _waitForProofs(Future<List<int>> pcztWithProofs) async {
+    try {
+      final proofs = await pcztWithProofs;
+      if (!mounted) return;
+      setState(() => _pcztWithProofs = proofs);
+    } catch (e, st) {
+      log('${widget.logTag}._waitForProofs: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _proofsFailed = true;
+        _stage = _SignStage.failed;
+        _error = widget.friendlyError(e);
+      });
+    }
+  }
+
+  void _startScanning() {
+    _scanController ??= MobileScannerController(
+      facing: CameraFacing.back,
+      formats: QrScanner.formats,
+      detectionSpeed: QrScanner.detectionSpeed,
+    );
+    setState(() {
+      _stage = _SignStage.scanning;
+      _scanHint = null;
+      _scanProgress = 0;
+    });
+  }
+
+  void _backToQr() {
+    setState(() {
+      _stage = _SignStage.showQr;
+      _scanHint = null;
+      _scanProgress = 0;
+    });
+  }
+
+  Future<void> _openCameraSettings() async {
+    _restartCameraOnResume = true;
+    final opened = await CameraPermissionSettings.open();
+    if (!opened) {
+      _restartCameraOnResume = false;
+      log('${widget.logTag}: failed to open camera permission settings');
+    }
+  }
+
+  Future<void> _restartCameraAfterSettings() async {
+    final scanController = _scanController;
+    if (scanController == null ||
+        scanController.value.isStarting ||
+        scanController.value.isRunning) {
+      return;
+    }
+
+    try {
+      await scanController.start();
+    } catch (e, st) {
+      log('${widget.logTag}: camera settings return retry error: $e\n$st');
+    }
+  }
+
+  Future<void> _handleScanComplete(ScanResult result) async {
+    if (_decoding) return;
+    setState(() {
+      _decoding = true;
+      _scanHint = widget.readingSignatureLabel;
+    });
+
+    late final Uint8List signedPczt;
+    try {
+      final signedPcztBytes = await rust_keystone.decodePcztFromCbor(
+        cbor: result.data,
+      );
+      signedPczt = Uint8List.fromList(signedPcztBytes);
+    } catch (e, st) {
+      log('${widget.logTag}: signed PCZT decode error: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _decoding = false;
+        _scanHint =
+            'This QR code could not be decoded as a Keystone signature.';
+      });
+      return;
+    }
+
+    while (mounted && _pcztWithProofs == null && !_proofsFailed) {
+      if (_stage == _SignStage.failed) break;
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    }
+
+    final pcztWithProofs = _pcztWithProofs;
+    if (!mounted) return;
+    if (pcztWithProofs == null) {
+      setState(() {
+        _decoding = false;
+        _stage = _SignStage.failed;
+        _error ??= 'Keystone signing could not be prepared.';
+      });
+      return;
+    }
+
+    final finalizingLabel = widget.finalizingSignatureLabel;
+    if (finalizingLabel != null) {
+      setState(() => _scanHint = finalizingLabel);
+    }
+
+    try {
+      await widget.onSigned(context, ref, pcztWithProofs, signedPczt);
+    } catch (e, st) {
+      log('${widget.logTag}._onSigned: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _decoding = false;
+        _stage = _SignStage.failed;
+        _error = widget.friendlyError(e);
+      });
+    }
+  }
+
+  void _handleDecodeError(Object error) {
+    if (!mounted || _decoding) return;
+    final message = error.toString().contains('Unexpected UR type')
+        ? 'Open the signed transaction QR on Keystone, then scan again.'
+        : 'Keep the QR code steady and fully visible.';
+    if (_scanHint == message) return;
+    setState(() => _scanHint = message);
+  }
+
+  void _cancel() {
+    if (_decoding) return;
+    context.pop();
+  }
+
+  ValueKey<String> _key(String suffix) {
+    return ValueKey('${widget.keyPrefix}_$suffix');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scanning = _stage == _SignStage.scanning;
+    return PopScope<void>(
+      canPop: !_decoding,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) _cancel();
+      },
+      child: Scaffold(
+        backgroundColor: Colors.black,
+        body: Stack(
+          key: _key('screen'),
+          fit: StackFit.expand,
+          children: [
+            if (scanning) _buildScanner() else _buildQrStage(),
+            SafeArea(
+              child: Column(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.sm,
+                      vertical: AppSpacing.s,
+                    ),
+                    child: Row(
+                      children: [
+                        if (scanning)
+                          Semantics(
+                            button: true,
+                            label: 'Toggle flashlight',
+                            excludeSemantics: true,
+                            child: GestureDetector(
+                              behavior: HitTestBehavior.opaque,
+                              onTap: () =>
+                                  unawaited(_scanController?.toggleTorch()),
+                              child: const SizedBox(
+                                width: 44,
+                                height: 44,
+                                child: Icon(
+                                  Icons.flashlight_on_outlined,
+                                  color: Colors.white,
+                                  size: 24,
+                                ),
+                              ),
+                            ),
+                          ),
+                        const Spacer(),
+                        Semantics(
+                          button: true,
+                          enabled: !_decoding,
+                          label: 'Cancel signing',
+                          excludeSemantics: true,
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.opaque,
+                            onTap: _decoding ? null : _cancel,
+                            child: const SizedBox(
+                              width: 44,
+                              height: 44,
+                              child: Center(
+                                child: AppIcon(
+                                  AppIcons.cross,
+                                  size: 24,
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const Spacer(),
+                  _buildBottomBar(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildQrStage() {
+    final colors = context.colors;
+    final title = _stage == _SignStage.failed
+        ? widget.failedTitle ?? widget.title
+        : widget.title;
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+        child: Column(
+          children: [
+            const SizedBox(height: 72),
+            Text(
+              title,
+              textAlign: TextAlign.center,
+              style: AppTypography.headlineSmall.copyWith(color: Colors.white),
+            ),
+            const SizedBox(height: AppSpacing.s),
+            Text(
+              widget.description,
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMedium.copyWith(
+                color: const Color(0xCCFFFFFF),
+              ),
+            ),
+            const Spacer(),
+            LayoutBuilder(
+              builder: (context, constraints) {
+                final availableWidth = constraints.maxWidth.isFinite
+                    ? constraints.maxWidth
+                    : 312.0;
+                final qrSize = (availableWidth - AppSpacing.sm * 2)
+                    .clamp(220.0, 280.0)
+                    .toDouble();
+                return Container(
+                  key: _key('qr_stage'),
+                  padding: const EdgeInsets.all(AppSpacing.sm),
+                  decoration: BoxDecoration(
+                    color: colors.background.ground,
+                    borderRadius: BorderRadius.circular(AppRadii.large),
+                  ),
+                  child: KeystonePcztQrStage(
+                    phase: switch (_stage) {
+                      _SignStage.showQr => KeystonePcztQrStagePhase.ready,
+                      _SignStage.failed => KeystonePcztQrStagePhase.failed,
+                      _ => KeystonePcztQrStagePhase.preparing,
+                    },
+                    urParts: _urParts,
+                    error: _error,
+                    size: qrSize,
+                    scanOptimized: true,
+                    frameInterval: const Duration(milliseconds: 100),
+                  ),
+                );
+              },
+            ),
+            const Spacer(),
+            const SizedBox(height: 96),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScanner() {
+    const viewfinderSize = 260.0;
+    final scanController = _scanController;
+    if (scanController == null) return const SizedBox.shrink();
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        AnimatedUrScannerView(
+          controller: scanController,
+          expectedUrType: 'zcash-pczt',
+          scanSessionResetToken: _stage,
+          errorBuilder: (context, error) => const SizedBox.shrink(),
+          onProgress: (progress) {
+            if (!mounted || _scanProgress == progress) return;
+            setState(() => _scanProgress = progress);
+          },
+          onDecodeError: _handleDecodeError,
+          onComplete: (result) => unawaited(_handleScanComplete(result)),
+        ),
+        ColorFiltered(
+          colorFilter: const ColorFilter.mode(
+            Color(0x99000000),
+            BlendMode.srcOut,
+          ),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              Container(
+                decoration: const BoxDecoration(
+                  color: Colors.black,
+                  backgroundBlendMode: BlendMode.dstOut,
+                ),
+              ),
+              Center(
+                child: Container(
+                  width: viewfinderSize,
+                  height: viewfinderSize,
+                  decoration: BoxDecoration(
+                    color: Colors.black,
+                    borderRadius: BorderRadius.circular(AppRadii.large),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        Center(
+          child: SizedBox(
+            width: viewfinderSize,
+            height: viewfinderSize,
+            child: const MobileScanViewfinderCorners(),
+          ),
+        ),
+        MobileScanCameraErrorOverlay(
+          controller: scanController,
+          maxWidth: viewfinderSize,
+          permissionDeniedMessage:
+              'Camera access is off. Allow it in Settings to scan Keystone signatures.',
+          unavailableMessage: 'The camera is unavailable right now.',
+          onOpenSettings: _openCameraSettings,
+        ),
+        Align(
+          alignment: Alignment.center,
+          child: Padding(
+            padding: const EdgeInsets.only(top: viewfinderSize + 96),
+            child: Text(
+              _decoding
+                  ? _scanHint ?? widget.readingSignatureLabel
+                  : _scanHint ??
+                        (_scanProgress > 0
+                            ? 'Scanning... $_scanProgress%'
+                            : 'Scan the signed QR on your Keystone'),
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMedium.copyWith(color: Colors.white),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBottomBar() {
+    final scanning = _stage == _SignStage.scanning;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.md,
+        AppSpacing.s,
+        AppSpacing.md,
+        AppSpacing.md,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: AppButton(
+              key: _key('cancel'),
+              expand: true,
+              variant: AppButtonVariant.ghost,
+              onPressed: _decoding ? null : _cancel,
+              child: const Text(
+                'Cancel',
+                style: TextStyle(color: Colors.white),
+              ),
+            ),
+          ),
+          const SizedBox(width: AppSpacing.s),
+          Expanded(
+            child: scanning
+                ? AppButton(
+                    key: _key('show_qr'),
+                    expand: true,
+                    variant: AppButtonVariant.secondary,
+                    onPressed: _decoding ? null : _backToQr,
+                    child: const Text('Show QR'),
+                  )
+                : AppButton(
+                    key: _key('next'),
+                    expand: true,
+                    onPressed: _stage == _SignStage.showQr
+                        ? _startScanning
+                        : null,
+                    trailing: const AppIcon(AppIcons.chevronForward),
+                    child: const Text('Next step'),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
+++ b/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
@@ -48,7 +48,14 @@ typedef MobileKeystonePcztSigned =
 
 typedef MobileKeystonePcztFriendlyError = String Function(Object error);
 
+typedef MobileKeystonePcztDecoder = Future<Uint8List> Function(List<int> cbor);
+
+typedef MobileKeystonePcztScannerBuilder =
+    Widget Function(BuildContext context, ValueChanged<ScanResult> onComplete);
+
 enum _SignStage { preparing, showQr, scanning, failed }
+
+const _disabledSigningControlColor = Color(0x61FFFFFF);
 
 /// Shared mobile Keystone PCZT round trip.
 ///
@@ -67,6 +74,8 @@ class MobileKeystonePcztSigningFlow extends ConsumerStatefulWidget {
     this.readingSignatureLabel = 'Reading signature...',
     this.finalizingSignatureLabel,
     this.logTag = 'MobileKeystonePcztSigningFlow',
+    @visibleForTesting this.signedPcztDecoder,
+    @visibleForTesting this.scannerBuilder,
     super.key,
   });
 
@@ -80,6 +89,8 @@ class MobileKeystonePcztSigningFlow extends ConsumerStatefulWidget {
   final MobileKeystonePcztPrepare preparePczt;
   final MobileKeystonePcztSigned onSigned;
   final MobileKeystonePcztFriendlyError friendlyError;
+  final MobileKeystonePcztDecoder? signedPcztDecoder;
+  final MobileKeystonePcztScannerBuilder? scannerBuilder;
 
   @override
   ConsumerState<MobileKeystonePcztSigningFlow> createState() =>
@@ -216,10 +227,8 @@ class _MobileKeystonePcztSigningFlowState
 
     late final Uint8List signedPczt;
     try {
-      final signedPcztBytes = await rust_keystone.decodePcztFromCbor(
-        cbor: result.data,
-      );
-      signedPczt = Uint8List.fromList(signedPcztBytes);
+      final decoder = widget.signedPcztDecoder ?? _decodeSignedPcztFromCbor;
+      signedPczt = await decoder(result.data);
     } catch (e, st) {
       log('${widget.logTag}: signed PCZT decode error: $e\n$st');
       if (!mounted) return;
@@ -286,6 +295,7 @@ class _MobileKeystonePcztSigningFlowState
   @override
   Widget build(BuildContext context) {
     final scanning = _stage == _SignStage.scanning;
+    final cancelColor = _decoding ? _disabledSigningControlColor : Colors.white;
     return PopScope<void>(
       canPop: !_decoding,
       onPopInvokedWithResult: (didPop, _) {
@@ -337,14 +347,14 @@ class _MobileKeystonePcztSigningFlowState
                           child: GestureDetector(
                             behavior: HitTestBehavior.opaque,
                             onTap: _decoding ? null : _cancel,
-                            child: const SizedBox(
+                            child: SizedBox(
                               width: 44,
                               height: 44,
                               child: Center(
                                 child: AppIcon(
                                   AppIcons.cross,
                                   size: 24,
-                                  color: Colors.white,
+                                  color: cancelColor,
                                 ),
                               ),
                             ),
@@ -431,10 +441,11 @@ class _MobileKeystonePcztSigningFlowState
     const viewfinderSize = 260.0;
     final scanController = _scanController;
     if (scanController == null) return const SizedBox.shrink();
-
-    return Stack(
-      fit: StackFit.expand,
-      children: [
+    final scannerView =
+        widget.scannerBuilder?.call(
+          context,
+          (result) => unawaited(_handleScanComplete(result)),
+        ) ??
         AnimatedUrScannerView(
           controller: scanController,
           expectedUrType: 'zcash-pczt',
@@ -446,7 +457,12 @@ class _MobileKeystonePcztSigningFlowState
           },
           onDecodeError: _handleDecodeError,
           onComplete: (result) => unawaited(_handleScanComplete(result)),
-        ),
+        );
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        scannerView,
         ColorFiltered(
           colorFilter: const ColorFilter.mode(
             Color(0x99000000),
@@ -511,6 +527,7 @@ class _MobileKeystonePcztSigningFlowState
 
   Widget _buildBottomBar() {
     final scanning = _stage == _SignStage.scanning;
+    final cancelColor = _decoding ? _disabledSigningControlColor : Colors.white;
     return Padding(
       padding: const EdgeInsets.fromLTRB(
         AppSpacing.md,
@@ -526,10 +543,7 @@ class _MobileKeystonePcztSigningFlowState
               expand: true,
               variant: AppButtonVariant.ghost,
               onPressed: _decoding ? null : _cancel,
-              child: const Text(
-                'Cancel',
-                style: TextStyle(color: Colors.white),
-              ),
+              child: Text('Cancel', style: TextStyle(color: cancelColor)),
             ),
           ),
           const SizedBox(width: AppSpacing.s),
@@ -556,4 +570,9 @@ class _MobileKeystonePcztSigningFlowState
       ),
     );
   }
+}
+
+Future<Uint8List> _decodeSignedPcztFromCbor(List<int> cbor) async {
+  final signedPcztBytes = await rust_keystone.decodePcztFromCbor(cbor: cbor);
+  return Uint8List.fromList(signedPcztBytes);
 }

--- a/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
+++ b/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
@@ -1,21 +1,20 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:flutter/material.dart' show Colors, Icons, Scaffold;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../rust/api/keystone.dart' as rust_keystone;
-import '../../../services/camera_permission_settings.dart';
 import '../../../services/qr_scanner.dart';
-import '../../address_scan/widgets/mobile_address_scan_view.dart'
-    show MobileScanCameraErrorOverlay, MobileScanViewfinderCorners;
+import '../../address_scan/widgets/mobile_address_scan_card.dart'
+    show MobileQrScanCard;
 import 'keystone_pczt_qr_stage.dart';
 
 class MobileKeystonePcztSigningAborted implements Exception {
@@ -55,7 +54,11 @@ typedef MobileKeystonePcztScannerBuilder =
 
 enum _SignStage { preparing, showQr, scanning, failed }
 
-const _disabledSigningControlColor = Color(0x61FFFFFF);
+const _mobileKeystoneQrSize = 321.0;
+const _mobileKeystoneMinQrSize = 200.0;
+const _mobileKeystoneModalMaxWidth = 393.0;
+const _mobileKeystoneQrInset = AppSpacing.xxs;
+const _mobileKeystoneScanCaption = 'Scan a Zcash QR code to continue';
 
 /// Shared mobile Keystone PCZT round trip.
 ///
@@ -76,6 +79,7 @@ class MobileKeystonePcztSigningFlow extends ConsumerStatefulWidget {
     this.logTag = 'MobileKeystonePcztSigningFlow',
     @visibleForTesting this.signedPcztDecoder,
     @visibleForTesting this.scannerBuilder,
+    @visibleForTesting this.forceScannerActiveForTesting = false,
     super.key,
   });
 
@@ -91,6 +95,7 @@ class MobileKeystonePcztSigningFlow extends ConsumerStatefulWidget {
   final MobileKeystonePcztFriendlyError friendlyError;
   final MobileKeystonePcztDecoder? signedPcztDecoder;
   final MobileKeystonePcztScannerBuilder? scannerBuilder;
+  final bool forceScannerActiveForTesting;
 
   @override
   ConsumerState<MobileKeystonePcztSigningFlow> createState() =>
@@ -98,15 +103,13 @@ class MobileKeystonePcztSigningFlow extends ConsumerStatefulWidget {
 }
 
 class _MobileKeystonePcztSigningFlowState
-    extends ConsumerState<MobileKeystonePcztSigningFlow>
-    with WidgetsBindingObserver {
+    extends ConsumerState<MobileKeystonePcztSigningFlow> {
   var _stage = _SignStage.preparing;
   String? _error;
   List<String> _urParts = const [];
   List<int>? _pcztWithProofs;
   bool _proofsFailed = false;
   bool _decoding = false;
-  bool _restartCameraOnResume = false;
   int _scanProgress = 0;
   String? _scanHint;
 
@@ -115,21 +118,11 @@ class _MobileKeystonePcztSigningFlowState
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addObserver(this);
     unawaited(_preparePczt());
   }
 
   @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state != AppLifecycleState.resumed) return;
-    if (!_restartCameraOnResume) return;
-    _restartCameraOnResume = false;
-    unawaited(_restartCameraAfterSettings());
-  }
-
-  @override
   void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
     unawaited(_scanController?.dispose());
     super.dispose();
   }
@@ -184,38 +177,6 @@ class _MobileKeystonePcztSigningFlowState
       _scanHint = null;
       _scanProgress = 0;
     });
-  }
-
-  void _backToQr() {
-    setState(() {
-      _stage = _SignStage.showQr;
-      _scanHint = null;
-      _scanProgress = 0;
-    });
-  }
-
-  Future<void> _openCameraSettings() async {
-    _restartCameraOnResume = true;
-    final opened = await CameraPermissionSettings.open();
-    if (!opened) {
-      _restartCameraOnResume = false;
-      log('${widget.logTag}: failed to open camera permission settings');
-    }
-  }
-
-  Future<void> _restartCameraAfterSettings() async {
-    final scanController = _scanController;
-    if (scanController == null ||
-        scanController.value.isStarting ||
-        scanController.value.isRunning) {
-      return;
-    }
-
-    try {
-      await scanController.start();
-    } catch (e, st) {
-      log('${widget.logTag}: camera settings return retry error: $e\n$st');
-    }
   }
 
   Future<void> _handleScanComplete(ScanResult result) async {
@@ -295,150 +256,177 @@ class _MobileKeystonePcztSigningFlowState
   @override
   Widget build(BuildContext context) {
     final scanning = _stage == _SignStage.scanning;
-    final cancelColor = _decoding ? _disabledSigningControlColor : Colors.white;
     return PopScope<void>(
       canPop: !_decoding,
       onPopInvokedWithResult: (didPop, _) {
         if (!didPop) _cancel();
       },
-      child: Scaffold(
-        backgroundColor: Colors.black,
-        body: Stack(
-          key: _key('screen'),
-          fit: StackFit.expand,
-          children: [
-            if (scanning) _buildScanner() else _buildQrStage(),
-            SafeArea(
-              child: Column(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: AppSpacing.sm,
-                      vertical: AppSpacing.s,
-                    ),
-                    child: Row(
-                      children: [
-                        if (scanning)
-                          Semantics(
-                            button: true,
-                            label: 'Toggle flashlight',
-                            excludeSemantics: true,
-                            child: GestureDetector(
-                              behavior: HitTestBehavior.opaque,
-                              onTap: () =>
-                                  unawaited(_scanController?.toggleTorch()),
-                              child: const SizedBox(
-                                width: 44,
-                                height: 44,
-                                child: Icon(
-                                  Icons.flashlight_on_outlined,
-                                  color: Colors.white,
-                                  size: 24,
-                                ),
-                              ),
-                            ),
-                          ),
-                        const Spacer(),
-                        Semantics(
-                          button: true,
-                          enabled: !_decoding,
-                          label: 'Cancel signing',
-                          excludeSemantics: true,
-                          child: GestureDetector(
-                            behavior: HitTestBehavior.opaque,
-                            onTap: _decoding ? null : _cancel,
-                            child: SizedBox(
-                              width: 44,
-                              height: 44,
-                              child: Center(
-                                child: AppIcon(
-                                  AppIcons.cross,
-                                  size: 24,
-                                  color: cancelColor,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  const Spacer(),
-                  _buildBottomBar(),
-                ],
-              ),
-            ),
-          ],
+      child: SizedBox.expand(
+        key: _key('screen'),
+        child: Align(
+          alignment: Alignment.bottomCenter,
+          child: scanning ? _buildScannerModal() : _buildQrModal(),
         ),
       ),
     );
   }
 
-  Widget _buildQrStage() {
+  Widget _buildQrModal() {
     final colors = context.colors;
     final title = _stage == _SignStage.failed
         ? widget.failedTitle ?? widget.title
-        : widget.title;
-    return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
-        child: Column(
-          children: [
-            const SizedBox(height: 72),
-            Text(
-              title,
-              textAlign: TextAlign.center,
-              style: AppTypography.headlineSmall.copyWith(color: Colors.white),
-            ),
-            const SizedBox(height: AppSpacing.s),
-            Text(
-              widget.description,
-              textAlign: TextAlign.center,
-              style: AppTypography.bodyMedium.copyWith(
-                color: const Color(0xCCFFFFFF),
-              ),
-            ),
-            const Spacer(),
-            LayoutBuilder(
-              builder: (context, constraints) {
-                final availableWidth = constraints.maxWidth.isFinite
-                    ? constraints.maxWidth
-                    : 312.0;
-                final qrSize = (availableWidth - AppSpacing.sm * 2)
-                    .clamp(220.0, 280.0)
-                    .toDouble();
-                return Container(
-                  key: _key('qr_stage'),
-                  padding: const EdgeInsets.all(AppSpacing.sm),
-                  decoration: BoxDecoration(
-                    color: colors.background.ground,
-                    borderRadius: BorderRadius.circular(AppRadii.large),
+        : 'Confirm with Keystone';
+    final actionEnabled = _stage == _SignStage.showQr;
+    final isPreparing = _stage == _SignStage.preparing;
+    final isFailed = _stage == _SignStage.failed;
+    final instruction = isPreparing
+        ? 'Loading the QR code ...'
+        : isFailed
+        ? _error ?? widget.friendlyError(StateError('Keystone signing failed.'))
+        : 'After you scanned, click Get Signature.';
+
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: _mobileKeystoneModalMaxWidth),
+      child: Stack(
+        key: _key('modal'),
+        children: [
+          MobileModalCard(
+            child: Stack(
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.sm,
+                    AppSpacing.base,
+                    AppSpacing.sm,
+                    AppSpacing.md,
                   ),
-                  child: KeystonePcztQrStage(
-                    phase: switch (_stage) {
-                      _SignStage.showQr => KeystonePcztQrStagePhase.ready,
-                      _SignStage.failed => KeystonePcztQrStagePhase.failed,
-                      _ => KeystonePcztQrStagePhase.preparing,
+                  child: LayoutBuilder(
+                    builder: (context, constraints) {
+                      final qrSize = _qrSizeFor(constraints);
+                      return Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.only(right: 40),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  title,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: AppTypography.bodyLarge.copyWith(
+                                    color: colors.text.accent,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                const SizedBox(height: AppSpacing.xxs),
+                                Text(
+                                  'Scan with your Keystone',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: AppTypography.bodyMedium.copyWith(
+                                    color: colors.text.secondary,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(height: 44),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: _mobileKeystoneQrInset,
+                            ),
+                            child: _buildQrContent(size: qrSize),
+                          ),
+                          const SizedBox(height: AppSpacing.sm),
+                          Text(
+                            instruction,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            textAlign: TextAlign.center,
+                            style: AppTypography.bodyMedium.copyWith(
+                              color: isFailed
+                                  ? colors.text.destructive
+                                  : colors.text.accent,
+                            ),
+                          ),
+                          const SizedBox(height: AppSpacing.base),
+                          AppButton(
+                            key: _key('get_signature'),
+                            expand: true,
+                            onPressed: actionEnabled ? _startScanning : null,
+                            child: const Text('Get Signature'),
+                          ),
+                          const SizedBox(height: AppSpacing.s),
+                          AppButton(
+                            key: _key('cancel'),
+                            expand: true,
+                            variant: AppButtonVariant.ghost,
+                            onPressed: _cancel,
+                            child: const Text('Close'),
+                          ),
+                        ],
+                      );
                     },
-                    urParts: _urParts,
-                    error: _error,
-                    size: qrSize,
-                    scanOptimized: true,
-                    frameInterval: const Duration(milliseconds: 100),
                   ),
-                );
-              },
+                ),
+                Positioned(
+                  top: 15.5,
+                  right: AppSpacing.sm,
+                  child: _KeystoneModalCloseButton(onTap: _cancel),
+                ),
+              ],
             ),
-            const Spacer(),
-            const SizedBox(height: 96),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
 
-  Widget _buildScanner() {
-    const viewfinderSize = 260.0;
+  double _qrSizeFor(BoxConstraints constraints) {
+    const titleBlockHeight = 26.0 + AppSpacing.xxs + 25.0;
+    const instructionBlockHeight = 50.0;
+    const fixedContentHeight =
+        titleBlockHeight +
+        44.0 +
+        AppSpacing.sm +
+        instructionBlockHeight +
+        AppSpacing.base +
+        AppButtonSizing.largeHeight +
+        AppSpacing.s +
+        AppButtonSizing.largeHeight;
+    final available = constraints.maxHeight - fixedContentHeight;
+    return available
+        .clamp(_mobileKeystoneMinQrSize, _mobileKeystoneQrSize)
+        .toDouble();
+  }
+
+  Widget _buildQrContent({required double size}) {
+    if (_stage == _SignStage.preparing) {
+      return _MobileKeystoneQrPlaceholder(
+        key: _key('qr_placeholder'),
+        size: size,
+      );
+    }
+
+    return KeystonePcztQrStage(
+      key: _key('qr_stage'),
+      phase: switch (_stage) {
+        _SignStage.showQr => KeystonePcztQrStagePhase.ready,
+        _SignStage.failed => KeystonePcztQrStagePhase.failed,
+        _ => KeystonePcztQrStagePhase.preparing,
+      },
+      urParts: _urParts,
+      error: _error,
+      size: size,
+      scanOptimized: true,
+      frameInterval: const Duration(milliseconds: 100),
+    );
+  }
+
+  Widget _buildScannerModal() {
     final scanController = _scanController;
     if (scanController == null) return const SizedBox.shrink();
     final scannerView =
@@ -459,114 +447,85 @@ class _MobileKeystonePcztSigningFlowState
           onComplete: (result) => unawaited(_handleScanComplete(result)),
         );
 
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        scannerView,
-        ColorFiltered(
-          colorFilter: const ColorFilter.mode(
-            Color(0x99000000),
-            BlendMode.srcOut,
-          ),
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              Container(
-                decoration: const BoxDecoration(
-                  color: Colors.black,
-                  backgroundBlendMode: BlendMode.dstOut,
-                ),
-              ),
-              Center(
-                child: Container(
-                  width: viewfinderSize,
-                  height: viewfinderSize,
-                  decoration: BoxDecoration(
-                    color: Colors.black,
-                    borderRadius: BorderRadius.circular(AppRadii.large),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-        Center(
-          child: SizedBox(
-            width: viewfinderSize,
-            height: viewfinderSize,
-            child: const MobileScanViewfinderCorners(),
-          ),
-        ),
-        MobileScanCameraErrorOverlay(
+    final caption = _decoding
+        ? _scanHint ?? widget.readingSignatureLabel
+        : _scanHint ??
+              (_scanProgress > 0
+                  ? 'Scanning... $_scanProgress%'
+                  : _mobileKeystoneScanCaption);
+
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: _mobileKeystoneModalMaxWidth),
+      child: MobileModalCard(
+        child: MobileQrScanCard(
+          key: _key('scanner_card'),
           controller: scanController,
-          maxWidth: viewfinderSize,
-          permissionDeniedMessage:
-              'Camera access is off. Allow it in Settings to scan Keystone signatures.',
-          unavailableMessage: 'The camera is unavailable right now.',
-          onOpenSettings: _openCameraSettings,
+          closeEnabled: !_decoding,
+          forceActiveForTesting: widget.forceScannerActiveForTesting,
+          caption: caption,
+          permissionTitle: 'Scan the signed Keystone QR',
+          unavailableDescription:
+              'Keystone signing needs a camera on this device.',
+          onClose: _cancel,
+          cameraViewBuilder: (_, _) => scannerView,
         ),
-        Align(
-          alignment: Alignment.center,
-          child: Padding(
-            padding: const EdgeInsets.only(top: viewfinderSize + 96),
-            child: Text(
-              _decoding
-                  ? _scanHint ?? widget.readingSignatureLabel
-                  : _scanHint ??
-                        (_scanProgress > 0
-                            ? 'Scanning... $_scanProgress%'
-                            : 'Scan the signed QR on your Keystone'),
-              textAlign: TextAlign.center,
-              style: AppTypography.bodyMedium.copyWith(color: Colors.white),
-            ),
-          ),
-        ),
-      ],
+      ),
     );
   }
+}
 
-  Widget _buildBottomBar() {
-    final scanning = _stage == _SignStage.scanning;
-    final cancelColor = _decoding ? _disabledSigningControlColor : Colors.white;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.md,
-        AppSpacing.s,
-        AppSpacing.md,
-        AppSpacing.md,
+class _MobileKeystoneQrPlaceholder extends StatelessWidget {
+  const _MobileKeystoneQrPlaceholder({required this.size, super.key});
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AppRadii.large),
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            colors.background.raised,
+            colors.background.raised.withValues(alpha: 0.32),
+            colors.background.raised,
+          ],
+        ),
       ),
-      child: Row(
-        children: [
-          Expanded(
-            child: AppButton(
-              key: _key('cancel'),
-              expand: true,
-              variant: AppButtonVariant.ghost,
-              onPressed: _decoding ? null : _cancel,
-              child: Text('Cancel', style: TextStyle(color: cancelColor)),
-            ),
+    );
+  }
+}
+
+class _KeystoneModalCloseButton extends StatelessWidget {
+  const _KeystoneModalCloseButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Semantics(
+      label: 'Close Keystone signing',
+      button: true,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: Container(
+          width: 32,
+          height: 32,
+          decoration: BoxDecoration(
+            color: colors.button.secondary.bg,
+            shape: BoxShape.circle,
           ),
-          const SizedBox(width: AppSpacing.s),
-          Expanded(
-            child: scanning
-                ? AppButton(
-                    key: _key('show_qr'),
-                    expand: true,
-                    variant: AppButtonVariant.secondary,
-                    onPressed: _decoding ? null : _backToQr,
-                    child: const Text('Show QR'),
-                  )
-                : AppButton(
-                    key: _key('next'),
-                    expand: true,
-                    onPressed: _stage == _SignStage.showQr
-                        ? _startScanning
-                        : null,
-                    trailing: const AppIcon(AppIcons.chevronForward),
-                    child: const Text('Next step'),
-                  ),
+          child: Center(
+            child: AppIcon(AppIcons.cross, size: 20, color: colors.icon.accent),
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
+++ b/lib/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart
@@ -50,13 +50,18 @@ typedef MobileKeystonePcztFriendlyError = String Function(Object error);
 typedef MobileKeystonePcztDecoder = Future<Uint8List> Function(List<int> cbor);
 
 typedef MobileKeystonePcztScannerBuilder =
-    Widget Function(BuildContext context, ValueChanged<ScanResult> onComplete);
+    Widget Function(
+      BuildContext context,
+      ValueChanged<ScanResult> onComplete,
+      Object? scanSessionResetToken,
+    );
 
 enum _SignStage { preparing, showQr, scanning, failed }
 
 const _mobileKeystoneQrSize = 321.0;
 const _mobileKeystoneMinQrSize = 200.0;
 const _mobileKeystoneModalMaxWidth = 393.0;
+const _mobileKeystoneModalBottomPadding = AppSpacing.base;
 const _mobileKeystoneQrInset = AppSpacing.xxs;
 const _mobileKeystoneScanCaption = 'Scan a Zcash QR code to continue';
 
@@ -111,6 +116,7 @@ class _MobileKeystonePcztSigningFlowState
   bool _proofsFailed = false;
   bool _decoding = false;
   int _scanProgress = 0;
+  int _scanSessionResetToken = 0;
   String? _scanHint;
 
   MobileScannerController? _scanController;
@@ -180,7 +186,7 @@ class _MobileKeystonePcztSigningFlowState
   }
 
   Future<void> _handleScanComplete(ScanResult result) async {
-    if (_decoding) return;
+    if (_decoding || _stage != _SignStage.scanning) return;
     setState(() {
       _decoding = true;
       _scanHint = widget.readingSignatureLabel;
@@ -195,6 +201,7 @@ class _MobileKeystonePcztSigningFlowState
       if (!mounted) return;
       setState(() {
         _decoding = false;
+        _scanSessionResetToken++;
         _scanHint =
             'This QR code could not be decoded as a Keystone signature.';
       });
@@ -227,6 +234,7 @@ class _MobileKeystonePcztSigningFlowState
     } catch (e, st) {
       log('${widget.logTag}._onSigned: ERROR: $e\n$st');
       if (!mounted) return;
+      _stopScannerIfRunning();
       setState(() {
         _decoding = false;
         _stage = _SignStage.failed;
@@ -249,6 +257,18 @@ class _MobileKeystonePcztSigningFlowState
     context.pop();
   }
 
+  void _stopScannerIfRunning() {
+    final scanController = _scanController;
+    if (scanController == null || !scanController.value.isRunning) return;
+    unawaited(
+      scanController.stop().catchError((Object e, StackTrace st) {
+        log(
+          '${widget.logTag}: scanner stop error after signing failure: $e\n$st',
+        );
+      }),
+    );
+  }
+
   ValueKey<String> _key(String suffix) {
     return ValueKey('${widget.keyPrefix}_$suffix');
   }
@@ -256,6 +276,7 @@ class _MobileKeystonePcztSigningFlowState
   @override
   Widget build(BuildContext context) {
     final scanning = _stage == _SignStage.scanning;
+    final modal = scanning ? _buildScannerModal() : _buildQrModal();
     return PopScope<void>(
       canPop: !_decoding,
       onPopInvokedWithResult: (didPop, _) {
@@ -263,10 +284,7 @@ class _MobileKeystonePcztSigningFlowState
       },
       child: SizedBox.expand(
         key: _key('screen'),
-        child: Align(
-          alignment: Alignment.bottomCenter,
-          child: scanning ? _buildScannerModal() : _buildQrModal(),
-        ),
+        child: Align(alignment: Alignment.bottomCenter, child: modal),
       ),
     );
   }
@@ -285,109 +303,111 @@ class _MobileKeystonePcztSigningFlowState
         ? _error ?? widget.friendlyError(StateError('Keystone signing failed.'))
         : 'After you scanned, click Get Signature.';
 
+    final surface = Stack(
+      key: _key('modal_surface'),
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.sm,
+            AppSpacing.base,
+            AppSpacing.sm,
+            _mobileKeystoneModalBottomPadding,
+          ),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final qrSize = _qrSizeFor(constraints);
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(right: 40),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTypography.bodyLarge.copyWith(
+                            color: colors.text.accent,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(height: AppSpacing.xxs),
+                        Text(
+                          'Scan with your Keystone',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTypography.bodyMedium.copyWith(
+                            color: colors.text.secondary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 44),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: _mobileKeystoneQrInset,
+                    ),
+                    child: _buildQrContent(size: qrSize),
+                  ),
+                  const SizedBox(height: AppSpacing.sm),
+                  Text(
+                    instruction,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                    style: AppTypography.bodyMedium.copyWith(
+                      color: isFailed
+                          ? colors.text.destructive
+                          : colors.text.accent,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.base),
+                  AppButton(
+                    key: _key('get_signature'),
+                    expand: true,
+                    onPressed: actionEnabled ? _startScanning : null,
+                    child: const Text('Get Signature'),
+                  ),
+                  const SizedBox(height: AppSpacing.s),
+                  AppButton(
+                    key: _key('cancel'),
+                    expand: true,
+                    variant: AppButtonVariant.ghost,
+                    onPressed: _cancel,
+                    child: const Text('Close'),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+        Positioned(
+          top: 15.5,
+          right: AppSpacing.sm,
+          child: _KeystoneModalCloseButton(onTap: _cancel),
+        ),
+      ],
+    );
+    return _buildModalFrame(surface);
+  }
+
+  Widget _buildModalFrame(Widget child) {
     return ConstrainedBox(
       constraints: const BoxConstraints(maxWidth: _mobileKeystoneModalMaxWidth),
       child: Stack(
         key: _key('modal'),
-        children: [
-          MobileModalCard(
-            child: Stack(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(
-                    AppSpacing.sm,
-                    AppSpacing.base,
-                    AppSpacing.sm,
-                    AppSpacing.md,
-                  ),
-                  child: LayoutBuilder(
-                    builder: (context, constraints) {
-                      final qrSize = _qrSizeFor(constraints);
-                      return Column(
-                        mainAxisSize: MainAxisSize.min,
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          Padding(
-                            padding: const EdgeInsets.only(right: 40),
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  title,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: AppTypography.bodyLarge.copyWith(
-                                    color: colors.text.accent,
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                                const SizedBox(height: AppSpacing.xxs),
-                                Text(
-                                  'Scan with your Keystone',
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: AppTypography.bodyMedium.copyWith(
-                                    color: colors.text.secondary,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(height: 44),
-                          Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: _mobileKeystoneQrInset,
-                            ),
-                            child: _buildQrContent(size: qrSize),
-                          ),
-                          const SizedBox(height: AppSpacing.sm),
-                          Text(
-                            instruction,
-                            maxLines: 2,
-                            overflow: TextOverflow.ellipsis,
-                            textAlign: TextAlign.center,
-                            style: AppTypography.bodyMedium.copyWith(
-                              color: isFailed
-                                  ? colors.text.destructive
-                                  : colors.text.accent,
-                            ),
-                          ),
-                          const SizedBox(height: AppSpacing.base),
-                          AppButton(
-                            key: _key('get_signature'),
-                            expand: true,
-                            onPressed: actionEnabled ? _startScanning : null,
-                            child: const Text('Get Signature'),
-                          ),
-                          const SizedBox(height: AppSpacing.s),
-                          AppButton(
-                            key: _key('cancel'),
-                            expand: true,
-                            variant: AppButtonVariant.ghost,
-                            onPressed: _cancel,
-                            child: const Text('Close'),
-                          ),
-                        ],
-                      );
-                    },
-                  ),
-                ),
-                Positioned(
-                  top: 15.5,
-                  right: AppSpacing.sm,
-                  child: _KeystoneModalCloseButton(onTap: _cancel),
-                ),
-              ],
-            ),
-          ),
-        ],
+        children: [MobileModalCard(child: child)],
       ),
     );
   }
 
   double _qrSizeFor(BoxConstraints constraints) {
     const titleBlockHeight = 26.0 + AppSpacing.xxs + 25.0;
-    const instructionBlockHeight = 50.0;
+    const instructionBlockHeight = 25.0;
     const fixedContentHeight =
         titleBlockHeight +
         44.0 +
@@ -404,7 +424,8 @@ class _MobileKeystonePcztSigningFlowState
   }
 
   Widget _buildQrContent({required double size}) {
-    if (_stage == _SignStage.preparing) {
+    if (_stage == _SignStage.preparing ||
+        (_stage == _SignStage.failed && _urParts.isEmpty)) {
       return _MobileKeystoneQrPlaceholder(
         key: _key('qr_placeholder'),
         size: size,
@@ -415,11 +436,11 @@ class _MobileKeystonePcztSigningFlowState
       key: _key('qr_stage'),
       phase: switch (_stage) {
         _SignStage.showQr => KeystonePcztQrStagePhase.ready,
-        _SignStage.failed => KeystonePcztQrStagePhase.failed,
+        _SignStage.failed => KeystonePcztQrStagePhase.ready,
         _ => KeystonePcztQrStagePhase.preparing,
       },
       urParts: _urParts,
-      error: _error,
+      error: null,
       size: size,
       scanOptimized: true,
       frameInterval: const Duration(milliseconds: 100),
@@ -429,15 +450,17 @@ class _MobileKeystonePcztSigningFlowState
   Widget _buildScannerModal() {
     final scanController = _scanController;
     if (scanController == null) return const SizedBox.shrink();
+    final scanSessionResetToken = (_stage, _scanSessionResetToken);
     final scannerView =
         widget.scannerBuilder?.call(
           context,
           (result) => unawaited(_handleScanComplete(result)),
+          scanSessionResetToken,
         ) ??
         AnimatedUrScannerView(
           controller: scanController,
           expectedUrType: 'zcash-pczt',
-          scanSessionResetToken: _stage,
+          scanSessionResetToken: scanSessionResetToken,
           errorBuilder: (context, error) => const SizedBox.shrink(),
           onProgress: (progress) {
             if (!mounted || _scanProgress == progress) return;
@@ -454,49 +477,98 @@ class _MobileKeystonePcztSigningFlowState
                   ? 'Scanning... $_scanProgress%'
                   : _mobileKeystoneScanCaption);
 
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxWidth: _mobileKeystoneModalMaxWidth),
-      child: MobileModalCard(
-        child: MobileQrScanCard(
-          key: _key('scanner_card'),
-          controller: scanController,
-          closeEnabled: !_decoding,
-          forceActiveForTesting: widget.forceScannerActiveForTesting,
-          caption: caption,
-          permissionTitle: 'Scan the signed Keystone QR',
-          unavailableDescription:
-              'Keystone signing needs a camera on this device.',
-          onClose: _cancel,
-          cameraViewBuilder: (_, _) => scannerView,
-        ),
+    return _buildModalFrame(
+      MobileQrScanCard(
+        key: _key('scanner_card'),
+        controller: scanController,
+        closeEnabled: !_decoding,
+        forceActiveForTesting: widget.forceScannerActiveForTesting,
+        caption: caption,
+        permissionTitle: 'Scan the signed Keystone QR',
+        unavailableDescription:
+            'Keystone signing needs a camera on this device.',
+        onClose: _cancel,
+        cameraViewBuilder: (_, _) => scannerView,
       ),
     );
   }
 }
 
-class _MobileKeystoneQrPlaceholder extends StatelessWidget {
+class _MobileKeystoneQrPlaceholder extends StatefulWidget {
   const _MobileKeystoneQrPlaceholder({required this.size, super.key});
 
   final double size;
 
   @override
+  State<_MobileKeystoneQrPlaceholder> createState() =>
+      _MobileKeystoneQrPlaceholderState();
+}
+
+class _MobileKeystoneQrPlaceholderState
+    extends State<_MobileKeystoneQrPlaceholder>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1400),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return Container(
-      width: size,
-      height: size,
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(AppRadii.large),
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [
-            colors.background.raised,
-            colors.background.raised.withValues(alpha: 0.32),
-            colors.background.raised,
-          ],
-        ),
-      ),
+    final base = colors.background.raised;
+    final highlight = colors.background.overlay.withValues(alpha: 0.72);
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        final bandHeight = widget.size * 0.72;
+        final travel = widget.size + bandHeight * 2;
+        final top = -bandHeight + travel * _controller.value;
+        return ClipRRect(
+          borderRadius: BorderRadius.circular(AppRadii.large),
+          child: SizedBox(
+            width: widget.size,
+            height: widget.size,
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                DecoratedBox(decoration: BoxDecoration(color: base)),
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  top: top,
+                  height: bandHeight,
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          base.withValues(alpha: 0),
+                          highlight,
+                          base.withValues(alpha: 0),
+                        ],
+                        stops: const [0, 0.5, 1],
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/src/features/send/screens/mobile/mobile_keystone_sign_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_keystone_sign_screen.dart
@@ -1,158 +1,96 @@
-import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:flutter/material.dart' show Colors, Icons, Scaffold;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:mobile_scanner/mobile_scanner.dart';
 
 import '../../../../../main.dart' show log;
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/storage/wallet_paths.dart';
-import '../../../../core/theme/app_theme.dart';
-import '../../../../core/widgets/app_button.dart';
-import '../../../../core/widgets/app_icon.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
 import '../../../../rust/api/keystone.dart' as rust_keystone;
 import '../../../../rust/api/sync.dart' as rust_sync;
-import '../../../../services/camera_permission_settings.dart';
-import '../../../../services/qr_scanner.dart';
-import '../../../keystone/widgets/keystone_pczt_qr_stage.dart';
+import '../../../keystone/widgets/mobile_keystone_pczt_signing_flow.dart';
 import '../../services/sapling_params.dart';
 import '../../services/send_flow.dart';
-import '../../../address_scan/widgets/mobile_address_scan_view.dart'
-    show MobileScanCameraErrorOverlay, MobileScanViewfinderCorners;
 import 'mobile_send_screen.dart' show MobileSaplingParamsSheet;
 
-enum _SignStage { preparing, showQr, scanning, failed }
-
-/// Mobile Keystone signing — Figma `Keystone Scan Windget` / `Keystone
-/// Scan Error` (4654:73731 / 4654:73823): the redacted PCZT plays as an
-/// animated QR for the device to scan ("Next step"), then the camera
-/// reads the signed PCZT back. Pops [KeystoneBroadcastArgs] on success
-/// and `null` on cancel; the caller owns broadcast and proposal
-/// cleanup (the proposal is consumed here once the PCZT is created —
-/// the caller's discard is idempotent either way).
-class MobileKeystoneSignScreen extends ConsumerStatefulWidget {
+/// Mobile Keystone signing. The send-specific work here is only PCZT
+/// preparation and the result payload; the QR display and signed-PCZT scan are
+/// shared by every mobile Keystone signing surface.
+class MobileKeystoneSignScreen extends ConsumerWidget {
   const MobileKeystoneSignScreen({required this.args, super.key});
 
   final SendReviewArgs args;
 
   @override
-  ConsumerState<MobileKeystoneSignScreen> createState() =>
-      _MobileKeystoneSignScreenState();
-}
-
-class _MobileKeystoneSignScreenState
-    extends ConsumerState<MobileKeystoneSignScreen>
-    with WidgetsBindingObserver {
-  var _stage = _SignStage.preparing;
-  String? _error;
-  List<String> _urParts = const [];
-  List<int>? _pcztWithProofs;
-  bool _proofsFailed = false;
-  bool _decoding = false;
-  bool _restartCameraOnResume = false;
-  int _scanProgress = 0;
-  String? _scanHint;
-
-  MobileScannerController? _scanController;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-    unawaited(_preparePczt());
+  Widget build(BuildContext context, WidgetRef ref) {
+    return MobileKeystonePcztSigningFlow(
+      title: 'Confirm transaction',
+      description:
+          'Use your Keystone wallet to scan this transaction QR code. '
+          'Follow the steps on your device.',
+      preparePczt: _preparePczt,
+      onSigned: _handleSignedPczt,
+      friendlyError: _friendlyError,
+      keyPrefix: 'mobile_keystone_sign',
+      logTag: 'MobileKeystoneSign',
+    );
   }
 
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state != AppLifecycleState.resumed) return;
-    if (!_restartCameraOnResume) return;
-    _restartCameraOnResume = false;
-    unawaited(_restartCameraAfterSettings());
-  }
+  Future<MobileKeystonePcztSigningPayload> _preparePczt(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final dbPath = await getWalletDbPath();
+    final endpoint = ref.read(rpcEndpointProvider);
+    var saplingParams = await loadSaplingParamsStatus();
 
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    unawaited(_scanController?.dispose());
-    super.dispose();
-  }
-
-  /// Same pipeline as the desktop review screen: params → create →
-  /// redact + encode (QR up fast) → proofs in the background.
-  Future<void> _preparePczt() async {
-    try {
-      final dbPath = await getWalletDbPath();
-      final endpoint = ref.read(rpcEndpointProvider);
-      final saplingParams = await loadSaplingParamsStatus();
-
-      if (widget.args.needsSaplingParams && !saplingParams.complete) {
-        final confirmed = await _confirmSaplingParamsDownload();
-        if (!confirmed) {
-          if (!mounted) return;
-          context.pop();
-          return;
-        }
-        await downloadMissingSaplingParams(
-          saplingParams,
-          log: (message) => log('MobileKeystoneSign: $message'),
-        );
+    if (args.needsSaplingParams && !saplingParams.complete) {
+      if (!context.mounted) {
+        throw const MobileKeystonePcztSigningAborted();
       }
-
-      if (!mounted) return;
-      final currentParams = await loadSaplingParamsStatus();
-
-      final pcztBytes = await rust_sync.createPcztFromProposal(
-        dbPath: dbPath,
-        network: endpoint.networkName,
-        proposalId: widget.args.proposalId,
-        sendFlowId: widget.args.sendFlowId,
+      final confirmed = await _confirmSaplingParamsDownload(context);
+      if (!confirmed) {
+        throw const MobileKeystonePcztSigningAborted();
+      }
+      await downloadMissingSaplingParams(
+        saplingParams,
+        log: (message) => log('MobileKeystoneSign: $message'),
       );
-
-      final redactedPczt = await rust_sync.redactPcztForSigner(
-        pcztBytes: pcztBytes,
-      );
-      final urParts = await rust_keystone.encodePcztUrParts(
-        pcztBytes: redactedPczt,
-        maxFragmentLen: BigInt.from(140),
-      );
-
-      if (!mounted) return;
-      setState(() {
-        _stage = _SignStage.showQr;
-        _urParts = urParts;
-      });
-
-      final pcztWithProofs = await rust_sync.addProofsToPczt(
-        pcztBytes: pcztBytes,
-        spendParamsPath: widget.args.needsSaplingParams
-            ? currentParams.spendPath
-            : null,
-        outputParamsPath: widget.args.needsSaplingParams
-            ? currentParams.outputPath
-            : null,
-      );
-      if (!mounted) return;
-      setState(() => _pcztWithProofs = pcztWithProofs);
-    } catch (e, st) {
-      log('MobileKeystoneSign._preparePczt: ERROR: $e\n$st');
-      if (!mounted) return;
-      setState(() {
-        if (_stage == _SignStage.showQr) {
-          // The QR is already on screen, so only proving failed.
-          _proofsFailed = true;
-        }
-        _stage = _SignStage.failed;
-        _error = _friendlyError(e.toString());
-      });
+      saplingParams = await loadSaplingParamsStatus();
     }
+
+    final pcztBytes = await rust_sync.createPcztFromProposal(
+      dbPath: dbPath,
+      network: endpoint.networkName,
+      proposalId: args.proposalId,
+      sendFlowId: args.sendFlowId,
+    );
+
+    final redactedPczt = await rust_sync.redactPcztForSigner(
+      pcztBytes: pcztBytes,
+    );
+    final urParts = await rust_keystone.encodePcztUrParts(
+      pcztBytes: redactedPczt,
+      maxFragmentLen: BigInt.from(140),
+    );
+
+    return MobileKeystonePcztSigningPayload(
+      urParts: urParts,
+      pcztWithProofs: rust_sync.addProofsToPczt(
+        pcztBytes: pcztBytes,
+        spendParamsPath: args.needsSaplingParams
+            ? saplingParams.spendPath
+            : null,
+        outputParamsPath: args.needsSaplingParams
+            ? saplingParams.outputPath
+            : null,
+      ),
+    );
   }
 
-  Future<bool> _confirmSaplingParamsDownload() async {
-    if (!mounted) return false;
+  Future<bool> _confirmSaplingParamsDownload(BuildContext context) async {
     final confirmed = await showAppMobileSheet<bool>(
       context: context,
       isDismissible: false,
@@ -161,8 +99,23 @@ class _MobileKeystoneSignScreenState
     return confirmed == true;
   }
 
-  String _friendlyError(String raw) {
-    final lower = raw.toLowerCase();
+  Future<void> _handleSignedPczt(
+    BuildContext context,
+    WidgetRef ref,
+    List<int> pcztWithProofs,
+    Uint8List signedPczt,
+  ) async {
+    context.pop(
+      KeystoneBroadcastArgs(
+        reviewArgs: args,
+        pcztWithProofsBytes: pcztWithProofs,
+        pcztWithSignaturesBytes: signedPczt,
+      ),
+    );
+  }
+
+  String _friendlyError(Object error) {
+    final lower = error.toString().toLowerCase();
     if (lower.contains('proposal not found') ||
         lower.contains('send flow mismatch')) {
       return 'Transaction expired before it could be signed.';
@@ -171,371 +124,5 @@ class _MobileKeystoneSignScreenState
       return 'Required proving parameters could not be prepared.';
     }
     return 'Keystone signing could not be prepared. Go back and try again.';
-  }
-
-  void _startScanning() {
-    _scanController ??= MobileScannerController(
-      facing: CameraFacing.back,
-      formats: QrScanner.formats,
-      detectionSpeed: QrScanner.detectionSpeed,
-    );
-    setState(() {
-      _stage = _SignStage.scanning;
-      _scanHint = null;
-      _scanProgress = 0;
-    });
-  }
-
-  void _backToQr() {
-    setState(() {
-      _stage = _SignStage.showQr;
-      _scanHint = null;
-      _scanProgress = 0;
-    });
-  }
-
-  Future<void> _openCameraSettings() async {
-    _restartCameraOnResume = true;
-    final opened = await CameraPermissionSettings.open();
-    if (!opened) {
-      _restartCameraOnResume = false;
-      log('MobileKeystoneSign: failed to open camera permission settings');
-    }
-  }
-
-  Future<void> _restartCameraAfterSettings() async {
-    final scanController = _scanController;
-    if (scanController == null ||
-        scanController.value.isStarting ||
-        scanController.value.isRunning) {
-      return;
-    }
-
-    try {
-      await scanController.start();
-    } catch (e, st) {
-      log('MobileKeystoneSign: camera settings return retry error: $e\n$st');
-    }
-  }
-
-  Future<void> _handleScanComplete(ScanResult result) async {
-    if (_decoding) return;
-    setState(() {
-      _decoding = true;
-      _scanHint = null;
-    });
-    try {
-      final signedPczt = await rust_keystone.decodePcztFromCbor(
-        cbor: result.data,
-      );
-      // The signed half is useless without the proofs half — wait for
-      // the background proving to land before handing both back.
-      while (mounted && _pcztWithProofs == null && !_proofsFailed) {
-        if (_stage == _SignStage.failed) break;
-        await Future<void>.delayed(const Duration(milliseconds: 200));
-      }
-      final pcztWithProofs = _pcztWithProofs;
-      if (!mounted) return;
-      if (pcztWithProofs == null) {
-        setState(() {
-          _decoding = false;
-          _stage = _SignStage.failed;
-          _error ??= 'Keystone signing could not be prepared.';
-        });
-        return;
-      }
-      context.pop(
-        KeystoneBroadcastArgs(
-          reviewArgs: widget.args,
-          pcztWithProofsBytes: pcztWithProofs,
-          pcztWithSignaturesBytes: Uint8List.fromList(signedPczt),
-        ),
-      );
-    } catch (e, st) {
-      log('MobileKeystoneSign: signed PCZT decode error: $e\n$st');
-      if (!mounted) return;
-      setState(() {
-        _decoding = false;
-        _scanHint =
-            'This QR code could not be decoded as a Keystone signature.';
-      });
-    }
-  }
-
-  void _handleDecodeError(Object error) {
-    if (!mounted || _decoding) return;
-    final message = error.toString().contains('Unexpected UR type')
-        ? 'Open the signed transaction QR on Keystone, then scan again.'
-        : 'Keep the QR code steady and fully visible.';
-    if (_scanHint == message) return;
-    setState(() => _scanHint = message);
-  }
-
-  void _cancel() => context.pop();
-
-  @override
-  Widget build(BuildContext context) {
-    final scanning = _stage == _SignStage.scanning;
-    return Scaffold(
-      backgroundColor: Colors.black,
-      body: Stack(
-        fit: StackFit.expand,
-        children: [
-          if (scanning) _buildScanner() else _buildQrStage(),
-          SafeArea(
-            child: Column(
-              children: [
-                Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSpacing.sm,
-                    vertical: AppSpacing.s,
-                  ),
-                  child: Row(
-                    children: [
-                      if (scanning)
-                        Semantics(
-                          button: true,
-                          label: 'Toggle flashlight',
-                          excludeSemantics: true,
-                          child: GestureDetector(
-                            behavior: HitTestBehavior.opaque,
-                            onTap: () =>
-                                unawaited(_scanController?.toggleTorch()),
-                            child: const SizedBox(
-                              width: 44,
-                              height: 44,
-                              child: Icon(
-                                Icons.flashlight_on_outlined,
-                                color: Colors.white,
-                                size: 24,
-                              ),
-                            ),
-                          ),
-                        ),
-                      const Spacer(),
-                      Semantics(
-                        button: true,
-                        label: 'Cancel signing',
-                        excludeSemantics: true,
-                        child: GestureDetector(
-                          behavior: HitTestBehavior.opaque,
-                          onTap: _cancel,
-                          child: const SizedBox(
-                            width: 44,
-                            height: 44,
-                            child: Center(
-                              child: AppIcon(
-                                AppIcons.cross,
-                                size: 24,
-                                color: Colors.white,
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                const Spacer(),
-                _buildBottomBar(),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildQrStage() {
-    final colors = context.colors;
-    return SafeArea(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
-        child: Column(
-          children: [
-            const SizedBox(height: 72),
-            Text(
-              'Confirm transaction',
-              textAlign: TextAlign.center,
-              style: AppTypography.headlineSmall.copyWith(color: Colors.white),
-            ),
-            const SizedBox(height: AppSpacing.s),
-            Text(
-              'Use your Keystone wallet to scan this transaction QR code. '
-              'Follow the steps on your device.',
-              textAlign: TextAlign.center,
-              style: AppTypography.bodyMedium.copyWith(
-                color: const Color(0xCCFFFFFF),
-              ),
-            ),
-            const Spacer(),
-            LayoutBuilder(
-              builder: (context, constraints) {
-                final availableWidth = constraints.maxWidth.isFinite
-                    ? constraints.maxWidth
-                    : 312.0;
-                final qrSize = (availableWidth - AppSpacing.sm * 2)
-                    .clamp(220.0, 280.0)
-                    .toDouble();
-                return Container(
-                  padding: const EdgeInsets.all(AppSpacing.sm),
-                  decoration: BoxDecoration(
-                    color: colors.background.ground,
-                    borderRadius: BorderRadius.circular(AppRadii.large),
-                  ),
-                  child: KeystonePcztQrStage(
-                    phase: switch (_stage) {
-                      _SignStage.showQr => KeystonePcztQrStagePhase.ready,
-                      _SignStage.failed => KeystonePcztQrStagePhase.failed,
-                      _ => KeystonePcztQrStagePhase.preparing,
-                    },
-                    urParts: _urParts,
-                    error: _error,
-                    size: qrSize,
-                    scanOptimized: true,
-                    frameInterval: const Duration(milliseconds: 100),
-                  ),
-                );
-              },
-            ),
-            const Spacer(),
-            // Space for the bottom bar in the outer stack.
-            const SizedBox(height: 96),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildScanner() {
-    const viewfinderSize = 260.0;
-    final scanController = _scanController;
-    if (scanController == null) return const SizedBox.shrink();
-
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        AnimatedUrScannerView(
-          controller: scanController,
-          expectedUrType: 'zcash-pczt',
-          scanSessionResetToken: _stage,
-          errorBuilder: (context, error) => const SizedBox.shrink(),
-          onProgress: (progress) {
-            if (!mounted || _scanProgress == progress) return;
-            setState(() => _scanProgress = progress);
-          },
-          onDecodeError: _handleDecodeError,
-          onComplete: (result) => unawaited(_handleScanComplete(result)),
-        ),
-        // Dark scrim with a clear viewfinder window, same treatment as
-        // the address scanner.
-        ColorFiltered(
-          colorFilter: const ColorFilter.mode(
-            Color(0x99000000),
-            BlendMode.srcOut,
-          ),
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              Container(
-                decoration: const BoxDecoration(
-                  color: Colors.black,
-                  backgroundBlendMode: BlendMode.dstOut,
-                ),
-              ),
-              Center(
-                child: Container(
-                  width: viewfinderSize,
-                  height: viewfinderSize,
-                  decoration: BoxDecoration(
-                    color: Colors.black,
-                    borderRadius: BorderRadius.circular(AppRadii.large),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-        Center(
-          child: SizedBox(
-            width: viewfinderSize,
-            height: viewfinderSize,
-            child: const MobileScanViewfinderCorners(),
-          ),
-        ),
-        MobileScanCameraErrorOverlay(
-          controller: scanController,
-          maxWidth: viewfinderSize,
-          permissionDeniedMessage:
-              'Camera access is off. Allow it in Settings to scan Keystone signatures.',
-          unavailableMessage: 'The camera is unavailable right now.',
-          onOpenSettings: _openCameraSettings,
-        ),
-        Align(
-          alignment: Alignment.center,
-          child: Padding(
-            padding: const EdgeInsets.only(top: viewfinderSize + 96),
-            child: Text(
-              _decoding
-                  ? 'Reading signature...'
-                  : _scanHint ??
-                        (_scanProgress > 0
-                            ? 'Scanning... $_scanProgress%'
-                            : 'Scan the signed QR on your Keystone'),
-              textAlign: TextAlign.center,
-              style: AppTypography.bodyMedium.copyWith(color: Colors.white),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildBottomBar() {
-    final scanning = _stage == _SignStage.scanning;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.md,
-        AppSpacing.s,
-        AppSpacing.md,
-        AppSpacing.md,
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: AppButton(
-              key: const ValueKey('mobile_keystone_sign_cancel'),
-              expand: true,
-              variant: AppButtonVariant.ghost,
-              onPressed: _cancel,
-              child: const Text(
-                'Cancel',
-                style: TextStyle(color: Colors.white),
-              ),
-            ),
-          ),
-          const SizedBox(width: AppSpacing.s),
-          Expanded(
-            child: scanning
-                ? AppButton(
-                    key: const ValueKey('mobile_keystone_sign_show_qr'),
-                    expand: true,
-                    variant: AppButtonVariant.secondary,
-                    onPressed: _decoding ? null : _backToQr,
-                    child: const Text('Show QR'),
-                  )
-                : AppButton(
-                    key: const ValueKey('mobile_keystone_sign_next'),
-                    expand: true,
-                    onPressed: _stage == _SignStage.showQr
-                        ? _startScanning
-                        : null,
-                    trailing: const AppIcon(AppIcons.chevronForward),
-                    child: const Text('Next step'),
-                  ),
-          ),
-        ],
-      ),
-    );
   }
 }

--- a/lib/src/features/swap/screens/mobile/mobile_swap_keystone_sign_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_keystone_sign_screen.dart
@@ -22,6 +22,22 @@ class MobileSwapKeystoneSignArgs {
   final SwapIntent intent;
 }
 
+sealed class MobileSwapKeystoneSignResult {
+  const MobileSwapKeystoneSignResult();
+}
+
+class MobileSwapKeystoneSignSuccess extends MobileSwapKeystoneSignResult {
+  const MobileSwapKeystoneSignSuccess(this.broadcast);
+
+  final SwapKeystoneBroadcastResult broadcast;
+}
+
+class MobileSwapKeystoneSignFailure extends MobileSwapKeystoneSignResult {
+  const MobileSwapKeystoneSignFailure(this.message);
+
+  final String message;
+}
+
 class MobileSwapKeystoneSignScreen extends ConsumerStatefulWidget {
   const MobileSwapKeystoneSignScreen({required this.args, super.key});
 
@@ -127,28 +143,39 @@ class _MobileSwapKeystoneSignScreenState
       throw StateError('Keystone signing could not be prepared.');
     }
 
-    final result = await ref
-        .read(swapHardwareSigningServiceProvider)
-        .broadcastSignedPczt(
-          pcztWithProofsBytes: pcztWithProofs,
-          pcztWithSignaturesBytes: signedPczt,
-          spendParamsPath: draft.needsSaplingParams
-              ? saplingParams!.spendPath
-              : null,
-          outputParamsPath: draft.needsSaplingParams
-              ? saplingParams!.outputPath
-              : null,
-        );
-    log(
-      'MobileSwapKeystoneSign: broadcast complete kind=zecDeposit '
-      'tx=${_shortSwapValue(result.txid)} status=${result.status}',
-    );
+    late final rust_sync.ExtractAndBroadcastPcztResult result;
+    try {
+      result = await ref
+          .read(swapHardwareSigningServiceProvider)
+          .broadcastSignedPczt(
+            pcztWithProofsBytes: pcztWithProofs,
+            pcztWithSignaturesBytes: signedPczt,
+            spendParamsPath: draft.needsSaplingParams
+                ? saplingParams!.spendPath
+                : null,
+            outputParamsPath: draft.needsSaplingParams
+                ? saplingParams!.outputPath
+                : null,
+          );
+      log(
+        'MobileSwapKeystoneSign: broadcast complete kind=zecDeposit '
+        'tx=${_shortSwapValue(result.txid)} status=${result.status}',
+      );
+    } catch (e, st) {
+      log('MobileSwapKeystoneSign._broadcast: ERROR: $e\n$st');
+      if (!context.mounted) return;
+      context.pop(MobileSwapKeystoneSignFailure(_friendlyError(e)));
+      return;
+    }
 
     if (!_hasBroadcastTxid(result)) {
-      throw _SwapSigningDisplayError(
-        result.message ??
-            'The transaction status is uncertain. Refresh activity before trying again.',
+      if (!context.mounted) return;
+      context.pop(
+        MobileSwapKeystoneSignFailure(
+          _friendlyBroadcastFailureMessage(result.message),
+        ),
       );
+      return;
     }
     if (result.status != SwapDepositBroadcastStatus.broadcasted) {
       log(
@@ -158,10 +185,12 @@ class _MobileSwapKeystoneSignScreenState
     }
     if (!context.mounted) return;
     context.pop(
-      SwapKeystoneBroadcastResult(
-        txHash: result.txid,
-        status: result.status,
-        message: result.message,
+      MobileSwapKeystoneSignSuccess(
+        SwapKeystoneBroadcastResult(
+          txHash: result.txid,
+          status: result.status,
+          message: result.message,
+        ),
       ),
     );
   }
@@ -176,10 +205,15 @@ class _MobileSwapKeystoneSignScreenState
     };
   }
 
-  String _friendlyError(Object error) {
-    if (error is _SwapSigningDisplayError) {
-      return error.message;
+  String _friendlyBroadcastFailureMessage(String? message) {
+    final trimmed = message?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return 'Transaction could not be broadcast.';
     }
+    return _friendlyError(trimmed);
+  }
+
+  String _friendlyError(Object error) {
     final lower = error.toString().toLowerCase();
     if (lower.contains('does not support tex')) {
       return 'Keystone does not support TEX sends yet.';
@@ -190,23 +224,14 @@ class _MobileSwapKeystoneSignScreenState
     if (lower.contains('proposal not found')) {
       return 'Transaction expired before it could be signed.';
     }
-    if (lower.contains('broadcast') || lower.contains('sendtransaction')) {
-      return 'Transaction could not be broadcast.';
-    }
     if (lower.contains('pczt') || lower.contains('signature')) {
       return 'Keystone signature could not be applied.';
     }
+    if (lower.contains('broadcast') || lower.contains('sendtransaction')) {
+      return 'Transaction could not be broadcast.';
+    }
     return 'ZEC deposit signing could not be completed.';
   }
-}
-
-class _SwapSigningDisplayError implements Exception {
-  const _SwapSigningDisplayError(this.message);
-
-  final String message;
-
-  @override
-  String toString() => message;
 }
 
 String _shortSwapValue(String? value) {

--- a/lib/src/features/swap/screens/mobile/mobile_swap_keystone_sign_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_keystone_sign_screen.dart
@@ -1,0 +1,216 @@
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../../main.dart' show log;
+import '../../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../../rust/api/sync.dart' as rust_sync;
+import '../../../keystone/widgets/mobile_keystone_pczt_signing_flow.dart';
+import '../../../send/screens/mobile/mobile_send_screen.dart'
+    show MobileSaplingParamsSheet;
+import '../../../send/services/sapling_params.dart';
+import '../../models/swap_deposit_broadcast_result.dart';
+import '../../models/swap_keystone_broadcast_result.dart';
+import '../../models/swap_models.dart';
+import '../../providers/swap_hardware_signing_service.dart';
+
+class MobileSwapKeystoneSignArgs {
+  const MobileSwapKeystoneSignArgs({required this.intent});
+
+  final SwapIntent intent;
+}
+
+class MobileSwapKeystoneSignScreen extends ConsumerStatefulWidget {
+  const MobileSwapKeystoneSignScreen({required this.args, super.key});
+
+  final MobileSwapKeystoneSignArgs args;
+
+  @override
+  ConsumerState<MobileSwapKeystoneSignScreen> createState() =>
+      _MobileSwapKeystoneSignScreenState();
+}
+
+class _MobileSwapKeystoneSignScreenState
+    extends ConsumerState<MobileSwapKeystoneSignScreen> {
+  SwapHardwarePcztDraft? _draft;
+  SaplingParamsStatus? _saplingParams;
+
+  @override
+  Widget build(BuildContext context) {
+    return MobileKeystonePcztSigningFlow(
+      title: 'Sign ZEC deposit',
+      failedTitle: 'Keystone signing failed',
+      description:
+          'Use your Keystone wallet to scan this transaction QR code. '
+          'Follow the steps on your device.',
+      preparePczt: _preparePczt,
+      onSigned: _handleSignedPczt,
+      friendlyError: _friendlyError,
+      keyPrefix: 'mobile_swap_keystone_sign',
+      finalizingSignatureLabel: 'Broadcasting ZEC deposit...',
+      logTag: 'MobileSwapKeystoneSign',
+    );
+  }
+
+  Future<MobileKeystonePcztSigningPayload> _preparePczt(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final accountUuid = widget.args.intent.accountUuid;
+    if (accountUuid == null || accountUuid.trim().isEmpty) {
+      throw StateError('Swap account is missing.');
+    }
+
+    final service = ref.read(swapHardwareSigningServiceProvider);
+    final draft = await service.createZecDepositPczt(
+      accountUuid: accountUuid,
+      intent: widget.args.intent,
+    );
+
+    SaplingParamsStatus? saplingParams;
+    if (draft.needsSaplingParams) {
+      saplingParams = await loadSaplingParamsStatus();
+      if (!saplingParams.complete) {
+        if (!context.mounted) {
+          throw const MobileKeystonePcztSigningAborted();
+        }
+        final confirmed = await _confirmSaplingParamsDownload(context);
+        if (!confirmed) {
+          throw const MobileKeystonePcztSigningAborted();
+        }
+        await downloadMissingSaplingParams(
+          saplingParams,
+          log: (message) => log('MobileSwapKeystoneSign: $message'),
+        );
+        saplingParams = await loadSaplingParamsStatus();
+      }
+    }
+
+    final urParts = await service.encodeSigningUrParts(draft: draft);
+    _draft = draft;
+    _saplingParams = saplingParams;
+
+    return MobileKeystonePcztSigningPayload(
+      urParts: urParts,
+      pcztWithProofs: service.addProofsForSigning(
+        draft: draft,
+        spendParamsPath: draft.needsSaplingParams
+            ? saplingParams!.spendPath
+            : null,
+        outputParamsPath: draft.needsSaplingParams
+            ? saplingParams!.outputPath
+            : null,
+      ),
+    );
+  }
+
+  Future<bool> _confirmSaplingParamsDownload(BuildContext context) async {
+    final confirmed = await showAppMobileSheet<bool>(
+      context: context,
+      isDismissible: false,
+      builder: (_) => const MobileSaplingParamsSheet(),
+    );
+    return confirmed == true;
+  }
+
+  Future<void> _handleSignedPczt(
+    BuildContext context,
+    WidgetRef ref,
+    List<int> pcztWithProofs,
+    Uint8List signedPczt,
+  ) async {
+    final draft = _draft;
+    final saplingParams = _saplingParams;
+    if (draft == null || (draft.needsSaplingParams && saplingParams == null)) {
+      throw StateError('Keystone signing could not be prepared.');
+    }
+
+    final result = await ref
+        .read(swapHardwareSigningServiceProvider)
+        .broadcastSignedPczt(
+          pcztWithProofsBytes: pcztWithProofs,
+          pcztWithSignaturesBytes: signedPczt,
+          spendParamsPath: draft.needsSaplingParams
+              ? saplingParams!.spendPath
+              : null,
+          outputParamsPath: draft.needsSaplingParams
+              ? saplingParams!.outputPath
+              : null,
+        );
+    log(
+      'MobileSwapKeystoneSign: broadcast complete kind=zecDeposit '
+      'tx=${_shortSwapValue(result.txid)} status=${result.status}',
+    );
+
+    if (!_hasBroadcastTxid(result)) {
+      throw _SwapSigningDisplayError(
+        result.message ??
+            'The transaction status is uncertain. Refresh activity before trying again.',
+      );
+    }
+    if (result.status != SwapDepositBroadcastStatus.broadcasted) {
+      log(
+        'MobileSwapKeystoneSign: broadcast returned ${result.status} '
+        'with tx=${_shortSwapValue(result.txid)}; recording txid for swap tracking',
+      );
+    }
+    if (!context.mounted) return;
+    context.pop(
+      SwapKeystoneBroadcastResult(
+        txHash: result.txid,
+        status: result.status,
+        message: result.message,
+      ),
+    );
+  }
+
+  bool _hasBroadcastTxid(rust_sync.ExtractAndBroadcastPcztResult result) {
+    return switch (result.status) {
+      SwapDepositBroadcastStatus.broadcasted ||
+      SwapDepositBroadcastStatus.broadcastUnknown ||
+      SwapDepositBroadcastStatus.broadcastedStorageFailed =>
+        result.txid.trim().isNotEmpty,
+      _ => false,
+    };
+  }
+
+  String _friendlyError(Object error) {
+    if (error is _SwapSigningDisplayError) {
+      return error.message;
+    }
+    final lower = error.toString().toLowerCase();
+    if (lower.contains('does not support tex')) {
+      return 'Keystone does not support TEX sends yet.';
+    }
+    if (lower.contains('sapling') || lower.contains('download')) {
+      return 'Required proving parameters could not be prepared.';
+    }
+    if (lower.contains('proposal not found')) {
+      return 'Transaction expired before it could be signed.';
+    }
+    if (lower.contains('broadcast') || lower.contains('sendtransaction')) {
+      return 'Transaction could not be broadcast.';
+    }
+    if (lower.contains('pczt') || lower.contains('signature')) {
+      return 'Keystone signature could not be applied.';
+    }
+    return 'ZEC deposit signing could not be completed.';
+  }
+}
+
+class _SwapSigningDisplayError implements Exception {
+  const _SwapSigningDisplayError(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+String _shortSwapValue(String? value) {
+  if (value == null) return 'null';
+  if (value.length <= 16) return value;
+  return '${value.substring(0, 7)}...${value.substring(value.length - 6)}';
+}

--- a/lib/src/features/swap/widgets/swap_activity_panel.dart
+++ b/lib/src/features/swap/widgets/swap_activity_panel.dart
@@ -17,6 +17,7 @@ import '../models/swap_activity_status_mapper.dart';
 import '../models/swap_keystone_broadcast_result.dart';
 import '../models/swap_models.dart';
 import '../providers/swap_state_provider.dart';
+import '../screens/mobile/mobile_swap_keystone_sign_screen.dart';
 import 'swap_deposit_tokens_page_content.dart';
 import 'swap_keystone_signing_overlay.dart';
 import 'mobile/mobile_swap_review_header.dart';
@@ -107,14 +108,23 @@ class _SwapActivityDetailSurfaceState
         _isHardwareIntent(intent) &&
         intent.direction == SwapDirection.zecToExternal &&
         !(intent.depositTxHash?.trim().isNotEmpty ?? false);
+    final request = needsAutoSign
+        ? _SwapKeystoneSigningRequest(
+            intentId: intent.id,
+            accountUuid: intent.accountUuid ?? _activeAccountUuid ?? '',
+            removeUnsentIntentOnCancel: true,
+          )
+        : null;
+    if (request != null && widget.layout == SwapActivityDetailLayout.mobile) {
+      setState(() => _initialIntentApplied = true);
+      unawaited(_openMobileKeystoneSigning(intent, request));
+      return;
+    }
+
     setState(() {
       _initialIntentApplied = true;
-      if (needsAutoSign) {
-        _keystoneSigningRequest = _SwapKeystoneSigningRequest(
-          intentId: intent.id,
-          accountUuid: intent.accountUuid ?? _activeAccountUuid ?? '',
-          removeUnsentIntentOnCancel: true,
-        );
+      if (request != null) {
+        _keystoneSigningRequest = request;
       }
     });
   }
@@ -176,11 +186,17 @@ class _SwapActivityDetailSurfaceState
   }
 
   void _signZecDeposit(SwapIntent intent) {
+    final request = _SwapKeystoneSigningRequest(
+      intentId: intent.id,
+      accountUuid: intent.accountUuid ?? _activeAccountUuid ?? '',
+    );
+    if (widget.layout == SwapActivityDetailLayout.mobile) {
+      unawaited(_openMobileKeystoneSigning(intent, request));
+      return;
+    }
+
     setState(() {
-      _keystoneSigningRequest = _SwapKeystoneSigningRequest(
-        intentId: intent.id,
-        accountUuid: intent.accountUuid ?? _activeAccountUuid ?? '',
-      );
+      _keystoneSigningRequest = request;
     });
   }
 
@@ -205,6 +221,36 @@ class _SwapActivityDetailSurfaceState
     final request = _keystoneSigningRequest;
     if (request == null) return;
     _closeKeystoneSigning();
+    _submitKeystoneDepositBroadcast(context, request, result);
+  }
+
+  Future<void> _openMobileKeystoneSigning(
+    SwapIntent intent,
+    _SwapKeystoneSigningRequest request,
+  ) async {
+    final result = await context.push<SwapKeystoneBroadcastResult>(
+      '/swap/keystone-sign',
+      extra: MobileSwapKeystoneSignArgs(intent: intent),
+    );
+    if (!mounted) return;
+    if (result == null) {
+      if (request.removeUnsentIntentOnCancel) {
+        unawaited(
+          ref
+              .read(swapStateProvider.notifier)
+              .removeUnsentHardwareDepositIntent(request.intentId),
+        );
+      }
+      return;
+    }
+    _submitKeystoneDepositBroadcast(context, request, result);
+  }
+
+  void _submitKeystoneDepositBroadcast(
+    BuildContext context,
+    _SwapKeystoneSigningRequest request,
+    SwapKeystoneBroadcastResult result,
+  ) {
     unawaited(
       ref
           .read(swapStateProvider.notifier)

--- a/lib/src/features/swap/widgets/swap_activity_panel.dart
+++ b/lib/src/features/swap/widgets/swap_activity_panel.dart
@@ -228,7 +228,7 @@ class _SwapActivityDetailSurfaceState
     SwapIntent intent,
     _SwapKeystoneSigningRequest request,
   ) async {
-    final result = await context.push<SwapKeystoneBroadcastResult>(
+    final result = await context.push<MobileSwapKeystoneSignResult>(
       '/swap/keystone-sign',
       extra: MobileSwapKeystoneSignArgs(intent: intent),
     );
@@ -243,7 +243,16 @@ class _SwapActivityDetailSurfaceState
       }
       return;
     }
-    _submitKeystoneDepositBroadcast(context, request, result);
+    switch (result) {
+      case MobileSwapKeystoneSignSuccess(:final broadcast):
+        _submitKeystoneDepositBroadcast(context, request, broadcast);
+      case MobileSwapKeystoneSignFailure(:final message):
+        showAppToast(
+          _toastContext(context),
+          message,
+          iconName: AppIcons.warning,
+        );
+    }
   }
 
   void _submitKeystoneDepositBroadcast(

--- a/test/core/navigation/mobile_routes_test.dart
+++ b/test/core/navigation/mobile_routes_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart' show CupertinoRouteTransitionMixin;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
@@ -19,9 +20,13 @@ import 'package:zcash_wallet/src/features/activity/screens/mobile/mobile_activit
 import 'package:zcash_wallet/src/features/home/screens/mobile/mobile_home_screen.dart';
 import 'package:zcash_wallet/src/features/receive/screens/mobile/mobile_receive_screen.dart';
 import 'package:zcash_wallet/src/features/send/screens/mobile/mobile_send_screen.dart';
+import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
+import 'package:zcash_wallet/src/features/swap/providers/swap_hardware_signing_service.dart';
+import 'package:zcash_wallet/src/features/swap/screens/mobile/mobile_swap_keystone_sign_screen.dart';
 import 'package:zcash_wallet/src/features/swap/screens/mobile/mobile_swap_screen.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
 
 import '../../fakes/fake_sync_notifier.dart';
 
@@ -56,7 +61,11 @@ GoRouter _router() => GoRouter(
   routes: buildMobileRoutes(entryRoutes: const []),
 );
 
-Widget _app(GoRouter router, {bool swapFeatureEnabled = true}) => ProviderScope(
+Widget _app(
+  GoRouter router, {
+  bool swapFeatureEnabled = true,
+  List<Override> overrides = const [],
+}) => ProviderScope(
   overrides: [
     appBootstrapProvider.overrideWithValue(_bootstrap()),
     swapFeatureEnabledProvider.overrideWithValue(swapFeatureEnabled),
@@ -71,6 +80,7 @@ Widget _app(GoRouter router, {bool swapFeatureEnabled = true}) => ProviderScope(
         ),
       ),
     ),
+    ...overrides,
   ],
   child: MaterialApp.router(
     routerConfig: router,
@@ -179,6 +189,37 @@ void main() {
     expect(route, isA<CupertinoRouteTransitionMixin<dynamic>>());
   });
 
+  testWidgets('swap Keystone signing route pushes a Cupertino page', (
+    tester,
+  ) async {
+    final router = _router();
+    await tester.pumpWidget(
+      _app(
+        router,
+        overrides: [
+          swapHardwareSigningServiceProvider.overrideWithValue(
+            const _FakeSwapHardwareSigningService(),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    unawaited(
+      router.push<void>(
+        '/swap/keystone-sign',
+        extra: MobileSwapKeystoneSignArgs(intent: _hardwareSwapIntent),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MobileSwapKeystoneSignScreen), findsOneWidget);
+    final route = ModalRoute.of(
+      tester.element(find.byType(MobileSwapKeystoneSignScreen)),
+    );
+    expect(route, isA<CupertinoRouteTransitionMixin<dynamic>>());
+  });
+
   testWidgets('receive pushes over a Cupertino shell page', (tester) async {
     await tester.pumpWidget(_app(_router()));
     await tester.pumpAndSettle();
@@ -199,4 +240,61 @@ void main() {
     expect(find.byType(MobileReceiveScreen), findsNothing);
     expect(find.byType(MobileHomeScreen), findsOneWidget);
   });
+}
+
+final _hardwareSwapIntent = SwapIntent(
+  id: 'swap-route-hardware',
+  pair: 'ZEC -> USDC',
+  sellAmount: '0.003 ZEC',
+  receiveEstimate: '0.21 USDC',
+  provider: 'NEAR Intents',
+  status: SwapIntentStatus.awaitingDeposit,
+  nextAction: 'Deposit ZEC',
+  sellAmountBaseUnits: BigInt.from(300000),
+  direction: SwapDirection.zecToExternal,
+  externalAsset: SwapAsset.usdc,
+  depositAddress: 't1route-deposit',
+  accountUuid: 'account-1',
+);
+
+class _FakeSwapHardwareSigningService implements SwapHardwareSigningService {
+  const _FakeSwapHardwareSigningService();
+
+  @override
+  Future<SwapHardwarePcztDraft> createZecDepositPczt({
+    required String accountUuid,
+    required SwapIntent intent,
+  }) async {
+    return SwapHardwarePcztDraft(
+      pcztBytes: const [1, 2, 3],
+      needsSaplingParams: false,
+      feeZatoshi: BigInt.zero,
+    );
+  }
+
+  @override
+  Future<List<String>> encodeSigningUrParts({
+    required SwapHardwarePcztDraft draft,
+  }) async {
+    return const ['ur:zcash-pczt/route-test'];
+  }
+
+  @override
+  Future<List<int>> addProofsForSigning({
+    required SwapHardwarePcztDraft draft,
+    String? spendParamsPath,
+    String? outputParamsPath,
+  }) async {
+    return const [4, 5, 6];
+  }
+
+  @override
+  Future<rust_sync.ExtractAndBroadcastPcztResult> broadcastSignedPczt({
+    required List<int> pcztWithProofsBytes,
+    required List<int> pcztWithSignaturesBytes,
+    String? spendParamsPath,
+    String? outputParamsPath,
+  }) {
+    throw UnimplementedError();
+  }
 }

--- a/test/core/navigation/mobile_routes_test.dart
+++ b/test/core/navigation/mobile_routes_test.dart
@@ -189,7 +189,7 @@ void main() {
     expect(route, isA<CupertinoRouteTransitionMixin<dynamic>>());
   });
 
-  testWidgets('swap Keystone signing route pushes a Cupertino page', (
+  testWidgets('swap Keystone signing route pushes a non-opaque modal page', (
     tester,
   ) async {
     final router = _router();
@@ -217,7 +217,8 @@ void main() {
     final route = ModalRoute.of(
       tester.element(find.byType(MobileSwapKeystoneSignScreen)),
     );
-    expect(route, isA<CupertinoRouteTransitionMixin<dynamic>>());
+    expect(route?.opaque, isFalse);
+    expect(route?.barrierColor, isNotNull);
   });
 
   testWidgets('receive pushes over a Cupertino shell page', (tester) async {

--- a/test/features/keystone/mobile_keystone_pczt_signing_flow_test.dart
+++ b/test/features/keystone/mobile_keystone_pczt_signing_flow_test.dart
@@ -13,6 +13,311 @@ import 'package:zcash_wallet/src/features/keystone/widgets/mobile_keystone_pczt_
 import 'package:zcash_wallet/src/services/qr_scanner.dart';
 
 void main() {
+  testWidgets('shows an animated QR skeleton while preparing PCZT', (
+    tester,
+  ) async {
+    final prepareCompleter = Completer<MobileKeystonePcztSigningPayload>();
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, _) => Center(
+            child: TextButton(
+              key: const ValueKey('open_signing'),
+              onPressed: () => context.push('/sign'),
+              child: const Text('Open signing'),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/sign',
+          builder: (_, _) => MobileKeystonePcztSigningFlow(
+            title: 'Confirm transaction',
+            description: 'Scan with Keystone.',
+            keyPrefix: 'test_keystone_sign',
+            preparePczt: (_, _) => prepareCompleter.future,
+            onSigned: (_, _, _, _) async {},
+            friendlyError: (_) => 'Keystone signing failed.',
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, child) =>
+              AppTheme(data: AppThemeData.light, child: child!),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('open_signing')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 120));
+
+    final placeholder = find.byKey(
+      const ValueKey('test_keystone_sign_qr_placeholder'),
+    );
+    expect(placeholder, findsOneWidget);
+    expect(
+      find.descendant(of: placeholder, matching: find.byType(AnimatedBuilder)),
+      findsOneWidget,
+    );
+    expect(find.text('Loading the QR code ...'), findsOneWidget);
+
+    prepareCompleter.complete(
+      MobileKeystonePcztSigningPayload(
+        urParts: const ['ur:zcash-pczt/test'],
+        pcztWithProofs: Future.value(const [1, 2, 3]),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      find.byKey(const ValueKey('test_keystone_sign_qr_stage')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('sizes the QR modal surface to the Figma mobile frame', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(393, 852);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, _) => Center(
+            child: TextButton(
+              key: const ValueKey('open_signing'),
+              onPressed: () => context.push('/sign'),
+              child: const Text('Open signing'),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/sign',
+          builder: (_, _) => MobileKeystonePcztSigningFlow(
+            title: 'Confirm transaction',
+            description: 'Scan with Keystone.',
+            keyPrefix: 'test_keystone_sign',
+            preparePczt: (_, _) async => MobileKeystonePcztSigningPayload(
+              urParts: const ['ur:zcash-pczt/test'],
+              pcztWithProofs: Future.value(const [1, 2, 3]),
+            ),
+            onSigned: (_, _, _, _) async {},
+            friendlyError: (_) => 'Keystone signing failed.',
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, child) =>
+              AppTheme(data: AppThemeData.light, child: child!),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('open_signing')));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getSize(find.byKey(const ValueKey('test_keystone_sign_modal'))),
+      const Size(393, 701),
+    );
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('test_keystone_sign_modal_surface')),
+      ),
+      const Size(361, 669),
+    );
+    expect(
+      tester.getSize(find.byKey(const ValueKey('test_keystone_sign_qr_stage'))),
+      const Size(321, 321),
+    );
+  });
+
+  testWidgets('ignores repeated scan completions after signing failure', (
+    tester,
+  ) async {
+    ValueChanged<ScanResult>? completeScan;
+    var signedCalls = 0;
+
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, _) => Center(
+            child: TextButton(
+              key: const ValueKey('open_signing'),
+              onPressed: () => context.push('/sign'),
+              child: const Text('Open signing'),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/sign',
+          builder: (_, _) => MobileKeystonePcztSigningFlow(
+            title: 'Confirm transaction',
+            description: 'Scan with Keystone.',
+            keyPrefix: 'test_keystone_sign',
+            preparePczt: (_, _) async => MobileKeystonePcztSigningPayload(
+              urParts: const ['ur:zcash-pczt/test'],
+              pcztWithProofs: Future.value(const [1, 2, 3]),
+            ),
+            signedPcztDecoder: (_) async => Uint8List.fromList(const [9]),
+            scannerBuilder: (_, onComplete, _) {
+              completeScan = onComplete;
+              return const SizedBox(key: ValueKey('fake_keystone_scanner'));
+            },
+            forceScannerActiveForTesting: true,
+            onSigned: (_, _, _, _) async {
+              signedCalls++;
+              throw StateError('broadcast rejected');
+            },
+            friendlyError: (_) => 'Transaction could not be broadcast.',
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, child) =>
+              AppTheme(data: AppThemeData.light, child: child!),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('open_signing')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('test_keystone_sign_get_signature')),
+    );
+    await tester.pump();
+
+    completeScan!(const ScanResult(urType: 'zcash-pczt', data: [1]));
+    await tester.pump();
+    await tester.pump();
+
+    expect(signedCalls, 1);
+    expect(find.text('Transaction could not be broadcast.'), findsOneWidget);
+
+    completeScan!(const ScanResult(urType: 'zcash-pczt', data: [1]));
+    await tester.pump();
+    await tester.pump();
+
+    expect(signedCalls, 1);
+    expect(find.text('Transaction could not be broadcast.'), findsOneWidget);
+  });
+
+  testWidgets('resets scanner session after signed PCZT decode failure', (
+    tester,
+  ) async {
+    ValueChanged<ScanResult>? completeScan;
+    Object? initialResetToken;
+    Object? retryResetToken;
+    var decodeCalls = 0;
+    var signedCalls = 0;
+
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, _) => Center(
+            child: TextButton(
+              key: const ValueKey('open_signing'),
+              onPressed: () => context.push('/sign'),
+              child: const Text('Open signing'),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/sign',
+          builder: (_, _) => MobileKeystonePcztSigningFlow(
+            title: 'Confirm transaction',
+            description: 'Scan with Keystone.',
+            keyPrefix: 'test_keystone_sign',
+            preparePczt: (_, _) async => MobileKeystonePcztSigningPayload(
+              urParts: const ['ur:zcash-pczt/test'],
+              pcztWithProofs: Future.value(const [1, 2, 3]),
+            ),
+            signedPcztDecoder: (_) async {
+              decodeCalls++;
+              if (decodeCalls == 1) {
+                throw StateError('invalid signed pczt');
+              }
+              return Uint8List.fromList(const [9]);
+            },
+            scannerBuilder: (_, onComplete, resetToken) {
+              completeScan = onComplete;
+              initialResetToken ??= resetToken;
+              retryResetToken = resetToken;
+              return const SizedBox(key: ValueKey('fake_keystone_scanner'));
+            },
+            forceScannerActiveForTesting: true,
+            onSigned: (_, _, _, _) async {
+              signedCalls++;
+            },
+            friendlyError: (_) => 'Keystone signing failed.',
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, child) =>
+              AppTheme(data: AppThemeData.light, child: child!),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('open_signing')));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('test_keystone_sign_get_signature')),
+    );
+    await tester.pump();
+
+    completeScan!(const ScanResult(urType: 'zcash-pczt', data: [1]));
+    await tester.pump();
+    await tester.pump();
+
+    expect(decodeCalls, 1);
+    expect(signedCalls, 0);
+    expect(
+      find.text('This QR code could not be decoded as a Keystone signature.'),
+      findsOneWidget,
+    );
+    expect(retryResetToken, isNot(equals(initialResetToken)));
+
+    completeScan!(const ScanResult(urType: 'zcash-pczt', data: [1]));
+    await tester.pump();
+    await tester.pump();
+
+    expect(decodeCalls, 2);
+    expect(signedCalls, 1);
+  });
+
   testWidgets('cancel controls stay disabled while finalizing signed PCZT', (
     tester,
   ) async {
@@ -44,7 +349,7 @@ void main() {
               pcztWithProofs: Future.value(const [1, 2, 3]),
             ),
             signedPcztDecoder: (_) async => Uint8List.fromList(const [9]),
-            scannerBuilder: (_, onComplete) {
+            scannerBuilder: (_, onComplete, _) {
               completeScan = onComplete;
               return const SizedBox(key: ValueKey('fake_keystone_scanner'));
             },

--- a/test/features/keystone/mobile_keystone_pczt_signing_flow_test.dart
+++ b/test/features/keystone/mobile_keystone_pczt_signing_flow_test.dart
@@ -376,7 +376,7 @@ void main() {
 
     expect(find.text('Confirm with Keystone'), findsOneWidget);
     expect(find.text('Scan with your Keystone'), findsOneWidget);
-    expect(find.text('Get Signature'), findsOneWidget);
+    expect(find.text('Get signature'), findsOneWidget);
     expect(find.text('Close'), findsOneWidget);
 
     await tester.tap(

--- a/test/features/keystone/mobile_keystone_pczt_signing_flow_test.dart
+++ b/test/features/keystone/mobile_keystone_pczt_signing_flow_test.dart
@@ -1,0 +1,109 @@
+@Tags(['mobile'])
+library;
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart';
+import 'package:zcash_wallet/src/services/qr_scanner.dart';
+
+void main() {
+  testWidgets('cancel controls stay disabled while finalizing signed PCZT', (
+    tester,
+  ) async {
+    final signingCompleter = Completer<void>();
+    ValueChanged<ScanResult>? completeScan;
+
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, _) => Center(
+            child: TextButton(
+              key: const ValueKey('open_signing'),
+              onPressed: () => context.push('/sign'),
+              child: const Text('Open signing'),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/sign',
+          builder: (_, _) => MobileKeystonePcztSigningFlow(
+            title: 'Confirm transaction',
+            description: 'Scan with Keystone.',
+            keyPrefix: 'test_keystone_sign',
+            finalizingSignatureLabel: 'Broadcasting ZEC deposit...',
+            preparePczt: (_, _) async => MobileKeystonePcztSigningPayload(
+              urParts: const ['ur:zcash-pczt/test'],
+              pcztWithProofs: Future.value(const [1, 2, 3]),
+            ),
+            signedPcztDecoder: (_) async => Uint8List.fromList(const [9]),
+            scannerBuilder: (_, onComplete) {
+              completeScan = onComplete;
+              return const SizedBox(key: ValueKey('fake_keystone_scanner'));
+            },
+            onSigned: (_, _, _, _) => signingCompleter.future,
+            friendlyError: (_) => 'Keystone signing failed.',
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, child) =>
+              AppTheme(data: AppThemeData.light, child: child!),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byKey(const ValueKey('open_signing')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('test_keystone_sign_next')));
+    await tester.pump();
+    expect(find.byKey(const ValueKey('fake_keystone_scanner')), findsOneWidget);
+
+    completeScan!(const ScanResult(urType: 'zcash-pczt', data: [1]));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Broadcasting ZEC deposit...'), findsOneWidget);
+
+    final cancelButton = tester.widget<AppButton>(
+      find.byKey(const ValueKey('test_keystone_sign_cancel')),
+    );
+    expect(cancelButton.onPressed, isNull);
+
+    final cancelText = tester.widget<Text>(
+      find.descendant(
+        of: find.byKey(const ValueKey('test_keystone_sign_cancel')),
+        matching: find.text('Cancel'),
+      ),
+    );
+    expect(cancelText.style?.color, isNot(Colors.white));
+
+    await tester.tap(
+      find.byKey(const ValueKey('test_keystone_sign_cancel')),
+      warnIfMissed: false,
+    );
+    await tester.pump();
+    expect(find.byKey(const ValueKey('fake_keystone_scanner')), findsOneWidget);
+
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+    expect(find.byKey(const ValueKey('fake_keystone_scanner')), findsOneWidget);
+
+    signingCompleter.complete();
+    await tester.pump();
+  });
+}

--- a/test/features/keystone/mobile_keystone_pczt_signing_flow_test.dart
+++ b/test/features/keystone/mobile_keystone_pczt_signing_flow_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
-import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/features/keystone/widgets/mobile_keystone_pczt_signing_flow.dart';
 import 'package:zcash_wallet/src/services/qr_scanner.dart';
 
@@ -49,6 +48,7 @@ void main() {
               completeScan = onComplete;
               return const SizedBox(key: ValueKey('fake_keystone_scanner'));
             },
+            forceScannerActiveForTesting: true,
             onSigned: (_, _, _, _) => signingCompleter.future,
             friendlyError: (_) => 'Keystone signing failed.',
           ),
@@ -69,7 +69,14 @@ void main() {
     await tester.tap(find.byKey(const ValueKey('open_signing')));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byKey(const ValueKey('test_keystone_sign_next')));
+    expect(find.text('Confirm with Keystone'), findsOneWidget);
+    expect(find.text('Scan with your Keystone'), findsOneWidget);
+    expect(find.text('Get Signature'), findsOneWidget);
+    expect(find.text('Close'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const ValueKey('test_keystone_sign_get_signature')),
+    );
     await tester.pump();
     expect(find.byKey(const ValueKey('fake_keystone_scanner')), findsOneWidget);
 
@@ -79,21 +86,8 @@ void main() {
 
     expect(find.text('Broadcasting ZEC deposit...'), findsOneWidget);
 
-    final cancelButton = tester.widget<AppButton>(
-      find.byKey(const ValueKey('test_keystone_sign_cancel')),
-    );
-    expect(cancelButton.onPressed, isNull);
-
-    final cancelText = tester.widget<Text>(
-      find.descendant(
-        of: find.byKey(const ValueKey('test_keystone_sign_cancel')),
-        matching: find.text('Cancel'),
-      ),
-    );
-    expect(cancelText.style?.color, isNot(Colors.white));
-
     await tester.tap(
-      find.byKey(const ValueKey('test_keystone_sign_cancel')),
+      find.bySemanticsLabel('Close scanner'),
       warnIfMissed: false,
     );
     await tester.pump();

--- a/test/features/swap/mobile_swap_keystone_signing_test.dart
+++ b/test/features/swap/mobile_swap_keystone_signing_test.dart
@@ -89,9 +89,56 @@ void main() {
     final args = capturedExtra! as MobileSwapKeystoneSignArgs;
     expect(args.intent.id, _hardwareIntent.id);
   });
+
+  testWidgets('mobile Keystone broadcast failure shows toast without submit', (
+    tester,
+  ) async {
+    const failureMessage = 'Keystone signature could not be applied.';
+    final swapProvider = _FakeSwapProvider();
+    final router = GoRouter(
+      initialLocation: '/activity/swap/${_hardwareIntent.id}',
+      routes: [
+        GoRoute(
+          path: '/activity/swap/:swapId',
+          builder: (_, state) => SwapActivityDetailSurface(
+            intentId: state.pathParameters['swapId'] ?? '',
+            returnTarget: SwapActivityReturnTarget.activity,
+            layout: SwapActivityDetailLayout.mobile,
+          ),
+        ),
+        GoRoute(
+          path: '/swap/keystone-sign',
+          builder: (context, _) => Center(
+            child: TextButton(
+              key: const ValueKey('fail_mobile_swap_keystone_signing'),
+              onPressed: () => context.pop(
+                const MobileSwapKeystoneSignFailure(failureMessage),
+              ),
+              child: const Text('Fail signing'),
+            ),
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(_app(router, swapProvider: swapProvider));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Deposit ZEC'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey('fail_mobile_swap_keystone_signing')),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text(failureMessage), findsOneWidget);
+    expect(swapProvider.submitDepositTransactionCalls, 0);
+  });
 }
 
-Widget _app(GoRouter router) {
+Widget _app(GoRouter router, {_FakeSwapProvider? swapProvider}) {
   final activityStore = _FakeSwapActivityStore([_hardwareIntent]);
   final preferencesStore = _FakeSwapComposerPreferencesStore();
   return ProviderScope(
@@ -101,7 +148,7 @@ Widget _app(GoRouter router) {
       swapInitialIntentsProvider.overrideWithValue([_hardwareIntent]),
       swapActivityStoreProvider.overrideWithValue(activityStore),
       swapComposerPreferencesStoreProvider.overrideWithValue(preferencesStore),
-      swapIntentProvider.overrideWithValue(const _FakeSwapProvider()),
+      swapIntentProvider.overrideWithValue(swapProvider ?? _FakeSwapProvider()),
       swapStatusPollIntervalProvider.overrideWithValue(
         const Duration(hours: 1),
       ),
@@ -152,7 +199,7 @@ final _bootstrap = AppBootstrapState(
 );
 
 class _FakeSwapProvider implements SwapProvider {
-  const _FakeSwapProvider();
+  int submitDepositTransactionCalls = 0;
 
   @override
   String get providerLabel => 'NEAR Intents';
@@ -183,8 +230,24 @@ class _FakeSwapProvider implements SwapProvider {
     required String txHash,
     String? depositMemo,
     String? nearSenderAccount,
-  }) {
-    throw UnimplementedError();
+  }) async {
+    submitDepositTransactionCalls += 1;
+    return SwapIntentSnapshot(
+      id: _hardwareIntent.id,
+      providerLabel: providerLabel,
+      pairText: _hardwareIntent.pair,
+      sellAmountText: _hardwareIntent.sellAmount,
+      receiveEstimateText: _hardwareIntent.receiveEstimate,
+      status: SwapIntentStatus.depositObserved,
+      nextAction: 'Waiting for swap provider confirmation.',
+      originChainTxHash: txHash,
+      depositInstruction: const SwapDepositInstruction(
+        asset: SwapAsset.zec,
+        address: 't1mobile-deposit',
+        expiresInLabel: '1 hour',
+        reuseWarning: 'Use this deposit address only once.',
+      ),
+    );
   }
 }
 

--- a/test/features/swap/mobile_swap_keystone_signing_test.dart
+++ b/test/features/swap/mobile_swap_keystone_signing_test.dart
@@ -1,0 +1,235 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/config/swap_feature_config.dart';
+import 'package:zcash_wallet/src/core/profile_pictures.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/swap/models/swap_activity_navigation.dart';
+import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
+import 'package:zcash_wallet/src/features/swap/providers/swap_activity_store.dart';
+import 'package:zcash_wallet/src/features/swap/providers/swap_composer_preferences_store.dart';
+import 'package:zcash_wallet/src/features/swap/providers/swap_state_provider.dart';
+import 'package:zcash_wallet/src/features/swap/screens/mobile/mobile_swap_keystone_sign_screen.dart';
+import 'package:zcash_wallet/src/features/swap/widgets/swap_activity_panel.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
+
+final _hardwareIntent = SwapIntent(
+  id: 'swap-mobile-hardware',
+  pair: 'ZEC -> USDC',
+  sellAmount: '0.0030 ZEC',
+  receiveEstimate: '0.21 USDC',
+  provider: 'NEAR Intents',
+  status: SwapIntentStatus.awaitingDeposit,
+  nextAction: 'Sign and send the ZEC deposit with Keystone.',
+  sellAmountBaseUnits: BigInt.from(300000),
+  direction: SwapDirection.zecToExternal,
+  externalAsset: SwapAsset.usdc,
+  depositAddress: 't1mobile-deposit',
+  accountUuid: 'account-1',
+);
+
+void main() {
+  setUp(() {
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.platformDispatcher.views.first
+      ..physicalSize = const Size(390, 844)
+      ..devicePixelRatio = 1.0;
+  });
+
+  testWidgets('hardware ZEC deposit opens mobile Keystone signing route', (
+    tester,
+  ) async {
+    Object? capturedExtra;
+    final router = GoRouter(
+      initialLocation: '/activity/swap/${_hardwareIntent.id}',
+      routes: [
+        GoRoute(
+          path: '/activity/swap/:swapId',
+          builder: (_, state) => SwapActivityDetailSurface(
+            intentId: state.pathParameters['swapId'] ?? '',
+            returnTarget: SwapActivityReturnTarget.activity,
+            layout: SwapActivityDetailLayout.mobile,
+          ),
+        ),
+        GoRoute(
+          path: '/swap/keystone-sign',
+          builder: (_, state) {
+            capturedExtra = state.extra;
+            return const SizedBox(
+              key: ValueKey('mobile_swap_keystone_sign_route'),
+            );
+          },
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(_app(router));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Deposit ZEC'), findsOneWidget);
+    expect(find.text('Get signature'), findsNothing);
+
+    await tester.tap(find.text('Deposit ZEC'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey('mobile_swap_keystone_sign_route')),
+      findsOneWidget,
+    );
+    expect(capturedExtra, isA<MobileSwapKeystoneSignArgs>());
+    final args = capturedExtra! as MobileSwapKeystoneSignArgs;
+    expect(args.intent.id, _hardwareIntent.id);
+  });
+}
+
+Widget _app(GoRouter router) {
+  final activityStore = _FakeSwapActivityStore([_hardwareIntent]);
+  final preferencesStore = _FakeSwapComposerPreferencesStore();
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap),
+      swapFeatureEnabledProvider.overrideWithValue(true),
+      swapInitialIntentsProvider.overrideWithValue([_hardwareIntent]),
+      swapActivityStoreProvider.overrideWithValue(activityStore),
+      swapComposerPreferencesStoreProvider.overrideWithValue(preferencesStore),
+      swapIntentProvider.overrideWithValue(const _FakeSwapProvider()),
+      swapStatusPollIntervalProvider.overrideWithValue(
+        const Duration(hours: 1),
+      ),
+      swapPriceRefreshIntervalProvider.overrideWithValue(
+        const Duration(hours: 1),
+      ),
+      syncProvider.overrideWith(
+        () => FakeSyncNotifier(
+          SyncState(
+            accountUuid: 'account-1',
+            hasAccountScopedData: true,
+            spendableBalance: BigInt.from(100000000),
+            totalBalance: BigInt.from(100000000),
+          ),
+        ),
+      ),
+    ],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+    ),
+  );
+}
+
+final _bootstrap = AppBootstrapState(
+  initialLocation: '/activity/swap/${_hardwareIntent.id}',
+  initialAccountState: const AccountState(
+    accounts: [
+      AccountInfo(
+        uuid: 'account-1',
+        name: 'Keystone',
+        order: 0,
+        profilePictureId: kDefaultProfilePictureId,
+        isHardware: true,
+      ),
+    ],
+    activeAccountUuid: 'account-1',
+    activeAddress: 'u1mobilehardware',
+  ),
+  initialSyncSnapshot: AppSyncSnapshot.empty,
+  network: 'main',
+  rpcEndpointConfig: defaultRpcEndpointConfig('main'),
+  themeMode: ThemeMode.system,
+  privacyModeEnabled: false,
+  isPasswordConfigured: true,
+  isUnlocked: true,
+  passwordRotationRecoveryFailed: false,
+);
+
+class _FakeSwapProvider implements SwapProvider {
+  const _FakeSwapProvider();
+
+  @override
+  String get providerLabel => 'NEAR Intents';
+
+  @override
+  Future<List<SwapAsset>> listSupportedExternalAssets() async {
+    return const [SwapAsset.usdc];
+  }
+
+  @override
+  Future<SwapQuote> quote(SwapQuoteRequest request) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SwapIntentSnapshot> startSwap(SwapQuote quote) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SwapIntentSnapshot> getStatus(String intentId, {String? depositMemo}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<SwapIntentSnapshot> submitDepositTransaction({
+    required String depositAddress,
+    required String txHash,
+    String? depositMemo,
+    String? nearSenderAccount,
+  }) {
+    throw UnimplementedError();
+  }
+}
+
+class _FakeSwapActivityStore implements SwapActivityStore {
+  _FakeSwapActivityStore(List<SwapIntent> initialIntents)
+    : _records = [
+        for (final intent in initialIntents)
+          SwapIntentRecord.fromIntent(intent),
+      ];
+
+  List<SwapIntentRecord> _records;
+
+  @override
+  Future<List<SwapIntentRecord>> loadRecords({
+    required String accountUuid,
+  }) async {
+    return _records;
+  }
+
+  @override
+  Future<void> saveRecords({
+    required String accountUuid,
+    required List<SwapIntentRecord> records,
+  }) async {
+    _records = records;
+  }
+
+  @override
+  Future<void> deleteForAccount({required String accountUuid}) async {
+    _records = [];
+  }
+}
+
+class _FakeSwapComposerPreferencesStore
+    implements SwapComposerPreferencesStore {
+  @override
+  Future<SwapComposerPreferences?> loadPreferences({
+    required String accountUuid,
+  }) async {
+    return null;
+  }
+
+  @override
+  Future<void> savePreferences({
+    required String accountUuid,
+    required SwapComposerPreferences preferences,
+  }) async {}
+}


### PR DESCRIPTION
## Summary

- Extract the mobile Keystone PCZT QR/signature scan round trip into a shared signing flow.
- Refactor mobile send signing to use that shared flow without changing its route contract.
- Add a mobile swap Keystone signing route for ZEC deposit swaps, matching the send-style full-screen QR -> scan flow.
- Prevent cancel/back navigation while a signed PCZT is being finalized so a broadcast cannot succeed without the activity record receiving the tx hash.

## Root Cause

Mobile swap was reusing the desktop-style Keystone signing overlay. That overlay opens `/send/keystone/scan` for signatures, but the mobile router does not expose that desktop scan route. Send already uses a separate full-screen mobile signing route, so swap needed the same mobile signing flow boundary instead of the desktop modal path.

## Commits

1. `Share mobile Keystone signing flow`
2. `Add mobile swap Keystone signing route`

## Validation

- `fvm flutter analyze`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/swap/mobile_swap_keystone_signing_test.dart`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/core/navigation/mobile_routes_test.dart`

## Notes

- Tested on a physical iPhone with a profile mobile build because iOS cannot launch Flutter debug builds from the home screen without Flutter tooling or Xcode.