### PR TITLE
[codex] Relax 1Click quote asset echo validation

### DIFF
--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
@@ -116,8 +116,6 @@ class NearIntentsOneClickSwapAdapter
     final quoteResponse = _OneClickQuoteResponse.fromJson(response.jsonObject);
     _validateQuoteResponseRequest(
       quoteResponse,
-      expectedOriginAsset: sellToken.assetId,
-      expectedDestinationAsset: receiveToken.assetId,
       expectedMode: request.mode,
       expectedFixedAmountBaseUnits: amountBaseUnits,
       expectedSlippageBps: requestedSlippageBps,
@@ -713,8 +711,6 @@ class NearIntentsOneClickSwapAdapter
 
   void _validateQuoteResponseRequest(
     _OneClickQuoteResponse response, {
-    required String expectedOriginAsset,
-    required String expectedDestinationAsset,
     required SwapQuoteMode expectedMode,
     required String expectedFixedAmountBaseUnits,
     required int expectedSlippageBps,
@@ -728,9 +724,7 @@ class NearIntentsOneClickSwapAdapter
     final hasMismatchedSwapType = actualSwapType == null
         ? actual.mode != expectedMode
         : actualSwapType != expectedMode.oneClickSwapType;
-    if (actual.originAsset != expectedOriginAsset ||
-        actual.destinationAsset != expectedDestinationAsset ||
-        hasMismatchedSwapType) {
+    if (hasMismatchedSwapType) {
       throw OneClickApiException(
         '1Click quote response did not match the requested route',
         operation: 'quote',

--- a/test/features/swap/near_intents_one_click_swap_adapter_test.dart
+++ b/test/features/swap/near_intents_one_click_swap_adapter_test.dart
@@ -141,7 +141,7 @@ void main() {
     expect(transport.requests, isEmpty);
   });
 
-  test('quote rejects response with a mismatched asset route', () async {
+  test('quote accepts response with a mismatched asset route echo', () async {
     final transport = _FakeOneClickTransport([
       _FakeResponse.get('/v0/tokens', _tokens),
       _FakeResponse.post(
@@ -149,9 +149,10 @@ void main() {
         _quoteResponse(
           originAsset: 'nep141:zec.omft.near',
           destinationAsset: 'nep141:wrap.near',
+          amountOut: '1250000',
           amountInFormatted: '1.5',
           amountOutFormatted: '1.25',
-          minAmountOut: '1237500000000000000000000',
+          minAmountOut: '1237500',
           depositAddress: 't1deposit',
           status: null,
         ),
@@ -159,28 +160,96 @@ void main() {
     ]);
     final provider = NearIntentsOneClickSwapAdapter(transport: transport);
 
-    await expectLater(
-      provider.quote(
-        const SwapQuoteRequest(
-          direction: SwapDirection.zecToExternal,
-          externalAsset: SwapAsset.usdc,
-          sellAmount: 1.5,
-          sellAmountText: '1.5',
-          destination: '0xrecipient',
-          refundAddress: 'u1refund',
-        ),
-      ),
-      throwsA(
-        isA<OneClickApiException>()
-            .having((error) => error.operation, 'operation', 'quote')
-            .having(
-              (error) => error.message,
-              'message',
-              contains('did not match the requested route'),
-            ),
+    final quote = await provider.quote(
+      const SwapQuoteRequest(
+        direction: SwapDirection.zecToExternal,
+        externalAsset: SwapAsset.usdc,
+        sellAmount: 1.5,
+        sellAmountText: '1.5',
+        destination: '0xrecipient',
+        refundAddress: 'u1refund',
       ),
     );
+
+    expect(quote.pairText, 'ZEC -> USDC');
+    expect(quote.receiveEstimateText, '1.25 USDC');
   });
+
+  test('quote accepts response that echoes BTC(OMNI) for BTC', () async {
+    final transport = _FakeOneClickTransport([
+      _FakeResponse.get('/v0/tokens', _tokensWithAdditionalAssets),
+      _FakeResponse.post(
+        '/v0/quote',
+        _quoteResponse(
+          originAsset: 'nep141:zec.omft.near',
+          destinationAsset: '1cs_v1:btc:native:coin',
+          amountInFormatted: '1.5',
+          amountOutFormatted: '0.00096',
+          minAmountOut: '95000',
+          depositAddress: 't1deposit',
+          quoteRequestRecipient: 'bc1recipient',
+          status: null,
+        ),
+      ),
+    ]);
+    final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+    final quote = await provider.quote(
+      const SwapQuoteRequest(
+        direction: SwapDirection.zecToExternal,
+        externalAsset: SwapAsset.btc,
+        sellAmount: 1.5,
+        sellAmountText: '1.5',
+        destination: 'bc1recipient',
+        refundAddress: 'u1refund',
+      ),
+    );
+
+    final request = transport.requests.last;
+    expect(request.body?['destinationAsset'], 'nep141:btc.omft.near');
+    expect(quote.pairText, 'ZEC -> BTC');
+    expect(quote.receiveEstimateText, '0.00096 BTC');
+  });
+
+  test(
+    'quote accepts response that echoes BTC(OMNI) for a BTC origin asset',
+    () async {
+      final transport = _FakeOneClickTransport([
+        _FakeResponse.get('/v0/tokens', _tokensWithAdditionalAssets),
+        _FakeResponse.post(
+          '/v0/quote',
+          _quoteResponse(
+            originAsset: '1cs_v1:btc:native:coin',
+            destinationAsset: 'nep141:zec.omft.near',
+            amountInFormatted: '0.001',
+            amountOutFormatted: '1.5',
+            minAmountOut: '149250000',
+            depositAddress: 'btc-deposit',
+            quoteRequestRefundTo: 'bc1refund',
+            quoteRequestRecipient: 'u1recipient',
+            status: null,
+          ),
+        ),
+      ]);
+      final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+      final quote = await provider.quote(
+        const SwapQuoteRequest(
+          direction: SwapDirection.externalToZec,
+          externalAsset: SwapAsset.btc,
+          sellAmount: 0.001,
+          sellAmountText: '0.001',
+          destination: 'u1recipient',
+          refundAddress: 'bc1refund',
+        ),
+      );
+
+      final request = transport.requests.last;
+      expect(request.body?['originAsset'], 'nep141:btc.omft.near');
+      expect(quote.pairText, 'BTC -> ZEC');
+      expect(quote.sellAmountText, '0.001 BTC');
+    },
+  );
 
   test('quote rejects response with a mismatched swap type', () async {
     final transport = _FakeOneClickTransport([


### PR DESCRIPTION
## Summary
- Stop rejecting 1Click quote responses solely because the echoed origin/destination asset ids differ from the requested ids.
- Keep swap type, fixed amount, formatted/base-unit amount, slippage, and address echo validation.
- Cover route-echo differences in both BTC directions, while preserving the requested asset in the review quote.

## Root cause
1Click can return a route-normalized asset id in `quoteRequest.originAsset` / `quoteRequest.destinationAsset`. Exact asset-id echo validation rejected otherwise usable quotes before the review sheet could open.

This mirrors the zodl-side behavior change discussed here:
- https://github.com/zodl-inc/zodl-android/commit/594789e2da1e0431f242849ff5fa14678e21b99c
- https://github.com/zodl-inc/zodl-android/commit/80337cbc4ef328d0d37722c4eb75338165a06c5b

## Validation
- `fvm dart format lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart test/features/swap/near_intents_one_click_swap_adapter_test.dart`
- `fvm flutter test test/features/swap/near_intents_one_click_swap_adapter_test.dart`
- `fvm flutter analyze`