### PR TITLE
Handle mobile wallet link already-imported items

### DIFF
--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -400,6 +400,7 @@ AccountInfo mergeBootstrappedAccountInfo({
     profilePictureId: normalizeProfilePictureId(
       storedAccount?.profilePictureId ?? kDefaultProfilePictureId,
     ),
+    walletLinkSourceAccountUuid: storedAccount?.walletLinkSourceAccountUuid,
   );
 }
 

--- a/lib/src/features/address_book/providers/address_book_provider.dart
+++ b/lib/src/features/address_book/providers/address_book_provider.dart
@@ -227,6 +227,21 @@ class AddressBookNotifier extends AsyncNotifier<AddressBookState> {
     return added;
   }
 
+  Future<Set<String>> alreadyImportedContactIds(
+    Iterable<AddressBookContact> importedContacts,
+  ) async {
+    final current = await _loadedState();
+    if (current.contacts.isEmpty) return const <String>{};
+
+    final existingKeys = {
+      for (final contact in current.contacts) _contactKey(contact),
+    };
+    return {
+      for (final imported in importedContacts)
+        if (existingKeys.contains(_contactKey(imported))) imported.id,
+    };
+  }
+
   Future<void> _persist(List<AddressBookContact> contacts) async {
     await ref.read(addressBookRepositoryProvider).saveContacts(contacts);
   }

--- a/lib/src/features/onboarding/mobile/mobile_wallet_link_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_wallet_link_screens.dart
@@ -426,6 +426,7 @@ class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
       });
     }
 
+    final submitting = state.submitting;
     return _WalletLinkSelectionScaffold(
       progress: _walletLinkAccountsProgress,
       title: 'Select account',
@@ -443,7 +444,9 @@ class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
       actionLabel: state.selectedAccountCount == state.importableAccountCount
           ? 'Deselect all'
           : 'Select all',
-      onAction: state.selectedAccountCount == state.importableAccountCount
+      onAction: submitting
+          ? null
+          : state.selectedAccountCount == state.importableAccountCount
           ? () => ref
                 .read(mobileWalletLinkControllerProvider.notifier)
                 .deselectAllAccounts()
@@ -452,7 +455,9 @@ class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
                 .selectAllImportableAccounts(),
       buttonLabel:
           'Link ${state.selectedAccountCount} account${state.selectedAccountCount == 1 ? '' : 's'}',
+      buttonLoadingLabel: 'Importing...',
       buttonEnabled: state.selectedAccountCount > 0,
+      buttonLoading: submitting,
       onButtonPressed: () {
         if (state.contacts.isEmpty) {
           _continueToPasscodeOrImport(context, ref);
@@ -466,9 +471,11 @@ class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
             _WalletLinkAccountRow(
               account: account,
               selected: state.selectedAccountUuids.contains(account.uuid),
-              onTap: () => ref
-                  .read(mobileWalletLinkControllerProvider.notifier)
-                  .toggleAccount(account.uuid),
+              onTap: submitting
+                  ? null
+                  : () => ref
+                        .read(mobileWalletLinkControllerProvider.notifier)
+                        .toggleAccount(account.uuid),
             ),
             const SizedBox(height: AppSpacing.s),
           ],
@@ -490,6 +497,7 @@ class MobileWalletLinkSelectContactsScreen extends ConsumerWidget {
       });
     }
 
+    final submitting = state.submitting;
     final groups = _groupContactsByNetwork(state.contacts);
     return _WalletLinkSelectionScaffold(
       progress: _walletLinkContactsProgress,
@@ -502,7 +510,9 @@ class MobileWalletLinkSelectContactsScreen extends ConsumerWidget {
       actionLabel: state.selectedContactCount == state.contacts.length
           ? 'Deselect all'
           : 'Select all',
-      onAction: state.selectedContactCount == state.contacts.length
+      onAction: submitting
+          ? null
+          : state.selectedContactCount == state.contacts.length
           ? () => ref
                 .read(mobileWalletLinkControllerProvider.notifier)
                 .deselectAllContacts()
@@ -511,7 +521,9 @@ class MobileWalletLinkSelectContactsScreen extends ConsumerWidget {
                 .selectAllContacts(),
       buttonLabel:
           'Import ${state.selectedContactCount} contact${state.selectedContactCount == 1 ? '' : 's'}',
+      buttonLoadingLabel: 'Importing...',
       buttonEnabled: state.selectedAccountCount > 0,
+      buttonLoading: submitting,
       onButtonPressed: () => _continueToPasscodeOrImport(context, ref),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -523,9 +535,11 @@ class MobileWalletLinkSelectContactsScreen extends ConsumerWidget {
               _WalletLinkContactRow(
                 contact: contact,
                 selected: state.selectedContactIds.contains(contact.id),
-                onTap: () => ref
-                    .read(mobileWalletLinkControllerProvider.notifier)
-                    .toggleContact(contact.id),
+                onTap: submitting
+                    ? null
+                    : () => ref
+                          .read(mobileWalletLinkControllerProvider.notifier)
+                          .toggleContact(contact.id),
               ),
               if (contactIndex != entry.value.length - 1)
                 const SizedBox(height: AppSpacing.s),
@@ -544,6 +558,7 @@ Future<void> _continueToPasscodeOrImport(
   WidgetRef ref,
 ) async {
   final state = ref.read(mobileWalletLinkControllerProvider);
+  if (state.submitting) return;
   final payload = state.payload;
   if (payload == null || state.selectedAccounts.isEmpty) return;
   final packageId = state.packageId;
@@ -571,6 +586,8 @@ Future<void> _continueToPasscodeOrImport(
   }
 
   final router = GoRouter.of(context);
+  final controller = ref.read(mobileWalletLinkControllerProvider.notifier);
+  controller.beginSubmit();
   try {
     final accountImportResult = await runWithSyncPausedForAccountMutation(
       ref,
@@ -592,10 +609,15 @@ Future<void> _continueToPasscodeOrImport(
       importedContactCount: importedContactCount,
     );
   } catch (error) {
+    controller.endSubmit();
     if (!context.mounted) return;
     ScaffoldMessenger.maybeOf(context)?.showSnackBar(
       SnackBar(content: Text(onboardingSubmitErrorMessage(error))),
     );
+    return;
+  }
+  if (!context.mounted) {
+    controller.endSubmit();
     return;
   }
   router.go('/home');
@@ -610,7 +632,9 @@ class _WalletLinkSelectionScaffold extends StatelessWidget {
     required this.actionLabel,
     required this.onAction,
     required this.buttonLabel,
+    required this.buttonLoadingLabel,
     required this.buttonEnabled,
+    required this.buttonLoading,
     required this.onButtonPressed,
     required this.child,
   });
@@ -620,112 +644,122 @@ class _WalletLinkSelectionScaffold extends StatelessWidget {
   final TextSpan subtitle;
   final String listTitle;
   final String actionLabel;
-  final VoidCallback onAction;
+  final VoidCallback? onAction;
   final String buttonLabel;
+  final String buttonLoadingLabel;
   final bool buttonEnabled;
+  final bool buttonLoading;
   final VoidCallback onButtonPressed;
   final Widget child;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    return Scaffold(
-      backgroundColor: colors.background.window,
-      body: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            MobileTopNav.steps(
-              progress: progress,
-              onBack: () => Navigator.of(context).maybePop(),
-            ),
-            Expanded(
-              child: Stack(
-                children: [
-                  SingleChildScrollView(
-                    padding: const EdgeInsets.fromLTRB(
-                      AppSpacing.sm,
-                      AppSpacing.md,
-                      AppSpacing.sm,
-                      132,
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Text(
-                          title,
-                          textAlign: TextAlign.center,
-                          style: AppTypography.displayLarge.copyWith(
-                            color: colors.text.accent,
+    return PopScope(
+      canPop: !buttonLoading,
+      child: Scaffold(
+        backgroundColor: colors.background.window,
+        body: SafeArea(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              MobileTopNav.steps(
+                progress: progress,
+                showBackButton: !buttonLoading,
+                onBack: () => Navigator.of(context).maybePop(),
+              ),
+              Expanded(
+                child: Stack(
+                  children: [
+                    SingleChildScrollView(
+                      padding: const EdgeInsets.fromLTRB(
+                        AppSpacing.sm,
+                        AppSpacing.md,
+                        AppSpacing.sm,
+                        132,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Text(
+                            title,
+                            textAlign: TextAlign.center,
+                            style: AppTypography.displayLarge.copyWith(
+                              color: colors.text.accent,
+                            ),
                           ),
-                        ),
-                        const SizedBox(height: AppSpacing.sm),
-                        Center(
-                          child: ConstrainedBox(
-                            constraints: const BoxConstraints(maxWidth: 320),
-                            child: Text.rich(
-                              subtitle,
-                              textAlign: TextAlign.center,
-                              style: AppTypography.bodyMedium.copyWith(
-                                color: colors.text.primary,
+                          const SizedBox(height: AppSpacing.sm),
+                          Center(
+                            child: ConstrainedBox(
+                              constraints: const BoxConstraints(maxWidth: 320),
+                              child: Text.rich(
+                                subtitle,
+                                textAlign: TextAlign.center,
+                                style: AppTypography.bodyMedium.copyWith(
+                                  color: colors.text.primary,
+                                ),
                               ),
                             ),
                           ),
-                        ),
-                        const SizedBox(height: AppSpacing.base),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: AppSpacing.xxs,
-                          ),
-                          child: Row(
-                            children: [
-                              Expanded(
-                                child: Text(
-                                  listTitle,
-                                  style: AppTypography.labelLarge.copyWith(
-                                    color: colors.text.accent,
-                                  ),
-                                ),
-                              ),
-                              GestureDetector(
-                                behavior: HitTestBehavior.opaque,
-                                onTap: onAction,
-                                child: Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: AppSpacing.xxs,
-                                    vertical: AppSpacing.xxs,
-                                  ),
+                          const SizedBox(height: AppSpacing.base),
+                          Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: AppSpacing.xxs,
+                            ),
+                            child: Row(
+                              children: [
+                                Expanded(
                                   child: Text(
-                                    actionLabel,
+                                    listTitle,
                                     style: AppTypography.labelLarge.copyWith(
-                                      color: colors.text.secondary,
-                                      fontWeight: FontWeight.w500,
+                                      color: colors.text.accent,
                                     ),
                                   ),
                                 ),
-                              ),
-                            ],
+                                GestureDetector(
+                                  behavior: HitTestBehavior.opaque,
+                                  onTap: onAction,
+                                  child: Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: AppSpacing.xxs,
+                                      vertical: AppSpacing.xxs,
+                                    ),
+                                    child: Text(
+                                      actionLabel,
+                                      style: AppTypography.labelLarge.copyWith(
+                                        color: onAction == null
+                                            ? colors.text.disabled
+                                            : colors.text.secondary,
+                                        fontWeight: FontWeight.w500,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
                           ),
-                        ),
-                        const SizedBox(height: AppSpacing.s),
-                        child,
-                      ],
+                          const SizedBox(height: AppSpacing.s),
+                          child,
+                        ],
+                      ),
                     ),
-                  ),
-                  Positioned(
-                    left: 0,
-                    right: 0,
-                    bottom: 0,
-                    child: _SelectionBottomAction(
-                      label: buttonLabel,
-                      enabled: buttonEnabled,
-                      onPressed: onButtonPressed,
+                    Positioned(
+                      left: 0,
+                      right: 0,
+                      bottom: 0,
+                      child: _SelectionBottomAction(
+                        label: buttonLabel,
+                        loadingLabel: buttonLoadingLabel,
+                        enabled: buttonEnabled,
+                        loading: buttonLoading,
+                        onPressed: onButtonPressed,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -735,12 +769,16 @@ class _WalletLinkSelectionScaffold extends StatelessWidget {
 class _SelectionBottomAction extends StatelessWidget {
   const _SelectionBottomAction({
     required this.label,
+    required this.loadingLabel,
     required this.enabled,
+    required this.loading,
     required this.onPressed,
   });
 
   final String label;
+  final String loadingLabel;
   final bool enabled;
+  final bool loading;
   final VoidCallback onPressed;
 
   @override
@@ -764,8 +802,9 @@ class _SelectionBottomAction extends StatelessWidget {
         ),
         child: AppButton(
           expand: true,
-          onPressed: enabled ? onPressed : null,
-          child: Text(label),
+          leading: loading ? const AppIcon(AppIcons.loader) : null,
+          onPressed: !loading && enabled ? onPressed : null,
+          child: Text(loading ? loadingLabel : label),
         ),
       ),
     );
@@ -781,12 +820,12 @@ class _WalletLinkAccountRow extends StatelessWidget {
 
   final WalletLinkTransferAccount account;
   final bool selected;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final enabled = account.isImportable;
+    final enabled = account.isImportable && onTap != null;
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: enabled ? onTap : null,
@@ -828,7 +867,7 @@ class _WalletLinkAccountRow extends StatelessWidget {
               ),
             ),
             const SizedBox(width: AppSpacing.xs),
-            _WalletLinkCheckbox(selected: selected && enabled),
+            _WalletLinkCheckbox(selected: selected && account.isImportable),
           ],
         ),
       ),
@@ -845,11 +884,12 @@ class _WalletLinkContactRow extends StatelessWidget {
 
   final AddressBookContact contact;
   final bool selected;
-  final VoidCallback onTap;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final enabled = onTap != null;
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: onTap,
@@ -877,7 +917,9 @@ class _WalletLinkContactRow extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: AppTypography.labelLarge.copyWith(
-                      color: colors.text.accent,
+                      color: enabled
+                          ? colors.text.accent
+                          : colors.text.secondary,
                       fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
                     ),
                   ),
@@ -887,7 +929,7 @@ class _WalletLinkContactRow extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: AppTypography.labelLarge.copyWith(
-                      color: selected
+                      color: enabled && selected
                           ? colors.text.accent
                           : colors.text.secondary,
                       fontWeight: FontWeight.w400,

--- a/lib/src/features/onboarding/mobile/mobile_wallet_link_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_wallet_link_screens.dart
@@ -433,30 +433,22 @@ class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
     final canContinueWithContactsOnly =
         state.importableContactCount > 0 &&
         ref.watch(appSecurityProvider).isPasswordConfigured;
+    final pendingAccounts = [
+      for (final account in state.sortedAccounts)
+        if (!state.isAccountAlreadyImported(account.uuid)) account,
+    ];
+    final alreadyImportedAccounts = [
+      for (final account in state.sortedAccounts)
+        if (state.isAccountAlreadyImported(account.uuid)) account,
+    ];
     return _WalletLinkSelectionScaffold(
       progress: _walletLinkAccountsProgress,
       title: 'Select account',
-      subtitle: const TextSpan(
-        text: 'Choose which desktop accounts to copy to this phone. ',
-        children: [
-          TextSpan(
-            text: 'Nothing on your computer changes.',
-            style: TextStyle(fontWeight: FontWeight.w600),
-          ),
-        ],
+      subtitle: TextSpan(
+        text:
+            '${_walletLinkCountLabel(state.importableAccountCount, 'account', 'accounts')} ready to import, '
+            '${alreadyImportedAccounts.length} already imported.',
       ),
-      listTitle:
-          '${state.accounts.length} account${state.accounts.length == 1 ? '' : 's'} found',
-      actionLabel: allAccountsSelected ? 'Deselect all' : 'Select all',
-      onAction: submitting || state.importableAccountCount == 0
-          ? null
-          : allAccountsSelected
-          ? () => ref
-                .read(mobileWalletLinkControllerProvider.notifier)
-                .deselectAllAccounts()
-          : () => ref
-                .read(mobileWalletLinkControllerProvider.notifier)
-                .selectAllImportableAccounts(),
       buttonLabel: state.selectedAccountCount == 0
           ? 'Continue'
           : 'Link ${state.selectedAccountCount} account${state.selectedAccountCount == 1 ? '' : 's'}',
@@ -473,19 +465,64 @@ class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
       },
       child: Column(
         children: [
-          for (final account in state.sortedAccounts) ...[
-            _WalletLinkAccountRow(
-              account: account,
-              selected: state.selectedAccountUuids.contains(account.uuid),
-              alreadyImported: state.isAccountAlreadyImported(account.uuid),
-              onTap: submitting || !state.isAccountSelectable(account)
+          if (pendingAccounts.isNotEmpty)
+            _WalletLinkListSection(
+              title:
+                  '${_walletLinkCountLabel(pendingAccounts.length, 'account', 'accounts')} found',
+              actionLabel: allAccountsSelected ? 'Deselect all' : 'Select all',
+              onAction: submitting || state.importableAccountCount == 0
                   ? null
+                  : allAccountsSelected
+                  ? () => ref
+                        .read(mobileWalletLinkControllerProvider.notifier)
+                        .deselectAllAccounts()
                   : () => ref
                         .read(mobileWalletLinkControllerProvider.notifier)
-                        .toggleAccount(account.uuid),
+                        .selectAllImportableAccounts(),
+              child: Column(
+                children: [
+                  for (final (index, account) in pendingAccounts.indexed) ...[
+                    _WalletLinkAccountRow(
+                      account: account,
+                      selected: state.selectedAccountUuids.contains(
+                        account.uuid,
+                      ),
+                      alreadyImported: false,
+                      onTap: submitting || !state.isAccountSelectable(account)
+                          ? null
+                          : () => ref
+                                .read(
+                                  mobileWalletLinkControllerProvider.notifier,
+                                )
+                                .toggleAccount(account.uuid),
+                    ),
+                    if (index != pendingAccounts.length - 1)
+                      const SizedBox(height: AppSpacing.s),
+                  ],
+                ],
+              ),
             ),
-            const SizedBox(height: AppSpacing.s),
-          ],
+          if (pendingAccounts.isNotEmpty && alreadyImportedAccounts.isNotEmpty)
+            const SizedBox(height: AppSpacing.base),
+          if (alreadyImportedAccounts.isNotEmpty)
+            _WalletLinkListSection(
+              title: '${alreadyImportedAccounts.length} already imported',
+              child: Column(
+                children: [
+                  for (final (index, account)
+                      in alreadyImportedAccounts.indexed) ...[
+                    _WalletLinkAccountRow(
+                      account: account,
+                      selected: false,
+                      alreadyImported: true,
+                      onTap: null,
+                    ),
+                    if (index != alreadyImportedAccounts.length - 1)
+                      const SizedBox(height: AppSpacing.s),
+                  ],
+                ],
+              ),
+            ),
         ],
       ),
     );
@@ -505,28 +542,29 @@ class MobileWalletLinkSelectContactsScreen extends ConsumerWidget {
     }
 
     final submitting = state.submitting;
-    final groups = _groupContactsByNetwork(state.contacts);
+    final pendingContacts = [
+      for (final contact in state.sortedContacts)
+        if (!state.isContactAlreadyImported(contact.id)) contact,
+    ];
+    final alreadyImportedContacts = [
+      for (final contact in state.sortedContacts)
+        if (state.isContactAlreadyImported(contact.id)) contact,
+    ];
+    final groups = _groupContactsByNetwork(pendingContacts);
+    final alreadyImportedGroups = _groupContactsByNetwork(
+      alreadyImportedContacts,
+    );
     final allContactsSelected =
         state.importableContactCount > 0 &&
         state.selectedContactCount == state.importableContactCount;
     return _WalletLinkSelectionScaffold(
       progress: _walletLinkContactsProgress,
       title: 'Import contacts',
-      subtitle: const TextSpan(
-        text: 'Choose which desktop contacts to bring to this phone.',
+      subtitle: TextSpan(
+        text:
+            '${_walletLinkCountLabel(state.contacts.length, 'contact', 'contacts')} found, '
+            '${alreadyImportedContacts.length} already imported.',
       ),
-      listTitle:
-          '${state.contacts.length} contact${state.contacts.length == 1 ? '' : 's'} found',
-      actionLabel: allContactsSelected ? 'Deselect all' : 'Select all',
-      onAction: submitting || state.importableContactCount == 0
-          ? null
-          : allContactsSelected
-          ? () => ref
-                .read(mobileWalletLinkControllerProvider.notifier)
-                .deselectAllContacts()
-          : () => ref
-                .read(mobileWalletLinkControllerProvider.notifier)
-                .selectAllContacts(),
       buttonLabel:
           'Import ${state.selectedContactCount} contact${state.selectedContactCount == 1 ? '' : 's'}',
       buttonLoadingLabel: 'Importing...',
@@ -537,29 +575,78 @@ class MobileWalletLinkSelectContactsScreen extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          for (final (groupIndex, entry) in groups.entries.indexed) ...[
-            _ContactGroupHeader(network: entry.key),
-            const SizedBox(height: AppSpacing.s),
-            for (final (contactIndex, contact) in _sortContactsForWalletLink(
-              state,
-              entry.value,
-            ).indexed) ...[
-              _WalletLinkContactRow(
-                contact: contact,
-                selected: state.selectedContactIds.contains(contact.id),
-                alreadyImported: state.isContactAlreadyImported(contact.id),
-                onTap: submitting || !state.isContactSelectable(contact)
-                    ? null
-                    : () => ref
-                          .read(mobileWalletLinkControllerProvider.notifier)
-                          .toggleContact(contact.id),
+          if (groups.isNotEmpty)
+            _WalletLinkListSection(
+              title:
+                  '${_walletLinkCountLabel(pendingContacts.length, 'contact', 'contacts')} found',
+              actionLabel: allContactsSelected ? 'Deselect all' : 'Select all',
+              onAction: submitting || state.importableContactCount == 0
+                  ? null
+                  : allContactsSelected
+                  ? () => ref
+                        .read(mobileWalletLinkControllerProvider.notifier)
+                        .deselectAllContacts()
+                  : () => ref
+                        .read(mobileWalletLinkControllerProvider.notifier)
+                        .selectAllContacts(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  for (final (groupIndex, entry) in groups.entries.indexed) ...[
+                    _ContactGroupHeader(network: entry.key),
+                    const SizedBox(height: AppSpacing.s),
+                    for (final (contactIndex, contact)
+                        in entry.value.indexed) ...[
+                      _WalletLinkContactRow(
+                        contact: contact,
+                        selected: state.selectedContactIds.contains(contact.id),
+                        alreadyImported: false,
+                        onTap: submitting || !state.isContactSelectable(contact)
+                            ? null
+                            : () => ref
+                                  .read(
+                                    mobileWalletLinkControllerProvider.notifier,
+                                  )
+                                  .toggleContact(contact.id),
+                      ),
+                      if (contactIndex != entry.value.length - 1)
+                        const SizedBox(height: AppSpacing.s),
+                    ],
+                    if (groupIndex != groups.length - 1)
+                      const SizedBox(height: AppSpacing.sm),
+                  ],
+                ],
               ),
-              if (contactIndex != entry.value.length - 1)
-                const SizedBox(height: AppSpacing.s),
-            ],
-            if (groupIndex != groups.length - 1)
-              const SizedBox(height: AppSpacing.sm),
-          ],
+            ),
+          if (groups.isNotEmpty && alreadyImportedGroups.isNotEmpty)
+            const SizedBox(height: AppSpacing.base),
+          if (alreadyImportedGroups.isNotEmpty)
+            _WalletLinkListSection(
+              title: '${alreadyImportedContacts.length} already imported',
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  for (final (groupIndex, entry)
+                      in alreadyImportedGroups.entries.indexed) ...[
+                    _ContactGroupHeader(network: entry.key),
+                    const SizedBox(height: AppSpacing.s),
+                    for (final (contactIndex, contact)
+                        in entry.value.indexed) ...[
+                      _WalletLinkContactRow(
+                        contact: contact,
+                        selected: false,
+                        alreadyImported: true,
+                        onTap: null,
+                      ),
+                      if (contactIndex != entry.value.length - 1)
+                        const SizedBox(height: AppSpacing.s),
+                    ],
+                    if (groupIndex != alreadyImportedGroups.length - 1)
+                      const SizedBox(height: AppSpacing.sm),
+                  ],
+                ],
+              ),
+            ),
         ],
       ),
     );
@@ -655,9 +742,6 @@ class _WalletLinkSelectionScaffold extends StatelessWidget {
     required this.progress,
     required this.title,
     required this.subtitle,
-    required this.listTitle,
-    required this.actionLabel,
-    required this.onAction,
     required this.buttonLabel,
     required this.buttonLoadingLabel,
     required this.buttonEnabled,
@@ -669,9 +753,6 @@ class _WalletLinkSelectionScaffold extends StatelessWidget {
   final double progress;
   final String title;
   final TextSpan subtitle;
-  final String listTitle;
-  final String actionLabel;
-  final VoidCallback? onAction;
   final String buttonLabel;
   final String buttonLoadingLabel;
   final bool buttonEnabled;
@@ -729,43 +810,6 @@ class _WalletLinkSelectionScaffold extends StatelessWidget {
                             ),
                           ),
                           const SizedBox(height: AppSpacing.base),
-                          Padding(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: AppSpacing.xxs,
-                            ),
-                            child: Row(
-                              children: [
-                                Expanded(
-                                  child: Text(
-                                    listTitle,
-                                    style: AppTypography.labelLarge.copyWith(
-                                      color: colors.text.accent,
-                                    ),
-                                  ),
-                                ),
-                                GestureDetector(
-                                  behavior: HitTestBehavior.opaque,
-                                  onTap: onAction,
-                                  child: Padding(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: AppSpacing.xxs,
-                                      vertical: AppSpacing.xxs,
-                                    ),
-                                    child: Text(
-                                      actionLabel,
-                                      style: AppTypography.labelLarge.copyWith(
-                                        color: onAction == null
-                                            ? colors.text.disabled
-                                            : colors.text.secondary,
-                                        fontWeight: FontWeight.w500,
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(height: AppSpacing.s),
                           child,
                         ],
                       ),
@@ -789,6 +833,67 @@ class _WalletLinkSelectionScaffold extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _WalletLinkListSection extends StatelessWidget {
+  const _WalletLinkListSection({
+    required this.title,
+    required this.child,
+    this.actionLabel,
+    this.onAction,
+  });
+
+  final String title;
+  final Widget child;
+  final String? actionLabel;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+          child: Row(
+            children: [
+              Expanded(
+                child: Text(
+                  title,
+                  style: AppTypography.labelLarge.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+              ),
+              if (actionLabel != null)
+                GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: onAction,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: AppSpacing.xxs,
+                      vertical: AppSpacing.xxs,
+                    ),
+                    child: Text(
+                      actionLabel!,
+                      style: AppTypography.labelLarge.copyWith(
+                        color: onAction == null
+                            ? colors.text.disabled
+                            : colors.text.secondary,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+        const SizedBox(height: AppSpacing.s),
+        child,
+      ],
     );
   }
 }
@@ -900,25 +1005,13 @@ class _WalletLinkAccountRow extends StatelessWidget {
                       fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
                     ),
                   ),
-                  if (alreadyImported) ...[
-                    const SizedBox(height: 2),
-                    Text(
-                      'Account already imported',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: AppTypography.labelLarge.copyWith(
-                        color: colors.text.destructive,
-                        fontWeight: FontWeight.w400,
-                      ),
-                    ),
-                  ],
                 ],
               ),
             ),
-            const SizedBox(width: AppSpacing.xs),
-            _WalletLinkCheckbox(
-              selected: selected && account.isImportable && !alreadyImported,
-            ),
+            if (!alreadyImported) ...[
+              const SizedBox(width: AppSpacing.xs),
+              _WalletLinkCheckbox(selected: selected && account.isImportable),
+            ],
           ],
         ),
       ),
@@ -976,15 +1069,11 @@ class _WalletLinkContactRow extends StatelessWidget {
                   ),
                   const SizedBox(height: 2),
                   Text(
-                    alreadyImported
-                        ? 'Contact already imported'
-                        : contact.addressPreview,
+                    contact.addressPreview,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: AppTypography.labelLarge.copyWith(
-                      color: alreadyImported
-                          ? colors.text.destructive
-                          : enabled && selected
+                      color: enabled && selected
                           ? colors.text.accent
                           : colors.text.secondary,
                       fontWeight: FontWeight.w400,
@@ -993,8 +1082,10 @@ class _WalletLinkContactRow extends StatelessWidget {
                 ],
               ),
             ),
-            const SizedBox(width: AppSpacing.xs),
-            _WalletLinkCheckbox(selected: selected && !alreadyImported),
+            if (!alreadyImported) ...[
+              const SizedBox(width: AppSpacing.xs),
+              _WalletLinkCheckbox(selected: selected),
+            ],
           ],
         ),
       ),
@@ -1061,7 +1152,7 @@ class _WalletLinkCheckbox extends StatelessWidget {
 }
 
 Map<AddressBookNetwork, List<AddressBookContact>> _groupContactsByNetwork(
-  List<AddressBookContact> contacts,
+  Iterable<AddressBookContact> contacts,
 ) {
   final grouped = <AddressBookNetwork, List<AddressBookContact>>{};
   for (final contact in contacts) {
@@ -1070,17 +1161,6 @@ Map<AddressBookNetwork, List<AddressBookContact>> _groupContactsByNetwork(
   return grouped;
 }
 
-List<AddressBookContact> _sortContactsForWalletLink(
-  MobileWalletLinkState state,
-  List<AddressBookContact> contacts,
-) {
-  final indexed = contacts.indexed.toList();
-  indexed.sort((a, b) {
-    final rank = (state.isContactAlreadyImported(a.$2.id) ? 1 : 0).compareTo(
-      state.isContactAlreadyImported(b.$2.id) ? 1 : 0,
-    );
-    if (rank != 0) return rank;
-    return a.$1.compareTo(b.$1);
-  });
-  return [for (final entry in indexed) entry.$2];
+String _walletLinkCountLabel(int count, String singular, String plural) {
+  return '$count ${count == 1 ? singular : plural}';
 }

--- a/lib/src/features/onboarding/mobile/mobile_wallet_link_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_wallet_link_screens.dart
@@ -737,7 +737,8 @@ Future<void> _completeEmptyWalletLinkAndGoBack(
     controller.endSubmit();
     return;
   }
-  _goBackFromWalletLink(context);
+  controller.endSubmit();
+  GoRouter.maybeOf(context)?.go('/onboarding/link-desktop');
 }
 
 Future<void> _continueToPasscodeOrImport(

--- a/lib/src/features/onboarding/mobile/mobile_wallet_link_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_wallet_link_screens.dart
@@ -427,6 +427,12 @@ class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
     }
 
     final submitting = state.submitting;
+    final allAccountsSelected =
+        state.importableAccountCount > 0 &&
+        state.selectedAccountCount == state.importableAccountCount;
+    final canContinueWithContactsOnly =
+        state.importableContactCount > 0 &&
+        ref.watch(appSecurityProvider).isPasswordConfigured;
     return _WalletLinkSelectionScaffold(
       progress: _walletLinkAccountsProgress,
       title: 'Select account',
@@ -441,22 +447,22 @@ class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
       ),
       listTitle:
           '${state.accounts.length} account${state.accounts.length == 1 ? '' : 's'} found',
-      actionLabel: state.selectedAccountCount == state.importableAccountCount
-          ? 'Deselect all'
-          : 'Select all',
-      onAction: submitting
+      actionLabel: allAccountsSelected ? 'Deselect all' : 'Select all',
+      onAction: submitting || state.importableAccountCount == 0
           ? null
-          : state.selectedAccountCount == state.importableAccountCount
+          : allAccountsSelected
           ? () => ref
                 .read(mobileWalletLinkControllerProvider.notifier)
                 .deselectAllAccounts()
           : () => ref
                 .read(mobileWalletLinkControllerProvider.notifier)
                 .selectAllImportableAccounts(),
-      buttonLabel:
-          'Link ${state.selectedAccountCount} account${state.selectedAccountCount == 1 ? '' : 's'}',
+      buttonLabel: state.selectedAccountCount == 0
+          ? 'Continue'
+          : 'Link ${state.selectedAccountCount} account${state.selectedAccountCount == 1 ? '' : 's'}',
       buttonLoadingLabel: 'Importing...',
-      buttonEnabled: state.selectedAccountCount > 0,
+      buttonEnabled:
+          state.selectedAccountCount > 0 || canContinueWithContactsOnly,
       buttonLoading: submitting,
       onButtonPressed: () {
         if (state.contacts.isEmpty) {
@@ -467,11 +473,12 @@ class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
       },
       child: Column(
         children: [
-          for (final account in state.accounts) ...[
+          for (final account in state.sortedAccounts) ...[
             _WalletLinkAccountRow(
               account: account,
               selected: state.selectedAccountUuids.contains(account.uuid),
-              onTap: submitting
+              alreadyImported: state.isAccountAlreadyImported(account.uuid),
+              onTap: submitting || !state.isAccountSelectable(account)
                   ? null
                   : () => ref
                         .read(mobileWalletLinkControllerProvider.notifier)
@@ -499,6 +506,9 @@ class MobileWalletLinkSelectContactsScreen extends ConsumerWidget {
 
     final submitting = state.submitting;
     final groups = _groupContactsByNetwork(state.contacts);
+    final allContactsSelected =
+        state.importableContactCount > 0 &&
+        state.selectedContactCount == state.importableContactCount;
     return _WalletLinkSelectionScaffold(
       progress: _walletLinkContactsProgress,
       title: 'Import contacts',
@@ -507,12 +517,10 @@ class MobileWalletLinkSelectContactsScreen extends ConsumerWidget {
       ),
       listTitle:
           '${state.contacts.length} contact${state.contacts.length == 1 ? '' : 's'} found',
-      actionLabel: state.selectedContactCount == state.contacts.length
-          ? 'Deselect all'
-          : 'Select all',
-      onAction: submitting
+      actionLabel: allContactsSelected ? 'Deselect all' : 'Select all',
+      onAction: submitting || state.importableContactCount == 0
           ? null
-          : state.selectedContactCount == state.contacts.length
+          : allContactsSelected
           ? () => ref
                 .read(mobileWalletLinkControllerProvider.notifier)
                 .deselectAllContacts()
@@ -522,7 +530,8 @@ class MobileWalletLinkSelectContactsScreen extends ConsumerWidget {
       buttonLabel:
           'Import ${state.selectedContactCount} contact${state.selectedContactCount == 1 ? '' : 's'}',
       buttonLoadingLabel: 'Importing...',
-      buttonEnabled: state.selectedAccountCount > 0,
+      buttonEnabled:
+          state.selectedAccountCount > 0 || state.selectedContactCount > 0,
       buttonLoading: submitting,
       onButtonPressed: () => _continueToPasscodeOrImport(context, ref),
       child: Column(
@@ -531,11 +540,15 @@ class MobileWalletLinkSelectContactsScreen extends ConsumerWidget {
           for (final (groupIndex, entry) in groups.entries.indexed) ...[
             _ContactGroupHeader(network: entry.key),
             const SizedBox(height: AppSpacing.s),
-            for (final (contactIndex, contact) in entry.value.indexed) ...[
+            for (final (contactIndex, contact) in _sortContactsForWalletLink(
+              state,
+              entry.value,
+            ).indexed) ...[
               _WalletLinkContactRow(
                 contact: contact,
                 selected: state.selectedContactIds.contains(contact.id),
-                onTap: submitting
+                alreadyImported: state.isContactAlreadyImported(contact.id),
+                onTap: submitting || !state.isContactSelectable(contact)
                     ? null
                     : () => ref
                           .read(mobileWalletLinkControllerProvider.notifier)
@@ -560,7 +573,10 @@ Future<void> _continueToPasscodeOrImport(
   final state = ref.read(mobileWalletLinkControllerProvider);
   if (state.submitting) return;
   final payload = state.payload;
-  if (payload == null || state.selectedAccounts.isEmpty) return;
+  if (payload == null ||
+      (state.selectedAccounts.isEmpty && state.selectedContacts.isEmpty)) {
+    return;
+  }
   final packageId = state.packageId;
   final completionToken = state.completionToken;
   final keyBytes = state.keyBytes;
@@ -571,6 +587,7 @@ Future<void> _continueToPasscodeOrImport(
   final contacts = state.selectedContacts;
   final security = ref.read(appSecurityProvider);
   if (!security.isPasswordConfigured) {
+    if (accounts.isEmpty) return;
     context.push(
       '/onboarding/set-passcode',
       extra: SetPasswordScreenArgs.importWalletLink(
@@ -589,18 +606,28 @@ Future<void> _continueToPasscodeOrImport(
   final controller = ref.read(mobileWalletLinkControllerProvider.notifier);
   controller.beginSubmit();
   try {
-    final accountImportResult = await runWithSyncPausedForAccountMutation(
-      ref,
-      () => ref
+    if (accounts.isEmpty) {
+      await ref
           .read(accountProvider.notifier)
-          .importLinkedWalletAccounts(
-            network: payload.network,
-            accountsToImport: accounts,
-          ),
-    );
-    final importedContactCount = await ref
-        .read(addressBookProvider.notifier)
-        .importContacts(contacts);
+          .validateLinkedWalletNetwork(payload.network);
+    }
+    final accountImportResult = accounts.isEmpty
+        ? const LinkedWalletAccountsImportResult(
+            importedCount: 0,
+            skippedDuplicateCount: 0,
+          )
+        : await runWithSyncPausedForAccountMutation(
+            ref,
+            () => ref
+                .read(accountProvider.notifier)
+                .importLinkedWalletAccounts(
+                  network: payload.network,
+                  accountsToImport: accounts,
+                ),
+          );
+    final importedContactCount = contacts.isEmpty
+        ? 0
+        : await ref.read(addressBookProvider.notifier).importContacts(contacts);
     await completeWalletLinkPackageBestEffort(
       packageId: packageId,
       completionToken: completionToken,
@@ -815,17 +842,19 @@ class _WalletLinkAccountRow extends StatelessWidget {
   const _WalletLinkAccountRow({
     required this.account,
     required this.selected,
+    required this.alreadyImported,
     required this.onTap,
   });
 
   final WalletLinkTransferAccount account;
   final bool selected;
+  final bool alreadyImported;
   final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final enabled = account.isImportable && onTap != null;
+    final enabled = account.isImportable && !alreadyImported && onTap != null;
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: enabled ? onTap : null,
@@ -856,18 +885,40 @@ class _WalletLinkAccountRow extends StatelessWidget {
             ),
             const SizedBox(width: AppSpacing.xs),
             Expanded(
-              child: Text(
-                account.displayName,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: AppTypography.labelLarge.copyWith(
-                  color: enabled ? colors.text.accent : colors.text.secondary,
-                  fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
-                ),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    account.displayName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: account.isImportable
+                          ? colors.text.accent
+                          : colors.text.secondary,
+                      fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+                    ),
+                  ),
+                  if (alreadyImported) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      'Account already imported',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTypography.labelLarge.copyWith(
+                        color: colors.text.destructive,
+                        fontWeight: FontWeight.w400,
+                      ),
+                    ),
+                  ],
+                ],
               ),
             ),
             const SizedBox(width: AppSpacing.xs),
-            _WalletLinkCheckbox(selected: selected && account.isImportable),
+            _WalletLinkCheckbox(
+              selected: selected && account.isImportable && !alreadyImported,
+            ),
           ],
         ),
       ),
@@ -879,20 +930,22 @@ class _WalletLinkContactRow extends StatelessWidget {
   const _WalletLinkContactRow({
     required this.contact,
     required this.selected,
+    required this.alreadyImported,
     required this.onTap,
   });
 
   final AddressBookContact contact;
   final bool selected;
+  final bool alreadyImported;
   final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final enabled = onTap != null;
+    final enabled = !alreadyImported && onTap != null;
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
-      onTap: onTap,
+      onTap: enabled ? onTap : null,
       child: Container(
         constraints: const BoxConstraints(minHeight: 64),
         padding: const EdgeInsets.only(
@@ -917,19 +970,21 @@ class _WalletLinkContactRow extends StatelessWidget {
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: AppTypography.labelLarge.copyWith(
-                      color: enabled
-                          ? colors.text.accent
-                          : colors.text.secondary,
+                      color: colors.text.accent,
                       fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
                     ),
                   ),
                   const SizedBox(height: 2),
                   Text(
-                    contact.addressPreview,
+                    alreadyImported
+                        ? 'Contact already imported'
+                        : contact.addressPreview,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: AppTypography.labelLarge.copyWith(
-                      color: enabled && selected
+                      color: alreadyImported
+                          ? colors.text.destructive
+                          : enabled && selected
                           ? colors.text.accent
                           : colors.text.secondary,
                       fontWeight: FontWeight.w400,
@@ -939,7 +994,7 @@ class _WalletLinkContactRow extends StatelessWidget {
               ),
             ),
             const SizedBox(width: AppSpacing.xs),
-            _WalletLinkCheckbox(selected: selected),
+            _WalletLinkCheckbox(selected: selected && !alreadyImported),
           ],
         ),
       ),
@@ -1013,4 +1068,19 @@ Map<AddressBookNetwork, List<AddressBookContact>> _groupContactsByNetwork(
     grouped.putIfAbsent(contact.network, () => []).add(contact);
   }
   return grouped;
+}
+
+List<AddressBookContact> _sortContactsForWalletLink(
+  MobileWalletLinkState state,
+  List<AddressBookContact> contacts,
+) {
+  final indexed = contacts.indexed.toList();
+  indexed.sort((a, b) {
+    final rank = (state.isContactAlreadyImported(a.$2.id) ? 1 : 0).compareTo(
+      state.isContactAlreadyImported(b.$2.id) ? 1 : 0,
+    );
+    if (rank != 0) return rank;
+    return a.$1.compareTo(b.$1);
+  });
+  return [for (final entry in indexed) entry.$2];
 }

--- a/lib/src/features/onboarding/mobile/mobile_wallet_link_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_wallet_link_screens.dart
@@ -433,6 +433,8 @@ class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
     final canContinueWithContactsOnly =
         state.importableContactCount > 0 &&
         ref.watch(appSecurityProvider).isPasswordConfigured;
+    final hasNothingToImport =
+        state.importableAccountCount == 0 && state.importableContactCount == 0;
     final pendingAccounts = [
       for (final account in state.sortedAccounts)
         if (!state.isAccountAlreadyImported(account.uuid)) account,
@@ -444,87 +446,108 @@ class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
     return _WalletLinkSelectionScaffold(
       progress: _walletLinkAccountsProgress,
       title: 'Select account',
-      subtitle: TextSpan(
-        text:
-            '${_walletLinkCountLabel(state.importableAccountCount, 'account', 'accounts')} ready to import, '
-            '${alreadyImportedAccounts.length} already imported.',
-      ),
-      buttonLabel: state.selectedAccountCount == 0
+      subtitle: hasNothingToImport
+          ? const TextSpan(
+              text: 'There is nothing new to import from this desktop link.',
+            )
+          : TextSpan(
+              text:
+                  '${_walletLinkCountLabel(state.importableAccountCount, 'account', 'accounts')} ready to import, '
+                  '${alreadyImportedAccounts.length} already imported.',
+            ),
+      buttonLabel: hasNothingToImport
+          ? 'Go back'
+          : state.selectedAccountCount == 0
           ? 'Continue'
           : 'Link ${state.selectedAccountCount} account${state.selectedAccountCount == 1 ? '' : 's'}',
       buttonLoadingLabel: 'Importing...',
       buttonEnabled:
-          state.selectedAccountCount > 0 || canContinueWithContactsOnly,
+          hasNothingToImport ||
+          state.selectedAccountCount > 0 ||
+          canContinueWithContactsOnly,
       buttonLoading: submitting,
       onButtonPressed: () {
+        if (hasNothingToImport) {
+          _goBackFromWalletLink(context);
+          return;
+        }
         if (state.contacts.isEmpty) {
           _continueToPasscodeOrImport(context, ref);
           return;
         }
         context.push('/onboarding/link-desktop/contacts');
       },
-      child: Column(
-        children: [
-          if (pendingAccounts.isNotEmpty)
-            _WalletLinkListSection(
-              title:
-                  '${_walletLinkCountLabel(pendingAccounts.length, 'account', 'accounts')} found',
-              actionLabel: allAccountsSelected ? 'Deselect all' : 'Select all',
-              onAction: submitting || state.importableAccountCount == 0
-                  ? null
-                  : allAccountsSelected
-                  ? () => ref
-                        .read(mobileWalletLinkControllerProvider.notifier)
-                        .deselectAllAccounts()
-                  : () => ref
-                        .read(mobileWalletLinkControllerProvider.notifier)
-                        .selectAllImportableAccounts(),
-              child: Column(
-                children: [
-                  for (final (index, account) in pendingAccounts.indexed) ...[
-                    _WalletLinkAccountRow(
-                      account: account,
-                      selected: state.selectedAccountUuids.contains(
-                        account.uuid,
-                      ),
-                      alreadyImported: false,
-                      onTap: submitting || !state.isAccountSelectable(account)
-                          ? null
-                          : () => ref
-                                .read(
-                                  mobileWalletLinkControllerProvider.notifier,
-                                )
-                                .toggleAccount(account.uuid),
+      child: hasNothingToImport
+          ? const _WalletLinkNothingToImportCard()
+          : Column(
+              children: [
+                if (pendingAccounts.isNotEmpty)
+                  _WalletLinkListSection(
+                    title:
+                        '${_walletLinkCountLabel(pendingAccounts.length, 'account', 'accounts')} found',
+                    actionLabel: allAccountsSelected
+                        ? 'Deselect all'
+                        : 'Select all',
+                    onAction: submitting || state.importableAccountCount == 0
+                        ? null
+                        : allAccountsSelected
+                        ? () => ref
+                              .read(mobileWalletLinkControllerProvider.notifier)
+                              .deselectAllAccounts()
+                        : () => ref
+                              .read(mobileWalletLinkControllerProvider.notifier)
+                              .selectAllImportableAccounts(),
+                    child: Column(
+                      children: [
+                        for (final (index, account)
+                            in pendingAccounts.indexed) ...[
+                          _WalletLinkAccountRow(
+                            account: account,
+                            selected: state.selectedAccountUuids.contains(
+                              account.uuid,
+                            ),
+                            alreadyImported: false,
+                            onTap:
+                                submitting ||
+                                    !state.isAccountSelectable(account)
+                                ? null
+                                : () => ref
+                                      .read(
+                                        mobileWalletLinkControllerProvider
+                                            .notifier,
+                                      )
+                                      .toggleAccount(account.uuid),
+                          ),
+                          if (index != pendingAccounts.length - 1)
+                            const SizedBox(height: AppSpacing.s),
+                        ],
+                      ],
                     ),
-                    if (index != pendingAccounts.length - 1)
-                      const SizedBox(height: AppSpacing.s),
-                  ],
-                ],
-              ),
-            ),
-          if (pendingAccounts.isNotEmpty && alreadyImportedAccounts.isNotEmpty)
-            const SizedBox(height: AppSpacing.base),
-          if (alreadyImportedAccounts.isNotEmpty)
-            _WalletLinkListSection(
-              title: '${alreadyImportedAccounts.length} already imported',
-              child: Column(
-                children: [
-                  for (final (index, account)
-                      in alreadyImportedAccounts.indexed) ...[
-                    _WalletLinkAccountRow(
-                      account: account,
-                      selected: false,
-                      alreadyImported: true,
-                      onTap: null,
+                  ),
+                if (pendingAccounts.isNotEmpty &&
+                    alreadyImportedAccounts.isNotEmpty)
+                  const SizedBox(height: AppSpacing.base),
+                if (alreadyImportedAccounts.isNotEmpty)
+                  _WalletLinkListSection(
+                    title: '${alreadyImportedAccounts.length} already imported',
+                    child: Column(
+                      children: [
+                        for (final (index, account)
+                            in alreadyImportedAccounts.indexed) ...[
+                          _WalletLinkAccountRow(
+                            account: account,
+                            selected: false,
+                            alreadyImported: true,
+                            onTap: null,
+                          ),
+                          if (index != alreadyImportedAccounts.length - 1)
+                            const SizedBox(height: AppSpacing.s),
+                        ],
+                      ],
                     ),
-                    if (index != alreadyImportedAccounts.length - 1)
-                      const SizedBox(height: AppSpacing.s),
-                  ],
-                ],
-              ),
+                  ),
+              ],
             ),
-        ],
-      ),
     );
   }
 }
@@ -651,6 +674,15 @@ class MobileWalletLinkSelectContactsScreen extends ConsumerWidget {
       ),
     );
   }
+}
+
+void _goBackFromWalletLink(BuildContext context) {
+  final navigator = Navigator.of(context);
+  if (navigator.canPop()) {
+    navigator.maybePop();
+    return;
+  }
+  GoRouter.maybeOf(context)?.go('/onboarding/link-desktop');
 }
 
 Future<void> _continueToPasscodeOrImport(
@@ -894,6 +926,60 @@ class _WalletLinkListSection extends StatelessWidget {
         const SizedBox(height: AppSpacing.s),
         child,
       ],
+    );
+  }
+}
+
+class _WalletLinkNothingToImportCard extends StatelessWidget {
+  const _WalletLinkNothingToImportCard();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Container(
+      constraints: const BoxConstraints(minHeight: 156),
+      padding: const EdgeInsets.all(AppSpacing.md),
+      decoration: BoxDecoration(
+        color: colors.background.ground,
+        borderRadius: BorderRadius.circular(AppRadii.medium),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 40,
+            height: 40,
+            decoration: BoxDecoration(
+              color: colors.background.raised,
+              borderRadius: BorderRadius.circular(AppRadii.small),
+            ),
+            child: Center(
+              child: AppIcon(
+                AppIcons.checkCircle,
+                size: 24,
+                color: colors.icon.accent,
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            'Nothing to import',
+            textAlign: TextAlign.center,
+            style: AppTypography.bodyLarge.copyWith(
+              color: colors.text.accent,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.xxs),
+          Text(
+            'Everything in this desktop link is already on this phone.',
+            textAlign: TextAlign.center,
+            style: AppTypography.bodyMedium.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/src/features/onboarding/mobile/mobile_wallet_link_screens.dart
+++ b/lib/src/features/onboarding/mobile/mobile_wallet_link_screens.dart
@@ -34,6 +34,15 @@ const _walletLinkScanProgress = 0.4;
 const _walletLinkAccountsProgress = 0.6;
 const _walletLinkContactsProgress = 0.8;
 
+typedef WalletLinkCompletionCallback =
+    Future<void> Function({
+      required String packageId,
+      required String completionToken,
+      required List<int> keyBytes,
+      required int importedAccountCount,
+      required int importedContactCount,
+    });
+
 class MobileWalletLinkIntroScreen extends StatelessWidget {
   const MobileWalletLinkIntroScreen({super.key});
 
@@ -415,7 +424,12 @@ class _WalletLinkScanErrorCard extends StatelessWidget {
 }
 
 class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
-  const MobileWalletLinkSelectAccountsScreen({super.key});
+  const MobileWalletLinkSelectAccountsScreen({
+    this.completeWalletLinkPackage = completeWalletLinkPackageBestEffort,
+    super.key,
+  });
+
+  final WalletLinkCompletionCallback completeWalletLinkPackage;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -468,7 +482,13 @@ class MobileWalletLinkSelectAccountsScreen extends ConsumerWidget {
       buttonLoading: submitting,
       onButtonPressed: () {
         if (hasNothingToImport) {
-          _goBackFromWalletLink(context);
+          unawaited(
+            _completeEmptyWalletLinkAndGoBack(
+              context,
+              ref,
+              completeWalletLinkPackage: completeWalletLinkPackage,
+            ),
+          );
           return;
         }
         if (state.contacts.isEmpty) {
@@ -683,6 +703,41 @@ void _goBackFromWalletLink(BuildContext context) {
     return;
   }
   GoRouter.maybeOf(context)?.go('/onboarding/link-desktop');
+}
+
+Future<void> _completeEmptyWalletLinkAndGoBack(
+  BuildContext context,
+  WidgetRef ref, {
+  required WalletLinkCompletionCallback completeWalletLinkPackage,
+}) async {
+  final state = ref.read(mobileWalletLinkControllerProvider);
+  if (state.submitting) return;
+  final packageId = state.packageId;
+  final completionToken = state.completionToken;
+  final keyBytes = state.keyBytes;
+  if (packageId == null || completionToken == null || keyBytes == null) {
+    _goBackFromWalletLink(context);
+    return;
+  }
+
+  final controller = ref.read(mobileWalletLinkControllerProvider.notifier);
+  controller.beginSubmit();
+  try {
+    await completeWalletLinkPackage(
+      packageId: packageId,
+      completionToken: completionToken,
+      keyBytes: keyBytes,
+      importedAccountCount: 0,
+      importedContactCount: 0,
+    );
+  } catch (_) {
+    // Completion is best-effort; the local no-op state should still exit.
+  }
+  if (!context.mounted) {
+    controller.endSubmit();
+    return;
+  }
+  _goBackFromWalletLink(context);
 }
 
 Future<void> _continueToPasscodeOrImport(

--- a/lib/src/features/wallet_link/models/wallet_link_models.dart
+++ b/lib/src/features/wallet_link/models/wallet_link_models.dart
@@ -400,6 +400,7 @@ class WalletLinkTransferAccount {
       ufvk: ufvk,
       seedFingerprint: seedFingerprint,
       profilePictureId: profilePictureId,
+      sourceAccountUuid: uuid,
     );
   }
 }

--- a/lib/src/features/wallet_link/providers/mobile_wallet_link_provider.dart
+++ b/lib/src/features/wallet_link/providers/mobile_wallet_link_provider.dart
@@ -6,6 +6,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../main.dart' show log;
 import '../../../features/address_book/models/address_book_contact.dart';
+import '../../../features/address_book/providers/address_book_provider.dart';
+import '../../../providers/account_provider.dart';
 import '../models/wallet_link_models.dart';
 import '../services/wallet_link_api_client.dart';
 
@@ -25,6 +27,8 @@ class MobileWalletLinkState {
     this.keyBytes,
     this.selectedAccountUuids = const <String>{},
     this.selectedContactIds = const <String>{},
+    this.alreadyImportedAccountUuids = const <String>{},
+    this.alreadyImportedContactIds = const <String>{},
     this.scanError,
     this.loading = false,
     this.submitting = false,
@@ -39,6 +43,8 @@ class MobileWalletLinkState {
   final List<int>? keyBytes;
   final Set<String> selectedAccountUuids;
   final Set<String> selectedContactIds;
+  final Set<String> alreadyImportedAccountUuids;
+  final Set<String> alreadyImportedContactIds;
   final MobileWalletLinkScanError? scanError;
   final bool loading;
   final bool submitting;
@@ -47,23 +53,75 @@ class MobileWalletLinkState {
   List<WalletLinkTransferAccount> get accounts =>
       payload?.supportedAccounts ?? const [];
   List<AddressBookContact> get contacts => payload?.contacts ?? const [];
+  List<WalletLinkTransferAccount> get sortedAccounts {
+    final indexed = accounts.indexed.toList();
+    indexed.sort((a, b) {
+      final rank = _accountDisplayRank(
+        a.$2,
+      ).compareTo(_accountDisplayRank(b.$2));
+      if (rank != 0) return rank;
+      return a.$1.compareTo(b.$1);
+    });
+    return [for (final entry in indexed) entry.$2];
+  }
+
+  List<AddressBookContact> get sortedContacts {
+    final indexed = contacts.indexed.toList();
+    indexed.sort((a, b) {
+      final rank = _contactDisplayRank(
+        a.$2,
+      ).compareTo(_contactDisplayRank(b.$2));
+      if (rank != 0) return rank;
+      return a.$1.compareTo(b.$1);
+    });
+    return [for (final entry in indexed) entry.$2];
+  }
 
   List<WalletLinkTransferAccount> get selectedAccounts => [
     for (final account in accounts)
-      if (selectedAccountUuids.contains(account.uuid) && account.isImportable)
+      if (selectedAccountUuids.contains(account.uuid) &&
+          isAccountSelectable(account))
         account,
   ];
 
   List<AddressBookContact> get selectedContacts => [
     for (final contact in contacts)
-      if (selectedContactIds.contains(contact.id)) contact,
+      if (selectedContactIds.contains(contact.id) &&
+          isContactSelectable(contact))
+        contact,
   ];
 
-  int get importableAccountCount =>
-      accounts.where((account) => account.isImportable).length;
+  int get importableAccountCount => accounts.where(isAccountSelectable).length;
+  int get importableContactCount => contacts.where(isContactSelectable).length;
   int get selectedAccountCount => selectedAccounts.length;
   int get selectedContactCount => selectedContacts.length;
   bool get hasPayload => payload != null;
+
+  bool isAccountAlreadyImported(String uuid) {
+    return alreadyImportedAccountUuids.contains(uuid);
+  }
+
+  bool isAccountSelectable(WalletLinkTransferAccount account) {
+    return account.isImportable && !isAccountAlreadyImported(account.uuid);
+  }
+
+  bool isContactAlreadyImported(String id) {
+    return alreadyImportedContactIds.contains(id);
+  }
+
+  bool isContactSelectable(AddressBookContact contact) {
+    return !isContactAlreadyImported(contact.id);
+  }
+
+  int _accountDisplayRank(WalletLinkTransferAccount account) {
+    if (isAccountAlreadyImported(account.uuid)) return 2;
+    if (!account.isImportable) return 1;
+    return 0;
+  }
+
+  int _contactDisplayRank(AddressBookContact contact) {
+    return isContactAlreadyImported(contact.id) ? 1 : 0;
+  }
 
   MobileWalletLinkState copyWith({
     WalletLinkTransferPayload? payload,
@@ -76,6 +134,8 @@ class MobileWalletLinkState {
     bool clearKeyBytes = false,
     Set<String>? selectedAccountUuids,
     Set<String>? selectedContactIds,
+    Set<String>? alreadyImportedAccountUuids,
+    Set<String>? alreadyImportedContactIds,
     MobileWalletLinkScanError? scanError,
     bool clearScanError = false,
     bool? loading,
@@ -91,6 +151,10 @@ class MobileWalletLinkState {
       keyBytes: clearKeyBytes ? null : keyBytes ?? this.keyBytes,
       selectedAccountUuids: selectedAccountUuids ?? this.selectedAccountUuids,
       selectedContactIds: selectedContactIds ?? this.selectedContactIds,
+      alreadyImportedAccountUuids:
+          alreadyImportedAccountUuids ?? this.alreadyImportedAccountUuids,
+      alreadyImportedContactIds:
+          alreadyImportedContactIds ?? this.alreadyImportedContactIds,
       scanError: clearScanError ? null : scanError ?? this.scanError,
       loading: loading ?? this.loading,
       submitting: submitting ?? this.submitting,
@@ -124,11 +188,19 @@ class MobileWalletLinkController extends Notifier<MobileWalletLinkState> {
           package.envelope,
           keyBytes: qr.keyBytes,
         );
+        final alreadyImportedAccounts = await _alreadyImportedAccountUuids(
+          payload,
+        );
+        final alreadyImportedContacts = await _alreadyImportedContactIds(
+          payload,
+        );
         final selectedAccounts = {
-          for (final account in payload.importableAccounts) account.uuid,
+          for (final account in payload.importableAccounts)
+            if (!alreadyImportedAccounts.contains(account.uuid)) account.uuid,
         };
         final selectedContacts = {
-          for (final contact in payload.contacts) contact.id,
+          for (final contact in payload.contacts)
+            if (!alreadyImportedContacts.contains(contact.id)) contact.id,
         };
         state = MobileWalletLinkState(
           payload: payload,
@@ -137,6 +209,8 @@ class MobileWalletLinkController extends Notifier<MobileWalletLinkState> {
           keyBytes: Uint8List.fromList(qr.keyBytes),
           selectedAccountUuids: selectedAccounts,
           selectedContactIds: selectedContacts,
+          alreadyImportedAccountUuids: alreadyImportedAccounts,
+          alreadyImportedContactIds: alreadyImportedContacts,
           scanResetToken: state.scanResetToken,
         );
         return true;
@@ -192,7 +266,7 @@ class MobileWalletLinkController extends Notifier<MobileWalletLinkState> {
     final account = state.accounts
         .where((item) => item.uuid == uuid)
         .firstOrNull;
-    if (account == null || !account.isImportable) return;
+    if (account == null || !state.isAccountSelectable(account)) return;
 
     final selected = {...state.selectedAccountUuids};
     if (!selected.remove(uuid)) {
@@ -205,7 +279,7 @@ class MobileWalletLinkController extends Notifier<MobileWalletLinkState> {
     state = state.copyWith(
       selectedAccountUuids: {
         for (final account in state.accounts)
-          if (account.isImportable) account.uuid,
+          if (state.isAccountSelectable(account)) account.uuid,
       },
     );
   }
@@ -215,6 +289,9 @@ class MobileWalletLinkController extends Notifier<MobileWalletLinkState> {
   }
 
   void toggleContact(String id) {
+    final contact = state.contacts.where((item) => item.id == id).firstOrNull;
+    if (contact == null || !state.isContactSelectable(contact)) return;
+
     final selected = {...state.selectedContactIds};
     if (!selected.remove(id)) {
       selected.add(id);
@@ -224,7 +301,10 @@ class MobileWalletLinkController extends Notifier<MobileWalletLinkState> {
 
   void selectAllContacts() {
     state = state.copyWith(
-      selectedContactIds: {for (final contact in state.contacts) contact.id},
+      selectedContactIds: {
+        for (final contact in state.contacts)
+          if (state.isContactSelectable(contact)) contact.id,
+      },
     );
   }
 
@@ -267,6 +347,52 @@ class MobileWalletLinkController extends Notifier<MobileWalletLinkState> {
       throw const FormatException('Wallet link payload is invalid.');
     }
     return payload;
+  }
+
+  Future<Set<String>> _alreadyImportedAccountUuids(
+    WalletLinkTransferPayload payload,
+  ) async {
+    final accountsToCheck = <LinkedWalletAccountImport>[];
+    for (final account in payload.importableAccounts) {
+      try {
+        accountsToCheck.add(account.toAccountImport());
+      } catch (error, stackTrace) {
+        log(
+          'MobileWalletLink.handleQrCode: account preflight skipped '
+          '"${account.displayName}": $error\n$stackTrace',
+        );
+      }
+    }
+    try {
+      return await ref
+          .read(accountProvider.notifier)
+          .alreadyImportedWalletLinkSourceAccountUuids(
+            network: payload.network,
+            accountsToCheck: accountsToCheck,
+          );
+    } catch (error, stackTrace) {
+      log(
+        'MobileWalletLink.handleQrCode: account preflight failed: '
+        '$error\n$stackTrace',
+      );
+      return const <String>{};
+    }
+  }
+
+  Future<Set<String>> _alreadyImportedContactIds(
+    WalletLinkTransferPayload payload,
+  ) async {
+    try {
+      return await ref
+          .read(addressBookProvider.notifier)
+          .alreadyImportedContactIds(payload.contacts);
+    } catch (error, stackTrace) {
+      log(
+        'MobileWalletLink.handleQrCode: contact preflight failed: '
+        '$error\n$stackTrace',
+      );
+      return const <String>{};
+    }
   }
 }
 

--- a/lib/src/features/wallet_link/providers/mobile_wallet_link_provider.dart
+++ b/lib/src/features/wallet_link/providers/mobile_wallet_link_provider.dart
@@ -27,6 +27,7 @@ class MobileWalletLinkState {
     this.selectedContactIds = const <String>{},
     this.scanError,
     this.loading = false,
+    this.submitting = false,
     this.scanResetToken = 0,
   });
 
@@ -40,6 +41,7 @@ class MobileWalletLinkState {
   final Set<String> selectedContactIds;
   final MobileWalletLinkScanError? scanError;
   final bool loading;
+  final bool submitting;
   final int scanResetToken;
 
   List<WalletLinkTransferAccount> get accounts =>
@@ -77,6 +79,7 @@ class MobileWalletLinkState {
     MobileWalletLinkScanError? scanError,
     bool clearScanError = false,
     bool? loading,
+    bool? submitting,
     int? scanResetToken,
   }) {
     return MobileWalletLinkState(
@@ -90,6 +93,7 @@ class MobileWalletLinkState {
       selectedContactIds: selectedContactIds ?? this.selectedContactIds,
       scanError: clearScanError ? null : scanError ?? this.scanError,
       loading: loading ?? this.loading,
+      submitting: submitting ?? this.submitting,
       scanResetToken: scanResetToken ?? this.scanResetToken,
     );
   }
@@ -172,6 +176,16 @@ class MobileWalletLinkController extends Notifier<MobileWalletLinkState> {
 
   void reset() {
     state = MobileWalletLinkState(scanResetToken: state.scanResetToken + 1);
+  }
+
+  void beginSubmit() {
+    if (state.submitting) return;
+    state = state.copyWith(submitting: true);
+  }
+
+  void endSubmit() {
+    if (!state.submitting) return;
+    state = state.copyWith(submitting: false);
   }
 
   void toggleAccount(String uuid) {

--- a/lib/src/providers/account_models.dart
+++ b/lib/src/providers/account_models.dart
@@ -7,6 +7,7 @@ class AccountInfo {
   final bool isHardware;
   final bool isSeedAnchor;
   final String profilePictureId;
+  final String? walletLinkSourceAccountUuid;
 
   const AccountInfo({
     required this.uuid,
@@ -15,6 +16,7 @@ class AccountInfo {
     this.isHardware = false,
     this.isSeedAnchor = false,
     this.profilePictureId = kDefaultProfilePictureId,
+    this.walletLinkSourceAccountUuid,
   });
 
   AccountInfo copyWith({
@@ -22,6 +24,7 @@ class AccountInfo {
     int? order,
     bool? isSeedAnchor,
     String? profilePictureId,
+    String? walletLinkSourceAccountUuid,
   }) => AccountInfo(
     uuid: uuid,
     name: name ?? this.name,
@@ -29,6 +32,8 @@ class AccountInfo {
     isHardware: isHardware,
     isSeedAnchor: isSeedAnchor ?? this.isSeedAnchor,
     profilePictureId: profilePictureId ?? this.profilePictureId,
+    walletLinkSourceAccountUuid:
+        walletLinkSourceAccountUuid ?? this.walletLinkSourceAccountUuid,
   );
 
   Map<String, dynamic> toJson() => {
@@ -38,6 +43,7 @@ class AccountInfo {
     'isHardware': isHardware,
     'isSeedAnchor': isSeedAnchor,
     'profilePictureId': profilePictureId,
+    'walletLinkSourceAccountUuid': walletLinkSourceAccountUuid,
   };
 
   factory AccountInfo.fromJson(Map<String, dynamic> json) => AccountInfo(
@@ -55,7 +61,16 @@ class AccountInfo {
     profilePictureId: normalizeProfilePictureId(
       json['profilePictureId'] as String? ?? kDefaultProfilePictureId,
     ),
+    walletLinkSourceAccountUuid: _normalizedOptionalString(
+      json['walletLinkSourceAccountUuid'],
+    ),
   );
+}
+
+String? _normalizedOptionalString(Object? value) {
+  if (value is! String) return null;
+  final normalized = value.trim();
+  return normalized.isEmpty ? null : normalized;
 }
 
 class AccountState {

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -73,6 +73,7 @@ class LinkedWalletAccountImport {
     this.ufvk,
     this.seedFingerprint,
     this.profilePictureId,
+    this.sourceAccountUuid,
   });
 
   final String name;
@@ -84,6 +85,7 @@ class LinkedWalletAccountImport {
   final String? ufvk;
   final List<int>? seedFingerprint;
   final String? profilePictureId;
+  final String? sourceAccountUuid;
 }
 
 class LinkedWalletAccountsImportResult {
@@ -811,24 +813,10 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
 
     try {
       final prev = state.value ?? const AccountState();
-      final normalizedNetwork = normalizeZcashNetworkName(network);
-      if (prev.accounts.isEmpty) {
-        final currentNetwork = normalizeZcashNetworkName(
-          ref.read(rpcEndpointProvider).networkName,
-        );
-        if (currentNetwork != normalizedNetwork) {
-          throw StateError(
-            'Linked wallet network does not match the current app network.',
-          );
-        }
-      } else {
-        final storedNetwork = await _getNetwork();
-        if (storedNetwork != normalizedNetwork) {
-          throw StateError(
-            'Linked wallet network does not match the current wallet.',
-          );
-        }
-      }
+      final normalizedNetwork = await _validateLinkedWalletNetwork(
+        network: network,
+        current: prev,
+      );
 
       final dbPath = await _getDbPath();
       if (prev.accounts.isEmpty) {
@@ -905,6 +893,9 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
             profilePictureId: normalizeProfilePictureId(
               input.profilePictureId ?? kDefaultProfilePictureId,
             ),
+            walletLinkSourceAccountUuid: _normalizedOptionalString(
+              input.sourceAccountUuid,
+            ),
           ),
         );
         nextOrder += 1;
@@ -942,6 +933,66 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       log('importLinkedWalletAccounts: ERROR: $e\n$st');
       rethrow;
     }
+  }
+
+  Future<void> validateLinkedWalletNetwork(String network) async {
+    final current = state.value ?? await future;
+    await _validateLinkedWalletNetwork(network: network, current: current);
+  }
+
+  Future<Set<String>> alreadyImportedWalletLinkSourceAccountUuids({
+    required String network,
+    required Iterable<LinkedWalletAccountImport> accountsToCheck,
+  }) async {
+    final inputs = accountsToCheck.toList(growable: false);
+    if (inputs.isEmpty) return const <String>{};
+
+    final prev = await future;
+    if (prev.accounts.isEmpty) return const <String>{};
+
+    final normalizedNetwork = normalizeZcashNetworkName(network);
+    final storedNetwork = await _getNetwork();
+    if (storedNetwork != normalizedNetwork) return const <String>{};
+
+    final importedSourceUuids = <String>{};
+    for (final account in prev.accounts) {
+      final sourceUuid = _normalizedOptionalString(
+        account.walletLinkSourceAccountUuid,
+      );
+      if (sourceUuid != null) importedSourceUuids.add(sourceUuid);
+    }
+    final alreadyImported = <String>{};
+    final dbPath = await _getDbPath();
+
+    for (final input in inputs) {
+      final sourceUuid = _normalizedOptionalString(input.sourceAccountUuid);
+      if (sourceUuid == null) continue;
+      if (importedSourceUuids.contains(sourceUuid)) {
+        alreadyImported.add(sourceUuid);
+        continue;
+      }
+      if (input.isHardware) continue;
+
+      final mnemonic = input.mnemonic?.trim();
+      if (mnemonic == null || mnemonic.isEmpty) continue;
+      try {
+        final isImported = await rust_wallet
+            .isSoftwareWalletLinkAccountImported(
+              mnemonic: mnemonic,
+              network: normalizedNetwork,
+              dbPath: dbPath,
+              zip32AccountIndex: input.zip32AccountIndex,
+            );
+        if (isImported) alreadyImported.add(sourceUuid);
+      } catch (error, stackTrace) {
+        log(
+          'alreadyImportedWalletLinkSourceAccountUuids: '
+          'software preflight failed for "${input.name}": $error\n$stackTrace',
+        );
+      }
+    }
+
+    return alreadyImported;
   }
 
   /// Check if the active account is a hardware wallet account.
@@ -1040,6 +1091,31 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
     );
   }
 
+  Future<String> _validateLinkedWalletNetwork({
+    required String network,
+    required AccountState current,
+  }) async {
+    final normalizedNetwork = normalizeZcashNetworkName(network);
+    if (current.accounts.isEmpty) {
+      final currentNetwork = normalizeZcashNetworkName(
+        ref.read(rpcEndpointProvider).networkName,
+      );
+      if (currentNetwork != normalizedNetwork) {
+        throw StateError(
+          'Linked wallet network does not match the current app network.',
+        );
+      }
+    } else {
+      final storedNetwork = await _getNetwork();
+      if (storedNetwork != normalizedNetwork) {
+        throw StateError(
+          'Linked wallet network does not match the current wallet.',
+        );
+      }
+    }
+    return normalizedNetwork;
+  }
+
   Future<void> _deleteExistingDb(String dbPath) async {
     for (final path in walletDbCleanupPaths(dbPath)) {
       final file = File(path);
@@ -1057,6 +1133,11 @@ bool isWalletLinkDuplicateImportError(Object error) {
       message == _duplicateKeystoneAccountImportMessage ||
       (message.contains('account corresponding to the data provided') &&
           message.contains('already exists in the wallet'));
+}
+
+String? _normalizedOptionalString(String? value) {
+  final normalized = value?.trim();
+  return normalized == null || normalized.isEmpty ? null : normalized;
 }
 
 String _normalizedExceptionMessage(Object error) {

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -150,6 +150,18 @@ Future<SoftwareWalletImportAccount> importSoftwareAccountAtIndex({
   isFirstWalletAccount: isFirstWalletAccount,
 );
 
+Future<bool> isSoftwareWalletLinkAccountImported({
+  required String mnemonic,
+  required String network,
+  required String dbPath,
+  required int zip32AccountIndex,
+}) => RustLib.instance.api.crateApiWalletIsSoftwareWalletLinkAccountImported(
+  mnemonic: mnemonic,
+  network: network,
+  dbPath: dbPath,
+  zip32AccountIndex: zip32AccountIndex,
+);
+
 /// Import a hardware wallet account using a UFVK (no mnemonic/seed needed).
 Future<AccountCreationResult> importHardwareAccount({
   required String dbPath,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 656298356;
+  int get rustContentHash => -30850900;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -530,6 +530,13 @@ abstract class RustLibApi extends BaseApi {
   });
 
   bool crateApiSyncIsMempoolObserverRunning();
+
+  Future<bool> crateApiWalletIsSoftwareWalletLinkAccountImported({
+    required String mnemonic,
+    required String network,
+    required String dbPath,
+    required int zip32AccountIndex,
+  });
 
   bool crateApiSyncIsSyncCancelRequested();
 
@@ -3709,12 +3716,52 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  Future<bool> crateApiWalletIsSoftwareWalletLinkAccountImported({
+    required String mnemonic,
+    required String network,
+    required String dbPath,
+    required int zip32AccountIndex,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(mnemonic, serializer);
+          sse_encode_String(network, serializer);
+          sse_encode_String(dbPath, serializer);
+          sse_encode_u_32(zip32AccountIndex, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 72,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_bool,
+          decodeErrorData: sse_decode_String,
+        ),
+        constMeta: kCrateApiWalletIsSoftwareWalletLinkAccountImportedConstMeta,
+        argValues: [mnemonic, network, dbPath, zip32AccountIndex],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiWalletIsSoftwareWalletLinkAccountImportedConstMeta =>
+      const TaskConstMeta(
+        debugName: "is_software_wallet_link_account_imported",
+        argNames: ["mnemonic", "network", "dbPath", "zip32AccountIndex"],
+      );
+
+  @override
   bool crateApiSyncIsSyncCancelRequested() {
     return handler.executeSync(
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 72)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3736,7 +3783,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 73)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_bool,
@@ -3763,7 +3810,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_u_64(ceremonyStartSeconds, serializer);
           sse_encode_u_64(voteEndTimeSeconds, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 74)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 75)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_opt_box_autoadd_u_64,
@@ -3796,7 +3843,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 76,
             port: port_,
           );
         },
@@ -3836,7 +3883,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 77,
             port: port_,
           );
         },
@@ -3879,7 +3926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 78,
             port: port_,
           );
         },
@@ -3936,7 +3983,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 79,
             port: port_,
           );
         },
@@ -3977,7 +4024,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 79)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 80)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_String,
@@ -4007,7 +4054,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 80,
+            funcId: 81,
             port: port_,
           );
         },
@@ -4042,7 +4089,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 82,
             port: port_,
           );
         },
@@ -4085,7 +4132,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 83,
             port: port_,
           );
         },
@@ -4139,7 +4186,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 84,
             port: port_,
           );
         },
@@ -4178,7 +4225,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 84,
+            funcId: 85,
             port: port_,
           );
         },
@@ -4230,7 +4277,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 85,
+            funcId: 86,
             port: port_,
           );
         },
@@ -4288,7 +4335,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 86,
+            funcId: 87,
             port: port_,
           );
         },
@@ -4349,7 +4396,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 88,
             port: port_,
           );
         },
@@ -4408,7 +4455,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 89,
             port: port_,
           );
         },
@@ -4455,7 +4502,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 90,
             port: port_,
           );
         },
@@ -4500,7 +4547,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4527,7 +4574,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4559,7 +4606,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -4596,7 +4643,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 94,
             port: port_,
           );
         },
@@ -4631,7 +4678,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 95,
             port: port_,
           );
         },
@@ -4673,7 +4720,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 96,
             port: port_,
           );
         },
@@ -4710,7 +4757,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -4748,7 +4795,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 98,
             port: port_,
           );
         },
@@ -4801,7 +4848,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 99,
             port: port_,
           );
         },
@@ -4869,7 +4916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 100,
             port: port_,
           );
         },
@@ -4916,7 +4963,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 101,
           )!;
         },
         codec: SseCodec(
@@ -4951,7 +4998,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 102,
             port: port_,
           );
         },
@@ -4984,7 +5031,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 103,
             port: port_,
           );
         },
@@ -5024,7 +5071,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 104,
             port: port_,
           );
         },
@@ -5065,7 +5112,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 105,
             port: port_,
           );
         },
@@ -5119,7 +5166,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 106,
             port: port_,
           );
         },
@@ -5169,7 +5216,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 106,
+              funcId: 107,
               port: port_,
             );
           },
@@ -5210,7 +5257,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 107,
+              funcId: 108,
               port: port_,
             );
           },
@@ -5242,7 +5289,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 109,
           )!;
         },
         codec: SseCodec(
@@ -5283,7 +5330,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
             port: port_,
           );
         },
@@ -5334,7 +5381,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5373,7 +5420,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5416,7 +5463,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
             port: port_,
           );
         },
@@ -5466,7 +5513,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
             port: port_,
           );
         },
@@ -5498,7 +5545,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },
@@ -5526,7 +5573,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
           )!;
         },
         codec: SseCodec(
@@ -5558,7 +5605,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
             port: port_,
           );
         },
@@ -5595,7 +5642,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 118,
             port: port_,
           );
         },
@@ -5626,7 +5673,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 119,
           )!;
         },
         codec: SseCodec(
@@ -5657,7 +5704,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 120,
             port: port_,
           );
         },

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -415,6 +415,24 @@ pub fn import_software_account_at_index(
     })
 }
 
+pub fn is_software_wallet_link_account_imported(
+    mnemonic: String,
+    network: String,
+    db_path: String,
+    zip32_account_index: u32,
+) -> Result<bool, String> {
+    catch(|| {
+        if !keys::wallet_exists(&db_path) {
+            return Ok(false);
+        }
+        let network = parse_network_and_migrate(&db_path, &network)?;
+        let seed = keys::mnemonic_to_seed(&mnemonic)?;
+        let existing_seed_accounts =
+            keys::existing_software_seed_account_state(&db_path, network, &seed)?;
+        Ok(existing_seed_accounts.contains(zip32_account_index))
+    })
+}
+
 fn import_discovered_software_wallet_accounts(
     network: WalletNetwork,
     db_path: &str,
@@ -1010,5 +1028,38 @@ mod tests {
         };
 
         assert_eq!(error, keys::DUPLICATE_SOFTWARE_ACCOUNT_MESSAGE);
+    }
+
+    #[test]
+    fn test_software_wallet_link_imported_preflight_matches_existing_index() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let db_path = temp_dir.path().join("wallet.db");
+        let db_path_str = db_path.to_str().unwrap();
+        let mnemonic = keys::generate_mnemonic();
+        let seed = keys::mnemonic_to_seed(&mnemonic).unwrap();
+
+        keys::init_db_and_create_account(
+            db_path_str,
+            WalletNetwork::Main,
+            &seed,
+            None,
+            "Account 1",
+        )
+        .unwrap();
+
+        assert!(is_software_wallet_link_account_imported(
+            mnemonic.clone(),
+            "main".to_string(),
+            db_path_str.to_string(),
+            0,
+        )
+        .unwrap());
+        assert!(!is_software_wallet_link_account_imported(
+            mnemonic,
+            "main".to_string(),
+            db_path_str.to_string(),
+            1,
+        )
+        .unwrap());
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 656298356;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -30850900;
 
 // Section: executor
 
@@ -2773,6 +2773,47 @@ fn wire__crate__api__sync__is_mempool_observer_running_impl(
                     Result::<_, ()>::Ok(crate::api::sync::is_mempool_observer_running())?;
                 Ok(output_ok)
             })())
+        },
+    )
+}
+fn wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "is_software_wallet_link_account_imported",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_mnemonic = <String>::sse_decode(&mut deserializer);
+            let api_network = <String>::sse_decode(&mut deserializer);
+            let api_db_path = <String>::sse_decode(&mut deserializer);
+            let api_zip32_account_index = <u32>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, String>((move || {
+                    let output_ok = crate::api::wallet::is_software_wallet_link_account_imported(
+                        api_mnemonic,
+                        api_network,
+                        api_db_path,
+                        api_zip32_account_index,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
         },
     )
 }
@@ -7021,45 +7062,46 @@ fn pde_ffi_dispatcher_primary_impl(
 67 => wire__crate__api__wallet__import_software_wallet_with_account_discovery_impl(port, ptr, rust_vec_len, data_len),
 68 => wire__crate__api__wallet__import_wallet_impl(port, ptr, rust_vec_len, data_len),
 69 => wire__crate__api__simple__init_app_impl(port, ptr, rust_vec_len, data_len),
-75 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
-76 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
-77 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
-78 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
-80 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
-81 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
-82 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
-83 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
-84 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-85 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
-86 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-87 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-90 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-92 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-93 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-94 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-95 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-97 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-99 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-101 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-103 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-104 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-105 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-106 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-107 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-109 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-116 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-117 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-119 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+72 => wire__crate__api__wallet__is_software_wallet_link_account_imported_impl(port, ptr, rust_vec_len, data_len),
+76 => wire__crate__api__wallet__list_accounts_impl(port, ptr, rust_vec_len, data_len),
+77 => wire__crate__api__voting__mark_delegation_submitted_impl(port, ptr, rust_vec_len, data_len),
+78 => wire__crate__api__voting__mark_share_confirmed_impl(port, ptr, rust_vec_len, data_len),
+79 => wire__crate__api__voting__mark_vote_submitted_impl(port, ptr, rust_vec_len, data_len),
+81 => wire__crate__api__voting__next_share_tracking_delay_seconds_impl(port, ptr, rust_vec_len, data_len),
+82 => wire__crate__api__voting__parse_signed_voting_pczt_impl(port, ptr, rust_vec_len, data_len),
+83 => wire__crate__api__voting__plan_share_submissions_impl(port, ptr, rust_vec_len, data_len),
+84 => wire__crate__api__voting__precompute_delegation_pir_impl(port, ptr, rust_vec_len, data_len),
+85 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+86 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
+87 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
+88 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+93 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+96 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+99 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+102 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+104 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+105 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+106 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+107 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+108 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+110 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+117 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+118 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+120 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -7080,17 +7122,17 @@ fn pde_ffi_dispatcher_sync_impl(
         64 => wire__crate__api__simple__greet_impl(ptr, rust_vec_len, data_len),
         70 => wire__crate__api__voting__is_last_moment_impl(ptr, rust_vec_len, data_len),
         71 => wire__crate__api__sync__is_mempool_observer_running_impl(ptr, rust_vec_len, data_len),
-        72 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
-        73 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
-        74 => {
+        73 => wire__crate__api__sync__is_sync_cancel_requested_impl(ptr, rust_vec_len, data_len),
+        74 => wire__crate__api__sync__is_sync_running_impl(ptr, rust_vec_len, data_len),
+        75 => {
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
-        79 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        91 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        100 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        108 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        115 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        118 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        80 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        101 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        109 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        116 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        119 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -14,6 +14,20 @@ void main() {
     expect(account.profilePictureId, 'pfp-03');
   });
 
+  test('AccountInfo.fromJson keeps wallet link source account uuid', () {
+    final account = AccountInfo.fromJson({
+      'uuid': 'account-1',
+      'name': 'Linked',
+      'order': 0,
+      'walletLinkSourceAccountUuid': ' 550e8400-e29b-41d4-a716-446655440000 ',
+    });
+
+    expect(
+      account.walletLinkSourceAccountUuid,
+      '550e8400-e29b-41d4-a716-446655440000',
+    );
+  });
+
   test('mergeBootstrappedAccountInfo keeps stored UI metadata', () {
     const rustAccount = AccountInfo(
       uuid: 'account-1',
@@ -28,6 +42,7 @@ void main() {
       isHardware: true,
       isSeedAnchor: false,
       profilePictureId: 'pfp-04',
+      walletLinkSourceAccountUuid: 'desktop-account-1',
     );
 
     final merged = mergeBootstrappedAccountInfo(
@@ -42,6 +57,7 @@ void main() {
     expect(merged.isHardware, isTrue);
     expect(merged.isSeedAnchor, isTrue);
     expect(merged.profilePictureId, 'pfp-04');
+    expect(merged.walletLinkSourceAccountUuid, 'desktop-account-1');
   });
 
   test(

--- a/test/features/address_book/address_book_provider_test.dart
+++ b/test/features/address_book/address_book_provider_test.dart
@@ -287,6 +287,41 @@ void main() {
       expect(repo.savedLists, hasLength(1));
     },
   );
+
+  test('alreadyImportedContactIds uses the import dedupe key', () async {
+    const evmAddress = '0xAbC0000000000000000000000000000000000123';
+    final repo = _FakeAddressBookRepository([
+      _contact(
+        id: 'eth-existing',
+        label: 'ETH existing',
+        network: AddressBookNetwork.ethereum,
+        address: evmAddress,
+      ),
+    ]);
+    final container = _container(repo);
+    addTearDown(container.dispose);
+
+    await container.read(addressBookProvider.future);
+
+    final alreadyImported = await container
+        .read(addressBookProvider.notifier)
+        .alreadyImportedContactIds([
+          _contact(
+            id: 'eth-duplicate',
+            label: 'ETH duplicate',
+            network: AddressBookNetwork.ethereum,
+            address: evmAddress.toLowerCase(),
+          ),
+          _contact(
+            id: 'near-new',
+            label: 'NEAR new',
+            network: AddressBookNetwork.near,
+            address: 'alice.near',
+          ),
+        ]);
+
+    expect(alreadyImported, {'eth-duplicate'});
+  });
 }
 
 ProviderContainer _container(AddressBookRepository repo) {

--- a/test/features/onboarding/mobile_wallet_link_screens_test.dart
+++ b/test/features/onboarding/mobile_wallet_link_screens_test.dart
@@ -51,6 +51,10 @@ Widget _routerApp(
   final router = GoRouter(
     routes: [
       GoRoute(path: '/', builder: (_, _) => child),
+      GoRoute(
+        path: '/onboarding/link-desktop',
+        builder: (_, _) => const Text('link intro route'),
+      ),
       GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
     ],
   );
@@ -210,6 +214,48 @@ MobileWalletLinkState _alreadyImportedState() {
   );
 }
 
+MobileWalletLinkState _nothingToImportState() {
+  const importedAccount = WalletLinkTransferAccount(
+    uuid: 'imported-account',
+    name: 'Imported account',
+    order: 0,
+    isHardware: false,
+    isSeedAnchor: true,
+    hardwareKind: null,
+    profilePictureId: null,
+    birthdayHeight: 120000,
+    zip32AccountIndex: 0,
+    ufvk: null,
+    seedFingerprint: null,
+    mnemonic: 'abandon ability able about above absent absorb abstract',
+  );
+  const importedContact = AddressBookContact(
+    id: 'imported-contact',
+    label: 'Imported contact',
+    network: AddressBookNetwork.zcash,
+    address: 'u1importedcontactaddress',
+    profilePictureId: 'profile_1',
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  );
+  final payload = WalletLinkTransferPayload(
+    version: 1,
+    exportedAt: DateTime.utc(2026, 7, 8),
+    network: 'main',
+    activeAccountUuid: importedAccount.uuid,
+    accounts: const [importedAccount],
+    contacts: const [importedContact],
+  );
+  return MobileWalletLinkState(
+    payload: payload,
+    packageId: '550e8400-e29b-41d4-a716-446655440000',
+    completionToken: 'completion-token',
+    keyBytes: List<int>.filled(32, 1),
+    alreadyImportedAccountUuids: const {'imported-account'},
+    alreadyImportedContactIds: const {'imported-contact'},
+  );
+}
+
 bool _hasIcon(WidgetTester tester, String name) {
   return tester
       .widgetList<AppIcon>(find.byType(AppIcon))
@@ -326,6 +372,34 @@ void main() {
     await tester.pump();
 
     expect(find.text('Import 1 contact'), findsOneWidget);
+  });
+
+  testWidgets('empty wallet link shows go back without imported sections', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _routerApp(
+        const MobileWalletLinkSelectAccountsScreen(),
+        state: _nothingToImportState(),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Nothing to import'), findsOneWidget);
+    expect(
+      find.text('Everything in this desktop link is already on this phone.'),
+      findsOneWidget,
+    );
+    expect(find.text('Go back'), findsOneWidget);
+    expect(find.text('1 already imported'), findsNothing);
+    expect(find.text('Imported account'), findsNothing);
+    expect(find.text('Imported contact'), findsNothing);
+    expect(find.text('Continue'), findsNothing);
+
+    await tester.tap(find.text('Go back'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('link intro route'), findsOneWidget);
   });
 
   testWidgets('contacts-only import validates the wallet link network', (

--- a/test/features/onboarding/mobile_wallet_link_screens_test.dart
+++ b/test/features/onboarding/mobile_wallet_link_screens_test.dart
@@ -47,8 +47,11 @@ Widget _routerApp(
   Widget child, {
   required MobileWalletLinkState state,
   List<Override> overrides = const [],
+  String initialLocation = '/',
+  List<RouteBase> routes = const [],
 }) {
   final router = GoRouter(
+    initialLocation: initialLocation,
     routes: [
       GoRoute(path: '/', builder: (_, _) => child),
       GoRoute(
@@ -56,6 +59,7 @@ Widget _routerApp(
         builder: (_, _) => const Text('link intro route'),
       ),
       GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
+      ...routes,
     ],
   );
 
@@ -421,6 +425,52 @@ void main() {
 
     expect(find.text('link intro route'), findsOneWidget);
   });
+
+  testWidgets(
+    'empty wallet link completion exits when accounts route can pop',
+    (tester) async {
+      final completion = _RecordingWalletLinkCompletion();
+
+      await tester.pumpWidget(
+        _routerApp(
+          const Text('root route'),
+          state: _nothingToImportState(),
+          initialLocation: '/scan',
+          routes: [
+            GoRoute(
+              path: '/scan',
+              builder: (context, _) => TextButton(
+                onPressed: () =>
+                    context.push('/onboarding/link-desktop/accounts'),
+                child: const Text('open accounts'),
+              ),
+            ),
+            GoRoute(
+              path: '/onboarding/link-desktop/accounts',
+              builder: (_, _) => MobileWalletLinkSelectAccountsScreen(
+                completeWalletLinkPackage: completion.call,
+              ),
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      await tester.tap(find.text('open accounts'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Go back'));
+      await tester.pump();
+
+      expect(find.text('Importing...'), findsOneWidget);
+      expect(completion.calls, hasLength(1));
+
+      completion.complete();
+      await tester.pumpAndSettle();
+
+      expect(find.text('link intro route'), findsOneWidget);
+      expect(find.text('Importing...'), findsNothing);
+    },
+  );
 
   testWidgets('contacts-only import validates the wallet link network', (
     tester,

--- a/test/features/onboarding/mobile_wallet_link_screens_test.dart
+++ b/test/features/onboarding/mobile_wallet_link_screens_test.dart
@@ -287,7 +287,9 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.text('Account already imported'), findsOneWidget);
+    expect(find.text('1 account found'), findsOneWidget);
+    expect(find.text('1 already imported'), findsOneWidget);
+    expect(find.text('Account already imported'), findsNothing);
     expect(find.text('Link 1 account'), findsOneWidget);
     expect(
       tester.getTopLeft(find.text('Fresh account')).dy,
@@ -311,7 +313,9 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.text('Contact already imported'), findsOneWidget);
+    expect(find.text('1 contact found'), findsOneWidget);
+    expect(find.text('1 already imported'), findsOneWidget);
+    expect(find.text('Contact already imported'), findsNothing);
     expect(find.text('Import 1 contact'), findsOneWidget);
     expect(
       tester.getTopLeft(find.text('Fresh contact')).dy,

--- a/test/features/onboarding/mobile_wallet_link_screens_test.dart
+++ b/test/features/onboarding/mobile_wallet_link_screens_test.dart
@@ -1,15 +1,23 @@
 @Tags(['mobile'])
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
+import 'package:zcash_wallet/src/features/address_book/providers/address_book_provider.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_wallet_link_screens.dart';
 import 'package:zcash_wallet/src/features/wallet_link/models/wallet_link_models.dart';
 import 'package:zcash_wallet/src/features/wallet_link/providers/mobile_wallet_link_provider.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 
 class _WalletLinkController extends MobileWalletLinkController {
   _WalletLinkController(this.initialState);
@@ -23,6 +31,7 @@ class _WalletLinkController extends MobileWalletLinkController {
 Widget _app(Widget child, {required MobileWalletLinkState state}) {
   return ProviderScope(
     overrides: [
+      appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
       mobileWalletLinkControllerProvider.overrideWith(
         () => _WalletLinkController(state),
       ),
@@ -30,6 +39,33 @@ Widget _app(Widget child, {required MobileWalletLinkState state}) {
     child: MaterialApp(
       builder: (_, c) => AppTheme(data: AppThemeData.light, child: c!),
       home: child,
+    ),
+  );
+}
+
+Widget _routerApp(
+  Widget child, {
+  required MobileWalletLinkState state,
+  List<Override> overrides = const [],
+}) {
+  final router = GoRouter(
+    routes: [
+      GoRoute(path: '/', builder: (_, _) => child),
+      GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(AppBootstrapState.empty),
+      mobileWalletLinkControllerProvider.overrideWith(
+        () => _WalletLinkController(state),
+      ),
+      ...overrides,
+    ],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, c) => AppTheme(data: AppThemeData.light, child: c!),
     ),
   );
 }
@@ -77,6 +113,100 @@ MobileWalletLinkState _state({
     selectedAccountUuids: const {'software-account'},
     selectedContactIds: contacts ? const {'contact-1'} : const {},
     submitting: submitting,
+  );
+}
+
+MobileWalletLinkState _contactsOnlyState() {
+  const contact = AddressBookContact(
+    id: 'contact-1',
+    label: 'Desktop contact',
+    network: AddressBookNetwork.zcash,
+    address: 'u1desktopcontactaddress',
+    profilePictureId: 'profile_1',
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  );
+  final payload = WalletLinkTransferPayload(
+    version: 1,
+    exportedAt: DateTime.utc(2026, 7, 8),
+    network: 'test',
+    activeAccountUuid: null,
+    accounts: const [],
+    contacts: const [contact],
+  );
+  return MobileWalletLinkState(
+    payload: payload,
+    packageId: '550e8400-e29b-41d4-a716-446655440000',
+    completionToken: 'completion-token',
+    keyBytes: List<int>.filled(32, 1),
+    selectedContactIds: const {'contact-1'},
+  );
+}
+
+MobileWalletLinkState _alreadyImportedState() {
+  const importedAccount = WalletLinkTransferAccount(
+    uuid: 'imported-account',
+    name: 'Imported account',
+    order: 0,
+    isHardware: false,
+    isSeedAnchor: true,
+    hardwareKind: null,
+    profilePictureId: null,
+    birthdayHeight: 120000,
+    zip32AccountIndex: 0,
+    ufvk: null,
+    seedFingerprint: null,
+    mnemonic: 'abandon ability able about above absent absorb abstract',
+  );
+  const freshAccount = WalletLinkTransferAccount(
+    uuid: 'fresh-account',
+    name: 'Fresh account',
+    order: 1,
+    isHardware: false,
+    isSeedAnchor: false,
+    hardwareKind: null,
+    profilePictureId: null,
+    birthdayHeight: 120000,
+    zip32AccountIndex: 1,
+    ufvk: null,
+    seedFingerprint: null,
+    mnemonic: 'abandon ability able about above absent absorb abstract',
+  );
+  const importedContact = AddressBookContact(
+    id: 'imported-contact',
+    label: 'Imported contact',
+    network: AddressBookNetwork.zcash,
+    address: 'u1importedcontactaddress',
+    profilePictureId: 'profile_1',
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  );
+  const freshContact = AddressBookContact(
+    id: 'fresh-contact',
+    label: 'Fresh contact',
+    network: AddressBookNetwork.zcash,
+    address: 'u1freshcontactaddress',
+    profilePictureId: 'profile_2',
+    createdAtMs: 2,
+    updatedAtMs: 2,
+  );
+  final payload = WalletLinkTransferPayload(
+    version: 1,
+    exportedAt: DateTime.utc(2026, 7, 8),
+    network: 'main',
+    activeAccountUuid: importedAccount.uuid,
+    accounts: const [importedAccount, freshAccount],
+    contacts: const [importedContact, freshContact],
+  );
+  return MobileWalletLinkState(
+    payload: payload,
+    packageId: '550e8400-e29b-41d4-a716-446655440000',
+    completionToken: 'completion-token',
+    keyBytes: List<int>.filled(32, 1),
+    selectedAccountUuids: const {'fresh-account'},
+    selectedContactIds: const {'fresh-contact'},
+    alreadyImportedAccountUuids: const {'imported-account'},
+    alreadyImportedContactIds: const {'imported-contact'},
   );
 }
 
@@ -145,4 +275,132 @@ void main() {
     expect(find.text('Deselect all'), findsOneWidget);
     expect(find.text('Select all'), findsNothing);
   });
+
+  testWidgets('already imported accounts are disabled and sorted last', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        const MobileWalletLinkSelectAccountsScreen(),
+        state: _alreadyImportedState(),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Account already imported'), findsOneWidget);
+    expect(find.text('Link 1 account'), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.text('Fresh account')).dy,
+      lessThan(tester.getTopLeft(find.text('Imported account')).dy),
+    );
+
+    await tester.tap(find.text('Imported account'));
+    await tester.pump();
+
+    expect(find.text('Link 1 account'), findsOneWidget);
+  });
+
+  testWidgets('already imported contacts are disabled and sorted last', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        const MobileWalletLinkSelectContactsScreen(),
+        state: _alreadyImportedState(),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Contact already imported'), findsOneWidget);
+    expect(find.text('Import 1 contact'), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.text('Fresh contact')).dy,
+      lessThan(tester.getTopLeft(find.text('Imported contact')).dy),
+    );
+
+    await tester.tap(find.text('Imported contact'));
+    await tester.pump();
+
+    expect(find.text('Import 1 contact'), findsOneWidget);
+  });
+
+  testWidgets('contacts-only import validates the wallet link network', (
+    tester,
+  ) async {
+    final accountNotifier = _ValidatingAccountNotifier(
+      validationError: StateError(
+        'Linked wallet network does not match the current wallet.',
+      ),
+    );
+    final addressBookNotifier = _RecordingAddressBookNotifier();
+
+    await tester.pumpWidget(
+      _routerApp(
+        const MobileWalletLinkSelectContactsScreen(),
+        state: _contactsOnlyState(),
+        overrides: [
+          accountProvider.overrideWith(() => accountNotifier),
+          addressBookProvider.overrideWith(() => addressBookNotifier),
+          appSecurityProvider.overrideWith(_ConfiguredSecurityNotifier.new),
+        ],
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.text('Import 1 contact'));
+    await tester.pumpAndSettle();
+
+    expect(accountNotifier.validatedNetworks, ['test']);
+    expect(addressBookNotifier.importCalls, 0);
+    expect(
+      find.textContaining('Linked wallet network does not match'),
+      findsOneWidget,
+    );
+    expect(find.text('home route'), findsNothing);
+  });
+}
+
+class _ValidatingAccountNotifier extends AccountNotifier {
+  _ValidatingAccountNotifier({this.validationError});
+
+  final Object? validationError;
+  final validatedNetworks = <String>[];
+
+  @override
+  FutureOr<AccountState> build() => const AccountState();
+
+  @override
+  Future<void> validateLinkedWalletNetwork(String network) async {
+    validatedNetworks.add(network);
+    final error = validationError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<LinkedWalletAccountsImportResult> importLinkedWalletAccounts({
+    required String network,
+    required List<LinkedWalletAccountImport> accountsToImport,
+  }) async {
+    throw StateError('Account import should not run for contacts-only import.');
+  }
+}
+
+class _RecordingAddressBookNotifier extends AddressBookNotifier {
+  int importCalls = 0;
+
+  @override
+  FutureOr<AddressBookState> build() => const AddressBookState();
+
+  @override
+  Future<int> importContacts(Iterable<AddressBookContact> imported) async {
+    importCalls += 1;
+    return imported.length;
+  }
+}
+
+class _ConfiguredSecurityNotifier extends AppSecurityNotifier {
+  @override
+  AppSecurityState build() {
+    return const AppSecurityState(isPasswordConfigured: true, isUnlocked: true);
+  }
 }

--- a/test/features/onboarding/mobile_wallet_link_screens_test.dart
+++ b/test/features/onboarding/mobile_wallet_link_screens_test.dart
@@ -377,9 +377,13 @@ void main() {
   testWidgets('empty wallet link shows go back without imported sections', (
     tester,
   ) async {
+    final completion = _RecordingWalletLinkCompletion();
+
     await tester.pumpWidget(
       _routerApp(
-        const MobileWalletLinkSelectAccountsScreen(),
+        MobileWalletLinkSelectAccountsScreen(
+          completeWalletLinkPackage: completion.call,
+        ),
         state: _nothingToImportState(),
       ),
     );
@@ -397,6 +401,22 @@ void main() {
     expect(find.text('Continue'), findsNothing);
 
     await tester.tap(find.text('Go back'));
+    await tester.pump();
+
+    expect(find.text('Importing...'), findsOneWidget);
+    expect(completion.calls, hasLength(1));
+    expect(
+      completion.calls.single.packageId,
+      _nothingToImportState().packageId,
+    );
+    expect(
+      completion.calls.single.completionToken,
+      _nothingToImportState().completionToken,
+    );
+    expect(completion.calls.single.importedAccountCount, 0);
+    expect(completion.calls.single.importedContactCount, 0);
+
+    completion.complete();
     await tester.pumpAndSettle();
 
     expect(find.text('link intro route'), findsOneWidget);
@@ -474,6 +494,50 @@ class _RecordingAddressBookNotifier extends AddressBookNotifier {
     importCalls += 1;
     return imported.length;
   }
+}
+
+class _RecordingWalletLinkCompletion {
+  final _completer = Completer<void>();
+  final calls = <_WalletLinkCompletionCall>[];
+
+  Future<void> call({
+    required String packageId,
+    required String completionToken,
+    required List<int> keyBytes,
+    required int importedAccountCount,
+    required int importedContactCount,
+  }) {
+    calls.add(
+      _WalletLinkCompletionCall(
+        packageId: packageId,
+        completionToken: completionToken,
+        keyBytes: keyBytes,
+        importedAccountCount: importedAccountCount,
+        importedContactCount: importedContactCount,
+      ),
+    );
+    return _completer.future;
+  }
+
+  void complete() {
+    _completer.complete();
+  }
+}
+
+class _WalletLinkCompletionCall {
+  const _WalletLinkCompletionCall({
+    required this.packageId,
+    required this.completionToken,
+    required this.keyBytes,
+    required this.importedAccountCount,
+    required this.importedContactCount,
+  });
+
+  final String packageId;
+  final String completionToken;
+  final List<int> keyBytes;
+  final int importedAccountCount;
+  final int importedContactCount;
 }
 
 class _ConfiguredSecurityNotifier extends AppSecurityNotifier {

--- a/test/features/onboarding/mobile_wallet_link_screens_test.dart
+++ b/test/features/onboarding/mobile_wallet_link_screens_test.dart
@@ -1,0 +1,148 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_wallet_link_screens.dart';
+import 'package:zcash_wallet/src/features/wallet_link/models/wallet_link_models.dart';
+import 'package:zcash_wallet/src/features/wallet_link/providers/mobile_wallet_link_provider.dart';
+
+class _WalletLinkController extends MobileWalletLinkController {
+  _WalletLinkController(this.initialState);
+
+  final MobileWalletLinkState initialState;
+
+  @override
+  MobileWalletLinkState build() => initialState;
+}
+
+Widget _app(Widget child, {required MobileWalletLinkState state}) {
+  return ProviderScope(
+    overrides: [
+      mobileWalletLinkControllerProvider.overrideWith(
+        () => _WalletLinkController(state),
+      ),
+    ],
+    child: MaterialApp(
+      builder: (_, c) => AppTheme(data: AppThemeData.light, child: c!),
+      home: child,
+    ),
+  );
+}
+
+MobileWalletLinkState _state({
+  required bool submitting,
+  bool contacts = false,
+}) {
+  const account = WalletLinkTransferAccount(
+    uuid: 'software-account',
+    name: 'Desktop account',
+    order: 0,
+    isHardware: false,
+    isSeedAnchor: true,
+    hardwareKind: null,
+    profilePictureId: null,
+    birthdayHeight: 120000,
+    zip32AccountIndex: 0,
+    ufvk: null,
+    seedFingerprint: null,
+    mnemonic: 'abandon ability able about above absent absorb abstract',
+  );
+  const contact = AddressBookContact(
+    id: 'contact-1',
+    label: 'Desktop contact',
+    network: AddressBookNetwork.zcash,
+    address: 'u1desktopcontactaddress',
+    profilePictureId: 'profile_1',
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  );
+  final payload = WalletLinkTransferPayload(
+    version: 1,
+    exportedAt: DateTime.utc(2026, 7, 8),
+    network: 'main',
+    activeAccountUuid: account.uuid,
+    accounts: const [account],
+    contacts: contacts ? const [contact] : const [],
+  );
+  return MobileWalletLinkState(
+    payload: payload,
+    packageId: '550e8400-e29b-41d4-a716-446655440000',
+    completionToken: 'completion-token',
+    keyBytes: List<int>.filled(32, 1),
+    selectedAccountUuids: const {'software-account'},
+    selectedContactIds: contacts ? const {'contact-1'} : const {},
+    submitting: submitting,
+  );
+}
+
+bool _hasIcon(WidgetTester tester, String name) {
+  return tester
+      .widgetList<AppIcon>(find.byType(AppIcon))
+      .any((icon) => icon.name == name);
+}
+
+bool _canPop(WidgetTester tester) {
+  return tester.widget<PopScope<dynamic>>(find.byType(PopScope)).canPop;
+}
+
+void main() {
+  setUp(() {
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.platformDispatcher.views.first
+      ..physicalSize = const Size(520, 1000)
+      ..devicePixelRatio = 1.0;
+  });
+
+  testWidgets('account selection shows importing progress while submitting', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        const MobileWalletLinkSelectAccountsScreen(),
+        state: _state(submitting: true),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Importing...'), findsOneWidget);
+    expect(find.text('Link 1 account'), findsNothing);
+    expect(_hasIcon(tester, AppIcons.loader), isTrue);
+    expect(_hasIcon(tester, AppIcons.chevronBackward), isFalse);
+    expect(_canPop(tester), isFalse);
+
+    await tester.tap(find.text('Deselect all'));
+    await tester.pump();
+
+    expect(find.text('Deselect all'), findsOneWidget);
+    expect(find.text('Select all'), findsNothing);
+  });
+
+  testWidgets('contact selection shows importing progress while submitting', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        const MobileWalletLinkSelectContactsScreen(),
+        state: _state(submitting: true, contacts: true),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Importing...'), findsOneWidget);
+    expect(find.text('Import 1 contact'), findsNothing);
+    expect(_hasIcon(tester, AppIcons.loader), isTrue);
+    expect(_hasIcon(tester, AppIcons.chevronBackward), isFalse);
+    expect(_canPop(tester), isFalse);
+
+    await tester.tap(find.text('Deselect all'));
+    await tester.pump();
+
+    expect(find.text('Deselect all'), findsOneWidget);
+    expect(find.text('Select all'), findsNothing);
+  });
+}

--- a/test/features/wallet_link/wallet_link_models_test.dart
+++ b/test/features/wallet_link/wallet_link_models_test.dart
@@ -198,5 +198,62 @@ void main() {
       'keystone',
       'legacy-keystone',
     ]);
+
+    final linkedImport = keystone.toAccountImport();
+    expect(linkedImport.sourceAccountUuid, 'keystone');
+  });
+
+  test('mobile wallet link state excludes already imported accounts', () {
+    const account1 = WalletLinkTransferAccount(
+      uuid: 'desktop-account-1',
+      name: 'Account 1',
+      order: 0,
+      isHardware: false,
+      isSeedAnchor: true,
+      hardwareKind: null,
+      profilePictureId: null,
+      birthdayHeight: 100,
+      zip32AccountIndex: 0,
+      ufvk: null,
+      seedFingerprint: null,
+      mnemonic: 'abandon abandon abandon abandon abandon abandon',
+    );
+    const account2 = WalletLinkTransferAccount(
+      uuid: 'desktop-account-2',
+      name: 'Account 2',
+      order: 1,
+      isHardware: false,
+      isSeedAnchor: false,
+      hardwareKind: null,
+      profilePictureId: null,
+      birthdayHeight: 100,
+      zip32AccountIndex: 1,
+      ufvk: null,
+      seedFingerprint: null,
+      mnemonic: 'abandon abandon abandon abandon abandon abandon',
+    );
+    final payload = WalletLinkTransferPayload(
+      version: 1,
+      exportedAt: DateTime.utc(2026, 7, 8),
+      network: 'main',
+      activeAccountUuid: account1.uuid,
+      accounts: const [account1, account2],
+      contacts: const [],
+    );
+
+    final state = MobileWalletLinkState(
+      payload: payload,
+      selectedAccountUuids: const {'desktop-account-1', 'desktop-account-2'},
+      alreadyImportedAccountUuids: const {'desktop-account-1'},
+    );
+
+    expect(state.importableAccountCount, 1);
+    expect(state.selectedAccounts.map((account) => account.uuid), [
+      'desktop-account-2',
+    ]);
+    expect(state.sortedAccounts.map((account) => account.uuid), [
+      'desktop-account-2',
+      'desktop-account-1',
+    ]);
   });
 }


### PR DESCRIPTION
## Summary
- show mobile wallet-link import progress while final processing is running
- mark already-imported accounts and contacts before import, keep them read-only, and move them into a separate section
- handle desktop links with nothing importable by showing a no-op state and a Go back CTA

## Validation
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/onboarding/mobile_wallet_link_screens_test.dart`
- `fvm flutter test test/features/wallet_link/wallet_link_models_test.dart`
- `fvm flutter analyze`
- `git diff --check`
