### PR TITLE
Improve swap error messages

### DIFF
--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_transport.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_transport.dart
@@ -1,11 +1,19 @@
 part of 'near_intents_one_click_swap_adapter.dart';
 
 class OneClickApiException implements Exception {
-  const OneClickApiException(this.message, {this.operation, this.statusCode});
+  const OneClickApiException(
+    this.message, {
+    this.operation,
+    this.statusCode,
+    this.providerMessage,
+    this.responseBody,
+  });
 
   final String message;
   final String? operation;
   final int? statusCode;
+  final String? providerMessage;
+  final String? responseBody;
 
   @override
   String toString() => 'OneClickApiException: $message';
@@ -109,7 +117,24 @@ void _expectSuccess(OneClickHttpResponse response, String operation) {
     '(${response.statusCode}): ${response.body}',
     operation: operation,
     statusCode: response.statusCode,
+    providerMessage: _providerMessageFromResponse(response.body),
+    responseBody: response.body,
   );
+}
+
+String? _providerMessageFromResponse(String body) {
+  try {
+    final decoded = jsonDecode(body);
+    if (decoded is Map<String, dynamic>) {
+      final message = decoded['message'];
+      if (message is String && message.trim().isNotEmpty) {
+        return message.trim();
+      }
+    }
+  } catch (_) {
+    return null;
+  }
+  return null;
 }
 
 Map<String, Object?> _withoutNulls(Map<String, Object?> value) {

--- a/lib/src/features/swap/providers/swap_failure_policy.dart
+++ b/lib/src/features/swap/providers/swap_failure_policy.dart
@@ -13,6 +13,7 @@ enum SwapFailureOperation {
 
 enum SwapFailureCategory {
   unsupportedAsset,
+  amountTooLow,
   amountPrecision,
   invalidRouteOrAddress,
   noQuoteOrLiquidity,
@@ -20,6 +21,7 @@ enum SwapFailureCategory {
   networkTimeout,
   unverifiedResponse,
   retryLater,
+  zecDepositFunding,
   walletPreflight,
   depositNotFound,
   depositRejected,
@@ -45,6 +47,11 @@ SwapFailureCategory swapFailureCategory(
     return _oneClickCategory(operation, error);
   }
 
+  if (operation == SwapFailureOperation.sendZecDeposit &&
+      _isZecDepositFundingError(error)) {
+    return SwapFailureCategory.zecDepositFunding;
+  }
+
   return switch (operation) {
     SwapFailureOperation.sendZecDeposit => SwapFailureCategory.walletPreflight,
     SwapFailureOperation.refreshStatus || SwapFailureOperation.submitDeposit =>
@@ -60,13 +67,17 @@ SwapFailureCategory _oneClickCategory(
   if (_isUnsupportedAssetError(error)) {
     return SwapFailureCategory.unsupportedAsset;
   }
-  if (_isAmountPrecisionError(error)) {
+  final isQuoteFailure = operation == SwapFailureOperation.quote;
+  if (isQuoteFailure && _isAmountTooLowError(error)) {
+    return SwapFailureCategory.amountTooLow;
+  }
+  if (isQuoteFailure && _isAmountPrecisionError(error)) {
     return SwapFailureCategory.amountPrecision;
   }
   if (_isUnverifiedResponseError(error)) {
     return SwapFailureCategory.unverifiedResponse;
   }
-  if (_isNoQuoteOrLiquidityError(error)) {
+  if (isQuoteFailure && _isNoQuoteOrLiquidityError(error)) {
     return SwapFailureCategory.noQuoteOrLiquidity;
   }
 
@@ -99,12 +110,15 @@ String _messageFor(
 ) {
   return switch (category) {
     SwapFailureCategory.unsupportedAsset => _unsupportedAssetMessage(operation),
+    SwapFailureCategory.amountTooLow =>
+      'Amount is too low for this swap.\nTry a larger amount.',
     SwapFailureCategory.amountPrecision =>
       'Amount has too many decimal places.\nUse fewer decimals and try again.',
     SwapFailureCategory.invalidRouteOrAddress =>
       'This route or address was rejected.\nEdit the details and request a new quote.',
     SwapFailureCategory.noQuoteOrLiquidity =>
-      'No quote is available for this route or amount.\nTry a smaller amount or another asset.',
+      'No quote is available for this route or amount.\n'
+          'Adjust the amount, slippage, or asset and try again.',
     SwapFailureCategory.serviceUnavailable => _serviceUnavailableMessage(
       operation,
     ),
@@ -113,6 +127,9 @@ String _messageFor(
       operation,
     ),
     SwapFailureCategory.retryLater => _retryLaterMessage(operation),
+    SwapFailureCategory.zecDepositFunding =>
+      'Not enough spendable ZEC to cover this swap and its network fee.\n'
+          'Try a smaller amount or use Max.',
     SwapFailureCategory.walletPreflight =>
       'ZEC deposit could not be prepared.\nCheck your balance and try again.',
     SwapFailureCategory.depositNotFound =>
@@ -184,19 +201,30 @@ String _unknownMessage(SwapFailureOperation operation) {
 }
 
 bool _isUnsupportedAssetError(OneClickApiException error) {
-  final message = error.message.toLowerCase();
+  final message = _oneClickSearchableMessage(error);
   return message.contains('does not currently list') ||
-      message.contains('unsupported 1click status pair');
+      message.contains('unsupported 1click status pair') ||
+      message.contains('tokenin is not valid') ||
+      message.contains('tokenout is not valid');
+}
+
+bool _isAmountTooLowError(OneClickApiException error) {
+  final message = _oneClickSearchableMessage(error);
+  return message.contains('amount is too low') ||
+      message.contains('try at least') ||
+      message.contains('no quotes found') ||
+      message.contains('below minimum') ||
+      (message.contains('minimum') && message.contains('amount'));
 }
 
 bool _isAmountPrecisionError(OneClickApiException error) {
-  final message = error.message.toLowerCase();
+  final message = _oneClickSearchableMessage(error);
   return message.contains('amount exceeds token precision') ||
       message.contains('too many decimal');
 }
 
 bool _isUnverifiedResponseError(OneClickApiException error) {
-  final message = error.message.toLowerCase();
+  final message = _oneClickSearchableMessage(error);
   return message.contains('did not match the requested route') ||
       message.contains('malformed 1click') ||
       message.contains('expected a json') ||
@@ -205,8 +233,9 @@ bool _isUnverifiedResponseError(OneClickApiException error) {
 }
 
 bool _isNoQuoteOrLiquidityError(OneClickApiException error) {
-  final message = error.message.toLowerCase();
+  final message = _oneClickSearchableMessage(error);
   return message.contains('liquidity') ||
+      message.contains('failed to get quote') ||
       message.contains('no quote') ||
       message.contains('no route') ||
       message.contains('route not found') ||
@@ -214,4 +243,17 @@ bool _isNoQuoteOrLiquidityError(OneClickApiException error) {
       message.contains('market maker') ||
       message.contains('cannot fulfill') ||
       message.contains("can't fulfill");
+}
+
+bool _isZecDepositFundingError(Object error) {
+  final message = error.toString().toLowerCase();
+  return message.contains('insufficient balance') ||
+      message.contains('insufficient funds');
+}
+
+String _oneClickSearchableMessage(OneClickApiException error) {
+  return [
+    error.providerMessage,
+    error.message,
+  ].whereType<String>().join(' ').toLowerCase();
 }

--- a/test/features/swap/near_intents_one_click_swap_adapter_test.dart
+++ b/test/features/swap/near_intents_one_click_swap_adapter_test.dart
@@ -1075,7 +1075,12 @@ void main() {
       throwsA(
         isA<OneClickApiException>()
             .having((error) => error.operation, 'operation', 'quote')
-            .having((error) => error.statusCode, 'statusCode', 401),
+            .having((error) => error.statusCode, 'statusCode', 401)
+            .having(
+              (error) => error.providerMessage,
+              'providerMessage',
+              'jwt missing',
+            ),
       ),
     );
   });

--- a/test/features/swap/swap_failure_policy_test.dart
+++ b/test/features/swap/swap_failure_policy_test.dart
@@ -18,25 +18,111 @@ void main() {
     );
   });
 
-  test(
-    'quote liquidity failures ask for a smaller amount or another asset',
-    () {
-      const error = OneClickApiException(
-        'No quote: insufficient liquidity from solver',
-        statusCode: 400,
-      );
+  test('quote liquidity failures ask the user to adjust swap details', () {
+    const error = OneClickApiException(
+      'No quote: insufficient liquidity from solver',
+      statusCode: 400,
+    );
 
-      expect(
-        swapFailureCategory(SwapFailureOperation.quote, error),
-        SwapFailureCategory.noQuoteOrLiquidity,
-      );
-      expect(
-        swapFailureMessage(SwapFailureOperation.quote, error),
-        'No quote is available for this route or amount.\n'
-        'Try a smaller amount or another asset.',
-      );
-    },
-  );
+    expect(
+      swapFailureCategory(SwapFailureOperation.quote, error),
+      SwapFailureCategory.noQuoteOrLiquidity,
+    );
+    expect(
+      swapFailureMessage(SwapFailureOperation.quote, error),
+      'No quote is available for this route or amount.\n'
+      'Adjust the amount, slippage, or asset and try again.',
+    );
+  });
+
+  test('quote amount minimum failures ask for a larger amount', () {
+    const error = OneClickApiException(
+      'NEAR Intents quote failed (400): '
+      '{"message":"Amount is too low for bridge, try at least 74256"}',
+      statusCode: 400,
+      providerMessage: 'Amount is too low for bridge, try at least 74256',
+    );
+
+    expect(
+      swapFailureCategory(SwapFailureOperation.quote, error),
+      SwapFailureCategory.amountTooLow,
+    );
+    expect(
+      swapFailureMessage(SwapFailureOperation.quote, error),
+      'Amount is too low for this swap.\nTry a larger amount.',
+    );
+  });
+
+  test('no quotes found failures follow the low amount guidance', () {
+    const error = OneClickApiException(
+      'NEAR Intents quote failed (400): {"message":"No quotes found"}',
+      statusCode: 400,
+      providerMessage: 'No quotes found',
+    );
+
+    expect(
+      swapFailureCategory(SwapFailureOperation.quote, error),
+      SwapFailureCategory.amountTooLow,
+    );
+    expect(
+      swapFailureMessage(SwapFailureOperation.quote, error),
+      'Amount is too low for this swap.\nTry a larger amount.',
+    );
+  });
+
+  test('failed to get quote failures stay in quote unavailable guidance', () {
+    const error = OneClickApiException(
+      'NEAR Intents quote failed (400): {"message":"Failed to get quote"}',
+      statusCode: 400,
+      providerMessage: 'Failed to get quote',
+    );
+
+    expect(
+      swapFailureCategory(SwapFailureOperation.quote, error),
+      SwapFailureCategory.noQuoteOrLiquidity,
+    );
+    expect(
+      swapFailureMessage(SwapFailureOperation.quote, error),
+      'No quote is available for this route or amount.\n'
+      'Adjust the amount, slippage, or asset and try again.',
+    );
+  });
+
+  test('low amount messages do not override status refresh guidance', () {
+    const error = OneClickApiException(
+      'NEAR Intents status failed (404): {"message":"No quotes found"}',
+      statusCode: 404,
+      providerMessage: 'No quotes found',
+    );
+
+    expect(
+      swapFailureCategory(SwapFailureOperation.refreshStatus, error),
+      SwapFailureCategory.depositNotFound,
+    );
+    expect(
+      swapFailureMessage(SwapFailureOperation.refreshStatus, error),
+      'Deposit is not indexed yet.\nCheck again in a few minutes.',
+    );
+  });
+
+  test('low amount messages do not override submit deposit guidance', () {
+    const error = OneClickApiException(
+      'NEAR Intents submit failed (422): '
+      '{"message":"Amount is too low for bridge, try at least 74256"}',
+      statusCode: 422,
+      providerMessage: 'Amount is too low for bridge, try at least 74256',
+    );
+
+    expect(
+      swapFailureCategory(SwapFailureOperation.submitDeposit, error),
+      SwapFailureCategory.depositRejected,
+    );
+    expect(
+      swapFailureMessage(SwapFailureOperation.submitDeposit, error),
+      'Deposit transaction was rejected.\n'
+      'Check the address, memo, and tx hash.',
+    );
+  });
 
   test('route rejection asks for corrected input', () {
     const error = OneClickApiException('invalid recipient', statusCode: 422);
@@ -198,19 +284,33 @@ void main() {
     );
   });
 
-  test(
-    'generic ZEC deposit failures are treated as wallet preflight issues',
-    () {
-      final error = StateError('insufficient balance');
+  test('ZEC deposit funding failures explain fee and spendable balance', () {
+    final error = Exception(
+      'Propose failed: Insufficient balance '
+      '(have 0, need 210000 including fee)',
+    );
 
-      expect(
-        swapFailureCategory(SwapFailureOperation.sendZecDeposit, error),
-        SwapFailureCategory.walletPreflight,
-      );
-      expect(
-        swapFailureMessage(SwapFailureOperation.sendZecDeposit, error),
-        'ZEC deposit could not be prepared.\nCheck your balance and try again.',
-      );
-    },
-  );
+    expect(
+      swapFailureCategory(SwapFailureOperation.sendZecDeposit, error),
+      SwapFailureCategory.zecDepositFunding,
+    );
+    expect(
+      swapFailureMessage(SwapFailureOperation.sendZecDeposit, error),
+      'Not enough spendable ZEC to cover this swap and its network fee.\n'
+      'Try a smaller amount or use Max.',
+    );
+  });
+
+  test('generic ZEC deposit failures keep the wallet preflight fallback', () {
+    final error = StateError('wallet database locked');
+
+    expect(
+      swapFailureCategory(SwapFailureOperation.sendZecDeposit, error),
+      SwapFailureCategory.walletPreflight,
+    );
+    expect(
+      swapFailureMessage(SwapFailureOperation.sendZecDeposit, error),
+      'ZEC deposit could not be prepared.\nCheck your balance and try again.',
+    );
+  });
 }

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -6959,7 +6959,9 @@ void main() {
     expect(sessionStore.savedIntents, isEmpty);
     expect(find.byKey(const ValueKey('swap_review_panel')), findsOneWidget);
     expect(
-      find.textContaining('ZEC deposit could not be prepared.'),
+      find.textContaining(
+        'Not enough spendable ZEC to cover this swap and its network fee.',
+      ),
       findsOneWidget,
     );
     expect(find.textContaining('Insufficient balance'), findsNothing);


### PR DESCRIPTION
## Summary

- Preserve 1Click provider error messages separately from the rendered app copy.
- Map quote minimum, no-quote, unsupported asset, and unavailable quote failures to user-facing swap guidance.
- Show a clearer ZEC deposit preflight message when spendable ZEC cannot cover the swap plus the network fee.

## Context

Linear: VZR-69

The 1Click API can return provider-specific messages such as low minimum amount or failed quote responses. This change keeps those messages available for classification while preventing raw provider responses from leaking into the swap UI.

## Validation

- `fvm flutter test test/features/swap/swap_activity_status_mapper_test.dart test/features/swap/swap_failure_policy_test.dart test/features/swap/near_intents_one_click_swap_adapter_test.dart`
- `fvm flutter analyze`
- `git diff --check`