### PR TITLE
Make mobile QR scan icon circular

### DIFF
--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -1377,43 +1377,51 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
                   onTap: () => unawaited(_openScanner()),
                   child: SizedBox(
                     height: 44,
-                    child: Row(
-                      children: [
-                        Container(
-                          width: 40,
-                          height: 32,
-                          decoration: BoxDecoration(
-                            color: colors.background.neutralSubtleOpacity,
-                            borderRadius: BorderRadius.circular(AppRadii.full),
-                          ),
-                          child: Center(
-                            child: AppIcon(
-                              AppIcons.qr,
-                              size: 16,
-                              color: colors.icon.accent,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppAssetSize.padding,
+                      ),
+                      child: Row(
+                        children: [
+                          Container(
+                            key: const ValueKey('mobile_send_scan_icon_frame'),
+                            width: AppAssetSize.size,
+                            height: AppAssetSize.size,
+                            decoration: BoxDecoration(
+                              color: colors.background.neutralSubtleOpacity,
+                              borderRadius: BorderRadius.circular(
+                                AppRadii.full,
+                              ),
+                            ),
+                            child: Center(
+                              child: AppIcon(
+                                AppIcons.qr,
+                                size: AppAssetSize.icon,
+                                color: colors.icon.accent,
+                              ),
                             ),
                           ),
-                        ),
-                        const SizedBox(width: AppSpacing.s),
-                        Expanded(
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              _RecipientLineText(
-                                'Scan a QR Code',
-                                color: colors.text.accent,
-                              ),
-                              const SizedBox(height: AppSpacing.xxs),
-                              _RecipientLineText(
-                                'Scan an address using camera',
-                                color: colors.text.secondary,
-                                fontWeight: FontWeight.w400,
-                              ),
-                            ],
+                          const SizedBox(width: AppSpacing.s),
+                          Expanded(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                _RecipientLineText(
+                                  'Scan a QR Code',
+                                  color: colors.text.accent,
+                                ),
+                                const SizedBox(height: AppSpacing.xxs),
+                                _RecipientLineText(
+                                  'Scan an address using camera',
+                                  color: colors.text.secondary,
+                                  fontWeight: FontWeight.w400,
+                                ),
+                              ],
+                            ),
                           ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/test/widgetbook/mobile_send_use_cases_test.dart
+++ b/test/widgetbook/mobile_send_use_cases_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/send/screens/mobile/mobile_send_screen.dart';
 import 'package:zcash_wallet/widgetbook/send_use_cases.dart';
 
@@ -39,6 +40,37 @@ void main() {
     expect(
       tester.getSize(find.byKey(const ValueKey('mobile_send_scan_row'))).height,
       44,
+    );
+    final scanRowFinder = find.byKey(const ValueKey('mobile_send_scan_row'));
+    final scanIconFrameFinder = find.byKey(
+      const ValueKey('mobile_send_scan_icon_frame'),
+    );
+    expect(
+      tester.getSize(scanIconFrameFinder),
+      const Size(AppAssetSizeMobile.size, AppAssetSizeMobile.size),
+    );
+    final scanIconFinder = find.descendant(
+      of: scanIconFrameFinder,
+      matching: find.byType(AppIcon),
+    );
+    final scanIcon = tester.widget<AppIcon>(scanIconFinder);
+    expect(scanIcon.size, AppAssetSizeMobile.icon);
+    final scanIconDecoration =
+        tester.widget<Container>(scanIconFrameFinder).decoration!
+            as BoxDecoration;
+    expect(
+      scanIconDecoration.borderRadius,
+      BorderRadius.circular(AppRadii.full),
+    );
+    expect(
+      tester.getTopLeft(scanIconFrameFinder).dx -
+          tester.getTopLeft(scanRowFinder).dx,
+      AppAssetSizeMobile.padding,
+    );
+    expect(
+      tester.getTopLeft(find.text('Scan a QR Code')).dx -
+          tester.getTopRight(scanIconFrameFinder).dx,
+      AppSpacing.s,
     );
     _expectVerticalGap(
       tester,


### PR DESCRIPTION
## Summary
- Update the mobile send recipient scan row so the QR icon background uses the mobile asset sizing token as a true circle.
- Align the QR icon size and row inset with the asset sizing tokens.
- Preserve a 12px gap between the circular QR affordance and the text label.

## Why
VZR-103 notes that the QR code affordance should be a perfect circle instead of a pill shape. The previous implementation used a 40x32 frame, which rendered as a pill.

## Validation
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/widgetbook/mobile_send_use_cases_test.dart`
- `fvm flutter analyze`