### PR TITLE
[codex] Expire mnemonic clipboard copies on iOS

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -108,6 +108,14 @@ import UIKit
       }
     }
 
+    let sensitiveClipboardChannel = FlutterMethodChannel(
+      name: "com.zcash.wallet/sensitive_clipboard",
+      binaryMessenger: messenger
+    )
+    sensitiveClipboardChannel.setMethodCallHandler { (call, result) in
+      SensitiveClipboardHandler.handle(call, result: result)
+    }
+
     let biometricUnlockChannel = FlutterMethodChannel(
       name: "com.zcash.wallet/biometric_unlock",
       binaryMessenger: messenger
@@ -192,6 +200,54 @@ import UIKit
       binaryMessenger: messenger
     )
     screenshotChannel.setStreamHandler(ScreenshotStreamHandler())
+  }
+}
+
+private enum SensitiveClipboardHandler {
+  private static let plainTextType = "public.utf8-plain-text"
+
+  static func handle(_ call: FlutterMethodCall, result: FlutterResult) {
+    switch call.method {
+    case "copyText":
+      guard
+        let args = call.arguments as? [String: Any],
+        let text = args["text"] as? String
+      else {
+        result(
+          FlutterError(
+            code: "bad_args",
+            message: "Expected text argument.",
+            details: nil
+          )
+        )
+        return
+      }
+
+      let expirationSeconds = max(1, seconds(from: args["expirationSeconds"]) ?? 60)
+      UIPasteboard.general.setItems(
+        [[plainTextType: text]],
+        options: [
+          .expirationDate: Date().addingTimeInterval(expirationSeconds),
+          .localOnly: true,
+        ]
+      )
+      result(nil)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private static func seconds(from value: Any?) -> TimeInterval? {
+    if let number = value as? NSNumber {
+      return number.doubleValue
+    }
+    if let int = value as? Int {
+      return TimeInterval(int)
+    }
+    if let double = value as? Double {
+      return double
+    }
+    return nil
   }
 }
 

--- a/lib/src/core/clipboard/sensitive_clipboard.dart
+++ b/lib/src/core/clipboard/sensitive_clipboard.dart
@@ -1,0 +1,34 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+const sensitiveClipboardDefaultExpiration = Duration(minutes: 1);
+
+abstract final class SensitiveClipboard {
+  static const _channel = MethodChannel('com.zcash.wallet/sensitive_clipboard');
+
+  @visibleForTesting
+  static bool? debugIsIosOverride;
+
+  static Future<void> copyText(
+    String text, {
+    Duration expiration = sensitiveClipboardDefaultExpiration,
+  }) async {
+    if (_supportsNativeExpiration) {
+      await _channel.invokeMethod<void>('copyText', {
+        'text': text,
+        'expirationSeconds': expiration.inSeconds,
+      });
+      return;
+    }
+
+    await Clipboard.setData(ClipboardData(text: text));
+  }
+
+  static bool get _supportsNativeExpiration {
+    final override = debugIsIosOverride;
+    if (override != null) return override;
+    return !kIsWeb && Platform.isIOS;
+  }
+}

--- a/lib/src/features/onboarding/create/secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/create/secret_passphrase_screen.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart' show CircularProgressIndicator;
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/clipboard/sensitive_clipboard.dart';
 import '../../../core/layout/app_desktop_shell.dart';
 import '../../../core/privacy/sensitive_privacy_overlay.dart';
 import '../../../core/theme/app_theme.dart';
@@ -177,7 +177,7 @@ class _SecretPassphraseScreenState
   Future<void> _copyMnemonic() async {
     final mnemonic = _mnemonic;
     if (mnemonic == null || !_revealed) return;
-    await Clipboard.setData(ClipboardData(text: mnemonic));
+    await SensitiveClipboard.copyText(mnemonic);
     if (!mounted) return;
     _copyResetTimer?.cancel();
     setState(() {

--- a/lib/src/features/onboarding/mobile/mobile_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_secret_passphrase_screen.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/clipboard/sensitive_clipboard.dart';
 import '../../../core/feedback/app_haptics.dart';
 import '../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../core/platform/screenshot_observer.dart';
@@ -120,7 +120,7 @@ class _MobileSecretPassphraseScreenState
   Future<void> _copy() async {
     final mnemonic = _mnemonic;
     if (mnemonic == null || !_revealed) return;
-    await Clipboard.setData(ClipboardData(text: mnemonic));
+    await SensitiveClipboard.copyText(mnemonic);
     unawaited(AppHaptics.copy());
     if (!mounted) return;
     _copyResetTimer?.cancel();

--- a/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../../main.dart' show log;
+import '../../../../core/clipboard/sensitive_clipboard.dart';
 import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/layout/mobile/mobile_top_nav.dart';
 import '../../../../core/platform/screenshot_observer.dart';
@@ -226,10 +227,9 @@ class _MobileSeedPhraseScreenState
       setState(() {
         _checking = false;
         _entry = '';
-        _gateError =
-            e.kind == DeviceOwnerAuthErrorKind.unavailable
-                ? kWalletResetDeviceAuthRequiredMessage
-                : kWalletResetDeviceAuthFailedMessage;
+        _gateError = e.kind == DeviceOwnerAuthErrorKind.unavailable
+            ? kWalletResetDeviceAuthRequiredMessage
+            : kWalletResetDeviceAuthFailedMessage;
       });
       return;
     } catch (e, st) {
@@ -315,6 +315,14 @@ class _MobileSeedPhraseScreenState
     await Clipboard.setData(ClipboardData(text: text));
     unawaited(AppHaptics.copy());
     if (mounted) showAppToast(context, toast);
+  }
+
+  Future<void> _copyMnemonic() async {
+    final mnemonic = _mnemonic;
+    if (mnemonic == null || mnemonic.isEmpty) return;
+    await SensitiveClipboard.copyText(mnemonic);
+    unawaited(AppHaptics.copy());
+    if (mounted) showAppToast(context, 'Secret passphrase copied');
   }
 
   // ── Screenshot warning ─────────────────────────────────────────────
@@ -518,7 +526,7 @@ class _MobileSeedPhraseScreenState
                   child: _CopyChip(
                     key: const ValueKey('mobile_seed_copy'),
                     label: 'Copy',
-                    onTap: () => _copy(_mnemonic, 'Secret passphrase copied'),
+                    onTap: _copyMnemonic,
                   ),
                 ),
               ],

--- a/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/settings_seed_phrase_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/clipboard/sensitive_clipboard.dart';
 import '../../../core/privacy/sensitive_privacy_overlay.dart';
 import '../../../core/security/password_policy.dart';
 import '../../../core/layout/app_desktop_backdrop_shell.dart';
@@ -315,7 +316,7 @@ class _SettingsSeedPhraseScreenState
   Future<void> _copyMnemonic() async {
     final mnemonic = _mnemonic;
     if (mnemonic == null || mnemonic.isEmpty) return;
-    await Clipboard.setData(ClipboardData(text: mnemonic));
+    await SensitiveClipboard.copyText(mnemonic);
     _markCopied(_SeedPhraseCopyTarget.phrase);
   }
 

--- a/test/core/clipboard/sensitive_clipboard_test.dart
+++ b/test/core/clipboard/sensitive_clipboard_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/clipboard/sensitive_clipboard.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const nativeChannel = MethodChannel('com.zcash.wallet/sensitive_clipboard');
+
+  tearDown(() {
+    SensitiveClipboard.debugIsIosOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(nativeChannel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  test(
+    'iOS copy sends text with the default expiration to native channel',
+    () async {
+      final calls = <MethodCall>[];
+      SensitiveClipboard.debugIsIosOverride = true;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(nativeChannel, (call) async {
+            calls.add(call);
+            return null;
+          });
+
+      await SensitiveClipboard.copyText('alpha bravo');
+
+      expect(calls, hasLength(1));
+      expect(calls.single.method, 'copyText');
+      expect(calls.single.arguments, {
+        'text': 'alpha bravo',
+        'expirationSeconds': 60,
+      });
+    },
+  );
+
+  test('non-iOS copy falls back to the Flutter clipboard', () async {
+    final copied = <String>[];
+    SensitiveClipboard.debugIsIosOverride = false;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+          if (call.method == 'Clipboard.setData') {
+            copied.add((call.arguments as Map)['text'] as String);
+          }
+          return null;
+        });
+
+    await SensitiveClipboard.copyText('charlie delta');
+
+    expect(copied, ['charlie delta']);
+  });
+}


### PR DESCRIPTION
## Summary
- Add an iOS-only sensitive clipboard bridge that writes mnemonic copies with a 60-second pasteboard expiration and local-only scope.
- Route secret passphrase copy actions through the sensitive clipboard helper while leaving address, transaction ID, and birthday copy behavior unchanged.
- Add Dart coverage for the native-channel path and non-iOS fallback.

## Validation
- `fvm flutter test test/core/clipboard/sensitive_clipboard_test.dart`
- `fvm flutter test test/features/onboarding/mobile_secret_passphrase_screen_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `fvm flutter test test/features/settings/mobile_seed_phrase_screen_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `fvm flutter analyze`
- `fvm flutter build ios --simulator --debug --dart-define=VIZOR_FORM_FACTOR=mobile`