### PR TITLE
Use flex input for external-to-ZEC swaps

### DIFF
--- a/lib/src/features/swap/domain/swap_direction.dart
+++ b/lib/src/features/swap/domain/swap_direction.dart
@@ -4,12 +4,16 @@ enum SwapDirection { zecToExternal, externalToZec }
 
 enum SwapQuoteMode {
   exactInput,
-  exactOutput;
+  exactOutput,
+  flexInput;
 
   String get oneClickSwapType => switch (this) {
     SwapQuoteMode.exactInput => 'EXACT_INPUT',
     SwapQuoteMode.exactOutput => 'EXACT_OUTPUT',
+    SwapQuoteMode.flexInput => 'FLEX_INPUT',
   };
+
+  bool get usesInputAmount => this != SwapQuoteMode.exactOutput;
 }
 
 extension SwapDirectionLabels on SwapDirection {

--- a/lib/src/features/swap/domain/swap_quote.dart
+++ b/lib/src/features/swap/domain/swap_quote.dart
@@ -36,18 +36,16 @@ class SwapQuoteRequest {
 
   SwapAsset get sellAsset => direction.fromAsset(externalAsset);
   SwapAsset get receiveAsset => direction.toAsset(externalAsset);
-  SwapAsset get amountAsset =>
-      mode == SwapQuoteMode.exactInput ? sellAsset : receiveAsset;
+  SwapAsset get amountAsset => mode.usesInputAmount ? sellAsset : receiveAsset;
 
   double get sellAmount {
-    if (mode != SwapQuoteMode.exactInput) {
+    if (!mode.usesInputAmount) {
       throw StateError('Exact-output quote requests do not carry sellAmount');
     }
     return amount;
   }
 
-  String? get sellAmountText =>
-      mode == SwapQuoteMode.exactInput ? amountText : null;
+  String? get sellAmountText => mode.usesInputAmount ? amountText : null;
 }
 
 class SwapDepositInstruction {
@@ -151,12 +149,12 @@ class SwapQuote {
     final receiveAsset = direction.toAsset(externalAsset);
     final rate = externalPerZec ?? externalAsset.fallbackExternalPerZec;
     final estimatedSellAmount = switch (mode) {
-      SwapQuoteMode.exactInput => quoteAmount,
+      SwapQuoteMode.exactInput || SwapQuoteMode.flexInput => quoteAmount,
       SwapQuoteMode.exactOutput =>
         direction.sendsZec ? quoteAmount / rate : quoteAmount * rate,
     };
     final receiveAmount = switch (mode) {
-      SwapQuoteMode.exactInput =>
+      SwapQuoteMode.exactInput || SwapQuoteMode.flexInput =>
         direction.sendsZec ? quoteAmount * rate : quoteAmount / rate,
       SwapQuoteMode.exactOutput => quoteAmount,
     };
@@ -218,7 +216,7 @@ class SwapQuote {
       '${mode == SwapQuoteMode.exactOutput ? sellAsset.formatAmountUp(sellAmount) : sellAsset.formatAmount(sellAmount)} ${sellAsset.symbol}';
   String get receiveEstimateText =>
       receiveEstimateTextOverride ??
-      '${mode == SwapQuoteMode.exactInput ? receiveAsset.formatAmountDown(receiveAmount) : receiveAsset.formatAmount(receiveAmount)} ${receiveAsset.symbol}';
+      '${mode.usesInputAmount ? receiveAsset.formatAmountDown(receiveAmount) : receiveAsset.formatAmount(receiveAmount)} ${receiveAsset.symbol}';
   String get minimumReceiveText =>
       minimumReceiveTextOverride ??
       '${receiveAsset.formatAmountDown(minimumReceiveAmount)} ${receiveAsset.symbol}';

--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_json.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_json.dart
@@ -75,6 +75,7 @@ String? _firstChainTxHash(Map<String, dynamic> json, String key) {
 SwapQuoteMode _oneClickSwapMode(String? value) {
   return switch (value?.trim().toUpperCase()) {
     'EXACT_OUTPUT' => SwapQuoteMode.exactOutput,
+    'FLEX_INPUT' => SwapQuoteMode.flexInput,
     _ => SwapQuoteMode.exactInput,
   };
 }

--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
@@ -907,7 +907,7 @@ class NearIntentsOneClickSwapAdapter
     for (final token in tokens) {
       final asset = _assetForToken(token);
       if (asset.symbol.toLowerCase() != ticker) continue;
-      candidates.putIfAbsent(_assetMarketKey(asset), () => asset);
+      candidates.putIfAbsent(token.assetId, () => asset);
     }
     return candidates.length == 1 ? candidates.values.single : null;
   }
@@ -925,11 +925,6 @@ class NearIntentsOneClickSwapAdapter
       decimals: token.decimals,
     );
   }
-
-  String _assetMarketKey(SwapAsset asset) =>
-      '${asset.symbol.toLowerCase()}:'
-      '${asset.chainTicker.toLowerCase()}:'
-      '${asset.decimals}';
 
   Map<String, String> _headers({bool contentType = false}) {
     return {

--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
@@ -122,7 +122,7 @@ class NearIntentsOneClickSwapAdapter
       expectedRecipient: requestedRecipient,
       sellToken: sellToken,
       receiveToken: receiveToken,
-      allowFlexibleAmountEcho:
+      allowFlexibleQuotedAmount:
           request.direction == SwapDirection.externalToZec &&
           quoteMode == SwapQuoteMode.flexInput,
     );
@@ -728,7 +728,7 @@ class NearIntentsOneClickSwapAdapter
     required String expectedRecipient,
     required _OneClickToken sellToken,
     required _OneClickToken receiveToken,
-    required bool allowFlexibleAmountEcho,
+    required bool allowFlexibleQuotedAmount,
   }) {
     final actual = response.quoteRequest;
     final actualSwapType = actual.swapTypeRaw?.trim().toUpperCase();
@@ -758,9 +758,9 @@ class NearIntentsOneClickSwapAdapter
       actual.amount,
       'quoteRequest.amount',
     );
-    if (!allowFlexibleAmountEcho &&
-        (responseFixedAmount != expectedFixedAmount ||
-            requestFixedAmount != expectedFixedAmount)) {
+    if (requestFixedAmount != expectedFixedAmount ||
+        (!allowFlexibleQuotedAmount &&
+            responseFixedAmount != expectedFixedAmount)) {
       throw OneClickApiException(
         '1Click quote response did not match the requested amount',
         operation: 'quote',

--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
@@ -657,6 +657,9 @@ class NearIntentsOneClickSwapAdapter
   }) {
     final details = response.swapDetails;
     if (details == null) return null;
+    if (response.quoteResponse.quoteRequest.mode == SwapQuoteMode.flexInput) {
+      return null;
+    }
     final quote = response.quoteResponse.quote;
     if (response.quoteResponse.quoteRequest.mode == SwapQuoteMode.exactOutput) {
       final expected = _statusDecimalAmount(

--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
@@ -122,6 +122,9 @@ class NearIntentsOneClickSwapAdapter
       expectedRecipient: requestedRecipient,
       sellToken: sellToken,
       receiveToken: receiveToken,
+      allowFlexibleAmountEcho:
+          request.direction == SwapDirection.externalToZec &&
+          quoteMode == SwapQuoteMode.flexInput,
     );
     return _quoteFromOneClick(
       quoteResponse,
@@ -725,6 +728,7 @@ class NearIntentsOneClickSwapAdapter
     required String expectedRecipient,
     required _OneClickToken sellToken,
     required _OneClickToken receiveToken,
+    required bool allowFlexibleAmountEcho,
   }) {
     final actual = response.quoteRequest;
     final actualSwapType = actual.swapTypeRaw?.trim().toUpperCase();
@@ -746,10 +750,17 @@ class NearIntentsOneClickSwapAdapter
         ? 'amountIn'
         : 'amountOut';
     final expectedFixedAmount = BigInt.parse(expectedFixedAmountBaseUnits);
-    if (_parseQuoteResponseBaseUnits(amountField, amountFieldName) !=
-            expectedFixedAmount ||
-        _parseQuoteResponseBaseUnits(actual.amount, 'quoteRequest.amount') !=
-            expectedFixedAmount) {
+    final responseFixedAmount = _parseQuoteResponseBaseUnits(
+      amountField,
+      amountFieldName,
+    );
+    final requestFixedAmount = _parseQuoteResponseBaseUnits(
+      actual.amount,
+      'quoteRequest.amount',
+    );
+    if (!allowFlexibleAmountEcho &&
+        (responseFixedAmount != expectedFixedAmount ||
+            requestFixedAmount != expectedFixedAmount)) {
       throw OneClickApiException(
         '1Click quote response did not match the requested amount',
         operation: 'quote',

--- a/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
+++ b/lib/src/features/swap/integrations/near_intents/near_intents_one_click_swap_adapter.dart
@@ -67,6 +67,7 @@ class NearIntentsOneClickSwapAdapter
   @override
   Future<SwapQuote> quote(SwapQuoteRequest request) async {
     _validateQuoteRequest(request);
+    final quoteMode = _oneClickQuoteModeForRequest(request);
     final amountText = _requiredQuoteAmountText(request);
 
     final tokens = await _ensureTokens();
@@ -80,9 +81,7 @@ class NearIntentsOneClickSwapAdapter
       tokens,
       operation: 'quote',
     );
-    final amountToken = request.mode == SwapQuoteMode.exactInput
-        ? sellToken
-        : receiveToken;
+    final amountToken = quoteMode.usesInputAmount ? sellToken : receiveToken;
     final amountBaseUnits = _toBaseUnits(amountText, amountToken.decimals);
     final requestedSlippageBps = request.slippageBps ?? slippageBps;
     final requestedRefundTo = request.refundAddress!.trim();
@@ -90,7 +89,7 @@ class NearIntentsOneClickSwapAdapter
 
     final body = <String, Object?>{
       'dry': request.dryRun,
-      'swapType': request.mode.oneClickSwapType,
+      'swapType': quoteMode.oneClickSwapType,
       'slippageTolerance': requestedSlippageBps,
       'originAsset': sellToken.assetId,
       'depositType': 'ORIGIN_CHAIN',
@@ -116,7 +115,7 @@ class NearIntentsOneClickSwapAdapter
     final quoteResponse = _OneClickQuoteResponse.fromJson(response.jsonObject);
     _validateQuoteResponseRequest(
       quoteResponse,
-      expectedMode: request.mode,
+      expectedMode: quoteMode,
       expectedFixedAmountBaseUnits: amountBaseUnits,
       expectedSlippageBps: requestedSlippageBps,
       expectedRefundTo: requestedRefundTo,
@@ -128,7 +127,7 @@ class NearIntentsOneClickSwapAdapter
       quoteResponse,
       direction: request.direction,
       externalAsset: request.externalAsset,
-      mode: request.mode,
+      mode: quoteMode,
       sellToken: sellToken,
       receiveToken: receiveToken,
       fallbackSlippageBps:
@@ -136,6 +135,14 @@ class NearIntentsOneClickSwapAdapter
           request.slippageBps ??
           slippageBps,
     );
+  }
+
+  SwapQuoteMode _oneClickQuoteModeForRequest(SwapQuoteRequest request) {
+    if (request.direction == SwapDirection.externalToZec &&
+        request.mode == SwapQuoteMode.exactInput) {
+      return SwapQuoteMode.flexInput;
+    }
+    return request.mode;
   }
 
   @override
@@ -732,10 +739,10 @@ class NearIntentsOneClickSwapAdapter
     }
 
     final quote = response.quote;
-    final amountField = expectedMode == SwapQuoteMode.exactInput
+    final amountField = expectedMode.usesInputAmount
         ? quote.amountIn
         : quote.amountOut;
-    final amountFieldName = expectedMode == SwapQuoteMode.exactInput
+    final amountFieldName = expectedMode.usesInputAmount
         ? 'amountIn'
         : 'amountOut';
     final expectedFixedAmount = BigInt.parse(expectedFixedAmountBaseUnits);
@@ -866,7 +873,32 @@ class NearIntentsOneClickSwapAdapter
         return entry.key;
       }
     }
+    final oneClickTickerAsset = _oneClickUniqueTickerAssetFromId(
+      assetId,
+      tokens,
+    );
+    if (oneClickTickerAsset != null) return oneClickTickerAsset;
     return null;
+  }
+
+  SwapAsset? _oneClickUniqueTickerAssetFromId(
+    String assetId,
+    List<_OneClickToken> tokens,
+  ) {
+    final parts = assetId.trim().toLowerCase().split(':');
+    if (parts.length < 2 || parts[0] != '1cs_v1') {
+      return null;
+    }
+
+    final ticker = parts[1];
+    if (ticker.isEmpty) return null;
+    final candidates = <String, SwapAsset>{};
+    for (final token in tokens) {
+      final asset = _assetForToken(token);
+      if (asset.symbol.toLowerCase() != ticker) continue;
+      candidates.putIfAbsent(_assetMarketKey(asset), () => asset);
+    }
+    return candidates.length == 1 ? candidates.values.single : null;
   }
 
   SwapAsset _assetForToken(_OneClickToken token) {
@@ -882,6 +914,11 @@ class NearIntentsOneClickSwapAdapter
       decimals: token.decimals,
     );
   }
+
+  String _assetMarketKey(SwapAsset asset) =>
+      '${asset.symbol.toLowerCase()}:'
+      '${asset.chainTicker.toLowerCase()}:'
+      '${asset.decimals}';
 
   Map<String, String> _headers({bool contentType = false}) {
     return {

--- a/lib/src/features/swap/models/swap_activity_status_mapper.dart
+++ b/lib/src/features/swap/models/swap_activity_status_mapper.dart
@@ -454,9 +454,16 @@ List<SwapStatusDetailRowData> _swapActivityIncompleteDepositDetails(
   final sourceAsset = swapActivitySellAsset(intent);
   final receiveAsset = swapActivityReceiveAsset(intent);
   final providerInfo = intent.providerRefundInfo;
+  final requiredDepositText =
+      _firstNonEmpty([providerInfo?.minimumDepositText, intent.sellAmount]) ??
+      intent.sellAmount;
   final missingDepositText = sourceAsset == null
       ? null
-      : _swapActivityMissingDepositText(intent, sourceAsset);
+      : _swapActivityMissingDepositText(
+          sourceAsset: sourceAsset,
+          requiredDepositText: requiredDepositText,
+          depositedAmountText: providerInfo?.depositedAmountText,
+        );
   final deadlineText = _swapActivityTimestampLabel(intent.depositDeadline);
 
   return [
@@ -481,7 +488,7 @@ List<SwapStatusDetailRowData> _swapActivityIncompleteDepositDetails(
       ),
     SwapStatusDetailRowData(
       label: 'Required deposit',
-      value: intent.sellAmount,
+      value: requiredDepositText,
     ),
     if (providerInfo?.depositedAmountText != null)
       SwapStatusDetailRowData(
@@ -762,14 +769,13 @@ bool swapActivityShowsDepositPage(
       );
 }
 
-String? _swapActivityMissingDepositText(
-  SwapIntent intent,
-  SwapAsset sourceAsset,
-) {
-  final requiredAmount = _numericAmount(intent.sellAmount);
-  final depositedAmount = _numericAmount(
-    intent.providerRefundInfo?.depositedAmountText ?? '',
-  );
+String? _swapActivityMissingDepositText({
+  required SwapAsset sourceAsset,
+  required String requiredDepositText,
+  required String? depositedAmountText,
+}) {
+  final requiredAmount = _numericAmount(requiredDepositText);
+  final depositedAmount = _numericAmount(depositedAmountText ?? '');
   if (requiredAmount == null || depositedAmount == null) return null;
   final missingAmount = requiredAmount - depositedAmount;
   if (!missingAmount.isFinite || missingAmount <= 0) return null;

--- a/lib/src/features/swap/models/swap_amount_input_mapper.dart
+++ b/lib/src/features/swap/models/swap_amount_input_mapper.dart
@@ -23,11 +23,11 @@ String? swapReceiveTokenTextFromFiatInput(
 SwapState swapStateWithIndicativeCounterpart(SwapState next) {
   final estimate = next.draftQuote;
   if (estimate == null) {
-    return next.quoteMode == SwapQuoteMode.exactInput
+    return next.quoteMode.usesInputAmount
         ? next.copyWith(receiveAmountText: '')
         : next.copyWith(amountText: '');
   }
-  if (next.quoteMode == SwapQuoteMode.exactInput) {
+  if (next.quoteMode.usesInputAmount) {
     return next.copyWith(
       receiveAmountText: estimate.receiveAsset.formatAmountDown(
         estimate.receiveAmount,

--- a/lib/src/features/swap/models/swap_state.dart
+++ b/lib/src/features/swap/models/swap_state.dart
@@ -139,14 +139,13 @@ class SwapState {
   }
 
   double? get quoteAmount =>
-      quoteMode == SwapQuoteMode.exactInput ? sellAmount : receiveAmount;
+      quoteMode.usesInputAmount ? sellAmount : receiveAmount;
 
-  String get quoteAmountText => quoteMode == SwapQuoteMode.exactInput
-      ? amountText.trim()
-      : receiveAmountText.trim();
+  String get quoteAmountText =>
+      quoteMode.usesInputAmount ? amountText.trim() : receiveAmountText.trim();
 
   String? get quoteAmountPrecisionError => swapTokenAmountPrecisionError(
-    asset: quoteMode == SwapQuoteMode.exactInput
+    asset: quoteMode.usesInputAmount
         ? direction.fromAsset(externalAsset)
         : direction.toAsset(externalAsset),
     amountText: quoteAmountText,
@@ -222,7 +221,7 @@ class SwapState {
     if (liveQuote == null || estimate == null) return null;
     if (liveQuote.direction != direction ||
         liveQuote.externalAsset != externalAsset ||
-        quoteMode != SwapQuoteMode.exactInput ||
+        !quoteMode.usesInputAmount ||
         liveQuote.sellAmount != estimate.sellAmount ||
         estimate.receiveAmount <= 0) {
       return null;

--- a/lib/src/features/swap/models/swap_state.dart
+++ b/lib/src/features/swap/models/swap_state.dart
@@ -221,11 +221,20 @@ class SwapState {
     if (liveQuote == null || estimate == null) return null;
     if (liveQuote.direction != direction ||
         liveQuote.externalAsset != externalAsset ||
-        !quoteMode.usesInputAmount ||
-        liveQuote.sellAmount != estimate.sellAmount ||
-        estimate.receiveAmount <= 0) {
+        !quoteMode.usesInputAmount) {
       return null;
     }
+    if (estimate.sellAmount > 0) {
+      final sellDelta =
+          (liveQuote.sellAmount - estimate.sellAmount) / estimate.sellAmount;
+      if (sellDelta.abs() >= swapQuoteDifferenceWarningThreshold) {
+        final sellAsset = estimate.sellAsset;
+        final liveText = sellAsset.formatAmount(liveQuote.sellAmount);
+        final estimateText = sellAsset.formatAmount(estimate.sellAmount);
+        return 'Live quote uses $liveText ${sellAsset.symbol} instead of $estimateText ${sellAsset.symbol}. Check the guaranteed minimum before you continue.';
+      }
+    }
+    if (estimate.receiveAmount <= 0) return null;
     final delta =
         (liveQuote.receiveAmount - estimate.receiveAmount) /
         estimate.receiveAmount;

--- a/lib/src/features/swap/providers/swap_state_provider.dart
+++ b/lib/src/features/swap/providers/swap_state_provider.dart
@@ -39,6 +39,9 @@ final class SwapStartedKeystoneSigning extends SwapStartResult {
   const SwapStartedKeystoneSigning(super.intentId);
 }
 
+SwapQuoteMode _inputQuoteModeForDirection(SwapDirection direction) =>
+    direction.sendsZec ? SwapQuoteMode.exactInput : SwapQuoteMode.flexInput;
+
 class SwapNotifier extends Notifier<SwapState> {
   var _quoteGeneration = 0;
   var _accountScopeGeneration = 0;
@@ -112,7 +115,7 @@ class SwapNotifier extends Notifier<SwapState> {
       swapStateWithIndicativeCounterpart(
         state.copyWith(
           direction: direction,
-          quoteMode: SwapQuoteMode.exactInput,
+          quoteMode: _inputQuoteModeForDirection(direction),
           amountInputMode: SwapAmountInputMode.token,
           receiveAmountInputMode: SwapAmountInputMode.token,
           amountFiatText: '',
@@ -136,7 +139,7 @@ class SwapNotifier extends Notifier<SwapState> {
       swapStateWithIndicativeCounterpart(
         state.copyWith(
           direction: nextDirection,
-          quoteMode: SwapQuoteMode.exactInput,
+          quoteMode: _inputQuoteModeForDirection(nextDirection),
           amountText: nextAmountText,
           receiveAmountText: '',
           amountInputMode: SwapAmountInputMode.token,
@@ -155,7 +158,7 @@ class SwapNotifier extends Notifier<SwapState> {
     state = swapStateWithDerivedFiatTexts(
       swapStateWithIndicativeCounterpart(
         state.copyWith(
-          quoteMode: SwapQuoteMode.exactInput,
+          quoteMode: _inputQuoteModeForDirection(state.direction),
           amountText: value,
           reviewVisible: false,
           clearMaxAmountError: true,
@@ -170,7 +173,7 @@ class SwapNotifier extends Notifier<SwapState> {
     state = swapStateWithDerivedFiatTexts(
       swapStateWithIndicativeCounterpart(
         state.copyWith(
-          quoteMode: SwapQuoteMode.exactInput,
+          quoteMode: _inputQuoteModeForDirection(state.direction),
           receiveAmountInputMode: SwapAmountInputMode.fiat,
           amountInputMode: SwapAmountInputMode.fiat,
           amountFiatText: value,
@@ -627,7 +630,7 @@ class SwapNotifier extends Notifier<SwapState> {
       reviewVisible: false,
       amountText: '',
       receiveAmountText: '',
-      quoteMode: SwapQuoteMode.exactInput,
+      quoteMode: _inputQuoteModeForDirection(state.direction),
       amountInputMode: SwapAmountInputMode.token,
       receiveAmountInputMode: SwapAmountInputMode.token,
       amountFiatText: '',
@@ -764,7 +767,7 @@ class SwapNotifier extends Notifier<SwapState> {
     state = state.copyWith(
       direction: direction,
       externalAsset: externalAsset,
-      quoteMode: SwapQuoteMode.exactInput,
+      quoteMode: _inputQuoteModeForDirection(direction),
       amountText: amountText,
       receiveAmountText: '',
       amountInputMode: SwapAmountInputMode.token,
@@ -1357,7 +1360,7 @@ class SwapNotifier extends Notifier<SwapState> {
     state = state.copyWith(
       amountText: '',
       receiveAmountText: '',
-      quoteMode: SwapQuoteMode.exactInput,
+      quoteMode: _inputQuoteModeForDirection(state.direction),
       amountInputMode: SwapAmountInputMode.token,
       receiveAmountInputMode: SwapAmountInputMode.token,
       amountFiatText: '',

--- a/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
+++ b/lib/src/features/swap/screens/mobile/mobile_swap_screen.dart
@@ -61,6 +61,8 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
   final ValueNotifier<_SwapModalSurface?> _swapModal =
       ValueNotifier<_SwapModalSurface?>(null);
   bool _modalRouteOpen = false;
+  String? _addressEditorDraftText;
+  bool _addressEditorDraftRemember = false;
 
   @override
   void dispose() {
@@ -89,19 +91,44 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
         pageBuilder: (_, _, _) => _buildSwapModal(),
       ).whenComplete(() {
         _modalRouteOpen = false;
-        if (mounted) setState(() => _swapModal.value = null);
+        if (mounted) {
+          setState(() {
+            _clearAddressEditorDraft();
+            _swapModal.value = null;
+          });
+        }
       }),
     );
+  }
+
+  void _openAddressEditor({String? draftText, bool? draftRemember}) {
+    _addressEditorDraftText = draftText ?? _addressEditorDraftText;
+    _addressEditorDraftRemember = draftRemember ?? _addressEditorDraftRemember;
+    _openModal(_SwapModalSurface.addressEditor);
+  }
+
+  void _captureAddressEditorDraft(String value, bool remember) {
+    _addressEditorDraftText = value;
+    _addressEditorDraftRemember = remember;
+  }
+
+  void _clearAddressEditorDraft() {
+    _addressEditorDraftText = null;
+    _addressEditorDraftRemember = false;
   }
 
   void _closeSwapModal() {
     if (_modalRouteOpen) {
       // State resets in the route's whenComplete.
+      _clearAddressEditorDraft();
       Navigator.of(context, rootNavigator: true).pop();
       return;
     }
     if (_swapModal.value != null) {
-      setState(() => _swapModal.value = null);
+      setState(() {
+        _clearAddressEditorDraft();
+        _swapModal.value = null;
+      });
     }
   }
 
@@ -137,6 +164,8 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
                 state: swapState,
                 contacts:
                     ref.watch(addressBookProvider).value?.contacts ?? const [],
+                initialAddress: _addressEditorDraftText,
+                initialRememberAddress: _addressEditorDraftRemember,
                 onSubmitted: (value, remember) {
                   if (remember) {
                     unawaited(_rememberSwapAddress(value, swapState));
@@ -144,9 +173,14 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
                   swapNotifier.updateDestination(value);
                   _closeSwapModal();
                 },
-                onScan: () => _openModal(_SwapModalSurface.addressScanner),
-                onOpenContacts: () =>
-                    _openModal(_SwapModalSurface.contactPicker),
+                onScan: (value, remember) {
+                  _captureAddressEditorDraft(value, remember);
+                  _openModal(_SwapModalSurface.addressScanner);
+                },
+                onOpenContacts: (value, remember) {
+                  _captureAddressEditorDraft(value, remember);
+                  _openModal(_SwapModalSurface.contactPicker);
+                },
                 onCancel: _closeSwapModal,
               ),
               // The address scanner is a bottom-sheet camera card (Figma
@@ -163,17 +197,16 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
                   return MobileScanOutcome.accepted(address);
                 },
                 onScanned: (value) {
-                  swapNotifier.updateDestination(value);
-                  _closeSwapModal();
+                  _openAddressEditor(draftText: value);
                 },
-                onClose: _closeSwapModal,
+                onClose: _openAddressEditor,
               ),
               _SwapModalSurface.contactPicker => AddressBookContactPickerModal(
                 title: swapContactPickerTitle(swapState),
                 networks: swapContactPickerNetworks(swapState),
                 emptyTitle: swapContactPickerEmptyTitle(swapState),
                 onSelected: _selectAddressBookContact,
-                onCancel: () => _openModal(_SwapModalSurface.addressEditor),
+                onCancel: _openAddressEditor,
               ),
               _SwapModalSurface.slippageSettings =>
                 MobileSwapSlippageStepperModal(
@@ -342,8 +375,7 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
                         onToggleDirection: swapNotifier.toggleDirection,
                         onOpenExternalAssetPicker: () =>
                             _openModal(_SwapModalSurface.assetSelector),
-                        onOpenDestinationAddress: () =>
-                            _openModal(_SwapModalSurface.addressEditor),
+                        onOpenDestinationAddress: _openAddressEditor,
                         onUseMaxZecAmount: swapNotifier.useMaxZecAmount,
                         zecAvailableText: zecAvailableText,
                         destinationContactName: swapDestinationContactFor(
@@ -373,8 +405,7 @@ class _MobileSwapScreenState extends ConsumerState<MobileSwapScreen> {
                             child: _MobileSwapReviewButton(
                               state: swapState,
                               zecAvailableZatoshi: sync.spendableBalance,
-                              onOpenDestinationAddress: () =>
-                                  _openModal(_SwapModalSurface.addressEditor),
+                              onOpenDestinationAddress: _openAddressEditor,
                               onReviewQuote: openReview,
                             ),
                           ),

--- a/lib/src/features/swap/widgets/mobile/mobile_swap_address_edit_modal.dart
+++ b/lib/src/features/swap/widgets/mobile/mobile_swap_address_edit_modal.dart
@@ -32,14 +32,18 @@ class MobileSwapAddressEditModal extends StatefulWidget {
     required this.onOpenContacts,
     required this.onCancel,
     this.contacts = const <AddressBookContact>[],
+    this.initialAddress,
+    this.initialRememberAddress = false,
     super.key,
   });
 
   final SwapState state;
   final void Function(String value, bool remember) onSubmitted;
-  final VoidCallback onScan;
-  final VoidCallback onOpenContacts;
+  final void Function(String value, bool remember) onScan;
+  final void Function(String value, bool remember) onOpenContacts;
   final VoidCallback onCancel;
+  final String? initialAddress;
+  final bool initialRememberAddress;
 
   /// Saved contacts; when the entered address matches one, its name is shown
   /// under the field so the user knows the address is correct.
@@ -59,7 +63,8 @@ class _MobileSwapAddressEditModalState
   @override
   void initState() {
     super.initState();
-    _controller = TextEditingController(text: widget.state.destinationText);
+    _controller = TextEditingController(text: _initialAddressText);
+    _rememberAddress = widget.initialRememberAddress;
     _focusNode = FocusNode(debugLabel: 'SwapAddressModalField');
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -70,15 +75,18 @@ class _MobileSwapAddressEditModalState
   @override
   void didUpdateWidget(covariant MobileSwapAddressEditModal oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.state.destinationText == widget.state.destinationText) {
-      return;
+    final oldAddressText =
+        oldWidget.initialAddress ?? oldWidget.state.destinationText;
+    final nextAddressText = _initialAddressText;
+    if (oldAddressText != nextAddressText) {
+      _controller.value = TextEditingValue(
+        text: nextAddressText,
+        selection: TextSelection.collapsed(offset: nextAddressText.length),
+      );
     }
-    _controller.value = TextEditingValue(
-      text: widget.state.destinationText,
-      selection: TextSelection.collapsed(
-        offset: widget.state.destinationText.length,
-      ),
-    );
+    if (oldWidget.initialRememberAddress != widget.initialRememberAddress) {
+      _rememberAddress = widget.initialRememberAddress;
+    }
   }
 
   @override
@@ -94,6 +102,9 @@ class _MobileSwapAddressEditModalState
     if (!_canSubmit) return;
     widget.onSubmitted(_controller.text.trim(), _rememberAddress);
   }
+
+  String get _initialAddressText =>
+      widget.initialAddress ?? widget.state.destinationText;
 
   void _toggleRemember() {
     setState(() => _rememberAddress = !_rememberAddress);
@@ -177,14 +188,20 @@ class _MobileSwapAddressEditModalState
                   SwapInlineIconButton(
                     key: const ValueKey('swap_address_contacts_button'),
                     iconName: AppIcons.users,
-                    onTap: widget.onOpenContacts,
+                    onTap: () => widget.onOpenContacts(
+                      _controller.text.trim(),
+                      _rememberAddress,
+                    ),
                     size: AppInputSizing.iconSize,
                   ),
                   const SizedBox(width: 8),
                   SwapInlineIconButton(
                     key: const ValueKey('swap_address_scan_button'),
                     iconName: AppIcons.qr,
-                    onTap: widget.onScan,
+                    onTap: () => widget.onScan(
+                      _controller.text.trim(),
+                      _rememberAddress,
+                    ),
                     size: AppInputSizing.iconSize,
                   ),
                 ],

--- a/lib/src/features/swap/widgets/mobile/mobile_swap_composer_ticket.dart
+++ b/lib/src/features/swap/widgets/mobile/mobile_swap_composer_ticket.dart
@@ -148,8 +148,7 @@ class _MobileSwapComposerTicketState extends State<MobileSwapComposerTicket> {
 
     final payActive =
         _amountFocusNode.hasFocus ||
-        (!_receiveAmountFocusNode.hasFocus &&
-            state.quoteMode == SwapQuoteMode.exactInput);
+        (!_receiveAmountFocusNode.hasFocus && state.quoteMode.usesInputAmount);
     final receiveActive = !payActive;
 
     final payCard = _SwapCard(

--- a/lib/src/features/swap/widgets/swap_composer_panel.dart
+++ b/lib/src/features/swap/widgets/swap_composer_panel.dart
@@ -140,8 +140,7 @@ class _SwapComposerPanelState extends State<SwapComposerPanel> {
 
     final payActive =
         _amountFocusNode.hasFocus ||
-        (!_receiveAmountFocusNode.hasFocus &&
-            state.quoteMode == SwapQuoteMode.exactInput);
+        (!_receiveAmountFocusNode.hasFocus && state.quoteMode.usesInputAmount);
     final receiveActive =
         _receiveAmountFocusNode.hasFocus ||
         (!_amountFocusNode.hasFocus &&

--- a/lib/src/features/swap/widgets/swap_deposit_tokens_page_content.dart
+++ b/lib/src/features/swap/widgets/swap_deposit_tokens_page_content.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/widgets.dart';
 import 'package:pretty_qr_code/pretty_qr_code.dart';
@@ -946,6 +947,12 @@ class _DepositDetailsList extends StatelessWidget {
   final String? memo;
   final bool mobile;
 
+  static const _desktopAmountRightWidth = 120.0;
+  static const _desktopAddressRightWidth = 177.0;
+  static const _desktopAmountLabelWidth = 60.0;
+  static const _desktopAddressLabelWidth = 125.0;
+  static const _desktopMemoLabelWidth = 60.0;
+
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -956,58 +963,98 @@ class _DepositDetailsList extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          _DepositDetailRow(
-            label: kAppFormFactor == AppFormFactor.mobile
-                ? 'Amount to deposit'
-                : 'Amount',
+          _detailRow(
+            label: mobile ? 'Amount to deposit' : 'Amount',
             value: amountText,
             copyText: _depositAmountCopyText(amountText, asset),
-            toastMessage: kAppFormFactor == AppFormFactor.mobile
-                ? 'Amount copied'
-                : 'Amount Copied',
+            toastMessage: mobile ? 'Amount copied' : 'Amount Copied',
             copyKey: const ValueKey('swap_copy_deposit_amount'),
             rightKey: const ValueKey('swap_deposit_amount_right_item'),
-            mobile: mobile,
+            desktopLabelWidth: _desktopAmountLabelWidth,
+            desktopRightWidth: _desktopAmountRightWidth,
+            desktopAllowRightSlotGrowth: true,
+            desktopValueOverflow: TextOverflow.visible,
           ),
-          _DepositDetailRow(
-            label: 'One-time address',
+          _detailRow(
+            label: 'One-time Address',
             value: compactSwapAddress(depositAddress),
             copyText: depositAddress,
             toastMessage: 'Address copied',
             copyKey: const ValueKey('swap_copy_deposit_address'),
             scaleValueToFit: true,
             rightKey: const ValueKey('swap_deposit_address_right_item'),
-            mobile: mobile,
+            desktopLabelWidth: _desktopAddressLabelWidth,
+            desktopRightWidth: _desktopAddressRightWidth,
           ),
           if (memo?.trim().isNotEmpty ?? false)
-            _DepositDetailRow(
+            _detailRow(
               label: 'Memo',
               value: memo!.trim(),
               copyText: memo!.trim(),
               toastMessage: 'Memo copied',
               copyKey: const ValueKey('swap_copy_deposit_memo'),
               rightKey: const ValueKey('swap_deposit_memo_right_item'),
-              mobile: mobile,
+              desktopLabelWidth: _desktopMemoLabelWidth,
+              desktopRightWidth: _desktopAddressRightWidth,
             ),
         ],
       ),
     );
   }
+
+  Widget _detailRow({
+    required String label,
+    required String value,
+    required String copyText,
+    required String toastMessage,
+    required Key copyKey,
+    required Key rightKey,
+    required double desktopLabelWidth,
+    required double desktopRightWidth,
+    bool desktopAllowRightSlotGrowth = false,
+    TextOverflow desktopValueOverflow = TextOverflow.ellipsis,
+    bool scaleValueToFit = false,
+  }) {
+    if (mobile) {
+      return _MobileDepositDetailRow(
+        label: label,
+        value: value,
+        copyText: copyText,
+        toastMessage: toastMessage,
+        copyKey: copyKey,
+        rightKey: rightKey,
+      );
+    }
+    return _DesktopDepositDetailRow(
+      label: label,
+      value: value,
+      copyText: copyText,
+      toastMessage: toastMessage,
+      copyKey: copyKey,
+      rightKey: rightKey,
+      labelWidth: desktopLabelWidth,
+      rightWidth: desktopRightWidth,
+      allowRightSlotGrowth: desktopAllowRightSlotGrowth,
+      valueOverflow: desktopValueOverflow,
+      scaleValueToFit: scaleValueToFit,
+    );
+  }
 }
 
-class _DepositDetailRow extends StatelessWidget {
-  const _DepositDetailRow({
+class _DesktopDepositDetailRow extends StatelessWidget {
+  const _DesktopDepositDetailRow({
     required this.label,
     required this.value,
     required this.copyText,
     required this.toastMessage,
     required this.copyKey,
     required this.rightKey,
+    required this.labelWidth,
+    required this.rightWidth,
+    this.allowRightSlotGrowth = false,
+    this.valueOverflow = TextOverflow.ellipsis,
     this.scaleValueToFit = false,
-    this.mobile = false,
   });
-
-  static const _mobileLabelMaxWidth = 134.0;
 
   final String label;
   final String value;
@@ -1015,21 +1062,143 @@ class _DepositDetailRow extends StatelessWidget {
   final String toastMessage;
   final Key copyKey;
   final Key rightKey;
+  final double labelWidth;
+  final double rightWidth;
+  final bool allowRightSlotGrowth;
+  final TextOverflow valueOverflow;
   final bool scaleValueToFit;
-  final bool mobile;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final labelText = Padding(
-      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
-      child: Text(
-        label,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: AppTypography.labelLarge.copyWith(color: colors.text.secondary),
+    final valueTextStyle = AppTypography.labelLarge.copyWith(
+      color: colors.text.accent,
+    );
+    return SizedBox(
+      height: 32,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final rowWidth = constraints.maxWidth;
+          final labelNaturalWidth =
+              _textWidth(context, label, AppTypography.labelLarge) +
+              (AppSpacing.xxs * 2);
+          final rightNaturalWidth = _rightNaturalWidth(
+            context,
+            style: valueTextStyle,
+          );
+          final desiredRightWidth = allowRightSlotGrowth
+              ? math.max(rightWidth, rightNaturalWidth)
+              : rightWidth;
+          final maxRightWidth = math.max(
+            0.0,
+            rowWidth - labelWidth - AppSpacing.s,
+          );
+          final effectiveRightWidth = math.min(
+            desiredRightWidth,
+            maxRightWidth,
+          );
+          final desiredLabelWidth = math.max(labelWidth, labelNaturalWidth);
+          final maxLabelWidth = math.max(
+            0.0,
+            rowWidth - effectiveRightWidth - AppSpacing.s,
+          );
+          final effectiveLabelWidth = math.min(
+            desiredLabelWidth,
+            maxLabelWidth,
+          );
+          final shouldScaleValue =
+              scaleValueToFit || effectiveRightWidth < desiredRightWidth;
+
+          return Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              SizedBox(
+                width: effectiveLabelWidth,
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment: Alignment.centerLeft,
+                  child: _DepositDetailLabel(label),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.s),
+              const Spacer(),
+              SizedBox(
+                width: effectiveRightWidth,
+                child: Padding(
+                  key: rightKey,
+                  padding: const EdgeInsets.only(right: AppSpacing.xxs),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Expanded(
+                        child: _DepositDetailValueText(
+                          value,
+                          overflow: valueOverflow,
+                          scaleToFit: shouldScaleValue,
+                          style: valueTextStyle,
+                        ),
+                      ),
+                      const SizedBox(width: AppSpacing.xxs),
+                      _DepositCopyButton(
+                        copyKey: copyKey,
+                        copyText: copyText,
+                        toastMessage: toastMessage,
+                        size: AppIconSize.medium,
+                        color: colors.icon.muted,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
       ),
     );
+  }
+
+  double _rightNaturalWidth(BuildContext context, {required TextStyle style}) {
+    return _textWidth(context, value, style) +
+        AppSpacing.xxs +
+        AppIconSize.medium +
+        AppSpacing.xxs;
+  }
+
+  double _textWidth(BuildContext context, String text, TextStyle style) {
+    final textPainter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: Directionality.of(context),
+      maxLines: 1,
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout();
+    return textPainter.width;
+  }
+}
+
+class _MobileDepositDetailRow extends StatelessWidget {
+  const _MobileDepositDetailRow({
+    required this.label,
+    required this.value,
+    required this.copyText,
+    required this.toastMessage,
+    required this.copyKey,
+    required this.rightKey,
+  });
+
+  static const _labelWidth = 134.0;
+  static const _copyIconSize = 20.0;
+
+  final String label;
+  final String value;
+  final String copyText;
+  final String toastMessage;
+  final Key copyKey;
+  final Key rightKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
     final valueTextStyle = AppTypography.labelLarge.copyWith(
       color: colors.text.accent,
     );
@@ -1037,85 +1206,54 @@ class _DepositDetailRow extends StatelessWidget {
       value,
       maxLines: 1,
       softWrap: false,
-      overflow: mobile ? TextOverflow.visible : TextOverflow.ellipsis,
+      overflow: TextOverflow.visible,
       textAlign: TextAlign.end,
       style: valueTextStyle,
     );
     return SizedBox(
       height: 32,
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          if (mobile)
-            // Keep the label column at the Figma width (so the value area
-            // stays >=190) but scale the label down to fit instead of
-            // truncating it — mirrors the value's own scaleDown, so labels
-            // like "Amount to deposit" / "One-time address" read in full.
-            ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: _mobileLabelMaxWidth),
+          SizedBox(
+            width: _labelWidth,
+            child: Align(
+              alignment: Alignment.centerLeft,
               child: FittedBox(
                 fit: BoxFit.scaleDown,
                 alignment: Alignment.centerLeft,
-                child: labelText,
+                child: _DepositDetailLabel(label),
               ),
-            )
-          else
-            Flexible(fit: FlexFit.loose, child: labelText),
+            ),
+          ),
           const SizedBox(width: AppSpacing.s),
           Expanded(
             child: Padding(
               key: rightKey,
-              padding: EdgeInsets.fromLTRB(
-                mobile ? AppSpacing.xs : 0,
-                mobile ? AppSpacing.xxs : 0,
+              padding: const EdgeInsets.fromLTRB(
+                AppSpacing.xs,
                 AppSpacing.xxs,
-                mobile ? AppSpacing.xxs : 0,
+                AppSpacing.xxs,
+                AppSpacing.xxs,
               ),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.end,
+                crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  Flexible(
-                    child: mobile
-                        ? FittedBox(
-                            fit: BoxFit.scaleDown,
-                            alignment: Alignment.centerRight,
-                            child: valueText,
-                          )
-                        : _DepositDetailValueText(
-                            value,
-                            scaleToFit: scaleValueToFit,
-                            style: valueTextStyle,
-                          ),
+                  Expanded(
+                    child: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      alignment: Alignment.centerRight,
+                      child: valueText,
+                    ),
                   ),
                   const SizedBox(width: AppSpacing.xxs),
-                  MouseRegion(
-                    cursor: SystemMouseCursors.click,
-                    child: GestureDetector(
-                      key: copyKey,
-                      behavior: HitTestBehavior.opaque,
-                      onTap: () {
-                        copyTextWithToast(
-                          context,
-                          text: copyText,
-                          toastMessage: toastMessage,
-                        );
-                      },
-                      child: kAppFormFactor == AppFormFactor.mobile
-                          ? SizedBox.square(
-                              dimension: 20,
-                              child: AppIcon(
-                                AppIcons.copy,
-                                size: 20,
-                                color: colors.icon.regular.withValues(
-                                  alpha: 0.72,
-                                ),
-                              ),
-                            )
-                          : AppIcon(
-                              AppIcons.copy,
-                              size: AppIconSize.medium,
-                              color: colors.icon.muted,
-                            ),
-                    ),
+                  _DepositCopyButton(
+                    copyKey: copyKey,
+                    copyText: copyText,
+                    toastMessage: toastMessage,
+                    size: _copyIconSize,
+                    color: colors.icon.regular.withValues(alpha: 0.72),
                   ),
                 ],
               ),
@@ -1127,14 +1265,76 @@ class _DepositDetailRow extends StatelessWidget {
   }
 }
 
+class _DepositDetailLabel extends StatelessWidget {
+  const _DepositDetailLabel(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+      child: Text(
+        label,
+        maxLines: 1,
+        overflow: TextOverflow.visible,
+        style: AppTypography.labelLarge.copyWith(color: colors.text.secondary),
+      ),
+    );
+  }
+}
+
+class _DepositCopyButton extends StatelessWidget {
+  const _DepositCopyButton({
+    required this.copyKey,
+    required this.copyText,
+    required this.toastMessage,
+    required this.size,
+    required this.color,
+  });
+
+  final Key copyKey;
+  final String copyText;
+  final String toastMessage;
+  final double size;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: size,
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          key: copyKey,
+          behavior: HitTestBehavior.opaque,
+          onTap: () {
+            copyTextWithToast(
+              context,
+              text: copyText,
+              toastMessage: toastMessage,
+            );
+          },
+          child: Center(
+            child: AppIcon(AppIcons.copy, size: size, color: color),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _DepositDetailValueText extends StatelessWidget {
   const _DepositDetailValueText(
     this.value, {
+    this.overflow = TextOverflow.ellipsis,
     required this.scaleToFit,
     required this.style,
   });
 
   final String value;
+  final TextOverflow overflow;
   final bool scaleToFit;
   final TextStyle style;
 
@@ -1144,7 +1344,7 @@ class _DepositDetailValueText extends StatelessWidget {
       value,
       maxLines: 1,
       softWrap: false,
-      overflow: scaleToFit ? TextOverflow.visible : TextOverflow.ellipsis,
+      overflow: scaleToFit ? TextOverflow.visible : overflow,
       textAlign: TextAlign.end,
       style: style,
     );

--- a/lib/src/features/swap/widgets/swap_deposit_tokens_page_content.dart
+++ b/lib/src/features/swap/widgets/swap_deposit_tokens_page_content.dart
@@ -976,7 +976,7 @@ class _DepositDetailsList extends StatelessWidget {
             desktopValueOverflow: TextOverflow.visible,
           ),
           _detailRow(
-            label: 'One-time Address',
+            label: 'One-time address',
             value: compactSwapAddress(depositAddress),
             copyText: depositAddress,
             toastMessage: 'Address copied',

--- a/test/features/swap/mobile_swap_deposit_tokens_page_content_test.dart
+++ b/test/features/swap/mobile_swap_deposit_tokens_page_content_test.dart
@@ -185,6 +185,14 @@ void main() {
     expect(addressText, findsOneWidget);
     expect(tester.getSize(addressRight).width, greaterThanOrEqualTo(190));
     expect(tester.getSize(copyButton), const Size(20, 20));
+    expect(
+      tester.getRect(addressText).right,
+      lessThanOrEqualTo(tester.getRect(copyButton).left - AppSpacing.xxs),
+    );
+    expect(
+      tester.getRect(copyButton).right,
+      lessThanOrEqualTo(tester.getRect(addressRight).right),
+    );
     expect(tester.widget<Text>(addressText).overflow, TextOverflow.visible);
     expect(
       find.ancestor(of: addressText, matching: find.byType(FittedBox)),

--- a/test/features/swap/mobile_swap_modal_route_test.dart
+++ b/test/features/swap/mobile_swap_modal_route_test.dart
@@ -24,6 +24,7 @@ import 'package:zcash_wallet/src/features/swap/screens/mobile/mobile_swap_screen
 import 'package:zcash_wallet/src/features/swap/widgets/mobile/mobile_swap_review_content.dart';
 import 'package:zcash_wallet/src/features/swap/widgets/mobile/mobile_swap_slippage_stepper_modal.dart';
 import 'package:zcash_wallet/src/features/swap/widgets/mobile/mobile_swap_address_edit_modal.dart';
+import 'package:zcash_wallet/src/features/address_scan/widgets/mobile_address_scan_card.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 
@@ -470,6 +471,66 @@ void main() {
       find.byKey(const ValueKey('swap_address_avatar_button')),
       findsNothing,
     );
+  });
+
+  testWidgets('QR scan returns to address editor before committing address', (
+    tester,
+  ) async {
+    const scannedAddress = '0x52908400098527886e0f7030069857d2e4169ee7';
+
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+    await tester.tap(find.bySemanticsLabel('Swap').last);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Add recipient address'));
+    await tester.pumpAndSettle();
+    expect(find.byType(MobileSwapAddressEditModal), findsOneWidget);
+
+    await tester.tap(find.byKey(const ValueKey('swap_address_scan_button')));
+    await tester.pumpAndSettle();
+    expect(find.byType(MobileAddressScanCard), findsOneWidget);
+
+    tester
+        .widget<MobileAddressScanCard>(find.byType(MobileAddressScanCard))
+        .onScanned(scannedAddress);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MobileSwapAddressEditModal), findsOneWidget);
+    expect(
+      tester
+          .widget<TextField>(
+            find.byKey(const ValueKey('swap_destination_field')),
+          )
+          .controller
+          ?.text,
+      scannedAddress,
+    );
+    expect(
+      find.byKey(const ValueKey('swap_address_remember_toggle')),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MobileSwapAddressEditModal), findsNothing);
+    expect(find.text('Add recipient address'), findsOneWidget);
+
+    await tester.tap(find.text('Add recipient address'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('swap_address_scan_button')));
+    await tester.pumpAndSettle();
+    tester
+        .widget<MobileAddressScanCard>(find.byType(MobileAddressScanCard))
+        .onScanned(scannedAddress);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('swap_address_update_button')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MobileSwapAddressEditModal), findsNothing);
+    expect(find.text('Add recipient address'), findsNothing);
   });
 
   // The screen-level morph (keyboardOpen ? cross : chevron) is driven by

--- a/test/features/swap/near_intents_one_click_swap_adapter_test.dart
+++ b/test/features/swap/near_intents_one_click_swap_adapter_test.dart
@@ -1846,6 +1846,41 @@ void main() {
     );
   });
 
+  test('status rejects duplicate 1Click ticker fallback market variants', () {
+    final transport = _FakeOneClickTransport([
+      _FakeResponse.get('/v0/tokens', _tokensWithDuplicateEthUsdc),
+      _FakeResponse.get(
+        '/v0/status',
+        _quoteResponse(
+          originAsset: '1cs_v1:usdc:native:coin',
+          destinationAsset: 'nep141:zec.omft.near',
+          swapType: 'FLEX_INPUT',
+          amountInFormatted: '12',
+          amountOutFormatted: '1',
+          minAmountOut: '99500000',
+          depositAddress: 'duplicate-market-deposit',
+          quoteRequestRefundTo: '0xrefund',
+          quoteRequestRecipient: 'u1recipient',
+          status: 'PROCESSING',
+        ),
+      ),
+    ]);
+    final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+    expect(
+      provider.getStatus('duplicate-market-deposit'),
+      throwsA(
+        isA<OneClickApiException>()
+            .having((error) => error.operation, 'operation', 'status')
+            .having(
+              (error) => error.message,
+              'message',
+              contains('Unsupported 1Click status pair'),
+            ),
+      ),
+    );
+  });
+
   test(
     'status derives minimum receive from swap details slippage when min amount is missing',
     () async {

--- a/test/features/swap/near_intents_one_click_swap_adapter_test.dart
+++ b/test/features/swap/near_intents_one_click_swap_adapter_test.dart
@@ -661,6 +661,53 @@ void main() {
   );
 
   test(
+    'flex-input quote rejects response with a different quote request amount',
+    () async {
+      final transport = _FakeOneClickTransport([
+        _FakeResponse.get('/v0/tokens', _tokens),
+        _FakeResponse.post(
+          '/v0/quote',
+          _quoteResponse(
+            originAsset: 'nep141:usdc.example',
+            destinationAsset: 'nep141:zec.omft.near',
+            swapType: 'FLEX_INPUT',
+            amountIn: '2000000',
+            amountInFormatted: '2',
+            amountOutFormatted: '0.03',
+            minAmountOut: '2985000',
+            depositAddress: '0xexternal-deposit',
+            quoteRequestAmount: '2000000',
+            quoteRequestRefundTo: '0xrefund',
+            quoteRequestRecipient: 'u1recipient',
+            status: null,
+          ),
+        ),
+      ]);
+      final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+      await expectLater(
+        provider.quote(
+          const SwapQuoteRequest(
+            direction: SwapDirection.externalToZec,
+            externalAsset: SwapAsset.usdc,
+            sellAmount: 1.5,
+            sellAmountText: '1.5',
+            destination: 'u1recipient',
+            refundAddress: '0xrefund',
+          ),
+        ),
+        throwsA(
+          isA<OneClickApiException>().having(
+            (error) => error.message,
+            'message',
+            '1Click quote response did not match the requested amount',
+          ),
+        ),
+      );
+    },
+  );
+
+  test(
     'quote rejects mismatched sell formatted and base-unit amounts',
     () async {
       final transport = _FakeOneClickTransport([

--- a/test/features/swap/near_intents_one_click_swap_adapter_test.dart
+++ b/test/features/swap/near_intents_one_click_swap_adapter_test.dart
@@ -2123,6 +2123,48 @@ void main() {
     },
   );
 
+  test(
+    'flex-input realised slippage uses provider percent without amount delta',
+    () async {
+      final transport = _FakeOneClickTransport([
+        _FakeResponse.get('/v0/tokens', _tokens),
+        _FakeResponse.get(
+          '/v0/status',
+          _quoteResponse(
+            originAsset: 'nep141:usdc.example',
+            destinationAsset: 'nep141:zec.omft.near',
+            swapType: 'FLEX_INPUT',
+            amountIn: '70000000',
+            amountInFormatted: '70',
+            amountOut: '100000000',
+            amountOutFormatted: '1',
+            minAmountOut: '99500000',
+            depositAddress: 'status-deposit',
+            status: 'SUCCESS',
+            swapDetails: {
+              'amountIn': '35000000',
+              'amountInFormatted': '35',
+              'amountOut': '50000000',
+              'amountOutFormatted': '0.5',
+              'slippage': 7,
+            },
+          ),
+        ),
+      ]);
+      final provider = NearIntentsOneClickSwapAdapter(
+        transport: transport,
+        now: () => DateTime.utc(2026, 5, 27, 7, 25),
+      );
+
+      final status = await provider.getStatus('status-deposit');
+
+      expect(status.status, SwapIntentStatus.complete);
+      expect(status.sellAmountText, '35 USDC');
+      expect(status.receiveEstimateText, '0.5 ZEC');
+      expect(status.realisedSlippageText, '0.07%');
+    },
+  );
+
   test('uses sell-asset delta for exact-output realised slippage', () async {
     final transport = _FakeOneClickTransport([
       _FakeResponse.get('/v0/tokens', _tokens),

--- a/test/features/swap/near_intents_one_click_swap_adapter_test.dart
+++ b/test/features/swap/near_intents_one_click_swap_adapter_test.dart
@@ -221,6 +221,7 @@ void main() {
           _quoteResponse(
             originAsset: '1cs_v1:btc:native:coin',
             destinationAsset: 'nep141:zec.omft.near',
+            swapType: 'FLEX_INPUT',
             amountInFormatted: '0.001',
             amountOutFormatted: '1.5',
             minAmountOut: '149250000',
@@ -245,11 +246,99 @@ void main() {
       );
 
       final request = transport.requests.last;
+      expect(request.body?['swapType'], 'FLEX_INPUT');
       expect(request.body?['originAsset'], 'nep141:btc.omft.near');
       expect(quote.pairText, 'BTC -> ZEC');
       expect(quote.sellAmountText, '0.001 BTC');
     },
   );
+
+  test(
+    'status accepts response that echoes BTC(OMNI) for a BTC origin asset',
+    () async {
+      final transport = _FakeOneClickTransport([
+        _FakeResponse.get('/v0/tokens', _tokensWithAdditionalAssets),
+        _FakeResponse.get(
+          '/v0/status',
+          _quoteResponse(
+            originAsset: '1cs_v1:btc:native:coin',
+            destinationAsset: 'nep141:zec.omft.near',
+            swapType: 'FLEX_INPUT',
+            amountInFormatted: '0.001',
+            amountOutFormatted: '1.5',
+            minAmountOut: '149250000',
+            depositAddress: 'btc-deposit',
+            quoteRequestRefundTo: 'bc1refund',
+            quoteRequestRecipient: 'u1recipient',
+            status: 'PROCESSING',
+          ),
+        ),
+      ]);
+      final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+      final status = await provider.getStatus('btc-deposit');
+
+      expect(status.pairText, 'BTC -> ZEC');
+      expect(status.sellAmountText, '0.001 BTC');
+      expect(status.status, SwapIntentStatus.processing);
+    },
+  );
+
+  test('status accepts unique 1Click ticker fallback assets', () async {
+    final transport = _FakeOneClickTransport([
+      _FakeResponse.get('/v0/tokens', _tokensWithAdditionalAssets),
+      _FakeResponse.get(
+        '/v0/status',
+        _quoteResponse(
+          originAsset: '1cs_v1:btc:provider:echo',
+          destinationAsset: 'nep141:zec.omft.near',
+          swapType: 'FLEX_INPUT',
+          amountInFormatted: '0.001',
+          amountOutFormatted: '1.5',
+          minAmountOut: '149250000',
+          depositAddress: 'btc-deposit',
+          quoteRequestRefundTo: 'bc1refund',
+          quoteRequestRecipient: 'u1recipient',
+          status: 'PROCESSING',
+        ),
+      ),
+    ]);
+    final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+    final status = await provider.getStatus('btc-deposit');
+
+    expect(status.pairText, 'BTC -> ZEC');
+    expect(status.sellAmountText, '0.001 BTC');
+    expect(status.status, SwapIntentStatus.processing);
+  });
+
+  test('status preserves exact 1Click BTC(OMNI) assets when listed', () async {
+    final transport = _FakeOneClickTransport([
+      _FakeResponse.get('/v0/tokens', _tokensWithExactBtcOmniAsset),
+      _FakeResponse.get(
+        '/v0/status',
+        _quoteResponse(
+          originAsset: '1cs_v1:btc:native:coin',
+          destinationAsset: 'nep141:zec.omft.near',
+          swapType: 'FLEX_INPUT',
+          amountInFormatted: '0.001',
+          amountOutFormatted: '1.5',
+          minAmountOut: '149250000',
+          depositAddress: 'btc-deposit',
+          quoteRequestRefundTo: 'bc1refund',
+          quoteRequestRecipient: 'u1recipient',
+          status: 'PROCESSING',
+        ),
+      ),
+    ]);
+    final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+    final status = await provider.getStatus('btc-deposit');
+
+    expect(status.pairText, 'BTC(OMNI) -> ZEC');
+    expect(status.sellAmountText, '0.001 BTC(OMNI)');
+    expect(status.status, SwapIntentStatus.processing);
+  });
 
   test('quote rejects response with a mismatched swap type', () async {
     final transport = _FakeOneClickTransport([
@@ -293,47 +382,119 @@ void main() {
     );
   });
 
-  test('quote rejects response with an unsupported swap type echo', () async {
+  test(
+    'quote rejects flex-input response for ZEC-to-external requests',
+    () async {
+      final transport = _FakeOneClickTransport([
+        _FakeResponse.get('/v0/tokens', _tokens),
+        _FakeResponse.post(
+          '/v0/quote',
+          _quoteResponse(
+            originAsset: 'nep141:zec.omft.near',
+            destinationAsset: 'nep141:usdc.example',
+            swapType: 'FLEX_INPUT',
+            amountInFormatted: '1.5',
+            amountOutFormatted: '105.25',
+            minAmountOut: '104750000',
+            depositAddress: 't1deposit',
+            status: null,
+          ),
+        ),
+      ]);
+      final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+      await expectLater(
+        provider.quote(
+          const SwapQuoteRequest(
+            direction: SwapDirection.zecToExternal,
+            externalAsset: SwapAsset.usdc,
+            sellAmount: 1.5,
+            sellAmountText: '1.5',
+            destination: '0xrecipient',
+            refundAddress: 'u1refund',
+          ),
+        ),
+        throwsA(
+          isA<OneClickApiException>()
+              .having((error) => error.operation, 'operation', 'quote')
+              .having(
+                (error) => error.message,
+                'message',
+                contains('did not match the requested route'),
+              ),
+        ),
+      );
+    },
+  );
+
+  test('status accepts flex-input quote request echo', () async {
     final transport = _FakeOneClickTransport([
       _FakeResponse.get('/v0/tokens', _tokens),
-      _FakeResponse.post(
-        '/v0/quote',
+      _FakeResponse.get(
+        '/v0/status',
         _quoteResponse(
-          originAsset: 'nep141:zec.omft.near',
-          destinationAsset: 'nep141:usdc.example',
-          quoteRequestSwapType: 'FLEX_INPUT',
-          amountInFormatted: '1.5',
-          amountOutFormatted: '105.25',
-          minAmountOut: '104750000',
-          depositAddress: 't1deposit',
-          status: null,
+          originAsset: 'nep141:usdc.example',
+          destinationAsset: 'nep141:zec.omft.near',
+          swapType: 'FLEX_INPUT',
+          amountInFormatted: '70',
+          amountOutFormatted: '1',
+          minAmountOut: '99500000',
+          depositAddress: 'status-deposit',
+          status: 'PROCESSING',
         ),
       ),
     ]);
     final provider = NearIntentsOneClickSwapAdapter(transport: transport);
 
-    await expectLater(
-      provider.quote(
+    final status = await provider.getStatus('status-deposit');
+
+    expect(status.pairText, 'USDC -> ZEC');
+    expect(status.sellAmountText, '70 USDC');
+    expect(status.receiveEstimateText, '1 ZEC');
+  });
+
+  test(
+    'quote accepts flex-input response for external assets into ZEC',
+    () async {
+      final transport = _FakeOneClickTransport([
+        _FakeResponse.get('/v0/tokens', _tokens),
+        _FakeResponse.post(
+          '/v0/quote',
+          _quoteResponse(
+            originAsset: 'nep141:usdc.example',
+            destinationAsset: 'nep141:zec.omft.near',
+            swapType: 'FLEX_INPUT',
+            amountInFormatted: '1.5',
+            amountOutFormatted: '0.021',
+            minAmountOut: '2089500',
+            depositAddress: '0xexternal-deposit',
+            quoteRequestRefundTo: '0xrefund',
+            quoteRequestRecipient: 'u1recipient',
+            status: null,
+          ),
+        ),
+      ]);
+      final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+      final quote = await provider.quote(
         const SwapQuoteRequest(
-          direction: SwapDirection.zecToExternal,
+          direction: SwapDirection.externalToZec,
           externalAsset: SwapAsset.usdc,
           sellAmount: 1.5,
           sellAmountText: '1.5',
-          destination: '0xrecipient',
-          refundAddress: 'u1refund',
+          destination: 'u1recipient',
+          refundAddress: '0xrefund',
         ),
-      ),
-      throwsA(
-        isA<OneClickApiException>()
-            .having((error) => error.operation, 'operation', 'quote')
-            .having(
-              (error) => error.message,
-              'message',
-              contains('did not match the requested route'),
-            ),
-      ),
-    );
-  });
+      );
+
+      final request = transport.requests.last;
+      expect(request.body?['swapType'], 'FLEX_INPUT');
+      expect(request.body?['amount'], '1500000');
+      expect(quote.mode, SwapQuoteMode.flexInput);
+      expect(quote.sellAmountText, '1.5 USDC');
+      expect(quote.receiveEstimateText, '0.021 ZEC');
+    },
+  );
 
   test('quote accepts exact-input response without a swap type echo', () async {
     final transport = _FakeOneClickTransport([
@@ -770,6 +931,7 @@ void main() {
         _quoteResponse(
           originAsset: 'nep141:usdc.example',
           destinationAsset: 'nep141:zec.omft.near',
+          swapType: 'FLEX_INPUT',
           amountInFormatted: '140.35',
           amountOutFormatted: '2',
           minAmountOut: '199000000',
@@ -798,6 +960,7 @@ void main() {
     final intent = await provider.startSwap(quote);
 
     final request = transport.requests.last;
+    expect(request.body?['swapType'], 'FLEX_INPUT');
     expect(request.body?['amount'], '140350000');
     expect(request.body?['originAsset'], 'nep141:usdc.example');
     expect(request.body?['destinationAsset'], 'nep141:zec.omft.near');
@@ -1153,6 +1316,7 @@ void main() {
           _quoteResponse(
             originAsset: 'nep141:wrap.near',
             destinationAsset: 'nep141:zec.omft.near',
+            swapType: 'FLEX_INPUT',
             amountInFormatted: '0.01',
             amountOutFormatted: '0.0002',
             minAmountOut: '19900',
@@ -1194,6 +1358,7 @@ void main() {
           _quoteResponse(
             originAsset: 'nep141:wrap.near',
             destinationAsset: 'nep141:zec.omft.near',
+            swapType: 'FLEX_INPUT',
             amountInFormatted: '0.123456789012345678901234',
             amountOutFormatted: '0.0002',
             minAmountOut: '19900',
@@ -1288,6 +1453,7 @@ void main() {
           _quoteResponse(
             originAsset: 'nep141:usdc.example',
             destinationAsset: 'nep141:zec.omft.near',
+            swapType: 'FLEX_INPUT',
             amountInFormatted: '140.35',
             amountOutFormatted: '2',
             minAmountOut: '199000000',
@@ -1511,6 +1677,41 @@ void main() {
     );
   });
 
+  test('status rejects ambiguous 1Click ticker fallback', () {
+    final transport = _FakeOneClickTransport([
+      _FakeResponse.get('/v0/tokens', _tokensWithNearUsdcFirst),
+      _FakeResponse.get(
+        '/v0/status',
+        _quoteResponse(
+          originAsset: '1cs_v1:usdc:native:coin',
+          destinationAsset: 'nep141:zec.omft.near',
+          swapType: 'FLEX_INPUT',
+          amountInFormatted: '12',
+          amountOutFormatted: '1',
+          minAmountOut: '99500000',
+          depositAddress: 'ambiguous-deposit',
+          quoteRequestRefundTo: '0xrefund',
+          quoteRequestRecipient: 'u1recipient',
+          status: 'PROCESSING',
+        ),
+      ),
+    ]);
+    final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+    expect(
+      provider.getStatus('ambiguous-deposit'),
+      throwsA(
+        isA<OneClickApiException>()
+            .having((error) => error.operation, 'operation', 'status')
+            .having(
+              (error) => error.message,
+              'message',
+              contains('Unsupported 1Click status pair'),
+            ),
+      ),
+    );
+  });
+
   test(
     'status derives minimum receive from swap details slippage when min amount is missing',
     () async {
@@ -1583,6 +1784,9 @@ void main() {
             _quoteResponse(
               originAsset: originAsset,
               destinationAsset: destinationAsset,
+              swapType: scenario.direction.sendsZec
+                  ? 'EXACT_INPUT'
+                  : 'FLEX_INPUT',
               amountInFormatted: scenario.direction.sendsZec ? '1' : '70',
               amountOutFormatted: scenario.direction.sendsZec ? '70' : '1',
               minAmountOut: scenario.direction.sendsZec
@@ -2069,6 +2273,16 @@ const _tokensWithAdditionalAssets = [
     'decimals': 9,
     'blockchain': 'sol',
     'symbol': 'SOL',
+  },
+];
+
+const _tokensWithExactBtcOmniAsset = [
+  ..._tokensWithAdditionalAssets,
+  {
+    'assetId': '1cs_v1:btc:native:coin',
+    'decimals': 8,
+    'blockchain': 'btc',
+    'symbol': 'BTC(OMNI)',
   },
 ];
 

--- a/test/features/swap/near_intents_one_click_swap_adapter_test.dart
+++ b/test/features/swap/near_intents_one_click_swap_adapter_test.dart
@@ -574,6 +574,93 @@ void main() {
   );
 
   test(
+    'exact-input quote rejects response with a different provider amount',
+    () async {
+      final transport = _FakeOneClickTransport([
+        _FakeResponse.get('/v0/tokens', _tokens),
+        _FakeResponse.post(
+          '/v0/quote',
+          _quoteResponse(
+            originAsset: 'nep141:zec.omft.near',
+            destinationAsset: 'nep141:usdc.example',
+            amountIn: '200000000',
+            amountInFormatted: '2',
+            amountOutFormatted: '140.5',
+            minAmountOut: '139797500',
+            depositAddress: 't1deposit',
+            quoteRequestAmount: '150000000',
+            status: null,
+          ),
+        ),
+      ]);
+      final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+      await expectLater(
+        provider.quote(
+          const SwapQuoteRequest(
+            direction: SwapDirection.zecToExternal,
+            externalAsset: SwapAsset.usdc,
+            sellAmount: 1.5,
+            sellAmountText: '1.5',
+            destination: '0xrecipient',
+            refundAddress: 'u1refund',
+          ),
+        ),
+        throwsA(
+          isA<OneClickApiException>().having(
+            (error) => error.message,
+            'message',
+            '1Click quote response did not match the requested amount',
+          ),
+        ),
+      );
+    },
+  );
+
+  test(
+    'flex-input quote accepts response with a different provider amount',
+    () async {
+      final transport = _FakeOneClickTransport([
+        _FakeResponse.get('/v0/tokens', _tokens),
+        _FakeResponse.post(
+          '/v0/quote',
+          _quoteResponse(
+            originAsset: 'nep141:usdc.example',
+            destinationAsset: 'nep141:zec.omft.near',
+            swapType: 'FLEX_INPUT',
+            amountIn: '2000000',
+            amountInFormatted: '2',
+            amountOutFormatted: '0.03',
+            minAmountOut: '2985000',
+            depositAddress: '0xexternal-deposit',
+            quoteRequestAmount: '1500000',
+            quoteRequestRefundTo: '0xrefund',
+            quoteRequestRecipient: 'u1recipient',
+            status: null,
+          ),
+        ),
+      ]);
+      final provider = NearIntentsOneClickSwapAdapter(transport: transport);
+
+      final quote = await provider.quote(
+        const SwapQuoteRequest(
+          direction: SwapDirection.externalToZec,
+          externalAsset: SwapAsset.usdc,
+          sellAmount: 1.5,
+          sellAmountText: '1.5',
+          destination: 'u1recipient',
+          refundAddress: '0xrefund',
+        ),
+      );
+
+      expect(transport.requests.last.body?['amount'], '1500000');
+      expect(quote.mode, SwapQuoteMode.flexInput);
+      expect(quote.sellAmountText, '2 USDC');
+      expect(quote.sellAmountBaseUnits, BigInt.from(2000000));
+    },
+  );
+
+  test(
     'quote rejects mismatched sell formatted and base-unit amounts',
     () async {
       final transport = _FakeOneClickTransport([

--- a/test/features/swap/swap_activity_status_mapper_test.dart
+++ b/test/features/swap/swap_activity_status_mapper_test.dart
@@ -94,10 +94,7 @@ void main() {
       ),
     );
 
-    expect(
-      presentation.details.where((row) => row.label == 'Tx ID'),
-      isEmpty,
-    );
+    expect(presentation.details.where((row) => row.label == 'Tx ID'), isEmpty);
   });
 
   test('adds address book labels to matching address detail rows', () {
@@ -436,6 +433,38 @@ void main() {
       presentation.details.map((detail) => detail.label),
       isNot(contains('Swap fee')),
     );
+  });
+
+  test('uses provider minimum deposit for flex-input incomplete deposits', () {
+    final presentation = swapActivityStatusPresentationForIntent(
+      _state(),
+      _intent(
+        status: SwapIntentStatus.incompleteDeposit,
+        direction: SwapDirection.externalToZec,
+        externalAsset: SwapAsset.usdc,
+        pair: 'USDC -> ZEC',
+        sellAmount: '140.35 USDC',
+        receiveEstimate: '2 ZEC',
+        depositAddress: '0xdeposit-address',
+        oneClickRecipient: 'u1recipient-address',
+        oneClickRefundTo: '0xrefund-address',
+        providerRefundInfo: const SwapProviderRefundInfo(
+          minimumDepositText: '139.65 USDC',
+          depositedAmountText: '139.00 USDC',
+        ),
+        nextAction: 'Deposit is below the minimum amount',
+      ),
+    );
+
+    expect(
+      _detailValue(presentation.details, 'Required deposit'),
+      '139.65 USDC',
+    );
+    expect(
+      _detailValue(presentation.details, 'Detected deposit'),
+      '139.00 USDC',
+    );
+    expect(_detailValue(presentation.details, 'Missing deposit'), '0.65 USDC');
   });
 
   test('maps deposit instructions by swap direction', () {

--- a/test/features/swap/swap_contract_test.dart
+++ b/test/features/swap/swap_contract_test.dart
@@ -73,4 +73,28 @@ void main() {
       expect(receiveZecQuote.slippageToleranceText, '0.0005 USDC (0.5%)');
     },
   );
+
+  test('warns when flex-input live quote changes the sell amount', () {
+    final state = SwapState(
+      direction: SwapDirection.externalToZec,
+      amountText: '1.5',
+      receiveAmountText: '',
+      destinationText: validEvmRecipient,
+      externalAsset: SwapAsset.usdc,
+      reviewVisible: true,
+      intents: const [],
+      quoteMode: SwapQuoteMode.flexInput,
+      reviewQuote: SwapQuote.estimate(
+        direction: SwapDirection.externalToZec,
+        externalAsset: SwapAsset.usdc,
+        mode: SwapQuoteMode.flexInput,
+        amount: 2,
+      ),
+    );
+
+    expect(
+      state.reviewAmountDifferenceWarning,
+      'Live quote uses 2.00 USDC instead of 1.50 USDC. Check the guaranteed minimum before you continue.',
+    );
+  });
 }

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -6279,6 +6279,7 @@ void main() {
 
     expect(swapProvider.requests, hasLength(1));
     expect(swapProvider.requests.single.direction, SwapDirection.externalToZec);
+    expect(swapProvider.requests.single.mode, SwapQuoteMode.flexInput);
     expect(
       swapProvider.requests.single.destination,
       'u1actualshieldedrecipient',
@@ -6330,6 +6331,7 @@ void main() {
 
     expect(swapProvider.requests, hasLength(1));
     expect(swapProvider.requests.single.direction, SwapDirection.externalToZec);
+    expect(swapProvider.requests.single.mode, SwapQuoteMode.flexInput);
     expect(
       swapProvider.requests.single.destination,
       'u1actualshieldedrecipient',

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -461,11 +461,11 @@ void main() {
     );
     final addressLabel = find.descendant(
       of: find.byKey(const ValueKey('swap_deposit_details')),
-      matching: find.text('One-time Address'),
+      matching: find.text('One-time address'),
     );
     expect(addressLabel, findsOneWidget);
     expect(find.text('One time'), findsNothing);
-    expect(find.text('One-time address'), findsNothing);
+    expect(find.text('One-time Address'), findsNothing);
     expect(tester.widget<Text>(addressLabel).overflow, TextOverflow.visible);
     final detailsRect = tester.getRect(
       find.byKey(const ValueKey('swap_deposit_details')),

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -428,12 +428,14 @@ void main() {
     await tester.pumpWidget(
       _themeHarness(
         AppToastHost(
-          child: SwapDepositTokensPageContent(
-            asset: SwapAsset.usdc,
-            amountText: '999.99 USDC',
-            depositAddress: depositAddress,
-            expiresInLabel: '16mins',
-            onDeposited: () {},
+          child: Center(
+            child: SwapDepositTokensPageContent(
+              asset: SwapAsset.usdc,
+              amountText: '999.99 USDC',
+              depositAddress: depositAddress,
+              expiresInLabel: '16mins',
+              onDeposited: () {},
+            ),
           ),
         ),
       ),
@@ -457,6 +459,67 @@ void main() {
       tester.widget<Text>(find.text(compactDepositAddress)).overflow,
       TextOverflow.visible,
     );
+    final addressLabel = find.descendant(
+      of: find.byKey(const ValueKey('swap_deposit_details')),
+      matching: find.text('One-time Address'),
+    );
+    expect(addressLabel, findsOneWidget);
+    expect(find.text('One time'), findsNothing);
+    expect(find.text('One-time address'), findsNothing);
+    expect(tester.widget<Text>(addressLabel).overflow, TextOverflow.visible);
+    final detailsRect = tester.getRect(
+      find.byKey(const ValueKey('swap_deposit_details')),
+    );
+    final amountRightRect = tester.getRect(
+      find.byKey(const ValueKey('swap_deposit_amount_right_item')),
+    );
+    final addressRightRect = tester.getRect(
+      find.byKey(const ValueKey('swap_deposit_address_right_item')),
+    );
+    final detailsContentRight = detailsRect.right - AppSpacing.sm;
+    expect(amountRightRect.width, greaterThanOrEqualTo(120));
+    expect(amountRightRect.right, closeTo(detailsContentRight, 0.01));
+    expect(addressRightRect.width, closeTo(177, 0.01));
+    expect(addressRightRect.right, closeTo(detailsContentRight, 0.01));
+    expect(
+      tester
+          .getRect(
+            find.descendant(
+              of: find.byKey(const ValueKey('swap_deposit_amount_right_item')),
+              matching: find.text('999.99 USDC'),
+            ),
+          )
+          .right,
+      lessThanOrEqualTo(
+        tester
+                .getRect(find.byKey(const ValueKey('swap_copy_deposit_amount')))
+                .left -
+            AppSpacing.xxs,
+      ),
+    );
+    expect(
+      tester.getRect(find.text(compactDepositAddress)).right,
+      lessThanOrEqualTo(
+        tester
+                .getRect(
+                  find.byKey(const ValueKey('swap_copy_deposit_address')),
+                )
+                .left -
+            AppSpacing.xxs,
+      ),
+    );
+    expect(
+      tester
+          .getRect(find.byKey(const ValueKey('swap_copy_deposit_address')))
+          .right,
+      lessThanOrEqualTo(
+        tester
+            .getRect(
+              find.byKey(const ValueKey('swap_deposit_address_right_item')),
+            )
+            .right,
+      ),
+    );
 
     await tester.tap(find.byKey(const ValueKey('swap_copy_deposit_amount')));
     await tester.pump();
@@ -467,6 +530,61 @@ void main() {
     await tester.pump();
 
     expect(clipboardWrites.last, depositAddress);
+  });
+
+  testWidgets('deposit amount row grows for precise token amounts', (
+    tester,
+  ) async {
+    const preciseAmount = '0.06058709 ZEC';
+    const depositAddress =
+        '0x1111111111111111111111111111111111111111111111111111111111111111';
+
+    await tester.pumpWidget(
+      _themeHarness(
+        AppToastHost(
+          child: Center(
+            child: SwapDepositTokensPageContent(
+              asset: SwapAsset.zec,
+              amountText: preciseAmount,
+              depositAddress: depositAddress,
+              expiresInLabel: '16mins',
+              onDeposited: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final amountRight = find.byKey(
+      const ValueKey('swap_deposit_amount_right_item'),
+    );
+    final amountText = find.descendant(
+      of: amountRight,
+      matching: find.text(preciseAmount),
+    );
+    final copyButton = find.byKey(const ValueKey('swap_copy_deposit_amount'));
+    final detailsRect = tester.getRect(
+      find.byKey(const ValueKey('swap_deposit_details')),
+    );
+    final amountRightRect = tester.getRect(amountRight);
+    final amountLabel = find.descendant(
+      of: find.byKey(const ValueKey('swap_deposit_details')),
+      matching: find.text('Amount'),
+    );
+
+    expect(amountLabel, findsOneWidget);
+    expect(tester.widget<Text>(amountLabel).overflow, TextOverflow.visible);
+    expect(amountText, findsOneWidget);
+    expect(tester.widget<Text>(amountText).overflow, TextOverflow.visible);
+    expect(amountRightRect.width, greaterThan(120));
+    expect(
+      amountRightRect.right,
+      closeTo(detailsRect.right - AppSpacing.sm, 0.01),
+    );
+    expect(
+      tester.getRect(amountText).right,
+      lessThanOrEqualTo(tester.getRect(copyButton).left - AppSpacing.xxs),
+    );
   });
 
   testWidgets('deposit timeout uses theme-specific failure illustration', (


### PR DESCRIPTION
## Problem

External -> ZEC swaps currently go through the 1Click `EXACT_INPUT` path. If an upstream wallet/swap route sends the user's nominal amount but only a slightly smaller amount reaches the NEAR Intents deposit address, 1Click can classify the swap as a partial deposit and refund it.

`FLEX_INPUT` avoids that for input-driven external -> ZEC swaps, but it also means incomplete-deposit recovery must use the provider's `minAmountIn` threshold instead of the quoted `amountIn` when showing the required and missing deposit amounts. Because 1Click quote responses also echo the original request, the adapter needs to keep request echo validation strict while allowing only the provider quoted input amount to move for flex-input quotes.

## Solution

- Add first-class `SwapQuoteMode.flexInput` support.
- Normalize external -> ZEC input-side quotes to 1Click `FLEX_INPUT`.
- Keep ZEC -> external exact-input behavior unchanged.
- Keep exact-output behavior unchanged for receive-amount-driven quotes.
- Keep `quoteRequest.amount` echo validation strict for every quote mode.
- Allow only the provider quoted input amount (`quote.amountIn`) to differ for external -> ZEC `FLEX_INPUT` quotes.
- Warn on review when a live flex-input quote changes the sell amount from the draft estimate.
- Treat `FLEX_INPUT` as input-side for amount asset, base-unit conversion, active input state, estimates, and parser/status mapping.
- Use provider `minAmountIn` as the incomplete-deposit required/missing baseline when present.
- Recover `1cs_v1:<ticker>:...` asset IDs during status recovery only when they map to one unique app asset, while preserving exact token matches and failing closed on ambiguous ticker matches.
- Keep desktop deposit detail rows aligned while preserving full compact address and amount display.
- Return mobile QR-scanned recipient/refund addresses to the address editor instead of committing immediately, so users can review the address and choose whether to remember it before tapping `Update`.
- Use sentence-case `One-time address` copy in deposit details.
- Update swap tests so external -> ZEC quote requests, strict 1Click request echoes, flexible quoted input amounts, incomplete-deposit display, exact BTC(OMNI) status matches, unique 1Click ticker fallback, ambiguous USDC status recovery, deposit detail layout/copy, and mobile QR address editing are covered.

Linear: VZR-107

## Validation

- `git diff --check`
- `fvm flutter test test/features/swap/near_intents_one_click_swap_adapter_test.dart`
- `fvm flutter test test/features/swap/swap_contract_test.dart`
- `fvm flutter test test/features/swap/swap_activity_status_mapper_test.dart`
- `fvm flutter test test/features/swap/swap_screen_test.dart --plain-name "deposit tokens copies numeric amount and fits compact address"`
- `fvm flutter test test/features/swap/mobile_swap_modal_route_test.dart --plain-name "QR scan returns to address editor before committing address" --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `fvm flutter test test/features/swap`
- `fvm flutter test test/features/swap --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `fvm flutter analyze`
- `fvm flutter run -d 00008140-000259801444801C --dart-define=VIZOR_FORM_FACTOR=mobile --release --no-resident`
- Live 1Click quote matrix through the Vizor proxy covered USDC on Ethereum/Base, ETH, BTC, SOL, NEAR, and USDT across flex-input, exact-input, and exact-output paths. DAI and some WBTC routes returned provider `No liquidity available`. The live checks verified the adapter accepts valid flex-input quotes while keeping `quoteRequest.amount` echo strict.
