### PR TITLE
Prevent mnemonic capture in mobile screenshots (VZR-105)

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1068,15 +1068,16 @@ final class SecureScreenshotShield {
     guard geometryObservers.isEmpty else { return }
     let nc = NotificationCenter.default
     let reassert: (Notification) -> Void = { [weak self] _ in
-      DispatchQueue.main.async {
-        guard let self else { return }
-        // A scene reconnect can swap in a fresh key window while a secret is
-        // still on screen, and Dart will not re-send setSensitiveContentVisible
-        // (the token set is unchanged). Re-graft to the live window here — a
-        // no-op when the window is unchanged — before re-pinning geometry, so
-        // the new window is inside the secure canvas and stays blanked.
-        self.attachLayerIfNeeded()
-        self.reassertWindowGeometry()
+      guard let self else { return }
+      // These observers deliver on the main queue. Re-graft synchronously so a
+      // newly active window is protected before UIKit presents its first frame.
+      self.attachLayerIfNeeded()
+      self.reassertWindowGeometry()
+
+      // Rotation can settle the final window bounds after its notification.
+      // Re-pin geometry once more without delaying the security attachment.
+      DispatchQueue.main.async { [weak self] in
+        self?.reassertWindowGeometry()
       }
     }
     geometryObservers = [

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -529,6 +529,36 @@ import UIKit
       }
     }
 
+    // MethodChannel for the native screenshot/recording privacy shield —
+    // mirrors the macOS `PrivacyExposureChannel` contract on the shared
+    // `privacy_shield` channel. iOS only needs the window-blanking half.
+    let privacyShieldChannel = FlutterMethodChannel(
+      name: "com.zcash.wallet/privacy_shield",
+      binaryMessenger: messenger
+    )
+    privacyShieldChannel.setMethodCallHandler { (call, result) in
+      switch call.method {
+      case "setSensitiveContentVisible":
+        guard
+          let args = call.arguments as? [String: Any],
+          let visible = args["visible"] as? Bool
+        else {
+          result(
+            FlutterError(
+              code: "bad_args",
+              message: "Expected visible argument.",
+              details: nil
+            )
+          )
+          return
+        }
+        SecureScreenshotShield.shared.setSensitiveContentVisible(visible)
+        result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     // EventChannel for screenshot detection — sensitive screens (secret
     // passphrase) warn when the user captures them.
     let screenshotChannel = FlutterEventChannel(
@@ -859,5 +889,160 @@ class ScreenshotStreamHandler: NSObject, FlutterStreamHandler {
       self.observer = nil
     }
     return nil
+  }
+}
+
+/// Blanks the whole app window in OS screenshots and screen recordings while a
+/// sensitive screen (secret passphrase / import) is showing.
+///
+/// Uses the canonical `isSecureTextEntry` layer trick: the key window's layer
+/// is re-parented into a hidden secure `UITextField`'s canvas layer, which
+/// iOS excludes from any capture. Toggling `isSecureTextEntry` then blanks or
+/// reveals the window without touching the layer tree again.
+///
+/// Every step is a defensive no-op on failure (no key window yet, missing
+/// superlayer, missing canvas layer). If the private UIKit layout this relies
+/// on changes in a future iOS release, the app degrades to its prior behavior
+/// (the post-capture screenshot warning sheet) instead of crashing.
+///
+/// Lives in this file so it needs no `project.pbxproj` entry, matching
+/// `ScreenshotStreamHandler`.
+final class SecureScreenshotShield {
+  static let shared = SecureScreenshotShield()
+
+  // Ported from no_screenshot's open-source iOS-26 technique. The secure-canvas
+  // capture exclusion already worked (stills came out black); only geometry was
+  // broken on iOS 26.5. Two fixes vs the old code: (1) find the canvas by the
+  // secure field's private CANVAS SUBVIEW class name instead of sublayer index
+  // (index `.last` grabbed a small offset aux layer on iOS 26.5), and (2) re-pin
+  // the reparented window layer to full window bounds so it no longer collapses
+  // into a corner. The flag stays as the single kill switch, and the screenshot
+  // warning sheet remains the permanent fallback if a future iOS breaks the
+  // private-layer layout this relies on.
+  private static let isNativeBlankingEnabled = true
+
+  private let secureField = UITextField()
+  private var isLayerAttached = false
+  private weak var shieldedWindow: UIWindow?
+  private weak var canvasLayer: CALayer?
+  private var geometryObservers: [NSObjectProtocol] = []
+
+  private init() {}
+
+  /// Idempotent: repeated calls with the same value only toggle the flag, and
+  /// the one-time layer setup runs at most once even across Dart hot restarts.
+  func setSensitiveContentVisible(_ visible: Bool) {
+    guard Self.isNativeBlankingEnabled else { return }
+    // MethodChannel callbacks land on the main thread, but never assume it for
+    // UIKit access — hop explicitly.
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      self.attachLayerIfNeeded()
+      // If the layer could not be attached (no window yet), a later call
+      // retries; nothing is toggled until the trick is wired up.
+      guard self.isLayerAttached else { return }
+      self.reassertWindowGeometry()
+      self.secureField.isSecureTextEntry = visible
+    }
+  }
+
+  private func attachLayerIfNeeded() {
+    guard !isLayerAttached else { return }
+    guard let window = Self.keyWindow() else { return }
+
+    secureField.isUserInteractionEnabled = false
+    secureField.translatesAutoresizingMaskIntoConstraints = false
+    // Stop a rightward shift under RTL device languages.
+    secureField.semanticContentAttribute = .forceLeftToRight
+    secureField.textAlignment = .left
+
+    // Build the field's internal (canvas) layer tree, then detach the field as a
+    // SUBVIEW so we never create a circular view hierarchy (an iOS 26 crash
+    // trap); only the LAYERS are grafted below.
+    window.addSubview(secureField)
+    secureField.layoutIfNeeded()
+    secureField.removeFromSuperview()
+
+    // Only re-parent once every dependency is present, so a partial failure
+    // leaves the window untouched.
+    guard let superlayer = window.layer.superlayer else { return }
+    guard let canvas = Self.secureCanvasLayer(of: secureField) else { return }
+
+    // Zero the container so the reparented window layer inherits no offset.
+    secureField.layer.frame = .zero
+    secureField.layer.masksToBounds = false
+    canvas.masksToBounds = false
+
+    superlayer.addSublayer(secureField.layer)
+    canvas.addSublayer(window.layer)
+
+    shieldedWindow = window
+    canvasLayer = canvas
+    isLayerAttached = true
+
+    reassertWindowGeometry()
+    installGeometryObservers()
+  }
+
+  /// Robust canvas identification: prefer the private secure-text canvas subview
+  /// by class name (stable across iOS 15..26, unlike the sublayer index), then
+  /// the largest-frame sublayer, then the historical index heuristic.
+  private static func secureCanvasLayer(of field: UITextField) -> CALayer? {
+    if let byName = field.subviews.first(where: {
+      String(describing: type(of: $0)).contains("CanvasView")
+    }) {
+      return byName.layer
+    }
+    if let biggest = field.layer.sublayers?.max(by: {
+      ($0.bounds.width * $0.bounds.height) < ($1.bounds.width * $1.bounds.height)
+    }) {
+      return biggest
+    }
+    if #available(iOS 17.0, *) { return field.layer.sublayers?.last }
+    return field.layer.sublayers?.first
+  }
+
+  /// Force the reparented window layer (and the canvas above it) back to full
+  /// window bounds at origin zero. UIKit re-lays the window layer on
+  /// rotation/scene changes, so this is re-run from the observers and before
+  /// each visibility toggle.
+  private func reassertWindowGeometry() {
+    guard let window = shieldedWindow, let canvas = canvasLayer else { return }
+    let full = CGRect(origin: .zero, size: window.bounds.size)
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    canvas.frame = full
+    canvas.masksToBounds = false
+    window.layer.frame = full
+    CATransaction.commit()
+  }
+
+  private func installGeometryObservers() {
+    guard geometryObservers.isEmpty else { return }
+    let nc = NotificationCenter.default
+    let reassert: (Notification) -> Void = { [weak self] _ in
+      DispatchQueue.main.async { self?.reassertWindowGeometry() }
+    }
+    geometryObservers = [
+      nc.addObserver(
+        forName: UIDevice.orientationDidChangeNotification,
+        object: nil, queue: .main, using: reassert
+      ),
+      nc.addObserver(
+        forName: UIScene.didActivateNotification,
+        object: nil, queue: .main, using: reassert
+      ),
+      nc.addObserver(
+        forName: UIApplication.didBecomeActiveNotification,
+        object: nil, queue: .main, using: reassert
+      ),
+    ]
+  }
+
+  private static func keyWindow() -> UIWindow? {
+    return UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .flatMap { $0.windows }
+      .first { $0.isKeyWindow }
   }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1034,7 +1034,16 @@ final class SecureScreenshotShield {
     guard geometryObservers.isEmpty else { return }
     let nc = NotificationCenter.default
     let reassert: (Notification) -> Void = { [weak self] _ in
-      DispatchQueue.main.async { self?.reassertWindowGeometry() }
+      DispatchQueue.main.async {
+        guard let self else { return }
+        // A scene reconnect can swap in a fresh key window while a secret is
+        // still on screen, and Dart will not re-send setSensitiveContentVisible
+        // (the token set is unchanged). Re-graft to the live window here — a
+        // no-op when the window is unchanged — before re-pinning geometry, so
+        // the new window is inside the secure canvas and stays blanked.
+        if self.isLayerAttached { self.attachLayerIfNeeded() }
+        self.reassertWindowGeometry()
+      }
     }
     geometryObservers = [
       nc.addObserver(

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -947,7 +947,20 @@ final class SecureScreenshotShield {
   }
 
   private func attachLayerIfNeeded() {
-    guard !isLayerAttached else { return }
+    // Re-graft if not attached, or if the window we grafted into is gone or is
+    // no longer the key window — a UIScene can reconnect and hand us a fresh
+    // UIWindow. Without this, `isLayerAttached` would latch to a dead window and
+    // silently stop blanking: a screenshot would then capture the secret in
+    // plaintext with no error and no fallback.
+    if isLayerAttached {
+      if let attached = shieldedWindow, attached === Self.keyWindow() {
+        return
+      }
+      removeGeometryObservers()
+      isLayerAttached = false
+      shieldedWindow = nil
+      canvasLayer = nil
+    }
     guard let window = Self.keyWindow() else { return }
 
     secureField.isUserInteractionEnabled = false
@@ -1037,6 +1050,14 @@ final class SecureScreenshotShield {
         object: nil, queue: .main, using: reassert
       ),
     ]
+  }
+
+  private func removeGeometryObservers() {
+    let nc = NotificationCenter.default
+    for observer in geometryObservers {
+      nc.removeObserver(observer)
+    }
+    geometryObservers.removeAll()
   }
 
   private static func keyWindow() -> UIWindow? {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -924,6 +924,7 @@ final class SecureScreenshotShield {
   private let secureField = UITextField()
   private var isLayerAttached = false
   private weak var shieldedWindow: UIWindow?
+  private weak var shieldedWindowLayer: CALayer?
   private weak var canvasLayer: CALayer?
   private var geometryObservers: [NSObjectProtocol] = []
 
@@ -947,20 +948,29 @@ final class SecureScreenshotShield {
   }
 
   private func attachLayerIfNeeded() {
+    // Keep the existing graft intact while UIKit temporarily has no key window.
+    // If the same window becomes key again, the identity check below reuses it
+    // instead of trying to insert the secure field beneath its own descendant.
+    guard let window = Self.keyWindow() else { return }
+
     // Re-graft if not attached, or if the window we grafted into is gone or is
     // no longer the key window — a UIScene can reconnect and hand us a fresh
     // UIWindow. Without this, `isLayerAttached` would latch to a dead window and
     // silently stop blanking: a screenshot would then capture the secret in
     // plaintext with no error and no fallback.
     if isLayerAttached {
-      if let attached = shieldedWindow, attached === Self.keyWindow() {
+      if let attached = shieldedWindow, attached === window {
         return
       }
+      Self.restoreLayerHierarchy(
+        windowLayer: shieldedWindowLayer,
+        secureLayer: secureField.layer
+      )
       isLayerAttached = false
       shieldedWindow = nil
+      shieldedWindowLayer = nil
       canvasLayer = nil
     }
-    guard let window = Self.keyWindow() else { return }
 
     secureField.isUserInteractionEnabled = false
     secureField.translatesAutoresizingMaskIntoConstraints = false
@@ -989,11 +999,27 @@ final class SecureScreenshotShield {
     canvas.addSublayer(window.layer)
 
     shieldedWindow = window
+    shieldedWindowLayer = window.layer
     canvasLayer = canvas
     isLayerAttached = true
 
     reassertWindowGeometry()
     installGeometryObservers()
+  }
+
+  /// Reverses the secure-canvas graft before moving the field to a different
+  /// window. The field layer occupies the window layer's former host position,
+  /// so restore the window there before attempting another UIKit attachment.
+  static func restoreLayerHierarchy(
+    windowLayer: CALayer?,
+    secureLayer: CALayer
+  ) {
+    let originalSuperlayer = secureLayer.superlayer
+    windowLayer?.removeFromSuperlayer()
+    secureLayer.removeFromSuperlayer()
+    if let originalSuperlayer, let windowLayer {
+      originalSuperlayer.addSublayer(windowLayer)
+    }
   }
 
   /// Robust canvas identification: prefer the private secure-text canvas subview

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -956,7 +956,6 @@ final class SecureScreenshotShield {
       if let attached = shieldedWindow, attached === Self.keyWindow() {
         return
       }
-      removeGeometryObservers()
       isLayerAttached = false
       shieldedWindow = nil
       canvasLayer = nil
@@ -1041,7 +1040,7 @@ final class SecureScreenshotShield {
         // (the token set is unchanged). Re-graft to the live window here — a
         // no-op when the window is unchanged — before re-pinning geometry, so
         // the new window is inside the secure canvas and stays blanked.
-        if self.isLayerAttached { self.attachLayerIfNeeded() }
+        self.attachLayerIfNeeded()
         self.reassertWindowGeometry()
       }
     }
@@ -1059,14 +1058,6 @@ final class SecureScreenshotShield {
         object: nil, queue: .main, using: reassert
       ),
     ]
-  }
-
-  private func removeGeometryObservers() {
-    let nc = NotificationCenter.default
-    for observer in geometryObservers {
-      nc.removeObserver(observer)
-    }
-    geometryObservers.removeAll()
   }
 
   private static func keyWindow() -> UIWindow? {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -934,9 +934,7 @@ final class SecureScreenshotShield {
   /// the one-time layer setup runs at most once even across Dart hot restarts.
   func setSensitiveContentVisible(_ visible: Bool) {
     guard Self.isNativeBlankingEnabled else { return }
-    // MethodChannel callbacks land on the main thread, but never assume it for
-    // UIKit access — hop explicitly.
-    DispatchQueue.main.async { [weak self] in
+    Self.performOnMain { [weak self] in
       guard let self else { return }
       self.attachLayerIfNeeded()
       // If the layer could not be attached (no window yet), a later call
@@ -944,6 +942,17 @@ final class SecureScreenshotShield {
       guard self.isLayerAttached else { return }
       self.reassertWindowGeometry()
       self.secureField.isSecureTextEntry = visible
+    }
+  }
+
+  /// MethodChannel handlers use the main thread by default. Apply inline there
+  /// so capture exclusion is enabled before the handler returns; retain a safe
+  /// fallback for any future caller that reaches this API off-main.
+  static func performOnMain(_ operation: @escaping () -> Void) {
+    if Thread.isMainThread {
+      operation()
+    } else {
+      DispatchQueue.main.async(execute: operation)
     }
   }
 

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -1,4 +1,5 @@
 import Flutter
+import QuartzCore
 import Security
 import UIKit
 import UserNotifications
@@ -7,6 +8,25 @@ import XCTest
 @testable import Runner
 
 class RunnerTests: XCTestCase {
+
+  func testScreenshotShieldRestoresWindowLayerBeforeRegrafting() {
+    let hostLayer = CALayer()
+    let secureLayer = CALayer()
+    let canvasLayer = CALayer()
+    let windowLayer = CALayer()
+    hostLayer.addSublayer(secureLayer)
+    secureLayer.addSublayer(canvasLayer)
+    canvasLayer.addSublayer(windowLayer)
+
+    SecureScreenshotShield.restoreLayerHierarchy(
+      windowLayer: windowLayer,
+      secureLayer: secureLayer
+    )
+
+    XCTAssertTrue(windowLayer.superlayer === hostLayer)
+    XCTAssertNil(secureLayer.superlayer)
+    XCTAssertFalse(canvasLayer.sublayers?.contains(windowLayer) ?? false)
+  }
 
   func testMigrationNotificationAuthorizationStatusIsFailClosed() {
     XCTAssertEqual(

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -9,6 +9,22 @@ import XCTest
 
 class RunnerTests: XCTestCase {
 
+  func testScreenshotShieldAppliesInlineOnMainThread() {
+    let applied = expectation(description: "secure flag applied inline")
+
+    DispatchQueue.main.async {
+      var didApply = false
+      SecureScreenshotShield.performOnMain {
+        didApply = true
+      }
+
+      XCTAssertTrue(didApply)
+      applied.fulfill()
+    }
+
+    wait(for: [applied], timeout: 1)
+  }
+
   func testScreenshotShieldRestoresWindowLayerBeforeRegrafting() {
     let hostLayer = CALayer()
     let secureLayer = CALayer()

--- a/lib/src/core/platform/screenshot_observer.dart
+++ b/lib/src/core/platform/screenshot_observer.dart
@@ -6,9 +6,12 @@ import 'package:flutter/services.dart';
 const _channel = EventChannel('com.zcash.wallet/screenshots');
 
 /// Emits whenever the OS reports a user screenshot (iOS only — Android
-/// would use FLAG_SECURE instead and never emits here). Errors from a
-/// missing host handler (tests, other platforms) are swallowed so
-/// listeners only ever see real events.
+/// uses FLAG_SECURE and never emits here). iOS now also blanks the window
+/// via the secure-field privacy shield (see `SecureScreenshotShield`), but
+/// keeps this stream as a secondary UX: the OS only reports the capture
+/// after it happens, so the warning sheet explains why the shot is blank.
+/// Errors from a missing host handler (tests, other platforms) are
+/// swallowed so listeners only ever see real events.
 Stream<void> screenshotEvents() {
   if (kIsWeb || !Platform.isIOS) return const Stream.empty();
   return _channel

--- a/lib/src/core/platform/screenshot_observer.dart
+++ b/lib/src/core/platform/screenshot_observer.dart
@@ -5,6 +5,13 @@ import 'package:flutter/services.dart';
 
 const _channel = EventChannel('com.zcash.wallet/screenshots');
 
+// Cache the broadcast stream so stacked screens (e.g. paste import → manual
+// import, both mounted) share ONE native subscription. Calling
+// receiveBroadcastStream() per listener creates competing listen/cancel pairs
+// on the single-listener native handler, so popping the top route would tear
+// down the handler and silently stop the still-mounted route's events.
+Stream<dynamic>? _broadcast;
+
 /// Emits whenever the OS reports a user screenshot (iOS only — Android
 /// uses FLAG_SECURE and never emits here). iOS now also blanks the window
 /// via the secure-field privacy shield (see `SecureScreenshotShield`), but
@@ -14,8 +21,6 @@ const _channel = EventChannel('com.zcash.wallet/screenshots');
 /// swallowed so listeners only ever see real events.
 Stream<void> screenshotEvents() {
   if (kIsWeb || !Platform.isIOS) return const Stream.empty();
-  return _channel
-      .receiveBroadcastStream()
-      .map((_) {})
-      .handleError((Object _) {});
+  final broadcast = _broadcast ??= _channel.receiveBroadcastStream();
+  return broadcast.map((_) {}).handleError((Object _) {});
 }

--- a/lib/src/core/privacy/route_coverage_aware.dart
+++ b/lib/src/core/privacy/route_coverage_aware.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/widgets.dart';
+
+/// Tracks whether this route has been fully covered by a route pushed on top.
+///
+/// A screen that shows a secret drives a global native screenshot shield
+/// (`SensitivePrivacyOverlay` → Android `FLAG_SECURE` / iOS secure-field
+/// blanking). When it pushes the next step, it must drop that token so the
+/// pushed, non-secret screens are not blanked — but only *after* the secret
+/// screen is off-screen. Keying the drop off the route's `secondaryAnimation`
+/// (rather than the push/pop `Future`) keeps the shield engaged through the
+/// entire push slide-out and pop slide-in, so the secret is never visible
+/// unblanked during a transition.
+mixin RouteCoverageAware<T extends StatefulWidget> on State<T> {
+  Animation<double>? _secondaryAnimation;
+  bool _coveredByNextRoute = false;
+
+  /// True only once the next route has fully slid over this one. False while
+  /// this route is on top and throughout both the push and pop transitions.
+  bool get isCoveredByNextRoute => _coveredByNextRoute;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final secondary = ModalRoute.of(context)?.secondaryAnimation;
+    if (identical(secondary, _secondaryAnimation)) return;
+    _secondaryAnimation?.removeStatusListener(_onSecondaryStatus);
+    _secondaryAnimation = secondary;
+    _secondaryAnimation?.addStatusListener(_onSecondaryStatus);
+    // Set directly — build runs right after didChangeDependencies; the listener
+    // uses setState for later status changes.
+    _coveredByNextRoute = secondary?.status == AnimationStatus.completed;
+  }
+
+  void _onSecondaryStatus(AnimationStatus status) {
+    final covered = status == AnimationStatus.completed;
+    if (covered == _coveredByNextRoute || !mounted) return;
+    setState(() => _coveredByNextRoute = covered);
+  }
+
+  @override
+  void dispose() {
+    _secondaryAnimation?.removeStatusListener(_onSecondaryStatus);
+    super.dispose();
+  }
+}

--- a/lib/src/core/privacy/sensitive_privacy_overlay.dart
+++ b/lib/src/core/privacy/sensitive_privacy_overlay.dart
@@ -149,7 +149,6 @@ class SensitivePrivacyOverlayController extends ChangeNotifier {
 
   bool _isSafe;
   bool _authPromptActive = false;
-  bool _screenshotSuppressionActive = false;
 
   /// Whether sensitive content may be shown unobscured.
   bool get isSafe => _isSafe;
@@ -172,27 +171,6 @@ class SensitivePrivacyOverlayController extends ChangeNotifier {
   void endAuthPrompt() {
     if (!_authPromptActive) return;
     _authPromptActive = false;
-    notifyListeners();
-  }
-
-  /// Suppresses the shield through the brief `inactive` transition the iOS
-  /// screenshot preview/editor causes. The native secure-field blanking already
-  /// blacks out the actual capture and the warning sheet already explains it, so
-  /// the extra blur flash during the screenshot flow is pure noise. The
-  /// The caller releases this via [endScreenshotSuppression] when the warning
-  /// sheet closes, so the suppression is scoped to the active screenshot flow
-  /// rather than a fixed timeout — a genuine backgrounding once the sheet is
-  /// gone still blurs.
-  void beginScreenshotSuppression() {
-    if (_screenshotSuppressionActive) return;
-    _screenshotSuppressionActive = true;
-    notifyListeners();
-  }
-
-  /// Releases the [beginScreenshotSuppression] marker.
-  void endScreenshotSuppression() {
-    if (!_screenshotSuppressionActive) return;
-    _screenshotSuppressionActive = false;
     notifyListeners();
   }
 
@@ -292,20 +270,6 @@ class SensitivePrivacyEnvironmentController
   }
 
   @override
-  void beginScreenshotSuppression() {
-    if (_disposed || _screenshotSuppressionActive) return;
-    super.beginScreenshotSuppression();
-    _syncSafety();
-  }
-
-  @override
-  void endScreenshotSuppression() {
-    if (_disposed || !_screenshotSuppressionActive) return;
-    super.endScreenshotSuppression();
-    _syncSafety();
-  }
-
-  @override
   void onWindowFocus() => _setWindowSafe(true);
 
   @override
@@ -362,10 +326,8 @@ class SensitivePrivacyEnvironmentController
   }
 
   void _syncSafety() {
-    final suppressedInactive =
-        _lifecycleInactive &&
-        (_authPromptActive || _screenshotSuppressionActive);
-    final lifecycleSafe = _lifecycleSafe || suppressedInactive;
+    final lifecycleSafe =
+        _lifecycleSafe || (_lifecycleInactive && _authPromptActive);
     _setSafe(lifecycleSafe && _windowSafe && _macOSNativeSafe);
   }
 

--- a/lib/src/core/privacy/sensitive_privacy_overlay.dart
+++ b/lib/src/core/privacy/sensitive_privacy_overlay.dart
@@ -179,7 +179,10 @@ class SensitivePrivacyOverlayController extends ChangeNotifier {
   /// screenshot preview/editor causes. The native secure-field blanking already
   /// blacks out the actual capture and the warning sheet already explains it, so
   /// the extra blur flash during the screenshot flow is pure noise. The
-  /// environment controller auto-releases this on the next foreground return.
+  /// The caller releases this via [endScreenshotSuppression] when the warning
+  /// sheet closes, so the suppression is scoped to the active screenshot flow
+  /// rather than a fixed timeout — a genuine backgrounding once the sheet is
+  /// gone still blurs.
   void beginScreenshotSuppression() {
     if (_screenshotSuppressionActive) return;
     _screenshotSuppressionActive = true;
@@ -264,7 +267,6 @@ class SensitivePrivacyEnvironmentController
   bool _macOSNativeSafe = true;
   bool _disposed = false;
   bool _deferAuthClear = false;
-  Timer? _screenshotSuppressionTimer;
 
   @override
   void beginAuthPrompt() {
@@ -291,26 +293,15 @@ class SensitivePrivacyEnvironmentController
 
   @override
   void beginScreenshotSuppression() {
-    final wasActive = _screenshotSuppressionActive;
-    _screenshotSuppressionActive = true;
-    // Backstop: if the app never goes inactive (the user ignores the preview),
-    // release after a short window so a genuine later backgrounding still
-    // blurs. It only clears while already foreground; if the editor is still
-    // up (inactive), the foreground transition clears it instead, so the
-    // shield never flashes during the editor dismiss animation.
-    _screenshotSuppressionTimer?.cancel();
-    _screenshotSuppressionTimer = Timer(const Duration(seconds: 8), () {
-      if (!_lifecycleInactive) endScreenshotSuppression();
-    });
-    if (!wasActive) _syncSafety();
+    if (_disposed || _screenshotSuppressionActive) return;
+    super.beginScreenshotSuppression();
+    _syncSafety();
   }
 
   @override
   void endScreenshotSuppression() {
-    _screenshotSuppressionTimer?.cancel();
-    _screenshotSuppressionTimer = null;
-    if (!_screenshotSuppressionActive) return;
-    _screenshotSuppressionActive = false;
+    if (_disposed || !_screenshotSuppressionActive) return;
+    super.endScreenshotSuppression();
     _syncSafety();
   }
 
@@ -344,13 +335,6 @@ class SensitivePrivacyEnvironmentController
       // frame where content is visible, unsuppressed, and unsafe.
       _deferAuthClear = false;
       _authPromptActive = false;
-    }
-    if (_screenshotSuppressionActive) {
-      // The iOS screenshot preview/editor handed foreground back; drop the
-      // suppression so a genuine later backgrounding blurs normally.
-      _screenshotSuppressionTimer?.cancel();
-      _screenshotSuppressionTimer = null;
-      _screenshotSuppressionActive = false;
     }
     _syncSafety();
   }
@@ -388,7 +372,6 @@ class SensitivePrivacyEnvironmentController
   @override
   void dispose() {
     _disposed = true;
-    _screenshotSuppressionTimer?.cancel();
     _macOSExposureSub?.cancel();
     _lifecycleListener?.dispose();
     if (_supportsPlatformPrivacySignals) {

--- a/lib/src/core/privacy/sensitive_privacy_overlay.dart
+++ b/lib/src/core/privacy/sensitive_privacy_overlay.dart
@@ -270,14 +270,14 @@ class SensitivePrivacyEnvironmentController
 
   @override
   void beginAuthPrompt() {
-    if (_authPromptActive) return;
+    if (_disposed || _authPromptActive) return;
     super.beginAuthPrompt();
     _syncSafety();
   }
 
   @override
   void endAuthPrompt() {
-    if (!_authPromptActive) return;
+    if (_disposed || !_authPromptActive) return;
     // The biometric sheet pushes the app to `inactive`; dropping suppression
     // now would flash the shield for the frames before `onResume`/`onShow`
     // arrives. Defer the release to the next foreground transition so

--- a/lib/src/core/privacy/sensitive_privacy_overlay.dart
+++ b/lib/src/core/privacy/sensitive_privacy_overlay.dart
@@ -19,6 +19,7 @@ bool get _supportsNativePrivacyShield => supportsNativePrivacyShield(
   isWeb: kIsWeb,
   isMacOS: !kIsWeb && Platform.isMacOS,
   isAndroid: !kIsWeb && Platform.isAndroid,
+  isIOS: !kIsWeb && Platform.isIOS,
 );
 
 @visibleForTesting
@@ -31,13 +32,23 @@ bool supportsPlatformPrivacySignals({
   return !isWeb && isMacOS;
 }
 
+/// Whether the platform can natively blank the app in OS screenshots and
+/// screen recordings via the `com.zcash.wallet/privacy_shield` channel.
+///
+/// - macOS suppresses Mission Control capture of the window.
+/// - Android sets `FLAG_SECURE`.
+/// - iOS re-parents the window layer into a `secureTextEntry` field's canvas
+///   (see `SecureScreenshotShield` in `ios/Runner/AppDelegate.swift`); the
+///   screenshot warning sheet stays as a secondary post-capture UX because
+///   iOS only notifies after the capture completes.
 @visibleForTesting
 bool supportsNativePrivacyShield({
   required bool isWeb,
   required bool isMacOS,
   required bool isAndroid,
+  required bool isIOS,
 }) {
-  return !isWeb && (isMacOS || isAndroid);
+  return !isWeb && (isMacOS || isAndroid || isIOS);
 }
 
 class MacOSPrivacyExposureEvent {
@@ -138,6 +149,7 @@ class SensitivePrivacyOverlayController extends ChangeNotifier {
 
   bool _isSafe;
   bool _authPromptActive = false;
+  bool _screenshotSuppressionActive = false;
 
   /// Whether sensitive content may be shown unobscured.
   bool get isSafe => _isSafe;
@@ -160,6 +172,24 @@ class SensitivePrivacyOverlayController extends ChangeNotifier {
   void endAuthPrompt() {
     if (!_authPromptActive) return;
     _authPromptActive = false;
+    notifyListeners();
+  }
+
+  /// Suppresses the shield through the brief `inactive` transition the iOS
+  /// screenshot preview/editor causes. The native secure-field blanking already
+  /// blacks out the actual capture and the warning sheet already explains it, so
+  /// the extra blur flash during the screenshot flow is pure noise. The
+  /// environment controller auto-releases this on the next foreground return.
+  void beginScreenshotSuppression() {
+    if (_screenshotSuppressionActive) return;
+    _screenshotSuppressionActive = true;
+    notifyListeners();
+  }
+
+  /// Releases the [beginScreenshotSuppression] marker.
+  void endScreenshotSuppression() {
+    if (!_screenshotSuppressionActive) return;
+    _screenshotSuppressionActive = false;
     notifyListeners();
   }
 
@@ -234,6 +264,7 @@ class SensitivePrivacyEnvironmentController
   bool _macOSNativeSafe = true;
   bool _disposed = false;
   bool _deferAuthClear = false;
+  Timer? _screenshotSuppressionTimer;
 
   @override
   void beginAuthPrompt() {
@@ -256,6 +287,31 @@ class SensitivePrivacyEnvironmentController
       super.endAuthPrompt();
       _syncSafety();
     }
+  }
+
+  @override
+  void beginScreenshotSuppression() {
+    final wasActive = _screenshotSuppressionActive;
+    _screenshotSuppressionActive = true;
+    // Backstop: if the app never goes inactive (the user ignores the preview),
+    // release after a short window so a genuine later backgrounding still
+    // blurs. It only clears while already foreground; if the editor is still
+    // up (inactive), the foreground transition clears it instead, so the
+    // shield never flashes during the editor dismiss animation.
+    _screenshotSuppressionTimer?.cancel();
+    _screenshotSuppressionTimer = Timer(const Duration(seconds: 8), () {
+      if (!_lifecycleInactive) endScreenshotSuppression();
+    });
+    if (!wasActive) _syncSafety();
+  }
+
+  @override
+  void endScreenshotSuppression() {
+    _screenshotSuppressionTimer?.cancel();
+    _screenshotSuppressionTimer = null;
+    if (!_screenshotSuppressionActive) return;
+    _screenshotSuppressionActive = false;
+    _syncSafety();
   }
 
   @override
@@ -289,6 +345,13 @@ class SensitivePrivacyEnvironmentController
       _deferAuthClear = false;
       _authPromptActive = false;
     }
+    if (_screenshotSuppressionActive) {
+      // The iOS screenshot preview/editor handed foreground back; drop the
+      // suppression so a genuine later backgrounding blurs normally.
+      _screenshotSuppressionTimer?.cancel();
+      _screenshotSuppressionTimer = null;
+      _screenshotSuppressionActive = false;
+    }
     _syncSafety();
   }
 
@@ -315,14 +378,17 @@ class SensitivePrivacyEnvironmentController
   }
 
   void _syncSafety() {
-    final lifecycleSafe =
-        _lifecycleSafe || (_lifecycleInactive && _authPromptActive);
+    final suppressedInactive =
+        _lifecycleInactive &&
+        (_authPromptActive || _screenshotSuppressionActive);
+    final lifecycleSafe = _lifecycleSafe || suppressedInactive;
     _setSafe(lifecycleSafe && _windowSafe && _macOSNativeSafe);
   }
 
   @override
   void dispose() {
     _disposed = true;
+    _screenshotSuppressionTimer?.cancel();
     _macOSExposureSub?.cancel();
     _lifecycleListener?.dispose();
     if (_supportsPlatformPrivacySignals) {

--- a/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
@@ -144,6 +144,9 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
       );
     } finally {
       _screenshotSheetShowing = false;
+      // Release the shield suppression now the warning sheet is gone, so a
+      // genuine later backgrounding still blurs.
+      _privacyController.endScreenshotSuppression();
     }
   }
 

--- a/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
@@ -1,12 +1,20 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart' show TextField;
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../main.dart' show log;
+import '../../../core/feedback/app_haptics.dart';
+import '../../../core/layout/mobile/app_mobile_sheet.dart';
+import '../../../core/platform/screenshot_observer.dart';
+import '../../../core/privacy/sensitive_privacy_overlay.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../rust/api/wallet.dart' as rust_wallet;
+import '../../settings/screens/mobile/mobile_seed_phrase_screen.dart'
+    show MobileSeedScreenshotWarningSheet;
 import '../shared/onboarding_flow_args.dart';
 import 'mobile_import_review_screen.dart';
 import 'mobile_import_screens.dart';
@@ -28,6 +36,8 @@ class MobileImportManualScreen extends StatefulWidget {
     this.initialAcceptedWords = const [],
     this.initialTypedWord,
     this.initialError,
+    this.screenshotStream,
+    this.privacyOverlayController,
     super.key,
   });
 
@@ -47,6 +57,13 @@ class MobileImportManualScreen extends StatefulWidget {
   @visibleForTesting
   final String? initialError;
 
+  /// Test seam — production listens to the platform screenshot events.
+  @visibleForTesting
+  final Stream<void>? screenshotStream;
+
+  @visibleForTesting
+  final SensitivePrivacyOverlayController? privacyOverlayController;
+
   @override
   State<MobileImportManualScreen> createState() =>
       _MobileImportManualScreenState();
@@ -59,9 +76,21 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
   final _focusNode = FocusNode();
   String? _error;
 
+  StreamSubscription<void>? _screenshotSub;
+  bool _screenshotSheetShowing = false;
+  late final bool _ownsPrivacyController;
+  late final SensitivePrivacyOverlayController _privacyController;
+
   @override
   void initState() {
     super.initState();
+    _ownsPrivacyController = widget.privacyOverlayController == null;
+    _privacyController =
+        widget.privacyOverlayController ??
+        SensitivePrivacyEnvironmentController();
+    _screenshotSub = (widget.screenshotStream ?? screenshotEvents()).listen(
+      (_) => _onScreenshot(),
+    );
     var words = widget.wordListOverride;
     if (words == null) {
       try {
@@ -86,10 +115,39 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
 
   @override
   void dispose() {
+    _screenshotSub?.cancel();
+    if (_ownsPrivacyController) _privacyController.dispose();
     _controller.dispose();
     _focusNode.dispose();
     super.dispose();
   }
+
+  Future<void> _onScreenshot() async {
+    // Only warn once a word is on screen — a typed word or an accepted word.
+    // An empty field has nothing to protect. Mirrors the reveal screens.
+    if ((_accepted.isEmpty && _typed.isEmpty) ||
+        _screenshotSheetShowing ||
+        !_isCurrentRoute ||
+        !mounted) {
+      return;
+    }
+    _screenshotSheetShowing = true;
+    // Suppress the privacy shield through the iOS screenshot preview/editor
+    // flow — the native blanking already blacks out the capture, so the extra
+    // blur flash is redundant noise.
+    _privacyController.beginScreenshotSuppression();
+    unawaited(AppHaptics.privacyToggle());
+    try {
+      await showAppMobileSheet<void>(
+        context: context,
+        builder: (_) => const MobileSeedScreenshotWarningSheet(),
+      );
+    } finally {
+      _screenshotSheetShowing = false;
+    }
+  }
+
+  bool get _isCurrentRoute => ModalRoute.of(context)?.isCurrent ?? true;
 
   List<String> get _suggestions {
     final prefix = _controller.text.trim().toLowerCase();
@@ -346,93 +404,99 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
     final colors = context.colors;
     final position = (_accepted.length + 1).clamp(1, kMnemonicMaxWords);
 
-    return MobileOnboardingStepScaffold(
-      progress: mobileImportProgress(1),
-      onBack: () => Navigator.of(context).maybePop(),
-      title: 'Enter your Secret Passphrase',
-      subtitle: 'Accept 12, 15, 18, 21 or 24 words',
-      // Only the CTA is pinned — it rides up above the keyboard (Figma
-      // 4746:83516). The autocomplete chips stay attached under the word
-      // field and scroll with the content. The stretch Column gives the
-      // expand:true button a tight width to fill.
-      bottomArea: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [_buildButtonRow()],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          _WordField(
-            index: position,
-            controller: _controller,
-            focusNode: _focusNode,
-            hasError: _error != null,
-            onChanged: _onChanged,
-            onSubmitted: _onSubmitted,
-          ),
-          if (_suggestions.isNotEmpty) ...[
-            const SizedBox(height: AppSpacing.sm),
-            SizedBox(
-              key: const ValueKey('mobile_import_manual_suggestions'),
-              height: _kManualSuggestionsHeight,
-              child: ListView(
-                scrollDirection: Axis.horizontal,
-                children: [
-                  for (final word in _suggestions)
-                    Center(
-                      child: Padding(
-                        padding: const EdgeInsets.only(right: AppSpacing.xs),
-                        child: _SuggestionChip(
-                          word: word,
-                          onTap: () => _acceptWord(word),
+    return SensitivePrivacyOverlay(
+      // Protect only once a word is on screen — an empty field has nothing to
+      // blank. Matches the `_onScreenshot` guard.
+      sensitiveContentVisible: _accepted.isNotEmpty || _typed.isNotEmpty,
+      controller: _privacyController,
+      child: MobileOnboardingStepScaffold(
+        progress: mobileImportProgress(1),
+        onBack: () => Navigator.of(context).maybePop(),
+        title: 'Enter your Secret Passphrase',
+        subtitle: 'Accept 12, 15, 18, 21 or 24 words',
+        // Only the CTA is pinned — it rides up above the keyboard (Figma
+        // 4746:83516). The autocomplete chips stay attached under the word
+        // field and scroll with the content. The stretch Column gives the
+        // expand:true button a tight width to fill.
+        bottomArea: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [_buildButtonRow()],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _WordField(
+              index: position,
+              controller: _controller,
+              focusNode: _focusNode,
+              hasError: _error != null,
+              onChanged: _onChanged,
+              onSubmitted: _onSubmitted,
+            ),
+            if (_suggestions.isNotEmpty) ...[
+              const SizedBox(height: AppSpacing.sm),
+              SizedBox(
+                key: const ValueKey('mobile_import_manual_suggestions'),
+                height: _kManualSuggestionsHeight,
+                child: ListView(
+                  scrollDirection: Axis.horizontal,
+                  children: [
+                    for (final word in _suggestions)
+                      Center(
+                        child: Padding(
+                          padding: const EdgeInsets.only(right: AppSpacing.xs),
+                          child: _SuggestionChip(
+                            word: word,
+                            onTap: () => _acceptWord(word),
+                          ),
                         ),
                       ),
-                    ),
-                ],
+                  ],
+                ),
               ),
-            ),
-          ],
-          if (_error != null) ...[
-            const SizedBox(height: AppSpacing.sm),
-            Text(
-              _error!,
-              textAlign: TextAlign.center,
-              style: AppTypography.bodySmall.copyWith(
-                color: colors.text.destructive,
+            ],
+            if (_error != null) ...[
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                _error!,
+                textAlign: TextAlign.center,
+                style: AppTypography.bodySmall.copyWith(
+                  color: colors.text.destructive,
+                ),
               ),
-            ),
-          ],
-          if (_accepted.isNotEmpty) ...[
-            const SizedBox(height: AppSpacing.md),
-            Text(
-              _accepted.join(' · '),
-              textAlign: TextAlign.center,
-              style: AppTypography.bodySmall.copyWith(
-                color: colors.text.secondary,
+            ],
+            if (_accepted.isNotEmpty) ...[
+              const SizedBox(height: AppSpacing.md),
+              Text(
+                _accepted.join(' · '),
+                textAlign: TextAlign.center,
+                style: AppTypography.bodySmall.copyWith(
+                  color: colors.text.secondary,
+                ),
               ),
-            ),
-            const SizedBox(height: AppSpacing.xs),
-            Semantics(
-              button: true,
-              child: GestureDetector(
-                behavior: HitTestBehavior.opaque,
-                onTap: _stepBack,
-                child: SizedBox(
-                  height: 36,
-                  child: Center(
-                    child: Text(
-                      'Undo last word',
-                      style: AppTypography.labelMedium.copyWith(
-                        color: colors.text.secondary,
+              const SizedBox(height: AppSpacing.xs),
+              Semantics(
+                button: true,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: _stepBack,
+                  child: SizedBox(
+                    height: 36,
+                    child: Center(
+                      child: Text(
+                        'Undo last word',
+                        style: AppTypography.labelMedium.copyWith(
+                          color: colors.text.secondary,
+                        ),
                       ),
                     ),
                   ),
                 ),
               ),
-            ),
+            ],
           ],
-        ],
+        ),
       ),
     );
   }

--- a/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
@@ -8,6 +8,7 @@ import '../../../../main.dart' show log;
 import '../../../core/feedback/app_haptics.dart';
 import '../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../core/platform/screenshot_observer.dart';
+import '../../../core/privacy/route_coverage_aware.dart';
 import '../../../core/privacy/sensitive_privacy_overlay.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
@@ -69,7 +70,8 @@ class MobileImportManualScreen extends StatefulWidget {
       _MobileImportManualScreenState();
 }
 
-class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
+class _MobileImportManualScreenState extends State<MobileImportManualScreen>
+    with RouteCoverageAware<MobileImportManualScreen> {
   late final List<String> _wordList;
   final List<String> _accepted = [];
   final _controller = TextEditingController();
@@ -78,10 +80,6 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
 
   StreamSubscription<void>? _screenshotSub;
   bool _screenshotSheetShowing = false;
-  // True while a route is pushed on top of this screen. The privacy overlay
-  // drives a global native shield token, so an offstage-but-mounted secret
-  // screen would otherwise keep blanking the pushed (non-secret) screens.
-  bool _coveredByPush = false;
   late final bool _ownsPrivacyController;
   late final SensitivePrivacyOverlayController _privacyController;
 
@@ -338,9 +336,9 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
       setState(() => _error = error);
       return;
     }
-    // Drop the native shield before pushing so birthday and the screens after
-    // it are not blanked; restore it if the user comes back.
-    setState(() => _coveredByPush = true);
+    // The shield stays engaged through the push transition and drops only once
+    // this screen is fully covered (RouteCoverageAware), so review and later
+    // screens are not blanked while the seed is no longer visible.
     context
         .push<Object?>(
           '/import/review',
@@ -348,7 +346,6 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
         )
         .then((result) {
           if (!mounted) return;
-          setState(() => _coveredByPush = false);
           if (result == MobileImportReviewResult.clear) {
             if (context.canPop()) {
               context.pop();
@@ -417,10 +414,10 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
 
     return SensitivePrivacyOverlay(
       // Protect only once a word is on screen — an empty field has nothing to
-      // blank. Matches the `_onScreenshot` guard. Drops while a next step is
-      // pushed on top so it does not blank those screens.
+      // blank. Matches the `_onScreenshot` guard. Drops once a next step has
+      // fully covered this screen so it does not blank those screens.
       sensitiveContentVisible:
-          (_accepted.isNotEmpty || _typed.isNotEmpty) && !_coveredByPush,
+          (_accepted.isNotEmpty || _typed.isNotEmpty) && !isCoveredByNextRoute,
       controller: _privacyController,
       child: MobileOnboardingStepScaffold(
         progress: mobileImportProgress(1),

--- a/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
@@ -134,10 +134,6 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen>
       return;
     }
     _screenshotSheetShowing = true;
-    // Suppress the privacy shield through the iOS screenshot preview/editor
-    // flow — the native blanking already blacks out the capture, so the extra
-    // blur flash is redundant noise.
-    _privacyController.beginScreenshotSuppression();
     unawaited(AppHaptics.privacyToggle());
     try {
       await showAppMobileSheet<void>(
@@ -146,9 +142,6 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen>
       );
     } finally {
       _screenshotSheetShowing = false;
-      // Release the shield suppression now the warning sheet is gone, so a
-      // genuine later backgrounding still blurs.
-      _privacyController.endScreenshotSuppression();
     }
   }
 

--- a/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_manual_screen.dart
@@ -78,6 +78,10 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
 
   StreamSubscription<void>? _screenshotSub;
   bool _screenshotSheetShowing = false;
+  // True while a route is pushed on top of this screen. The privacy overlay
+  // drives a global native shield token, so an offstage-but-mounted secret
+  // screen would otherwise keep blanking the pushed (non-secret) screens.
+  bool _coveredByPush = false;
   late final bool _ownsPrivacyController;
   late final SensitivePrivacyOverlayController _privacyController;
 
@@ -334,6 +338,9 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
       setState(() => _error = error);
       return;
     }
+    // Drop the native shield before pushing so birthday and the screens after
+    // it are not blanked; restore it if the user comes back.
+    setState(() => _coveredByPush = true);
     context
         .push<Object?>(
           '/import/review',
@@ -341,6 +348,7 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
         )
         .then((result) {
           if (!mounted) return;
+          setState(() => _coveredByPush = false);
           if (result == MobileImportReviewResult.clear) {
             if (context.canPop()) {
               context.pop();
@@ -409,8 +417,10 @@ class _MobileImportManualScreenState extends State<MobileImportManualScreen> {
 
     return SensitivePrivacyOverlay(
       // Protect only once a word is on screen — an empty field has nothing to
-      // blank. Matches the `_onScreenshot` guard.
-      sensitiveContentVisible: _accepted.isNotEmpty || _typed.isNotEmpty,
+      // blank. Matches the `_onScreenshot` guard. Drops while a next step is
+      // pushed on top so it does not blank those screens.
+      sensitiveContentVisible:
+          (_accepted.isNotEmpty || _typed.isNotEmpty) && !_coveredByPush,
       controller: _privacyController,
       child: MobileOnboardingStepScaffold(
         progress: mobileImportProgress(1),

--- a/lib/src/features/onboarding/mobile/mobile_import_review_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_import_review_screen.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import '../../../core/feedback/app_haptics.dart';
 import '../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../core/platform/screenshot_observer.dart';
+import '../../../core/privacy/route_coverage_aware.dart';
 import '../../../core/privacy/sensitive_privacy_overlay.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
@@ -58,7 +59,8 @@ class MobileImportReviewScreen extends StatefulWidget {
       _MobileImportReviewScreenState();
 }
 
-class _MobileImportReviewScreenState extends State<MobileImportReviewScreen> {
+class _MobileImportReviewScreenState extends State<MobileImportReviewScreen>
+    with RouteCoverageAware<MobileImportReviewScreen> {
   StreamSubscription<void>? _screenshotSub;
   late final bool _ownsPrivacyController;
   late final SensitivePrivacyOverlayController _privacyController;
@@ -127,7 +129,7 @@ class _MobileImportReviewScreenState extends State<MobileImportReviewScreen> {
   Widget build(BuildContext context) {
     final words = _words;
     return SensitivePrivacyOverlay(
-      sensitiveContentVisible: words.isNotEmpty,
+      sensitiveContentVisible: words.isNotEmpty && !isCoveredByNextRoute,
       controller: _privacyController,
       child: MobileOnboardingStepScaffold(
         progress: _kImportReviewProgress,

--- a/lib/src/features/onboarding/mobile/mobile_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_secret_passphrase_screen.dart
@@ -166,6 +166,10 @@ class _MobileSecretPassphraseScreenState
       return;
     }
     _screenshotSheetShowing = true;
+    // Suppress the privacy shield through the iOS screenshot preview/editor
+    // flow — the native blanking already blacks out the capture, so the extra
+    // blur flash is redundant noise.
+    _privacyController.beginScreenshotSuppression();
     unawaited(AppHaptics.privacyToggle());
     try {
       await showAppMobileSheet<void>(
@@ -185,6 +189,9 @@ class _MobileSecretPassphraseScreenState
     final words = _mnemonic?.split(' ') ?? const <String>[];
 
     return SensitivePrivacyOverlay(
+      // Protect only while the phrase is actually on screen. Before reveal the
+      // card shows no words, so blanking its screenshot and blurring the app
+      // switcher there is needless friction. Matches the `_onScreenshot` guard.
       sensitiveContentVisible: _revealed && _mnemonic != null,
       controller: _privacyController,
       child: MobileOnboardingStepScaffold(

--- a/lib/src/features/onboarding/mobile/mobile_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_secret_passphrase_screen.dart
@@ -166,10 +166,6 @@ class _MobileSecretPassphraseScreenState
       return;
     }
     _screenshotSheetShowing = true;
-    // Suppress the privacy shield through the iOS screenshot preview/editor
-    // flow — the native blanking already blacks out the capture, so the extra
-    // blur flash is redundant noise.
-    _privacyController.beginScreenshotSuppression();
     unawaited(AppHaptics.privacyToggle());
     try {
       await showAppMobileSheet<void>(
@@ -178,9 +174,6 @@ class _MobileSecretPassphraseScreenState
       );
     } finally {
       _screenshotSheetShowing = false;
-      // Release the shield suppression now the warning sheet is gone, so a
-      // genuine later backgrounding still blurs.
-      _privacyController.endScreenshotSuppression();
     }
   }
 

--- a/lib/src/features/onboarding/mobile/mobile_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_secret_passphrase_screen.dart
@@ -178,6 +178,9 @@ class _MobileSecretPassphraseScreenState
       );
     } finally {
       _screenshotSheetShowing = false;
+      // Release the shield suppression now the warning sheet is gone, so a
+      // genuine later backgrounding still blurs.
+      _privacyController.endScreenshotSuppression();
     }
   }
 

--- a/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
@@ -899,8 +899,11 @@ class MobileSeedScreenshotWarningSheet extends StatefulWidget {
 class _MobileSeedScreenshotWarningSheetState
     extends State<MobileSeedScreenshotWarningSheet> {
   late final AppLifecycleListener _lifecycleListener;
+  Timer? _inactiveGraceTimer;
+  var _canDismissOnInactive = false;
   var _dismissed = false;
 
+  static const _inactiveDismissGracePeriod = Duration(milliseconds: 500);
   static const _iconSize = 30.0;
   static const _titleMaxWidth = 253.0;
   static const _textHeightBehavior = TextHeightBehavior(
@@ -923,9 +926,18 @@ class _MobileSeedScreenshotWarningSheetState
   void initState() {
     super.initState();
     _lifecycleListener = AppLifecycleListener(
+      onInactive: _dismissAfterGracePeriod,
       onHide: _dismiss,
       onPause: _dismiss,
     );
+    _inactiveGraceTimer = Timer(_inactiveDismissGracePeriod, () {
+      if (mounted) _canDismissOnInactive = true;
+    });
+  }
+
+  void _dismissAfterGracePeriod() {
+    if (!_canDismissOnInactive) return;
+    _dismiss();
   }
 
   void _dismiss() {
@@ -936,6 +948,7 @@ class _MobileSeedScreenshotWarningSheetState
 
   @override
   void dispose() {
+    _inactiveGraceTimer?.cancel();
     _lifecycleListener.dispose();
     super.dispose();
   }

--- a/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
@@ -411,6 +411,10 @@ class _MobileSeedPhraseScreenState
       return;
     }
     _screenshotSheetShowing = true;
+    // Suppress the privacy shield through the iOS screenshot preview/editor
+    // flow — the native blanking already blacks out the capture, so the extra
+    // blur flash is redundant noise.
+    _privacyController.beginScreenshotSuppression();
     unawaited(AppHaptics.privacyToggle());
     try {
       await showAppMobileSheet<void>(
@@ -460,6 +464,9 @@ class _MobileSeedPhraseScreenState
       backgroundColor: colors.background.window,
       body: AppToastHost(
         child: SensitivePrivacyOverlay(
+          // Protect only in the reveal stage. The passcode gate shows no words,
+          // so blanking its screenshot and app-switcher snapshot is needless
+          // friction. Matches the `_onScreenshot` guard.
           sensitiveContentVisible:
               _stage == _SeedStage.reveal && _mnemonic != null,
           controller: _privacyController,

--- a/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
@@ -423,6 +423,9 @@ class _MobileSeedPhraseScreenState
       );
     } finally {
       _screenshotSheetShowing = false;
+      // Release the shield suppression now the warning sheet is gone, so a
+      // genuine later backgrounding still blurs.
+      _privacyController.endScreenshotSuppression();
     }
   }
 

--- a/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
@@ -888,8 +888,18 @@ class _BirthdayRow extends StatelessWidget {
 }
 
 /// Screenshot warning — Figma `If they try to screenshot` (4494:92098).
-class MobileSeedScreenshotWarningSheet extends StatelessWidget {
+class MobileSeedScreenshotWarningSheet extends StatefulWidget {
   const MobileSeedScreenshotWarningSheet({super.key});
+
+  @override
+  State<MobileSeedScreenshotWarningSheet> createState() =>
+      _MobileSeedScreenshotWarningSheetState();
+}
+
+class _MobileSeedScreenshotWarningSheetState
+    extends State<MobileSeedScreenshotWarningSheet> {
+  late final AppLifecycleListener _lifecycleListener;
+  var _dismissed = false;
 
   static const _iconSize = 30.0;
   static const _titleMaxWidth = 253.0;
@@ -910,12 +920,33 @@ class MobileSeedScreenshotWarningSheet extends StatelessWidget {
   static const _buttonLabelStyle = AppTypography.labelLarge;
 
   @override
+  void initState() {
+    super.initState();
+    _lifecycleListener = AppLifecycleListener(
+      onHide: _dismiss,
+      onPause: _dismiss,
+    );
+  }
+
+  void _dismiss() {
+    if (_dismissed || !mounted) return;
+    _dismissed = true;
+    Navigator.of(context).pop();
+  }
+
+  @override
+  void dispose() {
+    _lifecycleListener.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final colors = context.colors;
     return MobileModalScaffold(
       key: const ValueKey('mobile_seed_screenshot_sheet'),
       title: '',
-      onClose: () => Navigator.of(context).pop(),
+      onClose: _dismiss,
       showTitle: false,
       showClose: false,
       bottomPadding: AppSpacing.base,
@@ -984,7 +1015,7 @@ class MobileSeedScreenshotWarningSheet extends StatelessWidget {
             key: const ValueKey('mobile_seed_screenshot_ack'),
             expand: true,
             height: AppButtonSizing.largeHeight,
-            onPressed: () => Navigator.of(context).pop(),
+            onPressed: _dismiss,
             child: const Text('I understand', style: _buttonLabelStyle),
           ),
         ],

--- a/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart
@@ -411,10 +411,6 @@ class _MobileSeedPhraseScreenState
       return;
     }
     _screenshotSheetShowing = true;
-    // Suppress the privacy shield through the iOS screenshot preview/editor
-    // flow — the native blanking already blacks out the capture, so the extra
-    // blur flash is redundant noise.
-    _privacyController.beginScreenshotSuppression();
     unawaited(AppHaptics.privacyToggle());
     try {
       await showAppMobileSheet<void>(
@@ -423,9 +419,6 @@ class _MobileSeedPhraseScreenState
       );
     } finally {
       _screenshotSheetShowing = false;
-      // Release the shield suppression now the warning sheet is gone, so a
-      // genuine later backgrounding still blurs.
-      _privacyController.endScreenshotSuppression();
     }
   }
 

--- a/test/core/privacy/sensitive_privacy_overlay_test.dart
+++ b/test/core/privacy/sensitive_privacy_overlay_test.dart
@@ -17,12 +17,13 @@ void main() {
     expect(supportsPlatformPrivacySignals(isWeb: true, isMacOS: true), isFalse);
   });
 
-  test('native privacy shield supports macOS and Android', () {
+  test('native privacy shield supports macOS, Android, and iOS', () {
     expect(
       supportsNativePrivacyShield(
         isWeb: false,
         isMacOS: true,
         isAndroid: false,
+        isIOS: false,
       ),
       isTrue,
     );
@@ -31,6 +32,7 @@ void main() {
         isWeb: false,
         isMacOS: false,
         isAndroid: true,
+        isIOS: false,
       ),
       isTrue,
     );
@@ -39,11 +41,26 @@ void main() {
         isWeb: false,
         isMacOS: false,
         isAndroid: false,
+        isIOS: true,
+      ),
+      isTrue,
+    );
+    expect(
+      supportsNativePrivacyShield(
+        isWeb: false,
+        isMacOS: false,
+        isAndroid: false,
+        isIOS: false,
       ),
       isFalse,
     );
     expect(
-      supportsNativePrivacyShield(isWeb: true, isMacOS: true, isAndroid: true),
+      supportsNativePrivacyShield(
+        isWeb: true,
+        isMacOS: true,
+        isAndroid: true,
+        isIOS: true,
+      ),
       isFalse,
     );
   });
@@ -248,6 +265,54 @@ void main() {
       expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
 
       // A genuine background (no prompt) still covers the content.
+      controller.setLifecycleInactiveForTesting();
+      await tester.pump();
+      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'environment controller suppresses the shield across the iOS screenshot '
+    'preview inactive→resumed transition',
+    (tester) async {
+      final controller = SensitivePrivacyEnvironmentController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        AppTheme(
+          data: AppThemeData.light,
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: SensitivePrivacyOverlay(
+              sensitiveContentVisible: true,
+              controller: controller,
+              child: const SizedBox(width: 320, height: 240),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+
+      // A screenshot marks suppression while foreground; the preview/editor
+      // then drives the app inactive — the shield stays down (native blanking
+      // already blacks out the capture).
+      controller.beginScreenshotSuppression();
+      controller.setLifecycleInactiveForTesting();
+      await tester.pump();
+      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+
+      // A real background (hide) is not suppressed by the screenshot marker.
+      controller.setLifecycleHiddenForTesting();
+      await tester.pump();
+      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
+
+      // Returning to foreground clears the screenshot suppression in lockstep.
+      controller.setLifecycleForegroundForTesting();
+      await tester.pump();
+      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+
+      // A genuine later background (no screenshot) still covers the content.
       controller.setLifecycleInactiveForTesting();
       await tester.pump();
       expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);

--- a/test/core/privacy/sensitive_privacy_overlay_test.dart
+++ b/test/core/privacy/sensitive_privacy_overlay_test.dart
@@ -271,59 +271,6 @@ void main() {
     },
   );
 
-  testWidgets(
-    'environment controller suppresses the shield across the iOS screenshot '
-    'preview inactive→resumed transition',
-    (tester) async {
-      final controller = SensitivePrivacyEnvironmentController();
-      addTearDown(controller.dispose);
-
-      await tester.pumpWidget(
-        AppTheme(
-          data: AppThemeData.light,
-          child: Directionality(
-            textDirection: TextDirection.ltr,
-            child: SensitivePrivacyOverlay(
-              sensitiveContentVisible: true,
-              controller: controller,
-              child: const SizedBox(width: 320, height: 240),
-            ),
-          ),
-        ),
-      );
-
-      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
-
-      // A screenshot marks suppression while the warning sheet is up; the
-      // preview/editor then drives the app inactive — the shield stays down
-      // (native blanking already blacks out the capture).
-      controller.beginScreenshotSuppression();
-      controller.setLifecycleInactiveForTesting();
-      await tester.pump();
-      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
-
-      // A real background (hide) is not suppressed by the screenshot marker.
-      controller.setLifecycleHiddenForTesting();
-      await tester.pump();
-      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
-
-      // The editor closes to foreground and reopens — suppression persists
-      // while the sheet is up, so the preview reopen does not flash the shield.
-      controller.setLifecycleForegroundForTesting();
-      await tester.pump();
-      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
-      controller.setLifecycleInactiveForTesting();
-      await tester.pump();
-      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
-
-      // Dismissing the warning sheet releases suppression; the current
-      // inactive state is no longer safe, so the shield covers the content.
-      controller.endScreenshotSuppression();
-      await tester.pump();
-      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
-    },
-  );
-
   testWidgets('environment controller honors native macOS exposure events', (
     tester,
   ) async {

--- a/test/core/privacy/sensitive_privacy_overlay_test.dart
+++ b/test/core/privacy/sensitive_privacy_overlay_test.dart
@@ -294,9 +294,9 @@ void main() {
 
       expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
 
-      // A screenshot marks suppression while foreground; the preview/editor
-      // then drives the app inactive — the shield stays down (native blanking
-      // already blacks out the capture).
+      // A screenshot marks suppression while the warning sheet is up; the
+      // preview/editor then drives the app inactive — the shield stays down
+      // (native blanking already blacks out the capture).
       controller.beginScreenshotSuppression();
       controller.setLifecycleInactiveForTesting();
       await tester.pump();
@@ -307,13 +307,18 @@ void main() {
       await tester.pump();
       expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
 
-      // Returning to foreground clears the screenshot suppression in lockstep.
+      // The editor closes to foreground and reopens — suppression persists
+      // while the sheet is up, so the preview reopen does not flash the shield.
       controller.setLifecycleForegroundForTesting();
       await tester.pump();
       expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
-
-      // A genuine later background (no screenshot) still covers the content.
       controller.setLifecycleInactiveForTesting();
+      await tester.pump();
+      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+
+      // Dismissing the warning sheet releases suppression; the current
+      // inactive state is no longer safe, so the shield covers the content.
+      controller.endScreenshotSuppression();
       await tester.pump();
       expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
     },

--- a/test/features/onboarding/mobile_import_manual_screen_test.dart
+++ b/test/features/onboarding/mobile_import_manual_screen_test.dart
@@ -1,15 +1,20 @@
 @Tags(['mobile'])
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/privacy/sensitive_privacy_overlay.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_manual_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_review_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_screens.dart';
 import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args.dart';
+import 'package:zcash_wallet/src/features/settings/screens/mobile/mobile_seed_phrase_screen.dart';
 import 'package:zcash_wallet/src/rust/frb_generated.dart';
 
 const _wordList = ['abandon', 'ability', 'able', 'about', 'zebra'];
@@ -89,6 +94,35 @@ Widget _stackedManualApp() {
     child: MaterialApp.router(
       routerConfig: router,
       builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+    ),
+  );
+}
+
+Widget _screenshotApp({
+  Stream<void>? screenshotStream,
+  SensitivePrivacyOverlayController? privacyOverlayController,
+}) {
+  return ProviderScope(
+    child: MaterialApp(
+      builder: (_, c) => AppTheme(data: AppThemeData.light, child: c!),
+      home: MobileImportManualScreen(
+        wordListOverride: _wordList,
+        screenshotStream: screenshotStream,
+        privacyOverlayController: privacyOverlayController,
+      ),
+    ),
+  );
+}
+
+void _muteSystemChannel(WidgetTester tester) {
+  tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    SystemChannels.platform,
+    (call) async => null,
+  );
+  addTearDown(
+    () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      null,
     ),
   );
 }
@@ -346,6 +380,63 @@ void main() {
     expect(find.textContaining("Stopped at 'notaword'"), findsOneWidget);
     expect(find.text('Undo last word'), findsNothing);
   });
+
+  testWidgets('warns on a screenshot once a word is on screen', (tester) async {
+    final screenshots = StreamController<void>();
+    addTearDown(screenshots.close);
+    _muteSystemChannel(tester);
+
+    await tester.pumpWidget(
+      _screenshotApp(screenshotStream: screenshots.stream),
+    );
+    await tester.pump();
+
+    // Empty field — nothing to protect yet.
+    screenshots.add(null);
+    await tester.pumpAndSettle();
+    expect(find.byType(MobileSeedScreenshotWarningSheet), findsNothing);
+
+    await tester.enterText(
+      find.byKey(const ValueKey('mobile_import_manual_field')),
+      'abandon',
+    );
+    await tester.pump();
+
+    screenshots.add(null);
+    await tester.pumpAndSettle();
+    expect(find.byType(MobileSeedScreenshotWarningSheet), findsOneWidget);
+    expect(find.textContaining('Don’t take screenshots'), findsOneWidget);
+  });
+
+  testWidgets(
+    'covers the field once a word is on screen when the controller is unsafe',
+    (tester) async {
+      final privacyController = SensitivePrivacyOverlayController(
+        initiallySafe: false,
+      );
+      addTearDown(privacyController.dispose);
+
+      await tester.pumpWidget(
+        _screenshotApp(privacyOverlayController: privacyController),
+      );
+      await tester.pump();
+
+      // An empty field has nothing to blank, even when unsafe.
+      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+
+      await tester.enterText(
+        find.byKey(const ValueKey('mobile_import_manual_field')),
+        'ab',
+      );
+      await tester.pump();
+      // A typed word turns on protection; the shield covers the field.
+      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
+
+      privacyController.markSafe();
+      await tester.pump();
+      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
+    },
+  );
 }
 
 class _RustApiFake implements RustLibApi {

--- a/test/features/onboarding/mobile_import_screens_test.dart
+++ b/test/features/onboarding/mobile_import_screens_test.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/src/core/navigation/mobile_onboarding_routes.dart';
 import 'package:zcash_wallet/src/core/privacy/sensitive_privacy_overlay.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_manual_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_review_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_import_screens.dart';
 import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args.dart';
@@ -108,6 +109,31 @@ Widget _reviewApp({
         screenshotStream: screenshotStream,
         privacyOverlayController: privacyOverlayController,
       ),
+    ),
+  );
+}
+
+Widget _manualScreenshotApp({
+  required Stream<void> screenshotStream,
+  required SensitivePrivacyOverlayController privacyOverlayController,
+}) {
+  final router = GoRouter(
+    initialLocation: '/import/manual',
+    routes: [
+      GoRoute(
+        path: '/import/manual',
+        builder: (_, _) => MobileImportManualScreen(
+          wordListOverride: _validMnemonic.split(' '),
+          screenshotStream: screenshotStream,
+          privacyOverlayController: privacyOverlayController,
+        ),
+      ),
+    ],
+  );
+  return ProviderScope(
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
     ),
   );
 }
@@ -461,6 +487,54 @@ void main() {
     await tester.pump(const Duration(seconds: 3));
     expect(find.text('Clipboard is empty'), findsNothing);
   });
+
+  testWidgets(
+    'manual entry keeps the shield while its warning sheet is open under '
+    'real go_router routing',
+    (tester) async {
+      final screenshots = StreamController<void>();
+      addTearDown(screenshots.close);
+      final privacyController = SensitivePrivacyOverlayController(
+        initiallySafe: false,
+      );
+      addTearDown(privacyController.dispose);
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async => null,
+      );
+      addTearDown(
+        () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+          SystemChannels.platform,
+          null,
+        ),
+      );
+
+      await tester.pumpWidget(
+        _manualScreenshotApp(
+          screenshotStream: screenshots.stream,
+          privacyOverlayController: privacyController,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const ValueKey('mobile_import_manual_field')),
+        'abandon',
+      );
+      await tester.pump();
+      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
+
+      screenshots.add(null);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(MobileSeedScreenshotWarningSheet), findsOneWidget);
+      expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
+      final route = ModalRoute.of(
+        tester.element(find.byType(MobileImportManualScreen)),
+      );
+      expect(route?.secondaryAnimation?.status, AnimationStatus.dismissed);
+    },
+  );
 }
 
 class _RustApiFake implements RustLibApi {

--- a/test/features/onboarding/mobile_import_screens_test.dart
+++ b/test/features/onboarding/mobile_import_screens_test.dart
@@ -400,6 +400,44 @@ void main() {
     expect(find.text('Birthday: $_validMnemonic'), findsOneWidget);
   });
 
+  testWidgets('review releases sensitive visibility after birthday covers it', (
+    tester,
+  ) async {
+    _mockClipboard(tester, _validMnemonic);
+    await tester.pumpWidget(_entryAppWithBirthdayProbe());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('mobile_import_paste')));
+    await tester.pumpAndSettle();
+
+    final overlayFinder = find.byType(
+      SensitivePrivacyOverlay,
+      skipOffstage: false,
+    );
+    expect(
+      tester
+          .widget<SensitivePrivacyOverlay>(overlayFinder)
+          .sensitiveContentVisible,
+      isTrue,
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_import_review_continue')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byType(MobileImportReviewScreen, skipOffstage: false),
+      findsOneWidget,
+    );
+    expect(
+      tester
+          .widget<SensitivePrivacyOverlay>(overlayFinder)
+          .sensitiveContentVisible,
+      isFalse,
+    );
+  });
+
   testWidgets('clearing a pasted review preserves the import stack', (
     tester,
   ) async {

--- a/test/features/onboarding/mobile_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/mobile_secret_passphrase_screen_test.dart
@@ -349,7 +349,7 @@ void main() {
   });
 
   testWidgets(
-    'covers the revealed phrase when the privacy controller is unsafe',
+    'covers the phrase once revealed when the privacy controller is unsafe',
     (tester) async {
       final privacyController = SensitivePrivacyOverlayController(
         initiallySafe: false,
@@ -365,11 +365,13 @@ void main() {
         ),
       );
       await tester.pump();
+      // Before reveal the card shows no words, so nothing is blanked even when
+      // the controller is unsafe.
       expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsNothing);
 
+      // Revealing the phrase turns on protection; the shield covers the words.
       await tester.tap(find.text('Reveal phrase'));
       await tester.pump();
-
       expect(find.byKey(SensitivePrivacyOverlay.shieldKey), findsOneWidget);
 
       privacyController.markSafe();

--- a/test/features/settings/mobile_seed_phrase_screen_test.dart
+++ b/test/features/settings/mobile_seed_phrase_screen_test.dart
@@ -490,6 +490,37 @@ void main() {
   });
 
   testWidgets(
+    'dismisses the screenshot warning when hidden',
+    (tester) async {
+      final screenshots = StreamController<void>();
+      addTearDown(screenshots.close);
+      addTearDown(() {
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+      });
+
+      await tester.pumpWidget(_app(screenshotStream: screenshots.stream));
+      await _revealSecret(tester);
+      screenshots.add(null);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.byType(MobileSeedScreenshotWarningSheet), findsOneWidget);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(MobileSeedScreenshotWarningSheet), findsNothing);
+    },
+  );
+
+  testWidgets(
     'does not show screenshot warning when covered by another route',
     (tester) async {
       final screenshots = StreamController<void>();

--- a/test/features/settings/mobile_seed_phrase_screen_test.dart
+++ b/test/features/settings/mobile_seed_phrase_screen_test.dart
@@ -489,8 +489,40 @@ void main() {
     expect(tester.getSize(buttonFinder).height, 50);
   });
 
+  testWidgets('ignores immediate inactive then dismisses on a later inactive', (
+    tester,
+  ) async {
+    final screenshots = StreamController<void>();
+    addTearDown(screenshots.close);
+    addTearDown(() {
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    });
+
+    await tester.pumpWidget(_app(screenshotStream: screenshots.stream));
+    await _revealSecret(tester);
+    screenshots.add(null);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(find.byType(MobileSeedScreenshotWarningSheet), findsOneWidget);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MobileSeedScreenshotWarningSheet), findsOneWidget);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump(const Duration(seconds: 1));
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MobileSeedScreenshotWarningSheet), findsNothing);
+  });
+
   testWidgets(
-    'dismisses the screenshot warning when hidden',
+    'dismisses when hidden during the screenshot inactive grace period',
     (tester) async {
       final screenshots = StreamController<void>();
       addTearDown(screenshots.close);


### PR DESCRIPTION
## Problem

On mobile, the seed-phrase (mnemonic) screens only *warned* about screenshots — they never actually prevented the capture:

- The warning bottom sheet is triggered by iOS's `userDidTakeScreenshotNotification`, which fires **after** the screenshot is already saved. So the mnemonic could already be in the captured image before the user ever sees the warning — a false sense of protection (this is the VZR-105 report).
- iOS had **no pixel-level protection** at all. Android had `FLAG_SECURE` through the shared privacy overlay, but iOS's side of that channel was never wired up.
- The **import screens** (paste + word-by-word) rendered the entered mnemonic in plain text with **no shield and no warning** whatsoever.

## Fix

### 1. Actually blank the capture on iOS, not just warn

Added a native `SecureScreenshotShield` (in `AppDelegate`) that hosts the app window inside a secure `UITextField`'s canvas layer. iOS excludes that layer from screenshots, screen recordings, **and** the app-switcher snapshot, so the captured image comes out blank. The existing `privacy_shield` MethodChannel is now routed to iOS (it was macOS/Android only).

**iOS 26 gotcha:** the secure canvas is located by its private view *class name*, not by sublayer index. The index-based lookup that older implementations use broke on iOS 26.5 — it grabbed a small, offset layer and collapsed the whole app into a corner. After reparenting, the window layer is re-pinned to full bounds on rotation, scene activation, and foreground. The whole mechanism sits behind a kill-switch flag, and the post-capture warning sheet stays as a fallback.

### 2. Cover the import screens too

The paste and manual import screens now get the same blanking + warning as the reveal screens.

### 3. Only protect while the secret is actually on screen

Blanking and the warning are gated on the phrase being **revealed** / words being present. In the hidden states — the "you are about to see your phrase" card, the passcode gate, and the empty import form — screenshots work normally: no black image, no warning, and no app-switcher blur. (On Android this also means the recent-apps thumbnail is only blanked while the words are visible.)

### 4. Don't flash the privacy blur during the screenshot preview

Taking a screenshot briefly drives the app inactive (the iOS preview/editor covers it), which used to make the Flutter privacy blur flash on and off — pointless noise, since the capture is already blanked. The seed screens now suppress that blur through the screenshot flow and release it on the next foreground return. A genuine app switch still blurs normally.

## Testing

Verified on a **real iOS 26.5 device** (the secure-layer exclusion cannot be reproduced in the Simulator):

- Revealed seed: screenshot comes out **black**, screen recording black, app-switcher snapshot blank.
- Hidden states (warning card / passcode gate / empty import form): screenshots are **normal**, no warning sheet.
- Screenshot preview open → close: **no blur flash**.
- Full-size rendering confirmed, including rotation and background → foreground.

`fvm flutter analyze` is clean; the privacy-overlay and mobile seed/import widget tests pass.

## Notes

- **No new dependency.** The technique is ported in-repo (≈ the open-source `no_screenshot` approach). `screen_protector`'s closed-source binary path was deliberately avoided — an unauditable binary reparenting the key window on the seed-reveal screen is not acceptable supply-chain surface for a wallet.
- The iOS secure-layer trick relies on undocumented UIKit internals. It's behind a flag and degrades to the warning sheet if a future iOS breaks it, so **re-verify on a real device each iOS major**. The Simulator cannot validate the blanking — real-device QA is the merge gate.
