### PR TITLE
Align mobile account menu actions

### DIFF
--- a/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
+++ b/lib/src/features/accounts/screens/mobile/mobile_accounts_screen.dart
@@ -102,7 +102,9 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
       if (wasOpenForAccount) return;
     }
 
-    final accounts = ref.read(accountProvider).value?.accounts ?? const [];
+    final accountState = ref.read(accountProvider).value;
+    final accounts = accountState?.accounts ?? const [];
+    final isCurrentAccount = accountState?.activeAccountUuid == account.uuid;
     final canRemove = _canRemove(account, accounts);
 
     final overlay = Overlay.of(context, rootOverlay: true);
@@ -123,7 +125,12 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
       horizontal: AppSpacing.xxs,
       vertical: AppSpacing.sm,
     );
-    final menuHeight = canRemove ? 173.0 : 126.0;
+    final menuHeight = switch ((isCurrentAccount, canRemove)) {
+      (true, true) => 139.0,
+      (true, false) => 92.0,
+      (false, true) => 173.0,
+      (false, false) => 126.0,
+    };
     const bottomNavClearance = kMobileTabBarHeight + AppSpacing.lg;
     final colors = context.colors;
     final menuMaxTop = math.max(
@@ -215,12 +222,13 @@ class _MobileAccountsScreenState extends ConsumerState<MobileAccountsScreen> {
         label: 'Copy address',
         action: _AccountAction.copy,
       ),
-      item(
-        key: const ValueKey('mobile_account_menu_send'),
-        iconName: AppIcons.plane,
-        label: 'Send ZEC',
-        action: _AccountAction.send,
-      ),
+      if (!isCurrentAccount)
+        item(
+          key: const ValueKey('mobile_account_menu_send'),
+          iconName: AppIcons.plane,
+          label: 'Send ZEC',
+          action: _AccountAction.send,
+        ),
       item(
         key: const ValueKey('mobile_account_menu_edit'),
         iconName: AppIcons.edit,

--- a/test/features/accounts/mobile_accounts_screen_test.dart
+++ b/test/features/accounts/mobile_accounts_screen_test.dart
@@ -269,9 +269,10 @@ void main() {
     );
     await tester.pump();
 
-    // Imported account: edit + remove.
+    // Other imported account: send + edit + remove.
     await tester.tap(find.byKey(const ValueKey('mobile_accounts_menu_b')));
     await tester.pumpAndSettle();
+    expect(find.text('Send ZEC'), findsOneWidget);
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Remove account'), findsOneWidget);
     final openMenuButton = tester.widget<DecoratedBox>(
@@ -292,11 +293,16 @@ void main() {
     await tester.tapAt(const Offset(10, 10));
     await tester.pumpAndSettle();
 
-    // Seed anchor with another account: edit + remove.
+    // Current seed anchor with another account: edit + remove, but no send.
     await tester.tap(find.byKey(const ValueKey('mobile_accounts_menu_a')));
     await tester.pumpAndSettle();
+    expect(find.text('Send ZEC'), findsNothing);
     expect(find.text('Edit account'), findsOneWidget);
     expect(find.text('Remove account'), findsOneWidget);
+    expect(
+      tester.getSize(find.byKey(const ValueKey('mobile_account_menu_card'))),
+      const Size(173, 139),
+    );
   });
 
   testWidgets('the last remaining seed account resets the app on removal', (


### PR DESCRIPTION
## Summary
- Hide `Send ZEC` from the current account row menu on mobile account management.
- Keep `Send ZEC` available for other account rows and update the mobile menu height calculation.
- Add mobile widget coverage for current-vs-other account menu actions.

## Validation
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/accounts/mobile_accounts_screen_test.dart`