### PR TITLE
Restore secondary input shell

### DIFF
--- a/lib/src/core/theme/colors/app_surface_colors.dart
+++ b/lib/src/core/theme/colors/app_surface_colors.dart
@@ -5,8 +5,7 @@ import '../primitives.dart';
 /// Component-level surface colors.
 ///
 /// * [card] — Card components, list rows.
-/// * [input] — Text input background at rest.
-/// * [inputFocus] — Text input when focused.
+/// * [input] — Text input surface colors.
 /// * [nav] — Navigation rail background.
 /// * [navActive] — Active nav item indicator.
 /// * [tooltip] — Tooltip / popover background. Theme-invariant.
@@ -19,7 +18,6 @@ class AppSurfaceColors {
   const AppSurfaceColors({
     required this.card,
     required this.input,
-    required this.inputFocus,
     required this.nav,
     required this.navActive,
     required this.tooltip,
@@ -28,8 +26,7 @@ class AppSurfaceColors {
   });
 
   final Color card;
-  final Color input;
-  final Color inputFocus;
+  final AppInputSurfaceColors input;
   final Color nav;
   final Color navActive;
   final Color tooltip;
@@ -38,8 +35,7 @@ class AppSurfaceColors {
 
   static const dark = AppSurfaceColors(
     card: Primitives.p100Dark,
-    input: Primitives.p50Dark,
-    inputFocus: Primitives.p100Dark,
+    input: AppInputSurfaceColors.dark,
     nav: Primitives.p50Dark,
     navActive: Primitives.p150Dark,
     tooltip: Primitives.p200Dark,
@@ -49,8 +45,7 @@ class AppSurfaceColors {
 
   static const light = AppSurfaceColors(
     card: Primitives.p50Light,
-    input: Primitives.p0Light,
-    inputFocus: Primitives.p50Light,
+    input: AppInputSurfaceColors.light,
     nav: Primitives.p0Light,
     navActive: Primitives.p100Light,
     // Tooltip is the same concrete value in both modes; picking p800Light here
@@ -58,5 +53,30 @@ class AppSurfaceColors {
     tooltip: Primitives.p800Light,
     qrCode: Primitives.p0Light,
     scrollbarThumb: Primitives.p150Light,
+  );
+}
+
+/// Text input surface colors grouped by field variant/state.
+class AppInputSurfaceColors {
+  const AppInputSurfaceColors({
+    required this.primary,
+    required this.secondary,
+    required this.focus,
+  });
+
+  final Color primary;
+  final Color secondary;
+  final Color focus;
+
+  static const dark = AppInputSurfaceColors(
+    primary: Primitives.p50Dark,
+    secondary: Primitives.p150Dark,
+    focus: Primitives.p100Dark,
+  );
+
+  static const light = AppInputSurfaceColors(
+    primary: Primitives.p0Light,
+    secondary: Primitives.p100Light,
+    focus: Primitives.p50Light,
   );
 }

--- a/lib/src/core/widgets/app_text_field.dart
+++ b/lib/src/core/widgets/app_text_field.dart
@@ -316,12 +316,12 @@ class _AppTextFieldState extends State<AppTextField> {
       forceStrutHeight: true,
     );
 
-    // Figma Field Type=Secondary: filled gray shell (auth screens); its
-    // component stroke is white at 0% paint opacity, so neither surface
-    // draws an idle border. Primary keeps the white input surface.
+    // Figma Field Type=Secondary: filled auth-screen input shell. Keep it
+    // separate from both button and layout-depth tokens so unrelated token
+    // changes do not alter input surfaces. Primary keeps the white input shell.
     final baseShellColor = widget.surface == AppTextFieldSurface.secondary
-        ? colors.button.secondary.bg
-        : colors.surface.input;
+        ? colors.surface.input.secondary
+        : colors.surface.input.primary;
     final shellColor = widget.tone == AppTextFieldTone.destructive
         ? Color.alphaBlend(
             colors.background.utilityDestructiveAlphaSubtle,

--- a/lib/src/core/widgets/mobile_text_field.dart
+++ b/lib/src/core/widgets/mobile_text_field.dart
@@ -6,7 +6,7 @@ import 'package:flutter/widgets.dart';
 import '../theme/app_theme.dart';
 
 /// The shared single-line mobile text field (Figma `_Modal Type` field
-/// 4755:84371 / 4755:85337): a flat `surface.input` box sized by
+/// 4755:84371 / 4755:85337): a flat `surface.input.primary` box sized by
 /// [AppInputSizing] (60px tall, radius 16 on mobile), label-m Medium text, NO
 /// visible border by default and a bright `background.inverse` outline only
 /// while focused, over the layered surface shadow — the same shell the
@@ -149,7 +149,7 @@ class _MobileTextFieldState extends State<MobileTextField> {
       // AppTextField shell.
       height: widget.height ?? AppInputSizing.height,
       decoration: BoxDecoration(
-        color: widget.backgroundColor ?? colors.surface.input,
+        color: widget.backgroundColor ?? colors.surface.input.primary,
         borderRadius: BorderRadius.circular(
           widget.radius ?? AppInputSizing.radius,
         ),

--- a/lib/src/features/address_book/screens/mobile/mobile_address_book_screen.dart
+++ b/lib/src/features/address_book/screens/mobile/mobile_address_book_screen.dart
@@ -280,7 +280,7 @@ class _ContactsSearchFieldState extends State<_ContactsSearchField> {
   Widget build(BuildContext context) {
     final colors = context.colors;
     // The shared mobile input — same shell the swap modals and the contact
-    // picker use (surface.input box, search glyph, inline clear button).
+    // picker use (surface.input.primary box, search glyph, inline clear button).
     return MobileTextField(
       fieldKey: const ValueKey('mobile_contacts_search_field'),
       controller: _controller,
@@ -1337,14 +1337,14 @@ class _FieldShell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    // Mirror the resting MobileTextField surface (surface.input fill, radius
+    // Mirror the resting MobileTextField surface (surface.input.primary fill, radius
     // 16, 60px tall, the layered subtle shadow) so the network selector
     // matches the Name / Address fields in the same form.
     return Container(
       height: AppInputSizing.height,
       padding: const EdgeInsets.symmetric(horizontal: 12),
       decoration: BoxDecoration(
-        color: colors.surface.input,
+        color: colors.surface.input.primary,
         borderRadius: BorderRadius.circular(AppInputSizing.radius),
         boxShadow: [
           BoxShadow(color: colors.shadows.subtle, blurRadius: 1),

--- a/lib/src/features/onboarding/import/import_birthday_calendar_overlay.dart
+++ b/lib/src/features/onboarding/import/import_birthday_calendar_overlay.dart
@@ -208,7 +208,7 @@ class _ImportBirthdayCalendarPanelState
     final isMobile = kAppFormFactor == AppFormFactor.mobile;
     return DecoratedBox(
       decoration: BoxDecoration(
-        color: colors.surface.input,
+        color: colors.surface.input.primary,
         borderRadius: BorderRadius.circular(
           isMobile ? AppRadii.medium : AppRadii.large,
         ),

--- a/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/import/import_secret_passphrase_screen.dart
@@ -846,9 +846,9 @@ class _MnemonicWordCellState extends State<_MnemonicWordCell> {
     final shellColor = isInvalidUnfocused
         ? Color.alphaBlend(
             colors.background.utilityDestructiveAlphaSubtle,
-            colors.surface.input,
+            colors.surface.input.primary,
           )
-        : colors.surface.input;
+        : colors.surface.input.primary;
     final borderColor = isInvalidUnfocused
         ? colors.border.utilityDestructiveSubtle
         : isFocused

--- a/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/import/import_wallet_birthday_screen.dart
@@ -776,7 +776,7 @@ class _DatePickerField extends StatelessWidget {
             height: 46,
             padding: const EdgeInsets.only(left: AppSpacing.s, right: 10),
             decoration: BoxDecoration(
-              color: colors.surface.input,
+              color: colors.surface.input.primary,
               borderRadius: BorderRadius.circular(AppRadii.small),
               border: Border.all(color: const Color(0x00000000), width: 1.5),
               boxShadow: _birthdayFieldSurfaceShadow(colors),
@@ -838,9 +838,9 @@ class _BlockHeightField extends StatelessWidget {
         color: hasError
             ? Color.alphaBlend(
                 colors.background.utilityDestructiveAlphaSubtle,
-                colors.surface.input,
+                colors.surface.input.primary,
               )
-            : colors.surface.input,
+            : colors.surface.input.primary,
         borderRadius: BorderRadius.circular(AppRadii.small),
         border: Border.all(color: borderColor, width: 1.5),
         boxShadow: hasError

--- a/lib/src/features/onboarding/keystone/keystone_select_account_screen.dart
+++ b/lib/src/features/onboarding/keystone/keystone_select_account_screen.dart
@@ -322,7 +322,7 @@ class _AccountRadioCard extends StatelessWidget {
             bottom: AppSpacing.xxs,
           ),
           decoration: BoxDecoration(
-            color: colors.surface.input,
+            color: colors.surface.input.primary,
             border: Border.all(color: borderColor, width: selected ? 2 : 0),
             borderRadius: BorderRadius.circular(AppSpacing.sm),
             boxShadow: _accountCardShadow(colors, selected: selected),

--- a/lib/src/features/onboarding/keystone/keystone_wallet_birthday_screen.dart
+++ b/lib/src/features/onboarding/keystone/keystone_wallet_birthday_screen.dart
@@ -648,7 +648,7 @@ class _DatePickerField extends StatelessWidget {
             height: 46,
             padding: const EdgeInsets.only(left: AppSpacing.s, right: 10),
             decoration: BoxDecoration(
-              color: colors.surface.input,
+              color: colors.surface.input.primary,
               borderRadius: BorderRadius.circular(AppRadii.small),
               border: Border.all(color: const Color(0x00000000), width: 1.5),
               boxShadow: _birthdayFieldSurfaceShadow(colors),
@@ -710,9 +710,9 @@ class _BlockHeightField extends StatelessWidget {
         color: hasError
             ? Color.alphaBlend(
                 colors.background.utilityDestructiveAlphaSubtle,
-                colors.surface.input,
+                colors.surface.input.primary,
               )
-            : colors.surface.input,
+            : colors.surface.input.primary,
         borderRadius: BorderRadius.circular(AppRadii.small),
         border: Border.all(color: borderColor, width: 1.5),
         boxShadow: hasError

--- a/lib/src/features/onboarding/mobile/mobile_import_birthday_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_birthday_screen.dart
@@ -751,13 +751,13 @@ class _FieldShell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    // Raised white card (surface.input fill, radius 16, layered subtle
+    // Raised white card (surface.input.primary fill, radius 16, layered subtle
     // shadow) with a focus-only inverse outline — mirrors MobileTextField.
     return Container(
       height: AppInputSizing.height,
       padding: const EdgeInsets.symmetric(horizontal: AppSpacing.s),
       decoration: BoxDecoration(
-        color: colors.surface.input,
+        color: colors.surface.input.primary,
         borderRadius: BorderRadius.circular(AppInputSizing.radius),
         border: Border.all(
           color: focused ? colors.background.inverse : const Color(0x00000000),

--- a/lib/src/features/send/screens/mobile/mobile_send_screen.dart
+++ b/lib/src/features/send/screens/mobile/mobile_send_screen.dart
@@ -1640,7 +1640,10 @@ class _MobileSendScreenState extends ConsumerState<MobileSendScreen> {
         expand: true,
         constrainContent: true,
         disabledBackgroundColor: useBackdropColors
-            ? Color.alphaBlend(colors.button.disabled.bg, colors.surface.input)
+            ? Color.alphaBlend(
+                colors.button.disabled.bg,
+                colors.surface.input.primary,
+              )
             : null,
         enabledBorderColor: useBackdropColors
             ? colors.border.subtleOpacity

--- a/lib/src/features/send/screens/send_screen.dart
+++ b/lib/src/features/send/screens/send_screen.dart
@@ -1249,7 +1249,7 @@ class _SendAddMessageCard extends StatelessWidget {
       width: double.infinity,
       height: 128,
       decoration: BoxDecoration(
-        color: colors.surface.input,
+        color: colors.surface.input.primary,
         borderRadius: BorderRadius.circular(AppRadii.medium),
         boxShadow: _sendInputSurfaceShadow(colors),
       ),

--- a/lib/src/features/send/widgets/send_compose_view.dart
+++ b/lib/src/features/send/widgets/send_compose_view.dart
@@ -361,7 +361,7 @@ class _SendAddMemoCard extends StatelessWidget {
       width: double.infinity,
       height: 128,
       decoration: BoxDecoration(
-        color: colors.surface.input,
+        color: colors.surface.input.primary,
         borderRadius: BorderRadius.circular(AppRadii.medium),
         boxShadow: _sendInputSurfaceShadow(colors),
       ),

--- a/lib/src/features/voting/screens/voting_status_screen.dart
+++ b/lib/src/features/voting/screens/voting_status_screen.dart
@@ -1063,7 +1063,7 @@ class _KeystoneSigningMemo extends StatelessWidget {
       width: double.infinity,
       child: DecoratedBox(
         decoration: BoxDecoration(
-          color: colors.surface.input,
+          color: colors.surface.input.primary,
           border: Border.all(color: colors.border.subtle),
           borderRadius: BorderRadius.circular(AppRadii.small),
         ),

--- a/lib/widgetbook/color_use_cases.dart
+++ b/lib/widgetbook/color_use_cases.dart
@@ -386,16 +386,22 @@ Widget buildSurfaceUseCase(BuildContext context) {
         light: l.surface.card,
       ),
       TokenSwatch(
-        name: 'surface/input',
+        name: 'surface/input/primary',
         description: 'Text input background at rest',
-        dark: d.surface.input,
-        light: l.surface.input,
+        dark: d.surface.input.primary,
+        light: l.surface.input.primary,
       ),
       TokenSwatch(
-        name: 'surface/input-focus',
+        name: 'surface/input/secondary',
+        description: 'Filled secondary text input shell',
+        dark: d.surface.input.secondary,
+        light: l.surface.input.secondary,
+      ),
+      TokenSwatch(
+        name: 'surface/input/focus',
         description: 'Text input when focused',
-        dark: d.surface.inputFocus,
-        light: l.surface.inputFocus,
+        dark: d.surface.input.focus,
+        light: l.surface.input.focus,
       ),
       TokenSwatch(
         name: 'surface/nav',

--- a/test/core/theme/design_tokens_test.dart
+++ b/test/core/theme/design_tokens_test.dart
@@ -256,6 +256,13 @@ void main() {
     expect(dark.background.neutralScrim, const Color(0x80141818));
     expect(dark.background.neutralSubtleOpacity, const Color(0x33626767));
 
+    expect(light.surface.input.primary, Primitives.p0Light);
+    expect(light.surface.input.secondary, Primitives.p100Light);
+    expect(light.surface.input.focus, Primitives.p50Light);
+    expect(dark.surface.input.primary, Primitives.p50Dark);
+    expect(dark.surface.input.secondary, Primitives.p150Dark);
+    expect(dark.surface.input.focus, Primitives.p100Dark);
+
     expect(light.button.disabled.bg, const Color(0x33B8B8B8));
     expect(light.button.disabled.label, const Color(0x80858686));
     expect(dark.button.disabled.bg, const Color(0x334D5252));

--- a/test/core/widgets/app_text_field_test.dart
+++ b/test/core/widgets/app_text_field_test.dart
@@ -6,6 +6,30 @@ import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_text_field.dart';
 
 void main() {
+  testWidgets('secondary surface keeps its input shell in light mode', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const _ThemedHarness(
+        child: SizedBox(
+          width: 352,
+          child: AppTextField(
+            label: 'Password',
+            hintText: 'Enter password',
+            surface: AppTextFieldSurface.secondary,
+          ),
+        ),
+      ),
+    );
+
+    final decoration = _fieldShellDecoration(tester);
+    expect(decoration.color, AppThemeData.light.colors.surface.input.secondary);
+    expect(
+      decoration.color,
+      isNot(AppThemeData.light.colors.button.secondary.bg),
+    );
+  });
+
   testWidgets('single-line padded input area wins over root unfocus', (
     tester,
   ) async {
@@ -581,4 +605,21 @@ class _SizedTextArea extends StatelessWidget {
       ),
     );
   }
+}
+
+BoxDecoration _fieldShellDecoration(WidgetTester tester) {
+  final decorations = tester
+      .widgetList<DecoratedBox>(
+        find.descendant(
+          of: find.byType(AppTextField),
+          matching: find.byType(DecoratedBox),
+        ),
+      )
+      .map((box) => box.decoration)
+      .whereType<BoxDecoration>()
+      .where((decoration) => decoration.border is Border)
+      .toList();
+
+  expect(decorations, hasLength(1));
+  return decorations.single;
 }

--- a/test/features/onboarding/import_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/import_secret_passphrase_screen_test.dart
@@ -138,7 +138,7 @@ void main() {
     final emptyDecoration = _fieldShellDecoration(tester, 1);
     expect(_fieldBorder(emptyDecoration).top.color, Colors.transparent);
     expect(_fieldBorder(emptyDecoration).top.width, 1.5);
-    expect(emptyDecoration.color, colors.surface.input);
+    expect(emptyDecoration.color, colors.surface.input.primary);
     expect(emptyDecoration.boxShadow, isNotEmpty);
     expect(_fieldNumberColor(tester, '02'), colors.text.secondary);
     expect(
@@ -154,7 +154,7 @@ void main() {
       _fieldBorder(focusedInvalidPrefixDecoration).top.color,
       colors.background.inverse,
     );
-    expect(focusedInvalidPrefixDecoration.color, colors.surface.input);
+    expect(focusedInvalidPrefixDecoration.color, colors.surface.input.primary);
     expect(focusedInvalidPrefixDecoration.boxShadow, isNotEmpty);
     expect(_fieldNumberColor(tester, '01'), colors.text.accent);
 
@@ -170,7 +170,7 @@ void main() {
       invalidUnfocusedDecoration.color,
       Color.alphaBlend(
         colors.background.utilityDestructiveAlphaSubtle,
-        colors.surface.input,
+        colors.surface.input.primary,
       ),
     );
     expect(invalidUnfocusedDecoration.boxShadow, isEmpty);
@@ -185,7 +185,7 @@ void main() {
       _fieldBorder(validUnfocusedDecoration).top.color,
       Colors.transparent,
     );
-    expect(validUnfocusedDecoration.color, colors.surface.input);
+    expect(validUnfocusedDecoration.color, colors.surface.input.primary);
     expect(validUnfocusedDecoration.boxShadow, isNotEmpty);
     expect(_fieldNumberColor(tester, '03'), colors.text.accent);
     expect(_textField(tester, 2).style?.fontWeight, FontWeight.w400);

--- a/test/features/send/mobile_send_screen_test.dart
+++ b/test/features/send/mobile_send_screen_test.dart
@@ -863,7 +863,7 @@ void main() {
     var decoration = _continueButtonDecoration(tester);
     expect(
       decoration.color,
-      Color.alphaBlend(colors.button.disabled.bg, colors.surface.input),
+      Color.alphaBlend(colors.button.disabled.bg, colors.surface.input.primary),
     );
 
     await _enterAddress(tester, _invalidAddress);


### PR DESCRIPTION
## Summary
- Group text-field surface colors under `surface.input` (`primary`, `secondary`, `focus`).
- Restore the desktop unlock password input to the gray secondary field surface via `surface.input.secondary`.
- Keep PR #299 secondary button light-token changes intact.
- Add regression coverage so secondary input surfaces no longer depend on secondary button or generic layout-depth tokens.

## Impact from PR #299
PR #299 changed the light secondary button background token from gray to white. That was expected to affect secondary buttons and custom button-like controls that directly read `colors.button.secondary.bg`.

One unintended path also depended on that button token: `AppTextFieldSurface.secondary` used the secondary button background for its input shell. Because the desktop Unlock screen is the only production caller that opts into `AppTextFieldSurface.secondary`, the visible input regression was isolated to the `/unlock` password field, where the field changed from the expected gray shell to white.

## What changed
- `AppSurfaceColors.input` is now a nested `AppInputSurfaceColors` palette with `primary`, `secondary`, and `focus` roles.
- `AppTextFieldSurface.secondary` now reads `colors.surface.input.secondary` instead of `colors.button.secondary.bg` or a generic layout-depth token such as `colors.background.raised`.
- Existing primary input callers now read `colors.surface.input.primary`.
- `AppButtonVariant.secondary` and the secondary button token values are unchanged.
- Widgetbook color swatches and design token tests now expose `surface/input/primary`, `surface/input/secondary`, and `surface/input/focus`.
- The widget regression test asserts that the light secondary input shell resolves through `surface.input.secondary` and is not coupled to the secondary button background.

## Validation
- `fvm flutter test test/core/theme/design_tokens_test.dart test/core/widgets/app_text_field_test.dart test/features/onboarding/import_secret_passphrase_screen_test.dart test/features/send/mobile_send_screen_test.dart`
- `fvm flutter test test/features/send/mobile_send_screen_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `fvm flutter analyze`
- `git diff --check`
