### PR TITLE
Add mobile sync keep-awake

### DIFF
--- a/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
@@ -68,6 +68,23 @@ class MainActivity : FlutterFragmentActivity() {
                 else -> result.notImplemented()
             }
         }
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            SCREEN_AWAKE_CHANNEL
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "setEnabled" -> {
+                    val enabled = (call.arguments as? Map<*, *>)?.get("enabled") as? Boolean
+                    if (enabled == null) {
+                        result.error("bad_args", "Expected enabled argument.", null)
+                    } else {
+                        setScreenAwakeEnabled(enabled)
+                        result.success(null)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
     }
 
     /** REJECT is the platform's error haptic; older APIs report
@@ -133,9 +150,18 @@ class MainActivity : FlutterFragmentActivity() {
         }
     }
 
+    private fun setScreenAwakeEnabled(enabled: Boolean) {
+        if (enabled) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+    }
+
     companion object {
         private const val CAMERA_PERMISSION_CHANNEL = "com.zcash.wallet/camera_permission"
         private const val HAPTICS_CHANNEL = "com.zcash.wallet/haptics"
         private const val PRIVACY_SHIELD_CHANNEL = "com.zcash.wallet/privacy_shield"
+        private const val SCREEN_AWAKE_CHANNEL = "com.zcash.wallet/screen_awake"
     }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -162,6 +162,33 @@ import UIKit
       }
     }
 
+    let screenAwakeChannel = FlutterMethodChannel(
+      name: "com.zcash.wallet/screen_awake",
+      binaryMessenger: messenger
+    )
+    screenAwakeChannel.setMethodCallHandler { (call, result) in
+      switch call.method {
+      case "setEnabled":
+        guard
+          let args = call.arguments as? [String: Any],
+          let enabled = args["enabled"] as? Bool
+        else {
+          result(
+            FlutterError(
+              code: "bad_args",
+              message: "Expected enabled argument.",
+              details: nil
+            )
+          )
+          return
+        }
+        UIApplication.shared.isIdleTimerDisabled = enabled
+        result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     let cameraPermissionChannel = FlutterMethodChannel(
       name: "com.zcash.wallet/camera_permission",
       binaryMessenger: messenger

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -20,6 +20,7 @@ import 'src/core/theme/app_theme_host.dart';
 import 'src/core/theme/legacy_material_theme.dart';
 import 'src/core/widgets/app_button.dart';
 import 'src/core/widgets/app_icon.dart';
+import 'src/core/widgets/mobile/sync_keep_awake_interaction_listener.dart';
 import 'src/core/widgets/network_fallback_toast.dart';
 import 'src/features/activity/screens/activity_screen.dart';
 import 'src/features/activity/screens/activity_transaction_status_screen.dart';
@@ -893,20 +894,22 @@ class ZcashWalletApp extends ConsumerWidget {
                 router: router,
                 child: _RpcEndpointFailoverToastListener(
                   child: _DesktopOpaqueWindowBackground(
-                    child: GestureDetector(
-                      onTap: () {
-                        // Leaf-only: skip when the primary focus is a
-                        // `FocusScopeNode` rather than a concrete `FocusNode`.
-                        // Unfocusing the scope itself strips the scope's
-                        // "most-recently-focused child" memory, which leaves the
-                        // next Tab with no deterministic starting point.
-                        final primary = FocusManager.instance.primaryFocus;
-                        if (primary != null && primary is! FocusScopeNode) {
-                          primary.unfocus();
-                        }
-                      },
-                      behavior: HitTestBehavior.translucent,
-                      child: child!,
+                    child: SyncKeepAwakeInteractionListener(
+                      child: GestureDetector(
+                        onTap: () {
+                          // Leaf-only: skip when the primary focus is a
+                          // `FocusScopeNode` rather than a concrete `FocusNode`.
+                          // Unfocusing the scope itself strips the scope's
+                          // "most-recently-focused child" memory, which leaves the
+                          // next Tab with no deterministic starting point.
+                          final primary = FocusManager.instance.primaryFocus;
+                          if (primary != null && primary is! FocusScopeNode) {
+                            primary.unfocus();
+                          }
+                        },
+                        behavior: HitTestBehavior.translucent,
+                        child: child!,
+                      ),
                     ),
                   ),
                 ),

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -22,6 +22,7 @@ import 'src/core/widgets/app_button.dart';
 import 'src/core/widgets/app_icon.dart';
 import 'src/core/widgets/mobile/sync_keep_awake_interaction_listener.dart';
 import 'src/core/widgets/mobile/sync_keep_awake_native_host.dart';
+import 'src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart';
 import 'src/core/widgets/network_fallback_toast.dart';
 import 'src/features/activity/screens/activity_screen.dart';
 import 'src/features/activity/screens/activity_transaction_status_screen.dart';
@@ -896,21 +897,25 @@ class ZcashWalletApp extends ConsumerWidget {
                 child: _RpcEndpointFailoverToastListener(
                   child: _DesktopOpaqueWindowBackground(
                     child: SyncKeepAwakeNativeHost(
-                      child: SyncKeepAwakeInteractionListener(
-                        child: GestureDetector(
-                          onTap: () {
-                            // Leaf-only: skip when the primary focus is a
-                            // `FocusScopeNode` rather than a concrete `FocusNode`.
-                            // Unfocusing the scope itself strips the scope's
-                            // "most-recently-focused child" memory, which leaves the
-                            // next Tab with no deterministic starting point.
-                            final primary = FocusManager.instance.primaryFocus;
-                            if (primary != null && primary is! FocusScopeNode) {
-                              primary.unfocus();
-                            }
-                          },
-                          behavior: HitTestBehavior.translucent,
-                          child: child!,
+                      child: SyncKeepAwakePrivacyLockHost(
+                        child: SyncKeepAwakeInteractionListener(
+                          child: GestureDetector(
+                            onTap: () {
+                              // Leaf-only: skip when the primary focus is a
+                              // `FocusScopeNode` rather than a concrete `FocusNode`.
+                              // Unfocusing the scope itself strips the scope's
+                              // "most-recently-focused child" memory, which leaves the
+                              // next Tab with no deterministic starting point.
+                              final primary =
+                                  FocusManager.instance.primaryFocus;
+                              if (primary != null &&
+                                  primary is! FocusScopeNode) {
+                                primary.unfocus();
+                              }
+                            },
+                            behavior: HitTestBehavior.translucent,
+                            child: child!,
+                          ),
                         ),
                       ),
                     ),

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -21,6 +21,7 @@ import 'src/core/theme/legacy_material_theme.dart';
 import 'src/core/widgets/app_button.dart';
 import 'src/core/widgets/app_icon.dart';
 import 'src/core/widgets/mobile/sync_keep_awake_interaction_listener.dart';
+import 'src/core/widgets/mobile/sync_keep_awake_native_host.dart';
 import 'src/core/widgets/network_fallback_toast.dart';
 import 'src/features/activity/screens/activity_screen.dart';
 import 'src/features/activity/screens/activity_transaction_status_screen.dart';
@@ -894,21 +895,23 @@ class ZcashWalletApp extends ConsumerWidget {
                 router: router,
                 child: _RpcEndpointFailoverToastListener(
                   child: _DesktopOpaqueWindowBackground(
-                    child: SyncKeepAwakeInteractionListener(
-                      child: GestureDetector(
-                        onTap: () {
-                          // Leaf-only: skip when the primary focus is a
-                          // `FocusScopeNode` rather than a concrete `FocusNode`.
-                          // Unfocusing the scope itself strips the scope's
-                          // "most-recently-focused child" memory, which leaves the
-                          // next Tab with no deterministic starting point.
-                          final primary = FocusManager.instance.primaryFocus;
-                          if (primary != null && primary is! FocusScopeNode) {
-                            primary.unfocus();
-                          }
-                        },
-                        behavior: HitTestBehavior.translucent,
-                        child: child!,
+                    child: SyncKeepAwakeNativeHost(
+                      child: SyncKeepAwakeInteractionListener(
+                        child: GestureDetector(
+                          onTap: () {
+                            // Leaf-only: skip when the primary focus is a
+                            // `FocusScopeNode` rather than a concrete `FocusNode`.
+                            // Unfocusing the scope itself strips the scope's
+                            // "most-recently-focused child" memory, which leaves the
+                            // next Tab with no deterministic starting point.
+                            final primary = FocusManager.instance.primaryFocus;
+                            if (primary != null && primary is! FocusScopeNode) {
+                              primary.unfocus();
+                            }
+                          },
+                          behavior: HitTestBehavior.translucent,
+                          child: child!,
+                        ),
                       ),
                     ),
                   ),

--- a/lib/src/app_bootstrap.dart
+++ b/lib/src/app_bootstrap.dart
@@ -61,6 +61,8 @@ class AppBootstrapState {
     required this.passwordRotationRecoveryFailed,
     this.swapEnabledOverrideCachedForRelease = false,
     this.biometricUnlockEnabled = false,
+    this.syncKeepAwakeEnabled = false,
+    this.syncKeepAwakePromptSeen = false,
     this.failureKind,
     this.failureMessage,
   });
@@ -73,6 +75,8 @@ class AppBootstrapState {
   final ThemeMode themeMode;
   final bool privacyModeEnabled;
   final bool swapEnabledOverrideCachedForRelease;
+  final bool syncKeepAwakeEnabled;
+  final bool syncKeepAwakePromptSeen;
 
   /// Whether biometric unlock was enabled at startup, read synchronously from
   /// secure storage. The unlock screen uses this to paint the biometric
@@ -227,6 +231,16 @@ Future<AppBootstrapState> loadAppBootstrap() async {
     final swapEnabledOverrideCachedForRelease =
         await _readSwapEnabledOverrideCachedForRelease();
     final biometricUnlockEnabled = await _readBiometricUnlockEnabled(storage);
+    final syncKeepAwakeEnabled = await _readPlainBool(
+      storage,
+      key: kSyncKeepAwakeEnabledKey,
+      label: 'sync keep-awake enabled flag',
+    );
+    final syncKeepAwakePromptSeen = await _readPlainBool(
+      storage,
+      key: kSyncKeepAwakePromptSeenKey,
+      label: 'sync keep-awake prompt seen flag',
+    );
     final isPasswordConfigured = await storage.isPasswordConfigured();
     final isUnlocked = storage.hasSessionPassword;
     final dbPath = await _getDbPath();
@@ -325,6 +339,8 @@ Future<AppBootstrapState> loadAppBootstrap() async {
       privacyModeEnabled: privacyModeEnabled,
       swapEnabledOverrideCachedForRelease: swapEnabledOverrideCachedForRelease,
       biometricUnlockEnabled: biometricUnlockEnabled,
+      syncKeepAwakeEnabled: syncKeepAwakeEnabled,
+      syncKeepAwakePromptSeen: syncKeepAwakePromptSeen,
       isPasswordConfigured: isPasswordConfigured,
       isUnlocked: isUnlocked,
       passwordRotationRecoveryFailed: passwordRotationRecoveryFailed,
@@ -474,12 +490,24 @@ Future<bool> _readPrivacyModeEnabled(AppSecureStore storage) async {
 Future<bool> _readBiometricUnlockEnabled(AppSecureStore storage) async {
   // The enabled flag is written via writePlain (unencrypted), so it must be
   // read back via readPlain to match the biometric unlock provider's storage.
+  return _readPlainBool(
+    storage,
+    key: _biometricUnlockEnabledKey,
+    label: 'biometric unlock flag',
+  );
+}
+
+Future<bool> _readPlainBool(
+  AppSecureStore storage, {
+  required String key,
+  required String label,
+}) async {
   try {
-    return (await storage.readPlain(_biometricUnlockEnabledKey)) == 'true';
+    return (await storage.readPlain(key)) == 'true';
   } on SecureStorageUnavailableException {
     rethrow;
   } catch (e) {
-    log('bootstrap: failed to read biometric unlock flag: $e');
+    log('bootstrap: failed to read $label: $e');
     return false;
   }
 }

--- a/lib/src/core/storage/app_secure_store.dart
+++ b/lib/src/core/storage/app_secure_store.dart
@@ -21,6 +21,8 @@ import '../../rust/api/secret.dart' as rust_secret;
 const kWalletDbNameKey = 'zcash_wallet_db_name';
 const kThemeModeKey = 'zcash_theme_mode';
 const kPrivacyModeEnabledKey = 'zcash_privacy_mode_enabled';
+const kSyncKeepAwakeEnabledKey = 'zcash_sync_keep_awake_enabled';
+const kSyncKeepAwakePromptSeenKey = 'zcash_sync_keep_awake_prompt_seen';
 const kRpcEndpointUrlKey = 'zcash_rpc_endpoint_url';
 const kRpcEndpointPresetKey = 'zcash_rpc_endpoint_preset';
 const _secureStoreSaltKey = 'zcash_secure_store_salt';

--- a/lib/src/core/widgets/mobile/sync_keep_awake_interaction_listener.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_interaction_listener.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../layout/app_form_factor.dart';
+import '../../../providers/sync_keep_awake_provider.dart';
+
+class SyncKeepAwakeInteractionListener extends ConsumerWidget {
+  const SyncKeepAwakeInteractionListener({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (kAppFormFactor != AppFormFactor.mobile) return child;
+
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: (_) => _markInteraction(ref),
+      onPointerMove: (_) => _markInteraction(ref),
+      onPointerSignal: (_) => _markInteraction(ref),
+      child: child,
+    );
+  }
+
+  void _markInteraction(WidgetRef ref) {
+    ref.read(syncKeepAwakeInteractionProvider.notifier).markInteraction();
+  }
+}

--- a/lib/src/core/widgets/mobile/sync_keep_awake_native_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_native_host.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../layout/app_form_factor.dart';
+import '../../../providers/sync_keep_awake_provider.dart';
+import '../../../services/native_screen_awake.dart';
+
+class SyncKeepAwakeNativeHost extends ConsumerStatefulWidget {
+  const SyncKeepAwakeNativeHost({
+    required this.child,
+    this.bridge = const NativeScreenAwakeBridge(),
+    super.key,
+  });
+
+  final Widget child;
+  final NativeScreenAwakeBridge bridge;
+
+  @override
+  ConsumerState<SyncKeepAwakeNativeHost> createState() =>
+      _SyncKeepAwakeNativeHostState();
+}
+
+class _SyncKeepAwakeNativeHostState
+    extends ConsumerState<SyncKeepAwakeNativeHost> {
+  bool _lastRequestedEnabled = false;
+  bool _lastAppliedEnabled = false;
+  Future<void> _nativeQueue = Future<void>.value();
+
+  @override
+  Widget build(BuildContext context) {
+    if (kAppFormFactor == AppFormFactor.mobile) {
+      _requestNativeState(ref.watch(syncKeepAwakeActiveProvider));
+    }
+    return widget.child;
+  }
+
+  @override
+  void dispose() {
+    if (_lastRequestedEnabled || _lastAppliedEnabled) {
+      _requestNativeState(false, force: true);
+    }
+    super.dispose();
+  }
+
+  void _requestNativeState(bool enabled, {bool force = false}) {
+    if (!force && _lastRequestedEnabled == enabled) return;
+    _lastRequestedEnabled = enabled;
+    final bridge = widget.bridge;
+    _nativeQueue = _nativeQueue.then(
+      (_) => _applyNativeState(bridge, enabled, force: force),
+    );
+  }
+
+  Future<void> _applyNativeState(
+    NativeScreenAwakeBridge bridge,
+    bool enabled, {
+    required bool force,
+  }) async {
+    if (!force && _lastAppliedEnabled == enabled) return;
+    try {
+      await bridge.setEnabled(enabled);
+      _lastAppliedEnabled = enabled;
+    } catch (error) {
+      debugPrint(
+        'SyncKeepAwakeNativeHost: setEnabled($enabled) failed: $error',
+      );
+    }
+  }
+}

--- a/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
@@ -39,7 +39,8 @@ class _SyncKeepAwakePrivacyLockHostState
 
     final active = ref.watch(syncKeepAwakeActiveProvider);
     final interaction = ref.watch(syncKeepAwakeInteractionProvider);
-    final visible = ref.watch(syncKeepAwakePrivacyLockVisibleProvider);
+    final mode = ref.watch(syncKeepAwakePrivacyLockModeProvider);
+    final visible = mode != SyncKeepAwakePrivacyLockMode.hidden;
     _syncIdleTimer(active: active, interaction: interaction, visible: visible);
 
     return Stack(
@@ -47,7 +48,7 @@ class _SyncKeepAwakePrivacyLockHostState
       children: [
         widget.child,
         if (visible)
-          const Positioned.fill(child: SyncKeepAwakePrivacyLockScreen()),
+          Positioned.fill(child: SyncKeepAwakePrivacyLockScreen(mode: mode)),
       ],
     );
   }
@@ -66,6 +67,7 @@ class _SyncKeepAwakePrivacyLockHostState
     if (!active) {
       _idleTimer?.cancel();
       _idleTimer = null;
+      if (visible) return;
       _clearAfterFrameIfInactive();
       return;
     }
@@ -114,7 +116,12 @@ class _SyncKeepAwakePrivacyLockHostState
 }
 
 class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
-  const SyncKeepAwakePrivacyLockScreen({super.key});
+  const SyncKeepAwakePrivacyLockScreen({
+    this.mode = SyncKeepAwakePrivacyLockMode.syncing,
+    super.key,
+  });
+
+  final SyncKeepAwakePrivacyLockMode mode;
 
   static const _figmaReferenceHeight = 852.0;
   static const _shortScreenOuterMargin = 32.0;
@@ -126,25 +133,50 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
   static const _ringSize = 303.0;
   static const _ringToButtonGap = 129.0;
   static const _minimumRingToButtonGap = 48.0;
+  static const _logoToDoneStatusGap = 156.0;
+  static const _minimumLogoToDoneStatusGap = 48.0;
+  static const _doneStatusHeight = 200.0;
+  static const _doneStatusToButtonGap = 147.0;
+  static const _minimumDoneStatusToButtonGap = 48.0;
   static const _bodyWidth = 130.0;
-  static const _contentStackHeight =
-      _logoHeight +
-      _logoToRingGap +
-      _ringSize +
-      _ringToButtonGap +
-      AppButtonSizingMobile.largeHeight;
-  static const _minimumContentStackHeight =
-      _logoHeight +
-      _minimumLogoToRingGap +
-      _ringSize +
-      _minimumRingToButtonGap +
-      AppButtonSizingMobile.largeHeight;
+  static const _doneBodyWidth = 200.0;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.colors;
-    final sync = ref.watch(syncProvider).asData?.value;
+    final done = mode == SyncKeepAwakePrivacyLockMode.done;
+    final interrupted = mode == SyncKeepAwakePrivacyLockMode.interrupted;
+    final sync = done || interrupted
+        ? null
+        : ref.watch(syncProvider).asData?.value;
     final progress = sync?.displayPercentage ?? sync?.percentage ?? 0.0;
+    final main = switch (mode) {
+      SyncKeepAwakePrivacyLockMode.done => const _SyncKeepAwakeStatusLockup(
+        iconName: AppIcons.checkCircle,
+        iconKey: ValueKey('sync_keep_awake_privacy_done_check'),
+        title: 'Synced',
+        body: 'Synced successfully.\nYou can unlock Vizor.',
+        success: true,
+      ),
+      SyncKeepAwakePrivacyLockMode.interrupted =>
+        const _SyncKeepAwakeStatusLockup(
+          iconName: AppIcons.warning,
+          iconKey: ValueKey('sync_keep_awake_privacy_interrupted_warning'),
+          title: 'Sync paused',
+          body: 'Unlock Vizor to continue.',
+          success: false,
+        ),
+      SyncKeepAwakePrivacyLockMode.hidden ||
+      SyncKeepAwakePrivacyLockMode.syncing => _SyncKeepAwakeProgressLockup(
+        progress: progress,
+      ),
+    };
+    final semanticsLabel = switch (mode) {
+      SyncKeepAwakePrivacyLockMode.done => 'Vizor is synced',
+      SyncKeepAwakePrivacyLockMode.interrupted => 'Vizor sync is paused',
+      SyncKeepAwakePrivacyLockMode.hidden ||
+      SyncKeepAwakePrivacyLockMode.syncing => 'Vizor is syncing',
+    };
 
     return Material(
       color: colors.background.window,
@@ -152,7 +184,7 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
         scopesRoute: true,
         namesRoute: true,
         explicitChildNodes: true,
-        label: 'Vizor is syncing',
+        label: semanticsLabel,
         child: SafeArea(
           bottom: false,
           child: LayoutBuilder(
@@ -160,6 +192,7 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
               final layout = _resolveVerticalLayout(
                 availableHeight: constraints.maxHeight,
                 screenHeight: MediaQuery.sizeOf(context).height,
+                mode: mode,
               );
               return Column(
                 children: [
@@ -169,9 +202,9 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
                     width: _logoWidth,
                     height: _logoHeight,
                   ),
-                  SizedBox(height: layout.logoToRingGap),
-                  _SyncKeepAwakeProgressLockup(progress: progress),
-                  SizedBox(height: layout.ringToButtonGap),
+                  SizedBox(height: layout.logoToMainGap),
+                  main,
+                  SizedBox(height: layout.mainToButtonGap),
                   AppButton(
                     key: const ValueKey(
                       'sync_keep_awake_privacy_unlock_button',
@@ -179,7 +212,7 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
                     onPressed: () => ref
                         .read(syncKeepAwakePrivacyLockProvider.notifier)
                         .unlock(),
-                    leading: const AppIcon(AppIcons.unlock),
+                    leading: AppIcon(done ? AppIcons.faceId : AppIcons.unlock),
                     minWidth: 165,
                     child: const Text('Unlock Vizor'),
                   ),
@@ -195,46 +228,103 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
   _SyncKeepAwakeVerticalLayout _resolveVerticalLayout({
     required double availableHeight,
     required double screenHeight,
+    required SyncKeepAwakePrivacyLockMode mode,
   }) {
+    final spec = _SyncKeepAwakeLayoutSpec.forMode(mode);
     if (screenHeight >= _figmaReferenceHeight) {
-      return const _SyncKeepAwakeVerticalLayout(
+      return _SyncKeepAwakeVerticalLayout(
         topGap: _logoTopGap,
-        logoToRingGap: _logoToRingGap,
-        ringToButtonGap: _ringToButtonGap,
+        logoToMainGap: spec.logoToMainGap,
+        mainToButtonGap: spec.mainToButtonGap,
       );
     }
 
-    var logoToRingGap = _logoToRingGap;
-    var ringToButtonGap = _ringToButtonGap;
+    var logoToMainGap = spec.logoToMainGap;
+    var mainToButtonGap = spec.mainToButtonGap;
     final targetStackHeight = math.max(
-      _minimumContentStackHeight,
+      spec.minimumStackHeight,
       availableHeight - (_shortScreenOuterMargin * 2),
     );
     final reduction = math.min(
-      _contentStackHeight - targetStackHeight,
-      (_logoToRingGap - _minimumLogoToRingGap) +
-          (_ringToButtonGap - _minimumRingToButtonGap),
+      spec.stackHeight - targetStackHeight,
+      (spec.logoToMainGap - spec.minimumLogoToMainGap) +
+          (spec.mainToButtonGap - spec.minimumMainToButtonGap),
     );
 
     if (reduction > 0) {
-      final logoReducible = _logoToRingGap - _minimumLogoToRingGap;
-      final buttonReducible = _ringToButtonGap - _minimumRingToButtonGap;
+      final logoReducible = spec.logoToMainGap - spec.minimumLogoToMainGap;
+      final buttonReducible =
+          spec.mainToButtonGap - spec.minimumMainToButtonGap;
       final totalReducible = logoReducible + buttonReducible;
-      logoToRingGap -= reduction * logoReducible / totalReducible;
-      ringToButtonGap -= reduction * buttonReducible / totalReducible;
+      logoToMainGap -= reduction * logoReducible / totalReducible;
+      mainToButtonGap -= reduction * buttonReducible / totalReducible;
     }
 
     final stackHeight =
         _logoHeight +
-        logoToRingGap +
-        _ringSize +
-        ringToButtonGap +
+        logoToMainGap +
+        spec.mainHeight +
+        mainToButtonGap +
         AppButtonSizingMobile.largeHeight;
 
     return _SyncKeepAwakeVerticalLayout(
       topGap: math.max(0, (availableHeight - stackHeight) / 2),
-      logoToRingGap: logoToRingGap,
-      ringToButtonGap: ringToButtonGap,
+      logoToMainGap: logoToMainGap,
+      mainToButtonGap: mainToButtonGap,
+    );
+  }
+}
+
+class _SyncKeepAwakeLayoutSpec {
+  const _SyncKeepAwakeLayoutSpec({
+    required this.logoToMainGap,
+    required this.minimumLogoToMainGap,
+    required this.mainHeight,
+    required this.mainToButtonGap,
+    required this.minimumMainToButtonGap,
+  });
+
+  final double logoToMainGap;
+  final double minimumLogoToMainGap;
+  final double mainHeight;
+  final double mainToButtonGap;
+  final double minimumMainToButtonGap;
+
+  double get stackHeight =>
+      SyncKeepAwakePrivacyLockScreen._logoHeight +
+      logoToMainGap +
+      mainHeight +
+      mainToButtonGap +
+      AppButtonSizingMobile.largeHeight;
+
+  double get minimumStackHeight =>
+      SyncKeepAwakePrivacyLockScreen._logoHeight +
+      minimumLogoToMainGap +
+      mainHeight +
+      minimumMainToButtonGap +
+      AppButtonSizingMobile.largeHeight;
+
+  factory _SyncKeepAwakeLayoutSpec.forMode(SyncKeepAwakePrivacyLockMode mode) {
+    if (mode == SyncKeepAwakePrivacyLockMode.done ||
+        mode == SyncKeepAwakePrivacyLockMode.interrupted) {
+      return const _SyncKeepAwakeLayoutSpec(
+        logoToMainGap: SyncKeepAwakePrivacyLockScreen._logoToDoneStatusGap,
+        minimumLogoToMainGap:
+            SyncKeepAwakePrivacyLockScreen._minimumLogoToDoneStatusGap,
+        mainHeight: SyncKeepAwakePrivacyLockScreen._doneStatusHeight,
+        mainToButtonGap: SyncKeepAwakePrivacyLockScreen._doneStatusToButtonGap,
+        minimumMainToButtonGap:
+            SyncKeepAwakePrivacyLockScreen._minimumDoneStatusToButtonGap,
+      );
+    }
+    return const _SyncKeepAwakeLayoutSpec(
+      logoToMainGap: SyncKeepAwakePrivacyLockScreen._logoToRingGap,
+      minimumLogoToMainGap:
+          SyncKeepAwakePrivacyLockScreen._minimumLogoToRingGap,
+      mainHeight: SyncKeepAwakePrivacyLockScreen._ringSize,
+      mainToButtonGap: SyncKeepAwakePrivacyLockScreen._ringToButtonGap,
+      minimumMainToButtonGap:
+          SyncKeepAwakePrivacyLockScreen._minimumRingToButtonGap,
     );
   }
 }
@@ -242,13 +332,84 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
 class _SyncKeepAwakeVerticalLayout {
   const _SyncKeepAwakeVerticalLayout({
     required this.topGap,
-    required this.logoToRingGap,
-    required this.ringToButtonGap,
+    required this.logoToMainGap,
+    required this.mainToButtonGap,
   });
 
   final double topGap;
-  final double logoToRingGap;
-  final double ringToButtonGap;
+  final double logoToMainGap;
+  final double mainToButtonGap;
+}
+
+class _SyncKeepAwakeStatusLockup extends StatelessWidget {
+  const _SyncKeepAwakeStatusLockup({
+    required this.iconName,
+    required this.iconKey,
+    required this.title,
+    required this.body,
+    required this.success,
+  });
+
+  final String iconName;
+  final Key iconKey;
+  final String title;
+  final String body;
+  final bool success;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return SizedBox(
+      height: SyncKeepAwakePrivacyLockScreen._doneStatusHeight,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: AppIcon(
+                iconName,
+                key: iconKey,
+                size: 40,
+                color: success ? colors.sync.lightSuccess : colors.icon.warning,
+              ),
+            ),
+          ),
+          Positioned(
+            top: 100,
+            left: 0,
+            right: 0,
+            child: Text(
+              title,
+              textAlign: TextAlign.center,
+              style: AppTypography.displayLarge.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+          ),
+          Positioned(
+            top: 150,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: SizedBox(
+                width: SyncKeepAwakePrivacyLockScreen._doneBodyWidth,
+                child: Text(
+                  body,
+                  textAlign: TextAlign.center,
+                  style: AppTypography.bodyMediumStrong.copyWith(
+                    color: colors.text.primary,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
 }
 
 class _SyncKeepAwakeProgressLockup extends StatelessWidget {

--- a/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
@@ -254,54 +254,64 @@ class _SyncKeepAwakeVerticalLayout {
 class _SyncKeepAwakeProgressLockup extends StatelessWidget {
   const _SyncKeepAwakeProgressLockup({required this.progress});
 
+  static const _progressAnimationDuration = Duration(milliseconds: 420);
+
   final double progress;
 
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
+    final targetProgress = progress.clamp(0.0, 1.0).toDouble();
     return SizedBox.square(
       dimension: SyncKeepAwakePrivacyLockScreen._ringSize,
-      child: Stack(
-        children: [
-          Positioned.fill(
-            child: CustomPaint(
-              painter: _SyncKeepAwakeSegmentedRingPainter(
-                progress: progress,
-                trackColor: colors.background.raised,
-                progressColor: colors.sync.lightSuccess,
-              ),
-            ),
-          ),
-          Positioned(
-            top: 118,
-            left: 0,
-            right: 0,
-            child: Text(
-              '${formatSyncStatusPercentage(progress)}%',
-              textAlign: TextAlign.center,
-              style: AppTypography.displayLarge.copyWith(
-                color: colors.text.accent,
-              ),
-            ),
-          ),
-          Positioned(
-            top: 170,
-            left: 0,
-            right: 0,
-            child: Center(
-              child: SizedBox(
-                width: SyncKeepAwakePrivacyLockScreen._bodyWidth,
-                child: Text(
-                  'Vizor is syncing,\nstick around ...',
-                  textAlign: TextAlign.center,
-                  style: AppTypography.bodyMediumStrong.copyWith(
-                    color: colors.text.primary,
+      child: TweenAnimationBuilder<double>(
+        tween: Tween<double>(begin: targetProgress, end: targetProgress),
+        duration: _progressAnimationDuration,
+        curve: Curves.easeOutCubic,
+        builder: (context, animatedProgress, _) {
+          return Stack(
+            children: [
+              Positioned.fill(
+                child: CustomPaint(
+                  painter: _SyncKeepAwakeSegmentedRingPainter(
+                    progress: animatedProgress,
+                    trackColor: colors.background.raised,
+                    progressColor: colors.sync.lightSuccess,
                   ),
                 ),
               ),
-            ),
-          ),
-        ],
+              Positioned(
+                top: 118,
+                left: 0,
+                right: 0,
+                child: Text(
+                  '${formatSyncStatusPercentage(animatedProgress)}%',
+                  textAlign: TextAlign.center,
+                  style: AppTypography.displayLarge.copyWith(
+                    color: colors.text.accent,
+                  ),
+                ),
+              ),
+              Positioned(
+                top: 170,
+                left: 0,
+                right: 0,
+                child: Center(
+                  child: SizedBox(
+                    width: SyncKeepAwakePrivacyLockScreen._bodyWidth,
+                    child: Text(
+                      'Vizor is syncing,\nstick around ...',
+                      textAlign: TextAlign.center,
+                      style: AppTypography.bodyMediumStrong.copyWith(
+                        color: colors.text.primary,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
       ),
     );
   }
@@ -321,31 +331,36 @@ class _SyncKeepAwakeSegmentedRingPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     const segmentCount = 96;
-    const tickLength = 28.0;
+    const progressTickLength = 28.0;
+    const trackTickLength = 16.0;
+    const trackOuterRadiusOffset = 14.0;
     const strokeWidth = 2.5;
-    final clampedProgress = progress.clamp(0.0, 1.0);
+    final clampedProgress = progress.clamp(0.0, 1.0).toDouble();
     final center = Offset(size.width / 2, size.height / 2);
-    final radius = (size.shortestSide / 2) - (tickLength / 2) - 1;
-    final filledSegments = (segmentCount * clampedProgress).round();
+    final progressOuterRadius = (size.shortestSide / 2) - 1;
+    final trackOuterRadius = progressOuterRadius - trackOuterRadiusOffset;
+    final scaledProgress = segmentCount * clampedProgress;
     final trackPaint = Paint()
       ..color = trackColor
-      ..strokeWidth = strokeWidth
-      ..strokeCap = StrokeCap.round;
-    final progressPaint = Paint()
-      ..color = progressColor
       ..strokeWidth = strokeWidth
       ..strokeCap = StrokeCap.round;
 
     for (var index = 0; index < segmentCount; index++) {
       final angle = (-math.pi / 2) + (math.pi * 2 * index / segmentCount);
       final direction = Offset(math.cos(angle), math.sin(angle));
-      final outer = center + direction * (radius + tickLength / 2);
-      final inner = center + direction * (radius - tickLength / 2);
-      canvas.drawLine(
-        inner,
-        outer,
-        index < filledSegments ? progressPaint : trackPaint,
-      );
+      final segmentFill = (scaledProgress - index).clamp(0.0, 1.0).toDouble();
+      final outerRadius =
+          trackOuterRadius +
+          ((progressOuterRadius - trackOuterRadius) * segmentFill);
+      final tickLength =
+          trackTickLength +
+          ((progressTickLength - trackTickLength) * segmentFill);
+      final outer = center + direction * outerRadius;
+      final inner = outer - (direction * tickLength);
+      final paint = trackPaint
+        ..color = Color.lerp(trackColor, progressColor, segmentFill)!;
+
+      canvas.drawLine(inner, outer, paint);
     }
   }
 

--- a/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
@@ -333,12 +333,11 @@ class _SyncKeepAwakeSegmentedRingPainter extends CustomPainter {
     const segmentCount = 96;
     const progressTickLength = 28.0;
     const trackTickLength = 16.0;
-    const trackOuterRadiusOffset = 14.0;
     const strokeWidth = 2.5;
     final clampedProgress = progress.clamp(0.0, 1.0).toDouble();
     final center = Offset(size.width / 2, size.height / 2);
-    final progressOuterRadius = (size.shortestSide / 2) - 1;
-    final trackOuterRadius = progressOuterRadius - trackOuterRadiusOffset;
+    final tickCenterRadius =
+        (size.shortestSide / 2) - (progressTickLength / 2) - 1;
     final scaledProgress = segmentCount * clampedProgress;
     final trackPaint = Paint()
       ..color = trackColor
@@ -349,14 +348,12 @@ class _SyncKeepAwakeSegmentedRingPainter extends CustomPainter {
       final angle = (-math.pi / 2) + (math.pi * 2 * index / segmentCount);
       final direction = Offset(math.cos(angle), math.sin(angle));
       final segmentFill = (scaledProgress - index).clamp(0.0, 1.0).toDouble();
-      final outerRadius =
-          trackOuterRadius +
-          ((progressOuterRadius - trackOuterRadius) * segmentFill);
       final tickLength =
           trackTickLength +
           ((progressTickLength - trackTickLength) * segmentFill);
-      final outer = center + direction * outerRadius;
-      final inner = outer - (direction * tickLength);
+      final tickCenter = center + direction * tickCenterRadius;
+      final inner = tickCenter - (direction * tickLength / 2);
+      final outer = tickCenter + (direction * tickLength / 2);
       final paint = trackPaint
         ..color = Color.lerp(trackColor, progressColor, segmentFill)!;
 

--- a/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
@@ -1,0 +1,358 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../features/onboarding/shared/onboarding_welcome_art.dart';
+import '../../../providers/sync_keep_awake_provider.dart';
+import '../../../providers/sync_provider.dart';
+import '../../formatting/sync_status_label.dart';
+import '../../layout/app_form_factor.dart';
+import '../../theme/app_theme.dart';
+import '../app_button.dart';
+import '../app_icon.dart';
+
+class SyncKeepAwakePrivacyLockHost extends ConsumerStatefulWidget {
+  const SyncKeepAwakePrivacyLockHost({
+    required this.child,
+    this.idleTimeout = kSyncKeepAwakePrivacyIdleTimeout,
+    super.key,
+  });
+
+  final Widget child;
+  final Duration idleTimeout;
+
+  @override
+  ConsumerState<SyncKeepAwakePrivacyLockHost> createState() =>
+      _SyncKeepAwakePrivacyLockHostState();
+}
+
+class _SyncKeepAwakePrivacyLockHostState
+    extends ConsumerState<SyncKeepAwakePrivacyLockHost> {
+  Timer? _idleTimer;
+  bool _clearScheduled = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (kAppFormFactor != AppFormFactor.mobile) return widget.child;
+
+    final active = ref.watch(syncKeepAwakeActiveProvider);
+    final interaction = ref.watch(syncKeepAwakeInteractionProvider);
+    final visible = ref.watch(syncKeepAwakePrivacyLockVisibleProvider);
+    _syncIdleTimer(active: active, interaction: interaction, visible: visible);
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        widget.child,
+        if (visible)
+          const Positioned.fill(child: SyncKeepAwakePrivacyLockScreen()),
+      ],
+    );
+  }
+
+  @override
+  void dispose() {
+    _idleTimer?.cancel();
+    super.dispose();
+  }
+
+  void _syncIdleTimer({
+    required bool active,
+    required SyncKeepAwakeInteractionState interaction,
+    required bool visible,
+  }) {
+    if (!active) {
+      _idleTimer?.cancel();
+      _idleTimer = null;
+      _clearAfterFrameIfInactive();
+      return;
+    }
+
+    if (visible) {
+      _idleTimer?.cancel();
+      _idleTimer = null;
+      return;
+    }
+
+    final remaining =
+        widget.idleTimeout - interaction.idleDuration(DateTime.now());
+    _idleTimer?.cancel();
+    _idleTimer = Timer(
+      remaining <= Duration.zero ? Duration.zero : remaining,
+      () => _lockIfStillIdle(interaction.revision),
+    );
+  }
+
+  void _lockIfStillIdle(int expectedRevision) {
+    if (!mounted) return;
+    if (!ref.read(syncKeepAwakeActiveProvider)) return;
+    if (ref.read(syncKeepAwakePrivacyLockProvider).isLocked) return;
+
+    final interaction = ref.read(syncKeepAwakeInteractionProvider);
+    if (interaction.revision != expectedRevision) {
+      _syncIdleTimer(active: true, interaction: interaction, visible: false);
+      return;
+    }
+
+    ref.read(syncKeepAwakePrivacyLockProvider.notifier).lock();
+  }
+
+  void _clearAfterFrameIfInactive() {
+    if (_clearScheduled ||
+        !ref.read(syncKeepAwakePrivacyLockProvider).isLocked) {
+      return;
+    }
+    _clearScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _clearScheduled = false;
+      if (!mounted || ref.read(syncKeepAwakeActiveProvider)) return;
+      ref.read(syncKeepAwakePrivacyLockProvider.notifier).clear();
+    });
+  }
+}
+
+class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
+  const SyncKeepAwakePrivacyLockScreen({super.key});
+
+  static const _figmaReferenceHeight = 852.0;
+  static const _shortScreenOuterMargin = 32.0;
+  static const _logoTopGap = 110.0;
+  static const _logoWidth = 106.0;
+  static const _logoHeight = 40.0;
+  static const _logoToRingGap = 81.0;
+  static const _minimumLogoToRingGap = 48.0;
+  static const _ringSize = 303.0;
+  static const _ringToButtonGap = 129.0;
+  static const _minimumRingToButtonGap = 48.0;
+  static const _bodyWidth = 130.0;
+  static const _contentStackHeight =
+      _logoHeight +
+      _logoToRingGap +
+      _ringSize +
+      _ringToButtonGap +
+      AppButtonSizingMobile.largeHeight;
+  static const _minimumContentStackHeight =
+      _logoHeight +
+      _minimumLogoToRingGap +
+      _ringSize +
+      _minimumRingToButtonGap +
+      AppButtonSizingMobile.largeHeight;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.colors;
+    final sync = ref.watch(syncProvider).asData?.value;
+    final progress = sync?.displayPercentage ?? sync?.percentage ?? 0.0;
+
+    return Material(
+      color: colors.background.window,
+      child: Semantics(
+        scopesRoute: true,
+        namesRoute: true,
+        explicitChildNodes: true,
+        label: 'Vizor is syncing',
+        child: SafeArea(
+          bottom: false,
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final layout = _resolveVerticalLayout(
+                availableHeight: constraints.maxHeight,
+                screenHeight: MediaQuery.sizeOf(context).height,
+              );
+              return Column(
+                children: [
+                  SizedBox(height: layout.topGap),
+                  const VizorWordmark(
+                    key: ValueKey('sync_keep_awake_privacy_logo'),
+                    width: _logoWidth,
+                    height: _logoHeight,
+                  ),
+                  SizedBox(height: layout.logoToRingGap),
+                  _SyncKeepAwakeProgressLockup(progress: progress),
+                  SizedBox(height: layout.ringToButtonGap),
+                  AppButton(
+                    key: const ValueKey(
+                      'sync_keep_awake_privacy_unlock_button',
+                    ),
+                    onPressed: () => ref
+                        .read(syncKeepAwakePrivacyLockProvider.notifier)
+                        .unlock(),
+                    leading: const AppIcon(AppIcons.unlock),
+                    minWidth: 165,
+                    child: const Text('Unlock Vizor'),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  _SyncKeepAwakeVerticalLayout _resolveVerticalLayout({
+    required double availableHeight,
+    required double screenHeight,
+  }) {
+    if (screenHeight >= _figmaReferenceHeight) {
+      return const _SyncKeepAwakeVerticalLayout(
+        topGap: _logoTopGap,
+        logoToRingGap: _logoToRingGap,
+        ringToButtonGap: _ringToButtonGap,
+      );
+    }
+
+    var logoToRingGap = _logoToRingGap;
+    var ringToButtonGap = _ringToButtonGap;
+    final targetStackHeight = math.max(
+      _minimumContentStackHeight,
+      availableHeight - (_shortScreenOuterMargin * 2),
+    );
+    final reduction = math.min(
+      _contentStackHeight - targetStackHeight,
+      (_logoToRingGap - _minimumLogoToRingGap) +
+          (_ringToButtonGap - _minimumRingToButtonGap),
+    );
+
+    if (reduction > 0) {
+      final logoReducible = _logoToRingGap - _minimumLogoToRingGap;
+      final buttonReducible = _ringToButtonGap - _minimumRingToButtonGap;
+      final totalReducible = logoReducible + buttonReducible;
+      logoToRingGap -= reduction * logoReducible / totalReducible;
+      ringToButtonGap -= reduction * buttonReducible / totalReducible;
+    }
+
+    final stackHeight =
+        _logoHeight +
+        logoToRingGap +
+        _ringSize +
+        ringToButtonGap +
+        AppButtonSizingMobile.largeHeight;
+
+    return _SyncKeepAwakeVerticalLayout(
+      topGap: math.max(0, (availableHeight - stackHeight) / 2),
+      logoToRingGap: logoToRingGap,
+      ringToButtonGap: ringToButtonGap,
+    );
+  }
+}
+
+class _SyncKeepAwakeVerticalLayout {
+  const _SyncKeepAwakeVerticalLayout({
+    required this.topGap,
+    required this.logoToRingGap,
+    required this.ringToButtonGap,
+  });
+
+  final double topGap;
+  final double logoToRingGap;
+  final double ringToButtonGap;
+}
+
+class _SyncKeepAwakeProgressLockup extends StatelessWidget {
+  const _SyncKeepAwakeProgressLockup({required this.progress});
+
+  final double progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return SizedBox.square(
+      dimension: SyncKeepAwakePrivacyLockScreen._ringSize,
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: CustomPaint(
+              painter: _SyncKeepAwakeSegmentedRingPainter(
+                progress: progress,
+                trackColor: colors.background.raised,
+                progressColor: colors.sync.lightSuccess,
+              ),
+            ),
+          ),
+          Positioned(
+            top: 118,
+            left: 0,
+            right: 0,
+            child: Text(
+              '${formatSyncStatusPercentage(progress)}%',
+              textAlign: TextAlign.center,
+              style: AppTypography.displayLarge.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+          ),
+          Positioned(
+            top: 170,
+            left: 0,
+            right: 0,
+            child: Center(
+              child: SizedBox(
+                width: SyncKeepAwakePrivacyLockScreen._bodyWidth,
+                child: Text(
+                  'Vizor is syncing,\nstick around ...',
+                  textAlign: TextAlign.center,
+                  style: AppTypography.bodyMediumStrong.copyWith(
+                    color: colors.text.primary,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SyncKeepAwakeSegmentedRingPainter extends CustomPainter {
+  const _SyncKeepAwakeSegmentedRingPainter({
+    required this.progress,
+    required this.trackColor,
+    required this.progressColor,
+  });
+
+  final double progress;
+  final Color trackColor;
+  final Color progressColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const segmentCount = 96;
+    const tickLength = 28.0;
+    const strokeWidth = 2.5;
+    final clampedProgress = progress.clamp(0.0, 1.0);
+    final center = Offset(size.width / 2, size.height / 2);
+    final radius = (size.shortestSide / 2) - (tickLength / 2) - 1;
+    final filledSegments = (segmentCount * clampedProgress).round();
+    final trackPaint = Paint()
+      ..color = trackColor
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+    final progressPaint = Paint()
+      ..color = progressColor
+      ..strokeWidth = strokeWidth
+      ..strokeCap = StrokeCap.round;
+
+    for (var index = 0; index < segmentCount; index++) {
+      final angle = (-math.pi / 2) + (math.pi * 2 * index / segmentCount);
+      final direction = Offset(math.cos(angle), math.sin(angle));
+      final outer = center + direction * (radius + tickLength / 2);
+      final inner = center + direction * (radius - tickLength / 2);
+      canvas.drawLine(
+        inner,
+        outer,
+        index < filledSegments ? progressPaint : trackPaint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _SyncKeepAwakeSegmentedRingPainter oldDelegate) {
+    return oldDelegate.progress != progress ||
+        oldDelegate.trackColor != trackColor ||
+        oldDelegate.progressColor != progressColor;
+  }
+}

--- a/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
@@ -4,11 +4,16 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../features/onboarding/mobile/mobile_passcode_screen.dart';
+import '../../../features/onboarding/mobile/passcode_widgets.dart';
 import '../../../features/onboarding/shared/onboarding_welcome_art.dart';
+import '../../../providers/app_security_provider.dart';
 import '../../../providers/sync_keep_awake_provider.dart';
 import '../../../providers/sync_provider.dart';
+import '../../feedback/app_haptics.dart';
 import '../../formatting/sync_status_label.dart';
 import '../../layout/app_form_factor.dart';
+import '../../layout/mobile/mobile_top_nav.dart';
 import '../../theme/app_theme.dart';
 import '../app_button.dart';
 import '../app_icon.dart';
@@ -115,7 +120,7 @@ class _SyncKeepAwakePrivacyLockHostState
   }
 }
 
-class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
+class SyncKeepAwakePrivacyLockScreen extends ConsumerStatefulWidget {
   const SyncKeepAwakePrivacyLockScreen({
     this.mode = SyncKeepAwakePrivacyLockMode.syncing,
     super.key,
@@ -140,6 +145,129 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
   static const _minimumDoneStatusToButtonGap = 48.0;
   static const _bodyWidth = 130.0;
   static const _doneBodyWidth = 200.0;
+
+  @override
+  ConsumerState<SyncKeepAwakePrivacyLockScreen> createState() =>
+      _SyncKeepAwakePrivacyLockScreenState();
+}
+
+class _SyncKeepAwakePrivacyLockScreenState
+    extends ConsumerState<SyncKeepAwakePrivacyLockScreen> {
+  var _showPasscode = false;
+  var _passcodeEntry = '';
+  var _submittingPasscode = false;
+  String? _passcodeError;
+
+  @override
+  void didUpdateWidget(SyncKeepAwakePrivacyLockScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.mode == SyncKeepAwakePrivacyLockMode.hidden && _showPasscode) {
+      _resetPasscodePrompt();
+    }
+  }
+
+  void _openPasscodePrompt() {
+    setState(() {
+      _showPasscode = true;
+      _passcodeEntry = '';
+      _passcodeError = null;
+      _submittingPasscode = false;
+    });
+  }
+
+  void _returnToStatusScreen() {
+    if (_submittingPasscode) return;
+    setState(_resetPasscodePrompt);
+  }
+
+  void _resetPasscodePrompt() {
+    _showPasscode = false;
+    _passcodeEntry = '';
+    _passcodeError = null;
+    _submittingPasscode = false;
+  }
+
+  void _onPasscodeDigit(int digit) {
+    if (_submittingPasscode || _passcodeEntry.length >= kMobilePasscodeLength) {
+      return;
+    }
+    setState(() {
+      _passcodeEntry += '$digit';
+      _passcodeError = null;
+    });
+    if (_passcodeEntry.length == kMobilePasscodeLength) {
+      unawaited(_submitPasscode());
+    }
+  }
+
+  void _onPasscodeBackspace() {
+    if (_submittingPasscode || _passcodeEntry.isEmpty) return;
+    setState(() {
+      _passcodeEntry = _passcodeEntry.substring(0, _passcodeEntry.length - 1);
+      _passcodeError = null;
+    });
+  }
+
+  Future<void> _submitPasscode() async {
+    if (_submittingPasscode) return;
+    final passcode = _passcodeEntry;
+    setState(() {
+      _submittingPasscode = true;
+      _passcodeError = null;
+    });
+
+    var confirmed = false;
+    try {
+      confirmed = await ref
+          .read(appSecurityProvider.notifier)
+          .confirmPassword(passcode);
+    } catch (_) {
+      confirmed = false;
+    }
+    if (!mounted) return;
+
+    if (confirmed) {
+      ref.read(syncKeepAwakePrivacyLockProvider.notifier).unlock();
+      return;
+    }
+
+    unawaited(AppHaptics.error());
+    setState(() {
+      _submittingPasscode = false;
+      _passcodeEntry = '';
+      _passcodeError = 'Incorrect Passcode';
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_showPasscode) {
+      return _SyncKeepAwakePasscodeConfirmScreen(
+        mode: widget.mode,
+        entryLength: _passcodeEntry.length,
+        error: _passcodeError,
+        submitting: _submittingPasscode,
+        onBack: _returnToStatusScreen,
+        onDigit: _onPasscodeDigit,
+        onBackspace: _onPasscodeBackspace,
+      );
+    }
+
+    return _SyncKeepAwakeStatusScreen(
+      mode: widget.mode,
+      onUnlockPressed: _openPasscodePrompt,
+    );
+  }
+}
+
+class _SyncKeepAwakeStatusScreen extends ConsumerWidget {
+  const _SyncKeepAwakeStatusScreen({
+    required this.mode,
+    required this.onUnlockPressed,
+  });
+
+  final SyncKeepAwakePrivacyLockMode mode;
+  final VoidCallback onUnlockPressed;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -199,8 +327,8 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
                   SizedBox(height: layout.topGap),
                   const VizorWordmark(
                     key: ValueKey('sync_keep_awake_privacy_logo'),
-                    width: _logoWidth,
-                    height: _logoHeight,
+                    width: SyncKeepAwakePrivacyLockScreen._logoWidth,
+                    height: SyncKeepAwakePrivacyLockScreen._logoHeight,
                   ),
                   SizedBox(height: layout.logoToMainGap),
                   main,
@@ -209,9 +337,7 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
                     key: const ValueKey(
                       'sync_keep_awake_privacy_unlock_button',
                     ),
-                    onPressed: () => ref
-                        .read(syncKeepAwakePrivacyLockProvider.notifier)
-                        .unlock(),
+                    onPressed: onUnlockPressed,
                     leading: AppIcon(done ? AppIcons.faceId : AppIcons.unlock),
                     minWidth: 165,
                     child: const Text('Unlock Vizor'),
@@ -231,9 +357,9 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
     required SyncKeepAwakePrivacyLockMode mode,
   }) {
     final spec = _SyncKeepAwakeLayoutSpec.forMode(mode);
-    if (screenHeight >= _figmaReferenceHeight) {
+    if (screenHeight >= SyncKeepAwakePrivacyLockScreen._figmaReferenceHeight) {
       return _SyncKeepAwakeVerticalLayout(
-        topGap: _logoTopGap,
+        topGap: SyncKeepAwakePrivacyLockScreen._logoTopGap,
         logoToMainGap: spec.logoToMainGap,
         mainToButtonGap: spec.mainToButtonGap,
       );
@@ -243,7 +369,8 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
     var mainToButtonGap = spec.mainToButtonGap;
     final targetStackHeight = math.max(
       spec.minimumStackHeight,
-      availableHeight - (_shortScreenOuterMargin * 2),
+      availableHeight -
+          (SyncKeepAwakePrivacyLockScreen._shortScreenOuterMargin * 2),
     );
     final reduction = math.min(
       spec.stackHeight - targetStackHeight,
@@ -261,7 +388,7 @@ class SyncKeepAwakePrivacyLockScreen extends ConsumerWidget {
     }
 
     final stackHeight =
-        _logoHeight +
+        SyncKeepAwakePrivacyLockScreen._logoHeight +
         logoToMainGap +
         spec.mainHeight +
         mainToButtonGap +
@@ -339,6 +466,139 @@ class _SyncKeepAwakeVerticalLayout {
   final double topGap;
   final double logoToMainGap;
   final double mainToButtonGap;
+}
+
+class _SyncKeepAwakePasscodeConfirmScreen extends ConsumerWidget {
+  const _SyncKeepAwakePasscodeConfirmScreen({
+    required this.mode,
+    required this.entryLength,
+    required this.submitting,
+    required this.onBack,
+    required this.onDigit,
+    required this.onBackspace,
+    this.error,
+  });
+
+  final SyncKeepAwakePrivacyLockMode mode;
+  final int entryLength;
+  final bool submitting;
+  final VoidCallback onBack;
+  final ValueChanged<int> onDigit;
+  final VoidCallback onBackspace;
+  final String? error;
+
+  static const _topNavHeight = 74.0;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.colors;
+    final sync = ref.watch(syncProvider).asData?.value;
+    final progress = sync?.displayPercentage ?? sync?.percentage ?? 0.0;
+    return Material(
+      key: const ValueKey('sync_keep_awake_privacy_passcode_screen'),
+      color: colors.background.window,
+      child: Semantics(
+        scopesRoute: true,
+        namesRoute: true,
+        explicitChildNodes: true,
+        label: 'Confirm passcode to unlock Vizor',
+        child: SafeArea(
+          child: Column(
+            children: [
+              MobileTopNav.back(
+                title: _titleForMode(progress),
+                titleStyle: AppTypography.bodyMediumStrong.copyWith(
+                  color: colors.text.accent,
+                ),
+                height: _topNavHeight,
+                onBack: submitting ? null : onBack,
+              ),
+              Expanded(
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    final compact = constraints.maxHeight < 640;
+                    final verticalPadding = compact
+                        ? AppSpacing.s
+                        : AppSpacing.md;
+                    final topGap = compact ? 0.0 : AppSpacing.md;
+                    final sectionGap = compact ? AppSpacing.xs : AppSpacing.md;
+
+                    return Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: AppSpacing.sm,
+                        vertical: verticalPadding,
+                      ),
+                      child: Column(
+                        children: [
+                          SizedBox(height: topGap),
+                          Text(
+                            'Welcome Back',
+                            textAlign: TextAlign.center,
+                            style: AppTypography.displayLarge.copyWith(
+                              color: colors.text.accent,
+                            ),
+                          ),
+                          const SizedBox(height: AppSpacing.s),
+                          Text(
+                            _bodyForMode(),
+                            textAlign: TextAlign.center,
+                            style: AppTypography.bodyMediumStrong.copyWith(
+                              color: colors.text.primary,
+                            ),
+                          ),
+                          SizedBox(height: sectionGap),
+                          SizedBox(
+                            height: kPasscodePromptDigitsHeight,
+                            child: PasscodePromptField(
+                              length: kMobilePasscodeLength,
+                              filled: entryLength,
+                              error: error,
+                              minGap: 0,
+                            ),
+                          ),
+                          SizedBox(height: sectionGap),
+                          PasscodeNumpad(
+                            onDigit: onDigit,
+                            onBackspace: onBackspace,
+                            canDelete: entryLength > 0,
+                            enabled: !submitting,
+                          ),
+                          const Spacer(),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _titleForMode(double progress) {
+    return switch (mode) {
+      SyncKeepAwakePrivacyLockMode.done => 'Synced',
+      SyncKeepAwakePrivacyLockMode.interrupted => 'Sync paused',
+      SyncKeepAwakePrivacyLockMode.hidden ||
+      SyncKeepAwakePrivacyLockMode.syncing =>
+        '${formatSyncStatusPercentage(progress)}% Syncing...',
+    };
+  }
+
+  String _bodyForMode() {
+    if (submitting) return 'Checking passcode...';
+    return switch (mode) {
+      SyncKeepAwakePrivacyLockMode.done =>
+        'Synced successfully. Unlock Vizor to continue.',
+      SyncKeepAwakePrivacyLockMode.interrupted =>
+        'Sync paused. Unlock Vizor to continue.',
+      SyncKeepAwakePrivacyLockMode.hidden ||
+      SyncKeepAwakePrivacyLockMode.syncing =>
+        'Vizor is syncing, stick around ...',
+    };
+  }
 }
 
 class _SyncKeepAwakeStatusLockup extends StatelessWidget {

--- a/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
@@ -8,8 +8,10 @@ import '../../../features/onboarding/mobile/mobile_passcode_screen.dart';
 import '../../../features/onboarding/mobile/passcode_widgets.dart';
 import '../../../features/onboarding/shared/onboarding_welcome_art.dart';
 import '../../../providers/app_security_provider.dart';
+import '../../../providers/biometric_unlock_provider.dart';
 import '../../../providers/sync_keep_awake_provider.dart';
 import '../../../providers/sync_provider.dart';
+import '../../../services/biometric_unlock.dart';
 import '../../feedback/app_haptics.dart';
 import '../../formatting/sync_status_label.dart';
 import '../../layout/app_form_factor.dart';
@@ -156,6 +158,7 @@ class _SyncKeepAwakePrivacyLockScreenState
   var _showPasscode = false;
   var _passcodeEntry = '';
   var _submittingPasscode = false;
+  var _unlockAttemptInFlight = false;
   String? _passcodeError;
 
   @override
@@ -166,12 +169,13 @@ class _SyncKeepAwakePrivacyLockScreenState
     }
   }
 
-  void _openPasscodePrompt() {
+  void _openPasscodePrompt({String? error}) {
     setState(() {
       _showPasscode = true;
       _passcodeEntry = '';
-      _passcodeError = null;
+      _passcodeError = error;
       _submittingPasscode = false;
+      _unlockAttemptInFlight = false;
     });
   }
 
@@ -185,6 +189,7 @@ class _SyncKeepAwakePrivacyLockScreenState
     _passcodeEntry = '';
     _passcodeError = null;
     _submittingPasscode = false;
+    _unlockAttemptInFlight = false;
   }
 
   void _onPasscodeDigit(int digit) {
@@ -210,7 +215,50 @@ class _SyncKeepAwakePrivacyLockScreenState
 
   Future<void> _submitPasscode() async {
     if (_submittingPasscode) return;
-    final passcode = _passcodeEntry;
+    await _confirmPasscode(_passcodeEntry);
+  }
+
+  Future<void> _unlockOrPromptPasscode() async {
+    if (_submittingPasscode || _unlockAttemptInFlight) return;
+
+    setState(() {
+      _unlockAttemptInFlight = true;
+      _passcodeError = null;
+    });
+
+    final BiometricUnlockState biometric;
+    try {
+      biometric = await ref.read(biometricUnlockProvider.future);
+    } catch (_) {
+      if (mounted) _openPasscodePrompt();
+      return;
+    }
+    if (!mounted) return;
+
+    if (!biometric.usable) {
+      _openPasscodePrompt();
+      return;
+    }
+
+    final wasEnabled = biometric.enabled;
+    final passcode = await ref
+        .read(biometricUnlockProvider.notifier)
+        .readPasscode(reason: 'Unlock Vizor');
+    if (!mounted) return;
+
+    if (passcode == null) {
+      final now = ref.read(biometricUnlockProvider).value;
+      final error = wasEnabled && now != null && !now.enabled
+          ? biometric.availability.kind.changedMessage
+          : null;
+      _openPasscodePrompt(error: error);
+      return;
+    }
+
+    await _confirmPasscode(passcode);
+  }
+
+  Future<void> _confirmPasscode(String passcode) async {
     setState(() {
       _submittingPasscode = true;
       _passcodeError = null;
@@ -234,6 +282,8 @@ class _SyncKeepAwakePrivacyLockScreenState
     unawaited(AppHaptics.error());
     setState(() {
       _submittingPasscode = false;
+      _unlockAttemptInFlight = false;
+      _showPasscode = true;
       _passcodeEntry = '';
       _passcodeError = 'Incorrect Passcode';
     });
@@ -255,7 +305,9 @@ class _SyncKeepAwakePrivacyLockScreenState
 
     return _SyncKeepAwakeStatusScreen(
       mode: widget.mode,
-      onUnlockPressed: _openPasscodePrompt,
+      onUnlockPressed: _unlockAttemptInFlight || _submittingPasscode
+          ? null
+          : () => unawaited(_unlockOrPromptPasscode()),
     );
   }
 }
@@ -267,7 +319,7 @@ class _SyncKeepAwakeStatusScreen extends ConsumerWidget {
   });
 
   final SyncKeepAwakePrivacyLockMode mode;
-  final VoidCallback onUnlockPressed;
+  final VoidCallback? onUnlockPressed;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -277,6 +329,9 @@ class _SyncKeepAwakeStatusScreen extends ConsumerWidget {
     final sync = done || interrupted
         ? null
         : ref.watch(syncProvider).asData?.value;
+    final biometric =
+        ref.watch(biometricUnlockProvider).value ??
+        BiometricUnlockState.initial;
     final progress = sync?.displayPercentage ?? sync?.percentage ?? 0.0;
     final main = switch (mode) {
       SyncKeepAwakePrivacyLockMode.done => const _SyncKeepAwakeStatusLockup(
@@ -338,7 +393,7 @@ class _SyncKeepAwakeStatusScreen extends ConsumerWidget {
                       'sync_keep_awake_privacy_unlock_button',
                     ),
                     onPressed: onUnlockPressed,
-                    leading: AppIcon(done ? AppIcons.faceId : AppIcons.unlock),
+                    leading: _SyncKeepAwakeUnlockIcon(biometric: biometric),
                     minWidth: 165,
                     child: const Text('Unlock Vizor'),
                   ),
@@ -453,6 +508,23 @@ class _SyncKeepAwakeLayoutSpec {
       minimumMainToButtonGap:
           SyncKeepAwakePrivacyLockScreen._minimumRingToButtonGap,
     );
+  }
+}
+
+class _SyncKeepAwakeUnlockIcon extends StatelessWidget {
+  const _SyncKeepAwakeUnlockIcon({required this.biometric});
+
+  final BiometricUnlockState biometric;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!biometric.usable) return const AppIcon(AppIcons.unlock);
+
+    return switch (biometric.availability.kind) {
+      BiometricKind.face => const AppIcon(AppIcons.faceId),
+      BiometricKind.fingerprint => const Icon(Icons.fingerprint),
+      BiometricKind.none => const AppIcon(AppIcons.unlock),
+    };
   }
 }
 

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -8,6 +8,7 @@ import '../../../../core/feedback/app_haptics.dart';
 import '../../../../core/formatting/sync_status_label.dart';
 import '../../../../core/config/network_config.dart';
 import '../../../../core/formatting/zec_amount.dart';
+import '../../../../core/layout/mobile/app_mobile_sheet.dart';
 import '../../../../core/layout/mobile/app_mobile_tab_bar.dart';
 import '../../../../core/layout/mobile/mobile_top_nav_account.dart';
 import '../../../../core/layout/mobile/mobile_top_scroll_fade.dart';
@@ -18,6 +19,7 @@ import '../../../../core/widgets/app_icon.dart';
 import '../../../../core/widgets/app_toast.dart';
 import '../../../../providers/account_provider.dart';
 import '../../../../providers/privacy_mode_provider.dart';
+import '../../../../providers/sync_keep_awake_provider.dart';
 import '../../../../providers/sync_provider.dart';
 import '../../../../providers/zec_price_change_provider.dart';
 import '../../../accounts/widgets/mobile/mobile_accounts_sheet.dart';
@@ -88,6 +90,7 @@ class MobileHomeScreen extends ConsumerWidget {
               ],
             ),
           ),
+          const _SyncKeepAwakePromptHost(),
         ],
       ),
     );
@@ -121,6 +124,231 @@ const _mobileHomeBalanceTickerStyle = TextStyle(
 );
 
 const _mobileHomeActionButtonHeight = AppButtonSizing.largeHeight;
+
+class _SyncKeepAwakePromptHost extends ConsumerStatefulWidget {
+  const _SyncKeepAwakePromptHost();
+
+  @override
+  ConsumerState<_SyncKeepAwakePromptHost> createState() =>
+      _SyncKeepAwakePromptHostState();
+}
+
+class _SyncKeepAwakePromptHostState
+    extends ConsumerState<_SyncKeepAwakePromptHost> {
+  SyncKeepAwakeEtaSample? _etaSample;
+  DateTime? _promptRequestedForRun;
+  var _showingPrompt = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _evaluateCurrentSync();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(syncProvider, (_, next) {
+      final sync = next.asData?.value;
+      if (sync != null) _evaluateSync(sync);
+    });
+    ref.listen(syncKeepAwakeProvider, (previous, next) {
+      _evaluateCurrentSync();
+    });
+
+    return const SizedBox.shrink();
+  }
+
+  void _evaluateCurrentSync() {
+    final sync = ref.read(syncProvider).value;
+    if (sync != null) _evaluateSync(sync);
+  }
+
+  void _evaluateSync(SyncState sync) {
+    if (!sync.isSyncing ||
+        sync.lastSyncStartedAt != _etaSample?.syncStartedAt) {
+      _etaSample = null;
+    }
+
+    final estimate = estimateSyncKeepAwakeEta(
+      sync,
+      now: DateTime.now(),
+      previousSample: _etaSample,
+    );
+    if (estimate.sample != null) {
+      _etaSample = estimate.sample;
+    }
+
+    final startedAt = sync.lastSyncStartedAt;
+    if (_showingPrompt ||
+        startedAt == null ||
+        _promptRequestedForRun == startedAt) {
+      return;
+    }
+    final settings = ref.read(syncKeepAwakeProvider);
+    if (settings.enabled ||
+        settings.promptSeen ||
+        estimate.remaining == null ||
+        estimate.remaining! < kSyncKeepAwakePromptEtaThreshold) {
+      return;
+    }
+
+    _promptRequestedForRun = startedAt;
+    unawaited(_showPrompt());
+  }
+
+  Future<void> _showPrompt() async {
+    _showingPrompt = true;
+    try {
+      await ref.read(syncKeepAwakeProvider.notifier).markPromptSeen();
+      if (!mounted) return;
+      final enableKeepAwake = await showAppMobileSheet<bool>(
+        context: context,
+        builder: (sheetContext) => _SyncKeepAwakePromptSheet(
+          onKeepAwake: () => Navigator.of(sheetContext).pop(true),
+          onMaybeLater: () => Navigator.of(sheetContext).pop(false),
+        ),
+      );
+      if (!mounted || enableKeepAwake != true) return;
+      await ref
+          .read(syncKeepAwakeProvider.notifier)
+          .setEnabled(true, markPromptSeen: false);
+    } finally {
+      if (mounted) {
+        setState(() => _showingPrompt = false);
+      } else {
+        _showingPrompt = false;
+      }
+    }
+  }
+}
+
+class _SyncKeepAwakePromptSheet extends StatelessWidget {
+  const _SyncKeepAwakePromptSheet({
+    required this.onKeepAwake,
+    required this.onMaybeLater,
+  });
+
+  final VoidCallback onKeepAwake;
+  final VoidCallback onMaybeLater;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final bodyStyle = AppTypography.bodyMedium.copyWith(
+      color: colors.text.accent,
+    );
+
+    return MobileModalScaffold(
+      key: const ValueKey('mobile_sync_keep_awake_prompt_sheet'),
+      title: 'Keep screen awake during sync?',
+      onClose: onMaybeLater,
+      bodyGap: AppSpacing.xxs,
+      bottomPadding: AppSpacing.base,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'This will make long syncs much easier.',
+            style: AppTypography.bodyMedium.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _SyncKeepAwakePromptBullet(
+                iconName: AppIcons.cog,
+                text: 'You can turn it on and off in settings anytime.',
+                textStyle: bodyStyle.copyWith(fontWeight: FontWeight.w500),
+              ),
+              const SizedBox(height: AppSpacing.xs),
+              _SyncKeepAwakePromptBullet(
+                iconName: AppIcons.lock,
+                text:
+                    'After 1 minute of inactivity, the screen will be locked '
+                    'with the passcode while syncing continues in the '
+                    'background.',
+                textStyle: bodyStyle,
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.md),
+          AppButton(
+            key: const ValueKey('mobile_sync_keep_awake_prompt_enable'),
+            expand: true,
+            constrainContent: true,
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.sm,
+            ),
+            leading: const AppIcon(AppIcons.day),
+            onPressed: onKeepAwake,
+            child: const Text(
+              'Keep screen awake',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          AppButton(
+            key: const ValueKey('mobile_sync_keep_awake_prompt_later'),
+            variant: AppButtonVariant.ghost,
+            expand: true,
+            constrainContent: true,
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.sm,
+            ),
+            onPressed: onMaybeLater,
+            child: const Text(
+              'Maybe later',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SyncKeepAwakePromptBullet extends StatelessWidget {
+  const _SyncKeepAwakePromptBullet({
+    required this.iconName,
+    required this.text,
+    required this.textStyle,
+  });
+
+  final String iconName;
+  final String text;
+  final TextStyle textStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 32,
+          child: Padding(
+            padding: const EdgeInsets.only(top: AppSpacing.xxs),
+            child: Center(
+              child: AppIcon(
+                iconName,
+                size: 20,
+                color: context.colors.icon.accent,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.xxs),
+        Expanded(child: Text(text, style: textStyle)),
+      ],
+    );
+  }
+}
 
 class _ImportingBackground extends StatelessWidget {
   const _ImportingBackground();

--- a/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
@@ -45,9 +45,7 @@ class MobileSettingsScreen extends ConsumerWidget {
         ref.watch(biometricUnlockProvider).value ??
         BiometricUnlockState.initial;
     final syncKeepAwake = ref.watch(syncKeepAwakeProvider);
-    final settingsRowStyle = AppTypography.labelLarge.copyWith(
-      fontWeight: FontWeight.w400,
-    );
+    const settingsRowStyle = AppTypography.labelLarge;
     final settingsValueColor = context.colors.text.accent;
     final settingsChevronColor = context.colors.icon.accent;
     final seedPhraseEnabled = account != null && !account.isHardware;
@@ -169,6 +167,17 @@ class MobileSettingsScreen extends ConsumerWidget {
                   ],
                 ),
                 const SizedBox(height: AppSpacing.md),
+                _SyncKeepAwakeSettingsCard(
+                  enabled: syncKeepAwake.enabled,
+                  onToggle: () => unawaited(
+                    _toggleSyncKeepAwake(
+                      context,
+                      ref,
+                      enabled: syncKeepAwake.enabled,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.md),
                 _SettingsGroup(
                   title: 'System',
                   rows: [
@@ -197,25 +206,6 @@ class MobileSettingsScreen extends ConsumerWidget {
                       chevronColor: settingsChevronColor,
                       showChevron: true,
                       onTap: () => _showThemeSheet(context, ref, themeMode),
-                    ),
-                    MobileListRow(
-                      key: const ValueKey(
-                        'mobile_settings_sync_keep_awake_row',
-                      ),
-                      leading: _RowIcon(AppIcons.day),
-                      label: 'Keep screen awake',
-                      value: syncKeepAwake.enabled ? 'On' : 'Off',
-                      minRowHeight: _settingsRowHeight,
-                      textStyle: settingsRowStyle,
-                      valueTextStyle: settingsRowStyle,
-                      valueColor: settingsValueColor,
-                      onTap: () => unawaited(
-                        _toggleSyncKeepAwake(
-                          context,
-                          ref,
-                          enabled: syncKeepAwake.enabled,
-                        ),
-                      ),
                     ),
                     // No Figma frame for this row yet — listed in
                     // design_suggestion. Hidden on devices without
@@ -490,13 +480,148 @@ class _SettingsGroup extends StatelessWidget {
             child: Text(
               title,
               style: AppTypography.labelLarge.copyWith(
-                fontWeight: FontWeight.w400,
                 color: context.colors.text.secondary,
               ),
             ),
           ),
           ...rows,
         ],
+      ),
+    );
+  }
+}
+
+class _SyncKeepAwakeSettingsCard extends StatelessWidget {
+  const _SyncKeepAwakeSettingsCard({
+    required this.enabled,
+    required this.onToggle,
+  });
+
+  final bool enabled;
+  final VoidCallback onToggle;
+
+  static const _description =
+      'Keep the screen active while Vizor is syncing. This will make long '
+      'syncs easier. For security, the screen will lock with passcode after '
+      '1 minute of inactivity.';
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return MobileSurfaceCard(
+      cornerRadius: AppRadii.large,
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.sm,
+        AppSpacing.base,
+        AppSpacing.sm,
+        AppSpacing.base,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.xxs),
+            child: Text(
+              'Syncing',
+              style: AppTypography.labelLarge.copyWith(
+                color: colors.text.secondary,
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          Semantics(
+            button: true,
+            toggled: enabled,
+            label: 'Keep screen awake',
+            excludeSemantics: true,
+            child: GestureDetector(
+              key: const ValueKey('mobile_settings_sync_keep_awake_row'),
+              behavior: HitTestBehavior.opaque,
+              onTap: onToggle,
+              child: SizedBox(
+                height: _settingsRowHeight,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.xxs,
+                  ),
+                  child: Row(
+                    children: [
+                      const SizedBox.square(
+                        dimension: 32,
+                        child: Center(child: _RowIcon(AppIcons.day)),
+                      ),
+                      const SizedBox(width: AppSpacing.s),
+                      Expanded(
+                        child: Text(
+                          'Keep screen awake',
+                          overflow: TextOverflow.ellipsis,
+                          style: AppTypography.labelLarge.copyWith(
+                            color: colors.text.accent,
+                          ),
+                        ),
+                      ),
+                      _SyncKeepAwakeToggle(
+                        key: const ValueKey(
+                          'mobile_settings_sync_keep_awake_toggle',
+                        ),
+                        enabled: enabled,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            _description,
+            style: AppTypography.bodyMedium.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SyncKeepAwakeToggle extends StatelessWidget {
+  const _SyncKeepAwakeToggle({required this.enabled, super.key});
+
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final trackColor = enabled
+        ? colors.background.brandCrimsonStrong
+        : colors.background.raised;
+    final borderColor = enabled
+        ? colors.border.brandCrimsonStrong
+        : colors.border.regular;
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 140),
+      curve: Curves.easeOutCubic,
+      width: 64,
+      height: 28,
+      padding: const EdgeInsets.all(2),
+      decoration: BoxDecoration(
+        color: trackColor,
+        borderRadius: BorderRadius.circular(AppRadii.full),
+        border: Border.all(color: borderColor),
+      ),
+      child: AnimatedAlign(
+        duration: const Duration(milliseconds: 140),
+        curve: Curves.easeOutCubic,
+        alignment: enabled ? Alignment.centerRight : Alignment.centerLeft,
+        child: DecoratedBox(
+          key: const ValueKey('mobile_settings_sync_keep_awake_toggle_thumb'),
+          decoration: BoxDecoration(
+            color: const Color(0xFFFFFFFF),
+            borderRadius: BorderRadius.circular(AppRadii.full),
+          ),
+          child: const SizedBox(width: 40, height: 24),
+        ),
       ),
     );
   }

--- a/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
@@ -21,16 +21,15 @@ import '../../../../providers/account_provider.dart';
 import '../../../../providers/app_security_provider.dart';
 import '../../../../providers/biometric_unlock_provider.dart';
 import '../../../../providers/rpc_endpoint_provider.dart';
+import '../../../../providers/sync_keep_awake_provider.dart';
 import '../../../../providers/theme_mode_provider.dart';
 import '../../../../services/biometric_unlock.dart';
 import '../../../accounts/widgets/mobile/account_edit_sheets.dart';
 
 /// Mobile settings tab — Figma `SETTINGS` root frame (4494:65997).
 ///
-/// Phase 1 scope: the grouped list renders with live values, but only
-/// the theme row is interactive; the remaining rows enable as their
-/// mobile flows ship (secret passphrase needs the FaceID/screenshot
-/// guards, password/endpoint/address book need their own screens).
+/// Rows share the grouped-list pattern; each row owns its navigation or
+/// toggle behavior as the corresponding mobile flow ships.
 class MobileSettingsScreen extends ConsumerWidget {
   const MobileSettingsScreen({super.key});
 
@@ -45,6 +44,7 @@ class MobileSettingsScreen extends ConsumerWidget {
     final biometric =
         ref.watch(biometricUnlockProvider).value ??
         BiometricUnlockState.initial;
+    final syncKeepAwake = ref.watch(syncKeepAwakeProvider);
     final settingsRowStyle = AppTypography.labelLarge.copyWith(
       fontWeight: FontWeight.w400,
     );
@@ -197,6 +197,25 @@ class MobileSettingsScreen extends ConsumerWidget {
                       chevronColor: settingsChevronColor,
                       showChevron: true,
                       onTap: () => _showThemeSheet(context, ref, themeMode),
+                    ),
+                    MobileListRow(
+                      key: const ValueKey(
+                        'mobile_settings_sync_keep_awake_row',
+                      ),
+                      leading: _RowIcon(AppIcons.day),
+                      label: 'Keep screen awake',
+                      value: syncKeepAwake.enabled ? 'On' : 'Off',
+                      minRowHeight: _settingsRowHeight,
+                      textStyle: settingsRowStyle,
+                      valueTextStyle: settingsRowStyle,
+                      valueColor: settingsValueColor,
+                      onTap: () => unawaited(
+                        _toggleSyncKeepAwake(
+                          context,
+                          ref,
+                          enabled: syncKeepAwake.enabled,
+                        ),
+                      ),
                     ),
                     // No Figma frame for this row yet — listed in
                     // design_suggestion. Hidden on devices without
@@ -355,6 +374,19 @@ class MobileSettingsScreen extends ConsumerWidget {
     );
     if (selected != null && selected != current) {
       await ref.read(themeModeProvider.notifier).set(selected);
+    }
+  }
+
+  Future<void> _toggleSyncKeepAwake(
+    BuildContext context,
+    WidgetRef ref, {
+    required bool enabled,
+  }) async {
+    try {
+      await ref.read(syncKeepAwakeProvider.notifier).setEnabled(!enabled);
+    } catch (_) {
+      if (!context.mounted) return;
+      showAppToast(context, "Couldn't update screen awake setting.");
     }
   }
 }

--- a/lib/src/providers/sync_keep_awake_provider.dart
+++ b/lib/src/providers/sync_keep_awake_provider.dart
@@ -74,6 +74,46 @@ final syncKeepAwakeProvider =
       SyncKeepAwakeNotifier.new,
     );
 
+class SyncKeepAwakeInteractionState {
+  const SyncKeepAwakeInteractionState({
+    required this.lastInteractionAt,
+    this.revision = 0,
+  });
+
+  final DateTime lastInteractionAt;
+  final int revision;
+
+  Duration idleDuration(DateTime now) => now.difference(lastInteractionAt);
+}
+
+class SyncKeepAwakeInteractionNotifier
+    extends Notifier<SyncKeepAwakeInteractionState> {
+  @override
+  SyncKeepAwakeInteractionState build() {
+    return SyncKeepAwakeInteractionState(lastInteractionAt: DateTime.now());
+  }
+
+  void markInteraction({DateTime? at}) {
+    state = SyncKeepAwakeInteractionState(
+      lastInteractionAt: at ?? DateTime.now(),
+      revision: state.revision + 1,
+    );
+  }
+}
+
+final syncKeepAwakeInteractionProvider =
+    NotifierProvider<
+      SyncKeepAwakeInteractionNotifier,
+      SyncKeepAwakeInteractionState
+    >(SyncKeepAwakeInteractionNotifier.new);
+
+final syncKeepAwakeActiveProvider = Provider<bool>((ref) {
+  final settings = ref.watch(syncKeepAwakeProvider);
+  final sync = ref.watch(syncProvider).asData?.value;
+  if (sync == null) return false;
+  return shouldKeepScreenAwakeForSync(settings: settings, sync: sync);
+});
+
 class SyncKeepAwakeEtaSample {
   const SyncKeepAwakeEtaSample({
     required this.syncStartedAt,
@@ -104,7 +144,7 @@ bool isNearTipCatchUp(SyncState sync) {
       kSyncKeepAwakeNearTipBlockGap;
 }
 
-bool canEstimateSyncKeepAwakeEta(SyncState sync) {
+bool isSyncKeepAwakeEligibleSync(SyncState sync) {
   return sync.isSyncing &&
       !sync.isBackgroundMode &&
       sync.percentage > 0 &&
@@ -113,6 +153,17 @@ bool canEstimateSyncKeepAwakeEta(SyncState sync) {
       sync.chainTipHeight > 0 &&
       sync.scannedHeight > 0 &&
       !isNearTipCatchUp(sync);
+}
+
+bool canEstimateSyncKeepAwakeEta(SyncState sync) {
+  return isSyncKeepAwakeEligibleSync(sync);
+}
+
+bool shouldKeepScreenAwakeForSync({
+  required SyncKeepAwakeSettings settings,
+  required SyncState sync,
+}) {
+  return settings.enabled && isSyncKeepAwakeEligibleSync(sync);
 }
 
 SyncKeepAwakeEtaEstimate estimateSyncKeepAwakeEta(

--- a/lib/src/providers/sync_keep_awake_provider.dart
+++ b/lib/src/providers/sync_keep_awake_provider.dart
@@ -1,0 +1,218 @@
+import 'dart:math' as math;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../app_bootstrap.dart';
+import '../core/storage/app_secure_store.dart';
+import 'sync_provider.dart';
+
+const kSyncKeepAwakePromptEtaThreshold = Duration(minutes: 1);
+const kSyncKeepAwakeNearTipBlockGap = 2;
+
+class SyncKeepAwakeSettings {
+  const SyncKeepAwakeSettings({
+    required this.enabled,
+    required this.promptSeen,
+  });
+
+  final bool enabled;
+  final bool promptSeen;
+
+  SyncKeepAwakeSettings copyWith({bool? enabled, bool? promptSeen}) {
+    return SyncKeepAwakeSettings(
+      enabled: enabled ?? this.enabled,
+      promptSeen: promptSeen ?? this.promptSeen,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is SyncKeepAwakeSettings &&
+            other.enabled == enabled &&
+            other.promptSeen == promptSeen;
+  }
+
+  @override
+  int get hashCode => Object.hash(enabled, promptSeen);
+}
+
+class SyncKeepAwakeNotifier extends Notifier<SyncKeepAwakeSettings> {
+  static final _store = AppSecureStore.instance;
+
+  @override
+  SyncKeepAwakeSettings build() {
+    final bootstrap = ref.watch(appBootstrapProvider);
+    return SyncKeepAwakeSettings(
+      enabled: bootstrap.syncKeepAwakeEnabled,
+      promptSeen: bootstrap.syncKeepAwakePromptSeen,
+    );
+  }
+
+  Future<void> setEnabled(bool enabled, {bool markPromptSeen = true}) async {
+    await _store.writePlain(
+      kSyncKeepAwakeEnabledKey,
+      enabled ? 'true' : 'false',
+    );
+    if (markPromptSeen) {
+      await _store.writePlain(kSyncKeepAwakePromptSeenKey, 'true');
+    }
+    state = state.copyWith(
+      enabled: enabled,
+      promptSeen: markPromptSeen ? true : null,
+    );
+  }
+
+  Future<void> markPromptSeen() async {
+    await _store.writePlain(kSyncKeepAwakePromptSeenKey, 'true');
+    state = state.copyWith(promptSeen: true);
+  }
+}
+
+final syncKeepAwakeProvider =
+    NotifierProvider<SyncKeepAwakeNotifier, SyncKeepAwakeSettings>(
+      SyncKeepAwakeNotifier.new,
+    );
+
+class SyncKeepAwakeEtaSample {
+  const SyncKeepAwakeEtaSample({
+    required this.syncStartedAt,
+    required this.measuredAt,
+    required this.estimatedRemainingBlocks,
+  });
+
+  final DateTime syncStartedAt;
+  final DateTime measuredAt;
+  final double estimatedRemainingBlocks;
+}
+
+class SyncKeepAwakeEtaEstimate {
+  const SyncKeepAwakeEtaEstimate({
+    required this.remaining,
+    required this.sample,
+  });
+
+  const SyncKeepAwakeEtaEstimate.none() : remaining = null, sample = null;
+
+  final Duration? remaining;
+  final SyncKeepAwakeEtaSample? sample;
+}
+
+bool isNearTipCatchUp(SyncState sync) {
+  if (sync.chainTipHeight <= 0 || sync.scannedHeight <= 0) return false;
+  return sync.chainTipHeight - sync.scannedHeight <=
+      kSyncKeepAwakeNearTipBlockGap;
+}
+
+bool canEstimateSyncKeepAwakeEta(SyncState sync) {
+  return sync.isSyncing &&
+      !sync.isBackgroundMode &&
+      sync.percentage > 0 &&
+      sync.percentage < 1 &&
+      sync.lastSyncStartedAt != null &&
+      sync.chainTipHeight > 0 &&
+      sync.scannedHeight > 0 &&
+      !isNearTipCatchUp(sync);
+}
+
+SyncKeepAwakeEtaEstimate estimateSyncKeepAwakeEta(
+  SyncState sync, {
+  required DateTime now,
+  SyncKeepAwakeEtaSample? previousSample,
+}) {
+  final startedAt = sync.lastSyncStartedAt;
+  if (!canEstimateSyncKeepAwakeEta(sync) || startedAt == null) {
+    return const SyncKeepAwakeEtaEstimate.none();
+  }
+
+  final elapsed = now.difference(startedAt);
+  if (elapsed <= Duration.zero) {
+    return const SyncKeepAwakeEtaEstimate.none();
+  }
+
+  final estimatedRemainingBlocks = _estimatedRemainingBlocks(sync);
+  final sample = estimatedRemainingBlocks == null
+      ? null
+      : SyncKeepAwakeEtaSample(
+          syncStartedAt: startedAt,
+          measuredAt: now,
+          estimatedRemainingBlocks: estimatedRemainingBlocks,
+        );
+
+  final observedEta = sample == null
+      ? null
+      : _estimateFromObservedBlockRate(
+          sample: sample,
+          previousSample: previousSample,
+        );
+  if (observedEta != null) {
+    return SyncKeepAwakeEtaEstimate(remaining: observedEta, sample: sample);
+  }
+
+  final fallbackEta = _estimateFromRunPercentage(sync, elapsed);
+  return SyncKeepAwakeEtaEstimate(remaining: fallbackEta, sample: sample);
+}
+
+bool shouldShowSyncKeepAwakePrompt({
+  required SyncState sync,
+  required SyncKeepAwakeSettings settings,
+  required DateTime now,
+  SyncKeepAwakeEtaSample? previousSample,
+  Duration threshold = kSyncKeepAwakePromptEtaThreshold,
+}) {
+  if (settings.promptSeen) return false;
+  final remaining = estimateSyncKeepAwakeEta(
+    sync,
+    now: now,
+    previousSample: previousSample,
+  ).remaining;
+  return remaining != null && remaining >= threshold;
+}
+
+double? _estimatedRemainingBlocks(SyncState sync) {
+  final targetDelta = sync.displayTargetPercentage - sync.percentage;
+  if (sync.displayTargetBlocks > 0 && targetDelta > 0) {
+    final totalBlocks = sync.displayTargetBlocks / targetDelta;
+    if (totalBlocks.isFinite && totalBlocks > 0) {
+      return math.max(0.0, totalBlocks * (1 - sync.percentage));
+    }
+  }
+  return null;
+}
+
+Duration? _estimateFromObservedBlockRate({
+  required SyncKeepAwakeEtaSample sample,
+  SyncKeepAwakeEtaSample? previousSample,
+}) {
+  if (previousSample == null ||
+      previousSample.syncStartedAt != sample.syncStartedAt) {
+    return null;
+  }
+  final elapsedMicros = sample.measuredAt
+      .difference(previousSample.measuredAt)
+      .inMicroseconds;
+  if (elapsedMicros <= 0) return null;
+
+  final processedBlocks =
+      previousSample.estimatedRemainingBlocks - sample.estimatedRemainingBlocks;
+  if (processedBlocks <= 0 || !processedBlocks.isFinite) return null;
+
+  final blocksPerMicrosecond = processedBlocks / elapsedMicros;
+  if (blocksPerMicrosecond <= 0 || !blocksPerMicrosecond.isFinite) return null;
+
+  final remainingMicros =
+      sample.estimatedRemainingBlocks / blocksPerMicrosecond;
+  if (!remainingMicros.isFinite || remainingMicros < 0) return null;
+  return Duration(microseconds: remainingMicros.round());
+}
+
+Duration? _estimateFromRunPercentage(SyncState sync, Duration elapsed) {
+  final percentage = sync.percentage;
+  if (percentage <= 0 || percentage >= 1 || elapsed <= Duration.zero) {
+    return null;
+  }
+  final remainingMicros =
+      elapsed.inMicroseconds * (1 - percentage) / percentage;
+  if (!remainingMicros.isFinite || remainingMicros < 0) return null;
+  return Duration(microseconds: remainingMicros.round());
+}

--- a/lib/src/providers/sync_keep_awake_provider.dart
+++ b/lib/src/providers/sync_keep_awake_provider.dart
@@ -8,6 +8,7 @@ import 'app_security_provider.dart';
 import 'sync_provider.dart';
 
 const kSyncKeepAwakePromptEtaThreshold = Duration(minutes: 1);
+const kSyncKeepAwakePrivacyIdleTimeout = Duration(minutes: 1);
 const kSyncKeepAwakeNearTipBlockGap = 2;
 
 class SyncKeepAwakeSettings {
@@ -108,12 +109,71 @@ final syncKeepAwakeInteractionProvider =
       SyncKeepAwakeInteractionState
     >(SyncKeepAwakeInteractionNotifier.new);
 
+class SyncKeepAwakePrivacyLockState {
+  const SyncKeepAwakePrivacyLockState({required this.isLocked, this.lockedAt});
+
+  const SyncKeepAwakePrivacyLockState.unlocked()
+    : isLocked = false,
+      lockedAt = null;
+
+  final bool isLocked;
+  final DateTime? lockedAt;
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        other is SyncKeepAwakePrivacyLockState &&
+            other.isLocked == isLocked &&
+            other.lockedAt == lockedAt;
+  }
+
+  @override
+  int get hashCode => Object.hash(isLocked, lockedAt);
+}
+
+class SyncKeepAwakePrivacyLockNotifier
+    extends Notifier<SyncKeepAwakePrivacyLockState> {
+  @override
+  SyncKeepAwakePrivacyLockState build() {
+    return const SyncKeepAwakePrivacyLockState.unlocked();
+  }
+
+  void lock({DateTime? at}) {
+    if (state.isLocked) return;
+    state = SyncKeepAwakePrivacyLockState(
+      isLocked: true,
+      lockedAt: at ?? DateTime.now(),
+    );
+  }
+
+  void unlock({DateTime? at}) {
+    ref.read(syncKeepAwakeInteractionProvider.notifier).markInteraction(at: at);
+    clear();
+  }
+
+  void clear() {
+    if (!state.isLocked) return;
+    state = const SyncKeepAwakePrivacyLockState.unlocked();
+  }
+}
+
+final syncKeepAwakePrivacyLockProvider =
+    NotifierProvider<
+      SyncKeepAwakePrivacyLockNotifier,
+      SyncKeepAwakePrivacyLockState
+    >(SyncKeepAwakePrivacyLockNotifier.new);
+
 final syncKeepAwakeActiveProvider = Provider<bool>((ref) {
   if (ref.watch(appSecurityProvider).requiresUnlock) return false;
   final settings = ref.watch(syncKeepAwakeProvider);
   final sync = ref.watch(syncProvider).asData?.value;
   if (sync == null) return false;
   return shouldKeepScreenAwakeForSync(settings: settings, sync: sync);
+});
+
+final syncKeepAwakePrivacyLockVisibleProvider = Provider<bool>((ref) {
+  return ref.watch(syncKeepAwakeActiveProvider) &&
+      ref.watch(syncKeepAwakePrivacyLockProvider).isLocked;
 });
 
 class SyncKeepAwakeEtaSample {

--- a/lib/src/providers/sync_keep_awake_provider.dart
+++ b/lib/src/providers/sync_keep_awake_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../app_bootstrap.dart';
 import '../core/storage/app_secure_store.dart';
+import 'app_security_provider.dart';
 import 'sync_provider.dart';
 
 const kSyncKeepAwakePromptEtaThreshold = Duration(minutes: 1);
@@ -108,6 +109,7 @@ final syncKeepAwakeInteractionProvider =
     >(SyncKeepAwakeInteractionNotifier.new);
 
 final syncKeepAwakeActiveProvider = Provider<bool>((ref) {
+  if (ref.watch(appSecurityProvider).requiresUnlock) return false;
   final settings = ref.watch(syncKeepAwakeProvider);
   final sync = ref.watch(syncProvider).asData?.value;
   if (sync == null) return false;

--- a/lib/src/providers/sync_keep_awake_provider.dart
+++ b/lib/src/providers/sync_keep_awake_provider.dart
@@ -163,6 +163,8 @@ final syncKeepAwakePrivacyLockProvider =
       SyncKeepAwakePrivacyLockState
     >(SyncKeepAwakePrivacyLockNotifier.new);
 
+enum SyncKeepAwakePrivacyLockMode { hidden, syncing, done, interrupted }
+
 final syncKeepAwakeActiveProvider = Provider<bool>((ref) {
   if (ref.watch(appSecurityProvider).requiresUnlock) return false;
   final settings = ref.watch(syncKeepAwakeProvider);
@@ -171,9 +173,27 @@ final syncKeepAwakeActiveProvider = Provider<bool>((ref) {
   return shouldKeepScreenAwakeForSync(settings: settings, sync: sync);
 });
 
+final syncKeepAwakePrivacyLockModeProvider =
+    Provider<SyncKeepAwakePrivacyLockMode>((ref) {
+      if (ref.watch(appSecurityProvider).requiresUnlock) {
+        return SyncKeepAwakePrivacyLockMode.hidden;
+      }
+      if (!ref.watch(syncKeepAwakePrivacyLockProvider).isLocked) {
+        return SyncKeepAwakePrivacyLockMode.hidden;
+      }
+      final sync = ref.watch(syncProvider).asData?.value;
+      if (sync?.isSyncing == true && sync?.isBackgroundMode != true) {
+        return SyncKeepAwakePrivacyLockMode.syncing;
+      }
+      if (sync != null && isSyncKeepAwakeCompletedSync(sync)) {
+        return SyncKeepAwakePrivacyLockMode.done;
+      }
+      return SyncKeepAwakePrivacyLockMode.interrupted;
+    });
+
 final syncKeepAwakePrivacyLockVisibleProvider = Provider<bool>((ref) {
-  return ref.watch(syncKeepAwakeActiveProvider) &&
-      ref.watch(syncKeepAwakePrivacyLockProvider).isLocked;
+  return ref.watch(syncKeepAwakePrivacyLockModeProvider) !=
+      SyncKeepAwakePrivacyLockMode.hidden;
 });
 
 class SyncKeepAwakeEtaSample {
@@ -215,6 +235,12 @@ bool isSyncKeepAwakeEligibleSync(SyncState sync) {
       sync.chainTipHeight > 0 &&
       sync.scannedHeight > 0 &&
       !isNearTipCatchUp(sync);
+}
+
+bool isSyncKeepAwakeCompletedSync(SyncState sync) {
+  if (sync.isSyncing || sync.isBackgroundMode) return false;
+  if (sync.percentage >= 1 || sync.displayPercentage >= 1) return true;
+  return sync.chainTipHeight > 0 && sync.scannedHeight >= sync.chainTipHeight;
 }
 
 bool canEstimateSyncKeepAwakeEta(SyncState sync) {

--- a/lib/src/providers/sync_keep_awake_provider.dart
+++ b/lib/src/providers/sync_keep_awake_provider.dart
@@ -237,6 +237,22 @@ bool isSyncKeepAwakeEligibleSync(SyncState sync) {
       !isNearTipCatchUp(sync);
 }
 
+bool isSyncKeepAwakeActiveSync(SyncState sync) {
+  if (!sync.isSyncing ||
+      sync.isBackgroundMode ||
+      sync.percentage >= 1 ||
+      sync.lastSyncStartedAt == null) {
+    return false;
+  }
+
+  final hasKnownHeights = sync.chainTipHeight > 0 && sync.scannedHeight > 0;
+  if (hasKnownHeights) {
+    return !isNearTipCatchUp(sync);
+  }
+
+  return sync.displayTargetBlocks > kSyncKeepAwakeNearTipBlockGap;
+}
+
 bool isSyncKeepAwakeCompletedSync(SyncState sync) {
   if (sync.isSyncing || sync.isBackgroundMode) return false;
   if (sync.percentage >= 1 || sync.displayPercentage >= 1) return true;
@@ -251,7 +267,7 @@ bool shouldKeepScreenAwakeForSync({
   required SyncKeepAwakeSettings settings,
   required SyncState sync,
 }) {
-  return settings.enabled && isSyncKeepAwakeEligibleSync(sync);
+  return settings.enabled && isSyncKeepAwakeActiveSync(sync);
 }
 
 SyncKeepAwakeEtaEstimate estimateSyncKeepAwakeEta(

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -34,6 +34,8 @@ class SyncState {
   final bool isBackgroundMode;
   final double percentage;
   final double displayPercentage;
+  final double displayTargetPercentage;
+  final int displayTargetBlocks;
   final int scannedHeight;
   final int chainTipHeight;
   final BigInt transparentBalance;
@@ -80,6 +82,8 @@ class SyncState {
     this.isBackgroundMode = false,
     this.percentage = 0,
     double? displayPercentage,
+    double? displayTargetPercentage,
+    this.displayTargetBlocks = 0,
     this.scannedHeight = 0,
     this.chainTipHeight = 0,
     BigInt? transparentBalance,
@@ -104,6 +108,7 @@ class SyncState {
        hasRecentTransactionsData =
            hasRecentTransactionsData ?? hasAccountScopedData,
        displayPercentage = displayPercentage ?? percentage,
+       displayTargetPercentage = displayTargetPercentage ?? percentage,
        transparentBalance = transparentBalance ?? BigInt.zero,
        saplingBalance = saplingBalance ?? BigInt.zero,
        orchardBalance = orchardBalance ?? BigInt.zero,
@@ -124,6 +129,8 @@ class SyncState {
     bool? isBackgroundMode,
     double? percentage,
     double? displayPercentage,
+    double? displayTargetPercentage,
+    int? displayTargetBlocks,
     int? scannedHeight,
     int? chainTipHeight,
     BigInt? transparentBalance,
@@ -159,6 +166,9 @@ class SyncState {
       isBackgroundMode: isBackgroundMode ?? this.isBackgroundMode,
       percentage: percentage ?? this.percentage,
       displayPercentage: displayPercentage ?? this.displayPercentage,
+      displayTargetPercentage:
+          displayTargetPercentage ?? this.displayTargetPercentage,
+      displayTargetBlocks: displayTargetBlocks ?? this.displayTargetBlocks,
       scannedHeight: scannedHeight ?? this.scannedHeight,
       chainTipHeight: chainTipHeight ?? this.chainTipHeight,
       transparentBalance: transparentBalance ?? this.transparentBalance,
@@ -209,6 +219,8 @@ class SyncState {
       isBackgroundMode: isBackgroundMode,
       percentage: percentage,
       displayPercentage: displayPercentage,
+      displayTargetPercentage: displayTargetPercentage,
+      displayTargetBlocks: displayTargetBlocks,
       scannedHeight: scannedHeight,
       chainTipHeight: chainTipHeight,
       failure: failure,
@@ -1055,6 +1067,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         isBackgroundMode: _bgDelegate.isActive,
         percentage: 1.0,
         displayPercentage: 1.0,
+        displayTargetPercentage: 1.0,
+        displayTargetBlocks: 0,
         scannedHeight: scannedHeight,
         chainTipHeight: chainTipHeight,
         lastSyncStartedAt: prev?.lastSyncStartedAt ?? completedAt,
@@ -1430,6 +1444,8 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
             (!event.isComplete && event.isBackground) || _bgDelegate.isActive,
         percentage: actualPercentage,
         displayPercentage: displayPercentage,
+        displayTargetPercentage: event.displayTargetPercentage,
+        displayTargetBlocks: event.displayTargetBlocks,
         scannedHeight: event.scannedHeight,
         chainTipHeight: event.chainTipHeight,
         transparentBalance: useFetchedAccountData
@@ -1616,6 +1632,9 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         percentage: current?.percentage ?? 0.0,
         displayPercentage:
             current?.displayPercentage ?? current?.percentage ?? 0.0,
+        displayTargetPercentage:
+            current?.displayTargetPercentage ?? current?.percentage ?? 0.0,
+        displayTargetBlocks: current?.displayTargetBlocks ?? 0,
         scannedHeight: current?.scannedHeight ?? 0,
         chainTipHeight: current?.chainTipHeight ?? 0,
         transparentBalance: transparent ?? accountFallback?.transparentBalance,

--- a/lib/src/services/native_screen_awake.dart
+++ b/lib/src/services/native_screen_awake.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/services.dart';
+
+const kNativeScreenAwakeChannelName = 'com.zcash.wallet/screen_awake';
+
+class NativeScreenAwakeBridge {
+  const NativeScreenAwakeBridge({
+    MethodChannel channel = const MethodChannel(kNativeScreenAwakeChannelName),
+  }) : _channel = channel;
+
+  final MethodChannel _channel;
+
+  Future<void> setEnabled(bool enabled) {
+    return _channel.invokeMethod<void>('setEnabled', {'enabled': enabled});
+  }
+}

--- a/test/app_bootstrap_test.dart
+++ b/test/app_bootstrap_test.dart
@@ -135,4 +135,12 @@ void main() {
   test('empty bootstrap starts with privacy mode disabled', () {
     expect(AppBootstrapState.empty.privacyModeEnabled, isFalse);
   });
+
+  test(
+    'empty bootstrap starts with sync keep-awake disabled and unprompted',
+    () {
+      expect(AppBootstrapState.empty.syncKeepAwakeEnabled, isFalse);
+      expect(AppBootstrapState.empty.syncKeepAwakePromptSeen, isFalse);
+    },
+  );
 }

--- a/test/core/widgets/sync_keep_awake_interaction_listener_test.dart
+++ b/test/core/widgets/sync_keep_awake_interaction_listener_test.dart
@@ -1,0 +1,65 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/widgets/mobile/sync_keep_awake_interaction_listener.dart';
+import 'package:zcash_wallet/src/providers/sync_keep_awake_provider.dart';
+
+void main() {
+  testWidgets('records mobile pointer interactions without consuming them', (
+    tester,
+  ) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    var taps = 0;
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: Scaffold(
+            body: SyncKeepAwakeInteractionListener(
+              child: Center(
+                child: GestureDetector(
+                  key: const ValueKey('target'),
+                  onTap: () => taps += 1,
+                  child: const SizedBox.square(
+                    dimension: 120,
+                    child: Center(child: Text('Tap target')),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final initialRevision = container
+        .read(syncKeepAwakeInteractionProvider)
+        .revision;
+
+    await tester.tap(find.byKey(const ValueKey('target')));
+    await tester.pump();
+
+    expect(taps, 1);
+    expect(
+      container.read(syncKeepAwakeInteractionProvider).revision,
+      greaterThan(initialRevision),
+    );
+
+    final afterTapRevision = container
+        .read(syncKeepAwakeInteractionProvider)
+        .revision;
+
+    await tester.drag(find.byKey(const ValueKey('target')), const Offset(8, 0));
+    await tester.pump();
+
+    expect(
+      container.read(syncKeepAwakeInteractionProvider).revision,
+      greaterThan(afterTapRevision),
+    );
+  });
+}

--- a/test/core/widgets/sync_keep_awake_native_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_native_host_test.dart
@@ -56,6 +56,26 @@ void main() {
     expect(_enabledArgs(calls), [true, false]);
   });
 
+  testWidgets('enables native keep-awake during zero-percent first batch', (
+    tester,
+  ) async {
+    final calls = _recordScreenAwakeCalls();
+    final syncNotifier = FakeSyncNotifier(
+      _sync(
+        percentage: 0,
+        displayTargetBlocks: 100,
+        scannedHeight: 0,
+        chainTipHeight: 0,
+        lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+      ),
+    );
+
+    await tester.pumpWidget(_app(syncNotifier: syncNotifier));
+    await _drainNativeQueue(tester);
+
+    expect(_enabledArgs(calls), [true]);
+  });
+
   testWidgets('does not call native API when the setting is disabled', (
     tester,
   ) async {
@@ -157,6 +177,7 @@ SyncState _sync({
   bool isSyncing = true,
   bool isBackgroundMode = false,
   double percentage = 0.25,
+  int displayTargetBlocks = 0,
   int scannedHeight = 100,
   int chainTipHeight = 200,
   DateTime? lastSyncStartedAt,
@@ -165,6 +186,7 @@ SyncState _sync({
     isSyncing: isSyncing,
     isBackgroundMode: isBackgroundMode,
     percentage: percentage,
+    displayTargetBlocks: displayTargetBlocks,
     scannedHeight: scannedHeight,
     chainTipHeight: chainTipHeight,
     lastSyncStartedAt: lastSyncStartedAt,

--- a/test/core/widgets/sync_keep_awake_native_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_native_host_test.dart
@@ -1,0 +1,172 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/widgets/mobile/sync_keep_awake_native_host.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/services/native_screen_awake.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
+
+void main() {
+  testWidgets('does not call native API for near-tip catch-up', (tester) async {
+    final calls = _recordScreenAwakeCalls();
+    final syncNotifier = FakeSyncNotifier(
+      _sync(
+        scannedHeight: 100,
+        chainTipHeight: 102,
+        lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+      ),
+    );
+
+    await tester.pumpWidget(_app(syncNotifier: syncNotifier));
+    await _drainNativeQueue(tester);
+
+    expect(calls, isEmpty);
+  });
+
+  testWidgets('enables native keep-awake only while sync is eligible', (
+    tester,
+  ) async {
+    final calls = _recordScreenAwakeCalls();
+    final syncNotifier = FakeSyncNotifier(
+      _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+    );
+
+    await tester.pumpWidget(_app(syncNotifier: syncNotifier));
+    await _drainNativeQueue(tester);
+
+    expect(_enabledArgs(calls), [true]);
+
+    syncNotifier.emit(
+      _sync(
+        scannedHeight: 100,
+        chainTipHeight: 102,
+        lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+      ),
+    );
+    await _drainNativeQueue(tester);
+
+    expect(_enabledArgs(calls), [true, false]);
+  });
+
+  testWidgets('does not call native API when the setting is disabled', (
+    tester,
+  ) async {
+    final calls = _recordScreenAwakeCalls();
+    final syncNotifier = FakeSyncNotifier(
+      _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+    );
+
+    await tester.pumpWidget(
+      _app(syncNotifier: syncNotifier, syncKeepAwakeEnabled: false),
+    );
+    await _drainNativeQueue(tester);
+
+    expect(calls, isEmpty);
+  });
+
+  testWidgets('disables native keep-awake when the host is disposed', (
+    tester,
+  ) async {
+    final calls = _recordScreenAwakeCalls();
+    final syncNotifier = FakeSyncNotifier(
+      _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+    );
+
+    await tester.pumpWidget(_app(syncNotifier: syncNotifier));
+    await _drainNativeQueue(tester);
+    expect(_enabledArgs(calls), [true]);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await _drainNativeQueue(tester);
+
+    expect(_enabledArgs(calls), [true, false]);
+  });
+}
+
+List<MethodCall> _recordScreenAwakeCalls() {
+  final calls = <MethodCall>[];
+  const channel = MethodChannel(kNativeScreenAwakeChannelName);
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (call) async {
+        calls.add(call);
+        return null;
+      });
+  addTearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+  return calls;
+}
+
+List<bool?> _enabledArgs(List<MethodCall> calls) {
+  return [
+    for (final call in calls)
+      (call.arguments as Map<Object?, Object?>?)?['enabled'] as bool?,
+  ];
+}
+
+Future<void> _drainNativeQueue(WidgetTester tester) async {
+  await tester.pump();
+  await tester.idle();
+  await tester.pump();
+}
+
+Widget _app({
+  required FakeSyncNotifier syncNotifier,
+  bool syncKeepAwakeEnabled = true,
+}) {
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(
+        _bootstrap(syncKeepAwakeEnabled: syncKeepAwakeEnabled),
+      ),
+      syncProvider.overrideWith(() => syncNotifier),
+    ],
+    child: const MaterialApp(
+      home: SyncKeepAwakeNativeHost(child: SizedBox.shrink()),
+    ),
+  );
+}
+
+AppBootstrapState _bootstrap({required bool syncKeepAwakeEnabled}) {
+  return AppBootstrapState(
+    initialLocation: '/home',
+    initialAccountState: const AccountState(),
+    initialSyncSnapshot: AppSyncSnapshot.empty,
+    network: kZcashDefaultNetworkName,
+    rpcEndpointConfig: defaultRpcEndpointConfig(kZcashDefaultNetworkName),
+    themeMode: ThemeMode.dark,
+    privacyModeEnabled: false,
+    syncKeepAwakeEnabled: syncKeepAwakeEnabled,
+    syncKeepAwakePromptSeen: true,
+    isPasswordConfigured: true,
+    isUnlocked: true,
+    passwordRotationRecoveryFailed: false,
+  );
+}
+
+SyncState _sync({
+  bool isSyncing = true,
+  bool isBackgroundMode = false,
+  double percentage = 0.25,
+  int scannedHeight = 100,
+  int chainTipHeight = 200,
+  DateTime? lastSyncStartedAt,
+}) {
+  return SyncState(
+    isSyncing: isSyncing,
+    isBackgroundMode: isBackgroundMode,
+    percentage: percentage,
+    scannedHeight: scannedHeight,
+    chainTipHeight: chainTipHeight,
+    lastSyncStartedAt: lastSyncStartedAt,
+  );
+}

--- a/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
@@ -9,11 +9,26 @@ import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/mobile/sync_keep_awake_interaction_listener.dart';
 import 'package:zcash_wallet/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/passcode_widgets.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_keep_awake_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 
 import '../../fakes/fake_sync_notifier.dart';
+
+class _FakeSecurityNotifier extends AppSecurityNotifier {
+  _FakeSecurityNotifier({this.confirmResult = true});
+
+  final bool confirmResult;
+  final confirmedWith = <String>[];
+
+  @override
+  Future<bool> confirmPassword(String password) async {
+    confirmedWith.add(password);
+    return confirmResult;
+  }
+}
 
 void main() {
   testWidgets('shows the privacy screen after keep-awake idle timeout', (
@@ -85,11 +100,15 @@ void main() {
     expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
   });
 
-  testWidgets('unlock button clears the virtual privacy lock', (tester) async {
+  testWidgets('passcode confirmation clears the virtual privacy lock', (
+    tester,
+  ) async {
     _setMobileViewport(tester);
+    final security = _FakeSecurityNotifier();
     final container = ProviderContainer(
       overrides: [
         appBootstrapProvider.overrideWithValue(_bootstrap()),
+        appSecurityProvider.overrideWith(() => security),
         syncProvider.overrideWith(
           () => FakeSyncNotifier(
             _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
@@ -111,8 +130,53 @@ void main() {
     await tester.tap(find.text('Unlock Vizor'));
     await tester.pump();
 
-    expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
+    expect(find.text('Welcome Back'), findsOneWidget);
+    expect(find.text('25% Syncing...'), findsOneWidget);
+    expect(find.text('Vizor is syncing, stick around ...'), findsOneWidget);
+    expect(find.byType(PasscodeNumpad), findsOneWidget);
+    expect(find.bySemanticsLabel('Passcode help'), findsNothing);
+    expect(container.read(syncKeepAwakePrivacyLockProvider).isLocked, isTrue);
+
+    await _enterPasscode(tester, '123456');
+
+    expect(security.confirmedWith, ['123456']);
+    expect(find.text('Welcome Back'), findsNothing);
     expect(container.read(syncKeepAwakePrivacyLockProvider).isLocked, isFalse);
+  });
+
+  testWidgets('wrong passcode keeps the virtual privacy lock visible', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    final security = _FakeSecurityNotifier(confirmResult: false);
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_bootstrap()),
+        appSecurityProvider.overrideWith(() => security),
+        syncProvider.overrideWith(
+          () => FakeSyncNotifier(
+            _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: _themedApp()),
+    );
+    await _settleInitialSync(tester);
+    await tester.pump(const Duration(milliseconds: 60));
+    await tester.pump();
+
+    await tester.tap(find.text('Unlock Vizor'));
+    await tester.pump();
+    await _enterPasscode(tester, '999999');
+
+    expect(security.confirmedWith, ['999999']);
+    expect(container.read(syncKeepAwakePrivacyLockProvider).isLocked, isTrue);
+    expect(find.text('Incorrect Passcode'), findsOneWidget);
+    expect(find.text('Welcome Back'), findsOneWidget);
   });
 
   testWidgets('keeps the privacy screen and shows done after sync completes', (
@@ -455,6 +519,7 @@ Widget _app({required FakeSyncNotifier syncNotifier}) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
+      appSecurityProvider.overrideWith(_FakeSecurityNotifier.new),
       syncProvider.overrideWith(() => syncNotifier),
     ],
     child: _themedApp(),
@@ -466,6 +531,8 @@ Widget _privacyScreenApp({
 }) {
   return ProviderScope(
     overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap()),
+      appSecurityProvider.overrideWith(_FakeSecurityNotifier.new),
       syncProvider.overrideWith(
         () => FakeSyncNotifier(
           _sync(percentage: 0.63, lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
@@ -499,6 +566,15 @@ Widget _themedApp() {
 }
 
 Future<void> _settleInitialSync(WidgetTester tester) async {
+  await tester.pump();
+  await tester.pump();
+}
+
+Future<void> _enterPasscode(WidgetTester tester, String digits) async {
+  for (final digit in digits.split('')) {
+    await tester.tap(find.bySemanticsLabel('Digit $digit'));
+    await tester.pump();
+  }
   await tester.pump();
   await tester.pump();
 }

--- a/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
@@ -1,0 +1,266 @@
+@Tags(['mobile'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/mobile/sync_keep_awake_interaction_listener.dart';
+import 'package:zcash_wallet/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/sync_keep_awake_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+import '../../fakes/fake_sync_notifier.dart';
+
+void main() {
+  testWidgets('shows the privacy screen after keep-awake idle timeout', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    await tester.pumpWidget(
+      _app(
+        syncNotifier: FakeSyncNotifier(
+          _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+        ),
+      ),
+    );
+    await _settleInitialSync(tester);
+
+    await tester.pump(const Duration(milliseconds: 60));
+    await tester.pump();
+
+    expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+    expect(find.text('25%'), findsOneWidget);
+    expect(find.text('Unlock Vizor'), findsOneWidget);
+  });
+
+  testWidgets('does not show the privacy screen for near-tip catch-up', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    await tester.pumpWidget(
+      _app(
+        syncNotifier: FakeSyncNotifier(
+          _sync(
+            scannedHeight: 100,
+            chainTipHeight: 102,
+            lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+          ),
+        ),
+      ),
+    );
+    await _settleInitialSync(tester);
+
+    await tester.pump(const Duration(milliseconds: 80));
+    await tester.pump();
+
+    expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
+  });
+
+  testWidgets('recent interaction delays the privacy screen', (tester) async {
+    _setMobileViewport(tester);
+    await tester.pumpWidget(
+      _app(
+        syncNotifier: FakeSyncNotifier(
+          _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+        ),
+      ),
+    );
+    await _settleInitialSync(tester);
+
+    await tester.pump(const Duration(milliseconds: 30));
+    await tester.tap(find.byKey(const ValueKey('home_surface')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 30));
+    await tester.pump();
+
+    expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
+
+    await tester.pump(const Duration(milliseconds: 30));
+    await tester.pump();
+
+    expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+  });
+
+  testWidgets('unlock button clears the virtual privacy lock', (tester) async {
+    _setMobileViewport(tester);
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_bootstrap()),
+        syncProvider.overrideWith(
+          () => FakeSyncNotifier(
+            _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: _themedApp()),
+    );
+    await _settleInitialSync(tester);
+    await tester.pump(const Duration(milliseconds: 60));
+    await tester.pump();
+
+    expect(container.read(syncKeepAwakePrivacyLockProvider).isLocked, isTrue);
+
+    await tester.tap(find.text('Unlock Vizor'));
+    await tester.pump();
+
+    expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
+    expect(container.read(syncKeepAwakePrivacyLockProvider).isLocked, isFalse);
+  });
+
+  testWidgets('keeps the Figma vertical position on the reference viewport', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    await tester.pumpWidget(_privacyScreenApp());
+    await _settleInitialSync(tester);
+
+    final logoRect = tester.getRect(
+      find.byKey(const ValueKey('sync_keep_awake_privacy_logo')),
+    );
+
+    expect(logoRect.top, closeTo(110, 0.1));
+  });
+
+  testWidgets('centers the privacy stack on a shorter phone viewport', (
+    tester,
+  ) async {
+    _setMobileViewport(tester, size: const Size(375, 667));
+    await tester.pumpWidget(_privacyScreenApp());
+    await _settleInitialSync(tester);
+
+    final logoRect = tester.getRect(
+      find.byKey(const ValueKey('sync_keep_awake_privacy_logo')),
+    );
+    final buttonRect = tester.getRect(
+      find.byKey(const ValueKey('sync_keep_awake_privacy_unlock_button')),
+    );
+    final bottomGap =
+        tester.view.physicalSize.height / tester.view.devicePixelRatio -
+        buttonRect.bottom;
+
+    expect(logoRect.top, greaterThanOrEqualTo(0));
+    expect(buttonRect.bottom, lessThanOrEqualTo(667));
+    expect((logoRect.top - bottomGap).abs(), lessThanOrEqualTo(1));
+  });
+
+  testWidgets('keeps logo and unlock button visible on compact short phones', (
+    tester,
+  ) async {
+    _setMobileViewport(tester, size: const Size(320, 568));
+    await tester.pumpWidget(_privacyScreenApp());
+    await _settleInitialSync(tester);
+
+    final logoRect = tester.getRect(
+      find.byKey(const ValueKey('sync_keep_awake_privacy_logo')),
+    );
+    final buttonRect = tester.getRect(
+      find.byKey(const ValueKey('sync_keep_awake_privacy_unlock_button')),
+    );
+
+    expect(logoRect.top, greaterThanOrEqualTo(0));
+    expect(buttonRect.bottom, lessThanOrEqualTo(568));
+  });
+}
+
+void _setMobileViewport(
+  WidgetTester tester, {
+  Size size = const Size(393, 852),
+}) {
+  tester.view.physicalSize = size;
+  tester.view.devicePixelRatio = 1;
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(tester.view.resetDevicePixelRatio);
+}
+
+Widget _app({required FakeSyncNotifier syncNotifier}) {
+  return ProviderScope(
+    overrides: [
+      appBootstrapProvider.overrideWithValue(_bootstrap()),
+      syncProvider.overrideWith(() => syncNotifier),
+    ],
+    child: _themedApp(),
+  );
+}
+
+Widget _privacyScreenApp() {
+  return ProviderScope(
+    overrides: [
+      syncProvider.overrideWith(
+        () => FakeSyncNotifier(
+          _sync(percentage: 0.63, lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+        ),
+      ),
+    ],
+    child: MaterialApp(
+      builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
+      home: const SyncKeepAwakePrivacyLockScreen(),
+    ),
+  );
+}
+
+Widget _themedApp() {
+  return MaterialApp(
+    builder: (_, child) => AppTheme(data: AppThemeData.dark, child: child!),
+    home: SyncKeepAwakePrivacyLockHost(
+      idleTimeout: const Duration(milliseconds: 50),
+      child: SyncKeepAwakeInteractionListener(
+        child: Scaffold(
+          body: GestureDetector(
+            key: const ValueKey('home_surface'),
+            behavior: HitTestBehavior.opaque,
+            onTap: () {},
+            child: const Center(child: Text('Home')),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+Future<void> _settleInitialSync(WidgetTester tester) async {
+  await tester.pump();
+  await tester.pump();
+}
+
+AppBootstrapState _bootstrap() {
+  return AppBootstrapState(
+    initialLocation: '/home',
+    initialAccountState: const AccountState(),
+    initialSyncSnapshot: AppSyncSnapshot.empty,
+    network: kZcashDefaultNetworkName,
+    rpcEndpointConfig: defaultRpcEndpointConfig(kZcashDefaultNetworkName),
+    themeMode: ThemeMode.dark,
+    privacyModeEnabled: false,
+    syncKeepAwakeEnabled: true,
+    syncKeepAwakePromptSeen: true,
+    isPasswordConfigured: true,
+    isUnlocked: true,
+    passwordRotationRecoveryFailed: false,
+  );
+}
+
+SyncState _sync({
+  bool isSyncing = true,
+  bool isBackgroundMode = false,
+  double percentage = 0.25,
+  int scannedHeight = 100,
+  int chainTipHeight = 200,
+  DateTime? lastSyncStartedAt,
+}) {
+  return SyncState(
+    isSyncing: isSyncing,
+    isBackgroundMode: isBackgroundMode,
+    percentage: percentage,
+    scannedHeight: scannedHeight,
+    chainTipHeight: chainTipHeight,
+    lastSyncStartedAt: lastSyncStartedAt,
+  );
+}

--- a/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
@@ -129,6 +129,60 @@ void main() {
     expect(logoRect.top, closeTo(110, 0.1));
   });
 
+  testWidgets('renders the current display sync percentage', (tester) async {
+    _setMobileViewport(tester);
+    await tester.pumpWidget(_privacyScreenApp());
+    await _settleInitialSync(tester);
+    await tester.pump(const Duration(milliseconds: 420));
+
+    expect(find.text('63%'), findsOneWidget);
+  });
+
+  testWidgets('animates display sync percentage changes', (tester) async {
+    _setMobileViewport(tester);
+    final syncNotifier = FakeSyncNotifier(
+      _sync(
+        percentage: 0.05,
+        displayPercentage: 0.05,
+        lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+      ),
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [syncProvider.overrideWith(() => syncNotifier)],
+        child: MaterialApp(
+          builder: (_, child) =>
+              AppTheme(data: AppThemeData.light, child: child!),
+          home: const SyncKeepAwakePrivacyLockScreen(),
+        ),
+      ),
+    );
+    await _settleInitialSync(tester);
+    await tester.pump(const Duration(milliseconds: 420));
+
+    expect(find.text('5%'), findsOneWidget);
+
+    syncNotifier.emit(
+      _sync(
+        percentage: 0.10,
+        displayPercentage: 0.10,
+        lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('10%'), findsNothing);
+
+    await tester.pump(const Duration(milliseconds: 120));
+
+    expect(find.text('10%'), findsNothing);
+
+    await tester.pump(const Duration(milliseconds: 420));
+
+    expect(find.text('10%'), findsOneWidget);
+  });
+
   testWidgets('centers the privacy stack on a shorter phone viewport', (
     tester,
   ) async {
@@ -251,6 +305,7 @@ SyncState _sync({
   bool isSyncing = true,
   bool isBackgroundMode = false,
   double percentage = 0.25,
+  double? displayPercentage,
   int scannedHeight = 100,
   int chainTipHeight = 200,
   DateTime? lastSyncStartedAt,
@@ -259,6 +314,7 @@ SyncState _sync({
     isSyncing: isSyncing,
     isBackgroundMode: isBackgroundMode,
     percentage: percentage,
+    displayPercentage: displayPercentage,
     scannedHeight: scannedHeight,
     chainTipHeight: chainTipHeight,
     lastSyncStartedAt: lastSyncStartedAt,

--- a/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
@@ -1,19 +1,24 @@
 @Tags(['mobile'])
 library;
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/mobile/sync_keep_awake_interaction_listener.dart';
 import 'package:zcash_wallet/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/passcode_widgets.dart';
 import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/biometric_unlock_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_keep_awake_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/services/biometric_unlock.dart';
 
 import '../../fakes/fake_sync_notifier.dart';
 
@@ -29,6 +34,56 @@ class _FakeSecurityNotifier extends AppSecurityNotifier {
     return confirmResult;
   }
 }
+
+class _FakeBiometricUnlockNotifier extends BiometricUnlockNotifier {
+  _FakeBiometricUnlockNotifier(
+    this.initialState, {
+    this.passcode,
+    this.stateAfterRead,
+    this.buildCompleter,
+  });
+
+  final BiometricUnlockState initialState;
+  final String? passcode;
+  final BiometricUnlockState? stateAfterRead;
+  final Completer<BiometricUnlockState>? buildCompleter;
+  var reads = 0;
+
+  @override
+  Future<BiometricUnlockState> build() async =>
+      buildCompleter?.future ?? initialState;
+
+  @override
+  Future<String?> readPasscode({required String reason}) async {
+    reads += 1;
+    final nextState = stateAfterRead;
+    if (nextState != null) state = AsyncData(nextState);
+    return passcode;
+  }
+}
+
+const _disabledBiometricState = BiometricUnlockState(
+  availability: BiometricAvailability.unavailable,
+  enabled: false,
+);
+
+const _faceBiometricState = BiometricUnlockState(
+  availability: BiometricAvailability(
+    supported: true,
+    enrolled: true,
+    kind: BiometricKind.face,
+  ),
+  enabled: true,
+);
+
+const _fingerprintBiometricState = BiometricUnlockState(
+  availability: BiometricAvailability(
+    supported: true,
+    enrolled: true,
+    kind: BiometricKind.fingerprint,
+  ),
+  enabled: true,
+);
 
 void main() {
   testWidgets('shows the privacy screen after keep-awake idle timeout', (
@@ -109,6 +164,9 @@ void main() {
       overrides: [
         appBootstrapProvider.overrideWithValue(_bootstrap()),
         appSecurityProvider.overrideWith(() => security),
+        biometricUnlockProvider.overrideWith(
+          () => _FakeBiometricUnlockNotifier(_disabledBiometricState),
+        ),
         syncProvider.overrideWith(
           () => FakeSyncNotifier(
             _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
@@ -144,6 +202,184 @@ void main() {
     expect(container.read(syncKeepAwakePrivacyLockProvider).isLocked, isFalse);
   });
 
+  testWidgets(
+    'biometric confirmation clears the virtual lock without passcode UI',
+    (tester) async {
+      _setMobileViewport(tester);
+      final security = _FakeSecurityNotifier();
+      final biometric = _FakeBiometricUnlockNotifier(
+        _faceBiometricState,
+        passcode: '123456',
+      );
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(_bootstrap()),
+          appSecurityProvider.overrideWith(() => security),
+          biometricUnlockProvider.overrideWith(() => biometric),
+          syncProvider.overrideWith(
+            () => FakeSyncNotifier(
+              _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(container: container, child: _themedApp()),
+      );
+      await _settleInitialSync(tester);
+      await tester.pump(const Duration(milliseconds: 60));
+      await tester.pump();
+
+      expect(container.read(syncKeepAwakePrivacyLockProvider).isLocked, isTrue);
+      expect(_findAppIcon(AppIcons.faceId), findsOneWidget);
+
+      await tester.tap(find.text('Unlock Vizor'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(biometric.reads, 1);
+      expect(security.confirmedWith, ['123456']);
+      expect(find.text('Welcome Back'), findsNothing);
+      expect(find.byType(PasscodeNumpad), findsNothing);
+      expect(
+        container.read(syncKeepAwakePrivacyLockProvider).isLocked,
+        isFalse,
+      );
+    },
+  );
+
+  testWidgets(
+    'unlock attempt suppresses duplicate taps before probe resolves',
+    (tester) async {
+      _setMobileViewport(tester);
+      final security = _FakeSecurityNotifier();
+      final buildCompleter = Completer<BiometricUnlockState>();
+      final biometric = _FakeBiometricUnlockNotifier(
+        _faceBiometricState,
+        passcode: '123456',
+        buildCompleter: buildCompleter,
+      );
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(_bootstrap()),
+          appSecurityProvider.overrideWith(() => security),
+          biometricUnlockProvider.overrideWith(() => biometric),
+          syncProvider.overrideWith(
+            () => FakeSyncNotifier(
+              _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(container: container, child: _themedApp()),
+      );
+      await _settleInitialSync(tester);
+      await tester.pump(const Duration(milliseconds: 60));
+      await tester.pump();
+
+      await tester.tap(find.text('Unlock Vizor'));
+      await tester.tap(find.text('Unlock Vizor'));
+
+      buildCompleter.complete(_faceBiometricState);
+      await tester.pump();
+      await tester.pump();
+
+      expect(biometric.reads, 1);
+      expect(security.confirmedWith, ['123456']);
+      expect(
+        container.read(syncKeepAwakePrivacyLockProvider).isLocked,
+        isFalse,
+      );
+    },
+  );
+
+  testWidgets('biometric cancellation falls back to passcode confirmation', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    final security = _FakeSecurityNotifier();
+    final biometric = _FakeBiometricUnlockNotifier(_faceBiometricState);
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_bootstrap()),
+        appSecurityProvider.overrideWith(() => security),
+        biometricUnlockProvider.overrideWith(() => biometric),
+        syncProvider.overrideWith(
+          () => FakeSyncNotifier(
+            _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: _themedApp()),
+    );
+    await _settleInitialSync(tester);
+    await tester.pump(const Duration(milliseconds: 60));
+    await tester.pump();
+
+    await tester.tap(find.text('Unlock Vizor'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(biometric.reads, 1);
+    expect(security.confirmedWith, isEmpty);
+    expect(find.text('Welcome Back'), findsOneWidget);
+    expect(find.byType(PasscodeNumpad), findsOneWidget);
+    expect(container.read(syncKeepAwakePrivacyLockProvider).isLocked, isTrue);
+
+    await _enterPasscode(tester, '123456');
+
+    expect(security.confirmedWith, ['123456']);
+    expect(container.read(syncKeepAwakePrivacyLockProvider).isLocked, isFalse);
+  });
+
+  testWidgets('biometric invalidation explains the passcode fallback', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    final biometric = _FakeBiometricUnlockNotifier(
+      _faceBiometricState,
+      stateAfterRead: _faceBiometricState.copyWith(enabled: false),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_bootstrap()),
+        appSecurityProvider.overrideWith(_FakeSecurityNotifier.new),
+        biometricUnlockProvider.overrideWith(() => biometric),
+        syncProvider.overrideWith(
+          () => FakeSyncNotifier(
+            _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: _themedApp()),
+    );
+    await _settleInitialSync(tester);
+    await tester.pump(const Duration(milliseconds: 60));
+    await tester.pump();
+
+    await tester.tap(find.text('Unlock Vizor'));
+    await tester.pump();
+    await tester.pump();
+
+    expect(biometric.reads, 1);
+    expect(find.text('Face ID changed. Enter your passcode.'), findsOneWidget);
+    expect(find.byType(PasscodeNumpad), findsOneWidget);
+    expect(container.read(syncKeepAwakePrivacyLockProvider).isLocked, isTrue);
+  });
+
   testWidgets('wrong passcode keeps the virtual privacy lock visible', (
     tester,
   ) async {
@@ -153,6 +389,9 @@ void main() {
       overrides: [
         appBootstrapProvider.overrideWithValue(_bootstrap()),
         appSecurityProvider.overrideWith(() => security),
+        biometricUnlockProvider.overrideWith(
+          () => _FakeBiometricUnlockNotifier(_disabledBiometricState),
+        ),
         syncProvider.overrideWith(
           () => FakeSyncNotifier(
             _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
@@ -189,6 +428,9 @@ void main() {
     final container = ProviderContainer(
       overrides: [
         appBootstrapProvider.overrideWithValue(_bootstrap()),
+        biometricUnlockProvider.overrideWith(
+          () => _FakeBiometricUnlockNotifier(_disabledBiometricState),
+        ),
         syncProvider.overrideWith(() => syncNotifier),
       ],
     );
@@ -239,6 +481,9 @@ void main() {
     final container = ProviderContainer(
       overrides: [
         appBootstrapProvider.overrideWithValue(_bootstrap()),
+        biometricUnlockProvider.overrideWith(
+          () => _FakeBiometricUnlockNotifier(_disabledBiometricState),
+        ),
         syncProvider.overrideWith(() => syncNotifier),
       ],
     );
@@ -314,6 +559,9 @@ void main() {
       final container = ProviderContainer(
         overrides: [
           appBootstrapProvider.overrideWithValue(_bootstrap()),
+          biometricUnlockProvider.overrideWith(
+            () => _FakeBiometricUnlockNotifier(_disabledBiometricState),
+          ),
           syncProvider.overrideWith(() => syncNotifier),
         ],
       );
@@ -431,7 +679,12 @@ void main() {
 
     await tester.pumpWidget(
       ProviderScope(
-        overrides: [syncProvider.overrideWith(() => syncNotifier)],
+        overrides: [
+          biometricUnlockProvider.overrideWith(
+            () => _FakeBiometricUnlockNotifier(_disabledBiometricState),
+          ),
+          syncProvider.overrideWith(() => syncNotifier),
+        ],
         child: MaterialApp(
           builder: (_, child) =>
               AppTheme(data: AppThemeData.light, child: child!),
@@ -503,6 +756,54 @@ void main() {
     expect(logoRect.top, greaterThanOrEqualTo(0));
     expect(buttonRect.bottom, lessThanOrEqualTo(568));
   });
+
+  testWidgets('uses the unlock icon when biometric unlock is unavailable', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    await tester.pumpWidget(_privacyScreenApp());
+    await _settleInitialSync(tester);
+
+    expect(_findAppIcon(AppIcons.unlock), findsOneWidget);
+    expect(_findAppIcon(AppIcons.faceId), findsNothing);
+    expect(find.byIcon(Icons.fingerprint), findsNothing);
+  });
+
+  testWidgets('uses the Face ID icon when biometric unlock is usable', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    await tester.pumpWidget(
+      _privacyScreenApp(
+        biometricNotifier: () =>
+            _FakeBiometricUnlockNotifier(_faceBiometricState),
+      ),
+    );
+    await _settleInitialSync(tester);
+    await tester.pump();
+
+    expect(_findAppIcon(AppIcons.faceId), findsOneWidget);
+    expect(_findAppIcon(AppIcons.unlock), findsNothing);
+    expect(find.byIcon(Icons.fingerprint), findsNothing);
+  });
+
+  testWidgets('uses the fingerprint icon when fingerprint unlock is usable', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    await tester.pumpWidget(
+      _privacyScreenApp(
+        biometricNotifier: () =>
+            _FakeBiometricUnlockNotifier(_fingerprintBiometricState),
+      ),
+    );
+    await _settleInitialSync(tester);
+    await tester.pump();
+
+    expect(find.byIcon(Icons.fingerprint), findsOneWidget);
+    expect(_findAppIcon(AppIcons.unlock), findsNothing);
+    expect(_findAppIcon(AppIcons.faceId), findsNothing);
+  });
 }
 
 void _setMobileViewport(
@@ -520,6 +821,9 @@ Widget _app({required FakeSyncNotifier syncNotifier}) {
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
       appSecurityProvider.overrideWith(_FakeSecurityNotifier.new),
+      biometricUnlockProvider.overrideWith(
+        () => _FakeBiometricUnlockNotifier(_disabledBiometricState),
+      ),
       syncProvider.overrideWith(() => syncNotifier),
     ],
     child: _themedApp(),
@@ -528,11 +832,16 @@ Widget _app({required FakeSyncNotifier syncNotifier}) {
 
 Widget _privacyScreenApp({
   SyncKeepAwakePrivacyLockMode mode = SyncKeepAwakePrivacyLockMode.syncing,
+  BiometricUnlockNotifier Function()? biometricNotifier,
 }) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
       appSecurityProvider.overrideWith(_FakeSecurityNotifier.new),
+      biometricUnlockProvider.overrideWith(
+        biometricNotifier ??
+            () => _FakeBiometricUnlockNotifier(_disabledBiometricState),
+      ),
       syncProvider.overrideWith(
         () => FakeSyncNotifier(
           _sync(percentage: 0.63, lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
@@ -577,6 +886,13 @@ Future<void> _enterPasscode(WidgetTester tester, String digits) async {
   }
   await tester.pump();
   await tester.pump();
+}
+
+Finder _findAppIcon(String iconName) {
+  return find.byWidgetPredicate(
+    (widget) => widget is AppIcon && widget.name == iconName,
+    description: 'AppIcon($iconName)',
+  );
 }
 
 AppBootstrapState _bootstrap() {

--- a/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
@@ -115,6 +115,181 @@ void main() {
     expect(container.read(syncKeepAwakePrivacyLockProvider).isLocked, isFalse);
   });
 
+  testWidgets('keeps the privacy screen and shows done after sync completes', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    final syncNotifier = FakeSyncNotifier(
+      _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_bootstrap()),
+        syncProvider.overrideWith(() => syncNotifier),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: _themedApp()),
+    );
+    await _settleInitialSync(tester);
+    await tester.pump(const Duration(milliseconds: 60));
+    await tester.pump();
+
+    expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+
+    syncNotifier.emit(
+      _sync(
+        isSyncing: false,
+        percentage: 1,
+        displayPercentage: 1,
+        scannedHeight: 200,
+        chainTipHeight: 200,
+        lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+      ),
+    );
+    await tester.pump();
+
+    expect(container.read(syncKeepAwakeActiveProvider), isFalse);
+    expect(
+      container.read(syncKeepAwakePrivacyLockModeProvider),
+      SyncKeepAwakePrivacyLockMode.done,
+    );
+    expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
+    expect(find.text('Synced'), findsOneWidget);
+    expect(
+      find.text('Synced successfully.\nYou can unlock Vizor.'),
+      findsOneWidget,
+    );
+    expect(find.text('Unlock Vizor'), findsOneWidget);
+  });
+
+  testWidgets('keeps the privacy screen across near-tip follow-up syncs', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    final syncNotifier = FakeSyncNotifier(
+      _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_bootstrap()),
+        syncProvider.overrideWith(() => syncNotifier),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(container: container, child: _themedApp()),
+    );
+    await _settleInitialSync(tester);
+    await tester.pump(const Duration(milliseconds: 60));
+    await tester.pump();
+    syncNotifier.emit(
+      _sync(
+        isSyncing: false,
+        percentage: 1,
+        displayPercentage: 1,
+        scannedHeight: 200,
+        chainTipHeight: 200,
+        lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Synced'), findsOneWidget);
+
+    syncNotifier.emit(
+      _sync(
+        percentage: 0,
+        displayPercentage: 0,
+        scannedHeight: 200,
+        chainTipHeight: 202,
+        lastSyncStartedAt: DateTime(2026, 7, 9, 12, 2),
+      ),
+    );
+    await tester.pump();
+
+    expect(container.read(syncKeepAwakeActiveProvider), isFalse);
+    expect(
+      container.read(syncKeepAwakePrivacyLockModeProvider),
+      SyncKeepAwakePrivacyLockMode.syncing,
+    );
+    expect(find.text('Synced'), findsNothing);
+    expect(find.text('0%'), findsOneWidget);
+    expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+
+    syncNotifier.emit(
+      _sync(
+        isSyncing: false,
+        percentage: 1,
+        displayPercentage: 1,
+        scannedHeight: 202,
+        chainTipHeight: 202,
+        lastSyncStartedAt: DateTime(2026, 7, 9, 12, 2),
+      ),
+    );
+    await tester.pump();
+
+    expect(
+      container.read(syncKeepAwakePrivacyLockModeProvider),
+      SyncKeepAwakePrivacyLockMode.done,
+    );
+    expect(find.text('Synced'), findsOneWidget);
+    expect(find.text('Unlock Vizor'), findsOneWidget);
+  });
+
+  testWidgets(
+    'keeps the privacy screen with paused copy when sync stops early',
+    (tester) async {
+      _setMobileViewport(tester);
+      final syncNotifier = FakeSyncNotifier(
+        _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(_bootstrap()),
+          syncProvider.overrideWith(() => syncNotifier),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(container: container, child: _themedApp()),
+      );
+      await _settleInitialSync(tester);
+      await tester.pump(const Duration(milliseconds: 60));
+      await tester.pump();
+
+      syncNotifier.emit(
+        _sync(
+          isSyncing: false,
+          percentage: 0.5,
+          displayPercentage: 0.5,
+          scannedHeight: 150,
+          chainTipHeight: 200,
+          lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+        ),
+      );
+      await tester.pump();
+
+      expect(container.read(syncKeepAwakeActiveProvider), isFalse);
+      expect(
+        container.read(syncKeepAwakePrivacyLockModeProvider),
+        SyncKeepAwakePrivacyLockMode.interrupted,
+      );
+      expect(find.text('Synced'), findsNothing);
+      expect(
+        find.text('Synced successfully.\nYou can unlock Vizor.'),
+        findsNothing,
+      );
+      expect(find.text('Sync paused'), findsOneWidget);
+      expect(find.text('Unlock Vizor to continue.'), findsOneWidget);
+      expect(find.text('Unlock Vizor'), findsOneWidget);
+    },
+  );
+
   testWidgets('keeps the Figma vertical position on the reference viewport', (
     tester,
   ) async {
@@ -127,6 +302,48 @@ void main() {
     );
 
     expect(logoRect.top, closeTo(110, 0.1));
+  });
+
+  testWidgets('keeps the done state Figma vertical positions', (tester) async {
+    _setMobileViewport(tester);
+    await tester.pumpWidget(
+      _privacyScreenApp(mode: SyncKeepAwakePrivacyLockMode.done),
+    );
+    await _settleInitialSync(tester);
+
+    final checkRect = tester.getRect(
+      find.byKey(const ValueKey('sync_keep_awake_privacy_done_check')),
+    );
+    final titleRect = tester.getRect(find.text('Synced'));
+    final buttonRect = tester.getRect(
+      find.byKey(const ValueKey('sync_keep_awake_privacy_unlock_button')),
+    );
+
+    expect(checkRect.top, closeTo(306, 0.1));
+    expect(titleRect.top, closeTo(406, 0.1));
+    expect(buttonRect.top, closeTo(653, 0.1));
+  });
+
+  testWidgets('uses the status layout for the interrupted state', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    await tester.pumpWidget(
+      _privacyScreenApp(mode: SyncKeepAwakePrivacyLockMode.interrupted),
+    );
+    await _settleInitialSync(tester);
+
+    final warningRect = tester.getRect(
+      find.byKey(const ValueKey('sync_keep_awake_privacy_interrupted_warning')),
+    );
+    final titleRect = tester.getRect(find.text('Sync paused'));
+    final buttonRect = tester.getRect(
+      find.byKey(const ValueKey('sync_keep_awake_privacy_unlock_button')),
+    );
+
+    expect(warningRect.top, closeTo(306, 0.1));
+    expect(titleRect.top, closeTo(406, 0.1));
+    expect(buttonRect.top, closeTo(653, 0.1));
   });
 
   testWidgets('renders the current display sync percentage', (tester) async {
@@ -244,7 +461,9 @@ Widget _app({required FakeSyncNotifier syncNotifier}) {
   );
 }
 
-Widget _privacyScreenApp() {
+Widget _privacyScreenApp({
+  SyncKeepAwakePrivacyLockMode mode = SyncKeepAwakePrivacyLockMode.syncing,
+}) {
   return ProviderScope(
     overrides: [
       syncProvider.overrideWith(
@@ -255,7 +474,7 @@ Widget _privacyScreenApp() {
     ],
     child: MaterialApp(
       builder: (_, child) => AppTheme(data: AppThemeData.light, child: child!),
-      home: const SyncKeepAwakePrivacyLockScreen(),
+      home: SyncKeepAwakePrivacyLockScreen(mode: mode),
     ),
   );
 }

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/home/screens/mobile/mobile_home_screen.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/privacy_mode_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_keep_awake_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
@@ -27,6 +28,37 @@ class _FakePrivacyModeNotifier extends PrivacyModeNotifier {
   @override
   Future<void> set(bool enabled) async {
     state = enabled;
+  }
+}
+
+class _FakeSyncKeepAwakeNotifier extends SyncKeepAwakeNotifier {
+  _FakeSyncKeepAwakeNotifier([
+    this.initialState = const SyncKeepAwakeSettings(
+      enabled: false,
+      promptSeen: false,
+    ),
+  ]);
+
+  final SyncKeepAwakeSettings initialState;
+  int markPromptSeenCount = 0;
+  bool? lastEnabled;
+
+  @override
+  SyncKeepAwakeSettings build() => initialState;
+
+  @override
+  Future<void> markPromptSeen() async {
+    markPromptSeenCount += 1;
+    state = state.copyWith(promptSeen: true);
+  }
+
+  @override
+  Future<void> setEnabled(bool enabled, {bool markPromptSeen = true}) async {
+    lastEnabled = enabled;
+    state = state.copyWith(
+      enabled: enabled,
+      promptSeen: markPromptSeen ? true : null,
+    );
   }
 }
 
@@ -78,8 +110,11 @@ Widget _app(
     change24hPct: 13.12,
   ),
   FakeSyncNotifier? syncNotifier,
+  _FakeSyncKeepAwakeNotifier? keepAwakeNotifier,
 }) {
   final effectiveSyncNotifier = syncNotifier ?? FakeSyncNotifier(syncState);
+  final effectiveKeepAwakeNotifier =
+      keepAwakeNotifier ?? _FakeSyncKeepAwakeNotifier();
   final router = GoRouter(
     initialLocation: '/home',
     routes: [
@@ -97,6 +132,7 @@ Widget _app(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
       syncProvider.overrideWith(() => effectiveSyncNotifier),
+      syncKeepAwakeProvider.overrideWith(() => effectiveKeepAwakeNotifier),
       privacyModeProvider.overrideWith(_FakePrivacyModeNotifier.new),
       zecMarketDataSourceProvider.overrideWithValue(
         _FakeMarketDataSource(marketData),
@@ -174,6 +210,121 @@ void main() {
     expect(canvasRect.size, const Size(340, 220));
     expect(imageRect.size, const Size(246, 192));
     expect(canvasRect.bottom, moreOrLessEquals(744));
+  });
+
+  testWidgets('shows sync keep-awake prompt for long foreground sync', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(393, 852));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final keepAwakeNotifier = _FakeSyncKeepAwakeNotifier();
+    await tester.pumpWidget(
+      _app(
+        SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          isSyncing: true,
+          percentage: 0.25,
+          scannedHeight: 100,
+          chainTipHeight: 200,
+          lastSyncStartedAt: DateTime.now().subtract(
+            const Duration(seconds: 30),
+          ),
+        ),
+        keepAwakeNotifier: keepAwakeNotifier,
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('Keep screen awake during sync?'), findsOneWidget);
+    expect(find.text('This will make long syncs much easier.'), findsOneWidget);
+    expect(find.text('Keep screen awake'), findsOneWidget);
+    expect(find.text('Maybe later'), findsOneWidget);
+    expect(keepAwakeNotifier.markPromptSeenCount, 1);
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_sync_keep_awake_prompt_enable')),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(keepAwakeNotifier.lastEnabled, isTrue);
+    expect(find.text('Keep screen awake during sync?'), findsNothing);
+  });
+
+  testWidgets('does not repeat sync keep-awake prompt after it was seen', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(393, 852));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final keepAwakeNotifier = _FakeSyncKeepAwakeNotifier(
+      const SyncKeepAwakeSettings(enabled: false, promptSeen: true),
+    );
+    await tester.pumpWidget(
+      _app(
+        SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          isSyncing: true,
+          percentage: 0.25,
+          scannedHeight: 100,
+          chainTipHeight: 200,
+          lastSyncStartedAt: DateTime.now().subtract(
+            const Duration(seconds: 30),
+          ),
+        ),
+        keepAwakeNotifier: keepAwakeNotifier,
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('Keep screen awake during sync?'), findsNothing);
+    expect(keepAwakeNotifier.markPromptSeenCount, 0);
+  });
+
+  testWidgets('does not show sync keep-awake prompt when already enabled', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(393, 852));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    final keepAwakeNotifier = _FakeSyncKeepAwakeNotifier(
+      const SyncKeepAwakeSettings(enabled: true, promptSeen: false),
+    );
+    await tester.pumpWidget(
+      _app(
+        SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          isSyncing: true,
+          percentage: 0.25,
+          scannedHeight: 100,
+          chainTipHeight: 200,
+          lastSyncStartedAt: DateTime.now().subtract(
+            const Duration(seconds: 30),
+          ),
+        ),
+        keepAwakeNotifier: keepAwakeNotifier,
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('Keep screen awake during sync?'), findsNothing);
+    expect(keepAwakeNotifier.markPromptSeenCount, 0);
   });
 
   testWidgets('shows balance, actions, and empty activity when funded', (

--- a/test/features/settings/mobile_settings_screen_test.dart
+++ b/test/features/settings/mobile_settings_screen_test.dart
@@ -15,6 +15,7 @@ import 'package:zcash_wallet/src/core/widgets/mobile/mobile_list_row.dart';
 import 'package:zcash_wallet/src/features/settings/screens/mobile/mobile_settings_screen.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/biometric_unlock_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_keep_awake_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/providers/theme_mode_provider.dart';
 import 'package:zcash_wallet/src/services/biometric_unlock.dart';
@@ -88,16 +89,46 @@ class _FakeBiometricNotifier extends BiometricUnlockNotifier {
   }
 }
 
+class _FakeSyncKeepAwakeNotifier extends SyncKeepAwakeNotifier {
+  _FakeSyncKeepAwakeNotifier([
+    this.initialState = const SyncKeepAwakeSettings(
+      enabled: false,
+      promptSeen: false,
+    ),
+  ]);
+
+  final SyncKeepAwakeSettings initialState;
+  bool? lastEnabled;
+  bool? lastMarkPromptSeen;
+
+  @override
+  SyncKeepAwakeSettings build() => initialState;
+
+  @override
+  Future<void> setEnabled(bool enabled, {bool markPromptSeen = true}) async {
+    lastEnabled = enabled;
+    lastMarkPromptSeen = markPromptSeen;
+    state = state.copyWith(
+      enabled: enabled,
+      promptSeen: markPromptSeen ? true : null,
+    );
+  }
+}
+
 Widget _app({
   AccountState accountState = _accountState,
   BiometricUnlockState? biometric,
   BiometricUnlockNotifier Function()? biometricNotifier,
+  _FakeSyncKeepAwakeNotifier? syncKeepAwakeNotifier,
 }) {
   return ProviderScope(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap(accountState)),
       syncProvider.overrideWith(() => FakeSyncNotifier(SyncState())),
       themeModeProvider.overrideWith(_FakeThemeModeNotifier.new),
+      syncKeepAwakeProvider.overrideWith(
+        () => syncKeepAwakeNotifier ?? _FakeSyncKeepAwakeNotifier(),
+      ),
       if (biometricNotifier != null)
         biometricUnlockProvider.overrideWith(biometricNotifier)
       else if (biometric != null)
@@ -149,6 +180,14 @@ void main() {
     );
     expect(find.text('Theme'), findsOneWidget);
     expect(find.text('Dark'), findsOneWidget);
+    final keepAwakeRow = find.byKey(
+      const ValueKey('mobile_settings_sync_keep_awake_row'),
+    );
+    expect(keepAwakeRow, findsOneWidget);
+    expect(
+      find.descendant(of: keepAwakeRow, matching: find.text('Off')),
+      findsOneWidget,
+    );
     // The About entry stays hidden until the legal documents are ready.
     expect(find.text('About Vizor'), findsNothing);
     // Endpoint shows the live RPC host:port.
@@ -236,11 +275,56 @@ void main() {
     expect(find.text('Light'), findsOneWidget);
   });
 
+  testWidgets('sync keep-awake row toggles the persisted setting', (
+    tester,
+  ) async {
+    final notifier = _FakeSyncKeepAwakeNotifier();
+    await tester.pumpWidget(_app(syncKeepAwakeNotifier: notifier));
+    await tester.pump();
+
+    final row = find.byKey(
+      const ValueKey('mobile_settings_sync_keep_awake_row'),
+    );
+    expect(
+      find.descendant(of: row, matching: find.text('Off')),
+      findsOneWidget,
+    );
+
+    await tester.tap(row);
+    await tester.pump();
+
+    expect(notifier.lastEnabled, isTrue);
+    expect(notifier.lastMarkPromptSeen, isTrue);
+    expect(find.descendant(of: row, matching: find.text('On')), findsOneWidget);
+  });
+
+  testWidgets('sync keep-awake row reflects persisted enabled state', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        syncKeepAwakeNotifier: _FakeSyncKeepAwakeNotifier(
+          const SyncKeepAwakeSettings(enabled: true, promptSeen: true),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final row = find.byKey(
+      const ValueKey('mobile_settings_sync_keep_awake_row'),
+    );
+    expect(find.descendant(of: row, matching: find.text('On')), findsOneWidget);
+  });
+
   testWidgets('every settings row renders active', (tester) async {
     await tester.pumpWidget(_app());
     await tester.pump();
 
-    for (final label in ['Contacts', 'Secret Passphrase']) {
+    for (final label in [
+      'Contacts',
+      'Secret Passphrase',
+      'Keep screen awake',
+    ]) {
       final row = tester.widget<Text>(find.text(label));
       expect(
         row.style?.color,

--- a/test/features/settings/mobile_settings_screen_test.dart
+++ b/test/features/settings/mobile_settings_screen_test.dart
@@ -180,12 +180,20 @@ void main() {
     );
     expect(find.text('Theme'), findsOneWidget);
     expect(find.text('Dark'), findsOneWidget);
+    expect(find.text('Syncing'), findsOneWidget);
     final keepAwakeRow = find.byKey(
       const ValueKey('mobile_settings_sync_keep_awake_row'),
     );
     expect(keepAwakeRow, findsOneWidget);
     expect(
-      find.descendant(of: keepAwakeRow, matching: find.text('Off')),
+      find.descendant(
+        of: keepAwakeRow,
+        matching: find.text('Keep screen awake'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('Keep the screen active while Vizor is syncing'),
       findsOneWidget,
     );
     // The About entry stays hidden until the legal documents are ready.
@@ -286,16 +294,25 @@ void main() {
       const ValueKey('mobile_settings_sync_keep_awake_row'),
     );
     expect(
-      find.descendant(of: row, matching: find.text('Off')),
+      find.descendant(of: row, matching: find.text('Keep screen awake')),
       findsOneWidget,
     );
+    final thumb = find.byKey(
+      const ValueKey('mobile_settings_sync_keep_awake_toggle_thumb'),
+    );
+    final track = find.byKey(
+      const ValueKey('mobile_settings_sync_keep_awake_toggle'),
+    );
+    final offThumbLeft = tester.getTopLeft(thumb).dx;
+    final trackCenterX = tester.getCenter(track).dx;
 
     await tester.tap(row);
-    await tester.pump();
+    await tester.pumpAndSettle();
 
     expect(notifier.lastEnabled, isTrue);
     expect(notifier.lastMarkPromptSeen, isTrue);
-    expect(find.descendant(of: row, matching: find.text('On')), findsOneWidget);
+    expect(tester.getTopLeft(thumb).dx, greaterThan(offThumbLeft));
+    expect(tester.getCenter(thumb).dx, greaterThan(trackCenterX));
   });
 
   testWidgets('sync keep-awake row reflects persisted enabled state', (
@@ -313,7 +330,17 @@ void main() {
     final row = find.byKey(
       const ValueKey('mobile_settings_sync_keep_awake_row'),
     );
-    expect(find.descendant(of: row, matching: find.text('On')), findsOneWidget);
+    final thumb = find.byKey(
+      const ValueKey('mobile_settings_sync_keep_awake_toggle_thumb'),
+    );
+    final track = find.byKey(
+      const ValueKey('mobile_settings_sync_keep_awake_toggle'),
+    );
+    expect(
+      find.descendant(of: row, matching: find.text('Keep screen awake')),
+      findsOneWidget,
+    );
+    expect(tester.getCenter(thumb).dx, greaterThan(tester.getCenter(track).dx));
   });
 
   testWidgets('every settings row renders active', (tester) async {

--- a/test/providers/sync_keep_awake_provider_test.dart
+++ b/test/providers/sync_keep_awake_provider_test.dart
@@ -101,6 +101,30 @@ void main() {
     },
   );
 
+  test('screen keep-awake active provider stays false while locked', () async {
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(
+          _bootstrap(
+            syncKeepAwakeEnabled: true,
+            syncKeepAwakePromptSeen: true,
+            isPasswordConfigured: true,
+            isUnlocked: false,
+          ),
+        ),
+        syncProvider.overrideWith(
+          () => FakeSyncNotifier(
+            _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(syncProvider.future);
+    expect(container.read(syncKeepAwakeActiveProvider), isFalse);
+  });
+
   test('interaction notifier records the last user activity time', () {
     final container = ProviderContainer();
     addTearDown(container.dispose);
@@ -235,6 +259,8 @@ void main() {
 AppBootstrapState _bootstrap({
   bool syncKeepAwakeEnabled = false,
   bool syncKeepAwakePromptSeen = false,
+  bool isPasswordConfigured = false,
+  bool isUnlocked = false,
 }) {
   return AppBootstrapState(
     initialLocation: '/home',
@@ -246,8 +272,8 @@ AppBootstrapState _bootstrap({
     privacyModeEnabled: false,
     syncKeepAwakeEnabled: syncKeepAwakeEnabled,
     syncKeepAwakePromptSeen: syncKeepAwakePromptSeen,
-    isPasswordConfigured: false,
-    isUnlocked: false,
+    isPasswordConfigured: isPasswordConfigured,
+    isUnlocked: isUnlocked,
     passwordRotationRecoveryFailed: false,
   );
 }

--- a/test/providers/sync_keep_awake_provider_test.dart
+++ b/test/providers/sync_keep_awake_provider_test.dart
@@ -7,6 +7,8 @@ import 'package:zcash_wallet/src/providers/account_models.dart';
 import 'package:zcash_wallet/src/providers/sync_keep_awake_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 
+import '../fakes/fake_sync_notifier.dart';
+
 void main() {
   test('settings provider starts from bootstrap keep-awake fields', () {
     final container = ProviderContainer(
@@ -36,6 +38,94 @@ void main() {
     expect(
       isNearTipCatchUp(_sync(scannedHeight: 0, chainTipHeight: 0)),
       isFalse,
+    );
+  });
+
+  test('screen keep-awake requires enabled settings and eligible sync', () {
+    final startedAt = DateTime(2026, 7, 9, 12);
+    const enabled = SyncKeepAwakeSettings(enabled: true, promptSeen: true);
+    const disabled = SyncKeepAwakeSettings(enabled: false, promptSeen: true);
+    final eligibleSync = _sync(lastSyncStartedAt: startedAt);
+
+    expect(
+      shouldKeepScreenAwakeForSync(settings: enabled, sync: eligibleSync),
+      isTrue,
+    );
+    expect(
+      shouldKeepScreenAwakeForSync(settings: disabled, sync: eligibleSync),
+      isFalse,
+    );
+    expect(
+      shouldKeepScreenAwakeForSync(
+        settings: enabled,
+        sync: _sync(
+          scannedHeight: 100,
+          chainTipHeight: 102,
+          lastSyncStartedAt: startedAt,
+        ),
+      ),
+      isFalse,
+    );
+    expect(
+      shouldKeepScreenAwakeForSync(
+        settings: enabled,
+        sync: _sync(percentage: 0, lastSyncStartedAt: startedAt),
+      ),
+      isFalse,
+    );
+  });
+
+  test(
+    'screen keep-awake active provider combines settings and sync state',
+    () async {
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(
+            _bootstrap(
+              syncKeepAwakeEnabled: true,
+              syncKeepAwakePromptSeen: true,
+            ),
+          ),
+          syncProvider.overrideWith(
+            () => FakeSyncNotifier(
+              _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      expect(container.read(syncKeepAwakeActiveProvider), isFalse);
+      await container.read(syncProvider.future);
+      expect(container.read(syncKeepAwakeActiveProvider), isTrue);
+    },
+  );
+
+  test('interaction notifier records the last user activity time', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final first = DateTime(2026, 7, 9, 12);
+    final second = first.add(const Duration(seconds: 2));
+
+    container
+        .read(syncKeepAwakeInteractionProvider.notifier)
+        .markInteraction(at: first);
+    expect(
+      container.read(syncKeepAwakeInteractionProvider).lastInteractionAt,
+      first,
+    );
+    expect(container.read(syncKeepAwakeInteractionProvider).revision, 1);
+
+    container
+        .read(syncKeepAwakeInteractionProvider.notifier)
+        .markInteraction(at: second);
+    final state = container.read(syncKeepAwakeInteractionProvider);
+    expect(state.lastInteractionAt, second);
+    expect(state.revision, 2);
+    expect(
+      state.idleDuration(second.add(const Duration(seconds: 3))),
+      const Duration(seconds: 3),
     );
   });
 

--- a/test/providers/sync_keep_awake_provider_test.dart
+++ b/test/providers/sync_keep_awake_provider_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart' show ThemeMode;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/app_bootstrap.dart';
+import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
+import 'package:zcash_wallet/src/providers/account_models.dart';
+import 'package:zcash_wallet/src/providers/sync_keep_awake_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+void main() {
+  test('settings provider starts from bootstrap keep-awake fields', () {
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(
+          _bootstrap(syncKeepAwakeEnabled: true, syncKeepAwakePromptSeen: true),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      container.read(syncKeepAwakeProvider),
+      const SyncKeepAwakeSettings(enabled: true, promptSeen: true),
+    );
+  });
+
+  test('near-tip catch-up requires known heights and a gap of two or less', () {
+    expect(
+      isNearTipCatchUp(_sync(scannedHeight: 100, chainTipHeight: 102)),
+      isTrue,
+    );
+    expect(
+      isNearTipCatchUp(_sync(scannedHeight: 100, chainTipHeight: 103)),
+      isFalse,
+    );
+    expect(
+      isNearTipCatchUp(_sync(scannedHeight: 0, chainTipHeight: 0)),
+      isFalse,
+    );
+  });
+
+  test('ETA is not estimated for ineligible sync states', () {
+    final startedAt = DateTime(2026, 7, 9, 12);
+    final now = startedAt.add(const Duration(seconds: 30));
+
+    expect(
+      estimateSyncKeepAwakeEta(
+        _sync(percentage: 0, lastSyncStartedAt: startedAt),
+        now: now,
+      ).remaining,
+      isNull,
+    );
+    expect(
+      estimateSyncKeepAwakeEta(
+        _sync(
+          isBackgroundMode: true,
+          percentage: 0.25,
+          lastSyncStartedAt: startedAt,
+        ),
+        now: now,
+      ).remaining,
+      isNull,
+    );
+    expect(
+      estimateSyncKeepAwakeEta(
+        _sync(
+          percentage: 0.25,
+          scannedHeight: 100,
+          chainTipHeight: 102,
+          lastSyncStartedAt: startedAt,
+        ),
+        now: now,
+      ).remaining,
+      isNull,
+    );
+  });
+
+  test('ETA falls back to elapsed run percentage without samples', () {
+    final startedAt = DateTime(2026, 7, 9, 12);
+    final now = startedAt.add(const Duration(seconds: 30));
+
+    final estimate = estimateSyncKeepAwakeEta(
+      _sync(percentage: 0.25, lastSyncStartedAt: startedAt),
+      now: now,
+    );
+
+    expect(estimate.remaining, const Duration(seconds: 90));
+    expect(estimate.sample, isNull);
+  });
+
+  test('ETA uses display target block samples when available', () {
+    final startedAt = DateTime(2026, 7, 9, 12);
+    final previous = estimateSyncKeepAwakeEta(
+      _sync(
+        percentage: 0.10,
+        displayTargetPercentage: 0.20,
+        displayTargetBlocks: 100,
+        lastSyncStartedAt: startedAt,
+      ),
+      now: startedAt.add(const Duration(seconds: 10)),
+    );
+
+    final current = estimateSyncKeepAwakeEta(
+      _sync(
+        percentage: 0.20,
+        displayTargetPercentage: 0.30,
+        displayTargetBlocks: 100,
+        lastSyncStartedAt: startedAt,
+      ),
+      now: startedAt.add(const Duration(seconds: 20)),
+      previousSample: previous.sample,
+    );
+
+    expect(current.remaining, const Duration(seconds: 80));
+    expect(current.sample, isNotNull);
+  });
+
+  test('prompt requires unseen state and at least one minute ETA', () {
+    final startedAt = DateTime(2026, 7, 9, 12);
+    final sync = _sync(percentage: 0.25, lastSyncStartedAt: startedAt);
+    final now = startedAt.add(const Duration(seconds: 30));
+
+    expect(
+      shouldShowSyncKeepAwakePrompt(
+        sync: sync,
+        settings: const SyncKeepAwakeSettings(
+          enabled: false,
+          promptSeen: false,
+        ),
+        now: now,
+      ),
+      isTrue,
+    );
+    expect(
+      shouldShowSyncKeepAwakePrompt(
+        sync: sync,
+        settings: const SyncKeepAwakeSettings(enabled: false, promptSeen: true),
+        now: now,
+      ),
+      isFalse,
+    );
+  });
+}
+
+AppBootstrapState _bootstrap({
+  bool syncKeepAwakeEnabled = false,
+  bool syncKeepAwakePromptSeen = false,
+}) {
+  return AppBootstrapState(
+    initialLocation: '/home',
+    initialAccountState: AccountState(),
+    initialSyncSnapshot: AppSyncSnapshot.empty,
+    network: kZcashDefaultNetworkName,
+    rpcEndpointConfig: defaultRpcEndpointConfig(kZcashDefaultNetworkName),
+    themeMode: ThemeMode.system,
+    privacyModeEnabled: false,
+    syncKeepAwakeEnabled: syncKeepAwakeEnabled,
+    syncKeepAwakePromptSeen: syncKeepAwakePromptSeen,
+    isPasswordConfigured: false,
+    isUnlocked: false,
+    passwordRotationRecoveryFailed: false,
+  );
+}
+
+SyncState _sync({
+  bool isSyncing = true,
+  bool isBackgroundMode = false,
+  double percentage = 0.25,
+  double? displayTargetPercentage,
+  int displayTargetBlocks = 0,
+  int scannedHeight = 100,
+  int chainTipHeight = 200,
+  DateTime? lastSyncStartedAt,
+}) {
+  return SyncState(
+    isSyncing: isSyncing,
+    isBackgroundMode: isBackgroundMode,
+    percentage: percentage,
+    displayTargetPercentage: displayTargetPercentage,
+    displayTargetBlocks: displayTargetBlocks,
+    scannedHeight: scannedHeight,
+    chainTipHeight: chainTipHeight,
+    lastSyncStartedAt: lastSyncStartedAt,
+  );
+}

--- a/test/providers/sync_keep_awake_provider_test.dart
+++ b/test/providers/sync_keep_awake_provider_test.dart
@@ -153,6 +153,35 @@ void main() {
     );
   });
 
+  test('privacy lock provider tracks virtual lock and unlock activity', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final lockedAt = DateTime(2026, 7, 9, 12);
+    final unlockedAt = lockedAt.add(const Duration(seconds: 5));
+
+    container
+        .read(syncKeepAwakePrivacyLockProvider.notifier)
+        .lock(at: lockedAt);
+    expect(
+      container.read(syncKeepAwakePrivacyLockProvider),
+      SyncKeepAwakePrivacyLockState(isLocked: true, lockedAt: lockedAt),
+    );
+
+    container
+        .read(syncKeepAwakePrivacyLockProvider.notifier)
+        .unlock(at: unlockedAt);
+
+    expect(
+      container.read(syncKeepAwakePrivacyLockProvider),
+      const SyncKeepAwakePrivacyLockState.unlocked(),
+    );
+    expect(
+      container.read(syncKeepAwakeInteractionProvider).lastInteractionAt,
+      unlockedAt,
+    );
+  });
+
   test('ETA is not estimated for ineligible sync states', () {
     final startedAt = DateTime(2026, 7, 9, 12);
     final now = startedAt.add(const Duration(seconds: 30));

--- a/test/providers/sync_keep_awake_provider_test.dart
+++ b/test/providers/sync_keep_awake_provider_test.dart
@@ -125,6 +125,172 @@ void main() {
     expect(container.read(syncKeepAwakeActiveProvider), isFalse);
   });
 
+  test('privacy lock mode shows done after a locked sync completes', () async {
+    final syncNotifier = FakeSyncNotifier(
+      _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+    );
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(
+          _bootstrap(
+            syncKeepAwakeEnabled: true,
+            syncKeepAwakePromptSeen: true,
+            isPasswordConfigured: true,
+            isUnlocked: true,
+          ),
+        ),
+        syncProvider.overrideWith(() => syncNotifier),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(syncProvider.future);
+    container
+        .read(syncKeepAwakePrivacyLockProvider.notifier)
+        .lock(at: DateTime(2026, 7, 9, 12, 1));
+
+    expect(
+      container.read(syncKeepAwakePrivacyLockModeProvider),
+      SyncKeepAwakePrivacyLockMode.syncing,
+    );
+
+    syncNotifier.emit(
+      _sync(
+        isSyncing: false,
+        percentage: 1,
+        scannedHeight: 200,
+        chainTipHeight: 200,
+        lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+      ),
+    );
+
+    expect(container.read(syncKeepAwakeActiveProvider), isFalse);
+    expect(
+      container.read(syncKeepAwakePrivacyLockModeProvider),
+      SyncKeepAwakePrivacyLockMode.done,
+    );
+    expect(container.read(syncKeepAwakePrivacyLockVisibleProvider), isTrue);
+  });
+
+  test(
+    'privacy lock mode shows interrupted when locked sync stops early',
+    () async {
+      final syncNotifier = FakeSyncNotifier(
+        _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(
+            _bootstrap(
+              syncKeepAwakeEnabled: true,
+              syncKeepAwakePromptSeen: true,
+              isPasswordConfigured: true,
+              isUnlocked: true,
+            ),
+          ),
+          syncProvider.overrideWith(() => syncNotifier),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(syncProvider.future);
+      container
+          .read(syncKeepAwakePrivacyLockProvider.notifier)
+          .lock(at: DateTime(2026, 7, 9, 12, 1));
+
+      syncNotifier.emit(
+        _sync(
+          isSyncing: false,
+          percentage: 0.5,
+          scannedHeight: 150,
+          chainTipHeight: 200,
+          lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+        ),
+      );
+
+      expect(container.read(syncKeepAwakeActiveProvider), isFalse);
+      expect(container.read(syncKeepAwakePrivacyLockVisibleProvider), isTrue);
+      expect(
+        container.read(syncKeepAwakePrivacyLockModeProvider),
+        SyncKeepAwakePrivacyLockMode.interrupted,
+      );
+    },
+  );
+
+  test(
+    'privacy lock mode stays latched across near-tip follow-up syncs',
+    () async {
+      final syncNotifier = FakeSyncNotifier(
+        _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          appBootstrapProvider.overrideWithValue(
+            _bootstrap(
+              syncKeepAwakeEnabled: true,
+              syncKeepAwakePromptSeen: true,
+              isPasswordConfigured: true,
+              isUnlocked: true,
+            ),
+          ),
+          syncProvider.overrideWith(() => syncNotifier),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(syncProvider.future);
+      container
+          .read(syncKeepAwakePrivacyLockProvider.notifier)
+          .lock(at: DateTime(2026, 7, 9, 12, 1));
+      syncNotifier.emit(
+        _sync(
+          isSyncing: false,
+          percentage: 1,
+          scannedHeight: 200,
+          chainTipHeight: 200,
+          lastSyncStartedAt: DateTime(2026, 7, 9, 12),
+        ),
+      );
+
+      expect(
+        container.read(syncKeepAwakePrivacyLockModeProvider),
+        SyncKeepAwakePrivacyLockMode.done,
+      );
+
+      syncNotifier.emit(
+        _sync(
+          percentage: 0,
+          scannedHeight: 200,
+          chainTipHeight: 202,
+          lastSyncStartedAt: DateTime(2026, 7, 9, 12, 2),
+        ),
+      );
+
+      expect(container.read(syncKeepAwakeActiveProvider), isFalse);
+      expect(container.read(syncKeepAwakePrivacyLockVisibleProvider), isTrue);
+      expect(
+        container.read(syncKeepAwakePrivacyLockModeProvider),
+        SyncKeepAwakePrivacyLockMode.syncing,
+      );
+
+      syncNotifier.emit(
+        _sync(
+          isSyncing: false,
+          percentage: 1,
+          scannedHeight: 202,
+          chainTipHeight: 202,
+          lastSyncStartedAt: DateTime(2026, 7, 9, 12, 2),
+        ),
+      );
+
+      expect(container.read(syncKeepAwakePrivacyLockVisibleProvider), isTrue);
+      expect(
+        container.read(syncKeepAwakePrivacyLockModeProvider),
+        SyncKeepAwakePrivacyLockMode.done,
+      );
+    },
+  );
+
   test('interaction notifier records the last user activity time', () {
     final container = ProviderContainer();
     addTearDown(container.dispose);

--- a/test/providers/sync_keep_awake_provider_test.dart
+++ b/test/providers/sync_keep_awake_provider_test.dart
@@ -41,7 +41,7 @@ void main() {
     );
   });
 
-  test('screen keep-awake requires enabled settings and eligible sync', () {
+  test('screen keep-awake requires enabled settings and substantial work', () {
     final startedAt = DateTime(2026, 7, 9, 12);
     const enabled = SyncKeepAwakeSettings(enabled: true, promptSeen: true);
     const disabled = SyncKeepAwakeSettings(enabled: false, promptSeen: true);
@@ -70,6 +70,45 @@ void main() {
       shouldKeepScreenAwakeForSync(
         settings: enabled,
         sync: _sync(percentage: 0, lastSyncStartedAt: startedAt),
+      ),
+      isTrue,
+    );
+    expect(
+      shouldKeepScreenAwakeForSync(
+        settings: enabled,
+        sync: _sync(
+          percentage: 0,
+          displayTargetBlocks: 100,
+          scannedHeight: 0,
+          chainTipHeight: 0,
+          lastSyncStartedAt: startedAt,
+        ),
+      ),
+      isTrue,
+    );
+    expect(
+      shouldKeepScreenAwakeForSync(
+        settings: enabled,
+        sync: _sync(
+          percentage: 0,
+          displayTargetBlocks: 2,
+          scannedHeight: 0,
+          chainTipHeight: 0,
+          lastSyncStartedAt: startedAt,
+        ),
+      ),
+      isFalse,
+    );
+    expect(
+      shouldKeepScreenAwakeForSync(
+        settings: enabled,
+        sync: _sync(
+          percentage: 0,
+          displayTargetBlocks: 100,
+          scannedHeight: 100,
+          chainTipHeight: 102,
+          lastSyncStartedAt: startedAt,
+        ),
       ),
       isFalse,
     );
@@ -351,13 +390,27 @@ void main() {
   test('ETA is not estimated for ineligible sync states', () {
     final startedAt = DateTime(2026, 7, 9, 12);
     final now = startedAt.add(const Duration(seconds: 30));
+    final zeroProgressSync = _sync(
+      percentage: 0,
+      displayTargetBlocks: 100,
+      lastSyncStartedAt: startedAt,
+    );
 
     expect(
-      estimateSyncKeepAwakeEta(
-        _sync(percentage: 0, lastSyncStartedAt: startedAt),
-        now: now,
-      ).remaining,
+      estimateSyncKeepAwakeEta(zeroProgressSync, now: now).remaining,
       isNull,
+    );
+    expect(canEstimateSyncKeepAwakeEta(zeroProgressSync), isFalse);
+    expect(
+      shouldShowSyncKeepAwakePrompt(
+        sync: zeroProgressSync,
+        settings: const SyncKeepAwakeSettings(
+          enabled: false,
+          promptSeen: false,
+        ),
+        now: now,
+      ),
+      isFalse,
     );
     expect(
       estimateSyncKeepAwakeEta(

--- a/test/sync_state_test.dart
+++ b/test/sync_state_test.dart
@@ -44,6 +44,25 @@ void main() {
     expect(reset.displayPercentage, 0.25);
   });
 
+  test('display target defaults to actual percentage', () {
+    final state = SyncState(percentage: 0.25);
+
+    expect(state.displayTargetPercentage, 0.25);
+    expect(state.displayTargetBlocks, 0);
+  });
+
+  test('copyWith can update display target independently', () {
+    final state = SyncState(percentage: 0.25);
+    final next = state.copyWith(
+      displayTargetPercentage: 0.40,
+      displayTargetBlocks: 150,
+    );
+
+    expect(next.percentage, 0.25);
+    expect(next.displayTargetPercentage, 0.40);
+    expect(next.displayTargetBlocks, 150);
+  });
+
   test('scopedToAccount preserves data for the owning account', () {
     final tx = _tx('a' * 64);
     final state = SyncState(
@@ -76,6 +95,8 @@ void main() {
       isSyncing: true,
       percentage: 0.75,
       displayPercentage: 0.50,
+      displayTargetPercentage: 0.80,
+      displayTargetBlocks: 120,
       scannedHeight: 10,
       chainTipHeight: 20,
       totalBalance: BigInt.from(123),
@@ -94,6 +115,8 @@ void main() {
     expect(scoped.isSyncing, isTrue);
     expect(scoped.percentage, 0.75);
     expect(scoped.displayPercentage, 0.50);
+    expect(scoped.displayTargetPercentage, 0.80);
+    expect(scoped.displayTargetBlocks, 120);
     expect(scoped.scannedHeight, 10);
     expect(scoped.chainTipHeight, 20);
   });


### PR DESCRIPTION
## Summary
- Add mobile sync keep-awake settings, first-run prompt, and persistent state.
- Keep the device screen awake during eligible long foreground syncs, excluding near-tip catch-up syncs.
- Add the inactivity privacy overlay with sync progress/done states and passcode confirmation before unlock.

## Impact
- Mobile users can opt into keeping the screen awake during long syncs.
- Settings now includes a Syncing card with a Keep screen awake toggle.
- When enabled, idle long syncs show a privacy lock overlay after 1 minute.

## Validation
- `fvm flutter test test/providers/sync_keep_awake_provider_test.dart test/sync_state_test.dart test/app_bootstrap_test.dart`
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/core/widgets/sync_keep_awake_interaction_listener_test.dart test/core/widgets/sync_keep_awake_native_host_test.dart test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart test/features/home/mobile_home_screen_test.dart test/features/settings/mobile_settings_screen_test.dart`
- `fvm flutter analyze`
- `git diff --check`
