### PR TITLE
[codex] Add Android back exit confirmation

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,6 +11,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'src/app_bootstrap.dart';
 import 'src/core/config/swap_feature_config.dart';
 import 'src/core/layout/app_layout.dart';
+import 'src/core/navigation/mobile_exit_back_guard.dart';
 import 'src/core/navigation/mobile_onboarding_routes.dart';
 import 'src/core/navigation/mobile_routes.dart';
 import 'src/core/motion/onboarding_motion.dart';
@@ -183,7 +184,7 @@ Future<void> runZcashWalletApp() async {
   }
 }
 
-final _routerProvider = Provider<GoRouter>((ref) {
+final _routerProvider = Provider<_AppRouter>((ref) {
   final bootstrap = ref.watch(appBootstrapProvider);
   final refresh = ref.watch(routerRefreshProvider);
   ref.listen(walletProvider, (_, _) {
@@ -197,7 +198,21 @@ final _routerProvider = Provider<GoRouter>((ref) {
   });
   log('router: initialized');
 
-  return GoRouter(
+  final navigatorKey = GlobalKey<NavigatorState>();
+  final mobileExitBackGuard = MobileExitBackGuard();
+  late final GoRouter router;
+  final mobileExitBackDispatcher = MobileExitBackDispatcher(
+    exitBackGuard: mobileExitBackGuard,
+    navigatorKey: navigatorKey,
+    canPop: () => router.canPop(),
+    currentLocation: () =>
+        router.routerDelegate.currentConfiguration.uri.toString(),
+  );
+  ref.onDispose(mobileExitBackDispatcher.dispose);
+  final useMobileExitBackGuard = mobileExitBackGuard.enabled;
+
+  router = GoRouter(
+    navigatorKey: navigatorKey,
     initialLocation: bootstrap.initialLocation,
     refreshListenable: refresh,
     redirect: (context, state) =>
@@ -232,7 +247,30 @@ final _routerProvider = Provider<GoRouter>((ref) {
             ..._desktopRoutes(),
           ],
   );
+
+  return _AppRouter(
+    router: router,
+    backButtonDispatcher: useMobileExitBackGuard
+        ? mobileExitBackDispatcher
+        : router.backButtonDispatcher,
+    onNavigationNotification: useMobileExitBackGuard
+        ? mobileExitBackDispatcher.handleNavigationNotification
+        : null,
+  );
 });
+
+class _AppRouter {
+  const _AppRouter({
+    required this.router,
+    required this.backButtonDispatcher,
+    this.onNavigationNotification,
+  });
+
+  final GoRouter router;
+  final BackButtonDispatcher backButtonDispatcher;
+  final NotificationListenerCallback<NavigationNotification>?
+  onNavigationNotification;
+}
 
 /// Shared route guard for both the desktop and mobile route trees:
 /// blocking storage failure, wallet existence, unlock state, onboarding
@@ -821,7 +859,8 @@ class ZcashWalletApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final router = ref.watch(_routerProvider);
+    final appRouter = ref.watch(_routerProvider);
+    final router = appRouter.router;
     final themeMode = ref.watch(themeModeProvider);
 
     return MaterialApp.router(
@@ -830,7 +869,11 @@ class ZcashWalletApp extends ConsumerWidget {
       theme: buildLegacyLightTheme(),
       darkTheme: buildLegacyDarkTheme(),
       themeMode: themeMode,
-      routerConfig: router,
+      routeInformationProvider: router.routeInformationProvider,
+      routeInformationParser: router.routeInformationParser,
+      routerDelegate: router.routerDelegate,
+      backButtonDispatcher: appRouter.backButtonDispatcher,
+      onNavigationNotification: appRouter.onNavigationNotification,
       builder: (context, child) {
         return AppThemeHost(
           themeMode: themeMode,

--- a/lib/src/core/navigation/mobile_exit_back_guard.dart
+++ b/lib/src/core/navigation/mobile_exit_back_guard.dart
@@ -1,0 +1,276 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show SystemNavigator;
+
+import '../layout/app_form_factor.dart';
+import '../theme/app_theme.dart';
+
+class MobileExitBackGuard {
+  MobileExitBackGuard({TargetPlatform? platform, DateTime Function()? now})
+    : _platform = platform,
+      _now = now ?? DateTime.now;
+
+  static const exitHintMessage = 'Go back again to exit';
+  static const confirmationWindow = Duration(seconds: 2);
+
+  final TargetPlatform? _platform;
+  final DateTime Function() _now;
+
+  DateTime? _lastBackAt;
+  String? _lastLocation;
+  Timer? _resetTimer;
+
+  bool get enabled =>
+      kAppFormFactor == AppFormFactor.mobile &&
+      (_platform ?? defaultTargetPlatform) == TargetPlatform.android;
+
+  bool requestExit(
+    BuildContext context, {
+    required String location,
+    OverlayState? overlay,
+  }) {
+    if (!enabled) return true;
+
+    final now = _now();
+    final previousBackAt = _lastBackAt;
+    final confirmed =
+        _lastLocation == location &&
+        previousBackAt != null &&
+        now.difference(previousBackAt) <= confirmationWindow;
+
+    if (confirmed) {
+      reset();
+      _MobileExitBackHintOverlay.dismiss();
+      return true;
+    }
+
+    _lastBackAt = now;
+    _lastLocation = location;
+    _scheduleReset();
+    _MobileExitBackHintOverlay.show(context, overlay: overlay);
+    return false;
+  }
+
+  void reset() {
+    _resetTimer?.cancel();
+    _resetTimer = null;
+    _lastBackAt = null;
+    _lastLocation = null;
+  }
+
+  void _scheduleReset() {
+    _resetTimer?.cancel();
+    _resetTimer = Timer(confirmationWindow, () {
+      _resetTimer = null;
+      _lastBackAt = null;
+      _lastLocation = null;
+    });
+  }
+
+  static void dismissVisibleHint() {
+    _MobileExitBackHintOverlay.dismiss();
+  }
+}
+
+class MobileExitBackDispatcher extends RootBackButtonDispatcher {
+  MobileExitBackDispatcher({
+    required MobileExitBackGuard exitBackGuard,
+    required GlobalKey<NavigatorState> navigatorKey,
+    required bool Function() canPop,
+    required String Function() currentLocation,
+  }) : _exitBackGuard = exitBackGuard,
+       _navigatorKey = navigatorKey,
+       _canPop = canPop,
+       _currentLocation = currentLocation {
+    if (_exitBackGuard.enabled) {
+      _lifecycleListener = AppLifecycleListener(
+        onInactive: _clearExitBackGuard,
+        onHide: _clearExitBackGuard,
+        onPause: _clearExitBackGuard,
+        onShow: _clearExitBackGuard,
+        onResume: _clearExitBackGuard,
+      );
+    }
+  }
+
+  final MobileExitBackGuard _exitBackGuard;
+  final GlobalKey<NavigatorState> _navigatorKey;
+  final bool Function() _canPop;
+  final String Function() _currentLocation;
+  AppLifecycleListener? _lifecycleListener;
+
+  bool handleNavigationNotification(NavigationNotification notification) {
+    if (!_exitBackGuard.enabled) {
+      unawaited(
+        SystemNavigator.setFrameworkHandlesBack(notification.canHandlePop),
+      );
+      return true;
+    }
+
+    unawaited(SystemNavigator.setFrameworkHandlesBack(true));
+    return true;
+  }
+
+  @override
+  Future<bool> invokeCallback(Future<bool> defaultValue) async {
+    if (!_exitBackGuard.enabled) {
+      return super.invokeCallback(defaultValue);
+    }
+
+    if (_canPop()) {
+      final handledByRoute = await super.invokeCallback(
+        Future<bool>.value(false),
+      );
+      if (handledByRoute) {
+        _clearExitBackGuard();
+        return true;
+      }
+    }
+
+    final context = _navigatorKey.currentContext;
+    final overlay = _navigatorKey.currentState?.overlay;
+    if (context == null || overlay == null) return false;
+    if (!context.mounted) return false;
+
+    if (_exitBackGuard.requestExit(
+      context,
+      location: _currentLocation(),
+      overlay: overlay,
+    )) {
+      unawaited(SystemNavigator.pop());
+    }
+    return true;
+  }
+
+  void dispose() {
+    _lifecycleListener?.dispose();
+    _clearExitBackGuard();
+  }
+
+  void _clearExitBackGuard() {
+    _exitBackGuard.reset();
+    MobileExitBackGuard.dismissVisibleHint();
+  }
+}
+
+class _MobileExitBackHintOverlay {
+  static OverlayEntry? _entry;
+  static Timer? _timer;
+
+  static void show(BuildContext context, {OverlayState? overlay}) {
+    final targetOverlay =
+        overlay ?? Overlay.maybeOf(context, rootOverlay: true);
+    if (targetOverlay == null) return;
+
+    final themeElement = context
+        .getElementForInheritedWidgetOfExactType<AppTheme>();
+    final theme =
+        (themeElement?.widget as AppTheme?)?.data ??
+        (MediaQuery.platformBrightnessOf(context) == Brightness.dark
+            ? AppThemeData.dark
+            : AppThemeData.light);
+
+    dismiss();
+
+    late final OverlayEntry entry;
+    entry = OverlayEntry(
+      builder: (_) => AppTheme(
+        data: theme,
+        child: const _MobileExitBackHint(
+          message: MobileExitBackGuard.exitHintMessage,
+        ),
+      ),
+    );
+    _entry = entry;
+    targetOverlay.insert(entry);
+    _timer = Timer(MobileExitBackGuard.confirmationWindow, dismiss);
+  }
+
+  static void dismiss() {
+    _timer?.cancel();
+    _timer = null;
+    final entry = _entry;
+    _entry = null;
+    if (entry?.mounted ?? false) {
+      entry?.remove();
+    }
+  }
+}
+
+class _MobileExitBackHint extends StatelessWidget {
+  const _MobileExitBackHint({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final bottomInset = math.max(
+      MediaQuery.viewInsetsOf(context).bottom,
+      MediaQuery.viewPaddingOf(context).bottom,
+    );
+
+    return Positioned.fill(
+      child: IgnorePointer(
+        child: SafeArea(
+          minimum: EdgeInsets.fromLTRB(
+            AppSpacing.sm,
+            AppSpacing.sm,
+            AppSpacing.sm,
+            bottomInset + AppSpacing.sm,
+          ),
+          child: Align(
+            alignment: const Alignment(0, 0.35),
+            child: TweenAnimationBuilder<double>(
+              tween: Tween<double>(begin: 0, end: 1),
+              duration: const Duration(milliseconds: 160),
+              curve: Curves.easeOutCubic,
+              builder: (context, value, child) => Opacity(
+                opacity: value,
+                child: Transform.translate(
+                  offset: Offset(0, (1 - value) * AppSpacing.xs),
+                  child: child,
+                ),
+              ),
+              child: DecoratedBox(
+                key: const ValueKey('mobile_exit_back_hint_surface'),
+                decoration: BoxDecoration(
+                  color: colors.background.inverse,
+                  borderRadius: BorderRadius.circular(AppRadii.small),
+                  boxShadow: [
+                    BoxShadow(
+                      color: colors.shadows.regular,
+                      offset: const Offset(0, 8),
+                      blurRadius: 24,
+                    ),
+                  ],
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.sm,
+                    vertical: AppSpacing.s,
+                  ),
+                  child: Text(
+                    message,
+                    key: const ValueKey('mobile_exit_back_hint_text'),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: colors.text.inverse,
+                      decoration: TextDecoration.none,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/core/navigation/mobile_exit_back_guard_test.dart
+++ b/test/core/navigation/mobile_exit_back_guard_test.dart
@@ -1,0 +1,270 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show MethodCall, SystemChannels;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/navigation/mobile_exit_back_guard.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+
+_ExitBackTestRouter _exitBackRouter({
+  MobileExitBackGuard? exitBackGuard,
+  String initialLocation = '/home',
+  List<RouteBase> routes = const [],
+}) {
+  final navigatorKey = GlobalKey<NavigatorState>();
+  final guard =
+      exitBackGuard ?? MobileExitBackGuard(platform: TargetPlatform.android);
+  late final GoRouter router;
+  final dispatcher = MobileExitBackDispatcher(
+    exitBackGuard: guard,
+    navigatorKey: navigatorKey,
+    canPop: () => router.canPop(),
+    currentLocation: () =>
+        router.routerDelegate.currentConfiguration.uri.toString(),
+  );
+  addTearDown(dispatcher.dispose);
+  router = GoRouter(
+    navigatorKey: navigatorKey,
+    initialLocation: initialLocation,
+    routes: routes.isEmpty
+        ? [
+            _placeholderRoute('/home', 'Home route'),
+            _placeholderRoute('/detail', 'Detail route'),
+          ]
+        : routes,
+  );
+  return _ExitBackTestRouter(
+    router: router,
+    dispatcher: dispatcher,
+    exitBackGuard: guard,
+  );
+}
+
+class _ExitBackTestRouter {
+  const _ExitBackTestRouter({
+    required this.router,
+    required this.dispatcher,
+    required this.exitBackGuard,
+  });
+
+  final GoRouter router;
+  final MobileExitBackDispatcher dispatcher;
+  final MobileExitBackGuard exitBackGuard;
+}
+
+GoRoute _placeholderRoute(String path, String label) => GoRoute(
+  path: path,
+  builder: (_, _) => Center(child: Text(label)),
+);
+
+Widget _app(
+  _ExitBackTestRouter testRouter, {
+  AppThemeData theme = AppThemeData.dark,
+}) => MaterialApp.router(
+  routeInformationProvider: testRouter.router.routeInformationProvider,
+  routeInformationParser: testRouter.router.routeInformationParser,
+  routerDelegate: testRouter.router.routerDelegate,
+  backButtonDispatcher: testRouter.dispatcher,
+  onNavigationNotification: testRouter.dispatcher.handleNavigationNotification,
+  builder: (_, child) => AppTheme(data: theme, child: child!),
+);
+
+List<MethodCall> _capturePlatformCalls(WidgetTester tester) {
+  final calls = <MethodCall>[];
+  tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+    SystemChannels.platform,
+    (call) async {
+      calls.add(call);
+      return null;
+    },
+  );
+  addTearDown(
+    () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      null,
+    ),
+  );
+  return calls;
+}
+
+int _systemNavigatorPopCallCount(List<MethodCall> calls) =>
+    calls.where((call) => call.method == 'SystemNavigator.pop').length;
+
+void _clearExitHint(_ExitBackTestRouter testRouter) {
+  testRouter.exitBackGuard.reset();
+  MobileExitBackGuard.dismissVisibleHint();
+}
+
+void main() {
+  tearDown(MobileExitBackGuard.dismissVisibleHint);
+
+  testWidgets('android root back shows a lower exit hint before exiting', (
+    tester,
+  ) async {
+    final platformCalls = _capturePlatformCalls(tester);
+    final testRouter = _exitBackRouter();
+    await tester.pumpWidget(_app(testRouter));
+    await tester.pumpAndSettle();
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+
+    final surfaceFinder = find.byKey(
+      const ValueKey('mobile_exit_back_hint_surface'),
+    );
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsOneWidget);
+    expect(surfaceFinder, findsOneWidget);
+
+    final screenHeight = tester.getSize(find.byType(MaterialApp)).height;
+    final hintCenter = tester.getCenter(surfaceFinder);
+    expect(hintCenter.dy, greaterThan(screenHeight * 0.55));
+    expect(hintCenter.dy, lessThan(screenHeight * 0.8));
+    expect(_systemNavigatorPopCallCount(platformCalls), 0);
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+    expect(_systemNavigatorPopCallCount(platformCalls), 1);
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsNothing);
+  });
+
+  testWidgets('android root back requires the second press inside the window', (
+    tester,
+  ) async {
+    final testRouter = _exitBackRouter();
+    await tester.pumpWidget(_app(testRouter));
+    await tester.pumpAndSettle();
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsOneWidget);
+
+    await tester.pump(MobileExitBackGuard.confirmationWindow);
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsNothing);
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsOneWidget);
+    _clearExitHint(testRouter);
+  });
+
+  testWidgets('android root back confirmation resets after app lifecycle', (
+    tester,
+  ) async {
+    final platformCalls = _capturePlatformCalls(tester);
+    final testRouter = _exitBackRouter();
+    await tester.pumpWidget(_app(testRouter));
+    await tester.pumpAndSettle();
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsOneWidget);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    await tester.pump();
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsNothing);
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsOneWidget);
+    expect(_systemNavigatorPopCallCount(platformCalls), 0);
+    _clearExitHint(testRouter);
+  });
+
+  testWidgets('android root back guard covers unlock and onboarding routes', (
+    tester,
+  ) async {
+    final platformCalls = _capturePlatformCalls(tester);
+    final testRouter = _exitBackRouter(
+      initialLocation: '/unlock',
+      routes: [
+        _placeholderRoute('/unlock', 'Unlock route'),
+        _placeholderRoute('/welcome', 'Welcome route'),
+      ],
+    );
+    await tester.pumpWidget(_app(testRouter));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Unlock route'), findsOneWidget);
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsOneWidget);
+    expect(_systemNavigatorPopCallCount(platformCalls), 0);
+
+    testRouter.exitBackGuard.reset();
+    MobileExitBackGuard.dismissVisibleHint();
+    testRouter.router.go('/welcome');
+    await tester.pumpAndSettle();
+    expect(find.text('Welcome route'), findsOneWidget);
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsOneWidget);
+    expect(_systemNavigatorPopCallCount(platformCalls), 0);
+    _clearExitHint(testRouter);
+  });
+
+  testWidgets('android pushed routes pop before the exit hint is considered', (
+    tester,
+  ) async {
+    final testRouter = _exitBackRouter();
+    await tester.pumpWidget(_app(testRouter));
+    await tester.pumpAndSettle();
+
+    testRouter.router.push('/detail');
+    await tester.pumpAndSettle();
+    expect(find.text('Detail route'), findsOneWidget);
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Detail route'), findsNothing);
+    expect(find.text('Home route'), findsOneWidget);
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsNothing);
+  });
+
+  testWidgets('exit hint follows the resolved app theme', (tester) async {
+    final testRouter = _exitBackRouter();
+    await tester.pumpWidget(_app(testRouter, theme: AppThemeData.light));
+    await tester.pumpAndSettle();
+
+    expect(await testRouter.dispatcher.didPopRoute(), isTrue);
+    await tester.pump();
+
+    final decoration =
+        tester
+                .widget<DecoratedBox>(
+                  find.byKey(const ValueKey('mobile_exit_back_hint_surface')),
+                )
+                .decoration
+            as BoxDecoration;
+    expect(decoration.color, AppThemeData.light.colors.background.inverse);
+
+    final text = tester.widget<Text>(
+      find.byKey(const ValueKey('mobile_exit_back_hint_text')),
+    );
+    expect(text.style?.color, AppThemeData.light.colors.text.inverse);
+    expect(text.style?.decoration, TextDecoration.none);
+    _clearExitHint(testRouter);
+  });
+
+  testWidgets('non-Android mobile platforms do not intercept root back', (
+    tester,
+  ) async {
+    final testRouter = _exitBackRouter(
+      exitBackGuard: MobileExitBackGuard(platform: TargetPlatform.iOS),
+    );
+    await tester.pumpWidget(_app(testRouter));
+    await tester.pumpAndSettle();
+
+    expect(await testRouter.dispatcher.didPopRoute(), isFalse);
+    await tester.pump();
+    expect(find.text(MobileExitBackGuard.exitHintMessage), findsNothing);
+  });
+}

--- a/test/core/navigation/mobile_routes_test.dart
+++ b/test/core/navigation/mobile_routes_test.dart
@@ -162,7 +162,8 @@ void main() {
         ),
       ),
     );
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
 
     expect(find.byType(MobileSendAmountScreen), findsOneWidget);
     var route = ModalRoute.of(
@@ -182,7 +183,8 @@ void main() {
         ),
       ),
     );
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 600));
 
     expect(find.byType(MobileSendReviewScreen), findsOneWidget);
     route = ModalRoute.of(tester.element(find.byType(MobileSendReviewScreen)));


### PR DESCRIPTION
## Summary
- Add an Android-only mobile root back dispatcher that shows an exit hint before closing the app.
- Render the hint as a lower on-screen overlay using the resolved app theme.
- Cover root routes, pushed routes, lifecycle reset, unlock/onboarding routes, theme handling, and non-Android behavior with mobile tests.

## Validation
- fvm flutter test test/core/navigation --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile
- fvm flutter analyze
- git diff --check origin/main...HEAD
