### PR TITLE
[codex] Handle passcode input on pointer down

### DIFF
--- a/lib/src/features/onboarding/mobile/passcode_widgets.dart
+++ b/lib/src/features/onboarding/mobile/passcode_widgets.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:flutter/gestures.dart' show kPrimaryButton;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
@@ -179,11 +180,18 @@ class PasscodeNumpad extends StatelessWidget {
       final effectiveTap = enabled ? onTap : null;
       return Semantics(
         button: effectiveTap != null,
+        enabled: effectiveTap != null,
         label: label,
+        onTap: effectiveTap,
         excludeSemantics: true,
-        child: GestureDetector(
+        child: Listener(
           behavior: HitTestBehavior.opaque,
-          onTap: effectiveTap,
+          onPointerDown: effectiveTap == null
+              ? null
+              : (event) {
+                  if (event.buttons != kPrimaryButton) return;
+                  effectiveTap();
+                },
           child: SizedBox.square(
             dimension: kPasscodeKeySize,
             child: Center(child: child),

--- a/test/features/onboarding/mobile_unlock_screen_test.dart
+++ b/test/features/onboarding/mobile_unlock_screen_test.dart
@@ -217,6 +217,27 @@ void main() {
     expect(find.bySemanticsLabel('Delete digit'), findsNothing);
   });
 
+  testWidgets('digits register on pointer down before tap up', (tester) async {
+    await tester.pumpWidget(_app());
+    await tester.pump();
+
+    final gesture = await tester.startGesture(
+      tester.getCenter(find.bySemanticsLabel('Digit 1')),
+    );
+    await tester.pump();
+
+    var dots = tester.widget<PasscodeDots>(find.byType(PasscodeDots));
+    expect(dots.filled, 1);
+
+    await gesture.moveBy(const Offset(40, 0));
+    await tester.pump();
+
+    dots = tester.widget<PasscodeDots>(find.byType(PasscodeDots));
+    expect(dots.filled, 1);
+
+    await gesture.up();
+  });
+
   group('haptics', () {
     setUp(() {
       FlutterSecureStorage.setMockInitialValues({});


### PR DESCRIPTION
## Summary
- Handle passcode numpad actions on pointer down instead of tap up.
- Preserve semantic activation for passcode keys.
- Add mobile unlock coverage proving digits register before pointer up.

## Validation
- fvm dart format lib/src/features/onboarding/mobile/passcode_widgets.dart test/features/onboarding/mobile_unlock_screen_test.dart
- fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/onboarding/mobile_unlock_screen_test.dart test/features/onboarding/mobile_passcode_screen_test.dart test/features/settings/mobile_change_passcode_screen_test.dart test/features/settings/mobile_seed_phrase_screen_test.dart
- fvm flutter analyze lib/src/features/onboarding/mobile/passcode_widgets.dart test/features/onboarding/mobile_unlock_screen_test.dart
- git diff --check