### PR TITLE
[codex] Sync secondary button light tokens

### DIFF
--- a/lib/src/core/theme/colors/app_button_colors.dart
+++ b/lib/src/core/theme/colors/app_button_colors.dart
@@ -103,9 +103,9 @@ class AppSecondaryButtonColors {
   );
 
   static const light = AppSecondaryButtonColors(
-    bg: Primitives.p100Light,
-    bgHover: Primitives.p150Light,
-    bgPressed: Primitives.p150Light,
+    bg: Primitives.p0Light,
+    bgHover: Primitives.p100Light,
+    bgPressed: Primitives.p100Light,
     label: Primitives.p900Light,
   );
 }

--- a/test/core/theme/design_tokens_test.dart
+++ b/test/core/theme/design_tokens_test.dart
@@ -261,6 +261,15 @@ void main() {
     expect(dark.button.disabled.bg, const Color(0x334D5252));
     expect(dark.button.disabled.label, const Color(0x80858686));
 
+    expect(light.button.secondary.bg, Primitives.p0Light);
+    expect(light.button.secondary.bgHover, Primitives.p100Light);
+    expect(light.button.secondary.bgPressed, Primitives.p100Light);
+    expect(light.button.secondary.label, Primitives.p900Light);
+    expect(dark.button.secondary.bg, Primitives.p150Dark);
+    expect(dark.button.secondary.bgHover, Primitives.p200Dark);
+    expect(dark.button.secondary.bgPressed, Primitives.p200Dark);
+    expect(dark.button.secondary.label, Primitives.p800Dark);
+
     expect(light.button.destructive.bg, const Color(0xFF772E89));
     expect(light.button.destructive.bgHover, const Color(0xFF5E2673));
     expect(light.button.destructive.label, const Color(0xFFE6C5EC));


### PR DESCRIPTION
## Summary
- Update the light theme secondary button background token to match Figma `Semantic/Button/Button/Secondary/Bg`.
- Align light secondary hover/pressed colors with Figma `Secondary/Bg Hover`.
- Add regression coverage for secondary button semantic color mappings in the design token test.

## Validation
- `fvm dart format lib/src/core/theme/colors/app_button_colors.dart test/core/theme/design_tokens_test.dart`
- `fvm flutter test test/core/theme/design_tokens_test.dart`
- `git diff --check`