### PR TITLE
Improve sync performance with reorg-safe batching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -800,7 +800,7 @@ edge in `MobileBottomSafeArea`
   - Manual flow:
     - Start services: `./scripts/regtest/up.sh`
     - Run individual scenario tests: `cd rust && cargo test --test regtest_receive_sync -- --ignored --nocapture --test-threads=1`
-    - Other available targets: `regtest_send`, `regtest_import`, `regtest_multi_account`
+    - Other available targets: `regtest_send`, `regtest_import`, `regtest_multi_account`, `regtest_reorg`
     - Stop services: `./scripts/regtest/down.sh`
   - The one-shot runner streams the full test output to the terminal and also saves a copy to `.regtest-logs/regtest-rust-tests.log`.
 - `scripts/regtest/` utilities:
@@ -812,7 +812,8 @@ edge in `MobileBottomSafeArea`
   - `lib.sh` — shared helper functions used by the other regtest scripts; source it from scripts, do not run it directly.
 - Regtest prerequisites:
   - Docker Desktop / `docker compose` must be available.
-  - `grpcurl` is optional but recommended. If installed, the scripts use it to wait for `lightwalletd` gRPC readiness and chain-tip propagation; otherwise they fall back to a simpler TCP port check.
+  - `grpcurl` is optional for the general regtest utilities. If installed, the scripts use it to wait for `lightwalletd` gRPC readiness and chain-tip propagation; otherwise they fall back to a simpler TCP port check.
+  - `grpcurl` is required by `./run-regtest-rust-tests.sh` and the same-height `regtest_reorg` scenarios because they must verify that lightwalletd switched to the replacement tip hash. The one-shot runner checks this before resetting existing regtest state.
 - Debug vs Release: Rust crypto is ~5-10x slower in debug (`opt-level=0`). Use `--release` for realistic sync performance.
 
 ## Crate Versions

--- a/lib/src/providers/account_provider.dart
+++ b/lib/src/providers/account_provider.dart
@@ -601,6 +601,11 @@ class AccountNotifier extends AsyncNotifier<AccountState> {
       await _resetVotingProcessStateForAccount(account.uuid, dbPath: dbPath);
     }
 
+    // Sync has already been stopped by runWithSyncPausedForWalletReset. Wait
+    // for a detached WAL checkpoint that opened this DB, and invalidate one
+    // that is still queued, before deleting the randomized wallet path.
+    rust_wallet.quiesceWalletWalCheckpointForReset();
+
     var dbDeleted = false;
     try {
       await _deleteExistingDb(dbPath);

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -279,6 +279,46 @@ bool syncFailureWasRecordedWhileProgressAwaited({
       current?.lastSyncFailedAt != beforeAwait?.lastSyncFailedAt;
 }
 
+@visibleForTesting
+SyncState mergeProgressDataIntoConcurrentFailure({
+  required SyncState currentFailureState,
+  required SyncState progressState,
+}) {
+  // The DB reads performed by the progress callback may contain useful rows
+  // committed immediately before the stream failed. Merge only that
+  // account-scoped data into the newer failure state; its stopped lifecycle
+  // must win over the stale progress event that initiated those reads.
+  return currentFailureState.copyWith(
+    accountUuid: progressState.accountUuid,
+    hasBalanceData: progressState.hasBalanceData,
+    hasRecentTransactionsData: progressState.hasRecentTransactionsData,
+    transparentBalance: progressState.transparentBalance,
+    saplingBalance: progressState.saplingBalance,
+    orchardBalance: progressState.orchardBalance,
+    transparentPendingBalance: progressState.transparentPendingBalance,
+    saplingPendingBalance: progressState.saplingPendingBalance,
+    orchardPendingBalance: progressState.orchardPendingBalance,
+    canShieldTransparentBalance: progressState.canShieldTransparentBalance,
+    shieldTransparentFee: progressState.shieldTransparentFee,
+    shieldTransparentAmount: progressState.shieldTransparentAmount,
+    spendableBalance: progressState.spendableBalance,
+    totalBalance: progressState.totalBalance,
+    recentTransactions: progressState.recentTransactions,
+  );
+}
+
+@visibleForTesting
+bool shouldSmoothSyncProgress({
+  required SyncProgressEvent event,
+  required bool preserveConcurrentFailure,
+  required bool isBackgroundDelegateActive,
+}) {
+  return !preserveConcurrentFailure &&
+      !event.isComplete &&
+      event.isSyncing &&
+      !isBackgroundDelegateActive;
+}
+
 class SyncNotifier extends AsyncNotifier<SyncState> {
   SyncNotifier({Future<String> Function()? walletDbPathResolver})
     : _walletDbPathResolver = walletDbPathResolver ?? getWalletDbPath;
@@ -1487,76 +1527,84 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         ? 1.0
         : math.min(actualPercentage, maxDisplayPercentage);
 
-    state = AsyncData(
-      SyncState(
-        accountUuid: stateAccountUuid,
-        hasBalanceData: hasBalanceData,
-        hasRecentTransactionsData: hasRecentTransactionsData,
-        isSyncing: event.isSyncing && !event.isComplete,
-        isBackgroundMode:
-            (!event.isComplete && event.isBackground) || _bgDelegate.isActive,
-        percentage: actualPercentage,
-        displayPercentage: displayPercentage,
-        displayTargetPercentage: event.displayTargetPercentage,
-        displayTargetBlocks: event.displayTargetBlocks,
-        scannedHeight: event.scannedHeight,
-        chainTipHeight: event.chainTipHeight,
-        transparentBalance: useFetchedAccountData
-            ? transparent ?? stateScopedPrev?.transparentBalance
-            : stateScopedPrev?.transparentBalance,
-        saplingBalance: useFetchedAccountData
-            ? sapling ?? stateScopedPrev?.saplingBalance
-            : stateScopedPrev?.saplingBalance,
-        orchardBalance: useFetchedAccountData
-            ? orchard ?? stateScopedPrev?.orchardBalance
-            : stateScopedPrev?.orchardBalance,
-        transparentPendingBalance: useFetchedAccountData
-            ? transparentPending ?? stateScopedPrev?.transparentPendingBalance
-            : stateScopedPrev?.transparentPendingBalance,
-        saplingPendingBalance: useFetchedAccountData
-            ? saplingPending ?? stateScopedPrev?.saplingPendingBalance
-            : stateScopedPrev?.saplingPendingBalance,
-        orchardPendingBalance: useFetchedAccountData
-            ? orchardPending ?? stateScopedPrev?.orchardPendingBalance
-            : stateScopedPrev?.orchardPendingBalance,
-        canShieldTransparentBalance: useFetchedAccountData
-            ? canShieldTransparentBalance ??
-                  stateScopedPrev?.canShieldTransparentBalance ??
-                  false
-            : stateScopedPrev?.canShieldTransparentBalance ?? false,
-        shieldTransparentFee: useFetchedAccountData
-            ? shieldTransparentFee ?? stateScopedPrev?.shieldTransparentFee
-            : stateScopedPrev?.shieldTransparentFee,
-        shieldTransparentAmount: useFetchedAccountData
-            ? shieldTransparentAmount ??
-                  stateScopedPrev?.shieldTransparentAmount
-            : stateScopedPrev?.shieldTransparentAmount,
-        spendableBalance: useFetchedAccountData
-            ? spendable ?? stateScopedPrev?.spendableBalance
-            : stateScopedPrev?.spendableBalance,
-        totalBalance: useFetchedAccountData
-            ? total ?? stateScopedPrev?.totalBalance
-            : stateScopedPrev?.totalBalance,
-        failure: preserveConcurrentFailure ? currentState?.failure : null,
-        error: preserveConcurrentFailure ? currentState?.error : null,
-        recentTransactions: useFetchedAccountData
-            ? recentTxs
-            : stateScopedPrev?.recentTransactions ?? const [],
-        lastSyncStartedAt: syncStartedAt,
-        lastSyncCompletedAt: syncCompletedAt,
-        lastSyncFailedAt: currentState?.lastSyncFailedAt,
-        phase: event.phase,
-      ),
+    var nextState = SyncState(
+      accountUuid: stateAccountUuid,
+      hasBalanceData: hasBalanceData,
+      hasRecentTransactionsData: hasRecentTransactionsData,
+      isSyncing: event.isSyncing && !event.isComplete,
+      isBackgroundMode:
+          (!event.isComplete && event.isBackground) || _bgDelegate.isActive,
+      percentage: actualPercentage,
+      displayPercentage: displayPercentage,
+      displayTargetPercentage: event.displayTargetPercentage,
+      displayTargetBlocks: event.displayTargetBlocks,
+      scannedHeight: event.scannedHeight,
+      chainTipHeight: event.chainTipHeight,
+      transparentBalance: useFetchedAccountData
+          ? transparent ?? stateScopedPrev?.transparentBalance
+          : stateScopedPrev?.transparentBalance,
+      saplingBalance: useFetchedAccountData
+          ? sapling ?? stateScopedPrev?.saplingBalance
+          : stateScopedPrev?.saplingBalance,
+      orchardBalance: useFetchedAccountData
+          ? orchard ?? stateScopedPrev?.orchardBalance
+          : stateScopedPrev?.orchardBalance,
+      transparentPendingBalance: useFetchedAccountData
+          ? transparentPending ?? stateScopedPrev?.transparentPendingBalance
+          : stateScopedPrev?.transparentPendingBalance,
+      saplingPendingBalance: useFetchedAccountData
+          ? saplingPending ?? stateScopedPrev?.saplingPendingBalance
+          : stateScopedPrev?.saplingPendingBalance,
+      orchardPendingBalance: useFetchedAccountData
+          ? orchardPending ?? stateScopedPrev?.orchardPendingBalance
+          : stateScopedPrev?.orchardPendingBalance,
+      canShieldTransparentBalance: useFetchedAccountData
+          ? canShieldTransparentBalance ??
+                stateScopedPrev?.canShieldTransparentBalance ??
+                false
+          : stateScopedPrev?.canShieldTransparentBalance ?? false,
+      shieldTransparentFee: useFetchedAccountData
+          ? shieldTransparentFee ?? stateScopedPrev?.shieldTransparentFee
+          : stateScopedPrev?.shieldTransparentFee,
+      shieldTransparentAmount: useFetchedAccountData
+          ? shieldTransparentAmount ?? stateScopedPrev?.shieldTransparentAmount
+          : stateScopedPrev?.shieldTransparentAmount,
+      spendableBalance: useFetchedAccountData
+          ? spendable ?? stateScopedPrev?.spendableBalance
+          : stateScopedPrev?.spendableBalance,
+      totalBalance: useFetchedAccountData
+          ? total ?? stateScopedPrev?.totalBalance
+          : stateScopedPrev?.totalBalance,
+      failure: preserveConcurrentFailure ? currentState?.failure : null,
+      error: preserveConcurrentFailure ? currentState?.error : null,
+      recentTransactions: useFetchedAccountData
+          ? recentTxs
+          : stateScopedPrev?.recentTransactions ?? const [],
+      lastSyncStartedAt: syncStartedAt,
+      lastSyncCompletedAt: syncCompletedAt,
+      lastSyncFailedAt: currentState?.lastSyncFailedAt,
+      phase: event.phase,
     );
+    if (preserveConcurrentFailure && currentState != null) {
+      nextState = mergeProgressDataIntoConcurrentFailure(
+        currentFailureState: currentState,
+        progressState: nextState,
+      );
+    }
+    state = AsyncData(nextState);
 
-    if (event.isComplete || !event.isSyncing || _bgDelegate.isActive) {
-      _stopDisplayProgressTimer();
-    } else {
+    if (shouldSmoothSyncProgress(
+      event: event,
+      preserveConcurrentFailure: preserveConcurrentFailure,
+      isBackgroundDelegateActive: _bgDelegate.isActive,
+    )) {
       _startDisplayProgressSmoothing(
         basePercentage: displayPercentage,
         targetPercentage: event.displayTargetPercentage,
         targetBlocks: event.displayTargetBlocks,
       );
+    } else {
+      _stopDisplayProgressTimer();
     }
 
     // Handle sync completion here (not in onDone) to avoid race with async state update.

--- a/lib/src/providers/sync_provider.dart
+++ b/lib/src/providers/sync_provider.dart
@@ -250,6 +250,35 @@ class WalletMutationSyncPause {
       hadActiveSync || hadPolling || hadBackgroundSync || hadMempoolObserver;
 }
 
+@visibleForTesting
+Future<void> recordSyncFailureAndRefreshCommittedState({
+  required Object error,
+  required void Function(Object error) recordFailure,
+  required Future<void> Function() refreshCommittedState,
+  required void Function(Object error, StackTrace stackTrace) onRefreshError,
+}) async {
+  // Record first so the user sees the failure even if a DB read is slow. The
+  // refresh path merges against the latest SyncState and preserves this error.
+  recordFailure(error);
+  try {
+    await refreshCommittedState();
+  } catch (e, st) {
+    onRefreshError(e, st);
+  }
+}
+
+@visibleForTesting
+bool syncFailureWasRecordedWhileProgressAwaited({
+  required SyncState? beforeAwait,
+  required SyncState? current,
+}) {
+  final currentFailure = current?.failure;
+  if (currentFailure == null) return false;
+
+  return !identical(currentFailure, beforeAwait?.failure) ||
+      current?.lastSyncFailedAt != beforeAwait?.lastSyncFailedAt;
+}
+
 class SyncNotifier extends AsyncNotifier<SyncState> {
   SyncNotifier({Future<String> Function()? walletDbPathResolver})
     : _walletDbPathResolver = walletDbPathResolver ?? getWalletDbPath;
@@ -669,7 +698,19 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
       _startPolling();
       return;
     }
-    _recordSyncFailure(error);
+    // A sync error can arrive after scan/enhancement already committed useful
+    // wallet rows. In particular, the final enhancement drain may store one
+    // transaction and then fail on a sibling request. Refresh from the DB so
+    // the failure state does not strand those committed balances/history until
+    // the next successful sync or app restart.
+    await recordSyncFailureAndRefreshCommittedState(
+      error: error,
+      recordFailure: _recordSyncFailure,
+      refreshCommittedState: _refreshBalance,
+      onRefreshError: (e, st) {
+        log('Sync: post-failure wallet refresh failed: $e\n$st');
+      },
+    );
   }
 
   void _recordSyncFailure(Object error) {
@@ -1403,7 +1444,19 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
     }
     final stateAccountUuid = _getActiveAccountUuid();
     final useFetchedAccountData = accountUuid == stateAccountUuid;
-    final stateScopedPrev = _previousScopedState(state.value, stateAccountUuid);
+    // Read the latest state after the async DB calls. A stream error can be
+    // recorded while this progress handler is awaiting; preserve that failure
+    // instead of letting this older progress event clear it on completion.
+    final currentState = state.value;
+    final preserveConcurrentFailure =
+        syncFailureWasRecordedWhileProgressAwaited(
+          beforeAwait: prev,
+          current: currentState,
+        );
+    final stateScopedPrev = _previousScopedState(
+      currentState,
+      stateAccountUuid,
+    );
     final hasBalanceData = useFetchedAccountData
         ? didFetchBalance || (stateScopedPrev?.hasBalanceData ?? false)
         : stateScopedPrev?.hasBalanceData ?? false;
@@ -1484,12 +1537,14 @@ class SyncNotifier extends AsyncNotifier<SyncState> {
         totalBalance: useFetchedAccountData
             ? total ?? stateScopedPrev?.totalBalance
             : stateScopedPrev?.totalBalance,
+        failure: preserveConcurrentFailure ? currentState?.failure : null,
+        error: preserveConcurrentFailure ? currentState?.error : null,
         recentTransactions: useFetchedAccountData
             ? recentTxs
             : stateScopedPrev?.recentTransactions ?? const [],
         lastSyncStartedAt: syncStartedAt,
         lastSyncCompletedAt: syncCompletedAt,
-        lastSyncFailedAt: prev?.lastSyncFailedAt,
+        lastSyncFailedAt: currentState?.lastSyncFailedAt,
         phase: event.phase,
       ),
     );

--- a/lib/src/rust/api/wallet.dart
+++ b/lib/src/rust/api/wallet.dart
@@ -234,6 +234,11 @@ List<String> mnemonicWordList() =>
 bool walletExists({required String dbPath}) =>
     RustLib.instance.api.crateApiWalletWalletExists(dbPath: dbPath);
 
+/// Wait for an active detached WAL checkpoint, then invalidate any checkpoint
+/// that has not opened the wallet DB yet. Sync must already be stopped.
+void quiesceWalletWalCheckpointForReset() =>
+    RustLib.instance.api.crateApiWalletQuiesceWalletWalCheckpointForReset();
+
 /// Ensure an existing wallet database has the schema required by this build.
 Future<void> ensureWalletDbMigrated({
   required String dbPath,

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -79,7 +79,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => -30850900;
+  int get rustContentHash => -328122132;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -632,6 +632,8 @@ abstract class RustLibApi extends BaseApi {
     required BigInt orchardStartIndex,
     required List<SubtreeRoot> orchardRoots,
   });
+
+  void crateApiWalletQuiesceWalletWalCheckpointForReset();
 
   Future<void> crateApiVotingRecordShareDelegation({
     required String dbPath,
@@ -4371,6 +4373,32 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
+  void crateApiWalletQuiesceWalletWalCheckpointForReset() {
+    return handler.executeSync(
+      SyncTask(
+        callFfi: () {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiWalletQuiesceWalletWalCheckpointForResetConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiWalletQuiesceWalletWalCheckpointForResetConstMeta =>
+      const TaskConstMeta(
+        debugName: "quiesce_wallet_wal_checkpoint_for_reset",
+        argNames: [],
+      );
+
+  @override
   Future<void> crateApiVotingRecordShareDelegation({
     required String dbPath,
     required String accountUuid,
@@ -4396,7 +4424,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 88,
+            funcId: 89,
             port: port_,
           );
         },
@@ -4455,7 +4483,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 89,
+            funcId: 90,
             port: port_,
           );
         },
@@ -4502,7 +4530,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 90,
+            funcId: 91,
             port: port_,
           );
         },
@@ -4547,7 +4575,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 91,
+            funcId: 92,
             port: port_,
           );
         },
@@ -4574,7 +4602,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 93)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_unit,
@@ -4606,7 +4634,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 94,
             port: port_,
           );
         },
@@ -4643,7 +4671,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 95,
             port: port_,
           );
         },
@@ -4678,7 +4706,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 96,
             port: port_,
           );
         },
@@ -4720,7 +4748,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -4757,7 +4785,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 98,
             port: port_,
           );
         },
@@ -4795,7 +4823,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 99,
             port: port_,
           );
         },
@@ -4848,7 +4876,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 100,
             port: port_,
           );
         },
@@ -4916,7 +4944,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 101,
             port: port_,
           );
         },
@@ -4963,7 +4991,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 102,
           )!;
         },
         codec: SseCodec(
@@ -4998,7 +5026,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 102,
+            funcId: 103,
             port: port_,
           );
         },
@@ -5031,7 +5059,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 103,
+            funcId: 104,
             port: port_,
           );
         },
@@ -5071,7 +5099,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 105,
             port: port_,
           );
         },
@@ -5112,7 +5140,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 106,
             port: port_,
           );
         },
@@ -5166,7 +5194,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 107,
             port: port_,
           );
         },
@@ -5216,7 +5244,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 107,
+              funcId: 108,
               port: port_,
             );
           },
@@ -5257,7 +5285,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 108,
+              funcId: 109,
               port: port_,
             );
           },
@@ -5289,7 +5317,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
           )!;
         },
         codec: SseCodec(
@@ -5330,7 +5358,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },
@@ -5381,7 +5409,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -5420,7 +5448,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
             port: port_,
           );
         },
@@ -5463,7 +5491,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
             port: port_,
           );
         },
@@ -5513,7 +5541,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },
@@ -5545,7 +5573,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
             port: port_,
           );
         },
@@ -5573,7 +5601,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
           )!;
         },
         codec: SseCodec(
@@ -5605,7 +5633,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 118,
             port: port_,
           );
         },
@@ -5642,7 +5670,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 119,
             port: port_,
           );
         },
@@ -5673,7 +5701,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 120,
           )!;
         },
         codec: SseCodec(
@@ -5704,7 +5732,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 121,
             port: port_,
           );
         },

--- a/run-regtest-rust-tests.sh
+++ b/run-regtest-rust-tests.sh
@@ -31,6 +31,10 @@ Override with:
 
   SAPLING_PARAMS_DIR=/custom/path ./run-regtest-rust-tests.sh
 
+Prerequisites:
+
+  grpcurl    Required for deterministic same-height reorg tests.
+
 Options:
 
   --keep    Skip the final down/reset cleanup so the regtest state stays
@@ -55,6 +59,16 @@ for arg in "$@"; do
       ;;
   esac
 done
+
+# The full suite includes same-height reorg scenarios. A TCP or height-only
+# readiness check cannot distinguish the old lightwalletd tip from its
+# same-height replacement, so fail before resetting any existing regtest state
+# when the hash-capable gRPC probe is unavailable.
+if ! command -v grpcurl >/dev/null 2>&1; then
+  echo "grpcurl is required to run the full Rust regtest suite (same-height reorg verification)." >&2
+  echo "Install grpcurl and retry, or run an individual non-reorg test target manually." >&2
+  exit 1
+fi
 
 cleanup() {
   if [[ "$KEEP_STATE" -eq 1 ]]; then

--- a/run-regtest-rust-tests.sh
+++ b/run-regtest-rust-tests.sh
@@ -149,7 +149,8 @@ echo "==> Log file: $LOG_FILE"
     regtest_receive_sync \
     regtest_send \
     regtest_import \
-    regtest_multi_account
+    regtest_multi_account \
+    regtest_reorg
   do
     cargo test --test "$test_target" -- --ignored --nocapture --test-threads=1
   done

--- a/rust/examples/sync_bench.rs
+++ b/rust/examples/sync_bench.rs
@@ -14,17 +14,26 @@
 //!   LWD_URL    = <url>                     (default: mainnet stardust)
 //!   NETWORK    = main | test | regtest     (default: main)
 //!   LABEL      = free-form tag for the JSON summary (default: SCENARIO)
+//!   GIT_SHA    = optional source revision override (default: `git rev-parse HEAD`)
 //!
 //! Emits a single-line JSON summary to stdout prefixed with `BENCH_RESULT `.
 //! All engine logs go to stderr.
 
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
-use std::sync::Arc;
-use std::time::Instant;
+use std::collections::BTreeMap;
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, AtomicU8};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use rust_lib_zcash_wallet::api::{sync as sync_api, wallet as wallet_api};
 use rust_lib_zcash_wallet::wallet::keys;
 use rust_lib_zcash_wallet::wallet::sync_engine;
+use serde::Serialize;
+use serde_json::{json, Value};
+use tonic::transport::{ClientTlsConfig, Endpoint};
+use zcash_client_backend::proto::service::{
+    compact_tx_streamer_client::CompactTxStreamerClient, ChainSpec,
+};
 
 // Canonical 24-word BIP39 test vector (public knowledge, zero secrecy),
 // used only for the optional 2nd account in the `multi` scenario.
@@ -50,6 +59,70 @@ const DEFAULT_BIRTHDAY: u64 = 3346523;
 const DEFAULT_LWD_URL: &str = "https://us.zec.stardust.rest:443";
 const DEFAULT_NETWORK: &str = "main";
 
+#[derive(Debug, Serialize)]
+struct TipAnchor {
+    height: u64,
+    /// The lightwalletd `BlockId.hash` bytes, encoded without changing byte order.
+    hash_hex: String,
+}
+
+#[derive(Debug, Default)]
+struct ProgressStats {
+    events: u64,
+    phase_counts: BTreeMap<String, u64>,
+    first_scanned: Option<u64>,
+    last_scanned: u64,
+    last_tip: u64,
+    last_is_complete: bool,
+    complete_events: u64,
+    pending_download_start: Option<u64>,
+    /// Sum of each observed scan batch's end-minus-start delta. Unlike the
+    /// chain span, this includes work repeated after verification or rewind.
+    scan_blocks_processed: u64,
+}
+
+impl ProgressStats {
+    fn observe(&mut self, event: &sync_engine::SyncProgressEvent) {
+        self.events += 1;
+        let phase = if event.phase.is_empty() {
+            if event.is_complete {
+                "complete"
+            } else {
+                "unspecified"
+            }
+        } else {
+            event.phase.as_str()
+        };
+        *self.phase_counts.entry(phase.to_string()).or_default() += 1;
+
+        self.first_scanned.get_or_insert(event.scanned_height);
+        self.last_scanned = event.scanned_height;
+        self.last_tip = event.chain_tip_height;
+        self.last_is_complete = event.is_complete;
+        if event.is_complete {
+            self.complete_events += 1;
+        }
+
+        match event.phase.as_str() {
+            "download" => self.pending_download_start = Some(event.scanned_height),
+            "scan" => {
+                if let Some(start) = self.pending_download_start.take() {
+                    self.scan_blocks_processed = self
+                        .scan_blocks_processed
+                        .saturating_add(event.scanned_height.saturating_sub(start));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn net_scanned_delta(&self) -> u64 {
+        self.first_scanned
+            .map(|first| self.last_scanned.saturating_sub(first))
+            .unwrap_or(0)
+    }
+}
+
 /// Minimal stderr logger so we see the engine's per-batch timing logs.
 struct StderrLogger;
 impl log::Log for StderrLogger {
@@ -67,6 +140,76 @@ static LOGGER: StderrLogger = StderrLogger;
 
 fn env_or<'a>(key: &str, default: &'a str) -> String {
     std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+fn source_revision() -> Option<String> {
+    std::env::var("GIT_SHA")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            let output = Command::new("git")
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .ok()?;
+            output
+                .status
+                .success()
+                .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
+}
+
+fn source_is_dirty() -> Option<bool> {
+    Command::new("git")
+        .args(["status", "--porcelain", "--untracked-files=normal"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| !output.stdout.is_empty())
+}
+
+fn tuning_environment() -> BTreeMap<String, String> {
+    std::env::vars()
+        .filter(|(key, _)| key.starts_with("ZCASH_SYNC_") || key.starts_with("ZCASH_E2E_SYNC_"))
+        .collect()
+}
+
+async fn fetch_tip_anchor(lightwalletd_url: &str) -> Result<TipAnchor, String> {
+    let endpoint = Endpoint::from_shared(lightwalletd_url.to_string())
+        .map_err(|e| format!("invalid URL: {e}"))?
+        .connect_timeout(Duration::from_secs(10));
+    let channel = if lightwalletd_url.starts_with("https://") {
+        endpoint
+            .tls_config(ClientTlsConfig::new().with_webpki_roots())
+            .map_err(|e| format!("TLS config: {e}"))?
+            .connect()
+            .await
+            .map_err(|e| format!("connect: {e}"))?
+    } else {
+        endpoint
+            .connect()
+            .await
+            .map_err(|e| format!("connect: {e}"))?
+    };
+    let mut client = CompactTxStreamerClient::new(channel);
+    let mut request = tonic::Request::new(ChainSpec::default());
+    request.set_timeout(Duration::from_secs(20));
+    let block = client
+        .get_latest_block(request)
+        .await
+        .map_err(|e| format!("get_latest_block: {e}"))?
+        .into_inner();
+    Ok(TipAnchor {
+        height: block.height,
+        hash_hex: hex::encode(block.hash),
+    })
+}
+
+fn anchor_json(result: Result<TipAnchor, String>) -> (Value, Value) {
+    match result {
+        Ok(anchor) => (json!(anchor), Value::Null),
+        Err(error) => (Value::Null, json!(error)),
+    }
 }
 
 fn main() {
@@ -123,15 +266,12 @@ fn main() {
     let desired_mode = AtomicU8::new(1); // foreground
     let running_mode = 1u8;
 
-    // Phase accounting from progress events.
-    let events = Arc::new(AtomicU64::new(0));
-    let last_scanned = Arc::new(AtomicU64::new(0));
-    let last_tip = Arc::new(AtomicU64::new(0));
-    let events_cb = events.clone();
-    let last_scanned_cb = last_scanned.clone();
-    let last_tip_cb = last_tip.clone();
+    // Phase and actual scan-work accounting from progress events.
+    let progress = Arc::new(Mutex::new(ProgressStats::default()));
+    let progress_cb = progress.clone();
 
     let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let remote_tip_before = rt.block_on(fetch_tip_anchor(&lwd_url));
     let start = Instant::now();
     let result = rt.block_on(async {
         sync_engine::run_sync_inner(
@@ -142,22 +282,29 @@ fn main() {
             running_mode,
             &desired_mode,
             move |ev| {
-                events_cb.fetch_add(1, Ordering::Relaxed);
-                last_scanned_cb.store(ev.scanned_height, Ordering::Relaxed);
-                last_tip_cb.store(ev.chain_tip_height, Ordering::Relaxed);
+                progress_cb
+                    .lock()
+                    .expect("progress mutex poisoned")
+                    .observe(&ev);
             },
         )
         .await
     });
     let elapsed = start.elapsed();
+    let remote_tip_after = rt.block_on(fetch_tip_anchor(&lwd_url));
 
     if let Err(e) = &result {
         eprintln!("SYNC FAILED: {e}");
     }
 
-    let scanned = last_scanned.load(Ordering::Relaxed);
-    let tip = last_tip.load(Ordering::Relaxed);
-    let blocks = tip.saturating_sub(birthday);
+    let progress = progress.lock().expect("progress mutex poisoned");
+    let scanned = progress.last_scanned;
+    let tip = progress.last_tip;
+    let chain_span_blocks = tip.saturating_sub(birthday);
+    let blocks = progress.scan_blocks_processed;
+    let complete = progress.last_is_complete && progress.complete_events > 0;
+    let heights_match = scanned == tip;
+    let ok = result.is_ok() && complete && heights_match;
 
     // --- Balances ------------------------------------------------------------
     let mut balances = Vec::new();
@@ -165,10 +312,11 @@ fn main() {
         if let Ok(bal) =
             sync_api::get_balance(db_path_str.clone(), network.clone(), acct.uuid.clone())
         {
-            balances.push(format!(
-                "{{\"uuid\":\"{}\",\"total\":{},\"spendable\":{}}}",
-                acct.uuid, bal.total, bal.spendable
-            ));
+            balances.push(json!({
+                "uuid": acct.uuid.to_string(),
+                "total": bal.total,
+                "spendable": bal.spendable,
+            }));
         }
     }
 
@@ -179,24 +327,59 @@ fn main() {
         0.0
     };
 
-    // Machine-readable summary line.
-    println!(
-        "BENCH_RESULT {{\"label\":\"{label}\",\"scenario\":\"{scenario}\",\"ok\":{},\
-\"birthday\":{birthday},\"tip\":{tip},\"scanned\":{scanned},\"blocks\":{blocks},\
-\"accounts\":{},\"events\":{},\"elapsed_s\":{:.2},\"blocks_per_s\":{:.1},\"balances\":[{}]}}",
-        result.is_ok(),
-        accounts.len(),
-        events.load(Ordering::Relaxed),
-        secs,
-        bps,
-        balances.join(","),
-    );
+    let mut failure_reasons = Vec::new();
+    if let Err(error) = &result {
+        failure_reasons.push(format!("sync error: {error}"));
+    }
+    if !complete {
+        failure_reasons.push("no terminal complete progress event".to_string());
+    }
+    if !heights_match {
+        failure_reasons.push(format!("terminal scanned height {scanned} != tip {tip}"));
+    }
+
+    let (remote_tip_before, remote_tip_before_error) = anchor_json(remote_tip_before);
+    let (remote_tip_after, remote_tip_after_error) = anchor_json(remote_tip_after);
+    let summary = json!({
+        "label": label,
+        "scenario": scenario,
+        "ok": ok,
+        "failure_reasons": failure_reasons,
+        "birthday": birthday,
+        "tip": tip,
+        "scanned": scanned,
+        // Kept for compatibility, but now represents observed scan work rather
+        // than the misleading `tip - birthday` chain span.
+        "blocks": blocks,
+        "scan_blocks_processed": blocks,
+        "net_scanned_delta": progress.net_scanned_delta(),
+        "chain_span_blocks": chain_span_blocks,
+        "complete": complete,
+        "accounts": accounts.len(),
+        "events": progress.events,
+        "phase_counts": progress.phase_counts,
+        "elapsed_s": secs,
+        "blocks_per_s": bps,
+        "balances": balances,
+        "remote_tip_before": remote_tip_before,
+        "remote_tip_before_error": remote_tip_before_error,
+        "remote_tip_after": remote_tip_after,
+        "remote_tip_after_error": remote_tip_after_error,
+        "git_sha": source_revision(),
+        "git_dirty": source_is_dirty(),
+        "tuning_env": tuning_environment(),
+    });
+
+    // serde_json emits compact, escaped, single-line JSON suitable for JSONL
+    // collection after stripping the stable `BENCH_RESULT ` prefix.
+    println!("BENCH_RESULT {summary}");
 
     eprintln!(
         "=== DONE: {:.2}s, {} blocks, {:.1} blocks/s, ok={} ===",
-        secs,
-        blocks,
-        bps,
-        result.is_ok()
+        secs, blocks, bps, ok
     );
+
+    if !ok {
+        std::process::exit(1);
+    }
 }

--- a/rust/examples/sync_bench.rs
+++ b/rust/examples/sync_bench.rs
@@ -1,0 +1,202 @@
+//! Standalone sync performance benchmark harness.
+//!
+//! Drives the real sync engine (`run_sync_inner`) against mainnet lightwalletd,
+//! with a dev mnemonic and a fixed birthday, so we can measure cold-start sync
+//! wall-clock time and iterate on performance WITHOUT running the Flutter app.
+//!
+//! Usage:
+//!   cargo run --release --example sync_bench                 # single account
+//!   SCENARIO=multi cargo run --release --example sync_bench  # 2 accounts
+//!
+//! Env overrides:
+//!   SCENARIO   = single | multi           (default: single)
+//!   BIRTHDAY   = <height>                  (default: 3346523)
+//!   LWD_URL    = <url>                     (default: mainnet stardust)
+//!   NETWORK    = main | test | regtest     (default: main)
+//!   LABEL      = free-form tag for the JSON summary (default: SCENARIO)
+//!
+//! Emits a single-line JSON summary to stdout prefixed with `BENCH_RESULT `.
+//! All engine logs go to stderr.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use rust_lib_zcash_wallet::api::{sync as sync_api, wallet as wallet_api};
+use rust_lib_zcash_wallet::wallet::keys;
+use rust_lib_zcash_wallet::wallet::sync_engine;
+
+// Canonical 24-word BIP39 test vector (public knowledge, zero secrecy),
+// used only for the optional 2nd account in the `multi` scenario.
+const SECONDARY_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
+
+/// The benchmark wallet's mnemonic comes from the environment — NEVER
+/// hardcode a mnemonic in this file, even a throwaway dev one. The file is
+/// committed; an accidentally pushed mnemonic is unrecoverable.
+fn primary_mnemonic() -> String {
+    std::env::var("BENCH_MNEMONIC").unwrap_or_else(|_| {
+        eprintln!(
+            "BENCH_MNEMONIC is not set.\n\
+             Export the benchmark wallet's 24-word mnemonic first, e.g.:\n\
+             BENCH_MNEMONIC=\"word1 word2 ...\" cargo run --release --example sync_bench\n\
+             Use a throwaway dev wallet whose on-chain history matches the\n\
+             BIRTHDAY you pass; results are only comparable on the same wallet."
+        );
+        std::process::exit(2);
+    })
+}
+
+const DEFAULT_BIRTHDAY: u64 = 3346523;
+const DEFAULT_LWD_URL: &str = "https://us.zec.stardust.rest:443";
+const DEFAULT_NETWORK: &str = "main";
+
+/// Minimal stderr logger so we see the engine's per-batch timing logs.
+struct StderrLogger;
+impl log::Log for StderrLogger {
+    fn enabled(&self, m: &log::Metadata) -> bool {
+        m.level() <= log::Level::Info
+    }
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            eprintln!("[{}] {}", record.level(), record.args());
+        }
+    }
+    fn flush(&self) {}
+}
+static LOGGER: StderrLogger = StderrLogger;
+
+fn env_or<'a>(key: &str, default: &'a str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+fn main() {
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(log::LevelFilter::Info);
+    // rustls 0.23 needs an explicit crypto provider before the first TLS handshake.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let scenario = env_or("SCENARIO", "single");
+    let label = env_or("LABEL", &scenario);
+    let birthday: u64 = env_or("BIRTHDAY", &DEFAULT_BIRTHDAY.to_string())
+        .parse()
+        .expect("BIRTHDAY must be a u64");
+    let lwd_url = env_or("LWD_URL", DEFAULT_LWD_URL);
+    let network = env_or("NETWORK", DEFAULT_NETWORK);
+
+    // Fresh temp DB per run — always a cold sync from `birthday`.
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let db_path = tempdir.path().join("zcash_wallet.db");
+    let db_path_str = db_path.to_str().unwrap().to_string();
+
+    eprintln!("=== sync_bench: scenario={scenario} birthday={birthday} network={network} url={lwd_url} ===");
+
+    // --- Account setup -------------------------------------------------------
+    let import = wallet_api::import_wallet(
+        primary_mnemonic(),
+        Some(birthday),
+        network.clone(),
+        db_path_str.clone(),
+        Some("Account 1".into()),
+    )
+    .expect("import_wallet (account 1)");
+    eprintln!("account 1 uuid={}", import.account_uuid);
+
+    if scenario == "multi" {
+        let add = wallet_api::add_account(
+            db_path_str.clone(),
+            network.clone(),
+            "Account 2".into(),
+            SECONDARY_MNEMONIC.into(),
+            Some(birthday),
+        )
+        .expect("add_account (account 2)");
+        eprintln!("account 2 uuid={}", add.account_uuid);
+    }
+
+    let accounts =
+        wallet_api::list_accounts(db_path_str.clone(), network.clone()).expect("list_accounts");
+    eprintln!("accounts: {}", accounts.len());
+
+    // --- Run the real sync engine, timed -------------------------------------
+    let wallet_network = keys::parse_network(&network).expect("parse_network");
+    let cancel = Arc::new(AtomicBool::new(false));
+    let desired_mode = AtomicU8::new(1); // foreground
+    let running_mode = 1u8;
+
+    // Phase accounting from progress events.
+    let events = Arc::new(AtomicU64::new(0));
+    let last_scanned = Arc::new(AtomicU64::new(0));
+    let last_tip = Arc::new(AtomicU64::new(0));
+    let events_cb = events.clone();
+    let last_scanned_cb = last_scanned.clone();
+    let last_tip_cb = last_tip.clone();
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let start = Instant::now();
+    let result = rt.block_on(async {
+        sync_engine::run_sync_inner(
+            &db_path_str,
+            &lwd_url,
+            wallet_network,
+            cancel,
+            running_mode,
+            &desired_mode,
+            move |ev| {
+                events_cb.fetch_add(1, Ordering::Relaxed);
+                last_scanned_cb.store(ev.scanned_height, Ordering::Relaxed);
+                last_tip_cb.store(ev.chain_tip_height, Ordering::Relaxed);
+            },
+        )
+        .await
+    });
+    let elapsed = start.elapsed();
+
+    if let Err(e) = &result {
+        eprintln!("SYNC FAILED: {e}");
+    }
+
+    let scanned = last_scanned.load(Ordering::Relaxed);
+    let tip = last_tip.load(Ordering::Relaxed);
+    let blocks = tip.saturating_sub(birthday);
+
+    // --- Balances ------------------------------------------------------------
+    let mut balances = Vec::new();
+    for acct in &accounts {
+        if let Ok(bal) =
+            sync_api::get_balance(db_path_str.clone(), network.clone(), acct.uuid.clone())
+        {
+            balances.push(format!(
+                "{{\"uuid\":\"{}\",\"total\":{},\"spendable\":{}}}",
+                acct.uuid, bal.total, bal.spendable
+            ));
+        }
+    }
+
+    let secs = elapsed.as_secs_f64();
+    let bps = if secs > 0.0 {
+        blocks as f64 / secs
+    } else {
+        0.0
+    };
+
+    // Machine-readable summary line.
+    println!(
+        "BENCH_RESULT {{\"label\":\"{label}\",\"scenario\":\"{scenario}\",\"ok\":{},\
+\"birthday\":{birthday},\"tip\":{tip},\"scanned\":{scanned},\"blocks\":{blocks},\
+\"accounts\":{},\"events\":{},\"elapsed_s\":{:.2},\"blocks_per_s\":{:.1},\"balances\":[{}]}}",
+        result.is_ok(),
+        accounts.len(),
+        events.load(Ordering::Relaxed),
+        secs,
+        bps,
+        balances.join(","),
+    );
+
+    eprintln!(
+        "=== DONE: {:.2}s, {} blocks, {:.1} blocks/s, ok={} ===",
+        secs,
+        blocks,
+        bps,
+        result.is_ok()
+    );
+}

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -1,6 +1,6 @@
 use std::panic;
 
-use crate::wallet::{keys, network::WalletNetwork, transparent_receive_cache};
+use crate::wallet::{db, keys, network::WalletNetwork, transparent_receive_cache};
 use tonic::{transport::Channel, Request};
 use zcash_client_backend::proto::service::{
     self, compact_tx_streamer_client::CompactTxStreamerClient,
@@ -843,6 +843,13 @@ pub fn mnemonic_word_list() -> Vec<String> {
 #[flutter_rust_bridge::frb(sync)]
 pub fn wallet_exists(db_path: String) -> bool {
     keys::wallet_exists(&db_path)
+}
+
+/// Wait for an active detached WAL checkpoint, then invalidate any checkpoint
+/// that has not opened the wallet DB yet. Sync must already be stopped.
+#[flutter_rust_bridge::frb(sync)]
+pub fn quiesce_wallet_wal_checkpoint_for_reset() {
+    db::quiesce_wallet_wal_checkpoint_for_reset();
 }
 
 /// Ensure an existing wallet database has the schema required by this build.

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -37,7 +37,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -30850900;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -328122132;
 
 // Section: executor
 
@@ -3405,6 +3405,37 @@ fn wire__crate__api__sync__put_subtree_roots_impl(
                     Ok(output_ok)
                 })())
             }
+        },
+    )
+}
+fn wire__crate__api__wallet__quiesce_wallet_wal_checkpoint_for_reset_impl(
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "quiesce_wallet_wal_checkpoint_for_reset",
+            port: None,
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            transform_result_sse::<_, ()>((move || {
+                let output_ok = Result::<_, ()>::Ok({
+                    crate::api::wallet::quiesce_wallet_wal_checkpoint_for_reset();
+                })?;
+                Ok(output_ok)
+            })())
         },
     )
 }
@@ -7074,34 +7105,34 @@ fn pde_ffi_dispatcher_primary_impl(
 85 => wire__crate__api__wallet__preview_software_account_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
 86 => wire__crate__api__sync__propose_send_impl(port, ptr, rust_vec_len, data_len),
 87 => wire__crate__api__sync__put_subtree_roots_impl(port, ptr, rust_vec_len, data_len),
-88 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
-89 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
-90 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-91 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
-93 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-94 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
-95 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
-96 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
-97 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
-98 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
-99 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
-100 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
-102 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
-103 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
-104 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
-105 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
-106 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
-107 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
-108 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
-110 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
-111 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
-112 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
-113 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
-114 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
-115 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
-117 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
-118 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
-120 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
+89 => wire__crate__api__voting__record_share_delegation_impl(port, ptr, rust_vec_len, data_len),
+90 => wire__crate__api__voting__recover_vote_commitment_impl(port, ptr, rust_vec_len, data_len),
+91 => wire__crate__api__voting__recovered_vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+92 => wire__crate__api__sync__redact_pczt_for_signer_impl(port, ptr, rust_vec_len, data_len),
+94 => wire__crate__api__voting__reset_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+95 => wire__crate__api__voting__reset_voting_session_state_impl(port, ptr, rust_vec_len, data_len),
+96 => wire__crate__api__voting__resolve_static_voting_config_impl(port, ptr, rust_vec_len, data_len),
+97 => wire__crate__api__voting__resolve_voting_config_impl(port, ptr, rust_vec_len, data_len),
+98 => wire__crate__api__sync__rewind_to_height_impl(port, ptr, rust_vec_len, data_len),
+99 => wire__crate__api__sync__run_full_sync_blocking_impl(port, ptr, rust_vec_len, data_len),
+100 => wire__crate__api__sync__scan_blocks_impl(port, ptr, rust_vec_len, data_len),
+101 => wire__crate__api__voting__set_ballot_intent_impl(port, ptr, rust_vec_len, data_len),
+103 => wire__crate__api__sync__set_transaction_status_impl(port, ptr, rust_vec_len, data_len),
+104 => wire__crate__api__voting__setup_delegation_bundles_impl(port, ptr, rust_vec_len, data_len),
+105 => wire__crate__api__voting__share_tracking_flags_impl(port, ptr, rust_vec_len, data_len),
+106 => wire__crate__api__sync__shield_transparent_balance_impl(port, ptr, rust_vec_len, data_len),
+107 => wire__crate__api__sync__shield_transparent_balance_with_macos_stored_mnemonic_impl(port, ptr, rust_vec_len, data_len),
+108 => wire__crate__api__sync__start_full_sync_impl(port, ptr, rust_vec_len, data_len),
+109 => wire__crate__api__sync__start_mempool_observer_impl(port, ptr, rust_vec_len, data_len),
+111 => wire__crate__api__voting__store_keystone_signature_impl(port, ptr, rust_vec_len, data_len),
+112 => wire__crate__api__sync__suggest_scan_ranges_impl(port, ptr, rust_vec_len, data_len),
+113 => wire__crate__api__voting__sync_vote_tree_impl(port, ptr, rust_vec_len, data_len),
+114 => wire__crate__api__voting__trusted_voting_round_params_from_config_impl(port, ptr, rust_vec_len, data_len),
+115 => wire__crate__api__sync__update_chain_tip_impl(port, ptr, rust_vec_len, data_len),
+116 => wire__crate__api__sync__validate_address_impl(port, ptr, rust_vec_len, data_len),
+118 => wire__crate__api__voting__vote_commitment_wire_json_impl(port, ptr, rust_vec_len, data_len),
+119 => wire__crate__api__voting__vote_share_wire_json_impl(port, ptr, rust_vec_len, data_len),
+121 => wire__crate__api__sync__write_block_metadata_impl(port, ptr, rust_vec_len, data_len),
                         _ => unreachable!(),
                     }
 }
@@ -7128,11 +7159,16 @@ fn pde_ffi_dispatcher_sync_impl(
             wire__crate__api__voting__last_moment_buffer_seconds_impl(ptr, rust_vec_len, data_len)
         }
         80 => wire__crate__api__wallet__mnemonic_word_list_impl(ptr, rust_vec_len, data_len),
-        92 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
-        101 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
-        109 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
-        116 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
-        119 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
+        88 => wire__crate__api__wallet__quiesce_wallet_wal_checkpoint_for_reset_impl(
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        93 => wire__crate__api__keystone__reset_ur_session_impl(ptr, rust_vec_len, data_len),
+        102 => wire__crate__api__sync__set_sync_mode_impl(ptr, rust_vec_len, data_len),
+        110 => wire__crate__api__sync__stop_mempool_observer_impl(ptr, rust_vec_len, data_len),
+        117 => wire__crate__api__wallet__validate_mnemonic_impl(ptr, rust_vec_len, data_len),
+        120 => wire__crate__api__wallet__wallet_exists_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/rust/src/wallet/db.rs
+++ b/rust/src/wallet/db.rs
@@ -35,7 +35,10 @@ const SYNC_CONN_CACHE_SIZE: i64 = -65_536; // 64 MiB
 const SYNC_CONN_CACHE_SIZE: i64 = -32_768; // 32 MiB
 
 const SYNC_CONN_WAL_AUTOCHECKPOINT_PAGES: i64 = 10_000;
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 const SYNC_CONN_MMAP_BYTES: i64 = 268_435_456; // 256 MiB
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+const SYNC_CONN_MMAP_BYTES: i64 = 67_108_864; // 64 MiB
 
 pub(crate) fn open_wallet_db_with_timeout(
     db_path: &str,
@@ -101,24 +104,29 @@ fn configure_wallet_connection(
     }
     if matches!(tuning, ConnTuning::Sync) {
         debug_assert!(ensure_wal, "sync tuning requires WAL mode");
-        conn.pragma_update(None, "mmap_size", SYNC_CONN_MMAP_BYTES)
-            .map_err(|e| format!("Failed to set wallet DB mmap_size: {e}"))?;
-        conn.pragma_update(None, "temp_store", "MEMORY")
-            .map_err(|e| format!("Failed to set wallet DB temp_store: {e}"))?;
-        conn.pragma_update(None, "cache_size", SYNC_CONN_CACHE_SIZE)
-            .map_err(|e| format!("Failed to set wallet DB cache_size: {e}"))?;
-        conn.pragma_update(None, "synchronous", "NORMAL")
-            .map_err(|e| format!("Failed to set wallet DB synchronous mode: {e}"))?;
-        conn.pragma_update(
-            None,
+        // These are performance hints, not correctness requirements. If a
+        // platform SQLite build rejects one, retain its safer default instead
+        // of making wallet sync unavailable.
+        apply_optional_pragma(conn, "mmap_size", SYNC_CONN_MMAP_BYTES);
+        #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+        apply_optional_pragma(conn, "temp_store", "MEMORY");
+        apply_optional_pragma(conn, "cache_size", SYNC_CONN_CACHE_SIZE);
+        apply_optional_pragma(conn, "synchronous", "NORMAL");
+        apply_optional_pragma(
+            conn,
             "wal_autocheckpoint",
             SYNC_CONN_WAL_AUTOCHECKPOINT_PAGES,
-        )
-        .map_err(|e| format!("Failed to set wallet DB wal_autocheckpoint: {e}"))?;
+        );
     }
     rusqlite::vtab::array::load_module(conn)
         .map_err(|e| format!("Failed to load SQLite array module: {e}"))?;
     Ok(())
+}
+
+fn apply_optional_pragma(conn: &rusqlite::Connection, name: &str, value: impl rusqlite::ToSql) {
+    if let Err(e) = conn.pragma_update(None, name, value) {
+        log::warn!("wallet DB: optional sync PRAGMA {name} was not applied: {e}");
+    }
 }
 
 /// Reclaims the WAL accumulated by a completed bulk sync. Concurrent readers

--- a/rust/src/wallet/db.rs
+++ b/rust/src/wallet/db.rs
@@ -1,5 +1,9 @@
 use std::{
-    sync::{Mutex, OnceLock},
+    path::Path,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Mutex, OnceLock,
+    },
     time::{Duration, Instant},
 };
 
@@ -133,8 +137,20 @@ fn apply_optional_pragma(conn: &rusqlite::Connection, name: &str, value: impl ru
 /// can make TRUNCATE report busy; that is harmless and is retried after the
 /// next successful sync rather than failing this one.
 pub(crate) fn truncate_wallet_wal_best_effort(db_path: &str) {
+    if !Path::new(db_path).exists() {
+        log::info!("wallet DB WAL truncate skipped (wallet DB no longer exists)");
+        return;
+    }
+
     let outcome = (|| -> Result<(i64, i64, i64), String> {
-        let conn = rusqlite::Connection::open(db_path).map_err(|e| format!("open: {e}"))?;
+        // A detached checkpoint can outlive the wallet that scheduled it. Do
+        // not use Connection::open here: its CREATE flag would resurrect an
+        // empty DB after wallet reset deleted the randomized path.
+        let conn = rusqlite::Connection::open_with_flags(
+            db_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE,
+        )
+        .map_err(|e| format!("open existing DB: {e}"))?;
         conn.busy_timeout(READ_DB_BUSY_TIMEOUT)
             .map_err(|e| format!("busy_timeout: {e}"))?;
         conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
@@ -150,8 +166,58 @@ pub(crate) fn truncate_wallet_wal_best_effort(db_path: &str) {
         Ok((_, wal_frames, checkpointed)) => log::info!(
             "wallet DB WAL truncate skipped (busy; {checkpointed}/{wal_frames} frames checkpointed)"
         ),
+        Err(_) if !Path::new(db_path).exists() => {
+            log::info!("wallet DB WAL truncate skipped (wallet DB was removed)")
+        }
         Err(e) => log::warn!("wallet DB WAL truncate failed (harmless): {e}"),
     }
+}
+
+fn wal_checkpoint_generation() -> &'static AtomicU64 {
+    static GENERATION: AtomicU64 = AtomicU64::new(0);
+    &GENERATION
+}
+
+fn wal_checkpoint_gate() -> &'static Mutex<()> {
+    static GATE: OnceLock<Mutex<()>> = OnceLock::new();
+    GATE.get_or_init(|| Mutex::new(()))
+}
+
+fn lock_wal_checkpoint_gate() -> std::sync::MutexGuard<'static, ()> {
+    wal_checkpoint_gate().lock().unwrap_or_else(|poisoned| {
+        log::error!("wallet DB WAL checkpoint gate poisoned; continuing");
+        poisoned.into_inner()
+    })
+}
+
+/// Starts a best-effort checkpoint without extending the sync call's lifetime.
+/// The checkpoint gate makes reset either invalidate a not-yet-started task or
+/// wait for an already-open checkpoint connection before deleting the DB.
+pub(crate) fn spawn_wallet_wal_checkpoint(db_path: String) {
+    // This read must not wait for an earlier checkpoint; sync completion stays
+    // detached even when two successful syncs finish in quick succession.
+    let generation = wal_checkpoint_generation().load(Ordering::Acquire);
+    if let Err(e) = std::thread::Builder::new()
+        .name("zcash-wal-checkpoint".into())
+        .spawn(move || {
+            let _gate = lock_wal_checkpoint_gate();
+            if wal_checkpoint_generation().load(Ordering::Acquire) != generation {
+                log::info!("wallet DB WAL checkpoint skipped (wallet reset pending)");
+                return;
+            }
+            truncate_wallet_wal_best_effort(&db_path);
+        })
+    {
+        log::warn!("wallet DB WAL checkpoint thread could not start (harmless): {e}");
+    }
+}
+
+/// Prevents checkpoints scheduled for the current wallet generation from
+/// opening the DB after this returns. The caller must have stopped sync first,
+/// so no new checkpoint for this generation can be scheduled concurrently.
+pub(crate) fn quiesce_wallet_wal_checkpoint_for_reset() {
+    let _gate = lock_wal_checkpoint_gate();
+    wal_checkpoint_generation().fetch_add(1, Ordering::AcqRel);
 }
 
 pub(crate) fn with_wallet_db_write_lock<T>(
@@ -314,6 +380,17 @@ mod tests {
         assert!(std::fs::metadata(&wal_path).unwrap().len() > 0);
         truncate_wallet_wal_best_effort(db_path);
         assert_eq!(std::fs::metadata(&wal_path).unwrap().len(), 0);
+    }
+
+    #[test]
+    fn truncate_wallet_wal_best_effort_does_not_create_a_missing_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("deleted-wallet.db");
+        assert!(!db_path.exists());
+
+        truncate_wallet_wal_best_effort(db_path.to_str().unwrap());
+
+        assert!(!db_path.exists());
     }
 
     #[test]

--- a/rust/src/wallet/db.rs
+++ b/rust/src/wallet/db.rs
@@ -18,6 +18,25 @@ pub(crate) const ACCOUNT_MUTATION_DB_BUSY_TIMEOUT: Duration = Duration::from_sec
 pub(crate) const SYNC_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
 pub(crate) const READ_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// SQLite tuning profile for wallet database connections.
+///
+/// Only the sync engine may use `Sync`: its writes are derived from chain
+/// data and can be replayed after an interrupted commit. Account mutations,
+/// sends, and other interactive operations keep SQLite's durable defaults.
+#[derive(Clone, Copy)]
+enum ConnTuning {
+    Interactive,
+    Sync,
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+const SYNC_CONN_CACHE_SIZE: i64 = -65_536; // 64 MiB
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+const SYNC_CONN_CACHE_SIZE: i64 = -32_768; // 32 MiB
+
+const SYNC_CONN_WAL_AUTOCHECKPOINT_PAGES: i64 = 10_000;
+const WALLET_CONN_MMAP_BYTES: i64 = 268_435_456; // 256 MiB
+
 pub(crate) fn open_wallet_db_with_timeout(
     db_path: &str,
     network: WalletNetwork,
@@ -25,7 +44,19 @@ pub(crate) fn open_wallet_db_with_timeout(
 ) -> Result<WalletDatabase, String> {
     let conn = rusqlite::Connection::open(db_path)
         .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
-    configure_wallet_connection(&conn, timeout, true)?;
+    configure_wallet_connection(&conn, timeout, true, ConnTuning::Interactive)?;
+    Ok(WalletDb::from_connection(conn, network, SystemClock, OsRng))
+}
+
+/// Opens the sync engine's long-lived, chain-derived bulk-write connection.
+pub(crate) fn open_sync_wallet_db_with_timeout(
+    db_path: &str,
+    network: WalletNetwork,
+    timeout: Duration,
+) -> Result<WalletDatabase, String> {
+    let conn = rusqlite::Connection::open(db_path)
+        .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
+    configure_wallet_connection(&conn, timeout, true, ConnTuning::Sync)?;
     Ok(WalletDb::from_connection(conn, network, SystemClock, OsRng))
 }
 
@@ -36,7 +67,7 @@ pub(crate) fn open_wallet_db_for_read_with_timeout(
 ) -> Result<WalletDatabase, String> {
     let conn = rusqlite::Connection::open(db_path)
         .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
-    configure_wallet_connection(&conn, timeout, false)?;
+    configure_wallet_connection(&conn, timeout, false, ConnTuning::Interactive)?;
     Ok(WalletDb::from_connection(conn, network, SystemClock, OsRng))
 }
 
@@ -46,7 +77,7 @@ pub(crate) fn open_wallet_raw_conn_with_timeout(
 ) -> Result<rusqlite::Connection, String> {
     let conn = rusqlite::Connection::open(db_path)
         .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
-    configure_wallet_connection(&conn, timeout, true)?;
+    configure_wallet_connection(&conn, timeout, true, ConnTuning::Interactive)?;
     Ok(conn)
 }
 
@@ -54,9 +85,14 @@ fn configure_wallet_connection(
     conn: &rusqlite::Connection,
     timeout: Duration,
     ensure_wal: bool,
+    tuning: ConnTuning,
 ) -> Result<(), String> {
     conn.busy_timeout(timeout)
         .map_err(|e| format!("Failed to configure wallet DB busy timeout: {e}"))?;
+    conn.pragma_update(None, "mmap_size", WALLET_CONN_MMAP_BYTES)
+        .map_err(|e| format!("Failed to set wallet DB mmap_size: {e}"))?;
+    conn.pragma_update(None, "temp_store", "MEMORY")
+        .map_err(|e| format!("Failed to set wallet DB temp_store: {e}"))?;
     if ensure_wal {
         let journal_mode: String = conn
             .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get(0))
@@ -67,9 +103,47 @@ fn configure_wallet_connection(
             ));
         }
     }
+    if matches!(tuning, ConnTuning::Sync) {
+        debug_assert!(ensure_wal, "sync tuning requires WAL mode");
+        conn.pragma_update(None, "cache_size", SYNC_CONN_CACHE_SIZE)
+            .map_err(|e| format!("Failed to set wallet DB cache_size: {e}"))?;
+        conn.pragma_update(None, "synchronous", "NORMAL")
+            .map_err(|e| format!("Failed to set wallet DB synchronous mode: {e}"))?;
+        conn.pragma_update(
+            None,
+            "wal_autocheckpoint",
+            SYNC_CONN_WAL_AUTOCHECKPOINT_PAGES,
+        )
+        .map_err(|e| format!("Failed to set wallet DB wal_autocheckpoint: {e}"))?;
+    }
     rusqlite::vtab::array::load_module(conn)
         .map_err(|e| format!("Failed to load SQLite array module: {e}"))?;
     Ok(())
+}
+
+/// Reclaims the WAL accumulated by a completed bulk sync. Concurrent readers
+/// can make TRUNCATE report busy; that is harmless and is retried after the
+/// next successful sync rather than failing this one.
+pub(crate) fn truncate_wallet_wal_best_effort(db_path: &str) {
+    let outcome = (|| -> Result<(i64, i64, i64), String> {
+        let conn = rusqlite::Connection::open(db_path).map_err(|e| format!("open: {e}"))?;
+        conn.busy_timeout(READ_DB_BUSY_TIMEOUT)
+            .map_err(|e| format!("busy_timeout: {e}"))?;
+        conn.query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })
+        .map_err(|e| format!("wal_checkpoint: {e}"))
+    })();
+
+    match outcome {
+        Ok((0, wal_frames, checkpointed)) => {
+            log::info!("wallet DB WAL truncated ({checkpointed}/{wal_frames} frames checkpointed)")
+        }
+        Ok((_, wal_frames, checkpointed)) => log::info!(
+            "wallet DB WAL truncate skipped (busy; {checkpointed}/{wal_frames} frames checkpointed)"
+        ),
+        Err(e) => log::warn!("wallet DB WAL truncate failed (harmless): {e}"),
+    }
 }
 
 pub(crate) fn with_wallet_db_write_lock<T>(
@@ -131,12 +205,23 @@ pub(crate) fn open_readonly_conn_with_timeout(
 mod tests {
     use super::*;
 
+    fn pragma_i64(conn: &rusqlite::Connection, pragma: &str) -> i64 {
+        conn.pragma_query_value(None, pragma, |row| row.get(0))
+            .unwrap()
+    }
+
     #[test]
     fn configure_wallet_connection_enables_wal_mode() {
         let file = tempfile::NamedTempFile::new().unwrap();
         let conn = rusqlite::Connection::open(file.path()).unwrap();
 
-        configure_wallet_connection(&conn, Duration::from_millis(1), true).unwrap();
+        configure_wallet_connection(
+            &conn,
+            Duration::from_millis(1),
+            true,
+            ConnTuning::Interactive,
+        )
+        .unwrap();
 
         let journal_mode: String = conn
             .pragma_query_value(None, "journal_mode", |row| row.get(0))
@@ -149,12 +234,76 @@ mod tests {
         let file = tempfile::NamedTempFile::new().unwrap();
         let conn = rusqlite::Connection::open(file.path()).unwrap();
 
-        configure_wallet_connection(&conn, Duration::from_millis(1), false).unwrap();
+        configure_wallet_connection(
+            &conn,
+            Duration::from_millis(1),
+            false,
+            ConnTuning::Interactive,
+        )
+        .unwrap();
 
         let journal_mode: String = conn
             .pragma_query_value(None, "journal_mode", |row| row.get(0))
             .unwrap();
         assert_ne!(journal_mode.to_ascii_lowercase(), "wal");
+    }
+
+    #[test]
+    fn sync_tuning_applies_only_bulk_write_pragmas() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let conn = rusqlite::Connection::open(file.path()).unwrap();
+
+        configure_wallet_connection(&conn, Duration::from_millis(1), true, ConnTuning::Sync)
+            .unwrap();
+
+        assert_eq!(pragma_i64(&conn, "synchronous"), 1); // NORMAL
+        assert_eq!(pragma_i64(&conn, "cache_size"), SYNC_CONN_CACHE_SIZE);
+        assert_eq!(
+            pragma_i64(&conn, "wal_autocheckpoint"),
+            SYNC_CONN_WAL_AUTOCHECKPOINT_PAGES
+        );
+        assert_eq!(pragma_i64(&conn, "temp_store"), 2); // MEMORY
+        assert_eq!(pragma_i64(&conn, "mmap_size"), WALLET_CONN_MMAP_BYTES);
+    }
+
+    #[test]
+    fn interactive_tuning_keeps_durable_defaults() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let conn = rusqlite::Connection::open(file.path()).unwrap();
+
+        configure_wallet_connection(
+            &conn,
+            Duration::from_millis(1),
+            true,
+            ConnTuning::Interactive,
+        )
+        .unwrap();
+
+        assert_eq!(pragma_i64(&conn, "synchronous"), 2); // FULL
+        assert_eq!(pragma_i64(&conn, "wal_autocheckpoint"), 1_000);
+        assert_eq!(pragma_i64(&conn, "temp_store"), 2);
+        assert_eq!(pragma_i64(&conn, "mmap_size"), WALLET_CONN_MMAP_BYTES);
+    }
+
+    #[test]
+    fn truncate_wallet_wal_best_effort_resets_the_wal_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("wallet.db");
+        let db_path = db_path.to_str().unwrap();
+        let conn = rusqlite::Connection::open(db_path).unwrap();
+
+        configure_wallet_connection(&conn, Duration::from_millis(100), true, ConnTuning::Sync)
+            .unwrap();
+        conn.execute_batch("CREATE TABLE t (x BLOB);").unwrap();
+        for _ in 0..50 {
+            conn.execute("INSERT INTO t VALUES (randomblob(4096))", [])
+                .unwrap();
+        }
+
+        let wal_path = format!("{db_path}-wal");
+        assert!(std::fs::metadata(&wal_path).unwrap().len() > 0);
+        truncate_wallet_wal_best_effort(db_path);
+        assert_eq!(std::fs::metadata(&wal_path).unwrap().len(), 0);
     }
 
     #[test]

--- a/rust/src/wallet/db.rs
+++ b/rust/src/wallet/db.rs
@@ -35,7 +35,7 @@ const SYNC_CONN_CACHE_SIZE: i64 = -65_536; // 64 MiB
 const SYNC_CONN_CACHE_SIZE: i64 = -32_768; // 32 MiB
 
 const SYNC_CONN_WAL_AUTOCHECKPOINT_PAGES: i64 = 10_000;
-const WALLET_CONN_MMAP_BYTES: i64 = 268_435_456; // 256 MiB
+const SYNC_CONN_MMAP_BYTES: i64 = 268_435_456; // 256 MiB
 
 pub(crate) fn open_wallet_db_with_timeout(
     db_path: &str,
@@ -89,10 +89,6 @@ fn configure_wallet_connection(
 ) -> Result<(), String> {
     conn.busy_timeout(timeout)
         .map_err(|e| format!("Failed to configure wallet DB busy timeout: {e}"))?;
-    conn.pragma_update(None, "mmap_size", WALLET_CONN_MMAP_BYTES)
-        .map_err(|e| format!("Failed to set wallet DB mmap_size: {e}"))?;
-    conn.pragma_update(None, "temp_store", "MEMORY")
-        .map_err(|e| format!("Failed to set wallet DB temp_store: {e}"))?;
     if ensure_wal {
         let journal_mode: String = conn
             .pragma_update_and_check(None, "journal_mode", "WAL", |row| row.get(0))
@@ -105,6 +101,10 @@ fn configure_wallet_connection(
     }
     if matches!(tuning, ConnTuning::Sync) {
         debug_assert!(ensure_wal, "sync tuning requires WAL mode");
+        conn.pragma_update(None, "mmap_size", SYNC_CONN_MMAP_BYTES)
+            .map_err(|e| format!("Failed to set wallet DB mmap_size: {e}"))?;
+        conn.pragma_update(None, "temp_store", "MEMORY")
+            .map_err(|e| format!("Failed to set wallet DB temp_store: {e}"))?;
         conn.pragma_update(None, "cache_size", SYNC_CONN_CACHE_SIZE)
             .map_err(|e| format!("Failed to set wallet DB cache_size: {e}"))?;
         conn.pragma_update(None, "synchronous", "NORMAL")
@@ -263,13 +263,15 @@ mod tests {
             SYNC_CONN_WAL_AUTOCHECKPOINT_PAGES
         );
         assert_eq!(pragma_i64(&conn, "temp_store"), 2); // MEMORY
-        assert_eq!(pragma_i64(&conn, "mmap_size"), WALLET_CONN_MMAP_BYTES);
+        assert_eq!(pragma_i64(&conn, "mmap_size"), SYNC_CONN_MMAP_BYTES);
     }
 
     #[test]
     fn interactive_tuning_keeps_durable_defaults() {
         let file = tempfile::NamedTempFile::new().unwrap();
         let conn = rusqlite::Connection::open(file.path()).unwrap();
+        let default_temp_store = pragma_i64(&conn, "temp_store");
+        let default_mmap_size = pragma_i64(&conn, "mmap_size");
 
         configure_wallet_connection(
             &conn,
@@ -281,8 +283,8 @@ mod tests {
 
         assert_eq!(pragma_i64(&conn, "synchronous"), 2); // FULL
         assert_eq!(pragma_i64(&conn, "wal_autocheckpoint"), 1_000);
-        assert_eq!(pragma_i64(&conn, "temp_store"), 2);
-        assert_eq!(pragma_i64(&conn, "mmap_size"), WALLET_CONN_MMAP_BYTES);
+        assert_eq!(pragma_i64(&conn, "temp_store"), default_temp_store);
+        assert_eq!(pragma_i64(&conn, "mmap_size"), default_mmap_size);
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/block_source.rs
+++ b/rust/src/wallet/sync_engine/block_source.rs
@@ -4,10 +4,10 @@
 //! iterate compact blocks one at a time. Historically librustzcash
 //! wallets pointed that input at an on-disk SQLite cache
 //! (`FsBlockDb`). We deliberately skip the file-cache step and keep a
-//! single batch of compact blocks in memory:
+//! bounded set of compact-block batches in memory:
 //!
-//!   1. Batches are bounded (≤300 blocks on desktop, ≤100 on mobile),
-//!      so the memory footprint is small and predictable.
+//!   1. Batch count and estimated decoded size are bounded by the sync
+//!      engine's prefetch policy.
 //!   2. Avoiding the cache DB means one less file format to keep in
 //!      sync with librustzcash migrations and one less thing to clear
 //!      on reorg / rewind.
@@ -32,11 +32,36 @@ use zcash_protocol::consensus::BlockHeight;
 /// `scan_cached_blocks` call.
 pub(super) struct MemoryBlockSource {
     blocks: Vec<CompactBlock>,
+    wire_bytes: u64,
 }
 
 impl MemoryBlockSource {
     pub(super) fn new(blocks: Vec<CompactBlock>) -> Self {
-        Self { blocks }
+        let wire_bytes = blocks
+            .iter()
+            .map(|block| prost::Message::encoded_len(block) as u64)
+            .sum();
+        Self { blocks, wire_bytes }
+    }
+
+    pub(super) fn wire_bytes(&self) -> u64 {
+        self.wire_bytes
+    }
+
+    pub(super) fn block_count(&self) -> usize {
+        self.blocks.len()
+    }
+
+    pub(super) fn first_block(&self) -> Option<&CompactBlock> {
+        self.blocks.first()
+    }
+
+    pub(super) fn last_block(&self) -> Option<&CompactBlock> {
+        self.blocks.last()
+    }
+
+    pub(super) fn blocks(&self) -> &[CompactBlock] {
+        &self.blocks
     }
 }
 
@@ -85,5 +110,33 @@ impl chain::BlockSource for MemoryBlockSource {
             count += 1;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn records_wire_size_and_boundaries() {
+        let first = CompactBlock {
+            height: 10,
+            hash: vec![1; 32],
+            prev_hash: vec![0; 32],
+            ..Default::default()
+        };
+        let last = CompactBlock {
+            height: 11,
+            hash: vec![2; 32],
+            prev_hash: vec![1; 32],
+            ..Default::default()
+        };
+
+        let source = MemoryBlockSource::new(vec![first, last]);
+
+        assert_eq!(source.block_count(), 2);
+        assert!(source.wire_bytes() >= 128);
+        assert_eq!(source.first_block().unwrap().height, 10);
+        assert_eq!(source.last_block().unwrap().height, 11);
     }
 }

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -179,13 +179,8 @@ where
         // requests without an `end` height, which we can't service
         // without synthesizing a range), break rather than looping
         // forever on the same inert queue.
-        let actionable = requests.iter().any(|r| match r {
-            TransactionDataRequest::Enhancement(_) | TransactionDataRequest::GetStatus(_) => true,
-            TransactionDataRequest::TransactionsInvolvingAddress(req) => {
-                address_request_is_due(req, SystemTime::now()) && req.block_range_end().is_some()
-            }
-        });
-        if !actionable {
+        let signature = actionable_request_signature(&requests, SystemTime::now());
+        if signature.is_empty() {
             drained = true;
             break;
         }
@@ -197,17 +192,6 @@ where
         // still-unmined send regenerates until it mines) and re-servicing
         // it is pure duplication: up to 3 identical full-raw-tx fetches per
         // pass, every sync cycle, for the tx's whole unmined lifetime.
-        let signature: BTreeSet<TransactionDataRequest> = requests
-            .iter()
-            .filter(|r| match r {
-                TransactionDataRequest::TransactionsInvolvingAddress(req) => {
-                    address_request_is_due(req, SystemTime::now())
-                        && req.block_range_end().is_some()
-                }
-                _ => true,
-            })
-            .cloned()
-            .collect();
         // A GetStatus request for an unmined transaction is expected to
         // remain in the queue. It is the only repeated request that proves
         // the pass is idle: repeated Enhancement/address requests can mean
@@ -558,6 +542,18 @@ where
         }
     }
 
+    // The round limit bounds dependency expansion, but the last permitted
+    // round can itself clear the final requests. Without this read-back,
+    // `drained` remains false merely because there was no fourth iteration to
+    // observe the now-empty queue, and the completion barrier retries the
+    // entire sync despite all enhancement work having succeeded.
+    if !drained && failure.is_none() && !should_exit() {
+        let requests = db.transaction_data_requests().map_err(|e| {
+            SyncError::db(format!("transaction_data_requests after final round: {e}"))
+        })?;
+        drained = request_queue_is_drained(&requests, prev_signature.as_ref(), SystemTime::now());
+    }
+
     let total = enh_t0.elapsed();
     if total.as_millis() > 50 {
         log::info!(
@@ -618,6 +614,35 @@ fn address_request_is_supported(request: &TransactionsInvolvingAddress) -> bool 
         (request.tx_status_filter(), request.output_status_filter()),
         (TransactionStatusFilter::Mined, OutputStatusFilter::All)
     )
+}
+
+fn actionable_request_signature(
+    requests: &[TransactionDataRequest],
+    now: SystemTime,
+) -> BTreeSet<TransactionDataRequest> {
+    requests
+        .iter()
+        .filter(|request| match request {
+            TransactionDataRequest::TransactionsInvolvingAddress(request) => {
+                address_request_is_due(request, now) && request.block_range_end().is_some()
+            }
+            _ => true,
+        })
+        .cloned()
+        .collect()
+}
+
+fn request_queue_is_drained(
+    requests: &[TransactionDataRequest],
+    previous_signature: Option<&BTreeSet<TransactionDataRequest>>,
+    now: SystemTime,
+) -> bool {
+    let signature = actionable_request_signature(requests, now);
+    signature.is_empty()
+        || (previous_signature == Some(&signature)
+            && signature
+                .iter()
+                .all(|request| matches!(request, TransactionDataRequest::GetStatus(_))))
 }
 
 /// Stream a transparent address's transaction history in `[start, end]`
@@ -1058,6 +1083,39 @@ mod tests {
                 GetTransactionErrorAction::RetryAsNetwork,
             );
         }
+    }
+
+    #[test]
+    fn final_round_readback_accepts_only_a_verifiably_drained_queue() {
+        let now = SystemTime::now();
+        let processed_status = TransactionDataRequest::GetStatus(TxId::NULL);
+        let processed_signature = BTreeSet::from([processed_status.clone()]);
+
+        assert!(request_queue_is_drained(
+            &[],
+            Some(&processed_signature),
+            now,
+        ));
+        assert!(request_queue_is_drained(
+            &[processed_status],
+            Some(&processed_signature),
+            now,
+        ));
+
+        let newly_created = TransactionDataRequest::Enhancement(TxId::from_bytes([1; 32]));
+        assert!(!request_queue_is_drained(
+            &[newly_created],
+            Some(&processed_signature),
+            now,
+        ));
+
+        let stuck_enhancement = TransactionDataRequest::Enhancement(TxId::NULL);
+        let stuck_signature = BTreeSet::from([stuck_enhancement.clone()]);
+        assert!(!request_queue_is_drained(
+            &[stuck_enhancement],
+            Some(&stuck_signature),
+            now,
+        ));
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -35,6 +35,7 @@
 use std::collections::{BTreeMap, HashSet};
 
 use futures::StreamExt;
+use tokio::sync::mpsc;
 use tonic::{transport::Channel, Code, Status};
 use transparent::bundle::OutPoint;
 use zcash_client_backend::{
@@ -52,6 +53,12 @@ use crate::wallet::db::{with_wallet_db_write_lock, SYNC_DB_BUSY_TIMEOUT};
 use crate::wallet::network::WalletNetwork;
 
 use super::{lwd, SyncError, WalletDatabase};
+
+const ADDRESS_TX_CHANNEL_CAPACITY: usize = 4;
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+const DEFAULT_ENHANCEMENT_CONCURRENCY: u64 = 8;
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+const DEFAULT_ENHANCEMENT_CONCURRENCY: u64 = 4;
 
 /// Drains `db.transaction_data_requests()` against lightwalletd until
 /// the queue is empty or no request is actionable. Network fetches run
@@ -358,23 +365,23 @@ where
             .collect();
         n_addr_reqs += addr_items.len() as u64;
 
-        // Same as-they-arrive application for the address streams: each
-        // completed address's transactions are applied before the next
-        // result is awaited, so live memory is bounded by the
-        // ~`concurrency` in-flight per-address fetches rather than every
-        // address's parsed history at once.
+        // Each address fetch owns a bounded channel. The network task parses
+        // one transaction and sends it immediately; the caller applies items
+        // serially while other addresses continue up to the channel bound.
+        // This prevents a single heavily-used transparent address from
+        // accumulating its entire history in a Vec before the first DB write.
         let mut addr_stream = futures::stream::iter(addr_items)
             .map(|(addr_str, start, end)| {
                 let mut c = client.clone();
-                async move { fetch_address_txs(&mut c, addr_str, start, end, should_exit).await }
+                async move { start_address_txs(&mut c, addr_str, start, end, should_exit).await }
             })
             .buffer_unordered(concurrency);
         while let Some(result) = addr_stream.next().await {
             if should_exit() {
                 break 'rounds;
             }
-            let txs = match result {
-                Ok(Some(txs)) => txs,
+            let mut fetch = match result {
+                Ok(Some(fetch)) => fetch,
                 Ok(None) => break 'rounds,
                 Err(e) => {
                     // One address's history stream failing must not discard
@@ -388,7 +395,24 @@ where
                     continue;
                 }
             };
-            for (mined_height, tx) in txs {
+            loop {
+                let next = tokio::select! {
+                    item = fetch.receiver.recv() => item,
+                    _ = wait_until_exit(should_exit) => break 'rounds,
+                };
+                let Some(next) = next else {
+                    break;
+                };
+                let (mined_height, tx) = match next {
+                    Ok(item) => item,
+                    Err(e) => {
+                        log::warn!(
+                            "sync: address history stream failed (continuing with other addresses): {e}"
+                        );
+                        round_network_error = true;
+                        break;
+                    }
+                };
                 if should_exit() {
                     break 'rounds;
                 }
@@ -435,23 +459,42 @@ where
 }
 
 /// Concurrency for the enhancement network fetches. Overridable via
-/// `ZCASH_SYNC_ENHANCE_CONCURRENCY` for benchmark sweeps; defaults to 8,
-/// clamped to `[1, 32]`.
+/// `ZCASH_SYNC_ENHANCE_CONCURRENCY` for benchmark sweeps; defaults to 8 on
+/// desktop and 4 on mobile, clamped to `[1, 32]`.
 fn enhancement_concurrency() -> usize {
-    super::env_override_clamped("ZCASH_SYNC_ENHANCE_CONCURRENCY", 8, 1, 32) as usize
+    super::env_override_clamped(
+        "ZCASH_SYNC_ENHANCE_CONCURRENCY",
+        DEFAULT_ENHANCEMENT_CONCURRENCY,
+        1,
+        32,
+    ) as usize
 }
 
 /// Stream a transparent address's transaction history in `[start, end]`
 /// and parse each returned transaction. Network-only (no DB writes) so it
 /// can run concurrently with other address scans; the caller applies the
 /// results serially under the wallet-DB write lock.
-async fn fetch_address_txs<ShouldExit>(
+struct AddressTxFetch {
+    receiver: mpsc::Receiver<Result<(Option<BlockHeight>, Transaction), SyncError>>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for AddressTxFetch {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+/// Starts a transparent-address history stream and forwards parsed
+/// transactions through a bounded channel. The returned task is aborted when
+/// the consumer stops early (cancel, mode switch, or a failed sibling).
+async fn start_address_txs<ShouldExit>(
     client: &mut CompactTxStreamerClient<Channel>,
     address: String,
     start: u64,
     end: u64,
     should_exit: &ShouldExit,
-) -> Result<Option<Vec<(Option<BlockHeight>, Transaction)>>, SyncError>
+) -> Result<Option<AddressTxFetch>, SyncError>
 where
     ShouldExit: Fn() -> bool + Sync,
 {
@@ -463,32 +506,39 @@ where
         return Ok(None);
     };
     let mut stream = stream_result?;
-    let mut out = Vec::new();
-    loop {
-        let next = tokio::select! {
-            result = lwd::next_stream_message(&mut stream, "get_taddress_txids stream") => {
-                Some(result)
-            }
-            _ = wait_until_exit(should_exit) => None,
-        };
-        let Some(next) = next else {
-            return Ok(None);
-        };
-        match next {
-            Ok(Some(raw)) => {
-                if !raw.data.is_empty() {
-                    let mined_height = mined_height_from_raw_height(raw.height)?;
+    let (sender, receiver) = mpsc::channel(ADDRESS_TX_CHANNEL_CAPACITY);
+    let handle = tokio::spawn(async move {
+        loop {
+            match lwd::next_stream_message(&mut stream, "get_taddress_txids stream").await {
+                Ok(Some(raw)) => {
+                    if raw.data.is_empty() {
+                        continue;
+                    }
+                    let mined_height = match mined_height_from_raw_height(raw.height) {
+                        Ok(height) => height,
+                        Err(e) => {
+                            let _ = sender.send(Err(e)).await;
+                            break;
+                        }
+                    };
                     match Transaction::read(&raw.data[..], BranchId::Sapling) {
-                        Ok(tx) => out.push((mined_height, tx)),
+                        Ok(tx) => {
+                            if sender.send(Ok((mined_height, tx))).await.is_err() {
+                                break;
+                            }
+                        }
                         Err(e) => log::warn!("sync: Transaction::read (addr) failed: {e}"),
                     }
                 }
+                Ok(None) => break,
+                Err(e) => {
+                    let _ = sender.send(Err(e)).await;
+                    break;
+                }
             }
-            Ok(None) => break,
-            Err(e) => return Err(e),
         }
-    }
-    Ok(Some(out))
+    });
+    Ok(Some(AddressTxFetch { receiver, handle }))
 }
 
 async fn fill_missing_transparent_fee<ShouldExit>(

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -32,7 +32,10 @@
 //! (`should_exit`) or skip entirely: whatever remains is picked up by
 //! the next pass or the next sync run.
 
-use std::collections::{BTreeMap, HashSet};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    time::SystemTime,
+};
 
 use futures::StreamExt;
 use tokio::sync::mpsc;
@@ -40,8 +43,9 @@ use tonic::{transport::Channel, Code, Status};
 use transparent::bundle::OutPoint;
 use zcash_client_backend::{
     data_api::{
-        wallet::decrypt_and_store_transaction, TransactionDataRequest, TransactionStatus,
-        WalletRead, WalletWrite,
+        wallet::decrypt_and_store_transaction, OutputStatusFilter, TransactionDataRequest,
+        TransactionStatus, TransactionStatusFilter, TransactionsInvolvingAddress, WalletRead,
+        WalletWrite,
     },
     proto::service::compact_tx_streamer_client::CompactTxStreamerClient,
 };
@@ -95,13 +99,18 @@ pub(super) struct EnhancementOutcome {
     /// `Enhancement` and address-scoped requests (drives `has_new_tx`).
     pub stored: usize,
     /// True only when the pass verifiably left no actionable NEW work:
-    /// the queue read back empty/inert, or an entire round produced the
-    /// identical request set as the previous one (whatever remains is
-    /// persistent, e.g. GetStatus for a still-unmined send). False on
+    /// the queue read back empty/inert, or an entire round produced only the
+    /// same persistent GetStatus requests (e.g. for a still-unmined send). False on
     /// early exits (cancel, network error) and on 3-round exhaustion with
     /// fresh work still appearing — callers use this to decide whether the
     /// post-loop drain still has anything to do.
     pub drained: bool,
+    /// The first concrete failure encountered after any earlier successful
+    /// writes were retained. Callers can preserve `stored` for UI refreshes
+    /// while still propagating the correct parse/DB/network classification at
+    /// the final drain instead of flattening every incomplete pass to a
+    /// generic network error.
+    pub failure: Option<SyncError>,
 }
 
 pub(super) async fn run_enhancement<ShouldExit>(
@@ -117,7 +126,8 @@ where
     let mut failed_txids: HashSet<String> = HashSet::new();
     let mut stored: usize = 0;
     let mut drained = false;
-    let mut prev_signature: Option<std::collections::BTreeSet<String>> = None;
+    let mut failure: Option<SyncError> = None;
+    let mut prev_signature: Option<BTreeSet<TransactionDataRequest>> = None;
 
     // Telemetry to locate the cost of an enhancement pass.
     let enh_t0 = std::time::Instant::now();
@@ -137,6 +147,33 @@ where
             break;
         }
 
+        // zcash_client_sqlite 0.21 emits bounded address requests only for
+        // spend discovery, using (Mined, All). Its (All, Unspent) ephemeral
+        // discovery requests have no end height and are deferred above this
+        // layer. GetTaddressTxids cannot enforce mempool or currently-unspent
+        // filtering, so fail closed if a future backend emits a bounded
+        // unsupported combination instead of silently applying excess data.
+        if let Some(request) = requests.iter().find_map(|r| match r {
+            TransactionDataRequest::TransactionsInvolvingAddress(request)
+                if request.block_range_end().is_some()
+                    && address_request_is_due(request, SystemTime::now())
+                    && !address_request_is_supported(request) =>
+            {
+                Some(request)
+            }
+            _ => None,
+        }) {
+            record_first_failure(
+                &mut failure,
+                SyncError::Other(format!(
+                    "unsupported bounded transparent address filters: tx={:?}, output={:?}",
+                    request.tx_status_filter(),
+                    request.output_status_filter(),
+                )),
+            );
+            break;
+        }
+
         // If nothing in the queue is actionable (e.g. address-scoped
         // requests without an `end` height, which we can't service
         // without synthesizing a range), break rather than looping
@@ -144,7 +181,7 @@ where
         let actionable = requests.iter().any(|r| match r {
             TransactionDataRequest::Enhancement(_) | TransactionDataRequest::GetStatus(_) => true,
             TransactionDataRequest::TransactionsInvolvingAddress(req) => {
-                req.block_range_end().is_some()
+                address_request_is_due(req, SystemTime::now()) && req.block_range_end().is_some()
             }
         });
         if !actionable {
@@ -159,20 +196,27 @@ where
         // still-unmined send regenerates until it mines) and re-servicing
         // it is pure duplication: up to 3 identical full-raw-tx fetches per
         // pass, every sync cycle, for the tx's whole unmined lifetime.
-        let signature: std::collections::BTreeSet<String> = requests
+        let signature: BTreeSet<TransactionDataRequest> = requests
             .iter()
-            .map(|r| match r {
-                TransactionDataRequest::GetStatus(txid) => format!("s:{txid}"),
-                TransactionDataRequest::Enhancement(txid) => format!("e:{txid}"),
-                TransactionDataRequest::TransactionsInvolvingAddress(req) => format!(
-                    "a:{:?}:{}:{:?}",
-                    req.address(),
-                    req.block_range_start(),
-                    req.block_range_end(),
-                ),
+            .filter(|r| match r {
+                TransactionDataRequest::TransactionsInvolvingAddress(req) => {
+                    address_request_is_due(req, SystemTime::now())
+                        && req.block_range_end().is_some()
+                }
+                _ => true,
             })
+            .cloned()
             .collect();
-        if prev_signature.as_ref() == Some(&signature) {
+        // A GetStatus request for an unmined transaction is expected to
+        // remain in the queue. It is the only repeated request that proves
+        // the pass is idle: repeated Enhancement/address requests can mean
+        // parsing, validation, or DB application failed and must never be
+        // hidden as a successful drain.
+        if prev_signature.as_ref() == Some(&signature)
+            && signature
+                .iter()
+                .all(|r| matches!(r, TransactionDataRequest::GetStatus(_)))
+        {
             drained = true;
             break;
         }
@@ -218,7 +262,7 @@ where
         // aborts the in-flight fetches — without first draining every
         // response. The fee lookups use a dedicated client clone because
         // the stream holds a shared borrow of `client` while alive.
-        let mut round_network_error = false;
+        let mut round_had_failure = false;
         let mut fee_client = client.clone();
         let mut fetch_stream = futures::stream::iter(status_items)
             .map(|(txid, needs_status, is_enhancement)| {
@@ -244,55 +288,69 @@ where
             let txid_str = format!("{txid}");
             match res {
                 Ok(raw) => {
-                    let mined_height = match mined_height_from_raw_height(raw.height) {
-                        Ok(h) => h,
-                        Err(e) => {
-                            log::warn!("sync: invalid mined height for {txid_str} (skipping): {e}");
+                    // GetStatus only needs the server's height metadata. Do
+                    // not deserialize/decrypt the raw transaction or fetch
+                    // transparent parents unless full enhancement was also
+                    // requested for this txid.
+                    if is_enhancement {
+                        let mined_height = match mined_height_from_raw_height(raw.height) {
+                            Ok(h) => h,
+                            Err(e) => {
+                                log::warn!(
+                                    "sync: invalid mined height for {txid_str} (skipping): {e}"
+                                );
+                                round_had_failure = true;
+                                record_first_failure(&mut failure, e);
+                                continue;
+                            }
+                        };
+                        if raw.data.is_empty() {
+                            log::warn!("sync: empty transaction data for enhancement {txid_str}");
+                            round_had_failure = true;
+                            record_first_failure(
+                                &mut failure,
+                                SyncError::Parse(format!(
+                                    "empty transaction data for enhancement {txid_str}"
+                                )),
+                            );
                             continue;
                         }
-                    };
-                    if !raw.data.is_empty() {
-                        match Transaction::read(&raw.data[..], BranchId::Sapling) {
-                            Ok(tx) => {
-                                match with_wallet_db_write_lock(
-                                    "sync_engine.enhance.decrypt_and_store_transaction",
-                                    || {
-                                        decrypt_and_store_transaction(
-                                            &network,
-                                            db,
-                                            &tx,
-                                            mined_height,
-                                        )
-                                    },
-                                ) {
-                                    Ok(()) => {
-                                        if is_enhancement {
-                                            stored += 1;
-                                        }
-                                    }
-                                    Err(e) => log::error!(
-                                        "sync: decrypt_and_store_transaction failed: {e}"
-                                    ),
-                                }
-                                let fee_t = std::time::Instant::now();
-                                if let Err(e) = fill_missing_transparent_fee(
-                                    &mut fee_client,
-                                    db_path,
-                                    &tx,
-                                    should_exit,
-                                )
-                                .await
-                                {
-                                    log::warn!(
-                                        "sync: transparent fee enhancement failed for {txid_str}: {e}"
-                                    );
-                                }
-                                fee_time += fee_t.elapsed();
-                            }
+                        let tx = match parse_transaction_for_txid(&raw.data, txid) {
+                            Ok(tx) => tx,
                             Err(e) => {
-                                log::warn!("sync: Transaction::read failed for {txid_str}: {e}")
+                                log::warn!("sync: invalid transaction for {txid_str}: {e}");
+                                round_had_failure = true;
+                                record_first_failure(&mut failure, e);
+                                continue;
+                            }
+                        };
+                        match with_wallet_db_write_lock(
+                            "sync_engine.enhance.decrypt_and_store_transaction",
+                            || decrypt_and_store_transaction(&network, db, &tx, mined_height),
+                        ) {
+                            Ok(()) => stored += 1,
+                            Err(e) => {
+                                log::error!("sync: decrypt_and_store_transaction failed: {e}");
+                                round_had_failure = true;
+                                record_first_failure(
+                                    &mut failure,
+                                    SyncError::Db(format!(
+                                        "decrypt_and_store_transaction failed: {e}"
+                                    )),
+                                );
+                                continue;
                             }
                         }
+                        let fee_t = std::time::Instant::now();
+                        if let Err(e) =
+                            fill_missing_transparent_fee(&mut fee_client, db_path, &tx, should_exit)
+                                .await
+                        {
+                            log::warn!(
+                                "sync: transparent fee enhancement failed for {txid_str}: {e}"
+                            );
+                        }
+                        fee_time += fee_t.elapsed();
                     }
                     if needs_status {
                         match transaction_status_from_raw_height(raw.height) {
@@ -302,11 +360,22 @@ where
                                     || db.set_transaction_status(txid, status),
                                 ) {
                                     log::error!("sync: set_transaction_status failed: {e}");
+                                    round_had_failure = true;
+                                    record_first_failure(
+                                        &mut failure,
+                                        SyncError::Db(format!(
+                                            "set_transaction_status failed: {e}"
+                                        )),
+                                    );
                                 }
                             }
-                            Err(e) => log::warn!(
-                                "sync: invalid status height for {txid_str} (skipping): {e}"
-                            ),
+                            Err(e) => {
+                                log::warn!(
+                                    "sync: invalid status height for {txid_str} (skipping): {e}"
+                                );
+                                round_had_failure = true;
+                                record_first_failure(&mut failure, e);
+                            }
                         }
                     }
                 }
@@ -324,6 +393,11 @@ where
                             },
                         ) {
                             log::error!("sync: set_transaction_status failed: {e}");
+                            round_had_failure = true;
+                            record_first_failure(
+                                &mut failure,
+                                SyncError::Db(format!("set_transaction_status failed: {e}")),
+                            );
                         }
                     }
                     GetTransactionErrorAction::RetryAsNetwork => {
@@ -336,7 +410,13 @@ where
                             "sync: get_transaction failed for {txid_str} \
                              (ending pass after this round): {e}"
                         );
-                        round_network_error = true;
+                        round_had_failure = true;
+                        record_first_failure(
+                            &mut failure,
+                            SyncError::Network(format!(
+                                "get_transaction failed for {txid_str}: {e}"
+                            )),
+                        );
                     }
                 },
             }
@@ -346,10 +426,13 @@ where
         }
 
         // --- address-scoped requests: concurrent history streams, serial apply ---
-        let addr_items: Vec<(String, u64, u64)> = requests
+        let now = SystemTime::now();
+        let addr_items: Vec<(TransactionsInvolvingAddress, String, u64, u64)> = requests
             .iter()
             .filter_map(|r| match r {
-                TransactionDataRequest::TransactionsInvolvingAddress(req) => {
+                TransactionDataRequest::TransactionsInvolvingAddress(req)
+                    if address_request_is_due(req, now) =>
+                {
                     req.block_range_end().map(|end_height| {
                         let addr_str = zcash_keys::encoding::encode_transparent_address_p(
                             &network,
@@ -357,7 +440,7 @@ where
                         );
                         let start = u32::from(req.block_range_start()) as u64;
                         let end = u32::from(end_height) as u64;
-                        (addr_str, start, end.saturating_sub(1))
+                        (req.clone(), addr_str, start, end.saturating_sub(1))
                     })
                 }
                 _ => None,
@@ -371,11 +454,13 @@ where
         // This prevents a single heavily-used transparent address from
         // accumulating its entire history in a Vec before the first DB write.
         let mut addr_stream = futures::stream::iter(addr_items)
-            .map(|(addr_str, start, end)| {
+            .map(|(request, addr_str, start, end)| {
                 let mut c = client.clone();
-                async move { start_address_txs(&mut c, addr_str, start, end, should_exit).await }
+                async move {
+                    start_address_txs(&mut c, request, addr_str, start, end, should_exit).await
+                }
             })
-            .buffer_unordered(concurrency);
+            .buffer_unordered(address_enhancement_concurrency());
         while let Some(result) = addr_stream.next().await {
             if should_exit() {
                 break 'rounds;
@@ -391,10 +476,12 @@ where
                         "sync: address history fetch failed \
                          (continuing with other addresses): {e}"
                     );
-                    round_network_error = true;
+                    round_had_failure = true;
+                    record_first_failure(&mut failure, e);
                     continue;
                 }
             };
+            let mut apply_failed = false;
             loop {
                 let next = tokio::select! {
                     item = fetch.receiver.recv() => item,
@@ -404,12 +491,30 @@ where
                     break;
                 };
                 let (mined_height, tx) = match next {
-                    Ok(item) => item,
+                    Ok(AddressTxEvent::Transaction(item)) => item,
+                    Ok(AddressTxEvent::Complete) => {
+                        if !apply_failed {
+                            let as_of_height = BlockHeight::from_u32(fetch.end as u32);
+                            if let Err(e) = with_wallet_db_write_lock(
+                                "sync_engine.enhance.notify_address_checked",
+                                || db.notify_address_checked(fetch.request.clone(), as_of_height),
+                            ) {
+                                log::error!("sync: notify_address_checked failed: {e}");
+                                round_had_failure = true;
+                                record_first_failure(
+                                    &mut failure,
+                                    SyncError::Db(format!("notify_address_checked failed: {e}")),
+                                );
+                            }
+                        }
+                        break;
+                    }
                     Err(e) => {
                         log::warn!(
                             "sync: address history stream failed (continuing with other addresses): {e}"
                         );
-                        round_network_error = true;
+                        round_had_failure = true;
+                        record_first_failure(&mut failure, e);
                         break;
                     }
                 };
@@ -422,7 +527,15 @@ where
                 ) {
                     Ok(()) => stored += 1,
                     Err(e) => {
-                        log::error!("sync: decrypt_and_store_transaction (addr) failed: {e}")
+                        log::error!("sync: decrypt_and_store_transaction (addr) failed: {e}");
+                        round_had_failure = true;
+                        apply_failed = true;
+                        record_first_failure(
+                            &mut failure,
+                            SyncError::Db(format!(
+                                "decrypt_and_store_transaction (addr) failed: {e}"
+                            )),
+                        );
                     }
                 }
                 let fee_t = std::time::Instant::now();
@@ -439,7 +552,7 @@ where
         }
         drop(addr_stream);
 
-        if round_network_error {
+        if round_had_failure {
             break;
         }
     }
@@ -455,7 +568,17 @@ where
             fee_time.as_secs_f64(),
         );
     }
-    Ok(EnhancementOutcome { stored, drained })
+    Ok(EnhancementOutcome {
+        stored,
+        drained,
+        failure,
+    })
+}
+
+fn record_first_failure(slot: &mut Option<SyncError>, error: SyncError) {
+    if slot.is_none() {
+        *slot = Some(error);
+    }
 }
 
 /// Concurrency for the enhancement network fetches. Overridable via
@@ -470,13 +593,46 @@ fn enhancement_concurrency() -> usize {
     ) as usize
 }
 
+/// Transparent-address queries can correlate a wallet's addresses at a
+/// public lightwalletd. Keep them serialized unless the operator explicitly
+/// opts into trusted-provider parallelism. Setting this variable above one is
+/// therefore both a performance tuning knob and an explicit privacy choice.
+fn address_enhancement_concurrency() -> usize {
+    super::env_override_clamped(
+        "ZCASH_SYNC_TRUSTED_ADDRESS_CONCURRENCY",
+        1,
+        1,
+        DEFAULT_ENHANCEMENT_CONCURRENCY.max(1),
+    ) as usize
+}
+
+fn address_request_is_due(request: &TransactionsInvolvingAddress, now: SystemTime) -> bool {
+    request
+        .request_at()
+        .map_or(true, |request_at| request_at <= now)
+}
+
+fn address_request_is_supported(request: &TransactionsInvolvingAddress) -> bool {
+    matches!(
+        (request.tx_status_filter(), request.output_status_filter()),
+        (TransactionStatusFilter::Mined, OutputStatusFilter::All)
+    )
+}
+
 /// Stream a transparent address's transaction history in `[start, end]`
 /// and parse each returned transaction. Network-only (no DB writes) so it
 /// can run concurrently with other address scans; the caller applies the
 /// results serially under the wallet-DB write lock.
 struct AddressTxFetch {
-    receiver: mpsc::Receiver<Result<(Option<BlockHeight>, Transaction), SyncError>>,
+    request: TransactionsInvolvingAddress,
+    end: u64,
+    receiver: mpsc::Receiver<Result<AddressTxEvent, SyncError>>,
     handle: tokio::task::JoinHandle<()>,
+}
+
+enum AddressTxEvent {
+    Transaction((Option<BlockHeight>, Transaction)),
+    Complete,
 }
 
 impl Drop for AddressTxFetch {
@@ -490,6 +646,7 @@ impl Drop for AddressTxFetch {
 /// the consumer stops early (cancel, mode switch, or a failed sibling).
 async fn start_address_txs<ShouldExit>(
     client: &mut CompactTxStreamerClient<Channel>,
+    request: TransactionsInvolvingAddress,
     address: String,
     start: u64,
     end: u64,
@@ -512,7 +669,12 @@ where
             match lwd::next_stream_message(&mut stream, "get_taddress_txids stream").await {
                 Ok(Some(raw)) => {
                     if raw.data.is_empty() {
-                        continue;
+                        let _ = sender
+                            .send(Err(SyncError::parse(
+                                "empty transaction in transparent address history",
+                            )))
+                            .await;
+                        break;
                     }
                     let mined_height = match mined_height_from_raw_height(raw.height) {
                         Ok(height) => height,
@@ -521,16 +683,34 @@ where
                             break;
                         }
                     };
+                    if let Err(e) = validate_address_tx_height(mined_height, start, end) {
+                        let _ = sender.send(Err(e)).await;
+                        break;
+                    }
                     match Transaction::read(&raw.data[..], BranchId::Sapling) {
                         Ok(tx) => {
-                            if sender.send(Ok((mined_height, tx))).await.is_err() {
+                            if sender
+                                .send(Ok(AddressTxEvent::Transaction((mined_height, tx))))
+                                .await
+                                .is_err()
+                            {
                                 break;
                             }
                         }
-                        Err(e) => log::warn!("sync: Transaction::read (addr) failed: {e}"),
+                        Err(e) => {
+                            let _ = sender
+                                .send(Err(SyncError::parse(format!(
+                                    "Transaction::read (addr) failed: {e}"
+                                ))))
+                                .await;
+                            break;
+                        }
                     }
                 }
-                Ok(None) => break,
+                Ok(None) => {
+                    let _ = sender.send(Ok(AddressTxEvent::Complete)).await;
+                    break;
+                }
                 Err(e) => {
                     let _ = sender.send(Err(e)).await;
                     break;
@@ -538,7 +718,43 @@ where
             }
         }
     });
-    Ok(Some(AddressTxFetch { receiver, handle }))
+    Ok(Some(AddressTxFetch {
+        request,
+        end,
+        receiver,
+        handle,
+    }))
+}
+
+fn parse_transaction_for_txid(data: &[u8], expected_txid: TxId) -> Result<Transaction, SyncError> {
+    let tx = Transaction::read(data, BranchId::Sapling)
+        .map_err(|e| SyncError::parse(format!("Transaction::read failed: {e}")))?;
+    if tx.txid() != expected_txid {
+        return Err(SyncError::parse(format!(
+            "lightwalletd returned txid {} for requested {expected_txid}",
+            tx.txid()
+        )));
+    }
+    Ok(tx)
+}
+
+fn validate_address_tx_height(
+    mined_height: Option<BlockHeight>,
+    start: u64,
+    end: u64,
+) -> Result<(), SyncError> {
+    let Some(height) = mined_height else {
+        return Err(SyncError::parse(
+            "unmined transaction returned for a bounded transparent address history query",
+        ));
+    };
+    let height = u32::from(height) as u64;
+    if height < start || height > end {
+        return Err(SyncError::parse(format!(
+            "transparent address history returned height {height} outside [{start}, {end}]"
+        )));
+    }
+    Ok(())
 }
 
 async fn fill_missing_transparent_fee<ShouldExit>(
@@ -633,6 +849,13 @@ where
                 return Ok(BTreeMap::new());
             }
         };
+        if parent_tx.txid().as_ref() != outpoint.hash() {
+            return Err(SyncError::parse(format!(
+                "lightwalletd returned transparent parent {} for requested {}",
+                parent_tx.txid(),
+                hex::encode(outpoint.hash()),
+            )));
+        }
 
         let Some(parent_bundle) = parent_tx.transparent_bundle() else {
             return Ok(BTreeMap::new());
@@ -758,6 +981,8 @@ fn transaction_status_from_raw_height(raw_height: u64) -> Result<TransactionStat
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
+    use transparent::address::TransparentAddress;
 
     fn transparent_fee_test_tx() -> Transaction {
         let tx_bytes = hex::decode(
@@ -909,5 +1134,76 @@ mod tests {
             mined_height_from_raw_height(u32::MAX as u64 + 1),
             Err(SyncError::Parse(_)),
         ));
+    }
+
+    #[test]
+    fn enhancement_transaction_must_match_requested_txid() {
+        let tx = transparent_fee_test_tx();
+        let mut encoded = vec![];
+        tx.write(&mut encoded).unwrap();
+
+        assert!(parse_transaction_for_txid(&encoded, tx.txid()).is_ok());
+        assert!(matches!(
+            parse_transaction_for_txid(&encoded, TxId::NULL),
+            Err(SyncError::Parse(_)),
+        ));
+    }
+
+    #[test]
+    fn bounded_address_history_rejects_unmined_and_out_of_range_items() {
+        assert!(validate_address_tx_height(Some(BlockHeight::from_u32(10)), 10, 20).is_ok());
+        assert!(validate_address_tx_height(Some(BlockHeight::from_u32(20)), 10, 20).is_ok());
+        assert!(matches!(
+            validate_address_tx_height(None, 10, 20),
+            Err(SyncError::Parse(_)),
+        ));
+        assert!(matches!(
+            validate_address_tx_height(Some(BlockHeight::from_u32(9)), 10, 20),
+            Err(SyncError::Parse(_)),
+        ));
+        assert!(matches!(
+            validate_address_tx_height(Some(BlockHeight::from_u32(21)), 10, 20),
+            Err(SyncError::Parse(_)),
+        ));
+    }
+
+    #[test]
+    fn address_request_respects_decorrelation_time_and_preserves_filters() {
+        let now = SystemTime::now();
+        let request_at = now + Duration::from_secs(60);
+        let request = match TransactionDataRequest::transactions_involving_address(
+            TransparentAddress::PublicKeyHash([7; 20]),
+            BlockHeight::from_u32(10),
+            Some(BlockHeight::from_u32(20)),
+            Some(request_at),
+            TransactionStatusFilter::Mined,
+            OutputStatusFilter::Unspent,
+        ) {
+            TransactionDataRequest::TransactionsInvolvingAddress(request) => request,
+            _ => unreachable!(),
+        };
+
+        assert!(!address_request_is_due(&request, now));
+        assert!(address_request_is_due(
+            &request,
+            request_at + Duration::from_secs(1)
+        ));
+        assert_eq!(request.request_at(), Some(request_at));
+        assert_eq!(request.tx_status_filter(), &TransactionStatusFilter::Mined);
+        assert_eq!(request.output_status_filter(), &OutputStatusFilter::Unspent);
+        assert!(!address_request_is_supported(&request));
+
+        let supported = match TransactionDataRequest::transactions_involving_address(
+            TransparentAddress::PublicKeyHash([8; 20]),
+            BlockHeight::from_u32(10),
+            Some(BlockHeight::from_u32(20)),
+            None,
+            TransactionStatusFilter::Mined,
+            OutputStatusFilter::All,
+        ) {
+            TransactionDataRequest::TransactionsInvolvingAddress(request) => request,
+            _ => unreachable!(),
+        };
+        assert!(address_request_is_supported(&supported));
     }
 }

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -72,9 +72,10 @@ const DEFAULT_ENHANCEMENT_CONCURRENCY: u64 = 4;
 /// Returns an [`EnhancementOutcome`]: `stored` counts transactions applied
 /// via `decrypt_and_store_transaction` for `Enhancement` and
 /// address-scoped requests — the ones that add user-visible history data
-/// (memos, sent-tx recipients, transparent history rows) — and the caller
-/// folds a non-zero count into the batch's `has_new_tx` progress flag so
-/// the Dart side refreshes the visible history. `GetStatus` re-stores of a
+/// (memos, sent-tx recipients, transparent history rows). Post-batch callers
+/// fold a non-zero count into `has_new_tx`; if the final drain later returns
+/// an error, Dart refreshes committed DB state before retaining the failure.
+/// `GetStatus` re-stores of a
 /// still-pending tx are deliberately NOT counted: those requests persist
 /// while the tx is unmined and would otherwise flag `has_new_tx` on every
 /// pass without anything user-visible changing. `drained` tells the caller

--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -22,9 +22,19 @@
 //! because servicing one request can legally populate new requests
 //! (e.g. a newly-decrypted transaction may reveal additional parent
 //! transactions to enhance).
+//!
+//! The network fetches run concurrently (bounded by
+//! [`enhancement_concurrency`]) because servicing the queue serially
+//! cost ~150ms per request against a public lightwalletd — dozens of
+//! sequential round-trips that dominated a cold sync's non-scan time.
+//! DB writes stay serial under the wallet-DB write lock. The queue is
+//! derived from DB state, so a pass is always safe to stop early
+//! (`should_exit`) or skip entirely: whatever remains is picked up by
+//! the next pass or the next sync run.
 
 use std::collections::{BTreeMap, HashSet};
 
+use futures::StreamExt;
 use tonic::{transport::Channel, Code, Status};
 use transparent::bundle::OutPoint;
 use zcash_client_backend::{
@@ -34,7 +44,7 @@ use zcash_client_backend::{
     },
     proto::service::compact_tx_streamer_client::CompactTxStreamerClient,
 };
-use zcash_primitives::transaction::Transaction;
+use zcash_primitives::transaction::{Transaction, TxId};
 use zcash_protocol::consensus::{BlockHeight, BranchId};
 use zcash_protocol::value::{BalanceError, Zatoshis};
 
@@ -44,26 +54,79 @@ use crate::wallet::network::WalletNetwork;
 use super::{lwd, SyncError, WalletDatabase};
 
 /// Drains `db.transaction_data_requests()` against lightwalletd until
-/// the queue is empty or no request is actionable. Returns
-/// `SyncError::Db` if `db.transaction_data_requests()` itself fails.
-/// Per-request failures are split by semantics: an explicit
-/// "txid not recognized" response is recorded via
-/// `set_transaction_status` so it doesn't get retried forever, while
-/// transient network failures bubble up as `SyncError::Network` so the
-/// outer sync retry path can recover without deleting the request.
-pub(super) async fn run_enhancement(
+/// the queue is empty or no request is actionable. Network fetches run
+/// concurrently (bounded); results are applied serially under the
+/// wallet-DB write lock.
+///
+/// Returns an [`EnhancementOutcome`]: `stored` counts transactions applied
+/// via `decrypt_and_store_transaction` for `Enhancement` and
+/// address-scoped requests — the ones that add user-visible history data
+/// (memos, sent-tx recipients, transparent history rows) — and the caller
+/// folds a non-zero count into the batch's `has_new_tx` progress flag so
+/// the Dart side refreshes the visible history. `GetStatus` re-stores of a
+/// still-pending tx are deliberately NOT counted: those requests persist
+/// while the tx is unmined and would otherwise flag `has_new_tx` on every
+/// pass without anything user-visible changing. `drained` tells the caller
+/// whether the post-loop drain still has work (see the struct docs).
+///
+/// `should_exit` is consulted between rounds, between concurrent fetch
+/// completions (dropping the stream aborts in-flight RPCs), and between
+/// serial applies. When it fires, the pass stops promptly; the DB-derived
+/// queue means anything unserviced is retried by a later pass.
+///
+/// Failure policy: once anything has been committed in a pass, its
+/// `stored` count must reach the caller (the `has_new_tx` refresh signal
+/// depends on it, and serviced queue entries will not re-count on retry).
+/// So per-item failures are logged and skipped, an explicit "txid not
+/// recognized" response is recorded via `set_transaction_status` so it
+/// doesn't get retried forever, and a transient network failure ends the
+/// pass after the current round — but never discards the count. `Err` is
+/// returned only when reading the request queue itself fails.
+/// Result of an enhancement pass.
+pub(super) struct EnhancementOutcome {
+    /// Transactions applied via `decrypt_and_store_transaction` for
+    /// `Enhancement` and address-scoped requests (drives `has_new_tx`).
+    pub stored: usize,
+    /// True only when the pass verifiably left no actionable NEW work:
+    /// the queue read back empty/inert, or an entire round produced the
+    /// identical request set as the previous one (whatever remains is
+    /// persistent, e.g. GetStatus for a still-unmined send). False on
+    /// early exits (cancel, network error) and on 3-round exhaustion with
+    /// fresh work still appearing — callers use this to decide whether the
+    /// post-loop drain still has anything to do.
+    pub drained: bool,
+}
+
+pub(super) async fn run_enhancement<ShouldExit>(
     client: &mut CompactTxStreamerClient<Channel>,
     db: &mut WalletDatabase,
     db_path: &str,
     network: WalletNetwork,
-) -> Result<(), SyncError> {
+    should_exit: &ShouldExit,
+) -> Result<EnhancementOutcome, SyncError>
+where
+    ShouldExit: Fn() -> bool + Sync,
+{
     let mut failed_txids: HashSet<String> = HashSet::new();
+    let mut stored: usize = 0;
+    let mut drained = false;
+    let mut prev_signature: Option<std::collections::BTreeSet<String>> = None;
 
-    for _ in 0..3 {
+    // Telemetry to locate the cost of an enhancement pass.
+    let enh_t0 = std::time::Instant::now();
+    let mut n_status_reqs = 0u64;
+    let mut n_addr_reqs = 0u64;
+    let mut fee_time = std::time::Duration::ZERO;
+
+    'rounds: for _ in 0..3 {
+        if should_exit() {
+            break;
+        }
         let requests = db
             .transaction_data_requests()
             .map_err(|e| SyncError::db(format!("transaction_data_requests: {e}")))?;
         if requests.is_empty() {
+            drained = true;
             break;
         }
 
@@ -78,176 +141,368 @@ pub(super) async fn run_enhancement(
             }
         });
         if !actionable {
+            drained = true;
             break;
         }
 
-        for req in &requests {
-            match req {
-                TransactionDataRequest::GetStatus(txid)
-                | TransactionDataRequest::Enhancement(txid) => {
-                    let txid_str = format!("{txid}");
-                    if failed_txids.contains(&txid_str) {
-                        continue;
-                    }
+        // Rounds exist only to service requests that servicing itself
+        // enqueued (a decrypted tx can reveal parents to enhance). If this
+        // round's request set is identical to the previous one, nothing new
+        // arrived — whatever remains is persistent (GetStatus for a
+        // still-unmined send regenerates until it mines) and re-servicing
+        // it is pure duplication: up to 3 identical full-raw-tx fetches per
+        // pass, every sync cycle, for the tx's whole unmined lifetime.
+        let signature: std::collections::BTreeSet<String> = requests
+            .iter()
+            .map(|r| match r {
+                TransactionDataRequest::GetStatus(txid) => format!("s:{txid}"),
+                TransactionDataRequest::Enhancement(txid) => format!("e:{txid}"),
+                TransactionDataRequest::TransactionsInvolvingAddress(req) => format!(
+                    "a:{:?}:{}:{:?}",
+                    req.address(),
+                    req.block_range_start(),
+                    req.block_range_end(),
+                ),
+            })
+            .collect();
+        if prev_signature.as_ref() == Some(&signature) {
+            drained = true;
+            break;
+        }
+        prev_signature = Some(signature);
 
-                    match lwd::get_transaction(client, txid.as_ref().to_vec()).await {
-                        Ok(raw) => {
-                            let mined_height = mined_height_from_raw_height(raw.height)?;
-                            if !raw.data.is_empty() {
-                                match Transaction::read(&raw.data[..], BranchId::Sapling) {
-                                    Ok(tx) => {
-                                        if let Err(e) = with_wallet_db_write_lock(
-                                            "sync_engine.enhance.decrypt_and_store_transaction",
-                                            || {
-                                                decrypt_and_store_transaction(
-                                                    &network,
-                                                    db,
-                                                    &tx,
-                                                    mined_height,
-                                                )
-                                            },
-                                        ) {
-                                            log::error!(
-                                                "sync: decrypt_and_store_transaction failed: {e}"
-                                            );
-                                        }
-                                        if let Err(e) =
-                                            fill_missing_transparent_fee(client, db_path, &tx).await
-                                        {
-                                            log::warn!(
-                                                "sync: transparent fee enhancement failed for {txid_str}: {e}"
-                                            );
-                                        }
-                                    }
-                                    Err(e) => log::warn!(
-                                        "sync: Transaction::read failed for {txid_str}: {e}"
-                                    ),
-                                }
-                            }
-                            if matches!(req, TransactionDataRequest::GetStatus(_)) {
-                                let status = transaction_status_from_raw_height(raw.height)?;
-                                if let Err(e) = with_wallet_db_write_lock(
-                                    "sync_engine.enhance.set_transaction_status",
-                                    || db.set_transaction_status(*txid, status),
-                                ) {
-                                    log::error!("sync: set_transaction_status failed: {e}");
-                                }
-                            }
+        let concurrency = enhancement_concurrency();
+
+        // --- txid-scoped requests: concurrent GetTransaction, serial apply ---
+        // Coalesce request kinds for the same txid. Librustzcash may ask for
+        // both status and full enhancement at once; one raw transaction RPC
+        // can service both without racing two identical fetches/applies.
+        let mut status_by_txid: BTreeMap<TxId, (bool, bool)> = BTreeMap::new();
+        for request in &requests {
+            match request {
+                TransactionDataRequest::GetStatus(txid) => {
+                    status_by_txid.entry(*txid).or_default().0 = true;
+                }
+                TransactionDataRequest::Enhancement(txid) => {
+                    status_by_txid.entry(*txid).or_default().1 = true;
+                }
+                TransactionDataRequest::TransactionsInvolvingAddress(_) => {}
+            }
+        }
+        let status_items: Vec<(TxId, bool, bool)> = status_by_txid
+            .into_iter()
+            .filter(|(txid, _)| !failed_txids.contains(&format!("{txid}")))
+            .map(|(txid, (needs_status, is_enhancement))| (txid, needs_status, is_enhancement))
+            .collect();
+        n_status_reqs += status_items.len() as u64;
+
+        // Once anything has been committed to the DB in this pass, `stored`
+        // must survive to the return value — the caller derives the batch's
+        // `has_new_tx` (and hence the Dart history refresh) from it, and the
+        // serviced queue entries will NOT re-count on a retry. So from here
+        // on, per-item failures are logged and skipped, and a transient
+        // network failure ends the pass early (`round_network_error`) but
+        // never discards the count via `?`/`return Err`.
+        //
+        // Each result is applied AS IT ARRIVES from the bounded concurrent
+        // stream: peak memory is ~`concurrency` in-flight responses instead
+        // of the whole pass's payloads (raw transactions run to ~2 MB
+        // each), and a cancel or `break 'rounds` drops the stream — which
+        // aborts the in-flight fetches — without first draining every
+        // response. The fee lookups use a dedicated client clone because
+        // the stream holds a shared borrow of `client` while alive.
+        let mut round_network_error = false;
+        let mut fee_client = client.clone();
+        let mut fetch_stream = futures::stream::iter(status_items)
+            .map(|(txid, needs_status, is_enhancement)| {
+                let mut c = client.clone();
+                async move {
+                    let res = tokio::select! {
+                        result = lwd::get_transaction(&mut c, txid.as_ref().to_vec()) => {
+                            Some(result)
                         }
-                        Err(e) => match classify_get_transaction_error(&e) {
-                            GetTransactionErrorAction::MarkTxidNotRecognized => {
-                                log::warn!(
-                                    "sync: get_transaction did not recognize {txid_str}: {e}"
-                                );
-                                failed_txids.insert(txid_str);
-                                if let Err(e) = with_wallet_db_write_lock(
-                                    "sync_engine.enhance.set_transaction_status",
+                        _ = wait_until_exit(should_exit) => None,
+                    };
+                    (txid, needs_status, is_enhancement, res)
+                }
+            })
+            .buffer_unordered(concurrency);
+        while let Some((txid, needs_status, is_enhancement, res)) = fetch_stream.next().await {
+            let Some(res) = res else {
+                break 'rounds;
+            };
+            if should_exit() {
+                break 'rounds;
+            }
+            let txid_str = format!("{txid}");
+            match res {
+                Ok(raw) => {
+                    let mined_height = match mined_height_from_raw_height(raw.height) {
+                        Ok(h) => h,
+                        Err(e) => {
+                            log::warn!("sync: invalid mined height for {txid_str} (skipping): {e}");
+                            continue;
+                        }
+                    };
+                    if !raw.data.is_empty() {
+                        match Transaction::read(&raw.data[..], BranchId::Sapling) {
+                            Ok(tx) => {
+                                match with_wallet_db_write_lock(
+                                    "sync_engine.enhance.decrypt_and_store_transaction",
                                     || {
-                                        db.set_transaction_status(
-                                            *txid,
-                                            TransactionStatus::TxidNotRecognized,
+                                        decrypt_and_store_transaction(
+                                            &network,
+                                            db,
+                                            &tx,
+                                            mined_height,
                                         )
                                     },
                                 ) {
-                                    log::error!("sync: set_transaction_status failed: {e}");
+                                    Ok(()) => {
+                                        if is_enhancement {
+                                            stored += 1;
+                                        }
+                                    }
+                                    Err(e) => log::error!(
+                                        "sync: decrypt_and_store_transaction failed: {e}"
+                                    ),
                                 }
-                            }
-                            GetTransactionErrorAction::RetryAsNetwork => {
-                                return Err(SyncError::net(format!(
-                                    "get_transaction failed for {txid_str}: {e}"
-                                )));
-                            }
-                        },
-                    }
-                }
-                TransactionDataRequest::TransactionsInvolvingAddress(req) => {
-                    let end_height = match req.block_range_end() {
-                        Some(h) => h,
-                        None => continue,
-                    };
-                    let addr_str = zcash_keys::encoding::encode_transparent_address_p(
-                        &network,
-                        &req.address(),
-                    );
-                    let start = u32::from(req.block_range_start()) as u64;
-                    let end = u32::from(end_height) as u64;
-
-                    match lwd::get_taddress_txids(client, addr_str, start, end.saturating_sub(1))
-                        .await
-                    {
-                        Ok(mut stream) => {
-                            let mut fee_client = client.clone();
-                            loop {
-                                match lwd::next_stream_message(
-                                    &mut stream,
-                                    "get_taddress_txids stream",
+                                let fee_t = std::time::Instant::now();
+                                if let Err(e) = fill_missing_transparent_fee(
+                                    &mut fee_client,
+                                    db_path,
+                                    &tx,
+                                    should_exit,
                                 )
                                 .await
                                 {
-                                    Ok(Some(raw)) => {
-                                        if !raw.data.is_empty() {
-                                            let mined_height =
-                                                mined_height_from_raw_height(raw.height)?;
-                                            match Transaction::read(
-                                                &raw.data[..],
-                                                BranchId::Sapling,
-                                            ) {
-                                                Ok(tx) => {
-                                                    if let Err(e) = with_wallet_db_write_lock(
-                                                        "sync_engine.enhance.decrypt_and_store_transaction",
-                                                        || {
-                                                            decrypt_and_store_transaction(
-                                                                &network,
-                                                                db,
-                                                                &tx,
-                                                                mined_height,
-                                                            )
-                                                        },
-                                                    ) {
-                                                        log::error!(
-                                                            "sync: decrypt_and_store_transaction (addr) failed: {e}"
-                                                        );
-                                                    }
-                                                    if let Err(e) = fill_missing_transparent_fee(
-                                                        &mut fee_client,
-                                                        db_path,
-                                                        &tx,
-                                                    )
-                                                    .await
-                                                    {
-                                                        log::warn!(
-                                                            "sync: transparent fee enhancement (addr) failed for {}: {e}",
-                                                            tx.txid()
-                                                        );
-                                                    }
-                                                }
-                                                Err(e) => {
-                                                    log::warn!(
-                                                        "sync: Transaction::read (addr) failed: {e}"
-                                                    )
-                                                }
-                                            }
-                                        }
-                                    }
-                                    Ok(None) => break,
-                                    Err(e) => return Err(e),
+                                    log::warn!(
+                                        "sync: transparent fee enhancement failed for {txid_str}: {e}"
+                                    );
                                 }
+                                fee_time += fee_t.elapsed();
+                            }
+                            Err(e) => {
+                                log::warn!("sync: Transaction::read failed for {txid_str}: {e}")
                             }
                         }
-                        Err(e) => return Err(e),
+                    }
+                    if needs_status {
+                        match transaction_status_from_raw_height(raw.height) {
+                            Ok(status) => {
+                                if let Err(e) = with_wallet_db_write_lock(
+                                    "sync_engine.enhance.set_transaction_status",
+                                    || db.set_transaction_status(txid, status),
+                                ) {
+                                    log::error!("sync: set_transaction_status failed: {e}");
+                                }
+                            }
+                            Err(e) => log::warn!(
+                                "sync: invalid status height for {txid_str} (skipping): {e}"
+                            ),
+                        }
+                    }
+                }
+                Err(e) => match classify_get_transaction_error(&e) {
+                    GetTransactionErrorAction::MarkTxidNotRecognized => {
+                        log::warn!("sync: get_transaction did not recognize {txid_str}: {e}");
+                        failed_txids.insert(txid_str);
+                        if let Err(e) = with_wallet_db_write_lock(
+                            "sync_engine.enhance.set_transaction_status",
+                            || {
+                                db.set_transaction_status(
+                                    txid,
+                                    TransactionStatus::TxidNotRecognized,
+                                )
+                            },
+                        ) {
+                            log::error!("sync: set_transaction_status failed: {e}");
+                        }
+                    }
+                    GetTransactionErrorAction::RetryAsNetwork => {
+                        // Transient network failure: keep applying the
+                        // results that DID arrive, then end the pass after
+                        // this round instead of spinning two more rounds
+                        // against a failing endpoint. The DB-derived queue
+                        // retries on the next pass.
+                        log::warn!(
+                            "sync: get_transaction failed for {txid_str} \
+                             (ending pass after this round): {e}"
+                        );
+                        round_network_error = true;
+                    }
+                },
+            }
+        }
+        if should_exit() {
+            break;
+        }
+
+        // --- address-scoped requests: concurrent history streams, serial apply ---
+        let addr_items: Vec<(String, u64, u64)> = requests
+            .iter()
+            .filter_map(|r| match r {
+                TransactionDataRequest::TransactionsInvolvingAddress(req) => {
+                    req.block_range_end().map(|end_height| {
+                        let addr_str = zcash_keys::encoding::encode_transparent_address_p(
+                            &network,
+                            &req.address(),
+                        );
+                        let start = u32::from(req.block_range_start()) as u64;
+                        let end = u32::from(end_height) as u64;
+                        (addr_str, start, end.saturating_sub(1))
+                    })
+                }
+                _ => None,
+            })
+            .collect();
+        n_addr_reqs += addr_items.len() as u64;
+
+        // Same as-they-arrive application for the address streams: each
+        // completed address's transactions are applied before the next
+        // result is awaited, so live memory is bounded by the
+        // ~`concurrency` in-flight per-address fetches rather than every
+        // address's parsed history at once.
+        let mut addr_stream = futures::stream::iter(addr_items)
+            .map(|(addr_str, start, end)| {
+                let mut c = client.clone();
+                async move { fetch_address_txs(&mut c, addr_str, start, end, should_exit).await }
+            })
+            .buffer_unordered(concurrency);
+        while let Some(result) = addr_stream.next().await {
+            if should_exit() {
+                break 'rounds;
+            }
+            let txs = match result {
+                Ok(Some(txs)) => txs,
+                Ok(None) => break 'rounds,
+                Err(e) => {
+                    // One address's history stream failing must not discard
+                    // the other addresses' results (or the pass's stored
+                    // count): log, mark the round, keep applying.
+                    log::warn!(
+                        "sync: address history fetch failed \
+                         (continuing with other addresses): {e}"
+                    );
+                    round_network_error = true;
+                    continue;
+                }
+            };
+            for (mined_height, tx) in txs {
+                if should_exit() {
+                    break 'rounds;
+                }
+                match with_wallet_db_write_lock(
+                    "sync_engine.enhance.decrypt_and_store_transaction",
+                    || decrypt_and_store_transaction(&network, db, &tx, mined_height),
+                ) {
+                    Ok(()) => stored += 1,
+                    Err(e) => {
+                        log::error!("sync: decrypt_and_store_transaction (addr) failed: {e}")
+                    }
+                }
+                let fee_t = std::time::Instant::now();
+                if let Err(e) =
+                    fill_missing_transparent_fee(&mut fee_client, db_path, &tx, should_exit).await
+                {
+                    log::warn!(
+                        "sync: transparent fee enhancement (addr) failed for {}: {e}",
+                        tx.txid()
+                    );
+                }
+                fee_time += fee_t.elapsed();
+            }
+        }
+        drop(addr_stream);
+
+        if round_network_error {
+            break;
+        }
+    }
+
+    let total = enh_t0.elapsed();
+    if total.as_millis() > 50 {
+        log::info!(
+            "enhance: pass took {:.2}s (status/enh reqs={}, addr reqs={}, stored={}, transparent-fee {:.2}s)",
+            total.as_secs_f64(),
+            n_status_reqs,
+            n_addr_reqs,
+            stored,
+            fee_time.as_secs_f64(),
+        );
+    }
+    Ok(EnhancementOutcome { stored, drained })
+}
+
+/// Concurrency for the enhancement network fetches. Overridable via
+/// `ZCASH_SYNC_ENHANCE_CONCURRENCY` for benchmark sweeps; defaults to 8,
+/// clamped to `[1, 32]`.
+fn enhancement_concurrency() -> usize {
+    super::env_override_clamped("ZCASH_SYNC_ENHANCE_CONCURRENCY", 8, 1, 32) as usize
+}
+
+/// Stream a transparent address's transaction history in `[start, end]`
+/// and parse each returned transaction. Network-only (no DB writes) so it
+/// can run concurrently with other address scans; the caller applies the
+/// results serially under the wallet-DB write lock.
+async fn fetch_address_txs<ShouldExit>(
+    client: &mut CompactTxStreamerClient<Channel>,
+    address: String,
+    start: u64,
+    end: u64,
+    should_exit: &ShouldExit,
+) -> Result<Option<Vec<(Option<BlockHeight>, Transaction)>>, SyncError>
+where
+    ShouldExit: Fn() -> bool + Sync,
+{
+    let stream_result = tokio::select! {
+        result = lwd::get_taddress_txids(client, address, start, end) => Some(result),
+        _ = wait_until_exit(should_exit) => None,
+    };
+    let Some(stream_result) = stream_result else {
+        return Ok(None);
+    };
+    let mut stream = stream_result?;
+    let mut out = Vec::new();
+    loop {
+        let next = tokio::select! {
+            result = lwd::next_stream_message(&mut stream, "get_taddress_txids stream") => {
+                Some(result)
+            }
+            _ = wait_until_exit(should_exit) => None,
+        };
+        let Some(next) = next else {
+            return Ok(None);
+        };
+        match next {
+            Ok(Some(raw)) => {
+                if !raw.data.is_empty() {
+                    let mined_height = mined_height_from_raw_height(raw.height)?;
+                    match Transaction::read(&raw.data[..], BranchId::Sapling) {
+                        Ok(tx) => out.push((mined_height, tx)),
+                        Err(e) => log::warn!("sync: Transaction::read (addr) failed: {e}"),
                     }
                 }
             }
+            Ok(None) => break,
+            Err(e) => return Err(e),
         }
     }
-    Ok(())
+    Ok(Some(out))
 }
 
-async fn fill_missing_transparent_fee(
+async fn fill_missing_transparent_fee<ShouldExit>(
     client: &mut CompactTxStreamerClient<Channel>,
     db_path: &str,
     tx: &Transaction,
-) -> Result<(), SyncError> {
+    should_exit: &ShouldExit,
+) -> Result<(), SyncError>
+where
+    ShouldExit: Fn() -> bool + Sync,
+{
+    if should_exit() {
+        return Ok(());
+    }
     let Some(bundle) = tx.transparent_bundle() else {
         return Ok(());
     };
@@ -255,7 +510,7 @@ async fn fill_missing_transparent_fee(
         return Ok(());
     }
 
-    let prevout_values = fetch_transparent_prevout_values(client, tx).await?;
+    let prevout_values = fetch_transparent_prevout_values(client, tx, should_exit).await?;
     if prevout_values.is_empty() {
         return Ok(());
     }
@@ -269,16 +524,23 @@ async fn fill_missing_transparent_fee(
     persist_fee_if_missing(db_path, tx, fee)
 }
 
-async fn fetch_transparent_prevout_values(
+async fn fetch_transparent_prevout_values<ShouldExit>(
     client: &mut CompactTxStreamerClient<Channel>,
     tx: &Transaction,
-) -> Result<BTreeMap<OutPoint, Zatoshis>, SyncError> {
+    should_exit: &ShouldExit,
+) -> Result<BTreeMap<OutPoint, Zatoshis>, SyncError>
+where
+    ShouldExit: Fn() -> bool + Sync,
+{
     let Some(bundle) = tx.transparent_bundle() else {
         return Ok(BTreeMap::new());
     };
 
     let mut prevout_values = BTreeMap::new();
     for txin in &bundle.vin {
+        if should_exit() {
+            return Ok(BTreeMap::new());
+        }
         let outpoint = txin.prevout();
         if is_null_outpoint(outpoint) {
             return Ok(BTreeMap::new());
@@ -287,7 +549,14 @@ async fn fetch_transparent_prevout_values(
             continue;
         }
 
-        let parent_raw = match lwd::get_transaction(client, outpoint.hash().to_vec()).await {
+        let parent_result = tokio::select! {
+            result = lwd::get_transaction(client, outpoint.hash().to_vec()) => Some(result),
+            _ = wait_until_exit(should_exit) => None,
+        };
+        let Some(parent_result) = parent_result else {
+            return Ok(BTreeMap::new());
+        };
+        let parent_raw = match parent_result {
             Ok(raw) => raw,
             Err(e) => {
                 log::warn!(
@@ -329,6 +598,18 @@ async fn fetch_transparent_prevout_values(
     }
 
     Ok(prevout_values)
+}
+
+/// Resolves as soon as the caller's cancel/mode predicate becomes true.
+/// Keeping this as the second branch of each network `select!` means a sync
+/// handoff does not have to wait for a slow or stalled lightwalletd RPC.
+async fn wait_until_exit<ShouldExit>(should_exit: &ShouldExit)
+where
+    ShouldExit: Fn() -> bool + Sync,
+{
+    while !should_exit() {
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
 }
 
 fn should_fill_missing_transparent_fee(db_path: &str, tx: &Transaction) -> Result<bool, SyncError> {

--- a/rust/src/wallet/sync_engine/lwd.rs
+++ b/rust/src/wallet/sync_engine/lwd.rs
@@ -441,7 +441,14 @@ pub(super) async fn download_blocks(
     .await
     .map_err(|e| status_to_network_error("get_block_range", e))?;
 
-    let mut blocks = Vec::new();
+    // Sync batches are hard-capped by the orchestration layer (2000 desktop,
+    // 1000 mobile, 300 background, and 100 in the known sandblasting window),
+    // so reserving the exact inclusive range avoids repeated Vec growth while
+    // retaining a bounded allocation even for adversarial compact-block data.
+    let expected_blocks = u32::from(end)
+        .saturating_sub(u32::from(start))
+        .saturating_add(1) as usize;
+    let mut blocks = Vec::with_capacity(expected_blocks);
     while let Some(block) = next_stream_message(&mut stream, "get_block_range stream").await? {
         blocks.push(block);
     }

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -97,6 +97,7 @@ const PREFETCH_SANDBLASTING_WIRE_BYTES_PER_BLOCK: u64 = 90 * 1024;
 const PREFETCH_RESIDENT_BUDGET: u64 = 128 * 1024 * 1024;
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 const PREFETCH_RESIDENT_BUDGET: u64 = 32 * 1024 * 1024;
+const RESUBMIT_EVERY_BATCHES: u64 = 16;
 const TRANSPARENT_UTXO_RECENT_EXTERNAL_LIMIT: usize = 20;
 const TRANSPARENT_UTXO_SWEEP_EXTERNAL_LIMIT: usize = 20;
 
@@ -176,6 +177,24 @@ fn effective_prefetch_depth(running_mode: u8) -> usize {
         PREFETCH_DEPTH_FOREGROUND
     };
     env_override_clamped("ZCASH_SYNC_PREFETCH_DEPTH", default as u64, 1, 16) as usize
+}
+
+fn effective_resubmit_every() -> u64 {
+    env_override_clamped(
+        "ZCASH_SYNC_RESUBMIT_EVERY",
+        RESUBMIT_EVERY_BATCHES,
+        1,
+        u64::MAX,
+    )
+}
+
+fn should_run_post_batch_resubmit(
+    batch_found_tx: bool,
+    is_last_batch_of_range: bool,
+    batch_index: u64,
+    every: u64,
+) -> bool {
+    batch_found_tx || is_last_batch_of_range || batch_index % every.max(1) == 0
 }
 
 fn can_spawn_prefetch(
@@ -1396,6 +1415,9 @@ async fn run_sync_impl(
     let mut fetch_wait_total = std::time::Duration::ZERO;
     let mut fetch_batches = 0u64;
     let mut stale_prefetches = 0u64;
+    let resubmit_every = effective_resubmit_every();
+    let mut resubmit_total = std::time::Duration::ZERO;
+    let mut resubmit_passes = 0u64;
     log::info!(
         "[{}] sync: prefetch depth={}, resident budget={} MiB",
         elapsed(),
@@ -1878,113 +1900,80 @@ async fn run_sync_impl(
             return Ok(());
         }
 
+        let batch_found_tx = scan_summary.received_sapling_note_count() > 0
+            || scan_summary.spent_sapling_note_count() > 0
+            || scan_summary.received_orchard_note_count() > 0
+            || scan_summary.spent_orchard_note_count() > 0;
+
         // Enhancement
         run_enhancement(&mut client, &mut db, db_data_path, network).await?;
 
-        // Post-batch auto-resubmit. Matches zcash-android-wallet-sdk's
-        // lines 593/701 call sites (end of verify batch / end of
-        // regular batch).
-        //
-        // We deliberately re-fetch the chain tip via
-        // `get_latest_block` before each pass instead of reusing
-        // `tip.height` captured once at the top of `run_sync_impl`.
-        // `get_resubmittable_txs` decides "still inside expiry
-        // window" with `expiry_height > current_height`; using the
-        // stale top-of-sync tip meant a long catch-up session
-        // (several thousand blocks) could keep rebroadcasting txs
-        // whose expiry had already passed against the real chain
-        // tip. Refreshing here is one extra unary gRPC per batch,
-        // which is cheap compared to the batch download itself and
-        // closes the "resubmit expired tx forever" regression
-        // caught by Codex 2nd-round review finding 2.
-        //
-        // Pre-flight guard matches the one at the startup resubmit
-        // call site — if cancel or mode-change landed during
-        // `run_enhancement` (which can spend a second or two on a
-        // transparent-address scan), bail before opening a single
-        // new `send_transaction` RPC. The helper also consults the
-        // same closure between candidates and before each retry so
-        // a cancel arriving mid-pass stops initiating further
-        // broadcasts.
-        //
-        // Best-effort: helper swallows per-tx failures, we ignore
-        // the return value, and if the tip refresh itself fails we
-        // log and skip the pass rather than falling back to the
-        // stale height (the whole point of the refresh is to avoid
-        // rebroadcasting against a stale expiry window).
-        if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode {
-            log::info!(
-                "[{}] sync: cancel/mode observed before post-batch resubmit, exiting",
-                elapsed(),
-            );
-            return Ok(());
-        }
-        match get_latest_block(&mut client)
-            .await
-            .map(|tip| tip.height as u32)
-        {
-            Ok(fresh_tip_height) => {
-                // Promote the fresh tip to the authoritative value
-                // so progress events and the final completion event
-                // use the latest chain height, not the one from
-                // sync startup. Also update the DB so
-                // suggest_scan_ranges picks up any new blocks that
-                // appeared since the initial (or last periodic) tip
-                // fetch.
-                //
-                // IMPORTANT: update_chain_tip MUST succeed before
-                // we bump current_tip_height. If the DB write fails,
-                // suggest_scan_ranges still operates on the old tip
-                // and the loop may break with isComplete=true —
-                // bumping current_tip_height prematurely would make
-                // the completion event claim a height the wallet
-                // never actually scanned. (Codex 3rd-round finding.)
-                if (fresh_tip_height as u64) > current_tip_height {
-                    let fresh_bh = BlockHeight::from_u32(fresh_tip_height);
-                    match with_wallet_db_write_lock(
-                        "sync_engine.update_chain_tip.post_batch",
-                        || db.update_chain_tip(fresh_bh),
-                    ) {
-                        Ok(_) => {
-                            current_tip_height = fresh_tip_height as u64;
-                        }
-                        Err(e) => {
-                            log::warn!(
+        // Keep fresh-tip lookup and pending-send resubmit paired, but avoid
+        // doing both after every quiet batch in a long cold sync. Activity,
+        // the configured cadence, and the range boundary always trigger it.
+        let run_resubmit = should_run_post_batch_resubmit(
+            batch_found_tx,
+            end == range.block_range().end,
+            fetch_batches,
+            resubmit_every,
+        );
+        if run_resubmit {
+            if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode
+            {
+                log::info!(
+                    "[{}] sync: cancel/mode observed before post-batch resubmit, exiting",
+                    elapsed(),
+                );
+                return Ok(());
+            }
+
+            let resubmit_start = std::time::Instant::now();
+            match get_latest_block(&mut client)
+                .await
+                .map(|tip| tip.height as u32)
+            {
+                Ok(fresh_tip_height) => {
+                    if (fresh_tip_height as u64) > current_tip_height {
+                        let fresh_height = BlockHeight::from_u32(fresh_tip_height);
+                        match with_wallet_db_write_lock(
+                            "sync_engine.update_chain_tip.post_batch",
+                            || db.update_chain_tip(fresh_height),
+                        ) {
+                            Ok(()) => current_tip_height = fresh_tip_height as u64,
+                            Err(e) => log::warn!(
                                 "[{}] sync: post-batch update_chain_tip({fresh_tip_height}) \
                                  failed, keeping tip at {current_tip_height}: {e}",
                                 elapsed(),
-                            );
+                            ),
                         }
                     }
+                    last_tip_refresh = std::time::Instant::now();
+                    let _ = crate::wallet::sync::resubmit_pending_transactions(
+                        db_data_path,
+                        &mut client,
+                        fresh_tip_height,
+                        || {
+                            cancel.load(Ordering::Relaxed)
+                                || desired_mode.load(Ordering::SeqCst) != running_mode
+                        },
+                    )
+                    .await;
                 }
-                let _ = crate::wallet::sync::resubmit_pending_transactions(
-                    db_data_path,
-                    &mut client,
-                    fresh_tip_height,
-                    || {
-                        cancel.load(Ordering::Relaxed)
-                            || desired_mode.load(Ordering::SeqCst) != running_mode
-                    },
-                )
-                .await;
-            }
-            Err(e) => {
-                log::warn!(
+                Err(e) => log::warn!(
                     "[{}] sync: resubmit tip refresh failed, skipping pass: {e}",
                     elapsed(),
-                );
+                ),
             }
+            resubmit_total += resubmit_start.elapsed();
+            resubmit_passes += 1;
         }
         if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode {
-            log::info!("[{}] sync: exiting after resubmit pass", elapsed());
+            log::info!("[{}] sync: exiting after post-batch work", elapsed());
             return Ok(());
         }
 
         // Report progress
-        let has_new_tx = scan_summary.received_sapling_note_count() > 0
-            || scan_summary.spent_sapling_note_count() > 0
-            || scan_summary.received_orchard_note_count() > 0
-            || scan_summary.spent_orchard_note_count() > 0;
+        let has_new_tx = batch_found_tx;
         let post_ranges = db
             .suggest_scan_ranges()
             .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?;
@@ -2108,6 +2097,13 @@ async fn run_sync_impl(
         fetch_wait_total.as_secs_f64(),
         fetch_batches,
         stale_prefetches,
+    );
+    log::info!(
+        "[{}] sync: resubmit/tip refresh {:.2}s over {} passes (cadence={})",
+        elapsed(),
+        resubmit_total.as_secs_f64(),
+        resubmit_passes,
+        resubmit_every,
     );
     match transparent_receive_cache::refresh_all_from_wallet_db(
         db_data_path,
@@ -2371,6 +2367,18 @@ mod tests {
         assert!(can_spawn_prefetch(1, 4, 10, 10, 100, 10_000));
         assert!(!can_spawn_prefetch(1, 4, 10, 10, 400, 10_000));
         assert!(!can_spawn_prefetch(4, 4, 0, 1, 1, u64::MAX));
+    }
+
+    #[test]
+    fn post_batch_resubmit_cadence_preserves_activity_and_range_end() {
+        let every = RESUBMIT_EVERY_BATCHES;
+        assert!(!should_run_post_batch_resubmit(false, false, 1, every));
+        assert!(!should_run_post_batch_resubmit(false, false, 15, every));
+        assert!(should_run_post_batch_resubmit(false, false, 16, every));
+        assert!(should_run_post_batch_resubmit(true, false, 3, every));
+        assert!(should_run_post_batch_resubmit(false, true, 3, every));
+        assert!(should_run_post_batch_resubmit(false, false, 1, 1));
+        assert!(should_run_post_batch_resubmit(false, false, 7, 0));
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -162,7 +162,7 @@ fn effective_base_batch_size(default_batch_size: u32) -> u32 {
     default_batch_size
 }
 
-fn env_override_clamped(name: &str, default: u64, min: u64, max: u64) -> u64 {
+pub(super) fn env_override_clamped(name: &str, default: u64, min: u64, max: u64) -> u64 {
     std::env::var(name)
         .ok()
         .and_then(|value| value.parse::<u64>().ok())
@@ -188,7 +188,7 @@ fn effective_resubmit_every() -> u64 {
     )
 }
 
-fn should_run_post_batch_resubmit(
+fn should_run_post_batch_passes(
     batch_found_tx: bool,
     is_last_batch_of_range: bool,
     batch_index: u64,
@@ -1260,10 +1260,9 @@ async fn run_sync_impl(
             .map_err(|e| SyncError::db(format!("update_chain_tip: {e}")))
     })?;
 
-    // Match the cancellation granularity we already use for
-    // `run_enhancement`: let this stage run to completion once it has
-    // started, but don't enter it (or continue past it) after a
-    // cancel/mode change has already been observed.
+    // The upstream transparent UTXO refresh does not accept a cancellation
+    // predicate, so don't enter it (or continue past it) after a cancel/mode
+    // change has already been observed.
     if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode {
         log::info!(
             "[{}] sync: cancel/mode observed before transparent UTXO refresh, skipping",
@@ -1418,6 +1417,9 @@ async fn run_sync_impl(
     let resubmit_every = effective_resubmit_every();
     let mut resubmit_total = std::time::Duration::ZERO;
     let mut resubmit_passes = 0u64;
+    let mut enhancement_total = std::time::Duration::ZERO;
+    let mut enhancement_passes = 0u64;
+    let mut final_enhancement_drain_needed = true;
     log::info!(
         "[{}] sync: prefetch depth={}, resident budget={} MiB",
         elapsed(),
@@ -1905,19 +1907,42 @@ async fn run_sync_impl(
             || scan_summary.received_orchard_note_count() > 0
             || scan_summary.spent_orchard_note_count() > 0;
 
-        // Enhancement
-        run_enhancement(&mut client, &mut db, db_data_path, network).await?;
-
-        // Keep fresh-tip lookup and pending-send resubmit paired, but avoid
-        // doing both after every quiet batch in a long cold sync. Activity,
-        // the configured cadence, and the range boundary always trigger it.
-        let run_resubmit = should_run_post_batch_resubmit(
+        let run_post_batch_passes = should_run_post_batch_passes(
             batch_found_tx,
             end == range.block_range().end,
             fetch_batches,
             resubmit_every,
         );
-        if run_resubmit {
+        let should_exit = || {
+            cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode
+        };
+        let mut has_new_tx = batch_found_tx;
+
+        if run_post_batch_passes {
+            let enhancement_start = std::time::Instant::now();
+            match run_enhancement(&mut client, &mut db, db_data_path, network, &should_exit).await {
+                Ok(outcome) => {
+                    has_new_tx |= outcome.stored > 0;
+                    final_enhancement_drain_needed = !outcome.drained;
+                }
+                Err(e) => {
+                    final_enhancement_drain_needed = true;
+                    log::warn!(
+                        "[{}] sync: enhancement pass failed (queue retained): {e}",
+                        elapsed()
+                    );
+                }
+            }
+            enhancement_total += enhancement_start.elapsed();
+            enhancement_passes += 1;
+        } else {
+            final_enhancement_drain_needed = true;
+        }
+
+        // Keep fresh-tip lookup and pending-send resubmit paired, but avoid
+        // doing both after every quiet batch in a long cold sync. Activity,
+        // the configured cadence, and the range boundary always trigger it.
+        if run_post_batch_passes {
             if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode
             {
                 log::info!(
@@ -1939,7 +1964,13 @@ async fn run_sync_impl(
                             "sync_engine.update_chain_tip.post_batch",
                             || db.update_chain_tip(fresh_height),
                         ) {
-                            Ok(()) => current_tip_height = fresh_tip_height as u64,
+                            Ok(()) => {
+                                current_tip_height = fresh_tip_height as u64;
+                                // The address-history request ranges may now
+                                // extend beyond the enhancement pass that ran
+                                // immediately before this refresh.
+                                final_enhancement_drain_needed = true;
+                            }
                             Err(e) => log::warn!(
                                 "[{}] sync: post-batch update_chain_tip({fresh_tip_height}) \
                                  failed, keeping tip at {current_tip_height}: {e}",
@@ -1973,7 +2004,6 @@ async fn run_sync_impl(
         }
 
         // Report progress
-        let has_new_tx = batch_found_tx;
         let post_ranges = db
             .suggest_scan_ranges()
             .map_err(|e| SyncError::db(format!("suggest_scan_ranges: {e}")))?;
@@ -2083,6 +2113,44 @@ async fn run_sync_impl(
         }
     }
 
+    if final_enhancement_drain_needed
+        && !cancel.load(Ordering::Relaxed)
+        && desired_mode.load(Ordering::SeqCst) == running_mode
+    {
+        let should_exit = || {
+            cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode
+        };
+        let enhancement_start = std::time::Instant::now();
+        let final_outcome =
+            run_enhancement(&mut client, &mut db, db_data_path, network, &should_exit).await?;
+        enhancement_total += enhancement_start.elapsed();
+        enhancement_passes += 1;
+        if should_exit() {
+            log::info!(
+                "[{}] sync: exiting during final enhancement pass",
+                elapsed()
+            );
+            return Ok(());
+        }
+        if final_outcome.stored > 0 {
+            log::info!(
+                "[{}] sync: final enhancement pass stored {} transaction(s)",
+                elapsed(),
+                final_outcome.stored,
+            );
+        }
+        if !final_outcome.drained {
+            // Intermediate passes are best-effort so scanning can continue,
+            // but completion must preserve the previous correctness contract:
+            // transiently unserviceable enhancement work triggers the outer
+            // retry loop instead of reporting a fully-complete sync with an
+            // incomplete transaction-history queue.
+            return Err(SyncError::net(
+                "final transaction enhancement queue was not drained",
+            ));
+        }
+    }
+
     let (final_scanned_height, final_tip_height) =
         ensure_complete_scan_state(&db, current_tip_height)?;
     log::info!(
@@ -2104,6 +2172,12 @@ async fn run_sync_impl(
         resubmit_total.as_secs_f64(),
         resubmit_passes,
         resubmit_every,
+    );
+    log::info!(
+        "[{}] sync: enhancement {:.2}s over {} passes",
+        elapsed(),
+        enhancement_total.as_secs_f64(),
+        enhancement_passes,
     );
     match transparent_receive_cache::refresh_all_from_wallet_db(
         db_data_path,
@@ -2370,15 +2444,15 @@ mod tests {
     }
 
     #[test]
-    fn post_batch_resubmit_cadence_preserves_activity_and_range_end() {
+    fn post_batch_pass_cadence_preserves_activity_and_range_end() {
         let every = RESUBMIT_EVERY_BATCHES;
-        assert!(!should_run_post_batch_resubmit(false, false, 1, every));
-        assert!(!should_run_post_batch_resubmit(false, false, 15, every));
-        assert!(should_run_post_batch_resubmit(false, false, 16, every));
-        assert!(should_run_post_batch_resubmit(true, false, 3, every));
-        assert!(should_run_post_batch_resubmit(false, true, 3, every));
-        assert!(should_run_post_batch_resubmit(false, false, 1, 1));
-        assert!(should_run_post_batch_resubmit(false, false, 7, 0));
+        assert!(!should_run_post_batch_passes(false, false, 1, every));
+        assert!(!should_run_post_batch_passes(false, false, 15, every));
+        assert!(should_run_post_batch_passes(false, false, 16, every));
+        assert!(should_run_post_batch_passes(true, false, 3, every));
+        assert!(should_run_post_batch_passes(false, true, 3, every));
+        assert!(should_run_post_batch_passes(false, false, 1, 1));
+        assert!(should_run_post_batch_passes(false, false, 7, 0));
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -21,9 +21,9 @@ use zcash_protocol::consensus::{BlockHeight, NetworkUpgrade, Parameters};
 
 use crate::wallet::{
     db::{
-        open_readonly_conn_with_timeout, open_wallet_db_with_timeout,
-        open_wallet_raw_conn_with_timeout, with_wallet_db_write_lock, WalletDatabase,
-        SYNC_DB_BUSY_TIMEOUT,
+        open_readonly_conn_with_timeout, open_sync_wallet_db_with_timeout,
+        open_wallet_raw_conn_with_timeout, truncate_wallet_wal_best_effort,
+        with_wallet_db_write_lock, WalletDatabase, SYNC_DB_BUSY_TIMEOUT,
     },
     keys,
     network::WalletNetwork,
@@ -1927,6 +1927,7 @@ async fn run_sync_impl(
             e
         ),
     }
+    truncate_wallet_wal_best_effort(db_data_path);
     // Final progress
     let final_progress = SyncProgressEvent {
         scanned_height: final_scanned_height,
@@ -1947,7 +1948,7 @@ async fn run_sync_impl(
 // ==================== Helpers ====================
 
 fn open_db(path: &str, network: WalletNetwork) -> Result<WalletDatabase, SyncError> {
-    open_wallet_db_with_timeout(path, network, SYNC_DB_BUSY_TIMEOUT)
+    open_sync_wallet_db_with_timeout(path, network, SYNC_DB_BUSY_TIMEOUT)
         .map_err(|e| SyncError::db(format!("DB open: {e}")))
 }
 

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -1516,6 +1516,36 @@ async fn run_sync_impl(
                     prefetch.clear();
                     continue;
                 } else {
+                    // The resubmit/tip-refresh pass is intentionally
+                    // cadence-gated during long quiet scans. Before claiming
+                    // completion, obtain an authoritative tip once more so a
+                    // block mined since the last cadence tick cannot be
+                    // silently omitted from the scan queue.
+                    let final_tip = get_latest_block(&mut client).await?;
+                    let final_tip_height =
+                        block_height_from_u64(final_tip.height, "final lightwalletd tip height")?;
+                    let final_tip_height_u64 = u32::from(final_tip_height) as u64;
+                    if final_tip_height_u64 != current_tip_height {
+                        with_wallet_db_write_lock(
+                            "sync_engine.update_chain_tip.completion_refresh",
+                            || {
+                                db.update_chain_tip(final_tip_height).map_err(|e| {
+                                    SyncError::db(format!(
+                                        "update_chain_tip({final_tip_height_u64}) before completion: {e}"
+                                    ))
+                                })
+                            },
+                        )?;
+                        log::info!(
+                            "[{}] sync: completion tip advanced {} -> {}; rescanning newly queued ranges",
+                            elapsed(),
+                            current_tip_height,
+                            final_tip_height_u64,
+                        );
+                        current_tip_height = final_tip_height_u64;
+                        prefetch.clear();
+                        continue;
+                    }
                     ensure_complete_scan_state(&db, current_tip_height)?;
                     break;
                 }

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -53,7 +53,7 @@ pub(crate) mod mempool;
 
 use enhance::run_enhancement;
 pub(crate) use error::SyncError;
-use error::{RecoveryStrategy, MAX_REWINDS_PER_RUN, REWIND_DISTANCE};
+use error::{RecoveryStrategy, MAX_REWINDS_PER_RUN};
 use lwd::{download_blocks, download_subtree_roots, get_tree_state};
 pub(crate) use lwd::{
     get_latest_block, get_taddress_txids, next_stream_message, open_lwd_channel, send_transaction,
@@ -666,36 +666,173 @@ fn ensure_complete_scan_state(
     Ok((fully_scanned_height, db_tip_height))
 }
 
-fn rewind_for_canonical_tip_mismatch(
+async fn canonical_chain_state_at(
+    client: &mut CompactTxStreamerClient<Channel>,
+    height: BlockHeight,
+) -> Result<chain::ChainState, SyncError> {
+    let state = get_tree_state(client, u32::from(height) as u64)
+        .await?
+        .to_chain_state()
+        .map_err(|e| SyncError::parse(format!("parse canonical tree state at {height}: {e}")))?;
+    if state.block_height() != height {
+        return Err(SyncError::parse(format!(
+            "lightwalletd returned tree state for {}, requested {height}",
+            state.block_height(),
+        )));
+    }
+    Ok(state)
+}
+
+/// librustzcash deliberately retains received-note rows when a transaction is
+/// unmined by a rewind so memo and sent-note history are not lost. The retained
+/// commitment-tree position and Sapling/Orchard nullifier, however, belong to
+/// the orphaned branch. Clear only that re-derivable chain metadata so
+/// `check_witnesses` does not ask shardtree for an orphaned leaf and a later
+/// re-mining can store the note's new position/nullifier.
+fn clear_unmined_note_tree_metadata(db_path: &str) -> Result<usize, SyncError> {
+    with_wallet_db_write_lock("sync_engine.clear_unmined_note_tree_metadata", || {
+        let mut conn = open_wallet_raw_conn_with_timeout(db_path, SYNC_DB_BUSY_TIMEOUT)
+            .map_err(|e| SyncError::db(format!("open wallet DB for orphan-note cleanup: {e}")))?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| SyncError::db(format!("begin orphan-note cleanup: {e}")))?;
+        let mut cleared = 0usize;
+        for table in ["sapling_received_notes", "orchard_received_notes"] {
+            cleared += tx
+                .execute(
+                    &format!(
+                        "UPDATE {table}
+                         SET commitment_tree_position = NULL, nf = NULL
+                         WHERE commitment_tree_position IS NOT NULL
+                         AND EXISTS (
+                            SELECT 1 FROM transactions tx
+                            WHERE tx.id_tx = {table}.transaction_id
+                            AND tx.mined_height IS NULL
+                         )"
+                    ),
+                    [],
+                )
+                .map_err(|e| SyncError::db(format!("clear orphaned metadata in {table}: {e}")))?;
+        }
+        tx.commit()
+            .map_err(|e| SyncError::db(format!("commit orphan-note cleanup: {e}")))?;
+        Ok(cleared)
+    })
+}
+
+async fn rewind_for_canonical_tip_mismatch(
+    client: &mut CompactTxStreamerClient<Channel>,
     db: &mut WalletDatabase,
+    db_path: &str,
     remote_tip: BlockHeight,
+    remote_tip_hash: BlockHash,
 ) -> Result<u64, SyncError> {
     let mismatch_height = u32::from(remote_tip) as u64;
-    let requested = BlockHeight::from_u32(
-        u32::from(remote_tip).saturating_sub(u32::try_from(REWIND_DISTANCE).unwrap_or(10)),
-    );
-    let actual = with_wallet_db_write_lock(
-        "sync_engine.truncate_to_height.canonical_tip_mismatch",
-        || {
-            match db.truncate_to_height(requested) {
-            Ok(height) => Ok(height),
-            Err(SqliteClientError::RequestedRewindInvalid {
-                safe_rewind_height: Some(safe),
-                ..
-            }) => db.truncate_to_height(safe).map_err(|e| {
-                SyncError::db(format!(
-                    "truncate_to_height({safe}) after canonical tip mismatch: {e}"
-                ))
-            }),
-            Err(e) if is_sqlite_lock_contention(&e) => Err(SyncError::other(format!(
-                "truncate_to_height({requested}) after canonical tip mismatch: SQLite lock contention: {e}"
-            ))),
-            Err(e) => Err(SyncError::db(format!(
-                "truncate_to_height({requested}) after canonical tip mismatch: {e}"
-            ))),
-        }
-        },
-    )?;
+    let remote_tip_u32 = u32::from(remote_tip);
+    let local_tip_hash = db
+        .get_block_hash(remote_tip)
+        .map_err(|e| SyncError::db(format!("get wallet block hash at {remote_tip}: {e}")))?;
+
+    // A backward-moving tip can still be on the same branch. In that case a
+    // direct height truncation is sufficient and avoids a tree-state RPC.
+    let rewind_anchor = if local_tip_hash == Some(remote_tip_hash) {
+        with_wallet_db_write_lock("sync_engine.truncate_to_height.backward_tip", || {
+            db.truncate_to_height(remote_tip).map_err(|e| {
+                if is_sqlite_lock_contention(&e) {
+                    SyncError::other(format!(
+                        "truncate_to_height({remote_tip}): SQLite lock contention: {e}"
+                    ))
+                } else {
+                    SyncError::db(format!("truncate_to_height({remote_tip}): {e}"))
+                }
+            })
+        })?
+    } else {
+        // Hash mismatch means the fork point is unknown. A fixed ten-block
+        // rewind can splice a canonical batch onto an orphaned commitment
+        // frontier when the reorg is deeper. Find the highest common ancestor
+        // with exponentially spaced probes, then binary-search the boundary.
+        // This costs O(log reorg_depth) tree-state RPCs on the rare reorg path.
+        let mut last_mismatch = remote_tip_u32;
+        let mut distance = 1u32;
+        let (anchor_state, found_common_ancestor) = loop {
+            let candidate_u32 = remote_tip_u32.saturating_sub(distance);
+            let candidate = BlockHeight::from_u32(candidate_u32);
+            let state = canonical_chain_state_at(client, candidate).await?;
+            let local_hash = db
+                .get_block_hash(candidate)
+                .map_err(|e| SyncError::db(format!("get wallet block hash at {candidate}: {e}")))?;
+
+            if local_hash == Some(state.block_hash()) {
+                // `candidate` is equal and `last_mismatch` is unequal. Locate
+                // the highest equal height so the rescan is no larger than
+                // necessary while still preserving a valid old frontier.
+                let mut low_equal = candidate_u32;
+                let mut high_mismatch = last_mismatch;
+                let mut low_state = state;
+                while high_mismatch.saturating_sub(low_equal) > 1 {
+                    let mid_u32 = low_equal + (high_mismatch - low_equal) / 2;
+                    let mid = BlockHeight::from_u32(mid_u32);
+                    let mid_state = canonical_chain_state_at(client, mid).await?;
+                    let mid_local_hash = db.get_block_hash(mid).map_err(|e| {
+                        SyncError::db(format!("get wallet block hash at {mid}: {e}"))
+                    })?;
+                    if mid_local_hash == Some(mid_state.block_hash()) {
+                        low_equal = mid_u32;
+                        low_state = mid_state;
+                    } else {
+                        high_mismatch = mid_u32;
+                    }
+                }
+                break (low_state, true);
+            }
+
+            // If wallet block metadata is no longer retained, the canonical
+            // state at this lower height is still a safe reset anchor;
+            // truncate_to_chain_state can inject its frontiers below the
+            // retained checkpoint window without vendoring shardtree.
+            if candidate_u32 == 0 || local_hash.is_none() {
+                break (state, false);
+            }
+
+            last_mismatch = candidate_u32;
+            distance = distance.saturating_mul(2).min(remote_tip_u32);
+        };
+        let anchor_height = anchor_state.block_height();
+        with_wallet_db_write_lock(
+            "sync_engine.truncate_to_chain_state.canonical_tip_mismatch",
+            || {
+                db.truncate_to_chain_state(anchor_state).map_err(|e| {
+                    if is_sqlite_lock_contention(&e) {
+                        SyncError::other(format!(
+                            "truncate_to_chain_state({anchor_height}): SQLite lock contention: {e}"
+                        ))
+                    } else {
+                        SyncError::db(format!("truncate_to_chain_state({anchor_height}): {e}"))
+                    }
+                })
+            },
+        )?;
+        log::warn!(
+            "[{}] sync: canonical mismatch selected rewind anchor {} ({})",
+            elapsed(),
+            anchor_height,
+            if found_common_ancestor {
+                "highest common ancestor"
+            } else {
+                "canonical frontier fallback"
+            },
+        );
+        anchor_height
+    };
+    let cleared_notes = clear_unmined_note_tree_metadata(db_path)?;
+    if cleared_notes > 0 {
+        log::info!(
+            "[{}] sync: cleared orphan-branch tree metadata from {} unmined note(s)",
+            elapsed(),
+            cleared_notes,
+        );
+    }
 
     let ranges = with_wallet_db_write_lock(
         "sync_engine.update_chain_tip.canonical_tip_mismatch",
@@ -716,10 +853,10 @@ fn rewind_for_canonical_tip_mismatch(
     log::warn!(
         "[{}] sync: canonical tip mismatch rewound wallet to {} and queued {} block(s)",
         elapsed(),
-        u32::from(actual),
+        u32::from(rewind_anchor),
         pending,
     );
-    if u32::from(actual) < u32::from(remote_tip) && pending == 0 {
+    if u32::from(rewind_anchor) < u32::from(remote_tip) && pending == 0 {
         return Err(SyncError::continuity(
             mismatch_height,
             "canonical tip rewind produced no pending scan ranges",
@@ -827,6 +964,7 @@ fn queue_witness_repairs_if_needed(
 async fn repair_anchor_root_mismatch_if_needed(
     client: &mut CompactTxStreamerClient<Channel>,
     db: &mut WalletDatabase,
+    db_path: &str,
     current_tip_height: u64,
     repair_passes_this_run: &mut u32,
 ) -> Result<Option<u64>, SyncError> {
@@ -943,6 +1081,15 @@ async fn repair_anchor_root_mismatch_if_needed(
                 continue;
             }
         };
+
+        let cleared_notes = clear_unmined_note_tree_metadata(db_path)?;
+        if cleared_notes > 0 {
+            log::info!(
+                "[{}] sync: cleared orphan-branch tree metadata from {} unmined note(s)",
+                elapsed(),
+                cleared_notes,
+            );
+        }
 
         let pending_blocks = pending_scan_blocks(&post_rewind_ranges);
         let first_pending =
@@ -1592,6 +1739,7 @@ async fn run_sync_impl(
                 } else if let Some(repair_pending_blocks) = repair_anchor_root_mismatch_if_needed(
                     &mut client,
                     &mut db,
+                    db_data_path,
                     current_tip_height,
                     &mut anchor_root_repair_passes_this_run,
                 )
@@ -1659,7 +1807,14 @@ async fn run_sync_impl(
                         .unwrap_or(false)
                         || (local_covers_remote && local_hash != Some(final_tip_hash));
                     if canonical_mismatch {
-                        let pending = rewind_for_canonical_tip_mismatch(&mut db, final_tip_height)?;
+                        let pending = rewind_for_canonical_tip_mismatch(
+                            &mut client,
+                            &mut db,
+                            db_data_path,
+                            final_tip_height,
+                            final_tip_hash,
+                        )
+                        .await?;
                         current_tip_height = final_tip_height_u64;
                         initial_total = pending;
                         prev_remaining = pending;
@@ -1856,14 +2011,42 @@ async fn run_sync_impl(
         let DownloadedBatch {
             block_source,
             from_state,
+            synthetic_start_anchor,
             ..
         } = batch;
+
+        // The downloaded blocks and tree state may be mutually consistent
+        // while still starting from a different branch than the wallet DB.
+        // Compare the canonical start-state hash with our retained predecessor
+        // before touching commitment trees; otherwise a deep reorg can splice
+        // a new suffix onto an orphaned frontier without a prev-hash error.
+        let local_anchor_mismatch = if synthetic_start_anchor {
+            None
+        } else {
+            let anchor_height = from_state.block_height();
+            let local_anchor = db.get_block_hash(anchor_height).map_err(|e| {
+                SyncError::db(format!(
+                    "get wallet batch anchor hash at {anchor_height}: {e}"
+                ))
+            })?;
+            local_anchor
+                .filter(|hash| *hash != from_state.block_hash())
+                .map(|local_hash| {
+                    SyncError::continuity(
+                        u32::from(start) as u64,
+                        format!(
+                            "wallet anchor {anchor_height} hash {local_hash:?} differs from canonical {:?}",
+                            from_state.block_hash(),
+                        ),
+                    )
+                })
+        };
 
         // Start the next download before entering the synchronous scanner so
         // desktop's multi-thread runtime can overlap network I/O with the
         // current batch's CPU/SQLite work. Mobile defaults prefetch off because
         // its current-thread background runtime cannot provide this overlap.
-        if !cancel.load(Ordering::Relaxed) {
+        if local_anchor_mismatch.is_none() && !cancel.load(Ordering::Relaxed) {
             let range_end = range.block_range().end;
             let mut prefetch_start = prefetch.back().map(|item| item.end).unwrap_or(end);
             while prefetch_start < range_end {
@@ -1933,16 +2116,20 @@ async fn run_sync_impl(
         // becomes `SyncError::Db` (Fatal). Everything else (non-scan,
         // non-wallet — e.g. block-source errors, unrecognised scan
         // variants) becomes `SyncError::Other` (retry-with-backoff).
-        let scan_result = with_wallet_db_write_lock("sync_engine.scan_cached_blocks", || {
-            scan_cached_blocks(
-                &network,
-                &block_source,
-                &mut db,
-                start,
-                &from_state,
-                batch_size as usize,
-            )
-            .map_err(|e| match e {
+        let scan_result = if let Some(anchor_error) = local_anchor_mismatch {
+            prefetch.clear();
+            Err(anchor_error)
+        } else {
+            with_wallet_db_write_lock("sync_engine.scan_cached_blocks", || {
+                scan_cached_blocks(
+                    &network,
+                    &block_source,
+                    &mut db,
+                    start,
+                    &from_state,
+                    batch_size as usize,
+                )
+                .map_err(|e| match e {
                 ChainError::Scan(scan_err) if scan_err.is_continuity_error() => {
                     let at_height = u32::from(scan_err.at_height()) as u64;
                     SyncError::continuity(at_height, scan_err.to_string())
@@ -1974,9 +2161,10 @@ async fn run_sync_impl(
                         SyncError::db(format!("scan wallet: {wallet_err}"))
                     }
                 }
-                other => SyncError::other(format!("scan: {other}")),
+                    other => SyncError::other(format!("scan: {other}")),
+                })
             })
-        });
+        };
 
         // Handle the scan result. On a reorg we rewind the wallet to
         // `at_height - REWIND_DISTANCE` (bounded by `truncate_to_height`'s
@@ -2084,6 +2272,14 @@ async fn run_sync_impl(
                             }
                         },
                     )?;
+                    let cleared_notes = clear_unmined_note_tree_metadata(db_data_path)?;
+                    if cleared_notes > 0 {
+                        log::info!(
+                            "[{}] sync: cleared orphan-branch tree metadata from {} unmined note(s)",
+                            elapsed(),
+                            cleared_notes,
+                        );
+                    }
                     let current_tip = BlockHeight::from_u32(current_tip_height as u32);
                     let post_rewind_ranges = with_wallet_db_write_lock(
                         "sync_engine.update_chain_tip.after_rewind",

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -85,8 +85,14 @@ const BATCH_SIZE_FOREGROUND: u32 = 2000;
 const BATCH_SIZE_FOREGROUND: u32 = 1000;
 const BATCH_SIZE_BACKGROUND: u32 = 300;
 
-const PREFETCH_DEPTH_FOREGROUND: usize = 4;
-const PREFETCH_DEPTH_BACKGROUND: usize = 2;
+// Each prefetched batch performs a compact-block stream plus boundary
+// tree-state validation. A depth greater than one therefore multiplies
+// lightwalletd RPC pressure without improving scan throughput on the
+// single-threaded mobile runtime. Keep one look-ahead by default; operators
+// can opt into a deeper queue after measuring their endpoint and memory
+// budget, or set it to zero to disable prefetching entirely.
+const PREFETCH_DEPTH_FOREGROUND: usize = 1;
+const PREFETCH_DEPTH_BACKGROUND: usize = 1;
 
 /// The resident-memory estimate applies a conservative multiplier to the
 /// encoded compact-block size to account for decoded vectors and allocations.
@@ -176,7 +182,7 @@ fn effective_prefetch_depth(running_mode: u8) -> usize {
     } else {
         PREFETCH_DEPTH_FOREGROUND
     };
-    env_override_clamped("ZCASH_SYNC_PREFETCH_DEPTH", default as u64, 1, 16) as usize
+    env_override_clamped("ZCASH_SYNC_PREFETCH_DEPTH", default as u64, 0, 16) as usize
 }
 
 fn effective_resubmit_every() -> u64 {

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -2594,13 +2594,19 @@ async fn run_sync_impl(
     };
     progress_fn(final_progress);
 
-    // Completion must not wait behind a potentially busy checkpoint. Drop the
-    // long-lived sync connection first, then perform best-effort WAL
-    // maintenance on the blocking pool after the user-visible completion
-    // event has been delivered.
+    // Completion must not wait behind a potentially busy checkpoint. Both the
+    // FRB and iOS FFI entry points create a Tokio runtime per sync call, and
+    // dropping that runtime waits for its `spawn_blocking` tasks. Use a
+    // detached OS thread so the sync call and SYNC_RUNNING flag can finish
+    // independently after the user-visible completion event is delivered.
     drop(db);
     let checkpoint_path = db_data_path.to_string();
-    tokio::task::spawn_blocking(move || truncate_wallet_wal_best_effort(&checkpoint_path));
+    if let Err(e) = std::thread::Builder::new()
+        .name("zcash-wal-checkpoint".into())
+        .spawn(move || truncate_wallet_wal_best_effort(&checkpoint_path))
+    {
+        log::warn!("wallet DB WAL checkpoint thread could not start (harmless): {e}");
+    }
 
     Ok(())
 }

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -11,7 +11,7 @@ use zcash_client_backend::{
         chain::{self, error::Error as ChainError, scan_cached_blocks},
         scanning::{ScanPriority, ScanRange},
         wallet::ConfirmationsPolicy,
-        WalletCommitmentTrees, WalletRead, WalletWrite,
+        TransactionDataRequest, WalletCommitmentTrees, WalletRead, WalletWrite,
     },
     proto::service,
 };
@@ -53,7 +53,7 @@ pub(crate) mod mempool;
 
 use enhance::run_enhancement;
 pub(crate) use error::SyncError;
-use error::{RecoveryStrategy, MAX_REWINDS_PER_RUN};
+use error::{RecoveryStrategy, MAX_REWINDS_PER_RUN, REWIND_DISTANCE};
 use lwd::{download_blocks, download_subtree_roots, get_tree_state};
 pub(crate) use lwd::{
     get_latest_block, get_taddress_txids, next_stream_message, open_lwd_channel, send_transaction,
@@ -85,14 +85,18 @@ const BATCH_SIZE_FOREGROUND: u32 = 2000;
 const BATCH_SIZE_FOREGROUND: u32 = 1000;
 const BATCH_SIZE_BACKGROUND: u32 = 300;
 
-// Each prefetched batch performs a compact-block stream plus boundary
-// tree-state validation. A depth greater than one therefore multiplies
-// lightwalletd RPC pressure without improving scan throughput on the
-// single-threaded mobile runtime. Keep one look-ahead by default; operators
-// can opt into a deeper queue after measuring their endpoint and memory
-// budget, or set it to zero to disable prefetching entirely.
+// Desktop uses one look-ahead batch. Mobile sync can run on a current-thread
+// Tokio runtime (notably the iOS background FFI), where a spawned network task
+// cannot make progress while scan_cached_blocks is executing synchronously;
+// defaulting prefetch off avoids extra RPC and memory pressure there.
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 const PREFETCH_DEPTH_FOREGROUND: usize = 1;
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+const PREFETCH_DEPTH_FOREGROUND: usize = 0;
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 const PREFETCH_DEPTH_BACKGROUND: usize = 1;
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+const PREFETCH_DEPTH_BACKGROUND: usize = 0;
 
 /// The resident-memory estimate applies a conservative multiplier to the
 /// encoded compact-block size to account for decoded vectors and allocations.
@@ -103,7 +107,9 @@ const PREFETCH_SANDBLASTING_WIRE_BYTES_PER_BLOCK: u64 = 90 * 1024;
 const PREFETCH_RESIDENT_BUDGET: u64 = 128 * 1024 * 1024;
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 const PREFETCH_RESIDENT_BUDGET: u64 = 32 * 1024 * 1024;
-const RESUBMIT_EVERY_BATCHES: u64 = 16;
+const TIP_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+const STATUS_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+const RESUBMIT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(120);
 const TRANSPARENT_UTXO_RECENT_EXTERNAL_LIMIT: usize = 20;
 const TRANSPARENT_UTXO_SWEEP_EXTERNAL_LIMIT: usize = 20;
 
@@ -182,30 +188,22 @@ fn effective_prefetch_depth(running_mode: u8) -> usize {
     } else {
         PREFETCH_DEPTH_FOREGROUND
     };
-    env_override_clamped("ZCASH_SYNC_PREFETCH_DEPTH", default as u64, 0, 16) as usize
+    env_override_clamped("ZCASH_SYNC_PREFETCH_DEPTH", default as u64, 0, 1) as usize
 }
 
-fn effective_resubmit_every() -> u64 {
-    env_override_clamped(
-        "ZCASH_SYNC_RESUBMIT_EVERY",
-        RESUBMIT_EVERY_BATCHES,
-        1,
-        u64::MAX,
-    )
-}
-
-fn should_run_post_batch_passes(
-    batch_found_tx: bool,
-    is_last_batch_of_range: bool,
-    batch_index: u64,
-    every: u64,
-) -> bool {
-    batch_found_tx || is_last_batch_of_range || batch_index % every.max(1) == 0
+fn effective_resubmit_interval() -> std::time::Duration {
+    std::time::Duration::from_secs(env_override_clamped(
+        "ZCASH_SYNC_RESUBMIT_INTERVAL_SECS",
+        RESUBMIT_INTERVAL.as_secs(),
+        10,
+        3_600,
+    ))
 }
 
 fn can_spawn_prefetch(
     queued_batches: usize,
     depth: usize,
+    current_wire_bytes: u64,
     queued_blocks: u64,
     next_batch_blocks: u64,
     estimated_wire_bytes_per_block: u64,
@@ -214,17 +212,14 @@ fn can_spawn_prefetch(
     if queued_batches >= depth {
         return false;
     }
-    // Preserve at least one look-ahead batch even when the preceding batch
-    // was unusually large. The chain's sandblasting batch cap bounds that
-    // single-batch overshoot.
-    if queued_batches == 0 {
-        return true;
-    }
-    queued_blocks
-        .saturating_add(next_batch_blocks)
-        .saturating_mul(estimated_wire_bytes_per_block)
+    current_wire_bytes
+        .saturating_add(
+            queued_blocks
+                .saturating_add(next_batch_blocks)
+                .saturating_mul(estimated_wire_bytes_per_block),
+        )
         .saturating_mul(PREFETCH_DECODED_MEMORY_FACTOR)
-        < resident_budget
+        <= resident_budget
 }
 
 fn prefetch_wire_floor(start: BlockHeight) -> u64 {
@@ -236,11 +231,41 @@ fn prefetch_wire_floor(start: BlockHeight) -> u64 {
     }
 }
 
+fn memory_bounded_batch_size(
+    base_batch_size: u32,
+    start: BlockHeight,
+    range_end: BlockHeight,
+    estimated_wire_bytes_per_block: u64,
+    resident_budget: u64,
+) -> u32 {
+    let protocol_cap = batch_size_for_range(base_batch_size, start, range_end);
+    let bytes_per_block = estimated_wire_bytes_per_block.max(prefetch_wire_floor(start));
+    let estimated_resident_per_block =
+        bytes_per_block.saturating_mul(PREFETCH_DECODED_MEMORY_FACTOR);
+    let memory_cap = if estimated_resident_per_block == 0 {
+        protocol_cap
+    } else {
+        (resident_budget / estimated_resident_per_block).clamp(1, u64::from(u32::MAX)) as u32
+    };
+    protocol_cap.min(memory_cap)
+}
+
 struct DownloadedBatch {
     block_source: block_source::MemoryBlockSource,
     from_state: chain::ChainState,
     canonical_end_hash_at_fetch: BlockHash,
     synthetic_start_anchor: bool,
+}
+
+#[derive(Clone, Copy)]
+enum EndValidationMode {
+    /// Validate the downloaded last block against a concurrently fetched
+    /// canonical end state before returning.
+    Immediate,
+    /// Defer the canonical end-state lookup until the prefetched batch is
+    /// consumed. This removes one redundant tree-state RPC per prefetched
+    /// batch while retaining a fresh fork check immediately before scan.
+    Deferred,
 }
 
 fn compact_hash(bytes: &[u8], context: &str) -> Result<BlockHash, String> {
@@ -618,12 +643,12 @@ fn ensure_complete_scan_state(
         )));
     };
 
-    if db_tip_height < current_tip_height {
+    if db_tip_height != current_tip_height {
         return Err(SyncError::continuity(
             current_tip_height,
             format!(
                 "sync completion blocked: wallet DB chain tip {db_tip_height} \
-                 lags lightwalletd tip {current_tip_height}"
+                 does not equal lightwalletd tip {current_tip_height}"
             ),
         ));
     }
@@ -639,6 +664,68 @@ fn ensure_complete_scan_state(
     }
 
     Ok((fully_scanned_height, db_tip_height))
+}
+
+fn rewind_for_canonical_tip_mismatch(
+    db: &mut WalletDatabase,
+    remote_tip: BlockHeight,
+) -> Result<u64, SyncError> {
+    let mismatch_height = u32::from(remote_tip) as u64;
+    let requested = BlockHeight::from_u32(
+        u32::from(remote_tip).saturating_sub(u32::try_from(REWIND_DISTANCE).unwrap_or(10)),
+    );
+    let actual = with_wallet_db_write_lock(
+        "sync_engine.truncate_to_height.canonical_tip_mismatch",
+        || {
+            match db.truncate_to_height(requested) {
+            Ok(height) => Ok(height),
+            Err(SqliteClientError::RequestedRewindInvalid {
+                safe_rewind_height: Some(safe),
+                ..
+            }) => db.truncate_to_height(safe).map_err(|e| {
+                SyncError::db(format!(
+                    "truncate_to_height({safe}) after canonical tip mismatch: {e}"
+                ))
+            }),
+            Err(e) if is_sqlite_lock_contention(&e) => Err(SyncError::other(format!(
+                "truncate_to_height({requested}) after canonical tip mismatch: SQLite lock contention: {e}"
+            ))),
+            Err(e) => Err(SyncError::db(format!(
+                "truncate_to_height({requested}) after canonical tip mismatch: {e}"
+            ))),
+        }
+        },
+    )?;
+
+    let ranges = with_wallet_db_write_lock(
+        "sync_engine.update_chain_tip.canonical_tip_mismatch",
+        || -> Result<Vec<ScanRange>, SyncError> {
+            db.update_chain_tip(remote_tip).map_err(|e| {
+                SyncError::db(format!(
+                    "update_chain_tip({mismatch_height}) after canonical mismatch: {e}"
+                ))
+            })?;
+            db.suggest_scan_ranges().map_err(|e| {
+                SyncError::db(format!(
+                    "suggest_scan_ranges after canonical tip mismatch: {e}"
+                ))
+            })
+        },
+    )?;
+    let pending = pending_scan_blocks(&ranges);
+    log::warn!(
+        "[{}] sync: canonical tip mismatch rewound wallet to {} and queued {} block(s)",
+        elapsed(),
+        u32::from(actual),
+        pending,
+    );
+    if u32::from(actual) < u32::from(remote_tip) && pending == 0 {
+        return Err(SyncError::continuity(
+            mismatch_height,
+            "canonical tip rewind produced no pending scan ranges",
+        ));
+    }
+    Ok(pending)
 }
 
 fn queue_witness_repairs_if_needed(
@@ -1385,20 +1472,14 @@ async fn run_sync_impl(
     let mut verify_phase_announced = false;
     let mut main_phase_announced = false;
 
-    /// If the scan loop has been running longer than this without
-    /// refreshing the chain tip from lightwalletd, we re-fetch
-    /// the tip and call `update_chain_tip` so that
-    /// `suggest_scan_ranges` incorporates any new blocks that
-    /// appeared while the wallet was catching up.
-    ///
-    /// Matches zcash-android-wallet-sdk's
-    /// `SYNCHRONIZATION_RESTART_TIMEOUT = 10.minutes`
-    /// (CompactBlockProcessor.kt:1197). We don't restart the
-    /// whole sync like the SDK does — just refreshing the tip is
-    /// enough because our `suggest_scan_ranges` call at the top
-    /// of each loop iteration already reflects the new tip once
-    /// `update_chain_tip` has written it to the DB.
-    const TIP_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(600);
+    // If the scan loop has been running longer than the configured interval without
+    // refreshing the chain tip from lightwalletd, we re-fetch
+    // the tip and call `update_chain_tip` so that
+    // `suggest_scan_ranges` incorporates any new blocks that
+    // appeared while the wallet was catching up.
+    //
+    // We don't restart the whole sync like the Android SDK does; refreshing
+    // the tip is enough because suggest_scan_ranges observes it immediately.
     let mut last_tip_refresh = std::time::Instant::now();
 
     type PrefetchResult = Result<DownloadedBatch, SyncError>;
@@ -1415,17 +1496,23 @@ async fn run_sync_impl(
         }
     }
     let prefetch_depth = effective_prefetch_depth(running_mode);
+    let batch_resident_budget = if prefetch_depth > 0 {
+        PREFETCH_RESIDENT_BUDGET / 2
+    } else {
+        PREFETCH_RESIDENT_BUDGET
+    };
     let mut prefetch: VecDeque<Prefetch> = VecDeque::new();
     let mut estimated_wire_bytes_per_block = 0u64;
     let mut fetch_wait_total = std::time::Duration::ZERO;
     let mut fetch_batches = 0u64;
     let mut stale_prefetches = 0u64;
-    let resubmit_every = effective_resubmit_every();
+    let resubmit_interval = effective_resubmit_interval();
+    let mut last_resubmit = std::time::Instant::now();
+    let mut last_status_poll = std::time::Instant::now();
     let mut resubmit_total = std::time::Duration::ZERO;
     let mut resubmit_passes = 0u64;
     let mut enhancement_total = std::time::Duration::ZERO;
     let mut enhancement_passes = 0u64;
-    let mut final_enhancement_drain_needed = true;
     log::info!(
         "[{}] sync: prefetch depth={}, resident budget={} MiB",
         elapsed(),
@@ -1516,15 +1603,71 @@ async fn run_sync_impl(
                     prefetch.clear();
                     continue;
                 } else {
-                    // The resubmit/tip-refresh pass is intentionally
-                    // cadence-gated during long quiet scans. Before claiming
-                    // completion, obtain an authoritative tip once more so a
-                    // block mined since the last cadence tick cannot be
-                    // silently omitted from the scan queue.
+                    // Completion barrier: drain transaction enhancement first,
+                    // then verify the remote canonical (height, hash) against
+                    // the wallet DB immediately before emitting completion.
+                    let should_exit = || {
+                        cancel.load(Ordering::Relaxed)
+                            || desired_mode.load(Ordering::SeqCst) != running_mode
+                    };
+                    let enhancement_start = std::time::Instant::now();
+                    let final_outcome =
+                        run_enhancement(&mut client, &mut db, db_data_path, network, &should_exit)
+                            .await?;
+                    enhancement_total += enhancement_start.elapsed();
+                    enhancement_passes += 1;
+                    if should_exit() {
+                        log::info!(
+                            "[{}] sync: exiting during final enhancement pass",
+                            elapsed()
+                        );
+                        return Ok(());
+                    }
+                    if final_outcome.stored > 0 {
+                        log::info!(
+                            "[{}] sync: final enhancement pass stored {} transaction(s)",
+                            elapsed(),
+                            final_outcome.stored,
+                        );
+                    }
+                    if let Some(error) = final_outcome.failure {
+                        return Err(error);
+                    }
+                    if !final_outcome.drained {
+                        return Err(SyncError::other(
+                            "final transaction enhancement queue contains actionable work",
+                        ));
+                    }
+
                     let final_tip = get_latest_block(&mut client).await?;
                     let final_tip_height =
                         block_height_from_u64(final_tip.height, "final lightwalletd tip height")?;
                     let final_tip_height_u64 = u32::from(final_tip_height) as u64;
+                    let final_tip_hash = compact_hash(&final_tip.hash, "final lightwalletd tip")
+                        .map_err(SyncError::parse)?;
+                    let summary = wallet_summary_heights(&db)?;
+                    let local_db_tip = summary.map(|(_, tip)| tip);
+                    let local_hash = db
+                        .get_block_hash(final_tip_height)
+                        .map_err(|e| SyncError::db(format!("get final wallet block hash: {e}")))?;
+
+                    let local_covers_remote = local_db_tip
+                        .map(|height| height >= final_tip_height_u64)
+                        .unwrap_or(false);
+                    let canonical_mismatch = local_db_tip
+                        .map(|height| height > final_tip_height_u64)
+                        .unwrap_or(false)
+                        || (local_covers_remote && local_hash != Some(final_tip_hash));
+                    if canonical_mismatch {
+                        let pending = rewind_for_canonical_tip_mismatch(&mut db, final_tip_height)?;
+                        current_tip_height = final_tip_height_u64;
+                        initial_total = pending;
+                        prev_remaining = pending;
+                        force_witness_check_this_run = true;
+                        prefetch.clear();
+                        continue;
+                    }
+
                     if final_tip_height_u64 != current_tip_height {
                         with_wallet_db_write_lock(
                             "sync_engine.update_chain_tip.completion_refresh",
@@ -1537,7 +1680,7 @@ async fn run_sync_impl(
                             },
                         )?;
                         log::info!(
-                            "[{}] sync: completion tip advanced {} -> {}; rescanning newly queued ranges",
+                            "[{}] sync: completion tip changed {} -> {}; rescanning newly queued ranges",
                             elapsed(),
                             current_tip_height,
                             final_tip_height_u64,
@@ -1586,7 +1729,13 @@ async fn run_sync_impl(
         // making scan_cached_blocks much slower per block and
         // using more memory. Matches the SDK's
         // `SANDBLASTING_RANGE` check.
-        let batch_size = batch_size_for_range(base_batch_size, start, range.block_range().end);
+        let batch_size = memory_bounded_batch_size(
+            base_batch_size,
+            start,
+            range.block_range().end,
+            estimated_wire_bytes_per_block,
+            batch_resident_budget,
+        );
         let end = std::cmp::min(start + batch_size, range.block_range().end);
         let batch_blocks = u32::from(end).saturating_sub(u32::from(start)) as u64;
         let current_pct = if initial_total > 0 {
@@ -1644,7 +1793,7 @@ async fn run_sync_impl(
                                 u32::from(end) - 1,
                             );
                             prefetch.clear();
-                            download_batch(client.clone(), network, start, end).await?
+                            download_current_batch(client.clone(), network, start, end).await?
                         }
                         Err(e) => {
                             stale_prefetches += 1;
@@ -1655,7 +1804,7 @@ async fn run_sync_impl(
                                 u32::from(end) - 1,
                             );
                             prefetch.clear();
-                            download_batch(client.clone(), network, start, end).await?
+                            download_current_batch(client.clone(), network, start, end).await?
                         }
                     }
                 }
@@ -1665,7 +1814,7 @@ async fn run_sync_impl(
                         elapsed()
                     );
                     prefetch.clear();
-                    download_batch(client.clone(), network, start, end).await?
+                    download_current_batch(client.clone(), network, start, end).await?
                 }
                 Err(e) => {
                     log::warn!(
@@ -1673,21 +1822,22 @@ async fn run_sync_impl(
                         elapsed()
                     );
                     prefetch.clear();
-                    download_batch(client.clone(), network, start, end).await?
+                    download_current_batch(client.clone(), network, start, end).await?
                 }
             }
         } else {
             // The first batch, a range/priority change, or a rewind cannot
             // safely reuse predictions from the previous queue.
             prefetch.clear();
-            download_batch(client.clone(), network, start, end).await?
+            download_current_batch(client.clone(), network, start, end).await?
         };
         let fetch_wait = fetch_wait_start.elapsed();
         fetch_wait_total += fetch_wait;
         fetch_batches += 1;
+        let current_batch_wire_bytes = batch.block_source.wire_bytes();
         if batch.block_source.block_count() > 0 {
             estimated_wire_bytes_per_block =
-                (batch.block_source.wire_bytes() / batch.block_source.block_count() as u64).max(1);
+                (current_batch_wire_bytes / batch.block_source.block_count() as u64).max(1);
         }
         log::debug!(
             "[{}] sync: batch {} fetch-wait {:.0}ms ({} blocks, {} KiB wire)",
@@ -1708,6 +1858,60 @@ async fn run_sync_impl(
             from_state,
             ..
         } = batch;
+
+        // Start the next download before entering the synchronous scanner so
+        // desktop's multi-thread runtime can overlap network I/O with the
+        // current batch's CPU/SQLite work. Mobile defaults prefetch off because
+        // its current-thread background runtime cannot provide this overlap.
+        if !cancel.load(Ordering::Relaxed) {
+            let range_end = range.block_range().end;
+            let mut prefetch_start = prefetch.back().map(|item| item.end).unwrap_or(end);
+            while prefetch_start < range_end {
+                let prefetch_batch = memory_bounded_batch_size(
+                    base_batch_size,
+                    prefetch_start,
+                    range_end,
+                    estimated_wire_bytes_per_block,
+                    batch_resident_budget,
+                );
+                let prefetch_end = std::cmp::min(prefetch_start + prefetch_batch, range_end);
+                let next_batch_blocks =
+                    u32::from(prefetch_end).saturating_sub(u32::from(prefetch_start)) as u64;
+                let queued_blocks = prefetch
+                    .iter()
+                    .map(|item| u32::from(item.end).saturating_sub(u32::from(item.start)) as u64)
+                    .sum();
+                if !can_spawn_prefetch(
+                    prefetch.len(),
+                    prefetch_depth,
+                    current_batch_wire_bytes,
+                    queued_blocks,
+                    next_batch_blocks,
+                    estimated_wire_bytes_per_block.max(prefetch_wire_floor(prefetch_start)),
+                    PREFETCH_RESIDENT_BUDGET,
+                ) {
+                    break;
+                }
+
+                let batch_client = client.clone();
+                let batch_start = prefetch_start;
+                prefetch.push_back(Prefetch {
+                    start: batch_start,
+                    end: prefetch_end,
+                    handle: Some(tokio::spawn(async move {
+                        download_batch(
+                            batch_client,
+                            network,
+                            batch_start,
+                            prefetch_end,
+                            EndValidationMode::Deferred,
+                        )
+                        .await
+                    })),
+                });
+                prefetch_start = prefetch_end;
+            }
+        }
 
         // Scan from memory. There are three reorg-adjacent signals from
         // librustzcash that all need to land on `SyncError::Continuity`
@@ -1943,69 +2147,37 @@ async fn run_sync_impl(
             || scan_summary.received_orchard_note_count() > 0
             || scan_summary.spent_orchard_note_count() > 0;
 
-        let run_post_batch_passes = should_run_post_batch_passes(
-            batch_found_tx,
-            end == range.block_range().end,
-            fetch_batches,
-            resubmit_every,
-        );
+        let is_last_batch_of_range = end == range.block_range().end;
         let should_exit = || {
             cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode
         };
         let mut has_new_tx = batch_found_tx;
 
-        if run_post_batch_passes {
-            let enhancement_start = std::time::Instant::now();
-            match run_enhancement(&mut client, &mut db, db_data_path, network, &should_exit).await {
-                Ok(outcome) => {
-                    has_new_tx |= outcome.stored > 0;
-                    final_enhancement_drain_needed = !outcome.drained;
-                }
-                Err(e) => {
-                    final_enhancement_drain_needed = true;
-                    log::warn!(
-                        "[{}] sync: enhancement pass failed (queue retained): {e}",
-                        elapsed()
-                    );
-                }
-            }
-            enhancement_total += enhancement_start.elapsed();
-            enhancement_passes += 1;
-        } else {
-            final_enhancement_drain_needed = true;
-        }
-
-        // Keep fresh-tip lookup and pending-send resubmit paired, but avoid
-        // doing both after every quiet batch in a long cold sync. Activity,
-        // the configured cadence, and the range boundary always trigger it.
-        if run_post_batch_passes {
-            if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode
-            {
-                log::info!(
-                    "[{}] sync: cancel/mode observed before post-batch resubmit, exiting",
-                    elapsed(),
-                );
-                return Ok(());
-            }
-
+        // Tip refresh and resubmit have independent time/activity policies.
+        // Both need an authoritative height, so share one lookup when either
+        // is due without coupling enhancement to the same cadence.
+        let tip_refresh_due =
+            is_last_batch_of_range || last_tip_refresh.elapsed() >= TIP_REFRESH_INTERVAL;
+        let resubmit_time_due = last_resubmit.elapsed() >= resubmit_interval;
+        let needs_fresh_tip =
+            tip_refresh_due || resubmit_time_due || batch_found_tx || is_last_batch_of_range;
+        if needs_fresh_tip {
             let resubmit_start = std::time::Instant::now();
-            match get_latest_block(&mut client)
-                .await
-                .map(|tip| tip.height as u32)
-            {
-                Ok(fresh_tip_height) => {
-                    if (fresh_tip_height as u64) > current_tip_height {
-                        let fresh_height = BlockHeight::from_u32(fresh_tip_height);
+            match get_latest_block(&mut client).await {
+                Ok(fresh_tip) => {
+                    let fresh_height = block_height_from_u64(
+                        fresh_tip.height,
+                        "post-batch lightwalletd tip height",
+                    )?;
+                    let fresh_tip_height = u32::from(fresh_height) as u64;
+                    let tip_changed = fresh_tip_height != current_tip_height;
+                    if fresh_tip_height > current_tip_height {
                         match with_wallet_db_write_lock(
                             "sync_engine.update_chain_tip.post_batch",
                             || db.update_chain_tip(fresh_height),
                         ) {
                             Ok(()) => {
-                                current_tip_height = fresh_tip_height as u64;
-                                // The address-history request ranges may now
-                                // extend beyond the enhancement pass that ran
-                                // immediately before this refresh.
-                                final_enhancement_drain_needed = true;
+                                current_tip_height = fresh_tip_height;
                             }
                             Err(e) => log::warn!(
                                 "[{}] sync: post-batch update_chain_tip({fresh_tip_height}) \
@@ -2013,26 +2185,80 @@ async fn run_sync_impl(
                                 elapsed(),
                             ),
                         }
+                    } else if fresh_tip_height < current_tip_height {
+                        log::warn!(
+                            "[{}] sync: lightwalletd tip moved backward {} -> {}; canonical hash check will resolve it at completion",
+                            elapsed(),
+                            current_tip_height,
+                            fresh_tip_height,
+                        );
                     }
                     last_tip_refresh = std::time::Instant::now();
-                    let _ = crate::wallet::sync::resubmit_pending_transactions(
-                        db_data_path,
-                        &mut client,
-                        fresh_tip_height,
-                        || {
-                            cancel.load(Ordering::Relaxed)
-                                || desired_mode.load(Ordering::SeqCst) != running_mode
-                        },
-                    )
-                    .await;
+                    if resubmit_time_due || batch_found_tx || is_last_batch_of_range || tip_changed
+                    {
+                        let _ = crate::wallet::sync::resubmit_pending_transactions(
+                            db_data_path,
+                            &mut client,
+                            u32::from(fresh_height),
+                            || {
+                                cancel.load(Ordering::Relaxed)
+                                    || desired_mode.load(Ordering::SeqCst) != running_mode
+                            },
+                        )
+                        .await;
+                        last_resubmit = std::time::Instant::now();
+                        resubmit_passes += 1;
+                    }
                 }
                 Err(e) => log::warn!(
-                    "[{}] sync: resubmit tip refresh failed, skipping pass: {e}",
+                    "[{}] sync: post-batch tip refresh failed, skipping resubmit: {e}",
                     elapsed(),
                 ),
             }
             resubmit_total += resubmit_start.elapsed();
-            resubmit_passes += 1;
+        }
+
+        let requests = db
+            .transaction_data_requests()
+            .map_err(|e| SyncError::db(format!("transaction_data_requests for scheduling: {e}")))?;
+        let now = std::time::SystemTime::now();
+        let has_immediate_enhancement = requests.iter().any(|request| match request {
+            TransactionDataRequest::Enhancement(_) => true,
+            TransactionDataRequest::TransactionsInvolvingAddress(request) => {
+                request.block_range_end().is_some()
+                    && request.request_at().map_or(true, |due| due <= now)
+            }
+            TransactionDataRequest::GetStatus(_) => false,
+        });
+        let has_status_requests = requests
+            .iter()
+            .any(|request| matches!(request, TransactionDataRequest::GetStatus(_)));
+        let run_enhancement_now = has_immediate_enhancement
+            || batch_found_tx
+            || is_last_batch_of_range
+            || (has_status_requests && last_status_poll.elapsed() >= STATUS_POLL_INTERVAL);
+        if run_enhancement_now {
+            let enhancement_start = std::time::Instant::now();
+            match run_enhancement(&mut client, &mut db, db_data_path, network, &should_exit).await {
+                Ok(outcome) => {
+                    has_new_tx |= outcome.stored > 0;
+                    if let Some(error) = outcome.failure {
+                        log::warn!(
+                            "[{}] sync: enhancement pass retained failed work for final retry: {error}",
+                            elapsed(),
+                        );
+                    }
+                }
+                Err(e) => log::warn!(
+                    "[{}] sync: enhancement pass failed (queue retained): {e}",
+                    elapsed(),
+                ),
+            }
+            enhancement_total += enhancement_start.elapsed();
+            enhancement_passes += 1;
+            if has_status_requests {
+                last_status_poll = std::time::Instant::now();
+            }
         }
         if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode {
             log::info!("[{}] sync: exiting after post-batch work", elapsed());
@@ -2075,8 +2301,13 @@ async fn run_sync_impl(
             .find(|r| is_pending_scan_range(r))
             .map(|r| {
                 let next_start = r.block_range().start;
-                let next_batch_size =
-                    batch_size_for_range(base_batch_size, next_start, r.block_range().end);
+                let next_batch_size = memory_bounded_batch_size(
+                    base_batch_size,
+                    next_start,
+                    r.block_range().end,
+                    estimated_wire_bytes_per_block,
+                    batch_resident_budget,
+                );
                 let next_end = std::cmp::min(next_start + next_batch_size, r.block_range().end);
                 u32::from(next_end).saturating_sub(u32::from(next_start)) as u64
             })
@@ -2107,84 +2338,6 @@ async fn run_sync_impl(
         progress_fn(progress);
         #[cfg(debug_assertions)]
         maybe_sleep_for_e2e_sync_batch_delay().await;
-
-        // Refill a contiguous look-ahead queue. The most recently measured
-        // wire density is multiplied by a decoded-memory factor before the
-        // resident budget is checked.
-        if !cancel.load(Ordering::Relaxed) {
-            let range_end = range.block_range().end;
-            let mut prefetch_start = prefetch.back().map(|item| item.end).unwrap_or(end);
-            while prefetch_start < range_end {
-                let prefetch_batch =
-                    batch_size_for_range(base_batch_size, prefetch_start, range_end);
-                let prefetch_end = std::cmp::min(prefetch_start + prefetch_batch, range_end);
-                let next_batch_blocks =
-                    u32::from(prefetch_end).saturating_sub(u32::from(prefetch_start)) as u64;
-                let queued_blocks = prefetch
-                    .iter()
-                    .map(|item| u32::from(item.end).saturating_sub(u32::from(item.start)) as u64)
-                    .sum();
-                if !can_spawn_prefetch(
-                    prefetch.len(),
-                    prefetch_depth,
-                    queued_blocks,
-                    next_batch_blocks,
-                    estimated_wire_bytes_per_block.max(prefetch_wire_floor(prefetch_start)),
-                    PREFETCH_RESIDENT_BUDGET,
-                ) {
-                    break;
-                }
-
-                let batch_client = client.clone();
-                let batch_start = prefetch_start;
-                prefetch.push_back(Prefetch {
-                    start: batch_start,
-                    end: prefetch_end,
-                    handle: Some(tokio::spawn(async move {
-                        download_batch(batch_client, network, batch_start, prefetch_end).await
-                    })),
-                });
-                prefetch_start = prefetch_end;
-            }
-        }
-    }
-
-    if final_enhancement_drain_needed
-        && !cancel.load(Ordering::Relaxed)
-        && desired_mode.load(Ordering::SeqCst) == running_mode
-    {
-        let should_exit = || {
-            cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode
-        };
-        let enhancement_start = std::time::Instant::now();
-        let final_outcome =
-            run_enhancement(&mut client, &mut db, db_data_path, network, &should_exit).await?;
-        enhancement_total += enhancement_start.elapsed();
-        enhancement_passes += 1;
-        if should_exit() {
-            log::info!(
-                "[{}] sync: exiting during final enhancement pass",
-                elapsed()
-            );
-            return Ok(());
-        }
-        if final_outcome.stored > 0 {
-            log::info!(
-                "[{}] sync: final enhancement pass stored {} transaction(s)",
-                elapsed(),
-                final_outcome.stored,
-            );
-        }
-        if !final_outcome.drained {
-            // Intermediate passes are best-effort so scanning can continue,
-            // but completion must preserve the previous correctness contract:
-            // transiently unserviceable enhancement work triggers the outer
-            // retry loop instead of reporting a fully-complete sync with an
-            // incomplete transaction-history queue.
-            return Err(SyncError::net(
-                "final transaction enhancement queue was not drained",
-            ));
-        }
     }
 
     let (final_scanned_height, final_tip_height) =
@@ -2203,11 +2356,11 @@ async fn run_sync_impl(
         stale_prefetches,
     );
     log::info!(
-        "[{}] sync: resubmit/tip refresh {:.2}s over {} passes (cadence={})",
+        "[{}] sync: resubmit/tip refresh {:.2}s over {} passes (resubmit_interval={}s)",
         elapsed(),
         resubmit_total.as_secs_f64(),
         resubmit_passes,
-        resubmit_every,
+        resubmit_interval.as_secs(),
     );
     log::info!(
         "[{}] sync: enhancement {:.2}s over {} passes",
@@ -2231,7 +2384,6 @@ async fn run_sync_impl(
             e
         ),
     }
-    truncate_wallet_wal_best_effort(db_data_path);
     // Final progress
     let final_progress = SyncProgressEvent {
         scanned_height: final_scanned_height,
@@ -2245,6 +2397,14 @@ async fn run_sync_impl(
         phase: String::new(),
     };
     progress_fn(final_progress);
+
+    // Completion must not wait behind a potentially busy checkpoint. Drop the
+    // long-lived sync connection first, then perform best-effort WAL
+    // maintenance on the blocking pool after the user-visible completion
+    // event has been delivered.
+    drop(db);
+    let checkpoint_path = db_data_path.to_string();
+    tokio::task::spawn_blocking(move || truncate_wallet_wal_best_effort(&checkpoint_path));
 
     Ok(())
 }
@@ -2332,11 +2492,42 @@ async fn fetch_batch_start_state(
 /// Downloads blocks and both boundary states concurrently. Boundary
 /// validation happens before returning, so even the initial synchronous batch
 /// cannot mix compact blocks and a tree frontier from different forks.
+async fn download_current_batch(
+    client: CompactTxStreamerClient<Channel>,
+    network: WalletNetwork,
+    start: BlockHeight,
+    end_exclusive: BlockHeight,
+) -> Result<DownloadedBatch, SyncError> {
+    for attempt in 0..2 {
+        match download_batch(
+            client.clone(),
+            network,
+            start,
+            end_exclusive,
+            EndValidationMode::Immediate,
+        )
+        .await
+        {
+            Err(SyncError::Network(message))
+                if attempt == 0 && message.contains("inconsistent downloaded batch") =>
+            {
+                log::warn!(
+                    "[{}] sync: batch boundary changed during download; retrying locally",
+                    elapsed(),
+                );
+            }
+            result => return result,
+        }
+    }
+    unreachable!("bounded batch retry always returns on its final attempt")
+}
+
 async fn download_batch(
     client: CompactTxStreamerClient<Channel>,
     network: WalletNetwork,
     start: BlockHeight,
     end_exclusive: BlockHeight,
+    end_validation: EndValidationMode,
 ) -> Result<DownloadedBatch, SyncError> {
     let mut blocks_client = client.clone();
     let mut start_client = client.clone();
@@ -2346,13 +2537,14 @@ async fn download_batch(
     let (block_source, (from_state, synthetic_start_anchor), end_state) = tokio::try_join!(
         download_blocks(&mut blocks_client, start, end_height),
         fetch_batch_start_state(&mut start_client, network, start),
-        fetch_batch_end_state(&mut end_client, network, end_height),
+        fetch_batch_end_state(&mut end_client, network, end_height, end_validation),
     )?;
 
-    // lightwalletd does not expose a meaningful commitment-tree state before
-    // Sapling activation. In that era the compact-block stream is still
-    // canonical, so use its final block hash for boundary/reorg validation and
-    // avoid an RPC that some lightwalletd versions reject outright.
+    // For pre-Sapling batches there is no meaningful commitment-tree state;
+    // deferred prefetch validation likewise waits until consumption for the
+    // canonical end state. In both cases retain the stream's last hash as the
+    // expected value. A prefetched post-Sapling batch compares it to a fresh
+    // tree-state hash immediately before scan.
     let canonical_end_hash_at_fetch = match end_state {
         Some(state) => state.block_hash(),
         None => {
@@ -2379,8 +2571,11 @@ async fn fetch_batch_end_state(
     client: &mut CompactTxStreamerClient<Channel>,
     network: WalletNetwork,
     end_height: BlockHeight,
+    end_validation: EndValidationMode,
 ) -> Result<Option<chain::ChainState>, SyncError> {
-    if should_use_empty_chain_state(&network, end_height)? {
+    if matches!(end_validation, EndValidationMode::Deferred)
+        || should_use_empty_chain_state(&network, end_height)?
+    {
         Ok(None)
     } else {
         fetch_validated_chain_state(client, end_height)
@@ -2509,22 +2704,10 @@ mod tests {
 
     #[test]
     fn prefetch_budget_counts_estimated_decoded_memory() {
-        assert!(can_spawn_prefetch(0, 4, 10_000, 10_000, 10_000, 1));
-        assert!(can_spawn_prefetch(1, 4, 10, 10, 100, 10_000));
-        assert!(!can_spawn_prefetch(1, 4, 10, 10, 400, 10_000));
-        assert!(!can_spawn_prefetch(4, 4, 0, 1, 1, u64::MAX));
-    }
-
-    #[test]
-    fn post_batch_pass_cadence_preserves_activity_and_range_end() {
-        let every = RESUBMIT_EVERY_BATCHES;
-        assert!(!should_run_post_batch_passes(false, false, 1, every));
-        assert!(!should_run_post_batch_passes(false, false, 15, every));
-        assert!(should_run_post_batch_passes(false, false, 16, every));
-        assert!(should_run_post_batch_passes(true, false, 3, every));
-        assert!(should_run_post_batch_passes(false, true, 3, every));
-        assert!(should_run_post_batch_passes(false, false, 1, 1));
-        assert!(should_run_post_batch_passes(false, false, 7, 0));
+        assert!(can_spawn_prefetch(0, 1, 1_000, 0, 10, 100, 6_000));
+        assert!(!can_spawn_prefetch(0, 1, 1_000, 0, 10, 100, 5_999));
+        assert!(!can_spawn_prefetch(0, 1, 10_000, 0, 10_000, 10_000, 1));
+        assert!(!can_spawn_prefetch(1, 1, 0, 0, 1, 1, u64::MAX));
     }
 
     #[test]
@@ -2534,7 +2717,8 @@ mod tests {
         let one_batch_blocks = BATCH_SIZE_SANDBLASTING as u64;
         assert!(can_spawn_prefetch(
             0,
-            PREFETCH_DEPTH_BACKGROUND,
+            1,
+            0,
             0,
             one_batch_blocks,
             estimate,
@@ -2542,12 +2726,37 @@ mod tests {
         ));
         assert!(!can_spawn_prefetch(
             1,
-            PREFETCH_DEPTH_BACKGROUND,
+            1,
+            0,
             one_batch_blocks,
             one_batch_blocks,
             estimate,
             32 * 1024 * 1024,
         ));
+    }
+
+    #[test]
+    fn observed_dense_blocks_reduce_the_next_batch_size() {
+        let start = BlockHeight::from_u32(SANDBLASTING_END + 100);
+        let end = start + BATCH_SIZE_FOREGROUND;
+        let normal = memory_bounded_batch_size(
+            BATCH_SIZE_FOREGROUND,
+            start,
+            end,
+            PREFETCH_WIRE_FLOOR_BYTES_PER_BLOCK,
+            64 * 1024 * 1024,
+        );
+        let dense = memory_bounded_batch_size(
+            BATCH_SIZE_FOREGROUND,
+            start,
+            end,
+            256 * 1024,
+            64 * 1024 * 1024,
+        );
+
+        assert_eq!(normal, BATCH_SIZE_FOREGROUND);
+        assert!(dense < normal);
+        assert!(dense > 0);
     }
 
     #[test]

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, VecDeque};
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::Arc;
 
@@ -84,6 +84,19 @@ const BATCH_SIZE_FOREGROUND: u32 = 2000;
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 const BATCH_SIZE_FOREGROUND: u32 = 1000;
 const BATCH_SIZE_BACKGROUND: u32 = 300;
+
+const PREFETCH_DEPTH_FOREGROUND: usize = 4;
+const PREFETCH_DEPTH_BACKGROUND: usize = 2;
+
+/// The resident-memory estimate applies a conservative multiplier to the
+/// encoded compact-block size to account for decoded vectors and allocations.
+const PREFETCH_DECODED_MEMORY_FACTOR: u64 = 3;
+const PREFETCH_WIRE_FLOOR_BYTES_PER_BLOCK: u64 = 5 * 1024;
+const PREFETCH_SANDBLASTING_WIRE_BYTES_PER_BLOCK: u64 = 90 * 1024;
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
+const PREFETCH_RESIDENT_BUDGET: u64 = 128 * 1024 * 1024;
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+const PREFETCH_RESIDENT_BUDGET: u64 = 32 * 1024 * 1024;
 const TRANSPARENT_UTXO_RECENT_EXTERNAL_LIMIT: usize = 20;
 const TRANSPARENT_UTXO_SWEEP_EXTERNAL_LIMIT: usize = 20;
 
@@ -146,6 +159,140 @@ fn effective_base_batch_size(default_batch_size: u32) -> u32 {
     }
 
     default_batch_size
+}
+
+fn env_override_clamped(name: &str, default: u64, min: u64, max: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(|value| value.clamp(min, max))
+        .unwrap_or(default)
+}
+
+fn effective_prefetch_depth(running_mode: u8) -> usize {
+    let default = if running_mode == 2 {
+        PREFETCH_DEPTH_BACKGROUND
+    } else {
+        PREFETCH_DEPTH_FOREGROUND
+    };
+    env_override_clamped("ZCASH_SYNC_PREFETCH_DEPTH", default as u64, 1, 16) as usize
+}
+
+fn can_spawn_prefetch(
+    queued_batches: usize,
+    depth: usize,
+    queued_blocks: u64,
+    next_batch_blocks: u64,
+    estimated_wire_bytes_per_block: u64,
+    resident_budget: u64,
+) -> bool {
+    if queued_batches >= depth {
+        return false;
+    }
+    // Preserve at least one look-ahead batch even when the preceding batch
+    // was unusually large. The chain's sandblasting batch cap bounds that
+    // single-batch overshoot.
+    if queued_batches == 0 {
+        return true;
+    }
+    queued_blocks
+        .saturating_add(next_batch_blocks)
+        .saturating_mul(estimated_wire_bytes_per_block)
+        .saturating_mul(PREFETCH_DECODED_MEMORY_FACTOR)
+        < resident_budget
+}
+
+fn prefetch_wire_floor(start: BlockHeight) -> u64 {
+    let height = u32::from(start);
+    if (SANDBLASTING_START..SANDBLASTING_END).contains(&height) {
+        PREFETCH_SANDBLASTING_WIRE_BYTES_PER_BLOCK
+    } else {
+        PREFETCH_WIRE_FLOOR_BYTES_PER_BLOCK
+    }
+}
+
+struct DownloadedBatch {
+    block_source: block_source::MemoryBlockSource,
+    from_state: chain::ChainState,
+    canonical_end_hash_at_fetch: BlockHash,
+    synthetic_start_anchor: bool,
+}
+
+fn compact_hash(bytes: &[u8], context: &str) -> Result<BlockHash, String> {
+    BlockHash::try_from_slice(bytes)
+        .ok_or_else(|| format!("{context} hash has {} bytes, expected 32", bytes.len()))
+}
+
+/// Validates that blocks, the starting frontier, and the canonical state at
+/// the batch end all describe one contiguous branch before the batch is
+/// handed to `scan_cached_blocks`.
+fn validate_downloaded_batch(
+    batch: &DownloadedBatch,
+    start: BlockHeight,
+    end_exclusive: BlockHeight,
+) -> Result<(), String> {
+    let expected_count = u32::from(end_exclusive).saturating_sub(u32::from(start)) as usize;
+    if batch.block_source.block_count() != expected_count {
+        return Err(format!(
+            "batch {}..{} returned {} blocks, expected {expected_count}",
+            u32::from(start),
+            u32::from(end_exclusive),
+            batch.block_source.block_count(),
+        ));
+    }
+
+    let first = batch
+        .block_source
+        .first_block()
+        .ok_or_else(|| "batch is empty".to_string())?;
+    let last = batch
+        .block_source
+        .last_block()
+        .ok_or_else(|| "batch is empty".to_string())?;
+    if first.height != u32::from(start) as u64
+        || last.height != u32::from(end_exclusive).saturating_sub(1) as u64
+    {
+        return Err(format!(
+            "batch boundary heights are {}..{}, expected {}..{}",
+            first.height,
+            last.height,
+            u32::from(start),
+            u32::from(end_exclusive) - 1,
+        ));
+    }
+
+    if !batch.synthetic_start_anchor {
+        let first_prev = compact_hash(&first.prev_hash, "first block prev")?;
+        if first_prev != batch.from_state.block_hash() {
+            return Err(format!(
+                "first block at {} does not extend the fetched start state",
+                first.height
+            ));
+        }
+    }
+
+    for pair in batch.block_source.blocks().windows(2) {
+        let previous = &pair[0];
+        let next = &pair[1];
+        let previous_hash = compact_hash(&previous.hash, "previous block")?;
+        let next_prev = compact_hash(&next.prev_hash, "next block prev")?;
+        if next.height != previous.height.saturating_add(1) || next_prev != previous_hash {
+            return Err(format!(
+                "compact block chain is discontinuous between heights {} and {}",
+                previous.height, next.height
+            ));
+        }
+    }
+
+    let last_hash = compact_hash(&last.hash, "last block")?;
+    if last_hash != batch.canonical_end_hash_at_fetch {
+        return Err(format!(
+            "last block at {} does not match the canonical end state",
+            last.height
+        ));
+    }
+
+    Ok(())
 }
 
 #[cfg(debug_assertions)]
@@ -1230,25 +1377,7 @@ async fn run_sync_impl(
     const TIP_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(600);
     let mut last_tip_refresh = std::time::Instant::now();
 
-    // Prefetched block source from the previous iteration.
-    // When the scan loop processes a range that spans multiple batches,
-    // we kick off a background download of the next batch while running
-    // enhancement / resubmit / progress reporting for the current
-    // batch. This overlaps network I/O (download) with CPU-bound
-    // work (enhancement) and unrelated gRPC calls (resubmit), matching
-    // the SDK's `.buffer(1)` pipelining pattern in
-    // `CompactBlockProcessor.kt:1666`.
-    //
-    // `None` on the first iteration and whenever the previous batch
-    // was the last in its range (so there's nothing to prefetch until
-    // `suggest_scan_ranges` runs again).
-    type PrefetchResult =
-        Result<crate::wallet::sync_engine::block_source::MemoryBlockSource, SyncError>;
-    /// Prefetched block download state. Implements `Drop` to
-    /// abort the spawned tokio task when the loop exits for any
-    /// reason (cancel, mode change, error, break, reorg
-    /// `continue`) so detached downloads can't outlive the sync
-    /// session and leak network traffic after shutdown.
+    type PrefetchResult = Result<DownloadedBatch, SyncError>;
     struct Prefetch {
         handle: Option<tokio::task::JoinHandle<PrefetchResult>>,
         start: BlockHeight,
@@ -1261,7 +1390,18 @@ async fn run_sync_impl(
             }
         }
     }
-    let mut prefetch: Option<Prefetch> = None;
+    let prefetch_depth = effective_prefetch_depth(running_mode);
+    let mut prefetch: VecDeque<Prefetch> = VecDeque::new();
+    let mut estimated_wire_bytes_per_block = 0u64;
+    let mut fetch_wait_total = std::time::Duration::ZERO;
+    let mut fetch_batches = 0u64;
+    let mut stale_prefetches = 0u64;
+    log::info!(
+        "[{}] sync: prefetch depth={}, resident budget={} MiB",
+        elapsed(),
+        prefetch_depth,
+        PREFETCH_RESIDENT_BUDGET / (1024 * 1024),
+    );
 
     // 5. Sync loop
     loop {
@@ -1330,7 +1470,7 @@ async fn run_sync_impl(
                     force_witness_check_this_run = true;
                     initial_total = repair_pending_blocks;
                     prev_remaining = repair_pending_blocks;
-                    prefetch = None;
+                    prefetch.clear();
                     continue;
                 } else if let Some(repair_pending_blocks) = repair_anchor_root_mismatch_if_needed(
                     &mut client,
@@ -1343,7 +1483,7 @@ async fn run_sync_impl(
                     force_witness_check_this_run = true;
                     initial_total = repair_pending_blocks;
                     prev_remaining = repair_pending_blocks;
-                    prefetch = None;
+                    prefetch.clear();
                     continue;
                 } else {
                     ensure_complete_scan_state(&db, current_tip_height)?;
@@ -1423,52 +1563,91 @@ async fn run_sync_impl(
             batch_size,
         );
 
-        // Download blocks into memory — or use the prefetched data
-        // from the previous iteration if it matches this batch.
-        let block_source = if let Some(mut pf) = prefetch.take() {
-            if pf.start == start && pf.end == end {
-                // Prefetch matches. Take the handle out of the
-                // Option so Drop doesn't abort a completed task.
-                let handle = pf.handle.take().expect("prefetch handle present");
-                match handle.await {
-                    Ok(Ok(bs)) => {
-                        log::debug!(
-                            "[{}] sync: using prefetched blocks for {}-{}",
-                            elapsed(),
-                            u32::from(start),
-                            u32::from(end) - 1,
-                        );
-                        bs
-                    }
-                    _ => {
-                        // Prefetch failed — download synchronously.
-                        log::warn!("[{}] sync: prefetch failed, downloading fresh", elapsed(),);
-                        download_blocks(&mut client, start, end - 1).await?
+        let front_matches = prefetch
+            .front()
+            .map(|candidate| candidate.start == start && candidate.end == end)
+            .unwrap_or(false);
+        let fetch_wait_start = std::time::Instant::now();
+        let batch = if front_matches {
+            let mut prefetched = prefetch.pop_front().expect("matching front exists");
+            let handle = prefetched.handle.take().expect("prefetch handle exists");
+            match handle.await {
+                Ok(Ok(candidate)) => {
+                    match prefetched_batch_is_current(&mut client, &candidate, end).await {
+                        Ok(true) => candidate,
+                        Ok(false) => {
+                            stale_prefetches += 1;
+                            log::warn!(
+                                "[{}] sync: prefetched batch {}-{} was orphaned; downloading fresh",
+                                elapsed(),
+                                u32::from(start),
+                                u32::from(end) - 1,
+                            );
+                            prefetch.clear();
+                            download_batch(client.clone(), network, start, end).await?
+                        }
+                        Err(e) => {
+                            stale_prefetches += 1;
+                            log::warn!(
+                                "[{}] sync: could not revalidate prefetched batch {}-{} ({e}); downloading fresh",
+                                elapsed(),
+                                u32::from(start),
+                                u32::from(end) - 1,
+                            );
+                            prefetch.clear();
+                            download_batch(client.clone(), network, start, end).await?
+                        }
                     }
                 }
-            } else {
-                // Range changed (reorg, priority switch, etc.) —
-                // Drop the Prefetch, which aborts the background task.
-                drop(pf);
-                download_blocks(&mut client, start, end - 1).await?
+                Ok(Err(e)) => {
+                    log::warn!(
+                        "[{}] sync: prefetch download failed ({e}); downloading fresh",
+                        elapsed()
+                    );
+                    prefetch.clear();
+                    download_batch(client.clone(), network, start, end).await?
+                }
+                Err(e) => {
+                    log::warn!(
+                        "[{}] sync: prefetch task failed to join ({e}); downloading fresh",
+                        elapsed()
+                    );
+                    prefetch.clear();
+                    download_batch(client.clone(), network, start, end).await?
+                }
             }
         } else {
-            download_blocks(&mut client, start, end - 1).await?
+            // The first batch, a range/priority change, or a rewind cannot
+            // safely reuse predictions from the previous queue.
+            prefetch.clear();
+            download_batch(client.clone(), network, start, end).await?
         };
+        let fetch_wait = fetch_wait_start.elapsed();
+        fetch_wait_total += fetch_wait;
+        fetch_batches += 1;
+        if batch.block_source.block_count() > 0 {
+            estimated_wire_bytes_per_block =
+                (batch.block_source.wire_bytes() / batch.block_source.block_count() as u64).max(1);
+        }
+        log::debug!(
+            "[{}] sync: batch {} fetch-wait {:.0}ms ({} blocks, {} KiB wire)",
+            elapsed(),
+            u32::from(start),
+            fetch_wait.as_secs_f64() * 1000.0,
+            batch.block_source.block_count(),
+            batch.block_source.wire_bytes() / 1024,
+        );
 
         if cancel.load(Ordering::Relaxed) || desired_mode.load(Ordering::SeqCst) != running_mode {
             log::info!("[{}] sync: exiting after download", elapsed());
             return Ok(());
         }
 
-        // Get tree state
-        let from_state = if should_use_empty_chain_state(&network, start)? {
-            chain::ChainState::empty(start - 1, BlockHash([0u8; 32]))
-        } else {
-            let ts = get_tree_state(&mut client, u32::from(start - 1) as u64).await?;
-            ts.to_chain_state()
-                .map_err(|e| SyncError::parse(format!("parse tree state: {e}")))?
-        };
+        let DownloadedBatch {
+            block_source,
+            from_state,
+            ..
+        } = batch;
 
         // Scan from memory. There are three reorg-adjacent signals from
         // librustzcash that all need to land on `SyncError::Continuity`
@@ -1685,7 +1864,7 @@ async fn run_sync_impl(
                         initial_total = post_rewind_pending;
                         prev_remaining = post_rewind_pending;
                     }
-                    prefetch = None;
+                    prefetch.clear();
                     continue;
                 }
                 RecoveryStrategy::RetryWithBackoff | RecoveryStrategy::Fatal => {
@@ -1874,32 +2053,44 @@ async fn run_sync_impl(
         #[cfg(debug_assertions)]
         maybe_sleep_for_e2e_sync_batch_delay().await;
 
-        // Prefetch: if the current range still has blocks beyond
-        // `end`, kick off a background download of the next batch
-        // now, while the next loop iteration does suggest_scan_ranges
-        // + phase bookkeeping + (potentially) enhancement for the
-        // batch we just finished. The download runs on a cloned
-        // gRPC client so it doesn't conflict with the main client's
-        // unary RPCs (tree_state, get_latest_block, etc.).
-        //
-        // When the range is exhausted (end == range.end), we skip
-        // the prefetch — the next range comes from
-        // suggest_scan_ranges() which needs the DB state the current
-        // scan just committed, and we can't predict it in advance.
-        if end < range.block_range().end && !cancel.load(Ordering::Relaxed) {
-            let pf_start = end;
-            // Recompute batch_size for the prefetch range in case
-            // it crosses a sandblasting boundary differently.
-            let pf_batch = batch_size_for_range(base_batch_size, pf_start, range.block_range().end);
-            let pf_end = std::cmp::min(pf_start + pf_batch, range.block_range().end);
-            let mut pf_client = client.clone();
-            prefetch = Some(Prefetch {
-                start: pf_start,
-                end: pf_end,
-                handle: Some(tokio::spawn(async move {
-                    download_blocks(&mut pf_client, pf_start, pf_end - 1).await
-                })),
-            });
+        // Refill a contiguous look-ahead queue. The most recently measured
+        // wire density is multiplied by a decoded-memory factor before the
+        // resident budget is checked.
+        if !cancel.load(Ordering::Relaxed) {
+            let range_end = range.block_range().end;
+            let mut prefetch_start = prefetch.back().map(|item| item.end).unwrap_or(end);
+            while prefetch_start < range_end {
+                let prefetch_batch =
+                    batch_size_for_range(base_batch_size, prefetch_start, range_end);
+                let prefetch_end = std::cmp::min(prefetch_start + prefetch_batch, range_end);
+                let next_batch_blocks =
+                    u32::from(prefetch_end).saturating_sub(u32::from(prefetch_start)) as u64;
+                let queued_blocks = prefetch
+                    .iter()
+                    .map(|item| u32::from(item.end).saturating_sub(u32::from(item.start)) as u64)
+                    .sum();
+                if !can_spawn_prefetch(
+                    prefetch.len(),
+                    prefetch_depth,
+                    queued_blocks,
+                    next_batch_blocks,
+                    estimated_wire_bytes_per_block.max(prefetch_wire_floor(prefetch_start)),
+                    PREFETCH_RESIDENT_BUDGET,
+                ) {
+                    break;
+                }
+
+                let batch_client = client.clone();
+                let batch_start = prefetch_start;
+                prefetch.push_back(Prefetch {
+                    start: batch_start,
+                    end: prefetch_end,
+                    handle: Some(tokio::spawn(async move {
+                        download_batch(batch_client, network, batch_start, prefetch_end).await
+                    })),
+                });
+                prefetch_start = prefetch_end;
+            }
         }
     }
 
@@ -1910,6 +2101,13 @@ async fn run_sync_impl(
         elapsed(),
         final_scanned_height,
         final_tip_height,
+    );
+    log::info!(
+        "[{}] sync: fetch wait {:.2}s across {} batches (stale prefetches={})",
+        elapsed(),
+        fetch_wait_total.as_secs_f64(),
+        fetch_batches,
+        stale_prefetches,
     );
     match transparent_receive_cache::refresh_all_from_wallet_db(
         db_data_path,
@@ -1993,6 +2191,86 @@ fn should_use_empty_chain_state(
     Ok(start <= sapling_activation_height)
 }
 
+async fn fetch_validated_chain_state(
+    client: &mut CompactTxStreamerClient<Channel>,
+    height: BlockHeight,
+) -> Result<chain::ChainState, SyncError> {
+    let state = get_tree_state(client, u32::from(height) as u64)
+        .await?
+        .to_chain_state()
+        .map_err(|e| SyncError::parse(format!("parse tree state at {height}: {e}")))?;
+    if state.block_height() != height {
+        return Err(SyncError::net(format!(
+            "lightwalletd returned tree state for {}, requested {height}",
+            state.block_height()
+        )));
+    }
+    Ok(state)
+}
+
+async fn fetch_batch_start_state(
+    client: &mut CompactTxStreamerClient<Channel>,
+    network: WalletNetwork,
+    start: BlockHeight,
+) -> Result<(chain::ChainState, bool), SyncError> {
+    if should_use_empty_chain_state(&network, start)? {
+        Ok((
+            chain::ChainState::empty(start - 1, BlockHash([0; 32])),
+            true,
+        ))
+    } else {
+        Ok((fetch_validated_chain_state(client, start - 1).await?, false))
+    }
+}
+
+/// Downloads blocks and both boundary states concurrently. Boundary
+/// validation happens before returning, so even the initial synchronous batch
+/// cannot mix compact blocks and a tree frontier from different forks.
+async fn download_batch(
+    client: CompactTxStreamerClient<Channel>,
+    network: WalletNetwork,
+    start: BlockHeight,
+    end_exclusive: BlockHeight,
+) -> Result<DownloadedBatch, SyncError> {
+    let mut blocks_client = client.clone();
+    let mut start_client = client.clone();
+    let mut end_client = client;
+    let end_height = end_exclusive - 1;
+
+    let (block_source, (from_state, synthetic_start_anchor), end_state) = tokio::try_join!(
+        download_blocks(&mut blocks_client, start, end_height),
+        fetch_batch_start_state(&mut start_client, network, start),
+        fetch_validated_chain_state(&mut end_client, end_height),
+    )?;
+
+    let batch = DownloadedBatch {
+        block_source,
+        from_state,
+        canonical_end_hash_at_fetch: end_state.block_hash(),
+        synthetic_start_anchor,
+    };
+    validate_downloaded_batch(&batch, start, end_exclusive)
+        .map_err(|e| SyncError::net(format!("inconsistent downloaded batch: {e}")))?;
+    Ok(batch)
+}
+
+/// Re-checks a prefetched batch immediately before consumption. A successful
+/// prefetch may be several scan batches old; this closes the window where a
+/// reorg could otherwise leave a mutually consistent but orphaned batch in
+/// memory.
+async fn prefetched_batch_is_current(
+    client: &mut CompactTxStreamerClient<Channel>,
+    batch: &DownloadedBatch,
+    end_exclusive: BlockHeight,
+) -> Result<bool, SyncError> {
+    let current = fetch_validated_chain_state(client, end_exclusive - 1).await?;
+    Ok(prefetched_batch_matches_state(batch, &current))
+}
+
+fn prefetched_batch_matches_state(batch: &DownloadedBatch, current: &chain::ChainState) -> bool {
+    current.block_hash() == batch.canonical_end_hash_at_fetch
+}
+
 // ==================== Tests ====================
 //
 // Error-taxonomy tests now live alongside their types in `error.rs`. The
@@ -2004,6 +2282,119 @@ fn should_use_empty_chain_state(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_downloaded_batch() -> DownloadedBatch {
+        use zcash_client_backend::proto::compact_formats::CompactBlock;
+
+        let anchor_hash = BlockHash([0; 32]);
+        let first_hash = BlockHash([1; 32]);
+        let last_hash = BlockHash([2; 32]);
+        DownloadedBatch {
+            block_source: block_source::MemoryBlockSource::new(vec![
+                CompactBlock {
+                    height: 10,
+                    hash: first_hash.0.to_vec(),
+                    prev_hash: anchor_hash.0.to_vec(),
+                    ..Default::default()
+                },
+                CompactBlock {
+                    height: 11,
+                    hash: last_hash.0.to_vec(),
+                    prev_hash: first_hash.0.to_vec(),
+                    ..Default::default()
+                },
+            ]),
+            from_state: chain::ChainState::empty(BlockHeight::from_u32(9), anchor_hash),
+            canonical_end_hash_at_fetch: last_hash,
+            synthetic_start_anchor: false,
+        }
+    }
+
+    #[test]
+    fn downloaded_batch_requires_matching_start_and_end_boundaries() {
+        let mut batch = test_downloaded_batch();
+        assert!(validate_downloaded_batch(
+            &batch,
+            BlockHeight::from_u32(10),
+            BlockHeight::from_u32(12)
+        )
+        .is_ok());
+
+        batch.canonical_end_hash_at_fetch = BlockHash([9; 32]);
+        assert!(validate_downloaded_batch(
+            &batch,
+            BlockHeight::from_u32(10),
+            BlockHeight::from_u32(12)
+        )
+        .unwrap_err()
+        .contains("canonical end state"));
+
+        let mut batch = test_downloaded_batch();
+        batch.block_source = block_source::MemoryBlockSource::new(vec![
+            zcash_client_backend::proto::compact_formats::CompactBlock {
+                height: 10,
+                hash: vec![1; 32],
+                prev_hash: vec![7; 32],
+                ..Default::default()
+            },
+            zcash_client_backend::proto::compact_formats::CompactBlock {
+                height: 11,
+                hash: vec![2; 32],
+                prev_hash: vec![1; 32],
+                ..Default::default()
+            },
+        ]);
+        assert!(validate_downloaded_batch(
+            &batch,
+            BlockHeight::from_u32(10),
+            BlockHeight::from_u32(12)
+        )
+        .unwrap_err()
+        .contains("start state"));
+    }
+
+    #[test]
+    fn prefetched_batch_rejects_a_reorged_end_state() {
+        let batch = test_downloaded_batch();
+        let same_fork =
+            chain::ChainState::empty(BlockHeight::from_u32(11), batch.canonical_end_hash_at_fetch);
+        let replacement_fork =
+            chain::ChainState::empty(BlockHeight::from_u32(11), BlockHash([8; 32]));
+
+        assert!(prefetched_batch_matches_state(&batch, &same_fork));
+        assert!(!prefetched_batch_matches_state(&batch, &replacement_fork));
+    }
+
+    #[test]
+    fn prefetch_budget_counts_estimated_decoded_memory() {
+        assert!(can_spawn_prefetch(0, 4, 10_000, 10_000, 10_000, 1));
+        assert!(can_spawn_prefetch(1, 4, 10, 10, 100, 10_000));
+        assert!(!can_spawn_prefetch(1, 4, 10, 10, 400, 10_000));
+        assert!(!can_spawn_prefetch(4, 4, 0, 1, 1, u64::MAX));
+    }
+
+    #[test]
+    fn sandblasting_floor_prevents_mobile_queue_overshoot() {
+        let start = BlockHeight::from_u32(SANDBLASTING_START);
+        let estimate = prefetch_wire_floor(start);
+        let one_batch_blocks = BATCH_SIZE_SANDBLASTING as u64;
+        assert!(can_spawn_prefetch(
+            0,
+            PREFETCH_DEPTH_BACKGROUND,
+            0,
+            one_batch_blocks,
+            estimate,
+            32 * 1024 * 1024,
+        ));
+        assert!(!can_spawn_prefetch(
+            1,
+            PREFETCH_DEPTH_BACKGROUND,
+            one_batch_blocks,
+            one_batch_blocks,
+            estimate,
+            32 * 1024 * 1024,
+        ));
+    }
 
     #[test]
     fn empty_chain_state_uses_network_activation_height() {

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -1597,7 +1597,7 @@ async fn run_sync_impl(
             let handle = prefetched.handle.take().expect("prefetch handle exists");
             match handle.await {
                 Ok(Ok(candidate)) => {
-                    match prefetched_batch_is_current(&mut client, &candidate, end).await {
+                    match prefetched_batch_is_current(&mut client, network, &candidate, end).await {
                         Ok(true) => candidate,
                         Ok(false) => {
                             stale_prefetches += 1;
@@ -2310,18 +2310,47 @@ async fn download_batch(
     let (block_source, (from_state, synthetic_start_anchor), end_state) = tokio::try_join!(
         download_blocks(&mut blocks_client, start, end_height),
         fetch_batch_start_state(&mut start_client, network, start),
-        fetch_validated_chain_state(&mut end_client, end_height),
+        fetch_batch_end_state(&mut end_client, network, end_height),
     )?;
+
+    // lightwalletd does not expose a meaningful commitment-tree state before
+    // Sapling activation. In that era the compact-block stream is still
+    // canonical, so use its final block hash for boundary/reorg validation and
+    // avoid an RPC that some lightwalletd versions reject outright.
+    let canonical_end_hash_at_fetch = match end_state {
+        Some(state) => state.block_hash(),
+        None => {
+            let last = block_source
+                .last_block()
+                .ok_or_else(|| SyncError::net("empty compact-block batch"))?;
+            compact_hash(&last.hash, "last block")
+                .map_err(|e| SyncError::net(format!("invalid pre-Sapling batch: {e}")))?
+        }
+    };
 
     let batch = DownloadedBatch {
         block_source,
         from_state,
-        canonical_end_hash_at_fetch: end_state.block_hash(),
+        canonical_end_hash_at_fetch,
         synthetic_start_anchor,
     };
     validate_downloaded_batch(&batch, start, end_exclusive)
         .map_err(|e| SyncError::net(format!("inconsistent downloaded batch: {e}")))?;
     Ok(batch)
+}
+
+async fn fetch_batch_end_state(
+    client: &mut CompactTxStreamerClient<Channel>,
+    network: WalletNetwork,
+    end_height: BlockHeight,
+) -> Result<Option<chain::ChainState>, SyncError> {
+    if should_use_empty_chain_state(&network, end_height)? {
+        Ok(None)
+    } else {
+        fetch_validated_chain_state(client, end_height)
+            .await
+            .map(Some)
+    }
 }
 
 /// Re-checks a prefetched batch immediately before consumption. A successful
@@ -2330,9 +2359,16 @@ async fn download_batch(
 /// memory.
 async fn prefetched_batch_is_current(
     client: &mut CompactTxStreamerClient<Channel>,
+    network: WalletNetwork,
     batch: &DownloadedBatch,
     end_exclusive: BlockHeight,
 ) -> Result<bool, SyncError> {
+    if should_use_empty_chain_state(&network, end_exclusive - 1)? {
+        // There is no canonical tree-state RPC before Sapling. A fork in this
+        // historical range is still caught by scan_cached_blocks' continuity
+        // checks when the batch is consumed.
+        return Ok(true);
+    }
     let current = fetch_validated_chain_state(client, end_exclusive - 1).await?;
     Ok(prefetched_batch_matches_state(batch, &current))
 }

--- a/rust/src/wallet/sync_engine/mod.rs
+++ b/rust/src/wallet/sync_engine/mod.rs
@@ -22,8 +22,8 @@ use zcash_protocol::consensus::{BlockHeight, NetworkUpgrade, Parameters};
 use crate::wallet::{
     db::{
         open_readonly_conn_with_timeout, open_sync_wallet_db_with_timeout,
-        open_wallet_raw_conn_with_timeout, truncate_wallet_wal_best_effort,
-        with_wallet_db_write_lock, WalletDatabase, SYNC_DB_BUSY_TIMEOUT,
+        open_wallet_raw_conn_with_timeout, spawn_wallet_wal_checkpoint, with_wallet_db_write_lock,
+        WalletDatabase, SYNC_DB_BUSY_TIMEOUT,
     },
     keys,
     network::WalletNetwork,
@@ -2600,13 +2600,7 @@ async fn run_sync_impl(
     // detached OS thread so the sync call and SYNC_RUNNING flag can finish
     // independently after the user-visible completion event is delivered.
     drop(db);
-    let checkpoint_path = db_data_path.to_string();
-    if let Err(e) = std::thread::Builder::new()
-        .name("zcash-wal-checkpoint".into())
-        .spawn(move || truncate_wallet_wal_best_effort(&checkpoint_path))
-    {
-        log::warn!("wallet DB WAL checkpoint thread could not start (harmless): {e}");
-    }
+    spawn_wallet_wal_checkpoint(db_data_path.to_string());
 
     Ok(())
 }

--- a/rust/tests/regtest_reorg.rs
+++ b/rust/tests/regtest_reorg.rs
@@ -1,0 +1,63 @@
+mod common;
+
+use common::{
+    create_wallet, ensure_regtest_up, exclusive_regtest, execute_send, fund_wallet, get_balance,
+    mine_blocks, run_script, sync_wallet,
+};
+
+/// A reorg recovery is only complete when the wallet can spend again.
+/// A successful post-reorg send proves that the reconstructed note tree,
+/// witness, and anchor are accepted by the consensus node.
+#[test]
+#[ignore = "requires Dockerized zcashd/lightwalletd regtest services"]
+fn wallet_survives_reorg_and_can_still_spend() {
+    let _guard = exclusive_regtest();
+    ensure_regtest_up();
+
+    let (sender_dir, sender) = create_wallet("ReorgSender");
+    let sender_db = sender_dir.path().join("zcash_wallet.db");
+    let (receiver_dir, receiver) = create_wallet("ReorgReceiver");
+    let receiver_db = receiver_dir.path().join("zcash_wallet.db");
+
+    // Keep the funded note below the branch point so it must remain spendable
+    // after the wallet rewinds and scans the replacement branch.
+    fund_wallet(&sender.unified_address, "2.0");
+    mine_blocks(15);
+    sync_wallet(&sender_db);
+
+    let before = get_balance(&sender_db, &sender.account_uuid);
+    assert!(
+        before.spendable >= 200_000_000,
+        "expected at least 2 ZEC before the reorg, got {}",
+        before.spendable
+    );
+
+    run_script("reorg.sh", &["5", "25"]);
+    sync_wallet(&sender_db);
+
+    let after_reorg = get_balance(&sender_db, &sender.account_uuid);
+    assert_eq!(
+        after_reorg.spendable, before.spendable,
+        "funding below the branch point must survive the reorg"
+    );
+
+    let txid = execute_send(
+        &sender_db,
+        &sender.account_uuid,
+        &sender.mnemonic,
+        &receiver.unified_address,
+        50_000_000,
+    );
+    assert!(!txid.is_empty(), "post-reorg send must produce a txid");
+
+    mine_blocks(10);
+    sync_wallet(&sender_db);
+    sync_wallet(&receiver_db);
+
+    let received = get_balance(&receiver_db, &receiver.account_uuid);
+    assert!(
+        received.spendable >= 50_000_000,
+        "receiver should see the post-reorg send, got {}",
+        received.spendable
+    );
+}

--- a/rust/tests/regtest_reorg.rs
+++ b/rust/tests/regtest_reorg.rs
@@ -2,8 +2,20 @@ mod common;
 
 use common::{
     create_wallet, ensure_regtest_up, exclusive_regtest, execute_send, fund_wallet, get_balance,
-    mine_blocks, run_script, sync_wallet,
+    get_transaction_history, mine_blocks, run_script, sync_wallet,
 };
+
+use std::path::Path;
+
+fn wallet_scanned_tip(db_path: &Path) -> (u64, Vec<u8>) {
+    let conn = rusqlite::Connection::open(db_path).expect("open wallet db");
+    conn.query_row(
+        "SELECT height, hash FROM blocks ORDER BY height DESC LIMIT 1",
+        [],
+        |row| Ok((row.get::<_, u64>(0)?, row.get::<_, Vec<u8>>(1)?)),
+    )
+    .expect("wallet must have a scanned tip")
+}
 
 /// A reorg recovery is only complete when the wallet can spend again.
 /// A successful post-reorg send proves that the reconstructed note tree,
@@ -60,4 +72,182 @@ fn wallet_survives_reorg_and_can_still_spend() {
         "receiver should see the post-reorg send, got {}",
         received.spendable
     );
+}
+
+/// A reorg can replace the canonical tip without changing its height. This is
+/// the case a height-only completion check misses, so assert the wallet's
+/// stored block hash actually changes after the second sync.
+#[test]
+#[ignore = "requires Dockerized zcashd/lightwalletd regtest services"]
+fn same_height_reorg_replaces_wallet_tip_hash() {
+    let _guard = exclusive_regtest();
+    ensure_regtest_up();
+
+    let (wallet_dir, wallet) = create_wallet("SameHeightReorg");
+    let wallet_db = wallet_dir.path().join("zcash_wallet.db");
+
+    // Keep the received note below the replaced range. Its unchanged balance
+    // distinguishes a correct rewind/rescan from destructive recovery.
+    fund_wallet(&wallet.unified_address, "1.0");
+    sync_wallet(&wallet_db);
+
+    let balance_before = get_balance(&wallet_db, &wallet.account_uuid);
+    let (height_before, hash_before) = wallet_scanned_tip(&wallet_db);
+
+    run_script("reorg.sh", &["5", "6", "same-height"]);
+    sync_wallet(&wallet_db);
+
+    let (height_after, hash_after) = wallet_scanned_tip(&wallet_db);
+    assert_eq!(
+        height_after, height_before,
+        "same-height replacement must leave the scanned height unchanged"
+    );
+    assert_ne!(
+        hash_after, hash_before,
+        "wallet must replace its stored tip hash after a same-height reorg"
+    );
+
+    let balance_after = get_balance(&wallet_db, &wallet.account_uuid);
+    assert_eq!(
+        balance_after.spendable, balance_before.spendable,
+        "a note below the branch point must remain spendable"
+    );
+}
+
+/// Exercise transaction state on the branch that disappears: the sender's
+/// outgoing transaction and the receiver's note are first observed mined,
+/// then the exact transaction is kept out of the same-height replacement.
+#[test]
+#[ignore = "requires Dockerized zcashd/lightwalletd regtest services"]
+fn orphaned_send_is_unmined_and_receiver_loses_spendable_note() {
+    let _guard = exclusive_regtest();
+    ensure_regtest_up();
+
+    let (funder_dir, funder) = create_wallet("OrphanedSendFunder");
+    let funder_db = funder_dir.path().join("zcash_wallet.db");
+    let (sender_dir, sender) = create_wallet("OrphanedSendSender");
+    let sender_db = sender_dir.path().join("zcash_wallet.db");
+    let (receiver_dir, receiver) = create_wallet("OrphanedSendReceiver");
+    let receiver_db = receiver_dir.path().join("zcash_wallet.db");
+
+    // Keep the funder's note below the branch point. The parent and child
+    // transactions below are both externally submitted SDK transactions, so
+    // restarting zcashd removes them from the disconnected-branch mempool.
+    fund_wallet(&funder.unified_address, "2.0");
+    mine_blocks(15);
+    sync_wallet(&funder_db);
+
+    let parent_txids = execute_send(
+        &funder_db,
+        &funder.account_uuid,
+        &funder.mnemonic,
+        &sender.unified_address,
+        80_000_000,
+    );
+    let parent_parts: Vec<_> = parent_txids.split(',').collect();
+    assert_eq!(
+        parent_parts.len(),
+        1,
+        "parent funding must use a single transaction"
+    );
+    let parent_txid = parent_parts[0];
+    mine_blocks(10);
+    sync_wallet(&sender_db);
+    assert!(
+        get_balance(&sender_db, &sender.account_uuid).spendable >= 80_000_000,
+        "sender must first be able to spend the old-branch parent note"
+    );
+
+    let child_txids = execute_send(
+        &sender_db,
+        &sender.account_uuid,
+        &sender.mnemonic,
+        &receiver.unified_address,
+        50_000_000,
+    );
+    let child_parts: Vec<_> = child_txids.split(',').collect();
+    assert_eq!(
+        child_parts.len(),
+        1,
+        "child spend must use a single transaction"
+    );
+    let child_txid = child_parts[0];
+
+    // Parent and child are each mined in the first block of a ten-block run.
+    // The parent therefore sits at old_tip - 19; replacing twenty blocks
+    // removes both transactions and returns to the identical tip height.
+    mine_blocks(10);
+    sync_wallet(&sender_db);
+    sync_wallet(&receiver_db);
+
+    let receiver_mined = get_transaction_history(&receiver_db, &receiver.account_uuid);
+    assert!(
+        receiver_mined
+            .iter()
+            .any(|tx| tx.txid_hex == child_txid && tx.mined_height > 0),
+        "receiver must first observe the child transaction mined on the old branch"
+    );
+    assert!(
+        get_balance(&receiver_db, &receiver.account_uuid).spendable >= 50_000_000,
+        "receiver must first be able to spend the confirmed old-branch note"
+    );
+
+    let (old_height, old_hash) = wallet_scanned_tip(&sender_db);
+    let dropped_txids = format!("{parent_txid},{child_txid}");
+    run_script(
+        "reorg.sh",
+        &["19", "20", "same-height", "drop-mempool", &dropped_txids],
+    );
+    sync_wallet(&sender_db);
+    sync_wallet(&receiver_db);
+
+    let (new_height, new_hash) = wallet_scanned_tip(&sender_db);
+    assert_eq!(new_height, old_height, "replacement must be same-height");
+    assert_ne!(new_hash, old_hash, "sender must adopt the replacement tip");
+
+    let sender_history = get_transaction_history(&sender_db, &sender.account_uuid);
+    let orphaned_parent = sender_history
+        .iter()
+        .find(|tx| tx.txid_hex == parent_txid)
+        .expect("sender must retain the orphaned incoming parent transaction");
+    assert_eq!(
+        orphaned_parent.mined_height, 0,
+        "orphaned incoming parent transaction must no longer be marked mined"
+    );
+    let orphaned_child = sender_history
+        .iter()
+        .find(|tx| tx.txid_hex == child_txid)
+        .expect("sender must retain the locally-created orphan child transaction");
+    assert_eq!(
+        orphaned_child.mined_height, 0,
+        "orphaned outgoing child transaction must no longer be marked mined"
+    );
+
+    let receiver_history = get_transaction_history(&receiver_db, &receiver.account_uuid);
+    if let Some(receiver_orphan) = receiver_history.iter().find(|tx| tx.txid_hex == child_txid) {
+        assert_eq!(
+            receiver_orphan.mined_height, 0,
+            "orphaned incoming transaction must no longer be marked mined"
+        );
+    }
+    assert_eq!(
+        get_balance(&receiver_db, &receiver.account_uuid).spendable,
+        0,
+        "receiver must lose spendability of the orphaned note"
+    );
+
+    // Once the local transaction expires on the replacement branch, the
+    // invalid child must not become mined by automatic resubmission.
+    mine_blocks(50);
+    sync_wallet(&sender_db);
+    let expired_history = get_transaction_history(&sender_db, &sender.account_uuid);
+    let expired = expired_history
+        .iter()
+        .find(|tx| tx.txid_hex == child_txid)
+        .expect("sender must retain expired transaction history");
+    assert!(
+        expired.expired_unmined,
+        "orphaned send must eventually expire"
+    );
+    assert_eq!(expired.mined_height, 0, "invalid child must remain unmined");
 }

--- a/rust/tests/regtest_reorg.rs
+++ b/rust/tests/regtest_reorg.rs
@@ -17,6 +17,16 @@ fn wallet_scanned_tip(db_path: &Path) -> (u64, Vec<u8>) {
     .expect("wallet must have a scanned tip")
 }
 
+/// Send APIs return the conventional display txid (reversed byte order),
+/// while `TransactionInfo.txid_hex` intentionally exposes the wallet DB's
+/// raw txid bytes. Convert only for history lookup; zcashd RPCs still use the
+/// original display form.
+fn wallet_history_txid(display_txid: &str) -> String {
+    let mut bytes = hex::decode(display_txid).expect("valid display txid");
+    bytes.reverse();
+    hex::encode(bytes)
+}
+
 /// A reorg recovery is only complete when the wallet can spend again.
 /// A successful post-reorg send proves that the reconstructed note tree,
 /// witness, and anchor are accepted by the consensus node.
@@ -151,6 +161,7 @@ fn orphaned_send_is_unmined_and_receiver_loses_spendable_note() {
         "parent funding must use a single transaction"
     );
     let parent_txid = parent_parts[0];
+    let parent_history_txid = wallet_history_txid(parent_txid);
     mine_blocks(10);
     sync_wallet(&sender_db);
     assert!(
@@ -172,6 +183,7 @@ fn orphaned_send_is_unmined_and_receiver_loses_spendable_note() {
         "child spend must use a single transaction"
     );
     let child_txid = child_parts[0];
+    let child_history_txid = wallet_history_txid(child_txid);
 
     // Parent and child are each mined in the first block of a ten-block run.
     // The parent therefore sits at old_tip - 19; replacing twenty blocks
@@ -184,7 +196,7 @@ fn orphaned_send_is_unmined_and_receiver_loses_spendable_note() {
     assert!(
         receiver_mined
             .iter()
-            .any(|tx| tx.txid_hex == child_txid && tx.mined_height > 0),
+            .any(|tx| tx.txid_hex == child_history_txid && tx.mined_height > 0),
         "receiver must first observe the child transaction mined on the old branch"
     );
     assert!(
@@ -208,7 +220,7 @@ fn orphaned_send_is_unmined_and_receiver_loses_spendable_note() {
     let sender_history = get_transaction_history(&sender_db, &sender.account_uuid);
     let orphaned_parent = sender_history
         .iter()
-        .find(|tx| tx.txid_hex == parent_txid)
+        .find(|tx| tx.txid_hex == parent_history_txid)
         .expect("sender must retain the orphaned incoming parent transaction");
     assert_eq!(
         orphaned_parent.mined_height, 0,
@@ -216,7 +228,7 @@ fn orphaned_send_is_unmined_and_receiver_loses_spendable_note() {
     );
     let orphaned_child = sender_history
         .iter()
-        .find(|tx| tx.txid_hex == child_txid)
+        .find(|tx| tx.txid_hex == child_history_txid)
         .expect("sender must retain the locally-created orphan child transaction");
     assert_eq!(
         orphaned_child.mined_height, 0,
@@ -224,7 +236,10 @@ fn orphaned_send_is_unmined_and_receiver_loses_spendable_note() {
     );
 
     let receiver_history = get_transaction_history(&receiver_db, &receiver.account_uuid);
-    if let Some(receiver_orphan) = receiver_history.iter().find(|tx| tx.txid_hex == child_txid) {
+    if let Some(receiver_orphan) = receiver_history
+        .iter()
+        .find(|tx| tx.txid_hex == child_history_txid)
+    {
         assert_eq!(
             receiver_orphan.mined_height, 0,
             "orphaned incoming transaction must no longer be marked mined"
@@ -243,7 +258,7 @@ fn orphaned_send_is_unmined_and_receiver_loses_spendable_note() {
     let expired_history = get_transaction_history(&sender_db, &sender.account_uuid);
     let expired = expired_history
         .iter()
-        .find(|tx| tx.txid_hex == child_txid)
+        .find(|tx| tx.txid_hex == child_history_txid)
         .expect("sender must retain expired transaction history");
     assert!(
         expired.expired_unmined,

--- a/scripts/regtest/reorg.sh
+++ b/scripts/regtest/reorg.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Invalidate a recent block and mine a longer replacement branch.
+# Usage: reorg.sh [depth=5] [extra=25]
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+
+wait_for_zcashd
+wait_for_lightwalletd
+
+depth="${1:-5}"
+extra="${2:-25}"
+
+# invalidateblock also removes the named block, so the replacement branch
+# needs at least depth + 2 blocks to finish above the old tip.
+if (( extra < depth + 2 )); then
+  echo "reorg.sh: extra ($extra) must be at least depth + 2 ($((depth + 2)))" >&2
+  exit 1
+fi
+
+old_tip="$(zcash_cli getblockcount)"
+target_height=$((old_tip - depth))
+target_hash="$(zcash_cli getblockhash "$target_height")"
+
+zcash_cli invalidateblock "$target_hash"
+zcash_cli generate "$extra" >/dev/null
+
+new_tip="$(zcash_cli getblockcount)"
+if (( new_tip <= old_tip )); then
+  echo "reorg.sh: replacement branch did not exceed the old tip (old=$old_tip new=$new_tip)" >&2
+  exit 1
+fi
+
+wait_for_lightwalletd_tip "$new_tip"
+echo "reorg: invalidated height=$target_height (old_tip=$old_tip) -> new_tip=$new_tip"

--- a/scripts/regtest/reorg.sh
+++ b/scripts/regtest/reorg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Invalidate a recent block and mine a longer replacement branch.
-# Usage: reorg.sh [depth=5] [extra=25]
+# Invalidate a recent block and mine a replacement branch.
+# Usage: reorg.sh [depth=5] [extra=25] [longer|same-height] [keep-mempool|drop-mempool] [txids-to-drop]
 set -euo pipefail
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
@@ -10,26 +10,126 @@ wait_for_lightwalletd
 
 depth="${1:-5}"
 extra="${2:-25}"
+tip_mode="${3:-longer}"
+mempool_mode="${4:-keep-mempool}"
+txids_to_drop="${5:-}"
 
-# invalidateblock also removes the named block, so the replacement branch
-# needs at least depth + 2 blocks to finish above the old tip.
-if (( extra < depth + 2 )); then
-  echo "reorg.sh: extra ($extra) must be at least depth + 2 ($((depth + 2)))" >&2
-  exit 1
-fi
+case "$tip_mode" in
+  longer)
+    # invalidateblock also removes the named block, so the replacement branch
+    # needs at least depth + 2 blocks to finish above the old tip.
+    if (( extra < depth + 2 )); then
+      echo "reorg.sh: extra ($extra) must be at least depth + 2 ($((depth + 2)))" >&2
+      exit 1
+    fi
+    ;;
+  same-height)
+    if (( extra != depth + 1 )); then
+      echo "reorg.sh: same-height requires extra=depth+1 ($((depth + 1))), got $extra" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "reorg.sh: tip mode must be 'longer' or 'same-height', got '$tip_mode'" >&2
+    exit 1
+    ;;
+esac
+
+case "$mempool_mode" in
+  keep-mempool|drop-mempool) ;;
+  *)
+    echo "reorg.sh: mempool mode must be 'keep-mempool' or 'drop-mempool', got '$mempool_mode'" >&2
+    exit 1
+    ;;
+esac
 
 old_tip="$(zcash_cli getblockcount)"
 target_height=$((old_tip - depth))
 target_hash="$(zcash_cli getblockhash "$target_height")"
+old_tip_hash="$(zcash_cli getblockhash "$old_tip")"
 
 zcash_cli invalidateblock "$target_hash"
+
+# Transactions from disconnected blocks normally return to the mempool and
+# would simply be mined again on the replacement branch. Restarting zcashd
+# clears externally-submitted transactions from its non-persistent regtest
+# mempool, making orphan-transaction tests deterministic. Transactions owned
+# by zcashd's own wallet may be rebroadcast after restart, so assert the
+# caller's specific transaction is absent instead of requiring a globally
+# empty mempool.
+if [[ "$mempool_mode" == "drop-mempool" ]]; then
+  if [[ -z "$txids_to_drop" ]]; then
+    echo "reorg.sh: drop-mempool requires a comma-separated txids-to-drop value" >&2
+    exit 1
+  fi
+  compose restart zcashd >/dev/null
+  wait_for_zcashd
+  # lightwalletd treats a transient zcashd RPC failure as fatal. Restart it
+  # explicitly after zcashd is ready; `compose up` can otherwise observe the
+  # old process as running just before that process exits.
+  compose restart lightwalletd >/dev/null
+  wait_for_lightwalletd
+  mempool_json="$(zcash_cli getrawmempool)"
+  if ! python3 - "$txids_to_drop" "$mempool_json" <<'PY'
+import json
+import sys
+
+txids = sys.argv[1].split(",")
+mempool = json.loads(sys.argv[2])
+raise SystemExit(0 if all(txid not in mempool for txid in txids) else 1)
+PY
+  then
+    echo "reorg.sh: a disconnected transaction returned to the mempool after restart: $txids_to_drop" >&2
+    exit 1
+  fi
+fi
+
 zcash_cli generate "$extra" >/dev/null
 
 new_tip="$(zcash_cli getblockcount)"
-if (( new_tip <= old_tip )); then
+new_tip_hash="$(zcash_cli getblockhash "$new_tip")"
+if [[ "$tip_mode" == "longer" ]] && (( new_tip <= old_tip )); then
   echo "reorg.sh: replacement branch did not exceed the old tip (old=$old_tip new=$new_tip)" >&2
   exit 1
 fi
+if [[ "$tip_mode" == "same-height" ]] && (( new_tip != old_tip )); then
+  echo "reorg.sh: replacement branch did not finish at the old height (old=$old_tip new=$new_tip)" >&2
+  exit 1
+fi
+if [[ "$new_tip_hash" == "$old_tip_hash" ]]; then
+  echo "reorg.sh: replacement branch retained the old tip hash $old_tip_hash" >&2
+  exit 1
+fi
 
-wait_for_lightwalletd_tip "$new_tip"
-echo "reorg: invalidated height=$target_height (old_tip=$old_tip) -> new_tip=$new_tip"
+# A height-only wait returns immediately for a same-height reorg while
+# lightwalletd may still serve the old branch. Wait for the canonical hash at
+# the replacement tip so the test cannot race its next wallet sync.
+if command -v grpcurl >/dev/null 2>&1; then
+  observed_hash=""
+  for _ in $(seq 1 120); do
+    observed_hash="$(
+      grpcurl \
+        -plaintext \
+        -import-path "$ROOT_DIR/protos" \
+        -proto service.proto \
+        -d "{\"height\": $new_tip}" \
+        "${LIGHTWALLETD_HOST}:${LIGHTWALLETD_PORT}" \
+        cash.z.wallet.sdk.rpc.CompactTxStreamer/GetTreeState \
+        2>/dev/null \
+        | python3 -c 'import json, sys; print(json.load(sys.stdin).get("hash", ""))' \
+      || true
+    )"
+    if [[ "$observed_hash" == "$new_tip_hash" ]]; then
+      break
+    fi
+    sleep 1
+  done
+  if [[ "$observed_hash" != "$new_tip_hash" ]]; then
+    echo "reorg.sh: lightwalletd did not switch to replacement hash $new_tip_hash" >&2
+    exit 1
+  fi
+else
+  wait_for_lightwalletd_tip "$new_tip"
+fi
+
+echo "reorg: invalidated height=$target_height old_tip=$old_tip old_hash=$old_tip_hash new_tip=$new_tip new_hash=$new_tip_hash"

--- a/scripts/regtest/reorg.sh
+++ b/scripts/regtest/reorg.sh
@@ -43,6 +43,15 @@ case "$mempool_mode" in
     ;;
 esac
 
+# A same-height replacement cannot be synchronized reliably by watching only
+# GetLatestBlock.height: the old and new branches have the same value. Fail
+# deterministically when the hash-capable gRPC probe is unavailable instead of
+# racing the next wallet sync against stale lightwalletd state.
+if [[ "$tip_mode" == "same-height" ]] && ! command -v grpcurl >/dev/null 2>&1; then
+  echo "reorg.sh: same-height mode requires grpcurl to verify the replacement tip hash" >&2
+  exit 1
+fi
+
 old_tip="$(zcash_cli getblockcount)"
 target_height=$((old_tip - depth))
 target_hash="$(zcash_cli getblockhash "$target_height")"
@@ -129,6 +138,7 @@ if command -v grpcurl >/dev/null 2>&1; then
     exit 1
   fi
 else
+  # Height is sufficient only when the replacement branch must be longer.
   wait_for_lightwalletd_tip "$new_tip"
 fi
 

--- a/test/providers/sync_provider_test.dart
+++ b/test/providers/sync_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/src/providers/sync_failure.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
+import 'package:zcash_wallet/src/services/background_sync_delegate.dart';
 
 void main() {
   test(
@@ -75,6 +76,88 @@ void main() {
           error: newFailure.rawMessage,
           lastSyncFailedAt: newFailedAt,
         ),
+      ),
+      isTrue,
+    );
+  });
+
+  test('stale progress merges data without reviving a failed sync', () {
+    final failure = classifySyncFailure(StateError('sync failed'));
+    final failedAt = DateTime.utc(2026, 1, 2);
+    final failureState = SyncState(
+      accountUuid: 'account',
+      isSyncing: false,
+      isBackgroundMode: false,
+      percentage: 0.4,
+      displayPercentage: 0.4,
+      displayTargetPercentage: 0.4,
+      displayTargetBlocks: 0,
+      scannedHeight: 40,
+      chainTipHeight: 100,
+      failure: failure,
+      error: failure.rawMessage,
+      lastSyncFailedAt: failedAt,
+      phase: '',
+    );
+    final staleProgress = SyncState(
+      accountUuid: 'account',
+      hasBalanceData: true,
+      hasRecentTransactionsData: true,
+      isSyncing: true,
+      percentage: 0.5,
+      displayPercentage: 0.5,
+      displayTargetPercentage: 0.6,
+      displayTargetBlocks: 10,
+      scannedHeight: 50,
+      chainTipHeight: 100,
+      orchardBalance: BigInt.from(42),
+      totalBalance: BigInt.from(42),
+      phase: 'scan',
+    );
+
+    final merged = mergeProgressDataIntoConcurrentFailure(
+      currentFailureState: failureState,
+      progressState: staleProgress,
+    );
+
+    expect(merged.isSyncing, isFalse);
+    expect(merged.percentage, 0.4);
+    expect(merged.displayTargetBlocks, 0);
+    expect(merged.scannedHeight, 40);
+    expect(merged.phase, isEmpty);
+    expect(merged.failure, same(failure));
+    expect(merged.lastSyncFailedAt, failedAt);
+    expect(merged.hasAccountScopedData, isTrue);
+    expect(merged.orchardBalance, BigInt.from(42));
+    expect(merged.totalBalance, BigInt.from(42));
+  });
+
+  test('stale progress cannot restart smoothing after a sync failure', () {
+    const progress = SyncProgressEvent(
+      scannedHeight: 50,
+      chainTipHeight: 100,
+      percentage: 0.5,
+      displayTargetPercentage: 0.6,
+      displayTargetBlocks: 10,
+      isSyncing: true,
+      isComplete: false,
+      hasNewTx: true,
+      phase: 'scan',
+    );
+
+    expect(
+      shouldSmoothSyncProgress(
+        event: progress,
+        preserveConcurrentFailure: true,
+        isBackgroundDelegateActive: false,
+      ),
+      isFalse,
+    );
+    expect(
+      shouldSmoothSyncProgress(
+        event: progress,
+        preserveConcurrentFailure: false,
+        isBackgroundDelegateActive: false,
       ),
       isTrue,
     );

--- a/test/providers/sync_provider_test.dart
+++ b/test/providers/sync_provider_test.dart
@@ -1,7 +1,85 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/providers/sync_failure.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 
 void main() {
+  test(
+    'sync failure records error before refreshing committed DB state',
+    () async {
+      final events = <String>[];
+      final error = StateError('final enhancement failed');
+
+      await recordSyncFailureAndRefreshCommittedState(
+        error: error,
+        recordFailure: (recorded) {
+          expect(recorded, same(error));
+          events.add('record');
+        },
+        refreshCommittedState: () async {
+          events.add('refresh');
+        },
+        onRefreshError: (_, _) => fail('refresh should succeed'),
+      );
+
+      expect(events, ['record', 'refresh']);
+    },
+  );
+
+  test(
+    'sync failure remains recorded when committed-state refresh fails',
+    () async {
+      final events = <String>[];
+      final error = StateError('sync failed');
+      final refreshError = StateError('DB unavailable');
+
+      await recordSyncFailureAndRefreshCommittedState(
+        error: error,
+        recordFailure: (_) => events.add('record'),
+        refreshCommittedState: () async {
+          events.add('refresh');
+          throw refreshError;
+        },
+        onRefreshError: (recorded, _) {
+          expect(recorded, same(refreshError));
+          events.add('refresh-error');
+        },
+      );
+
+      expect(events, ['record', 'refresh', 'refresh-error']);
+    },
+  );
+
+  test('progress preserves only a failure recorded during its async wait', () {
+    final oldFailure = classifySyncFailure(StateError('old failure'));
+    final newFailure = classifySyncFailure(StateError('new failure'));
+    final oldFailedAt = DateTime.utc(2026, 1, 1);
+    final newFailedAt = DateTime.utc(2026, 1, 2);
+    final beforeAwait = SyncState(
+      failure: oldFailure,
+      error: oldFailure.rawMessage,
+      lastSyncFailedAt: oldFailedAt,
+    );
+
+    expect(
+      syncFailureWasRecordedWhileProgressAwaited(
+        beforeAwait: beforeAwait,
+        current: beforeAwait,
+      ),
+      isFalse,
+    );
+    expect(
+      syncFailureWasRecordedWhileProgressAwaited(
+        beforeAwait: beforeAwait,
+        current: SyncState(
+          failure: newFailure,
+          error: newFailure.rawMessage,
+          lastSyncFailedAt: newFailedAt,
+        ),
+      ),
+      isTrue,
+    );
+  });
+
   test(
     'clearCachedWalletDbPath forces the next DB path lookup to refresh',
     () async {


### PR DESCRIPTION
## Summary

- tune the long-lived sync SQLite connection while keeping interactive durability defaults
- add memory-bounded compact-block prefetch and reduce redundant tip, status, and resubmit work
- bound and parallelize transaction enhancement while preserving committed progress and final queue drain correctness
- harden same-height and deep reorg recovery, sync failure refresh, and detached WAL checkpoint/reset coordination
- add a fail-closed Rust sync benchmark plus reorg and provider regression coverage

This implementation intentionally keeps upstream `shardtree` unchanged and does not include the earlier vendored fast-merge experiment.

## Impact

Cold and catch-up sync perform less serialized network and database work, while foreground/background handoff, cancellation, wallet reset, and reorg recovery retain explicit safety checks.

## Validation

- `cd rust && cargo fmt --check`
- `cd rust && cargo test` — 213 passed, 1 explicitly ignored slow transaction-construction test; Docker regtest cases remain opt-in
- `fvm flutter analyze` — no issues
- `fvm flutter test test/providers/sync_provider_test.dart` — 4 passed
- `fvm flutter test` — 1,594 passed and 54 mobile-lane tests skipped; two unrelated baseline tests fail identically on `origin/main`: the transparent receive widgetbook modal size expectation and the uninstall settings off-screen tap

The branch was rebased onto the current `origin/main` before publication.