### PR TITLE
Fix mobile text field shell focus

### DIFF
--- a/lib/src/core/widgets/mobile_text_field.dart
+++ b/lib/src/core/widgets/mobile_text_field.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart' show InputDecoration, TextField;
 import 'package:flutter/services.dart'
-    show TextInputAction, TextInputFormatter, TextInputType;
+    show TextInputAction, TextInputFormatter, TextInputType, TextSelection;
 import 'package:flutter/widgets.dart';
 
 import '../theme/app_theme.dart';
@@ -89,6 +89,9 @@ class MobileTextField extends StatefulWidget {
 }
 
 class _MobileTextFieldState extends State<MobileTextField> {
+  final GlobalKey _textFieldRegionKey = GlobalKey();
+  Offset? _pendingShellTapGlobalPosition;
+
   @override
   void initState() {
     super.initState();
@@ -113,6 +116,35 @@ class _MobileTextFieldState extends State<MobileTextField> {
   // Repaint the border when focus toggles.
   void _onFocusChanged() {
     if (mounted) setState(() {});
+  }
+
+  void _handleShellTapDown(TapDownDetails details) {
+    _pendingShellTapGlobalPosition = details.globalPosition;
+  }
+
+  void _requestFocusFromShell() {
+    final tapPosition = _pendingShellTapGlobalPosition;
+    _pendingShellTapGlobalPosition = null;
+    if (tapPosition != null && _isInsideTextFieldRegion(tapPosition)) {
+      return;
+    }
+
+    if (!widget.focusNode.hasFocus) {
+      widget.focusNode.requestFocus();
+    }
+    widget.controller.selection = TextSelection.collapsed(
+      offset: widget.controller.text.length,
+    );
+  }
+
+  bool _isInsideTextFieldRegion(Offset globalPosition) {
+    final renderObject = _textFieldRegionKey.currentContext?.findRenderObject();
+    if (renderObject is! RenderBox || !renderObject.attached) {
+      return false;
+    }
+
+    final localPosition = renderObject.globalToLocal(globalPosition);
+    return (Offset.zero & renderObject.size).contains(localPosition);
   }
 
   @override
@@ -142,54 +174,62 @@ class _MobileTextFieldState extends State<MobileTextField> {
       ),
       BoxShadow(color: colors.shadows.subtle, blurRadius: 1),
     ];
-    return Container(
-      // Mobile input metrics (AppInputSizing → 60px tall, radius 16); desktop
-      // resolves these to 46 / 12. The surface fill, the focus-only inverse
-      // outline and the layered surface shadow mirror the canonical
-      // AppTextField shell.
-      height: widget.height ?? AppInputSizing.height,
-      decoration: BoxDecoration(
-        color: widget.backgroundColor ?? colors.surface.input.primary,
-        borderRadius: BorderRadius.circular(
-          widget.radius ?? AppInputSizing.radius,
+    return GestureDetector(
+      behavior: HitTestBehavior.translucent,
+      onTapDown: _handleShellTapDown,
+      onTap: _requestFocusFromShell,
+      child: Container(
+        // Mobile input metrics (AppInputSizing → 60px tall, radius 16); desktop
+        // resolves these to 46 / 12. The surface fill, the focus-only inverse
+        // outline and the layered surface shadow mirror the canonical
+        // AppTextField shell.
+        height: widget.height ?? AppInputSizing.height,
+        decoration: BoxDecoration(
+          color: widget.backgroundColor ?? colors.surface.input.primary,
+          borderRadius: BorderRadius.circular(
+            widget.radius ?? AppInputSizing.radius,
+          ),
+          border: Border.all(
+            color: focused
+                ? widget.focusedBorderColor ?? colors.background.inverse
+                : widget.restingBorderColor ?? const Color(0x00000000),
+            width: 1.5,
+            strokeAlign: BorderSide.strokeAlignInside,
+          ),
+          boxShadow: focused
+              ? widget.focusedBoxShadow ?? surfaceShadow
+              : surfaceShadow,
         ),
-        border: Border.all(
-          color: focused
-              ? widget.focusedBorderColor ?? colors.background.inverse
-              : widget.restingBorderColor ?? const Color(0x00000000),
-          width: 1.5,
-          strokeAlign: BorderSide.strokeAlignInside,
-        ),
-        boxShadow: focused
-            ? widget.focusedBoxShadow ?? surfaceShadow
-            : surfaceShadow,
-      ),
-      child: Row(
-        children: [
-          if (widget.leading != null) widget.leading!,
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: TextField(
-                key: widget.fieldKey,
-                controller: widget.controller,
-                focusNode: widget.focusNode,
-                onChanged: widget.onChanged,
-                onSubmitted: widget.onSubmitted,
-                textInputAction: widget.textInputAction,
-                keyboardType: widget.keyboardType,
-                inputFormatters: widget.inputFormatters,
-                style: textStyle,
-                cursorColor: colors.text.accent,
-                decoration: InputDecoration.collapsed(
-                  hintText: widget.hintText,
-                  hintStyle: hintStyle,
+        child: Row(
+          children: [
+            if (widget.leading != null) widget.leading!,
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                child: KeyedSubtree(
+                  key: _textFieldRegionKey,
+                  child: TextField(
+                    key: widget.fieldKey,
+                    controller: widget.controller,
+                    focusNode: widget.focusNode,
+                    onChanged: widget.onChanged,
+                    onSubmitted: widget.onSubmitted,
+                    textInputAction: widget.textInputAction,
+                    keyboardType: widget.keyboardType,
+                    inputFormatters: widget.inputFormatters,
+                    style: textStyle,
+                    cursorColor: colors.text.accent,
+                    decoration: InputDecoration.collapsed(
+                      hintText: widget.hintText,
+                      hintStyle: hintStyle,
+                    ),
+                  ),
                 ),
               ),
             ),
-          ),
-          if (widget.trailing != null) widget.trailing!,
-        ],
+            if (widget.trailing != null) widget.trailing!,
+          ],
+        ),
       ),
     );
   }

--- a/test/core/widgets/mobile_text_field_test.dart
+++ b/test/core/widgets/mobile_text_field_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/mobile_text_field.dart';
+
+void main() {
+  testWidgets('shell tap outside the inner text field moves caret to end', (
+    tester,
+  ) async {
+    const text = 't1zcashrecipientaddress';
+    final controller = TextEditingController.fromValue(
+      TextEditingValue(
+        text: text,
+        selection: TextSelection(baseOffset: 0, extentOffset: text.length),
+      ),
+    );
+    final focusNode = FocusNode();
+    var rootTapCount = 0;
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      _ThemedHarness(
+        onRootTap: () => rootTapCount += 1,
+        child: SizedBox(
+          width: 320,
+          child: MobileTextField(
+            controller: controller,
+            focusNode: focusNode,
+            hintText: 'Search',
+            leading: const SizedBox(width: 56, height: 60),
+          ),
+        ),
+      ),
+    );
+
+    final shellRect = tester.getRect(find.byType(MobileTextField));
+    await tester.tapAt(Offset(shellRect.left + 12, shellRect.center.dy));
+    await tester.pump();
+
+    expect(focusNode.hasFocus, isTrue);
+    expect(controller.selection.isCollapsed, isTrue);
+    expect(controller.selection.extentOffset, text.length);
+    expect(rootTapCount, isZero);
+  });
+
+  testWidgets('trailing action keeps its tap handling', (tester) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    var trailingTapCount = 0;
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      _ThemedHarness(
+        child: SizedBox(
+          width: 320,
+          child: MobileTextField(
+            controller: controller,
+            focusNode: focusNode,
+            hintText: 'Search',
+            trailing: GestureDetector(
+              key: const ValueKey('mobile_text_field_trailing_action'),
+              behavior: HitTestBehavior.opaque,
+              onTap: () => trailingTapCount += 1,
+              child: const SizedBox(width: 48, height: 60),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_text_field_trailing_action')),
+    );
+    await tester.pump();
+
+    expect(trailingTapCount, 1);
+    expect(focusNode.hasFocus, isFalse);
+  });
+}
+
+class _ThemedHarness extends StatelessWidget {
+  const _ThemedHarness({required this.child, this.onRootTap});
+
+  final Widget child;
+  final VoidCallback? onRootTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: AppTheme(
+        data: AppThemeData.light,
+        child: Scaffold(
+          body: GestureDetector(
+            onTap: onRootTap,
+            behavior: HitTestBehavior.translucent,
+            child: Center(child: child),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Expand `MobileTextField` focus handling so shell taps request focus.
- Collapse shell-tap selection to the end of the text to avoid preserving a full-range selection on iOS.
- Add widget coverage for shell taps and trailing actions.

## Root cause
Container taps previously bypassed the native `TextField` selection gesture path. When a controller already held a valid full-range selection, focusing from the shell preserved that selection instead of placing the caret like a native text field tap.

## Validation
- `fvm flutter test test/core/widgets/mobile_text_field_test.dart`
- `fvm flutter analyze`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/send/mobile_send_screen_test.dart test/features/address_book/mobile_address_book_screen_test.dart test/features/accounts/mobile_accounts_screen_test.dart test/features/settings/mobile_endpoint_screen_test.dart test/features/address_book/mobile_address_book_contact_picker_modal_test.dart`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/swap/mobile_swap_modal_route_test.dart test/features/swap/mobile_swap_asset_selector_modal_test.dart`