### PR TITLE
[codex] Allow deleting seed anchor accounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,13 +224,16 @@ What this means for our DB shape:
 - Calling `create_account()` later is not a clean rescue mechanism for an `Imported`-only DB because that path itself depends on seed-aware initialization and seed relevance.
 
 **Account deletion and reset invariants.** Per-account deletion is allowed for
-`Imported` accounts and for a `Derived` account only if another `Derived`
-account remains. Dart enforces this in `AccountNotifier.removeAccount`, and
-Rust `delete_account` repeats the check inside the wallet DB write lock so the
-invariant does not depend on a single UI caller. Deleting the last remaining
-account is not a per-account delete; the Accounts UI treats it as a full wallet
-reset, clearing the wallet DB, secure storage, active account state, and routing
-back to onboarding.
+any listed account while another account remains, including the initial
+`Derived` seed-anchor account. Deleting that account can leave the wallet DB
+containing only `Imported` accounts, which is the same migration tradeoff
+accepted for Keystone-first onboarding: current schema and UFVK-tolerant
+migrations should work, but a future seed-requiring migration may need a product
+recovery path. Deleting the last remaining account is not a per-account delete;
+the Accounts UI treats it as a full wallet reset, clearing the wallet DB, secure
+storage, active account state, and routing back to onboarding. Dart
+`AccountNotifier.removeAccount` and Rust `delete_account` still validate the
+target account exists before removing account-scoped wallet rows.
 
 **Account identification**: `AccountUuid` (UUID string like `"550e8400-e29b-41d4-a716-446655440000"`). Passed as `String` between Dart and Rust via `Uuid::parse_str()` / `Uuid::to_string()`.
 
@@ -382,7 +385,7 @@ rust/src/
 │   ├── mod.rs          # pub mod keys, sync, sync_engine, keystone
 │   ├── keys.rs         # Key derivation, mnemonic, account creation (Derived + Imported),
 │   │                    # list_accounts, ensure_db_initialized, parse_account_uuid,
-│   │                    # delete_account with last-Derived seed-anchor guard,
+│   │                    # delete_account with account existence check and row cleanup,
 │   │                    # init_db_and_create_account (software first-account bootstrap),
 │   │                    # import_hardware_account (Keystone UFVK import;
 │   │                    # Keystone-first is allowed)

--- a/lib/src/features/accounts/screens/accounts_screen.dart
+++ b/lib/src/features/accounts/screens/accounts_screen.dart
@@ -693,9 +693,6 @@ class _AccountsList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final accountCount = otherAccounts.length + (activeAccount == null ? 0 : 1);
-    final seedAnchorCount =
-        otherAccounts.where((account) => account.isSeedAnchor).length +
-        (activeAccount?.isSeedAnchor == true ? 1 : 0);
     return Align(
       alignment: Alignment.topCenter,
       child: SizedBox(
@@ -723,11 +720,7 @@ class _AccountsList extends StatelessWidget {
                       onSendZec: onSendZec,
                       onEditAccount: onEditAccount,
                       onRemove: onRemoveAccount,
-                      showRemove: _AccountsList._canRemoveAccount(
-                        activeAccount!,
-                        accountCount,
-                        seedAnchorCount,
-                      ),
+                      showRemove: _AccountsList._canRemoveAccount(accountCount),
                       initiallyOpenMenu:
                           initialOpenMenuAccountUuid == activeAccount!.uuid,
                     ),
@@ -748,7 +741,6 @@ class _AccountsList extends StatelessWidget {
                     _OtherAccountsRows(
                       accounts: otherAccounts,
                       accountCount: accountCount,
-                      seedAnchorCount: seedAnchorCount,
                       onSelectAccount: onSelectAccount,
                       onCopyAddress: onCopyAddress,
                       onSendZec: onSendZec,
@@ -766,14 +758,8 @@ class _AccountsList extends StatelessWidget {
     );
   }
 
-  static bool _canRemoveAccount(
-    AccountInfo account,
-    int accountCount,
-    int seedAnchorCount,
-  ) {
-    if (accountCount == 1) return true;
-    if (!account.isSeedAnchor) return true;
-    return seedAnchorCount > 1;
+  static bool _canRemoveAccount(int accountCount) {
+    return accountCount > 0;
   }
 
   static double _accountsRowsHeight(int count) {
@@ -821,7 +807,6 @@ class _OtherAccountsRows extends StatelessWidget {
   const _OtherAccountsRows({
     required this.accounts,
     required this.accountCount,
-    required this.seedAnchorCount,
     required this.onSelectAccount,
     required this.onCopyAddress,
     required this.onSendZec,
@@ -832,7 +817,6 @@ class _OtherAccountsRows extends StatelessWidget {
 
   final List<AccountInfo> accounts;
   final int accountCount;
-  final int seedAnchorCount;
   final Future<void> Function(String uuid) onSelectAccount;
   final ValueChanged<AccountInfo> onCopyAddress;
   final ValueChanged<AccountInfo> onSendZec;
@@ -867,11 +851,7 @@ class _OtherAccountsRows extends StatelessWidget {
           onSendZec: onSendZec,
           onEditAccount: onEditAccount,
           onRemove: onRemoveAccount,
-          showRemove: _AccountsList._canRemoveAccount(
-            account,
-            accountCount,
-            seedAnchorCount,
-          ),
+          showRemove: _AccountsList._canRemoveAccount(accountCount),
           initiallyOpenMenu: initialOpenMenuAccountUuid == account.uuid,
         ),
       );
@@ -1270,9 +1250,8 @@ class _AccountContextMenu extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // Figma: the current account's menu is Edit account / Copy address;
-    // other accounts get Copy address / Send ZEC / Edit account. Remove
-    // stays gated by the account-invariant rules rather than the mock,
-    // since it is the only path to remove (or reset via) an account.
+    // other accounts get Copy address / Send ZEC / Edit account. Remove is
+    // shown for every account and becomes reset when it is the last one.
     return AppContextMenu(
       width: _width,
       children: [

--- a/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
+++ b/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
@@ -86,13 +86,10 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
     }
   }
 
-  /// Mirrors the desktop eligibility rule: the last remaining account
-  /// is removable because removal becomes a full app reset.
+  /// Mirrors the desktop eligibility rule: account removal is available for
+  /// every listed account. The last remaining account becomes a full app reset.
   bool _canRemove(AccountInfo account, List<AccountInfo> accounts) {
-    if (accounts.length == 1) return true;
-    if (!account.isSeedAnchor) return true;
-    final seedAnchorCount = accounts.where((a) => a.isSeedAnchor).length;
-    return seedAnchorCount > 1;
+    return accounts.any((candidate) => candidate.uuid == account.uuid);
   }
 
   /// Anchored dark popup at the row's ⋯ button — Figma `Accounts` row

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -454,15 +454,6 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       for (final account in prev.accounts)
         if (account.uuid != uuid) account,
     ];
-    final seedAnchorCount = prev.accounts
-        .where((account) => account.isSeedAnchor)
-        .length;
-    if (target.isSeedAnchor && seedAnchorCount <= 1 && remaining.isNotEmpty) {
-      throw StateError(
-        'The last seed anchor account cannot be removed while other accounts remain.',
-      );
-    }
-
     final dbPath = await _getDbPath();
     final network = await _getNetwork();
     await _resetVotingProcessStateForAccount(uuid, dbPath: dbPath);

--- a/rust/src/wallet/keys.rs
+++ b/rust/src/wallet/keys.rs
@@ -427,7 +427,9 @@ pub fn import_hardware_account(
     Ok((uuid_str, addr_str))
 }
 
-/// Init DB + create first account as Derived (so seed relevance checks pass on future migrations).
+/// Init DB + create the bootstrap software account as Derived.
+/// This pins the DB seed fingerprint for seed-aware initialization, but the
+/// account may later be deleted like any other non-final account.
 /// Returns (account_uuid, unified_address).
 pub fn init_db_and_create_account(
     db_path: &str,
@@ -443,8 +445,8 @@ pub fn init_db_and_create_account(
     let (account_id, usk) = with_wallet_db_write_lock("keys.create_account", || {
         let mut db = open_wallet_db_for_mutation(db_path, network)?;
 
-        // First account uses create_account (Derived) — ensures at least one Derived account
-        // exists for future init_wallet_db seed relevance checks.
+        // The bootstrap account uses create_account (Derived) so initial
+        // seed-aware DB setup records the seed fingerprint.
         db.create_account(name, seed, &birthday, None)
             .map_err(|e| format!("Failed to create account: {e}"))
     })?;
@@ -610,39 +612,9 @@ pub fn delete_account(
     let account_id = parse_account_uuid(account_uuid)?;
     with_wallet_db_write_lock("keys.delete_account", || {
         let db = open_wallet_db_for_mutation(db_path, network)?;
-        let target = db
-            .get_account(account_id)
+        db.get_account(account_id)
             .map_err(|e| format!("Failed to load account: {e}"))?
             .ok_or_else(|| format!("Account not found: {}", account_id.expose_uuid()))?;
-        let account_ids = db
-            .get_account_ids()
-            .map_err(|e| format!("Failed to list accounts: {e}"))?;
-
-        if matches!(target.source(), AccountSource::Derived { .. }) {
-            let mut has_remaining_accounts = false;
-            let mut has_other_seed_anchor = false;
-            for id in &account_ids {
-                if *id == account_id {
-                    continue;
-                }
-                has_remaining_accounts = true;
-                let account = db
-                    .get_account(*id)
-                    .map_err(|e| format!("Failed to load account: {e}"))?
-                    .ok_or_else(|| format!("Account not found: {}", id.expose_uuid()))?;
-                if matches!(account.source(), AccountSource::Derived { .. }) {
-                    has_other_seed_anchor = true;
-                    break;
-                }
-            }
-
-            if has_remaining_accounts && !has_other_seed_anchor {
-                return Err(
-                    "The last seed anchor account cannot be removed while other accounts remain."
-                        .into(),
-                );
-            }
-        }
 
         // zcash_client_sqlite 0.19.5 has a named-parameter bug in
         // wallet::delete_account: the sent_notes rewrite binds `:address`
@@ -2293,7 +2265,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_account_rejects_last_seed_anchor_with_remaining_accounts() {
+    fn test_delete_account_allows_last_seed_anchor_with_remaining_accounts() {
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join("wallet.db");
         let db_path_str = db_path.to_str().unwrap();
@@ -2320,12 +2292,12 @@ mod tests {
         )
         .unwrap();
 
-        let error = delete_account(db_path_str, WalletNetwork::Main, &first_uuid).unwrap_err();
-        assert!(error.contains("last seed anchor account cannot be removed"));
+        delete_account(db_path_str, WalletNetwork::Main, &first_uuid).unwrap();
 
         let accounts = list_accounts(db_path_str, WalletNetwork::Main).unwrap();
-        assert_eq!(accounts.len(), 2);
-        assert!(accounts.iter().any(|account| account.uuid == first_uuid));
+        assert_eq!(accounts.len(), 1);
+        assert!(accounts.iter().all(|account| account.uuid != first_uuid));
+        assert!(accounts.iter().all(|account| !account.is_seed_anchor));
     }
 
     fn seed_internal_sent_note_to_account(db_path: &str, from_uuid: &str, to_uuid: &str) {

--- a/test/features/accounts/accounts_screen_test.dart
+++ b/test/features/accounts/accounts_screen_test.dart
@@ -316,7 +316,7 @@ void main() {
     expect(find.text('Remove account'), findsNothing);
   });
 
-  testWidgets('current account menu shows edit actions and copy only', (
+  testWidgets('current account menu shows edit, copy, and remove actions', (
     tester,
   ) async {
     await tester.binding.setSurfaceSize(const Size(1512, 982));
@@ -335,8 +335,12 @@ void main() {
     expect(find.text('Copy address'), findsOneWidget);
     expect(find.text('Send ZEC'), findsNothing);
     expect(find.text('Edit account'), findsOneWidget);
-    expect(find.text('Remove account'), findsNothing);
-    _expectVerticalTextOrder(tester, const ['Edit account', 'Copy address']);
+    expect(find.text('Remove account'), findsOneWidget);
+    _expectVerticalTextOrder(tester, const [
+      'Edit account',
+      'Copy address',
+      'Remove account',
+    ]);
   });
 
   testWidgets('current imported account can be removed', (tester) async {
@@ -548,52 +552,51 @@ void main() {
     );
   });
 
-  testWidgets(
-    'seed anchor is protected while imported accounts can be removed',
-    (tester) async {
-      await tester.binding.setSurfaceSize(const Size(1512, 982));
-      addTearDown(() async {
-        await tester.binding.setSurfaceSize(null);
-      });
+  testWidgets('seed anchor and imported accounts can be removed', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(1512, 982));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
 
-      const accountState = AccountState(
-        accounts: [
-          AccountInfo(uuid: 'account-1', name: 'Imported First', order: 0),
-          AccountInfo(
-            uuid: 'account-2',
-            name: 'Seed Anchor',
-            order: 1,
-            isSeedAnchor: true,
-          ),
-          AccountInfo(uuid: 'account-3', name: 'Imported Other', order: 2),
-        ],
-        activeAccountUuid: 'account-1',
-        activeAddress: 'u1accountsaddress',
-      );
-      await tester.pumpWidget(
-        _accountsHarness(
-          accountNotifier: () => _FakeAccountNotifier(accountState),
+    const accountState = AccountState(
+      accounts: [
+        AccountInfo(uuid: 'account-1', name: 'Imported First', order: 0),
+        AccountInfo(
+          uuid: 'account-2',
+          name: 'Seed Anchor',
+          order: 1,
+          isSeedAnchor: true,
         ),
-      );
-      await tester.pump();
+        AccountInfo(uuid: 'account-3', name: 'Imported Other', order: 2),
+      ],
+      activeAccountUuid: 'account-1',
+      activeAddress: 'u1accountsaddress',
+    );
+    await tester.pumpWidget(
+      _accountsHarness(
+        accountNotifier: () => _FakeAccountNotifier(accountState),
+      ),
+    );
+    await tester.pump();
 
-      await tester.tap(
-        find.byKey(const ValueKey('accounts_row_menu_button_account-3')),
-      );
-      await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('accounts_row_menu_button_account-3')),
+    );
+    await tester.pumpAndSettle();
 
-      expect(find.text('Remove account'), findsOneWidget);
+    expect(find.text('Remove account'), findsOneWidget);
 
-      await tester.tapAt(const Offset(20, 20));
-      await tester.pumpAndSettle();
-      await tester.tap(
-        find.byKey(const ValueKey('accounts_row_menu_button_account-2')),
-      );
-      await tester.pumpAndSettle();
+    await tester.tapAt(const Offset(20, 20));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('accounts_row_menu_button_account-2')),
+    );
+    await tester.pumpAndSettle();
 
-      expect(find.text('Remove account'), findsNothing);
-    },
-  );
+    expect(find.text('Remove account'), findsOneWidget);
+  });
 
   testWidgets('seed anchor can be removed when another seed anchor remains', (
     tester,

--- a/test/features/accounts/mobile_accounts_screen_test.dart
+++ b/test/features/accounts/mobile_accounts_screen_test.dart
@@ -253,8 +253,9 @@ void main() {
     expect(safeArea.bottom, isFalse);
   });
 
-  testWidgets('imported accounts offer removal; the last seed anchor with '
-      'other accounts does not', (tester) async {
+  testWidgets('imported accounts and seed anchors offer removal', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       _app(
         AccountState(
@@ -291,11 +292,11 @@ void main() {
     await tester.tapAt(const Offset(10, 10));
     await tester.pumpAndSettle();
 
-    // Last seed anchor with another account: edit only.
+    // Seed anchor with another account: edit + remove.
     await tester.tap(find.byKey(const ValueKey('mobile_accounts_menu_a')));
     await tester.pumpAndSettle();
     expect(find.text('Edit account'), findsOneWidget);
-    expect(find.text('Remove account'), findsNothing);
+    expect(find.text('Remove account'), findsOneWidget);
   });
 
   testWidgets('the last remaining seed account resets the app on removal', (

--- a/test/widgetbook/accounts_use_cases_test.dart
+++ b/test/widgetbook/accounts_use_cases_test.dart
@@ -18,7 +18,7 @@ void main() {
     expect(find.text('Remove account'), findsOneWidget);
   });
 
-  testWidgets('accounts current menu use case renders edit actions and copy', (
+  testWidgets('accounts current menu use case renders account actions', (
     tester,
   ) async {
     await _pumpAccountsUseCase(tester, buildAccountsCurrentMenuUseCase);
@@ -27,7 +27,7 @@ void main() {
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Copy address'), findsOneWidget);
     expect(find.text('Send ZEC'), findsNothing);
-    expect(find.text('Remove account'), findsNothing);
+    expect(find.text('Remove account'), findsOneWidget);
   });
 
   testWidgets('accounts modal use cases render each modal state', (


### PR DESCRIPTION
## Summary
- Allow deleting the initial Derived seed-anchor account when other accounts remain.
- Keep last-account removal as the full wallet reset path.
- Update desktop/mobile account menu tests, Rust deletion coverage, and architecture notes for Imported-only DB tradeoffs.

## Why
The previous guard made the first software account effectively undeletable in multi-account wallets. Imported-only DBs are already accepted for Keystone-first onboarding, so this aligns software seed-anchor deletion with that policy while preserving the full reset behavior for the final account.

## Validation
- `git diff --check`
- `fvm flutter test test/features/accounts/accounts_screen_test.dart test/features/accounts/mobile_accounts_screen_test.dart test/widgetbook/accounts_use_cases_test.dart test/providers/account_provider_test.dart`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/accounts/mobile_accounts_screen_test.dart`
- `fvm flutter analyze`
- `cd rust && cargo test delete_account`