### PR TITLE
[codex] Update Keystone connect instructions

### DIFF
--- a/lib/src/features/onboarding/keystone/keystone_how_to_connect_screen.dart
+++ b/lib/src/features/onboarding/keystone/keystone_how_to_connect_screen.dart
@@ -141,7 +141,7 @@ class _TitleBlock extends StatelessWidget {
 class _KeystoneInstructionsPanel extends StatelessWidget {
   const _KeystoneInstructionsPanel();
 
-  static const double _height = 392;
+  static const double _minHeight = 392;
   static const _radius = BorderRadius.all(Radius.circular(24));
 
   @override
@@ -152,7 +152,7 @@ class _KeystoneInstructionsPanel extends StatelessWidget {
 
     return Container(
       width: double.infinity,
-      height: _height,
+      constraints: const BoxConstraints(minHeight: _minHeight),
       padding: const EdgeInsets.symmetric(
         horizontal: AppSpacing.sm,
         vertical: AppSpacing.md,
@@ -181,10 +181,8 @@ class _KeystoneInstructionsPanel extends StatelessWidget {
             iconName: AppIcons.importWallet,
             stepNumber: 1,
             title: 'Check Keystone firmware',
-            body:
-                'Check if your Keystone device has the latest version of '
-                'the Cypherpunk firmware, update or install if needed.',
-            action: _FirmwareButton(),
+            body: null,
+            action: _FirmwareBodyWithLink(),
           ),
           SizedBox(height: AppSpacing.md),
           _Divider(),
@@ -296,21 +294,50 @@ class _InstructionHeader extends StatelessWidget {
   }
 }
 
-class _FirmwareButton extends StatelessWidget {
-  const _FirmwareButton();
+class _FirmwareBodyWithLink extends StatelessWidget {
+  const _FirmwareBodyWithLink();
 
   @override
   Widget build(BuildContext context) {
-    return Align(
-      alignment: Alignment.centerRight,
+    final bodyStyle = AppTypography.bodyMedium.copyWith(
+      color: context.colors.text.primary,
+    );
+    return Text.rich(
+      TextSpan(
+        style: bodyStyle,
+        children: const [
+          TextSpan(
+            text:
+                'Make sure your Keystone is on the latest Cypherpunk firmware. ',
+          ),
+          WidgetSpan(
+            alignment: PlaceholderAlignment.middle,
+            child: _FirmwareInlineLink(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FirmwareInlineLink extends StatelessWidget {
+  const _FirmwareInlineLink();
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      link: true,
+      label: 'Download Keystone firmware',
       child: AppButton(
         onPressed: _openKeystoneFirmware,
         variant: AppButtonVariant.ghost,
-        size: AppButtonSize.medium,
-        minWidth: 96,
-        iconGap: 0,
+        size: AppButtonSize.small,
+        height: 24,
+        contentPadding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+        iconGap: AppSpacing.xxs,
         leading: const AppIcon(AppIcons.link),
-        child: const Text('Keystone Firmware'),
+        child: const Text('link'),
       ),
     );
   }
@@ -319,48 +346,98 @@ class _FirmwareButton extends StatelessWidget {
 class _ConnectionSteps extends StatelessWidget {
   const _ConnectionSteps();
 
-  static const _steps = [
-    'Unlock your Keystone.',
-    'Tap the ... Menu, then go to Sync',
-    'Open the Zcash QR Code in order to connect.',
-    'Grant camera access in your laptop settings and proceed with QR code '
-        'import to Vizor.',
+  static const _keystoneSteps = [
+    'Tap ••• (top right), then Connect software wallet.',
+    'Select Vizor (or ZODL)',
   ];
+  static const _vizorSteps = ['Scan the dynamic QR code on your Keystone.'];
 
   static const _markerWidth = 15.0;
   static const _markerGap = 6.0;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
+    return const Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        for (var i = 0; i < _steps.length; i++)
-          _ConnectionStepRow(index: i + 1, text: _steps[i]),
+        _ConnectionStepGroup(
+          title: 'On your Keystone',
+          startIndex: 1,
+          steps: _keystoneSteps,
+        ),
+        SizedBox(height: AppSpacing.sm),
+        _ConnectionStepGroup(
+          title: 'On Vizor',
+          startIndex: 3,
+          steps: _vizorSteps,
+        ),
+      ],
+    );
+  }
+}
+
+class _ConnectionStepGroup extends StatelessWidget {
+  const _ConnectionStepGroup({
+    required this.title,
+    required this.startIndex,
+    required this.steps,
+  });
+
+  final String title;
+  final int startIndex;
+  final List<String> steps;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: AppTypography.bodyMediumStrong.copyWith(
+            color: context.colors.text.accent,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.xxs),
+        for (var i = 0; i < steps.length; i++)
+          _ConnectionStepRow(
+            index: startIndex + i,
+            text: steps[i],
+            isFirstInGroup: i == 0,
+          ),
       ],
     );
   }
 }
 
 class _ConnectionStepRow extends StatelessWidget {
-  const _ConnectionStepRow({required this.index, required this.text});
+  const _ConnectionStepRow({
+    required this.index,
+    required this.text,
+    required this.isFirstInGroup,
+  });
 
   final int index;
   final String text;
+  final bool isFirstInGroup;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
     final style = AppTypography.bodyMedium.copyWith(color: colors.text.primary);
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        SizedBox(
-          width: _ConnectionSteps._markerWidth,
-          child: Text('$index.', style: style, textAlign: TextAlign.right),
-        ),
-        const SizedBox(width: _ConnectionSteps._markerGap),
-        Expanded(child: Text(text, style: style)),
-      ],
+    return Padding(
+      padding: EdgeInsets.only(top: isFirstInGroup ? 0 : AppSpacing.xxs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: _ConnectionSteps._markerWidth,
+            child: Text('$index.', style: style, textAlign: TextAlign.right),
+          ),
+          const SizedBox(width: _ConnectionSteps._markerGap),
+          Expanded(child: Text(text, style: style)),
+        ],
+      ),
     );
   }
 }

--- a/lib/src/features/onboarding/mobile/mobile_keystone_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_keystone_screens.dart
@@ -37,7 +37,6 @@ class MobileKeystoneIntroScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colors = context.colors;
     return MobileOnboardingStepScaffold(
       progress: 0.2,
       onBack: () => Navigator.of(context).maybePop(),
@@ -64,31 +63,7 @@ class MobileKeystoneIntroScreen extends StatelessWidget {
                   title: '1. Check Keystone firmware',
                 ),
                 const SizedBox(height: AppSpacing.sm),
-                Text(
-                  'Check if your Keystone device has the latest version of '
-                  'the Cypherpunk firmware, update or install if needed.',
-                  style: AppTypography.bodyMedium.copyWith(
-                    color: colors.text.primary,
-                  ),
-                ),
-                const SizedBox(height: AppSpacing.sm),
-                Semantics(
-                  button: true,
-                  link: true,
-                  label: 'Keystone firmware link',
-                  child: AppButton(
-                    variant: AppButtonVariant.ghost,
-                    size: AppButtonSize.medium,
-                    height: 36,
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: AppSpacing.xs,
-                    ),
-                    leading: const AppIcon(AppIcons.link),
-                    onPressed: () =>
-                        unawaited(launchAboutUrl(_keystoneFirmwareUrl)),
-                    child: const Text('Keystone firmware'),
-                  ),
-                ),
+                const _FirmwareBodyWithLink(),
               ],
             ),
           ),
@@ -103,37 +78,25 @@ class MobileKeystoneIntroScreen extends StatelessWidget {
                   title: '2. Prepare to connect',
                 ),
                 const SizedBox(height: AppSpacing.sm),
+                const _StepGroupHeading('On your Keystone'),
+                const SizedBox(height: AppSpacing.xxs),
                 for (final (i, step) in const [
-                  'Unlock your Keystone.',
-                  'Tap the ... menu, then go to Sync.',
-                  'Open the Zcash QR code in order to connect.',
-                  'Allow camera access when prompted and scan the QR code '
-                      'with your phone.',
-                ].indexed) ...[
-                  if (i > 0) const SizedBox(height: AppSpacing.xxs),
-                  Row(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      SizedBox(
-                        width: 20,
-                        child: Text(
-                          '${i + 1}.',
-                          style: AppTypography.bodyMedium.copyWith(
-                            color: colors.text.primary,
-                          ),
-                        ),
-                      ),
-                      Expanded(
-                        child: Text(
-                          step,
-                          style: AppTypography.bodyMedium.copyWith(
-                            color: colors.text.primary,
-                          ),
-                        ),
-                      ),
-                    ],
+                  'Tap ••• (top right), then Connect software wallet.',
+                  'Select Vizor (or ZODL)',
+                ].indexed)
+                  _NumberedStep(
+                    index: i + 1,
+                    text: step,
+                    isFirstInGroup: i == 0,
                   ),
-                ],
+                const SizedBox(height: AppSpacing.sm),
+                const _StepGroupHeading('On Vizor'),
+                const SizedBox(height: AppSpacing.xxs),
+                const _NumberedStep(
+                  index: 3,
+                  text: 'Scan the dynamic QR code on your Keystone.',
+                  isFirstInGroup: true,
+                ),
               ],
             ),
           ),
@@ -161,6 +124,99 @@ class _KeystoneIntroCard extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(AppSpacing.xxs),
         child: child,
+      ),
+    );
+  }
+}
+
+class _FirmwareBodyWithLink extends StatelessWidget {
+  const _FirmwareBodyWithLink();
+
+  @override
+  Widget build(BuildContext context) {
+    final bodyStyle = AppTypography.bodyMedium.copyWith(
+      color: context.colors.text.primary,
+    );
+    return Text.rich(
+      TextSpan(
+        style: bodyStyle,
+        children: const [
+          TextSpan(
+            text:
+                'Make sure your Keystone is on the latest Cypherpunk firmware. ',
+          ),
+          WidgetSpan(
+            alignment: PlaceholderAlignment.middle,
+            child: _FirmwareInlineLink(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FirmwareInlineLink extends StatelessWidget {
+  const _FirmwareInlineLink();
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      link: true,
+      label: 'Download Keystone firmware',
+      child: AppButton(
+        variant: AppButtonVariant.ghost,
+        size: AppButtonSize.small,
+        height: 24,
+        contentPadding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+        iconGap: AppSpacing.xxs,
+        leading: const AppIcon(AppIcons.link),
+        onPressed: () => unawaited(launchAboutUrl(_keystoneFirmwareUrl)),
+        child: const Text('link'),
+      ),
+    );
+  }
+}
+
+class _StepGroupHeading extends StatelessWidget {
+  const _StepGroupHeading(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: AppTypography.bodyMediumStrong.copyWith(
+        color: context.colors.text.accent,
+      ),
+    );
+  }
+}
+
+class _NumberedStep extends StatelessWidget {
+  const _NumberedStep({
+    required this.index,
+    required this.text,
+    required this.isFirstInGroup,
+  });
+
+  final int index;
+  final String text;
+  final bool isFirstInGroup;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final style = AppTypography.bodyMedium.copyWith(color: colors.text.primary);
+    return Padding(
+      padding: EdgeInsets.only(top: isFirstInGroup ? 0 : AppSpacing.xxs),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(width: 20, child: Text('$index.', style: style)),
+          Expanded(child: Text(text, style: style)),
+        ],
       ),
     );
   }

--- a/test/features/onboarding/keystone_how_to_connect_screen_test.dart
+++ b/test/features/onboarding/keystone_how_to_connect_screen_test.dart
@@ -22,9 +22,22 @@ void main() {
     expect(find.text('Connect Keystone'), findsOneWidget);
     expect(find.text('Prepare your Keystone wallet'), findsOneWidget);
     expect(find.text('1. Check Keystone firmware'), findsOneWidget);
-    expect(find.text('Keystone Firmware'), findsOneWidget);
+    expect(find.textContaining('Make sure your Keystone'), findsOneWidget);
+    expect(find.text('link'), findsOneWidget);
+    expect(find.text('Download firmware'), findsNothing);
     expect(find.text('2. Prepare to connect'), findsOneWidget);
-    expect(find.text('Unlock your Keystone.'), findsOneWidget);
+    expect(find.text('On your Keystone'), findsOneWidget);
+    expect(find.text('Unlock it.'), findsNothing);
+    expect(
+      find.text('Tap ••• (top right), then Connect software wallet.'),
+      findsOneWidget,
+    );
+    expect(find.text('Select Vizor (or ZODL)'), findsOneWidget);
+    expect(find.text('On Vizor'), findsOneWidget);
+    expect(
+      find.text('Scan the dynamic QR code on your Keystone.'),
+      findsOneWidget,
+    );
     expect(find.text("I'm ready now"), findsOneWidget);
   });
 

--- a/test/features/onboarding/mobile_keystone_intro_screen_test.dart
+++ b/test/features/onboarding/mobile_keystone_intro_screen_test.dart
@@ -57,6 +57,9 @@ void main() {
     expect(find.byKey(prepareCardKey), findsOneWidget);
     expect(find.text('1. Check Keystone firmware'), findsOneWidget);
     expect(find.text('2. Prepare to connect'), findsOneWidget);
+    expect(find.textContaining('Make sure your Keystone'), findsOneWidget);
+    expect(find.text('link'), findsOneWidget);
+    expect(find.text('Download firmware'), findsNothing);
 
     expect(tester.getSize(find.byKey(firmwareCardKey)).width, 361);
     expect(tester.getSize(find.byKey(prepareCardKey)).width, 361);
@@ -74,10 +77,16 @@ void main() {
 
     expect(find.text('Continue'), findsOneWidget);
     expect(find.text('Tell me how Zcash works'), findsNothing);
+    expect(find.text('On your Keystone'), findsOneWidget);
+    expect(find.text('Unlock it.'), findsNothing);
     expect(
-      find.text(
-        'Allow camera access when prompted and scan the QR code with your phone.',
-      ),
+      find.text('Tap ••• (top right), then Connect software wallet.'),
+      findsOneWidget,
+    );
+    expect(find.text('Select Vizor (or ZODL)'), findsOneWidget);
+    expect(find.text('On Vizor'), findsOneWidget);
+    expect(
+      find.text('Scan the dynamic QR code on your Keystone.'),
       findsOneWidget,
     );
 

--- a/test/widgetbook/mobile_keystone_use_cases_test.dart
+++ b/test/widgetbook/mobile_keystone_use_cases_test.dart
@@ -128,7 +128,12 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(find.text('Connect Keystone'), findsOneWidget);
     expect(find.text('1. Check Keystone firmware'), findsOneWidget);
+    expect(find.text('link'), findsOneWidget);
+    expect(find.text('Download firmware'), findsNothing);
     expect(find.text('2. Prepare to connect'), findsOneWidget);
+    expect(find.text('On your Keystone'), findsOneWidget);
+    expect(find.text('Unlock it.'), findsNothing);
+    expect(find.text('On Vizor'), findsOneWidget);
     expect(find.text('Continue'), findsOneWidget);
   });
 


### PR DESCRIPTION
## Summary
- Update Keystone onboarding copy for firmware and connection steps
- Make the firmware URL an inline compact link in the body copy
- Align mobile, desktop, and widgetbook test expectations with the new instructions

## Validation
- fvm flutter test test/features/onboarding/keystone_how_to_connect_screen_test.dart
- fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/onboarding/mobile_keystone_intro_screen_test.dart test/widgetbook/mobile_keystone_use_cases_test.dart
- fvm flutter analyze
- Ran on iPhone 17 simulator with --dart-define=VIZOR_FORM_FACTOR=mobile