### PR TITLE
Polish desktop Pay flows (VZR-116, VZR-117, VZR-118)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -740,6 +740,28 @@ WidgetsFlutterBinding.ensureInitialized()
 → runApp()
 ```
 
+### Figma comparison entry point
+
+For deterministic code-to-Figma screenshots, use `lib/figma_compare.dart`
+instead of temporarily rerouting the production app or capturing Widgetbook
+chrome. It reuses the production macOS window initialization and native shell
+without starting Rust, storage, sync, wallet, or network state. Registered
+states live in `lib/figma_compare/figma_compare_scenarios.dart` and must use
+deterministic dev-only mocks.
+
+```bash
+fvm flutter run -d macos -t lib/figma_compare.dart \
+  --dart-define=FIGMA_COMPARE_SCENARIO=pay-recipient \
+  --dart-define=FIGMA_COMPARE_OUTPUT=pay-recipient/content.png
+```
+
+Relative outputs go to the app sandbox's `vizor-figma-compare` temporary
+directory. The entry point emits a 1x Flutter-content PNG plus a native-window
+PNG, automatically restores a minimized window before capture, and returns it
+and the previously foreground app to their original states afterward. Full
+workflow, output paths, mobile capture, and cleanup rules are in
+`FIGMA-AI-FIX.md`.
+
 Important desktop design rule:
 
 - `Scaffold.backgroundColor: Colors.transparent` is required anywhere the native acrylic/translucent shell should remain visible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,12 @@ Untagged tests may run in either lane and must be lane-agnostic:
   `fvm flutter run -t lib/widgetbook.dart --dart-define=VIZOR_FORM_FACTOR=mobile`.
   Only `lib/main.dart` asserts the match.
 
+## Editing Figma
+
+When the user explicitly asks you to modify a Figma file or design, read
+`FIGMA-AI-FIX.md` completely before starting and use it as the instructions and
+reference for that work.
+
 ## Figma Layer Interpretation
 
 When reading or implementing Figma designs, distinguish app UI from

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -740,27 +740,33 @@ WidgetsFlutterBinding.ensureInitialized()
 → runApp()
 ```
 
-### Figma comparison entry point
+### Figma comparison tooling
 
-For deterministic code-to-Figma screenshots, use `lib/figma_compare.dart`
-instead of temporarily rerouting the production app or capturing Widgetbook
-chrome. It reuses the production macOS window initialization and native shell
-without starting Rust, storage, sync, wallet, or network state. Registered
-states live in `lib/figma_compare/figma_compare_scenarios.dart` and must use
-deterministic dev-only mocks.
+For deterministic code-to-Figma screenshots, use the widget-test capture as
+the normal iteration path. It renders the same `FigmaCompareApp` and registered
+scenario without building Rust, CocoaPods, Xcode, or a macOS app:
 
 ```bash
-fvm flutter run -d macos -t lib/figma_compare.dart \
-  --dart-define=FIGMA_COMPARE_SCENARIO=pay-recipient \
-  --dart-define=FIGMA_COMPARE_OUTPUT=pay-recipient/content.png
+scripts/figma-compare.sh widget --scenario pay-recipient --theme dark
 ```
 
-Relative outputs go to the app sandbox's `vizor-figma-compare` temporary
-directory. The entry point emits a 1x Flutter-content PNG plus a native-window
-PNG, automatically restores a minimized window before capture, and returns it
-and the previously foreground app to their original states afterward. Full
-workflow, output paths, mobile capture, and cleanup rules are in
-`FIGMA-AI-FIX.md`.
+Use the native entry point only for final macOS window-shell and restoration
+verification:
+
+```bash
+scripts/figma-compare.sh native --scenario pay-recipient --theme dark
+```
+
+Registered states live in
+`lib/figma_compare/figma_compare_scenarios.dart` and must use deterministic
+dev-only mocks. Outputs go below the app sandbox's `vizor-figma-compare`
+temporary directory: `content.widget.png` is the fast app-content reference;
+`content.png` and `content.window.png` are the real-engine and native-window
+final evidence. The native entry point reuses production macOS window
+initialization without starting Rust, storage, sync, wallet, or network state,
+automatically restores a minimized window before capture, and returns it and
+the previously foreground app to their original states afterward. Full
+workflow, mobile capture, and cleanup rules are in `FIGMA-AI-FIX.md`.
 
 Important desktop design rule:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,50 @@ When the user explicitly asks you to modify a Figma file or design, read
 `FIGMA-AI-FIX.md` completely before starting and use it as the instructions and
 reference for that work.
 
+## Figma Visual Verification
+
+Use the widget-test capture as the default visual-comparison path in both
+directions: when applying an existing Flutter implementation to Figma and when
+implementing a Figma design in Flutter, then capturing the result to find and
+correct differences from the design.
+
+- Represent the required screen and state as a deterministic scenario in
+  `lib/figma_compare/figma_compare_scenarios.dart`. Prefer reusing an existing
+  Widgetbook fixture. The scenario must not depend on production wallet data,
+  storage, network, or Rust state.
+- Match the Figma reference's form factor, logical viewport, theme, locale,
+  content, and component state. Use the widget-test renderer for normal
+  desktop and mobile iterations:
+
+  ```bash
+  scripts/figma-compare.sh widget \
+    --scenario <scenario> \
+    --theme <dark|light>
+
+  scripts/figma-compare.sh widget \
+    --form-factor mobile \
+    --scenario <mobile-scenario> \
+    --theme <dark|light>
+  ```
+
+- Compare `content.widget.png` with the corresponding Figma capture side by
+  side and, when practical, with an overlay or image diff. After implementing
+  from Figma, correct the Flutter code and repeat the widget capture until no
+  actionable visual difference remains. Do not use Widgetbook chrome as
+  comparison evidence.
+- If the required state is not registered, add a reusable deterministic
+  capture scenario before falling back to a running platform app. Temporary
+  production routes, bootstrap overrides, or provider changes are a last
+  resort and must be removed before completion.
+- Use native macOS or iOS Simulator captures only for a final check of behavior
+  the widget-test renderer cannot represent, such as operating-system chrome,
+  the real window shell, native insets, or a material platform-rendering
+  difference. Keep the widget capture as the primary app-content comparison.
+- A request to compare an implementation with Figma does not authorize any
+  Figma mutation. Do not copy, move, or edit Figma nodes unless the user
+  explicitly requests a Figma change. When they do, read `FIGMA-AI-FIX.md` in
+  full and follow its target-approval, copy-only, and visual-parity workflow.
+
 ## Figma Layer Interpretation
 
 When reading or implementing Figma designs, distinguish app UI from

--- a/FIGMA-AI-FIX.md
+++ b/FIGMA-AI-FIX.md
@@ -48,6 +48,12 @@ to use?
 
 ## Copy-only editing policy
 
+The Vizor design system itself is strictly read-only and must never be
+modified. This prohibition includes every design-system page, component
+master, component set, variant, variable, style, token, and shared asset. It
+still applies when changing the design system would appear to be the easiest
+way to satisfy the request.
+
 Existing Figma screens and components are immutable. Never rename, delete,
 move, reparent, detach, resize, restyle, or otherwise mutate an existing source
 node. Do not modify an existing component's variants, properties, auto-layout,
@@ -59,11 +65,17 @@ After the user approves the target:
 1. Copy only the approved screen or component into the
    [AI Test page](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=8001-32299&m=dev).
 2. Apply every requested change only to that new copy and its descendants.
+   When modifying or adding a screen, reuse the existing Vizor design-system
+   component instances, variables, styles, tokens, and layout patterns as much
+   as possible. Do not recreate an available design-system asset with detached
+   or ad-hoc layers.
 3. If a nested shared component must change, copy that component into the AI
    Test page too, then retarget only the copied screen's instance to the copied
    component. Never change the original main component.
 4. If the requested change would require mutating anything outside the copied
    subtree, stop and ask the user before continuing.
+   If a required asset does not exist in the design system, also stop and ask
+   the user rather than adding it to or modifying the design system.
 5. Before reporting completion, verify that every mutated node is a descendant
    of the approved copy on the AI Test page and that all original nodes remain
    unchanged.

--- a/FIGMA-AI-FIX.md
+++ b/FIGMA-AI-FIX.md
@@ -19,6 +19,13 @@ Unless the user specifies another source, find the Figma screen corresponding
 to the code in
 [Vizor Design System AI Test](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=5572-69081&m=dev).
 
+If no confident match can be found in that default location, do not force a
+match, select a merely similar screen or component, or expand the search to
+other Figma pages without the user's direction. Report that no confident match
+was found, summarize the location and candidates checked, and wait for the
+user to provide another location or target before copying or editing anything.
+Treat an uncertain candidate the same as no match.
+
 Treat every match as a candidate until the user approves it. Before copying or
 editing anything:
 

--- a/FIGMA-AI-FIX.md
+++ b/FIGMA-AI-FIX.md
@@ -3,5 +3,31 @@
 
 # Figma AI Fix
 
-This document contains the project instructions and reference material for
-AI-assisted changes made directly in Figma.
+This documentation covers only the Vizor design system in
+[Vizor Design System AI Test](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?m=dev).
+It does not document product flows, feature mockups, WIP screens, QA pages, or
+implementation behavior.
+
+Read [source and scope](figma-ai-fix/00-source-and-scope.md) first. Then read
+only the topic documents needed for the requested Figma change.
+
+| Document | Purpose and contents |
+| --- | --- |
+| [00-source-and-scope.md](figma-ai-fix/00-source-and-scope.md) | Source file, authoritative design-system page set, exclusions, naming rules, and inventory totals. |
+| [01-color-system.md](figma-ai-fix/01-color-system.md) | Dark/Light color variables: primitives, semantic roles, and OS utility colors. |
+| [02-sizing-and-layout.md](figma-ai-fix/02-sizing-and-layout.md) | Desktop/Mobile sizing variables for units, spacing, radii, windows, and component dimensions. |
+| [03-typography.md](figma-ai-fix/03-typography.md) | Desktop/Mobile font variables, local text styles, and the Paragraph component. |
+| [04-effects-and-grid.md](figma-ai-fix/04-effects-and-grid.md) | Local effect styles and the desktop layout grid. |
+| [05-brand-and-app-icon.md](figma-ai-fix/05-brand-and-app-icon.md) | Vizor identity, logos, symbols, 3D marks, and app-icon assets. |
+| [06-icons.md](figma-ai-fix/06-icons.md) | Complete local icon-component inventory and exact node IDs. |
+| [07-illustrations-assets-and-placeholders.md](figma-ai-fix/07-illustrations-assets-and-placeholders.md) | Illustrations, PFPs, full-page states, user imagery, and placeholders. |
+| [08-actions-status-and-feedback.md](figma-ai-fix/08-actions-status-and-feedback.md) | Buttons, badges, chips, tooltips, and toasts with properties and variants. |
+| [09-inputs-selection-and-dropdowns.md](figma-ai-fix/09-inputs-selection-and-dropdowns.md) | Fields, text areas, dropdowns, radio controls, and checkboxes. |
+| [10-navigation-tabs-and-modals.md](figma-ai-fix/10-navigation-tabs-and-modals.md) | Sidebar/navigation assets, tabs, and modal families. |
+| [11-data-cards-lists-and-tables.md](figma-ai-fix/11-data-cards-lists-and-tables.md) | Asset/table building blocks, context menus, cards, pagination, and lists. |
+| [12-swap-components.md](figma-ai-fix/12-swap-components.md) | Design-system components from the Swap UI page; no product-flow behavior. |
+| [13-platform-and-local-utilities.md](figma-ai-fix/13-platform-and-local-utilities.md) | Scrollbars, macOS presentation utilities, keyboards, and local organizational helpers. |
+
+The live Figma file is the source of truth. If a documented value or node no
+longer matches Figma, re-read the relevant design-system page instead of
+guessing or copying a product-screen override.

--- a/FIGMA-AI-FIX.md
+++ b/FIGMA-AI-FIX.md
@@ -203,6 +203,48 @@ captures to compare the same app-content bounds. Follow the repository's Figma
 layer-interpretation rules for presentation-only macOS backgrounds and window
 controls.
 
+### Scrollable screens
+
+Treat a scrollable design as a fixed viewport containing longer content, not
+as an arbitrarily tall app window.
+
+1. Keep the copied top-level `Screen` at the same desktop or mobile viewport
+   dimensions used by Flutter. Do not lengthen that frame merely because its
+   content scrolls.
+2. Put the scrolling content in a nested frame whose bounds match the actual
+   scroll region. Enable clipping on the viewport frame, extend the content
+   below it, and set vertical overflow scrolling in the prototype when the
+   available Figma operation supports it.
+3. Match the code's scroll ownership. Headers, sidebars, bottom navigation,
+   CTAs, and other elements that remain fixed in Flutter stay outside the
+   scrolling frame. Elements that scroll in Flutter must not be made fixed in
+   Figma for convenience.
+4. Use the top position as the canonical copied screen. Add separate sibling
+   copies for middle or bottom positions only when the visible UI materially
+   changes there, such as a sticky-header transition, fixed action, scrollbar
+   thumb, bottom-only content, lazy-loading state, pagination, or a
+   user-requested scroll position. Name the states consistently, for example
+   `Activity / Scroll top`, `Activity / Scroll middle`, and
+   `Activity / Scroll bottom`.
+5. Register and capture a deterministic Flutter scenario for every required
+   scroll position. Prefer scenario IDs such as `activity-top`,
+   `activity-middle`, and `activity-bottom`; use offset `0`, an explicitly
+   documented middle target, and `maxScrollExtent` respectively. Set the
+   position without animation (for example with `jumpTo`) only after layout and
+   assets are ready, then compare each widget PNG with its matching Figma copy.
+6. Show a scrollbar only when the implementation shows one. Reuse the existing
+   design-system `Scrollbar` component and its `scroll=Top`, `scroll=Middle`, or
+   `scroll=bottom` variant documented in
+   `figma-ai-fix/13-platform-and-local-utilities.md`. Never redraw or modify the
+   design-system component. Do not invent a custom scrollbar for native
+   platform scrolling that the app itself does not render.
+7. Do not stitch viewport screenshots or use a vertically stretched `Screen`
+   as primary parity evidence. If the user needs the entire information
+   architecture visible at once, create a separate, clearly labeled
+   `Full content spec` reference frame in addition to the real clipped screen.
+   That reference is documentation only and is not an app viewport or parity
+   result.
+
 ### 3. Capture and compare the Figma copy
 
 1. Set the copied Figma screen to the same viewport or frame dimensions,

--- a/FIGMA-AI-FIX.md
+++ b/FIGMA-AI-FIX.md
@@ -8,6 +8,66 @@ This documentation covers only the Vizor design system in
 It does not document product flows, feature mockups, WIP screens, QA pages, or
 implementation behavior.
 
+The topic documents under `figma-ai-fix/` remain design-system-only. The
+workflow below governs how product screens are identified and safely copied
+when the user explicitly requests a Figma change; it does not add those product
+screens to the design-system documentation.
+
+## Screen matching and approval gate
+
+Unless the user specifies another source, find the Figma screen corresponding
+to the code in
+[Vizor Design System AI Test](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=5572-69081&m=dev).
+
+Treat every match as a candidate until the user approves it. Before copying or
+editing anything:
+
+1. Report the Figma page name, screen or component name, node ID, direct URL,
+   and the concrete reason it matches the code.
+2. If more than one candidate is plausible, report the candidates instead of
+   choosing one silently.
+3. Explicitly tell the user that nothing has been copied or edited yet and ask
+   whether the identified screen or component is the intended target.
+4. Wait for explicit approval. Do not copy or edit the candidate before that
+   approval.
+
+Use this confirmation format:
+
+```markdown
+I found the likely matching Figma screen:
+
+- Page:
+- Screen/component:
+- Node ID:
+- URL:
+- Match rationale:
+
+I have not copied or edited anything yet. Is this the correct screen/component
+to use?
+```
+
+## Copy-only editing policy
+
+Existing Figma screens and components are immutable. Never rename, delete,
+move, reparent, detach, resize, restyle, or otherwise mutate an existing source
+node. Do not modify an existing component's variants, properties, auto-layout,
+text, fills, effects, variables, styles, or main component. Shared assets that
+could change an existing screen are also immutable.
+
+After the user approves the target:
+
+1. Copy only the approved screen or component into the
+   [AI Test page](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=8001-32299&m=dev).
+2. Apply every requested change only to that new copy and its descendants.
+3. If a nested shared component must change, copy that component into the AI
+   Test page too, then retarget only the copied screen's instance to the copied
+   component. Never change the original main component.
+4. If the requested change would require mutating anything outside the copied
+   subtree, stop and ask the user before continuing.
+5. Before reporting completion, verify that every mutated node is a descendant
+   of the approved copy on the AI Test page and that all original nodes remain
+   unchanged.
+
 Read [source and scope](figma-ai-fix/00-source-and-scope.md) first. Then read
 only the topic documents needed for the requested Figma change.
 

--- a/FIGMA-AI-FIX.md
+++ b/FIGMA-AI-FIX.md
@@ -101,11 +101,11 @@ styling or layout temporarily to make the reference resemble the Figma copy.
 2. Determine which form factors the code change affects. Validate both desktop
    and mobile when both are affected; otherwise validate only the affected or
    explicitly requested form factor.
-3. Use `lib/figma_compare.dart` instead of the production entry point or
-   Widgetbook chrome whenever the required state is registered in
-   `lib/figma_compare/figma_compare_scenarios.dart`. This entry point reproduces
-   the production desktop window bootstrap but skips Rust, wallet, storage,
-   sync, and network initialization.
+3. Use the widget-test capture through `scripts/figma-compare.sh widget` as the
+   default iteration path whenever the required state is registered in
+   `lib/figma_compare/figma_compare_scenarios.dart`. It renders the same
+   `FigmaCompareApp` without building Rust, CocoaPods, Xcode, or a platform app.
+   Do not use Widgetbook chrome as comparison evidence.
 4. If the required state is not registered, prefer adding a deterministic
    dev-only scenario that reuses an existing Widgetbook fixture. A scenario
    must not depend on production wallet data, storage, network, or Rust state.
@@ -122,44 +122,81 @@ styling or layout temporarily to make the reference resemble the Figma copy.
 
 Always use `fvm flutter`, never bare `flutter`.
 
-- **Desktop:** Run the macOS desktop app without a mobile form-factor define,
-  using the comparison entry point and a registered deterministic scenario:
+- **Desktop, normal iteration:** Capture a registered deterministic scenario
+  through the widget-test renderer:
 
   ```bash
-  fvm flutter run -d macos -t lib/figma_compare.dart \
-    --dart-define=FIGMA_COMPARE_SCENARIO=pay-recipient \
-    --dart-define=FIGMA_COMPARE_THEME=dark \
-    --dart-define=FIGMA_COMPARE_OUTPUT=pay-recipient/content.png
+  scripts/figma-compare.sh widget \
+    --scenario pay-recipient \
+    --theme dark
   ```
 
-  A relative output path is written below the sandbox's system temporary
-  directory, normally
-  `~/Library/Containers/com.keplr.vizor/Data/tmp/vizor-figma-compare/`.
-  The command prints both resolved paths. It produces:
+  This loads the real app fonts, fixes the logical viewport to 1080x720 and DPR
+  to 1 by default, mocks only native appearance synchronization, and writes a
+  1x logical-pixel PNG:
 
-  - `content.png`: the Flutter app-content render at a deterministic 1x logical
-    pixel ratio. Use this as the primary Figma parity reference.
+  - `~/Library/Containers/com.keplr.vizor/Data/tmp/vizor-figma-compare/<scenario>/content.widget.png`
+
+  Use this app-content-only image for every normal Figma comparison and
+  correction iteration. It deliberately contains no titlebar, traffic lights,
+  native window inset, privacy overlay, or other operating-system behavior.
+  Override the logical viewport or DPR only when the target design requires it,
+  using `--width`, `--height`, and `--pixel-ratio`.
+
+- **Desktop, final native verification:** After the widget capture and copied
+  Figma screen are effectively identical, run the real macOS comparison entry
+  point once before reporting completion:
+
+  ```bash
+  scripts/figma-compare.sh native \
+    --scenario pay-recipient \
+    --theme dark
+  ```
+
+  This reproduces the production desktop window bootstrap while omitting Rust
+  runtime initialization and all wallet, storage, sync, and network startup.
+  The platform build can still compile the Rust plugin; this path is final
+  evidence, not the fast iteration path. It produces:
+
+  - `content.png`: the same app content through the real macOS Flutter engine.
   - `content.window.png`: the exact native NSWindow at its backing pixel ratio,
-    including the macOS titlebar and traffic lights. Use this only to verify the
-    production window shell, sizing, and native insets.
+    including the macOS titlebar and traffic lights.
+
+  Compare `content.widget.png` with `content.png` for any material renderer
+  difference, ignoring only minor font rasterization noise. Use
+  `content.window.png` only to verify the production window shell, sizing, and
+  native insets. A mismatch in app content must return to the normal widget
+  iteration; do not waive it merely because the native check is last.
 
   The macOS capture transaction records the current window and foreground-app
   state. If the comparison window is minimized or hidden, it deminiaturizes and
   activates the window, makes it key and visible, waits for Flutter and privacy
   state to settle, captures the exact window ID, then restores the previous
   minimized/hidden state and foreground app. Do not bypass the production
-  privacy overlay. `FIGMA_COMPARE_START_MINIMIZED=true` exists only to verify
-  this restoration behavior; it is not needed for normal captures.
+  privacy overlay. Pass `--start-minimized` only to verify this restoration
+  behavior; it is not needed for normal captures.
 
   macOS 14 and newer use ScreenCaptureKit; macOS 11-13 use the restored-window
   Core Graphics compatibility path. If Screen Recording permission is
   requested, grant it before treating the native-window capture as evidence.
-- **Mobile:** Boot an iOS Simulator and run the app with
-  `--dart-define=VIZOR_FORM_FACTOR=mobile` and a scenario explicitly marked as
-  mobile-capable. Record the simulator device, OS, orientation, and viewport,
-  then capture the same target state with deterministic data. Use
-  `xcrun simctl io <device-id> screenshot <output.png>` for the simulator
-  screenshot.
+- **Mobile:** Use the widget-test renderer first with a scenario explicitly
+  marked as mobile-capable:
+
+  ```bash
+  scripts/figma-compare.sh widget \
+    --form-factor mobile \
+    --scenario <mobile-scenario> \
+    --theme dark
+  ```
+
+  The default logical viewport is 393x852 at DPR 3; override it to match the
+  selected simulator. The widget PNG remains a 393x852 logical-pixel image.
+  After parity is reached, boot that iOS Simulator and run the same
+  deterministic state with `--dart-define=VIZOR_FORM_FACTOR=mobile`.
+  Record the simulator device, OS, orientation, and viewport, then use
+  `xcrun simctl io <device-id> screenshot <output.png>` for the required final
+  platform screenshot. The wrapper's `native` mode currently verifies macOS
+  only.
 
 Do not treat operating-system chrome as app UI. Crop or otherwise normalize
 captures to compare the same app-content bounds. Follow the repository's Figma
@@ -200,8 +237,9 @@ Before reporting completion:
 
 1. Remove every temporary route, bootstrap override, dependency override,
    mock, and other one-off capture-only code change. Never commit those
-   temporary changes. The permanent comparison entry point and reusable,
-   deterministic scenario registry are repository tooling and are not removed.
+   temporary changes. The permanent widget capture tests, comparison entry
+   point, wrapper script, and reusable deterministic scenario registry are
+   repository tooling and are not removed.
 2. Confirm that the Git state has returned to its starting condition apart
    from pre-existing user changes and any separately authorized repository
    documentation changes.

--- a/FIGMA-AI-FIX.md
+++ b/FIGMA-AI-FIX.md
@@ -101,13 +101,21 @@ styling or layout temporarily to make the reference resemble the Figma copy.
 2. Determine which form factors the code change affects. Validate both desktop
    and mobile when both are affected; otherwise validate only the affected or
    explicitly requested form factor.
-3. Temporary code changes are allowed only to expose the target screen and
-   make its state reproducible. This includes a temporary direct route,
-   bootstrap state, dependency override, and deterministic mock data.
-4. Keep temporary routing and mock changes isolated from production design
-   changes. Do not alter the target's visual properties, component structure,
-   text, layout, or tokens merely to influence the comparison.
-5. Fix the content, loading or error state, theme, locale, text scale, and any
+3. Use `lib/figma_compare.dart` instead of the production entry point or
+   Widgetbook chrome whenever the required state is registered in
+   `lib/figma_compare/figma_compare_scenarios.dart`. This entry point reproduces
+   the production desktop window bootstrap but skips Rust, wallet, storage,
+   sync, and network initialization.
+4. If the required state is not registered, prefer adding a deterministic
+   dev-only scenario that reuses an existing Widgetbook fixture. A scenario
+   must not depend on production wallet data, storage, network, or Rust state.
+   Temporary production routing, bootstrap, or provider changes are a last
+   resort and must still be removed before completion.
+5. Keep comparison fixtures and any temporary routing or mock changes isolated
+   from production design changes. Do not alter the target's visual properties,
+   component structure, text, layout, or tokens merely to influence the
+   comparison.
+6. Fix the content, loading or error state, theme, locale, text scale, and any
    time-dependent data so repeated captures show the same screen.
 
 ### 2. Capture the Flutter reference on each required form factor
@@ -115,13 +123,43 @@ styling or layout temporarily to make the reference resemble the Figma copy.
 Always use `fvm flutter`, never bare `flutter`.
 
 - **Desktop:** Run the macOS desktop app without a mobile form-factor define,
-  navigate directly to the target screen, set a known window size, and capture
-  the app content. Mock data may be used when needed to reproduce the relevant
-  state.
+  using the comparison entry point and a registered deterministic scenario:
+
+  ```bash
+  fvm flutter run -d macos -t lib/figma_compare.dart \
+    --dart-define=FIGMA_COMPARE_SCENARIO=pay-recipient \
+    --dart-define=FIGMA_COMPARE_THEME=dark \
+    --dart-define=FIGMA_COMPARE_OUTPUT=pay-recipient/content.png
+  ```
+
+  A relative output path is written below the sandbox's system temporary
+  directory, normally
+  `~/Library/Containers/com.keplr.vizor/Data/tmp/vizor-figma-compare/`.
+  The command prints both resolved paths. It produces:
+
+  - `content.png`: the Flutter app-content render at a deterministic 1x logical
+    pixel ratio. Use this as the primary Figma parity reference.
+  - `content.window.png`: the exact native NSWindow at its backing pixel ratio,
+    including the macOS titlebar and traffic lights. Use this only to verify the
+    production window shell, sizing, and native insets.
+
+  The macOS capture transaction records the current window and foreground-app
+  state. If the comparison window is minimized or hidden, it deminiaturizes and
+  activates the window, makes it key and visible, waits for Flutter and privacy
+  state to settle, captures the exact window ID, then restores the previous
+  minimized/hidden state and foreground app. Do not bypass the production
+  privacy overlay. `FIGMA_COMPARE_START_MINIMIZED=true` exists only to verify
+  this restoration behavior; it is not needed for normal captures.
+
+  macOS 14 and newer use ScreenCaptureKit; macOS 11-13 use the restored-window
+  Core Graphics compatibility path. If Screen Recording permission is
+  requested, grant it before treating the native-window capture as evidence.
 - **Mobile:** Boot an iOS Simulator and run the app with
-  `--dart-define=VIZOR_FORM_FACTOR=mobile`. Record the simulator device, OS,
-  orientation, and viewport, then capture the same target state with
-  deterministic data.
+  `--dart-define=VIZOR_FORM_FACTOR=mobile` and a scenario explicitly marked as
+  mobile-capable. Record the simulator device, OS, orientation, and viewport,
+  then capture the same target state with deterministic data. Use
+  `xcrun simctl io <device-id> screenshot <output.png>` for the simulator
+  screenshot.
 
 Do not treat operating-system chrome as app UI. Crop or otherwise normalize
 captures to compare the same app-content bounds. Follow the repository's Figma
@@ -161,11 +199,19 @@ modified design-system asset.
 Before reporting completion:
 
 1. Remove every temporary route, bootstrap override, dependency override,
-   mock, and other capture-only code change. Never commit those temporary
-   changes.
+   mock, and other one-off capture-only code change. Never commit those
+   temporary changes. The permanent comparison entry point and reusable,
+   deterministic scenario registry are repository tooling and are not removed.
 2. Confirm that the Git state has returned to its starting condition apart
    from pre-existing user changes and any separately authorized repository
    documentation changes.
+   Remove generated comparison artifacts with:
+
+   ```bash
+   rm -rf "$HOME/Library/Containers/com.keplr.vizor/Data/tmp/vizor-figma-compare"
+   ```
+
+   Generated captures must never be committed.
 3. Confirm that all Figma mutations are descendants of the approved AI Test
    copy and that the source screen, all other existing screens, and the entire
    design system remain unchanged.

--- a/FIGMA-AI-FIX.md
+++ b/FIGMA-AI-FIX.md
@@ -1,0 +1,7 @@
+> **Scope gate:** If the user has not explicitly asked you to modify a Figma
+> file or design, stop here. You do not need to read any further.
+
+# Figma AI Fix
+
+This document contains the project instructions and reference material for
+AI-assisted changes made directly in Figma.

--- a/FIGMA-AI-FIX.md
+++ b/FIGMA-AI-FIX.md
@@ -80,6 +80,97 @@ After the user approves the target:
    of the approved copy on the AI Test page and that all original nodes remain
    unchanged.
 
+## Code-to-Figma visual parity workflow
+
+Use this workflow when the user explicitly asks to apply a design change that
+already exists in Flutter code to Figma. Complete the screen-matching,
+approval, and copy-only steps above before starting this workflow. The running
+Flutter implementation is the visual reference; never change production
+styling or layout temporarily to make the reference resemble the Figma copy.
+
+### 1. Establish an isolated, reproducible runtime reference
+
+1. Record the starting Git status and preserve all pre-existing user changes.
+2. Determine which form factors the code change affects. Validate both desktop
+   and mobile when both are affected; otherwise validate only the affected or
+   explicitly requested form factor.
+3. Temporary code changes are allowed only to expose the target screen and
+   make its state reproducible. This includes a temporary direct route,
+   bootstrap state, dependency override, and deterministic mock data.
+4. Keep temporary routing and mock changes isolated from production design
+   changes. Do not alter the target's visual properties, component structure,
+   text, layout, or tokens merely to influence the comparison.
+5. Fix the content, loading or error state, theme, locale, text scale, and any
+   time-dependent data so repeated captures show the same screen.
+
+### 2. Capture the Flutter reference on each required form factor
+
+Always use `fvm flutter`, never bare `flutter`.
+
+- **Desktop:** Run the macOS desktop app without a mobile form-factor define,
+  navigate directly to the target screen, set a known window size, and capture
+  the app content. Mock data may be used when needed to reproduce the relevant
+  state.
+- **Mobile:** Boot an iOS Simulator and run the app with
+  `--dart-define=VIZOR_FORM_FACTOR=mobile`. Record the simulator device, OS,
+  orientation, and viewport, then capture the same target state with
+  deterministic data.
+
+Do not treat operating-system chrome as app UI. Crop or otherwise normalize
+captures to compare the same app-content bounds. Follow the repository's Figma
+layer-interpretation rules for presentation-only macOS backgrounds and window
+controls.
+
+### 3. Capture and compare the Figma copy
+
+1. Set the copied Figma screen to the same viewport or frame dimensions,
+   theme, locale, content, and component state as the Flutter reference.
+2. Capture only the modified copy on the AI Test page. Never use a modified
+   original screen or design-system asset as comparison evidence.
+3. Compare the Flutter and Figma captures side by side and, when practical,
+   with a transparent overlay or image-difference view.
+4. Check at least frame and container dimensions, layout, spacing, alignment,
+   typography, colors, borders, effects, icons, images, component states,
+   clipping, wrapping, and overflow.
+5. Treat correctable layout, sizing, color, asset, and state differences as
+   mismatches. Ignore only unavoidable rendering noise such as minor native
+   font rasterization or operating-system chrome that is outside the app UI.
+
+### 4. Iterate until no actionable difference remains
+
+When a mismatch is found, modify only the approved copy on the AI Test page,
+capture that copy again, and repeat the comparison against the Flutter
+reference. Do not impose an arbitrary iteration limit. Continue until every
+required desktop and mobile capture is effectively identical and no
+correctable difference remains.
+
+The initial target approval covers visual corrections within the approved
+copied subtree. Stop and ask the user again if the target or requested scope
+changes, an edit would escape that subtree, or the work requires a missing or
+modified design-system asset.
+
+### 5. Clean up and report completion
+
+Before reporting completion:
+
+1. Remove every temporary route, bootstrap override, dependency override,
+   mock, and other capture-only code change. Never commit those temporary
+   changes.
+2. Confirm that the Git state has returned to its starting condition apart
+   from pre-existing user changes and any separately authorized repository
+   documentation changes.
+3. Confirm that all Figma mutations are descendants of the approved AI Test
+   copy and that the source screen, all other existing screens, and the entire
+   design system remain unchanged.
+4. Report the source-node URL, copied-node URL, validated platforms and
+   device/window configuration, tested UI states, comparison evidence,
+   mismatches corrected during iteration, and any remaining unavoidable
+   rendering-only differences.
+
+Report success only after all required form factors meet these completion
+conditions. If parity cannot be reached, report the concrete blocker instead
+of claiming completion.
+
 Read [source and scope](figma-ai-fix/00-source-and-scope.md) first. Then read
 only the topic documents needed for the requested Figma change.
 

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,4 +1,8 @@
 tags:
+  # Screenshot generation is an explicit tooling lane. The wrapper supplies
+  # --update-goldens, the deterministic defines, and --run-skipped.
+  figma-capture:
+    skip: "Figma capture only: scripts/figma-compare.sh widget --scenario <id>"
   # Mobile-UI tests are opt-in: skipped in the default (desktop) lane,
   # re-enabled by the mobile lane command in the skip reason below.
   # See "Design Token Form Factor" in AGENTS.md.

--- a/figma-ai-fix/00-source-and-scope.md
+++ b/figma-ai-fix/00-source-and-scope.md
@@ -1,0 +1,80 @@
+# Source and scope
+
+## Source of truth
+
+- File: [Vizor Design System AI Test](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?m=dev)
+- File key: `HJxo289BJD7R6tz0OoGSQu`
+- Inventory captured: `2026-07-13`
+- Variable collections: `3`
+- Local text styles: `15`
+- Local effect styles: `6`
+- Local grid styles: `1`
+- Component sets: `53`
+- Standalone components: `148`
+- Component-set variants: `236`
+
+The URL originally supplied for access selects the `🎨 Design Updates 🎨`
+page. That page is not the design-system root. Use the design-system pages
+listed below as the documentation scope.
+
+## Scope rules
+
+- Include only variables, styles, reusable components, source assets, and
+  showrooms on the listed design-system pages.
+- Exclude product screens and flows: Design Updates, desktop/mobile app pages,
+  handed-off feature pages, QA, WIP, and backlog pages.
+- Preserve exact Figma names in references, including spelling mistakes,
+  capitalization, duplicate names, and leading underscores.
+- A leading underscore identifies an internal-style building block in this
+  file. Prefer its public parent component when one exists; inspect the actual
+  composition before using the internal asset directly.
+- Use Figma variable modes exactly as defined. Color uses Dark/Light; sizing and
+  fonts use Desktop/Mobile.
+- Reuse an existing component, variable, or style before creating a new one.
+- This is a point-in-time index. Live Figma values and node structure take
+  precedence over this snapshot.
+
+## Design-system pages
+
+| Page | Page ID | Top-level children | Component sets | Standalone components |
+| --- | --- | --- | --- | --- |
+| [Identity](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=4-2&m=dev) | `4:2` | 62 | 0 | 5 |
+| [App Icon](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=1567-44492&m=dev) | `1567:44492` | 14 | 0 | 2 |
+| [Assets / Tables](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=377-31688&m=dev) | `377:31688` | 22 | 9 | 4 |
+| [Buttons](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=54-462&m=dev) | `54:462` | 9 | 2 | 2 |
+| [Badge](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=806-59103&m=dev) | `806:59103` | 4 | 1 | 1 |
+| [Cards](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=400-42053&m=dev) | `400:42053` | 15 | 7 | 3 |
+| [Colors](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=110-65&m=dev) | `110:65` | 19 | 0 | 0 |
+| [Chip](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=115-3307&m=dev) | `115:3307` | 1 | 1 | 0 |
+| [Dropdown](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=2841-108859&m=dev) | `2841:108859` | 4 | 0 | 1 |
+| [Icons](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=54-461&m=dev) | `54:461` | 103 | 0 | 95 |
+| [Inputs](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=355-13933&m=dev) | `355:13933` | 10 | 3 | 2 |
+| [Illustrations](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=115-4359&m=dev) | `115:4359` | 44 | 2 | 17 |
+| [Lists](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=970-72935&m=dev) | `970:72935` | 4 | 0 | 2 |
+| [Modal](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=485-26307&m=dev) | `485:26307` | 7 | 4 | 1 |
+| [Navigation](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=303-1919&m=dev) | `303:1919` | 10 | 4 | 3 |
+| [Placeholders](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=54-924&m=dev) | `54:924` | 4 | 0 | 1 |
+| [Radio / Checkbox](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=677-55548&m=dev) | `677:55548` | 5 | 4 | 0 |
+| [Swap UI](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=2788-43761&m=dev) | `2788:43761` | 7 | 6 | 1 |
+| [Tooltip](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=2361-70162&m=dev) | `2361:70162` | 3 | 3 | 0 |
+| [Text](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=1532-37193&m=dev) | `1532:37193` | 1 | 0 | 1 |
+| [Toast](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=1567-44215&m=dev) | `1567:44215` | 4 | 1 | 0 |
+| [Tabs](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=485-30867&m=dev) | `485:30867` | 4 | 3 | 0 |
+| [Users](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=4018-40198&m=dev) | `4018:40198` | 15 | 0 | 0 |
+| [Utility](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=355-23650&m=dev) | `355:23650` | 3 | 1 | 0 |
+| [OS Utility](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=258-3983&m=dev) | `258:3983` | 11 | 2 | 6 |
+| [Local Utility](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=10-650&m=dev) | `10:650` | 6 | 0 | 1 |
+
+## Excluded page families
+
+The following file areas were intentionally not copied into these documents:
+
+- `AI Test` and separator pages
+- `🎨 Design Updates 🎨` and `🛠️ QA 🛠️`
+- `🖥️ DESKTOP APP 🖥️` and its handed-off feature pages
+- `🍎 MOBILE APP 🍎` and its handed-off feature pages
+- `🚧 WIP 🚧`, multisig, gift-card, polling, and wow-effect WIP pages
+- `Design Requests / Backlog`
+
+Those areas can be inspected for a feature-specific request, but their local
+overrides must not be promoted into the design-system reference automatically.

--- a/figma-ai-fix/00-source-and-scope.md
+++ b/figma-ai-fix/00-source-and-scope.md
@@ -30,7 +30,15 @@ listed below as the documentation scope.
   composition before using the internal asset directly.
 - Use Figma variable modes exactly as defined. Color uses Dark/Light; sizing and
   fonts use Desktop/Mobile.
-- Reuse an existing component, variable, or style before creating a new one.
+- Treat the entire Vizor design system as read-only. Never modify a
+  design-system page, component master, component set, variant, variable,
+  style, token, or shared asset.
+- When modifying or adding a screen on the AI Test page, reuse existing
+  design-system component instances, variables, styles, tokens, and layout
+  patterns as much as possible. Do not recreate an available asset with
+  detached or ad-hoc layers.
+- If the requested screen needs a design-system asset that does not exist, ask
+  the user how to proceed instead of adding to or changing the design system.
 - This is a point-in-time index. Live Figma values and node structure take
   precedence over this snapshot.
 

--- a/figma-ai-fix/01-color-system.md
+++ b/figma-ai-fix/01-color-system.md
@@ -1,0 +1,231 @@
+# Color system
+
+Source collection: `2 Color Theme` (`VariableCollectionId:54:927`).
+The collection has `Dark` and `Light` modes. Use semantic
+variables in composed UI. Primitive colors are foundations for aliases; OS
+utility colors are limited to platform-presentation assets.
+
+## Primitive colors
+
+| Variable | Type | Scopes | Dark | Light |
+| --- | --- | --- | --- | --- |
+| `_ Primitive/Gray/0` | `COLOR` | `ALL_SCOPES` | `#141818` | `#FFFFFF` |
+| `_ Primitive/Gray/50` | `COLOR` | `ALL_SCOPES` | `#1B1F1F` | `#F7F7F7` |
+| `_ Primitive/Gray/100` | `COLOR` | `ALL_SCOPES` | `#232828` | `#EBEBEB` |
+| `_ Primitive/Gray/150` | `COLOR` | `ALL_SCOPES` | `#2D3232` | `#E1E1E1` |
+| `_ Primitive/Gray/200` | `COLOR` | `ALL_SCOPES` | `#393E3E` | `#D4D4D4` |
+| `_ Primitive/Gray/300` | `COLOR` | `ALL_SCOPES` | `#4D5252` | `#B8B8B8` |
+| `_ Primitive/Gray/400` | `COLOR` | `ALL_SCOPES` | `#626767` | `#9A9A9A` |
+| `_ Primitive/Gray/500` | `COLOR` | `ALL_SCOPES` | `#858686` | `#858686` |
+| `_ Primitive/Gray/600` | `COLOR` | `ALL_SCOPES` | `#A3A4A4` | `#626767` |
+| `_ Primitive/Gray/700` | `COLOR` | `ALL_SCOPES` | `#C2C3C3` | `#4D5252` |
+| `_ Primitive/Gray/800` | `COLOR` | `ALL_SCOPES` | `#F7F7F7` | `#2E3232` |
+| `_ Primitive/Gray/900` | `COLOR` | `ALL_SCOPES` | `#FFFFFF` | `#141818` |
+| `_ Primitive/Crimson/0` | `COLOR` | `ALL_SCOPES` | `#080305` | `#F6EBEF` |
+| `_ Primitive/Crimson/50` | `COLOR` | `ALL_SCOPES` | `#19080F` | `#E1B9C8` |
+| `_ Primitive/Crimson/100` | `COLOR` | `ALL_SCOPES` | `#32111D` | `#CF92A8` |
+| `_ Primitive/Crimson/150` | `COLOR` | `ALL_SCOPES` | `#4C192C` | `#BE6A88` |
+| `_ Primitive/Crimson/200` | `COLOR` | `ALL_SCOPES` | `#6D243F` | `#B35074` |
+| `_ Primitive/Crimson/300` | `COLOR` | `ALL_SCOPES` | `#862D4E` | `#A83861` |
+| `_ Primitive/Crimson/400` | `COLOR` | `ALL_SCOPES` | `#A83861` | `#862D4E` |
+| `_ Primitive/Crimson/500` | `COLOR` | `ALL_SCOPES` | `#B35074` | `#6D243F` |
+| `_ Primitive/Crimson/600` | `COLOR` | `ALL_SCOPES` | `#BE6A88` | `#4C192C` |
+| `_ Primitive/Crimson/700` | `COLOR` | `ALL_SCOPES` | `#CF92A8` | `#32111D` |
+| `_ Primitive/Crimson/800` | `COLOR` | `ALL_SCOPES` | `#E1B9C8` | `#19080F` |
+| `_ Primitive/Crimson/900` | `COLOR` | `ALL_SCOPES` | `#F5EBEE` | `#080305` |
+| `_ Primitive/Plum/0` | `COLOR` | `ALL_SCOPES` | `#0B060D` | `#F6ECF9` |
+| `_ Primitive/Plum/50` | `COLOR` | `ALL_SCOPES` | `#2F133A` | `#E6C5EC` |
+| `_ Primitive/Plum/100` | `COLOR` | `ALL_SCOPES` | `#4E205F` | `#CD8CD9` |
+| `_ Primitive/Plum/150` | `COLOR` | `ALL_SCOPES` | `#5E2673` | `#C06ECE` |
+| `_ Primitive/Plum/200` | `COLOR` | `ALL_SCOPES` | `#772E89` | `#B85BC8` |
+| `_ Primitive/Plum/300` | `COLOR` | `ALL_SCOPES` | `#9338A7` | `#AB40BF` |
+| `_ Primitive/Plum/400` | `COLOR` | `ALL_SCOPES` | `#AB40BF` | `#9338A7` |
+| `_ Primitive/Plum/500` | `COLOR` | `ALL_SCOPES` | `#B85BC8` | `#772E89` |
+| `_ Primitive/Plum/600` | `COLOR` | `ALL_SCOPES` | `#C06ECE` | `#5E2673` |
+| `_ Primitive/Plum/700` | `COLOR` | `ALL_SCOPES` | `#CD8CD9` | `#4E205F` |
+| `_ Primitive/Plum/800` | `COLOR` | `ALL_SCOPES` | `#E6C5EC` | `#2F133A` |
+| `_ Primitive/Plum/900` | `COLOR` | `ALL_SCOPES` | `#F6ECF9` | `#0C050E` |
+| `_ Primitive/Gray/Alpha/0-50` | `COLOR` | `ALL_SCOPES` | `#1418187F80` | `#FFFFFF7F80` |
+| `_ Primitive/Gray/Alpha/300-20` | `COLOR` | `ALL_SCOPES` | `#4D525232CD` | `#B8B8B832CD` |
+| `_ Primitive/Green/0` | `COLOR` | `ALL_SCOPES` | `#001E0A` | `#D3FFE4` |
+| `_ Primitive/Green/50` | `COLOR` | `ALL_SCOPES` | `#023A21` | `#C2F5D5` |
+| `_ Primitive/Green/100` | `COLOR` | `ALL_SCOPES` | `#005B35` | `#A9ECC4` |
+| `_ Primitive/Green/150` | `COLOR` | `ALL_SCOPES` | `#007F49` | `#89E5B0` |
+| `_ Primitive/Green/200` | `COLOR` | `ALL_SCOPES` | `#00A460` | `#64DD9C` |
+| `_ Primitive/Green/300` | `COLOR` | `ALL_SCOPES` | `#0DC87D` | `#3BD38B` |
+| `_ Primitive/Green/400` | `COLOR` | `ALL_SCOPES` | `#3BD38B` | `#0DC87D` |
+| `_ Primitive/Green/500` | `COLOR` | `ALL_SCOPES` | `#64DD9C` | `#00A460` |
+| `_ Primitive/Green/600` | `COLOR` | `ALL_SCOPES` | `#89E5B0` | `#007F49` |
+| `_ Primitive/Green/700` | `COLOR` | `ALL_SCOPES` | `#A9ECC4` | `#005B35` |
+| `_ Primitive/Green/800` | `COLOR` | `ALL_SCOPES` | `#C2F5D5` | `#023A21` |
+| `_ Primitive/Green/900` | `COLOR` | `ALL_SCOPES` | `#D3FFE4` | `#001E0A` |
+| `_ Primitive/Gray/Alpha/300-50` | `COLOR` | `ALL_SCOPES` | `#4D52527F80` | `#B8B8B87F80` |
+| `_ Primitive/Gray/Alpha/300-10` | `COLOR` | `ALL_SCOPES` | `#4D525219E6` | `#B8B8B819E6` |
+| `_ Primitive/Crimson/Alpha/300-15` | `COLOR` | `ALL_SCOPES` | `#862D4E25DA` | `#A8386125DA` |
+| `_ Primitive/Crimson/Alpha/400-15` | `COLOR` | `ALL_SCOPES` | `#A8386125DA` | `#862D4E25DA` |
+| `_ Primitive/Crimson/Alpha/300-25` | `COLOR` | `ALL_SCOPES` | `#862D4E3FC0` | `#A838613FC0` |
+| `_ Primitive/Crimson/Alpha/400-25` | `COLOR` | `ALL_SCOPES` | `#A838613FC0` | `#862D4E3FC0` |
+| `_ Primitive/Crimson/Alpha/400-35` | `COLOR` | `ALL_SCOPES` | `#A8386158A7` | `#862D4E58A7` |
+| `_ Primitive/Crimson/Alpha/300-35` | `COLOR` | `ALL_SCOPES` | `#862D4E58A7` | `#A8386158A7` |
+| `_ Primitive/Green/Alpha/300-15` | `COLOR` | `ALL_SCOPES` | `#0DC87D25DA` | `#3BD38B25DA` |
+| `_ Primitive/Green/Alpha/300-25` | `COLOR` | `ALL_SCOPES` | `#0DC87D3FC0` | `#3BD38B3FC0` |
+| `_ Primitive/Green/Alpha/400-15` | `COLOR` | `ALL_SCOPES` | `#3BD38B25DA` | `#0DC87D25DA` |
+| `_ Primitive/Green/Alpha/400-25` | `COLOR` | `ALL_SCOPES` | `#3BD38B3FC0` | `#0DC87D3FC0` |
+| `_ Primitive/Gray/Alpha/300-35` | `COLOR` | `ALL_SCOPES` | `#4D525258A7` | `#B8B8B858A7` |
+| `_ Primitive/Gray/Alpha/400-20` | `COLOR` | `ALL_SCOPES` | `#62676732CD` | `#9A9A9A32CD` |
+| `_ Primitive/Gray/Alpha/400-35` | `COLOR` | `ALL_SCOPES` | `#62676758A7` | `#9A9A9A58A7` |
+| `_ Primitive/Gray/Alpha/300-15` | `COLOR` | `ALL_SCOPES` | `#4D525225DA` | `#B8B8B825DA` |
+| `_ Primitive/Gray/Alpha/0-30` | `COLOR` | `ALL_SCOPES` | `#1418184CB3` | `#FFFFFF4CB3` |
+| `_ Primitive/Gray/Alpha/900-20` | `COLOR` | `ALL_SCOPES` | `#FFFFFF32CD` | `#14181832CD` |
+| `_ Primitive/Gray/Alpha/900-50` | `COLOR` | `ALL_SCOPES` | `#FFFFFF7F80` | `#1418187F80` |
+| `_ Primitive/Gray/Alpha/700-50` | `COLOR` | `ALL_SCOPES` | `#C2C3C37F80` | `#4D52527F80` |
+| `_ Primitive/Plum/Alpha/400-25` | `COLOR` | `ALL_SCOPES` | `#AB40BF3FC0` | `#9338A73FC0` |
+| `_ Primitive/Plum/Alpha/400-15` | `COLOR` | `ALL_SCOPES` | `#AB40BF25DA` | `#9338A725DA` |
+| `_ Primitive/Gray/Alpha/Transparent` | `COLOR` | `ALL_SCOPES` | `#14181800` | `#FFFFFF00` |
+| `_ Primitive/Gray/Alpha/150-15` | `COLOR` | `ALL_SCOPES` | `#2D323225DA` | `#E1E1E125DA` |
+| `_ Primitive/Gray/Alpha/0-15` | `COLOR` | `ALL_SCOPES` | `#14181825DA` | `#FFFFFF25DA` |
+| `_ Primitive/Gray/Alpha/900-10` | `COLOR` | `ALL_SCOPES` | `#FFFFFF19E6` | `#14181819E6` |
+| `_ Primitive/Gray/Alpha/0-10` | `COLOR` | `ALL_SCOPES` | `#14181819E6` | `#FFFFFF19E6` |
+| `_ Primitive/Green/Alpha/900-50` | `COLOR` | `ALL_SCOPES` | `#D3FFE47F80` | `#001E0A7F80` |
+| `_ Primitive/Gray/Alpha/900-50 2` | `COLOR` | `ALL_SCOPES` | `#FFFFFF7F80` | `#1418187F80` |
+| `_ Primitive/Green/Alpha/900-65` | `COLOR` | `ALL_SCOPES` | `#D3FFE4A55A` | `#001E0AA55A` |
+| `_ Primitive/Gray/Alpha/900-5` | `COLOR` | `ALL_SCOPES` | `#FFFFFFCF3` | `#141818CF3` |
+| `_ Primitive/Gray/Alpha/0-5` | `COLOR` | `ALL_SCOPES` | `#141818CF3` | `#FFFFFFCF3` |
+| `_ Primitive/Crimson/Alpha/300-10` | `COLOR` | `ALL_SCOPES` | `#862D4E19E6` | `#A8386119E6` |
+| `_ Primitive/Plum/Alpha/400-8` | `COLOR` | `ALL_SCOPES` | `#AB40BF13EC` | `#9338A713EC` |
+| `_ Primitive/Plum/Alpha/400-4` | `COLOR` | `ALL_SCOPES` | `#AB40BF9F6` | `#9338A79F6` |
+| `_ Primitive/Gray/Alpha/500-50` | `COLOR` | `ALL_SCOPES` | `#8586867F80` | `#8586867F80` |
+
+## Semantic colors
+
+| Variable | Type | Scopes | Dark | Light |
+| --- | --- | --- | --- | --- |
+| `Semantic/Foreground/Neutral/ground` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/50` | `→ _ Primitive/Gray/0` |
+| `Semantic/Foreground/Neutral/base` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/100` | `→ _ Primitive/Gray/50` |
+| `Semantic/Foreground/Neutral/raised` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/150` | `→ _ Primitive/Gray/100` |
+| `Semantic/Foreground/Neutral/overlay` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/200` | `→ _ Primitive/Gray/150` |
+| `Semantic/Border/Neutral/Subtle` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/150` | `→ _ Primitive/Gray/150` |
+| `Semantic/Border/Neutral/Default` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/300` | `→ _ Primitive/Gray/200` |
+| `Semantic/Border/Neutral/Medium` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/400` | `→ _ Primitive/Gray/300` |
+| `Semantic/Text/Neutral/disabled` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/400` | `→ _ Primitive/Gray/400` |
+| `Semantic/Text/Neutral/muted` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/500` | `→ _ Primitive/Gray/500` |
+| `Semantic/Text/Neutral/secondary` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/600` | `→ _ Primitive/Gray/600` |
+| `Semantic/Text/Neutral/primary` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/700` | `→ _ Primitive/Gray/700` |
+| `Semantic/Text/Neutral/accent` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/900` | `→ _ Primitive/Gray/900` |
+| `Semantic/Text/Neutral/inverse` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/0` | `→ _ Primitive/Gray/0` |
+| `Semantic/Button/Button/Primary/Bg` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/800` | `→ _ Primitive/Gray/800` |
+| `Semantic/Button/Button/Primary/Bg Hover` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Crimson/300` | `→ _ Primitive/Crimson/400` |
+| `Semantic/Button/Button/Primary/Label` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/50` | `→ _ Primitive/Gray/100` |
+| `Semantic/Button/Button/Secondary/Bg` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/150` | `→ _ Primitive/Gray/0` |
+| `Semantic/Button/Button/Secondary/Bg Hover` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/200` | `→ _ Primitive/Gray/100` |
+| `Semantic/Button/Button/Secondary/Label` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/800` | `→ _ Primitive/Gray/900` |
+| `Semantic/Button/Button/Ghost/Bg` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/0` | `→ _ Primitive/Gray/0` |
+| `Semantic/Button/Button/Ghost/Bg Hover` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/100` | `→ _ Primitive/Gray/100` |
+| `Semantic/Button/Button/Ghost/Border` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/300` | `→ _ Primitive/Gray/300` |
+| `Semantic/Button/Button/Ghost/Label` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/700` | `→ _ Primitive/Gray/800` |
+| `Semantic/Button/Button/Disabled/Bg` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/300-20` | `→ _ Primitive/Gray/Alpha/300-20` |
+| `Semantic/Button/Button/Disabled/Label` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/500-50` | `→ _ Primitive/Gray/Alpha/500-50` |
+| `Semantic/Icon/default` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/700` | `→ _ Primitive/Gray/700` |
+| `Semantic/Icon/muted` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/500` | `→ _ Primitive/Gray/500` |
+| `Semantic/Icon/accent` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/800` | `→ _ Primitive/Gray/900` |
+| `Semantic/Icon/disabled` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/300` | `→ _ Primitive/Gray/300` |
+| `Semantic/Icon/inverse` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/0` | `→ _ Primitive/Gray/0` |
+| `Semantic/State/Neutral/Alpha/Hover Opacity` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/0-15` | `→ _ Primitive/Gray/Alpha/900-5` |
+| `Semantic/State/Neutral/Pressed` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/150` | `→ _ Primitive/Gray/150` |
+| `Semantic/State/Neutral/Focus` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/200` | `→ _ Primitive/Gray/200` |
+| `Semantic/State/Neutral/Selected` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/150` | `→ _ Primitive/Gray/150` |
+| `Semantic/State/Neutral/Focus Ring` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/800` | `→ _ Primitive/Gray/900` |
+| `Semantic/State/Neutral/Focus Gap` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/0` | `→ _ Primitive/Gray/0` |
+| `Semantic/State/Brand/Focus Ring Brand` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Crimson/400` | `→ _ Primitive/Crimson/300` |
+| `Semantic/Icon/Brand/Crimson` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Crimson/400` | `→ _ Primitive/Crimson/300` |
+| `Semantic/Text/Brand/Crimson` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Crimson/400` | `→ _ Primitive/Crimson/300` |
+| `Semantic/Icon/Utility/Destructive` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/400` | `→ _ Primitive/Plum/300` |
+| `Semantic/Fade/illustration fade` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/0-50` | `#14181800` |
+| `Semantic/Foreground/Neutral/Alpha/Subtle Opacity` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/400-20` | `→ _ Primitive/Gray/Alpha/300-20` |
+| `Semantic/Foreground/Brand/Crimson Strong` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Crimson/400` | `→ _ Primitive/Crimson/300` |
+| `Semantic/Foreground/Brand/Crimson Subtle` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Crimson/100` | `→ _ Primitive/Crimson/0` |
+| `Semantic/Icon/Utility/Positive` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Green/300` | `→ _ Primitive/Green/500` |
+| `Semantic/Border/Utility/Destructive` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/400` | `→ _ Primitive/Plum/300` |
+| `Semantic/Foreground/Utility/Destructive Subtle` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/50` | `→ _ Primitive/Plum/0` |
+| `Semantic/Foreground/Neutral/Alpha/Medium Opacity` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/300-50` | `→ _ Primitive/Gray/Alpha/300-35` |
+| `Semantic/Border/Brand/Crimson Strong` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Crimson/400` | `→ _ Primitive/Crimson/300` |
+| `Semantic/Foreground/Brand/Alpha/Crimson Alpha` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Crimson/Alpha/300-35` | `→ _ Primitive/Crimson/Alpha/300-15` |
+| `Semantic/Foreground/Utility/Alpha/Success Alpha` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Green/Alpha/300-15` | `→ _ Primitive/Green/Alpha/300-15` |
+| `Semantic/Foreground/Neutral/Inverse` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/800` | `→ _ Primitive/Gray/800` |
+| `Semantic/Text/Positive/Strong` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Green/400` | `→ _ Primitive/Green/500` |
+| `Semantic/Foreground/Neutral/Alpha/Scrim` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/0-50` | `→ _ Primitive/Gray/Alpha/900-50` |
+| `Semantic/Border/Neutral/Strong` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/800` | `→ _ Primitive/Gray/900` |
+| `Semantic/Border/Utility/Success` | `COLOR` | `ALL_SCOPES` | `→ VariableID:1359:16154` | `→ VariableID:1359:16153` |
+| `Semantic/Foreground/Utility/Alpha/Destructive Alpha` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/Alpha/400-25` | `→ _ Primitive/Plum/Alpha/400-15` |
+| `Semantic/Button/Button/Destructive/Bg` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/200` | `→ _ Primitive/Plum/500` |
+| `Semantic/Button/Button/Destructive/Bg Hover` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/150` | `→ _ Primitive/Plum/600` |
+| `Semantic/Button/Button/Destructive/Label` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/800` | `→ _ Primitive/Plum/50` |
+| `Semantic/State/Utility/Focus Ring Destructive` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/200` | `→ _ Primitive/Plum/400` |
+| `Semantic/Border/Neutral/Alpha/Subtle Opacity` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/900-10` | `→ _ Primitive/Gray/Alpha/900-5` |
+| `Semantic/Foreground/Exceptions/Home Card` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/50` | `→ _ Primitive/Gray/800` |
+| `Semantic/State/Neutral/Alpha/Selected Opacity` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/0-30` | `→ _ Primitive/Gray/Alpha/900-5` |
+| `Semantic/State/Neutral/Hover` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/100` | `→ _ Primitive/Gray/50` |
+| `Semantic/Text/Exception/Home Card Text` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/800` | `→ _ Primitive/Gray/0` |
+| `Semantic/Shadows/Shadow 1` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/Transparent` | `→ _ Primitive/Gray/150` |
+| `Semantic/Shadows/Shadow 2` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/Transparent` | `→ _ Primitive/Gray/300` |
+| `Semantic/Icon/Utility/Destructive Light` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/300` | `→ _ Primitive/Plum/200` |
+| `Semantic/Border/Neutral/Alpha/Inverse Opacity` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/150-15` | `→ _ Primitive/Gray/Alpha/0-10` |
+| `Semantic/Sync/Light Success` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Green/300` | `→ _ Primitive/Green/400` |
+| `Semantic/Sync/Text` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Green/900` | `→ _ Primitive/Green/700` |
+| `Semantic/Sync/Glow` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/500` | `→ _ Primitive/Green/200` |
+| `Semantic/Sync/Light Error` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/600` | `→ _ Primitive/Gray/500` |
+| `Semantic/Sync/Text Error` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/900-50` | `→ _ Primitive/Gray/Alpha/900-50` |
+| `Semantic/Sync/Text Syncing` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Green/Alpha/900-65` | `→ _ Primitive/Green/Alpha/900-65` |
+| `Semantic/Shadows/Shadow 3` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/Transparent` | `→ _ Primitive/Gray/Alpha/900-20` |
+| `Semantic/Nav Panel/Active/Bg` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Crimson/Alpha/400-15` | `→ _ Primitive/Crimson/Alpha/300-10` |
+| `Semantic/Nav Panel/Active/Label` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Crimson/900` | `→ _ Primitive/Crimson/800` |
+| `Semantic/Nav Panel/Hover/Bg` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/900-10` | `→ _ Primitive/Gray/Alpha/900-5` |
+| `Semantic/Nav Panel/Active/Icon` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Crimson/400` | `→ _ Primitive/Crimson/300` |
+| `Semantic/Nav Panel/Badge/Bg` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Crimson/300` | `→ _ Primitive/Crimson/300` |
+| `Semantic/Nav Panel/Badge/Label` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/900` | `→ _ Primitive/Gray/0` |
+| `Semantic/Text/Destructive/Destructive` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/500` | `→ _ Primitive/Plum/300` |
+| `Semantic/Text/Destructive/Destructive Light` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/400` | `→ _ Primitive/Plum/150` |
+| `Semantic/Text/Destructive/Success` | `COLOR` | `ALL_SCOPES` | `→ VariableID:1359:16154` | `→ VariableID:1359:16153` |
+| `Semantic/Button/Button/Primary/Label Hover` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/800` | `→ _ Primitive/Gray/100` |
+| `Semantic/Shadows/Subtle` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/Transparent` | `→ _ Primitive/Gray/Alpha/900-5` |
+| `Semantic/Shadows/Default` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/Transparent` | `→ _ Primitive/Gray/Alpha/900-10` |
+| `Semantic/Foreground/Utility/Alpha/Destructive Alpha Subtle` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/Alpha/400-8` | `→ _ Primitive/Plum/Alpha/400-8` |
+| `Semantic/Border/Utility/Destructive Subtle` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/100` | `→ _ Primitive/Plum/100` |
+| `Semantic/Foreground/Neutral/Alpha/Strong Opacity` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Gray/Alpha/300-50` | `→ _ Primitive/Gray/Alpha/500-50` |
+| `Semantic/Foreground/Utility/Positive Strong` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Green/300` | `→ _ Primitive/Green/500` |
+| `Semantic/Foreground/Utility/Destructive Strong` | `COLOR` | `ALL_SCOPES` | `→ _ Primitive/Plum/300` | `→ _ Primitive/Plum/400` |
+
+## OS utility colors
+
+| Variable | Type | Scopes | Dark | Light |
+| --- | --- | --- | --- | --- |
+| `_OS Utility/MacOS/Window` | `COLOR` | `ALL_SCOPES` | `#0F0F0F` | `#F7F7F7` |
+| `_OS Utility/MacOS/Font` | `COLOR` | `ALL_SCOPES` | `#FFFFFFCB34` | `#1A1A1AD827` |
+| `_OS Utility/MacOS/Disabled Stop Light` | `COLOR` | `ALL_SCOPES` | `#FFFFFF19E6` | `#1A1A1A19E6` |
+| `_OS Utility/MacOS/Scroll Bar` | `COLOR` | `ALL_SCOPES` | `#FFFFFF1EE1` | `#1A1A1A1EE1` |
+| `_OS Utility/MacOS/Nav Panel` | `COLOR` | `ALL_SCOPES` | `#1A1A1A4CB3` | `#FFFFFF4CB3` |
+| `_OS Utility/MacOS/Thin Border` | `COLOR` | `ALL_SCOPES` | `#1A1A1A3AC5` | `#FFFFFF8B74` |
+| `_OS Utility/MacOS/Inner Border` | `COLOR` | `ALL_SCOPES` | `#1A1A1A3AC5` | `#1A1A1A3AC5` |
+| `_OS Utility/MacOS/Window Transparent` | `COLOR` | `ALL_SCOPES` | `#0F0F0F00` | `#F5F5F500` |
+| `_OS Utility/Mobile/OS Status Bar` | `COLOR` | `ALL_SCOPES` | `#FFFFFF` | `#000000` |
+
+## Color showroom
+
+## [Colors](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=110-65&m=dev)
+
+Page ID: `110:65`. Top-level children: 19. Reusable assets found: 0 component sets and 0 standalone components.
+
+### Supporting showroom or source material
+
+- `Showroom Light` (`SECTION`)
+- `Showroom Dark` (`SECTION`)
+- `image 1` (`RECTANGLE`)
+- `Rectangle 4` (`RECTANGLE`)
+- `Rectangle 5` (`RECTANGLE`)
+- `Rectangle 6` (`RECTANGLE`)
+- `Password` (`FRAME`)
+- `Secret Passphrase 2` (`FRAME`)
+- `Secret Passphrase 4` (`FRAME`)
+- `Home Default` (`FRAME`)
+
+This page contains source/showroom material but no reusable local component or component set.

--- a/figma-ai-fix/02-sizing-and-layout.md
+++ b/figma-ai-fix/02-sizing-and-layout.md
@@ -1,0 +1,82 @@
+# Sizing and layout
+
+Source collection: `1 Sizing` (`VariableCollectionId:90:45`).
+The modes are `Desktop` and `Mobile`. Select the intended
+form-factor mode; do not infer sizing from operating-system chrome.
+
+| Variable | Type | Scopes | Desktop | Mobile |
+| --- | --- | --- | --- | --- |
+| `_ Units/1dp` | `FLOAT` | `ALL_SCOPES` | `2` | `2` |
+| `_ Units/2dp` | `FLOAT` | `ALL_SCOPES` | `4` | `4` |
+| `_ Units/4dp` | `FLOAT` | `ALL_SCOPES` | `8` | `8` |
+| `_ Units/6dp` | `FLOAT` | `ALL_SCOPES` | `12` | `12` |
+| `_ Units/8dp` | `FLOAT` | `ALL_SCOPES` | `16` | `16` |
+| `_ Units/12dp` | `FLOAT` | `ALL_SCOPES` | `24` | `24` |
+| `_ Units/16dp` | `FLOAT` | `ALL_SCOPES` | `32` | `32` |
+| `_ Units/24dp` | `FLOAT` | `ALL_SCOPES` | `48` | `48` |
+| `_ Units/32dp` | `FLOAT` | `ALL_SCOPES` | `64` | `64` |
+| `_ Units/48dp` | `FLOAT` | `ALL_SCOPES` | `96` | `96` |
+| `_ Units/64dp` | `FLOAT` | `ALL_SCOPES` | `128` | `128` |
+| `Spacing/XXS` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/2dp` | `→ _ Units/2dp` |
+| `Spacing/XS` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/4dp` | `→ _ Units/4dp` |
+| `Spacing/S` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/6dp` | `→ _ Units/6dp` |
+| `Spacing/SM` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/8dp` | `→ _ Units/8dp` |
+| `Spacing/MD` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/12dp` | `→ _ Units/12dp` |
+| `Spacing/Base` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/16dp` | `→ _ Units/16dp` |
+| `Spacing/LG` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/24dp` | `→ _ Units/24dp` |
+| `Spacing/XL` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/32dp` | `→ _ Units/32dp` |
+| `Spacing/2XL` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/48dp` | `→ _ Units/48dp` |
+| `Spacing/3XL` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/64dp` | `→ _ Units/64dp` |
+| `Radii/S` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/6dp` | `→ _ Units/6dp` |
+| `Radii/Full` | `FLOAT` | `ALL_SCOPES` | `999` | `999` |
+| `Radii/L` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/16dp` | `→ _ Units/16dp` |
+| `Radii/XS` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/4dp` | `→ _ Units/4dp` |
+| `Window/Min Width` | `FLOAT` | `ALL_SCOPES` | `1080` | `1080` |
+| `Window/Min Height` | `FLOAT` | `ALL_SCOPES` | `720` | `720` |
+| `Radii/M` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/12dp` | `→ _ Units/12dp` |
+| `Radii/SM` | `FLOAT` | `ALL_SCOPES` | `→ _ Units/8dp` | `→ _ Units/8dp` |
+| `Window/Max Width` | `FLOAT` | `ALL_SCOPES` | `1296` | `1296` |
+| `Window/Max Height` | `FLOAT` | `ALL_SCOPES` | `864` | `864` |
+| `Window/Content Area Max Width` | `FLOAT` | `ALL_SCOPES` | `420` | `420` |
+| `Buttons/LHeight` | `FLOAT` | `ALL_SCOPES` | `44` | `50` |
+| `Assets/Size` | `FLOAT` | `ALL_SCOPES` | `32` | `40` |
+| `Assets/Icon` | `FLOAT` | `ALL_SCOPES` | `16` | `18` |
+| `Assets/LeftRightPadding` | `FLOAT` | `ALL_SCOPES` | `4` | `0` |
+| `Input/Height` | `FLOAT` | `ALL_SCOPES` | `46` | `60` |
+| `Input/Radii` | `FLOAT` | `ALL_SCOPES` | `→ Radii/S` | `→ Radii/SM` |
+| `Input/Icon Wrap Width` | `FLOAT` | `ALL_SCOPES` | `32` | `36` |
+| `Input/Icon Size` | `FLOAT` | `ALL_SCOPES` | `20` | `24` |
+| `Radio/MinHeight` | `FLOAT` | `ALL_SCOPES` | `40` | `64` |
+| `Radio/CheckCirciel` | `FLOAT` | `ALL_SCOPES` | `16` | `24` |
+| `Radio/CheckIcon` | `FLOAT` | `ALL_SCOPES` | `12` | `16` |
+| `Tabs/SimpleTabsHeight` | `FLOAT` | `ALL_SCOPES` | `25` | `32` |
+| `Tabs/SimpleTabsIcons` | `FLOAT` | `ALL_SCOPES` | `16` | `20` |
+| `Radio/IconSize` | `FLOAT` | `ALL_SCOPES` | `18` | `20` |
+| `Radio/RadioPFPSize` | `FLOAT` | `ALL_SCOPES` | `40` | `56` |
+| `Radio/RadioPFPSelectIcon` | `FLOAT` | `ALL_SCOPES` | `20` | `24` |
+| `Radio/RadioPFPCheck` | `FLOAT` | `ALL_SCOPES` | `16` | `20` |
+| `Assets/ImgGap` | `FLOAT` | `ALL_SCOPES` | `→ Spacing/XS` | `→ Spacing/S` |
+| `Context Menu/TopBottomPadding` | `FLOAT` | `ALL_SCOPES` | `8` | `16` |
+| `Context Menu/LeftRightPadding` | `FLOAT` | `ALL_SCOPES` | `4` | `4` |
+| `Context Menu/Radii` | `FLOAT` | `ALL_SCOPES` | `12` | `16` |
+| `Context Menu/IconSize` | `FLOAT` | `ALL_SCOPES` | `16` | `20` |
+| `Context Menu/IconGap` | `FLOAT` | `ALL_SCOPES` | `4` | `8` |
+| `Context Menu/ListGap` | `FLOAT` | `ALL_SCOPES` | `4` | `8` |
+| `Tabs/TabsHeight` | `FLOAT` | `ALL_SCOPES` | `36` | `40` |
+| `Tabs/TabsIconSize` | `FLOAT` | `ALL_SCOPES` | `16` | `20` |
+| `Tabs/TabWidth` | `FLOAT` | `ALL_SCOPES` | `128` | `160` |
+| `Tabs/TabsIconGap` | `FLOAT` | `ALL_SCOPES` | `4` | `8` |
+| `Buttons/LMinWidth` | `FLOAT` | `ALL_SCOPES` | `196` | `0` |
+| `Toast/Height` | `FLOAT` | `ALL_SCOPES` | `32` | `40` |
+| `Toast/IconSize` | `FLOAT` | `ALL_SCOPES` | `16` | `20` |
+| `Buttons/MSIconSize` | `FLOAT` | `ALL_SCOPES` | `16` | `20` |
+
+## Layout interpretation
+
+- `_ Units` are the numeric foundations.
+- `Spacing` and `Radii` are shared layout primitives.
+- `Window` defines desktop content constraints.
+- Button, asset, input, radio, tab, context-menu, and toast groups define
+  component-specific dimensions.
+- The local desktop grid is recorded in
+  [effects and grid](04-effects-and-grid.md).

--- a/figma-ai-fix/03-typography.md
+++ b/figma-ai-fix/03-typography.md
@@ -1,0 +1,107 @@
+# Typography
+
+Source collection: `3 Fonts` (`VariableCollectionId:174:272`).
+The modes are `Desktop` and `Mobile`. The display, body,
+label, and code roles combine Young Serif, Geist, and Geist Mono.
+
+## Font variables
+
+| Variable | Type | Scopes | Desktop | Mobile |
+| --- | --- | --- | --- | --- |
+| `Headline XL/fontSize` | `FLOAT` | `ALL_SCOPES` | `45` | `40` |
+| `Headline XL/lineHeight` | `FLOAT` | `ALL_SCOPES` | `48` | `40` |
+| `Headline XL/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `-1.350000023841858` | `-1.350000023841858` |
+| `Headline L/fontSize` | `FLOAT` | `ALL_SCOPES` | `32` | `32` |
+| `Headline L/lineHeight` | `FLOAT` | `ALL_SCOPES` | `33` | `33` |
+| `Headline L/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `0` | `0` |
+| `Headline M/fontSize` | `FLOAT` | `ALL_SCOPES` | `28` | `24` |
+| `Headline M/lineHeight` | `FLOAT` | `ALL_SCOPES` | `30` | `28` |
+| `Headline M/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `-0.2800000011920929` | `-0.4000000059604645` |
+| `Headline S/fontSize` | `FLOAT` | `ALL_SCOPES` | `16` | `18` |
+| `Headline S/lineHeight` | `FLOAT` | `ALL_SCOPES` | `20` | `22` |
+| `Headline S/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `0` | `0` |
+| `Body/Body L/fontSize` | `FLOAT` | `ALL_SCOPES` | `16` | `18` |
+| `Body/Body L/lineHeight` | `FLOAT` | `ALL_SCOPES` | `24` | `26` |
+| `Body/Body L/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `-0.23999999463558197` | `-0.23999999463558197` |
+| `Body/Body M/fontSize` | `FLOAT` | `ALL_SCOPES` | `14` | `16` |
+| `Body/Body M/lineHeight` | `FLOAT` | `ALL_SCOPES` | `21` | `25` |
+| `Body/Body M/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `-0.20999999344348907` | `-0.20999999344348907` |
+| `Body/Body M Medium/fontSize` | `FLOAT` | `ALL_SCOPES` | `14` | `16` |
+| `Body/Body M Medium/lineHeight` | `FLOAT` | `ALL_SCOPES` | `21` | `25` |
+| `Body/Body M Medium/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `-0.20999999344348907` | `-0.20999999344348907` |
+| `Body/Body S/fontSize` | `FLOAT` | `ALL_SCOPES` | `12` | `14` |
+| `Body/Body S/lineHeight` | `FLOAT` | `ALL_SCOPES` | `18` | `20` |
+| `Body/Body S/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `-0.11999999731779099` | `-0.11999999731779099` |
+| `Body/Body XS/fontSize` | `FLOAT` | `ALL_SCOPES` | `11` | `13` |
+| `Body/Body XS/lineHeight` | `FLOAT` | `ALL_SCOPES` | `16` | `18` |
+| `Body/Body XS/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `-0.054999999701976776` | `-0.054999999701976776` |
+| `Label/Label M/fontSize` | `FLOAT` | `ALL_SCOPES` | `14` | `16` |
+| `Label/Label M/lineHeight` | `FLOAT` | `ALL_SCOPES` | `16` | `17` |
+| `Label/Label M/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `-0.05999999865889549` | `-0.03999999910593033` |
+| `Label/Label S/fontSize` | `FLOAT` | `ALL_SCOPES` | `13` | `14` |
+| `Label/Label S/lineHeight` | `FLOAT` | `ALL_SCOPES` | `14` | `15` |
+| `Label/Label S/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `0` | `0` |
+| `Code/Code M/fontSize` | `FLOAT` | `ALL_SCOPES` | `14` | `16` |
+| `Code/Code M/lineHeight` | `FLOAT` | `ALL_SCOPES` | `21` | `21` |
+| `Code/Code M/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `0` | `0` |
+| `Code/Code S/fontSize` | `FLOAT` | `ALL_SCOPES` | `13` | `13` |
+| `Code/Code S/lineHeight` | `FLOAT` | `ALL_SCOPES` | `17` | `17` |
+| `Code/Code S/letterSpacing` | `FLOAT` | `ALL_SCOPES` | `0` | `0` |
+| `Headline XL/fontFamily` | `STRING` | `ALL_SCOPES` | `Libre Caslon Text` | `Libre Caslon Text` |
+| `Headline XL/fontStyle` | `STRING` | `ALL_SCOPES` | `Regular` | `Regular` |
+| `Headline L/fontFamily` | `STRING` | `ALL_SCOPES` | `Libre Caslon Text` | `Libre Caslon Text` |
+| `Headline L/fontStyle` | `STRING` | `ALL_SCOPES` | `Regular` | `Regular` |
+| `Headline M/fontFamily` | `STRING` | `ALL_SCOPES` | `Libre Caslon Text` | `Libre Caslon Text` |
+| `Headline M/fontStyle` | `STRING` | `ALL_SCOPES` | `Medium` | `Medium` |
+| `Headline S/fontFamily` | `STRING` | `ALL_SCOPES` | `Geist` | `Geist` |
+| `Headline S/fontStyle` | `STRING` | `ALL_SCOPES` | `Medium` | `Medium` |
+| `Body/Body L/fontFamily` | `STRING` | `ALL_SCOPES` | `Geist` | `Geist` |
+| `Body/Body L/fontStyle` | `STRING` | `ALL_SCOPES` | `Medium` | `Medium` |
+| `Body/Body M/fontFamily` | `STRING` | `ALL_SCOPES` | `Geist` | `Geist` |
+| `Body/Body M/fontStyle` | `STRING` | `ALL_SCOPES` | `Regular` | `Regular` |
+| `Body/Body M Medium/fontFamily` | `STRING` | `ALL_SCOPES` | `Geist` | `Geist` |
+| `Body/Body M Medium/fontStyle` | `STRING` | `ALL_SCOPES` | `Medium` | `Medium` |
+| `Body/Body S/fontFamily` | `STRING` | `ALL_SCOPES` | `Geist` | `Geist` |
+| `Body/Body S/fontStyle` | `STRING` | `ALL_SCOPES` | `Regular` | `Regular` |
+| `Body/Body XS/fontFamily` | `STRING` | `ALL_SCOPES` | `Geist` | `Geist` |
+| `Body/Body XS/fontStyle` | `STRING` | `ALL_SCOPES` | `Regular` | `Regular` |
+| `Label/Label M/fontFamily` | `STRING` | `ALL_SCOPES` | `Geist` | `Geist` |
+| `Label/Label M/fontStyle` | `STRING` | `ALL_SCOPES` | `Medium` | `Medium` |
+| `Label/Label S/fontFamily` | `STRING` | `ALL_SCOPES` | `Geist` | `Geist` |
+| `Label/Label S/fontStyle` | `STRING` | `ALL_SCOPES` | `Medium` | `Medium` |
+| `Code/Code M/fontFamily` | `STRING` | `ALL_SCOPES` | `Geist Mono` | `Geist Mono` |
+| `Code/Code M/fontStyle` | `STRING` | `ALL_SCOPES` | `Medium` | `Medium` |
+| `Code/Code S/fontFamily` | `STRING` | `ALL_SCOPES` | `Geist Mono` | `Geist Mono` |
+| `Code/Code S/fontStyle` | `STRING` | `ALL_SCOPES` | `Medium` | `Medium` |
+
+## Local text styles
+
+| Style | Font | Size | Line height | Letter spacing | Case |
+| --- | --- | --- | --- | --- | --- |
+| `Fonts/Display/Headline XL` | `Young Serif Medium` | `45` | `48 PIXELS` | `-1.350000023841858 PIXELS` | `ORIGINAL` |
+| `Fonts/Display/Headline L` | `Young Serif Medium` | `32` | `33 PIXELS` | `0 PIXELS` | `ORIGINAL` |
+| `Fonts/Display/Headline M` | `Young Serif Medium` | `28` | `30 PIXELS` | `-0.2800000011920929 PIXELS` | `ORIGINAL` |
+| `Fonts/Display/Headline S` | `Geist Medium` | `16` | `20 PIXELS` | `0 PIXELS` | `ORIGINAL` |
+| `Fonts/Body/Body L` | `Geist SemiBold` | `16` | `24 PIXELS` | `-0.23999999463558197 PIXELS` | `ORIGINAL` |
+| `Fonts/Body/Body M Medium` | `Geist Medium` | `14` | `21 PIXELS` | `-0.20999999344348907 PIXELS` | `ORIGINAL` |
+| `Fonts/Body/Body M` | `Geist Regular` | `14` | `21 PIXELS` | `-0.20999999344348907 PIXELS` | `ORIGINAL` |
+| `Fonts/Body/Body S` | `Geist Regular` | `12` | `18 PIXELS` | `-0.11999999731779099 PIXELS` | `ORIGINAL` |
+| `Fonts/Body/Body XS` | `Geist Regular` | `11` | `16 PIXELS` | `-0.054999999701976776 PIXELS` | `ORIGINAL` |
+| `Fonts/Label/Label M Semibold` | `Geist SemiBold` | `14` | `16 PIXELS` | `-0.05999999865889549 PIXELS` | `ORIGINAL` |
+| `Fonts/Label/Label M Medium` | `Geist Medium` | `14` | `16 PIXELS` | `-0.05999999865889549 PIXELS` | `ORIGINAL` |
+| `Fonts/Label/Label M` | `Geist Regular` | `14` | `16 PIXELS` | `-0.05999999865889549 PIXELS` | `ORIGINAL` |
+| `Fonts/Label/Label S` | `Geist Medium` | `13` | `14 PIXELS` | `0 PIXELS` | `ORIGINAL` |
+| `Fonts/Code/Code M` | `Geist Mono Medium` | `14` | `21 PIXELS` | `0 PIXELS` | `ORIGINAL` |
+| `Fonts/Code/Code S` | `Geist Mono Medium` | `13` | `17 PIXELS` | `0 PIXELS` | `ORIGINAL` |
+
+## Text components
+
+## [Text](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=1532-37193&m=dev)
+
+Page ID: `1532:37193`. Top-level children: 1. Reusable assets found: 0 component sets and 1 standalone components.
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `Paragraph` | `1532:37194` | — |

--- a/figma-ai-fix/04-effects-and-grid.md
+++ b/figma-ai-fix/04-effects-and-grid.md
@@ -1,0 +1,21 @@
+# Effects and grid
+
+## Local effect styles
+
+| Style | Node ID | Effects |
+| --- | --- | --- |
+| `Utility/MacOS/System Window` | `S:afe09d261e76bb818c4041334518c345ce259769,` | DROP_SHADOW; offset 0,16; radius 48; spread 0; #00000058A7; visible; NORMAL<br>DROP_SHADOW; offset 0,0; radius 0; spread 1; #0000003AC5; visible; NORMAL<br>BACKGROUND_BLUR; radius 35; visible<br>INNER_SHADOW; offset 0,0; radius 1; spread 1; #FFFFFF25DA; visible; NORMAL<br>DROP_SHADOW; offset 0,0; radius 0; spread 1.5; #1A1A1A3AC5; visible; NORMAL |
+| `Utility/MacOS/System Nav` | `S:7c4dd2960b24d885224c1359648e58d1ae3aaf23,` | DROP_SHADOW; offset 0,0; radius 44; spread 0; #0000001EE1; visible; NORMAL<br>DROP_SHADOW; offset 0,0; radius 0; spread 1; #1A1A1A3AC5; visible; NORMAL<br>BACKGROUND_BLUR; radius 35; visible<br>INNER_SHADOW; offset 0,0; radius 1; spread 1; #FFFFFF25DA; visible; NORMAL |
+| `Scrim Blur` | `S:1871c66c99d377e2fc34db5c9dc585269c357084,` | BACKGROUND_BLUR; radius 30; visible |
+| `Shadow 1` | `S:7924a0fbc1a1bb9da0f1ec9fa6e1f3e7281a1698,` | DROP_SHADOW; offset 0,10; radius 15; spread 0; #14181800; visible; NORMAL<br>DROP_SHADOW; offset 0,2; radius 2; spread 0; #14181800; visible; NORMAL |
+| `Shadow Surface` | `S:be1704eb2ee75bc58231d912b1139dc3ed96f2d0,` | DROP_SHADOW; offset 0,0; radius 1; spread 0; #14181800; visible; NORMAL<br>DROP_SHADOW; offset 0,1; radius 2; spread 0; #14181800; visible; NORMAL<br>DROP_SHADOW; offset 0,2; radius 4; spread 0; #14181800; visible; NORMAL<br>DROP_SHADOW; offset 0,0; radius 1; spread 0; #14181800; visible; NORMAL |
+| `Shadow Overlay` | `S:f083e734d779062386f009176b244f3249aff791,` | DROP_SHADOW; offset 0,14; radius 28; spread 0; #00000013EC; visible; NORMAL<br>DROP_SHADOW; offset 0,-6; radius 12; spread 0; #0000007F8; visible; NORMAL<br>DROP_SHADOW; offset 0,2; radius 8; spread 0; #000000EF1; visible; NORMAL<br>INNER_SHADOW; offset 0,0; radius 2; spread 0; #FFFFFF25DA; visible; NORMAL |
+
+## Local grid styles
+
+| Style | Node ID | Definition |
+| --- | --- | --- |
+| `Desktop` | `S:e6832f9c06ba6e653f43a296d9af0375a555fe93,` | `[{"pattern":"COLUMNS","visible":true,"color":{"r":1,"g":1,"b":1,"a":0.15000000596046448},"gutterSize":24,"alignment":"STRETCH","count":12,"offset":32,"boundVariables":{}}]` |
+
+There are no local paint styles in this file. Color is represented by the
+variable system documented in [color system](01-color-system.md).

--- a/figma-ai-fix/05-brand-and-app-icon.md
+++ b/figma-ai-fix/05-brand-and-app-icon.md
@@ -1,0 +1,80 @@
+# Brand and app icon
+
+Use the exact reusable marks from these pages. Do not recreate the Vizor symbol or wordmark from ad-hoc vectors when a component exists.
+
+## [Identity](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=4-2&m=dev)
+
+Page ID: `4:2`. Top-level children: 62. Reusable assets found: 0 component sets and 5 standalone components.
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `Logo Text` | `238:3866` | — |
+| `Symbol` | `877:62602` | — |
+| `Logo` | `1370:26306` | — |
+| `Logo 3D` | `1370:26333` | — |
+| `Symbol 3D` | `1370:26281` | — |
+
+### Supporting showroom or source material
+
+- `Rectangle 241` (`VECTOR`)
+- `Ellipse 23` (`ELLIPSE`)
+- `Ellipse 22` (`ELLIPSE`)
+- `Vector 75` (`VECTOR`)
+- `Vector 18` (`VECTOR`)
+- `Badge` (`FRAME`)
+- `Final` (`FRAME`)
+- `image 60` (`RECTANGLE`)
+- `Vector 74` (`VECTOR`)
+- `Logo` (`GROUP`)
+- `image 63` (`RECTANGLE`)
+- `image 64` (`RECTANGLE`)
+- `image 65` (`RECTANGLE`)
+- `image 66` (`RECTANGLE`)
+- `Ellipse 21` (`VECTOR`)
+- `image 58` (`RECTANGLE`)
+- `Vector 76` (`VECTOR`)
+- `Group 113` (`GROUP`)
+- `image 70` (`RECTANGLE`)
+- `image 72` (`RECTANGLE`)
+- `Group 110` (`GROUP`)
+- `Group 114` (`GROUP`)
+- `Vizor` (`TEXT`)
+- `VIZOR` (`TEXT`)
+- `Vector 78` (`VECTOR`)
+- `Rectangle 231` (`VECTOR`)
+- `Rectangle 232` (`VECTOR`)
+- `image 73` (`RECTANGLE`)
+- `image 74` (`RECTANGLE`)
+- `Vector 79` (`VECTOR`)
+- `Vector 80` (`VECTOR`)
+- `Rectangle 233` (`VECTOR`)
+- `Rectangle 235` (`VECTOR`)
+- `Group 115` (`GROUP`)
+- `Rectangle 237` (`RECTANGLE`)
+- `Rectangle 238` (`RECTANGLE`)
+- `Group 117` (`GROUP`)
+- `Group 116` (`GROUP`)
+- `image 75` (`RECTANGLE`)
+- `image 76` (`RECTANGLE`)
+- `image 77` (`RECTANGLE`)
+
+## [App Icon](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=1567-44492&m=dev)
+
+Page ID: `1567:44492`. Top-level children: 14. Reusable assets found: 0 component sets and 2 standalone components.
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `App Icon` | `256:3919` | — |
+| `_App Icon` | `4479:47970` | — |
+
+### Supporting showroom or source material
+
+- `App Icon` (`FRAME`)
+- `Windows` (`FRAME`)
+- `Mobile` (`FRAME`)
+- `image 61` (`RECTANGLE`)
+- `image 62` (`RECTANGLE`)

--- a/figma-ai-fix/06-icons.md
+++ b/figma-ai-fix/06-icons.md
@@ -1,0 +1,118 @@
+# Icons
+
+This is the complete local reusable icon inventory on the Icons page. Preserve exact names and node IDs when selecting or replacing icons. Apply semantic icon-color variables rather than embedding one-off colors.
+
+## [Icons](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=54-461&m=dev)
+
+Page ID: `54:461`. Top-level children: 103. Reusable assets found: 0 component sets and 95 standalone components.
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `Add New` | `54:729` | add, plus, new |
+| `Plus` | `5032:93212` | add, plus, new |
+| `Minus` | `6321:34356` | minus, subtract |
+| `Import` | `54:728` | import, arrow, get, download |
+| `Paste` | `4575:108565` | Paste, Clipboard |
+| `Paste Failed` | `4746:84066` | Paste, Clipboard |
+| `Shield Keyhole Fill` | `107:2321` | shield, key, security, shielded, balance, Zcash |
+| `Shield Keyhole Outline` | `392:40159` | shield, key, security, shielded, balance, zcash |
+| `Transparent Balance` | `508:41957` | Transparent, Balance, Zcash |
+| `Book` | `107:2318` | book, learn, info, help |
+| `Wallet` | `107:2322` | wallet, assets, coins |
+| `key` | `107:2316` | key, security, seed, phrase |
+| `zCash` | `107:2329` | assets, zcash, zec |
+| `zCash Currency` | `324:5061` | assets, zcash, zec |
+| `Block` | `115:2934` | hex, block |
+| `Skip` | `114:2587` | skip, next |
+| `Arrow Down Triangle` | `1439:28205` | Down, Drop |
+| `Arrow Up Triangle` | `1439:28215` | skip, next |
+| `Chevron Right` | `107:2422` | forward, arrow, chevron |
+| `Chevron Left` | `107:2423` | back, arrow, chevron |
+| `Copy` | `115:3411` | copy, address |
+| `eye` | `115:5183` | show, reveal, eye |
+| `Eye Closed` | `377:31344` | Eye, Hide |
+| `Time` | `118:6501` | wait, loading, time |
+| `warning` | `160:6684` | — |
+| `Help` | `324:6876` | Help, About, Question |
+| `Link` | `303:3135` | — |
+| `Crystal Ball` | `304:3252` | Know, See, Tell, Predict |
+| `Expand` | `324:5042` | Expand, Arrows |
+| `Collapsed` | `378:33478` | Close, Collapse, Arrows |
+| `Log Out` | `324:6763` | Sign Out, Leave, Log Out |
+| `Check Circle` | `333:7316` | Check, Done, Success |
+| `Arrow Bottom Left` | `333:7387` | Arrow, Send |
+| `Arrow Top Right` | `333:7388` | — |
+| `Arrow Down` | `333:7510` | Receive, Received, Arrow |
+| `Arrow Up` | `1432:27362` | Up, Arrow |
+| `Skull` | `333:7450` | — |
+| `Vizor Icon` | `1562:40561` | Vizor, Brand, Icon |
+| `Plane` | `333:7493` | Send, Sent |
+| `Uturn Back` | `336:8344` | Back, Turn, Return, Arrow |
+| `Uturn Up` | `4265:116202` | Back, Turn, Return, Arrow |
+| `Cog` | `344:8389` | Settings, Gear, Cog, Parameter |
+| `Users Fill` | `344:8467` | Users, Contacts, Accounts |
+| `QR` | `344:8747` | QR, Scan, qr Code, Code |
+| `Renew` | `348:10593` | Update, Renew, New, Restart, Refresh, Update |
+| `Cross` | `355:13921` | Cross, Cancel, Close, X, Clear |
+| `Scroll` | `355:23578` | parchment, scroll, message, edit, note |
+| `Arrow Down Circle` | `366:27297` | Arrow, Down, Receive |
+| `History` | `371:29452` | Activity, History, Log, Time |
+| `Loader` | `402:43668` | Loading, Loader, Spinner, Syncing |
+| `Dragon` | `970:76556` | Loading, Loader, Spinner, Syncing |
+| `Lock` | `410:45071` | Password, Private, Lock, Safe |
+| `Unlock` | `410:45084` | Password, Private, Lock, Safe, Unlock |
+| `Calendar` | `485:29049` | Date, Cal, Calendar |
+| `Theme` | `639:46593` | Theme, Light, Dark Mode |
+| `Endpoint` | `662:46715` | Server, Endpoint, Connect, Network |
+| `Monitor` | `806:58583` | Monitor, System, Desktop, Computer |
+| `Day` | `806:58584` | Sun, Light, Light Mode, Day, Day mode |
+| `Night` | `806:58585` | Night, Night Mode, Dark, Dark Mode, Moon |
+| `Check` | `877:61795` | Check, Done, Success |
+| `Sync` | `1183:18438` | Sync, Synchronization |
+| `Search` | `1430:27266` | Search, Look, magnifier |
+| `User` | `1510:33029` | User, Profile, Icon, Account |
+| `Options` | `2011:32574` | Context, Menu, More, Info, Options, Dots |
+| `Options Vertical` | `4360:100802` | Context, Menu, More, Info, Options, Dots |
+| `Trash` | `2011:33623` | Trash, Delete, Remove |
+| `Restore` | `4360:101339` | Trash, Delete, Remove, Restore |
+| `Camera` | `2200:32104` | Camera, Cam, QR |
+| `Camera Denied` | `2200:32117` | Camera, Cam, QR |
+| `Keystone` | `2216:42893` | Keystone, Hardware, Cold Wallet |
+| `Home Fill` | `2283:33027` | home, castle, tower |
+| `Double Arrow Vertical` | `2728:3338` | Change, Swap, Switch, Arrows, Arrow |
+| `Sub Arrow` | `2728:30980` | Sub, Directory, Arrow, Return, Enter |
+| `Swap Arrows Outline` | `2728:31077` | Swap, Arrows |
+| `percent` | `2785:12197` | fee, percent, |
+| `coins` | `2814:76404` | — |
+| `Edit` | `2865:121738` | Edit, pen |
+| `Shield Asset` | `517:41997` | shield, key, security, shielded, balance, zcash |
+| `Filter` | `4069:369488` | Filter, Sort |
+| `globe` | `4086:481025` | globe, web, earth, website |
+| `github` | `4086:481024` | — |
+| `Cancel` | `4235:81841` | Cross, Cancel, Close, X, Clear |
+| `polls` | `4341:79236` | Polling, Poll, Polls, Vote, Governance |
+| `trophy` | `4369:130701` | trophy, award, win |
+| `Warning Circle` | `4386:42230` | Warning, Error |
+| `Share` | `4562:91537` | — |
+| `backspace` | `4885:22877` | — |
+| `Face Id` | `4887:22526` | — |
+| `fingerprint` | `4887:23574` | — |
+| `Gift Card` | `5265:70304` | Card, Gift, Gift Card |
+| `Mobile` | `5283:103371` | Link, Mobile, Connect, App |
+| `Pay` | `5407:152976` | — |
+| `money bag` | `5434:124375` | — |
+| `Keystone Scan` | `5460:24699` | — |
+| `Focused Sync` | `6002:121002` | — |
+
+### Supporting showroom or source material
+
+- `Vector (Stroke)` (`VECTOR`)
+- `ant-design:fire-filled` (`FRAME`)
+- `image 1` (`RECTANGLE`)
+- `image 2` (`RECTANGLE`)
+- `image 8` (`RECTANGLE`)
+- `image 18` (`RECTANGLE`)
+- `image 22` (`RECTANGLE`)
+- `image 23` (`RECTANGLE`)

--- a/figma-ai-fix/07-illustrations-assets-and-placeholders.md
+++ b/figma-ai-fix/07-illustrations-assets-and-placeholders.md
@@ -1,0 +1,132 @@
+# Illustrations, assets, and placeholders
+
+These pages contain reusable illustrations, PFPs, empty/error states, source imagery, user-image material, and placeholders. Prefer existing full-page and state components before importing a new illustration.
+
+## [Illustrations](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=115-4359&m=dev)
+
+Page ID: `115:4359`. Top-level children: 44. Reusable assets found: 2 component sets and 17 standalone components.
+
+### Component sets
+
+#### `PFP` — `677:55572`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `PFP` | `VARIANT` | `Knight` |
+
+Variants (15):
+
+| Variant | Node ID |
+| --- | --- |
+| `PFP=Knight` | `677:55571` |
+| `PFP=Viking` | `2088:45976` |
+| `PFP=Samurai` | `2088:45978` |
+| `PFP=Dark Champion` | `2088:45980` |
+| `PFP=Crusader` | `2088:45982` |
+| `PFP=Shinobi` | `2088:45984` |
+| `PFP=Skull` | `4190:1084370` |
+| `PFP=Valkiria` | `2088:45988` |
+| `PFP=Sorcerer` | `2088:45986` |
+| `PFP=Wanderer` | `4190:1083223` |
+| `PFP=Mage` | `4190:1083225` |
+| `PFP=Rogue` | `4190:1083227` |
+| `PFP=Jester` | `4190:1083229` |
+| `PFP=Cleric` | `4190:1084366` |
+| `PFP=Bob` | `4190:1084368` |
+
+#### `_Full Page Illustration` — `4175:592580`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Type` | `VARIANT` | `Home` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Home` | `4175:592579` |
+| `Type=Password` | `4175:593838` |
+| `Type=Empty` | `4353:91054` |
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `Welcome Bg` | `415:45659` | — |
+| `Success` | `476:23601` | — |
+| `Welcome BG Dark` | `1370:23247` | — |
+| `Welcome BG Light` | `1370:23260` | — |
+| `Fail` | `1440:28754` | — |
+| `Knight` | `303:2101` | — |
+| `Key` | `303:2100` | — |
+| `Crystal Ball` | `303:2099` | — |
+| `Book` | `303:2098` | — |
+| `Chest` | `303:2097` | — |
+| `Password` | `4184:1081187` | — |
+| `Keystone` | `2332:68340` | — |
+| `Empty` | `4175:595001` | — |
+| `Fail` | `4182:1079110` | — |
+| `Rest` | `4185:1081408` | — |
+| `No Results` | `4175:595003` | — |
+| `Customise Account` | `5498:97899` | — |
+
+### Supporting showroom or source material
+
+- `image 43` (`RECTANGLE`)
+- `knight-light` (`RECTANGLE`)
+- `image 18` (`RECTANGLE`)
+- `image 20` (`RECTANGLE`)
+- `image 29` (`RECTANGLE`)
+- `image 31` (`RECTANGLE`)
+- `image 30` (`RECTANGLE`)
+- `image 21` (`RECTANGLE`)
+- `image 33` (`RECTANGLE`)
+- `image 32` (`RECTANGLE`)
+- `image 23` (`RECTANGLE`)
+- `image 24` (`RECTANGLE`)
+- `image 27` (`RECTANGLE`)
+- `image 28` (`RECTANGLE`)
+- `image 25` (`RECTANGLE`)
+- `image 26` (`RECTANGLE`)
+- `New Illustrations WIP` (`FRAME`)
+- `Contacts Empty Search` (`FRAME`)
+- `image 55` (`RECTANGLE`)
+- `Password` (`RECTANGLE`)
+- `HOME` (`RECTANGLE`)
+- `Group 26` (`GROUP`)
+- `No Results Illustration` (`FRAME`)
+- `Fail Illustration` (`FRAME`)
+- `Group 28` (`GROUP`)
+- `image 6` (`RECTANGLE`)
+
+## [Placeholders](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=54-924&m=dev)
+
+Page ID: `54:924`. Top-level children: 4. Reusable assets found: 0 component sets and 1 standalone components.
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `placeholder-image` | `54:929` | — |
+
+### Supporting showroom or source material
+
+- `Rectangle 38` (`RECTANGLE`)
+- `Vector 5` (`VECTOR`)
+- `Vector 6` (`VECTOR`)
+
+## [Users](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=4018-40198&m=dev)
+
+Page ID: `4018:40198`. Top-level children: 15. Reusable assets found: 0 component sets and 0 standalone components.
+
+### Supporting showroom or source material
+
+- `image 41` (`RECTANGLE`)
+- `image 42` (`RECTANGLE`)
+- `image 2` (`RECTANGLE`)
+
+This page contains source/showroom material but no reusable local component or component set.

--- a/figma-ai-fix/08-actions-status-and-feedback.md
+++ b/figma-ai-fix/08-actions-status-and-feedback.md
@@ -1,0 +1,241 @@
+# Actions, status, and feedback
+
+Use component properties and variants rather than detaching instances. Button style, state, and size are independent axes; status and feedback components carry their own type/state variants.
+
+## [Buttons](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=54-462&m=dev)
+
+Page ID: `54:462`. Top-level children: 9. Reusable assets found: 2 component sets and 2 standalone components.
+
+### Component sets
+
+#### `Button` — `54:81`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Show Leading Icon#355:32` | `BOOLEAN` | `true` |
+| `Show Trailing Icon#355:53` | `BOOLEAN` | `true` |
+| `Leading Icon#355:74` | `INSTANCE_SWAP` | `54:729` |
+| `Trailing Icon#355:95` | `INSTANCE_SWAP` | `54:729` |
+| `Button Label#422:1` | `TEXT` | `Create New Wallet` |
+| `Show Label#450:22` | `BOOLEAN` | `true` |
+| `Style` | `VARIANT` | `Accent` |
+| `State` | `VARIANT` | `Default` |
+| `Size` | `VARIANT` | `L` |
+
+Variants (39):
+
+| Variant | Node ID |
+| --- | --- |
+| `Style=Accent, State=Default, Size=L` | `54:51` |
+| `Style=Destructive, State=Default, Size=L` | `877:61408` |
+| `Style=Accent, State=Default, Size=M` | `504:40366` |
+| `Style=Destructive, State=Default, Size=M` | `877:61414` |
+| `Style=Accent, State=Default, Size=S` | `115:3113` |
+| `Style=Destructive, State=Default, Size=S` | `877:61420` |
+| `Style=Accent, State=Hovererd, Size=L` | `54:1039` |
+| `Style=Destructive, State=Hovererd, Size=L` | `877:61426` |
+| `Style=Accent, State=Hovererd, Size=M` | `504:40372` |
+| `Style=Destructive, State=Hovererd, Size=M` | `877:61432` |
+| `Style=Accent, State=Hovererd, Size=S` | `115:3115` |
+| `Style=Destructive, State=Hovererd, Size=S` | `877:61438` |
+| `Style=Accent, State=Keyboard Focused, Size=L` | `54:880` |
+| `Style=Destructive, State=Keyboard Focused, Size=L` | `877:61444` |
+| `Style=Accent, State=Keyboard Focused, Size=M` | `504:40378` |
+| `Style=Destructive, State=Keyboard Focused, Size=M` | `877:61451` |
+| `Style=Accent, State=Keyboard Focused, Size=S` | `115:3117` |
+| `Style=Destructive, State=Keyboard Focused, Size=S` | `877:61458` |
+| `Style=Secondary, State=Default, Size=L` | `54:603` |
+| `Style=Secondary, State=Default, Size=M` | `504:40385` |
+| `Style=Secondary, State=Default, Size=S` | `115:3120` |
+| `Style=Secondary, State=Hovererd, Size=L` | `54:1034` |
+| `Style=Secondary, State=Hovererd, Size=M` | `504:40391` |
+| `Style=Secondary, State=Hovererd, Size=S` | `115:3122` |
+| `Style=Secondary, State=Keyboard Focused, Size=L` | `54:891` |
+| `Style=Secondary, State=Keyboard Focused, Size=M` | `504:40397` |
+| `Style=Secondary, State=Keyboard Focused, Size=S` | `115:3124` |
+| `Style=Ghost, State=Default, Size=L` | `107:2426` |
+| `Style=Ghost, State=Default, Size=M` | `504:40404` |
+| `Style=Ghost, State=Default, Size=S` | `115:3127` |
+| `Style=Ghost, State=Keyboard Focused, Size=L` | `107:2440` |
+| `Style=Ghost, State=Keyboard Focused, Size=M` | `504:40410` |
+| `Style=Ghost, State=Keyboard Focused, Size=S` | `115:3129` |
+| `Style=Ghost, State=Hovererd, Size=L` | `107:2435` |
+| `Style=Ghost, State=Hovererd, Size=M` | `504:40417` |
+| `Style=Disabled, State=Default, Size=L` | `355:15533` |
+| `Style=Disabled, State=Default, Size=M` | `504:40423` |
+| `Style=Disabled, State=Default, Size=S` | `355:15571` |
+| `Style=Ghost, State=Hovererd, Size=S` | `115:3132` |
+
+#### `Buttons Stack` — `2190:29856`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Property 1` | `VARIANT` | `Vertical` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `Property 1=Vertical` | `439:17619` |
+| `Property 1=Horisontal` | `2190:30428` |
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `Floating Button` | `877:62267` | — |
+| `Floating button` | `4077:382199` | — |
+
+### Supporting showroom or source material
+
+- `Showroom Dark` (`FRAME`)
+- `Showroom Light` (`FRAME`)
+- `Home` (`FRAME`)
+
+## [Badge](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=806-59103&m=dev)
+
+Page ID: `806:59103`. Top-level children: 4. Reusable assets found: 1 component sets and 1 standalone components.
+
+### Component sets
+
+#### `Badge` — `806:59217`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Show Badge Icon#806:94` | `BOOLEAN` | `false` |
+| `Badge Label#806:95` | `TEXT` | `Down` |
+| `Type` | `VARIANT` | `Neutral` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Neutral` | `806:59221` |
+| `Type=Success` | `806:59111` |
+| `Type=Destructive` | `806:59224` |
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `Badge` | `2216:41021` | — |
+
+### Supporting showroom or source material
+
+- `Showroom` (`SECTION`)
+
+## [Chip](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=115-3307&m=dev)
+
+Page ID: `115:3307`. Top-level children: 1. Reusable assets found: 1 component sets and 0 standalone components.
+
+### Component sets
+
+#### `Chip` — `115:3333`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Chip Leading Icon#115:11` | `BOOLEAN` | `true` |
+| `Chip Trailing Icon#115:14` | `BOOLEAN` | `true` |
+| `Type` | `VARIANT` | `Default` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Default` | `115:2764` |
+| `Type=Icons` | `115:3334` |
+
+## [Tooltip](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=2361-70162&m=dev)
+
+Page ID: `2361:70162`. Top-level children: 3. Reusable assets found: 3 component sets and 0 standalone components.
+
+### Component sets
+
+#### `Tooltip` — `2361:70163`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Default` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `2361:70149` |
+| `State=Shown` | `2361:70164` |
+
+#### `_Tooltip Body` — `2361:70188`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Direction` | `VARIANT` | `Top Left` |
+
+Variants (12):
+
+| Variant | Node ID |
+| --- | --- |
+| `Direction=Top Right` | `2361:70547` |
+| `Direction=Bottom Right` | `2361:70927` |
+| `Direction=Bottom Left` | `2361:70969` |
+| `Direction=Top Center` | `2361:70187` |
+| `Direction=Left Center` | `2361:70983` |
+| `Direction=Right Center` | `2361:71040` |
+| `Direction=Left Top` | `2361:70998` |
+| `Direction=Right Top` | `2361:71047` |
+| `Direction=Left Bottom` | `2361:71012` |
+| `Direction=Right Bottom` | `2361:71054` |
+| `Direction=Top Left` | `2361:70899` |
+| `Direction=Bottom Center` | `2361:70955` |
+
+#### `_Tooltip Content` — `2361:71096`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Text#2361:0` | `TEXT` | `Zcash is a privacy-focused cryptocurrency which features an encrypted ledger using zero-knowledge proofs.` |
+| `Title#2361:2` | `TEXT` | `Title` |
+| `Show Button#2361:6` | `BOOLEAN` | `false` |
+| `Property 1` | `VARIANT` | `Default` |
+
+Variants (1):
+
+| Variant | Node ID |
+| --- | --- |
+| `Property 1=Default` | `2361:71095` |
+
+## [Toast](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=1567-44215&m=dev)
+
+Page ID: `1567:44215`. Top-level children: 4. Reusable assets found: 1 component sets and 0 standalone components.
+
+### Component sets
+
+#### `Toast` — `1567:44216`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Type` | `VARIANT` | `Neutral` |
+
+Variants (1):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Neutral` | `1567:44217` |
+
+### Supporting showroom or source material
+
+- `Showroom` (`FRAME`)

--- a/figma-ai-fix/09-inputs-selection-and-dropdowns.md
+++ b/figma-ai-fix/09-inputs-selection-and-dropdowns.md
@@ -1,0 +1,198 @@
+# Inputs, selection, and dropdowns
+
+Use the existing state/type properties for fields and selection controls. Preserve the Figma property's exact spelling when addressing an instance property programmatically.
+
+## [Inputs](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=355-13933&m=dev)
+
+Page ID: `355:13933`. Top-level children: 10. Reusable assets found: 3 component sets and 2 standalone components.
+
+### Component sets
+
+#### `Field` — `355:13970`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Show Label#355:20` | `BOOLEAN` | `true` |
+| `Field Value#355:21` | `TEXT` | `1234` |
+| `Placehodler#355:22` | `TEXT` | `Min. 8 chars and symbols` |
+| `Show Leading Icon#355:23` | `BOOLEAN` | `true` |
+| `Field Icon#355:24` | `INSTANCE_SWAP` | `410:45071` |
+| `Input ZEC Unit#5372:15` | `BOOLEAN` | `false` |
+| `Input $ Unit#5378:30` | `BOOLEAN` | `false` |
+| `Show Input Error#5378:45` | `BOOLEAN` | `false` |
+| `Show Currency Switch#5378:58` | `BOOLEAN` | `false` |
+| `State` | `VARIANT` | `Default` |
+| `Type` | `VARIANT` | `Primary` |
+
+Variants (12):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default, Type=Primary` | `355:13932` |
+| `State=Default, Type=Secondary` | `4363:120364` |
+| `State=Error, Type=Primary` | `355:22867` |
+| `State=Error, Type=Secondary` | `4363:120381` |
+| `State=Hovered, Type=Primary` | `355:13992` |
+| `State=Hovered, Type=Secondary` | `4363:120415` |
+| `State=Focus, Type=Primary` | `371:29909` |
+| `State=Focus, Type=Secondary` | `4363:120431` |
+| `State=Active, Type=Primary` | `4040:77507` |
+| `State=Active, Type=Secondary` | `4363:120448` |
+| `State=Filled, Type=Primary` | `355:14026` |
+| `State=Filled, Type=Secondary` | `4363:120465` |
+
+#### `Text Area` — `355:23636`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Show Label#355:116` | `BOOLEAN` | `true` |
+| `Field Value#355:117` | `TEXT` | `Zcash is a privacy-focused cryptocurrency which features an encrypted ledger using zero-knowledge proofs. Launched in October 2016, Zcash was developed by cryptographers at Johns Hopkins University and MIT and derived its code from bitcoin.` |
+| `Placehodler#355:118` | `TEXT` | `Placeholder` |
+| `Show Icon#355:119` | `BOOLEAN` | `true` |
+| `Field Icon#355:120` | `INSTANCE_SWAP` | `344:8467` |
+| `State` | `VARIANT` | `Default` |
+
+Variants (6):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `355:24157` |
+| `State=Hover` | `4040:77427` |
+| `State=Active` | `4040:77533` |
+| `State=Focus` | `355:20782` |
+| `State=Filled` | `4040:77454` |
+| `State=Error` | `355:24211` |
+
+#### `Field Word` — `415:48466`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Index#417:135` | `TEXT` | `01` |
+| `Word#417:140` | `TEXT` | `Cinnamon` |
+| `State` | `VARIANT` | `Default` |
+
+Variants (6):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `415:48465` |
+| `State=Hover` | `415:48467` |
+| `State=Active` | `417:50921` |
+| `State=Filled` | `417:50932` |
+| `State=Fcosed` | `417:50943` |
+| `State=Error` | `417:50954` |
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `_Input Switch Currency` | `5378:138384` | — |
+| `Field Title` | `355:14243` | — |
+
+### Supporting showroom or source material
+
+- `Showroom Dark` (`FRAME`)
+- `Showroom Light` (`FRAME`)
+
+## [Dropdown](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=2841-108859&m=dev)
+
+Page ID: `2841:108859`. Top-level children: 4. Reusable assets found: 0 component sets and 1 standalone components.
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `_Accounts Dropdown` | `4058:153252` | — |
+
+### Supporting showroom or source material
+
+- `_Filters Dropdown` (`FRAME`)
+- `Dropdown` (`FRAME`)
+
+## [Radio / Checkbox](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=677-55548&m=dev)
+
+Page ID: `677:55548`. Top-level children: 5. Reusable assets found: 4 component sets and 0 standalone components.
+
+### Component sets
+
+#### `Radio PFP` — `677:55553`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Default` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `677:55561` |
+| `State=Selected` | `746:56306` |
+| `State=Focsued` | `746:56315` |
+
+#### `Radio Card` — `746:57484`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Show Leading Icon#746:72` | `BOOLEAN` | `true` |
+| `Description#746:76` | `TEXT` | `Auto changes.` |
+| `Show Description#746:80` | `BOOLEAN` | `true` |
+| `Title#746:84` | `TEXT` | `System (Auto)` |
+| `Show Badge#806:88` | `BOOLEAN` | `false` |
+| `State` | `VARIANT` | `Default` |
+| `Size` | `VARIANT` | `S` |
+
+Variants (4):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default, Size=S` | `746:57482` |
+| `State=Current, Size=S` | `746:57483` |
+| `State=Selected (Focus), Size=S` | `4077:382537` |
+| `State=Disabled, Size=S` | `806:59256` |
+
+#### `Checkbox Card` — `5283:102612`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Show Leading Icon#746:72` | `BOOLEAN` | `true` |
+| `Description#746:76` | `TEXT` | `Auto changes.` |
+| `Show Description#746:80` | `BOOLEAN` | `true` |
+| `Title#746:84` | `TEXT` | `System (Auto)` |
+| `Show Badge#806:88` | `BOOLEAN` | `false` |
+| `State` | `VARIANT` | `UNchecked` |
+| `Size` | `VARIANT` | `S` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=UNchecked, Size=S` | `5283:102613` |
+| `State=Checked, Size=S` | `5283:102625` |
+| `State=Disabled, Size=S` | `5283:102649` |
+
+#### `Checkbox` — `2779:48810`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Default` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `2779:48809` |
+| `State=Check` | `2779:48808` |

--- a/figma-ai-fix/10-navigation-tabs-and-modals.md
+++ b/figma-ai-fix/10-navigation-tabs-and-modals.md
@@ -1,0 +1,248 @@
+# Navigation, tabs, and modals
+
+Compose navigation and overlays from their public component sets. Internal assets with leading underscores are documented for identification, not as the default entry point.
+
+## [Navigation](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=303-1919&m=dev)
+
+Page ID: `303:1919`. Top-level children: 10. Reusable assets found: 4 component sets and 3 standalone components.
+
+### Component sets
+
+#### `Navigtaion Item` — `303:2119`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Indicator#4001:0` | `BOOLEAN` | `false` |
+| `Page Icon#4002:0` | `INSTANCE_SWAP` | `107:2329` |
+| `Page Title#4002:4` | `TEXT` | `Intro to Zcash` |
+| `State` | `VARIANT` | `Default` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `303:1976` |
+| `State=Hover` | `1198:22288` |
+| `State=Active` | `303:2120` |
+
+#### `Sidebar` — `303:2206`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Type` | `VARIANT` | `Onboarding` |
+
+Variants (4):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Onboarding` | `303:2000` |
+| `Type=Import Wallet` | `1136:19345` |
+| `Type=Keystone` | `2216:39887` |
+| `Type=Wallet` | `324:4791` |
+
+#### `Nav User` — `324:5473`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Keystone Badge#2216:19` | `BOOLEAN` | `false` |
+| `State` | `VARIANT` | `Default` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `324:5101` |
+| `State=Hover` | `1202:25842` |
+| `State=Open` | `4058:162254` |
+
+#### `User Image` — `677:52637`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Keystone badge#2216:15` | `BOOLEAN` | `false` |
+| `Size` | `VARIANT` | `XS` |
+
+Variants (6):
+
+| Variant | Node ID |
+| --- | --- |
+| `Size=XS` | `4353:81254` |
+| `Size=S` | `324:5092` |
+| `Size=M` | `677:52638` |
+| `Size=L` | `4001:50904` |
+| `Size=XL` | `677:53310` |
+| `Size=XXL` | `4190:1083094` |
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `_Nav Account` | `4001:50932` | — |
+| `Page Toolbar` | `415:47179` | — |
+| `_Nav Item Indicator` | `4001:52382` | — |
+
+### Supporting showroom or source material
+
+- `Home Default` (`FRAME`)
+
+## [Tabs](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=485-30867&m=dev)
+
+Page ID: `485:30867`. Top-level children: 4. Reusable assets found: 3 component sets and 0 standalone components.
+
+### Component sets
+
+#### `Tab` — `946:64280`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Tab Label#946:99` | `TEXT` | `Shielded` |
+| `Show Leading Icon#946:100` | `BOOLEAN` | `true` |
+| `Tab Icon#946:101` | `INSTANCE_SWAP` | `115:3411` |
+| `State` | `VARIANT` | `Default` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `946:64210` |
+| `State=Active` | `946:64281` |
+
+#### `Tabs` — `970:65945`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Tab` | `VARIANT` | `1` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `Tab=1` | `946:64216` |
+| `Tab=2` | `970:65946` |
+
+#### `Simple Tabs` — `1510:33746`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Show Icons#2809:0` | `BOOLEAN` | `false` |
+| `Tab 1#2809:3` | `TEXT` | `Enter the Date` |
+| `Tab 2#2809:6` | `TEXT` | `Enter the Block Height` |
+| `Select` | `VARIANT` | `1` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `Select=1` | `1510:33747` |
+| `Select=2` | `1510:33744` |
+
+## [Modal](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=485-26307&m=dev)
+
+Page ID: `485:26307`. Top-level children: 7. Reusable assets found: 4 component sets and 1 standalone components.
+
+### Component sets
+
+#### `Cal Cell` — `485:28276`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Type` | `VARIANT` | `Default` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Default` | `485:26298` |
+| `Type=Hover` | `485:31212` |
+| `Type=Selected` | `485:28277` |
+
+#### `_Modal Type` — `664:49157`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Dialog Body#677:69` | `SLOT` | — |
+| `Unordered List#970:102` | `SLOT` | — |
+| `Show Close#4236:0` | `BOOLEAN` | `false` |
+| `Type` | `VARIANT` | `Date Picker` |
+
+Variants (16):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Date Picker` | `485:29175` |
+| `Type=Update Name` | `664:49158` |
+| `Type=Update PFP` | `677:54419` |
+| `Type=Edit/Add Contact` | `2841:111387` |
+| `Type=Dialog` | `2071:43954` |
+| `Type=Radio Group` | `746:57351` |
+| `Type=Info / List` | `970:67827` |
+| `Type=Address Verification` | `4470:68773` |
+| `Type=Address Verification Non Zec` | `4731:86101` |
+| `Type=Seed Security` | `1644:45231` |
+| `Type=Keystone QR` | `2218:58297` |
+| `Type=Swap Address` | `2779:43450` |
+| `Type=QR Scan` | `2779:52359` |
+| `Type=Slippage` | `2785:8754` |
+| `Type=Asset Select` | `2809:73422` |
+| `Type=Contacts` | `4058:182744` |
+
+#### `Camera Modal` — `2782:53932`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Modal Camera` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Loading` | `2782:53931` |
+| `State=Utility` | `2782:53930` |
+| `State=Modal Camera` | `2782:53929` |
+
+#### `_Asset Modal Scroll` — `2809:74618`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Default` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `2809:74515` |
+| `State=Empty` | `2809:74619` |
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `Modal Scrim` | `664:48921` | — |
+
+### Supporting showroom or source material
+
+- `Screen` (`FRAME`)
+- `Access Denied` (`FRAME`)
+- `No Cam found` (`FRAME`)

--- a/figma-ai-fix/11-data-cards-lists-and-tables.md
+++ b/figma-ai-fix/11-data-cards-lists-and-tables.md
@@ -1,0 +1,333 @@
+# Data, cards, lists, and tables
+
+This group contains reusable asset rows, menus, pagination, card families, review information, and list content. Keep the distinction between public components and underscore-prefixed internal building blocks.
+
+## [Assets / Tables](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=377-31688&m=dev)
+
+Page ID: `377:31688`. Top-level children: 22. Reusable assets found: 9 component sets and 4 standalone components.
+
+### Component sets
+
+#### `Asset Image` — `333:7271`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Show Asset Sub Icon#400:128` | `BOOLEAN` | `false` |
+| `Icon#1510:4` | `INSTANCE_SWAP` | `366:27297` |
+| `Show PFP Chain#2864:24` | `BOOLEAN` | `false` |
+| `Show Network#2870:31` | `BOOLEAN` | `false` |
+| `Type` | `VARIANT` | `Default` |
+
+Variants (6):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Default` | `4046:88839` |
+| `Type=Simple Icon` | `4231:67999` |
+| `Type=Swap Progress` | `2814:85472` |
+| `Type=Sub Tx` | `2814:83819` |
+| `Type=PFP` | `2011:32645` |
+| `Type=Currency` | `2771:35839` |
+
+#### `Content Line` — `344:8468`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Left Left Label#344:11` | `BOOLEAN` | `true` |
+| `Show Right Icon#344:12` | `BOOLEAN` | `false` |
+| `Show Left Icon#344:13` | `BOOLEAN` | `false` |
+| `Left Icon#344:14` | `INSTANCE_SWAP` | `333:7316` |
+| `Right Icon#344:15` | `INSTANCE_SWAP` | `333:7316` |
+| `State` | `VARIANT` | `Default` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `398:40639` |
+| `State=Hover` | `1510:31381` |
+| `State=Focus Keyboard` | `677:54568` |
+
+#### `_Divider` — `4360:100898`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Type` | `VARIANT` | `Default` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Default` | `1183:17856` |
+| `Type=Expand` | `4360:100899` |
+
+#### `_Page Content` — `1433:28031`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Icon#1439:0` | `INSTANCE_SWAP` | `107:2422` |
+| `Type` | `VARIANT` | `Text` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Text` | `1433:27988` |
+| `Type=Icon` | `1433:28032` |
+
+#### `_Page Item` — `1439:28071`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Default` |
+
+Variants (4):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `1439:28080` |
+| `State=Hover` | `1439:28130` |
+| `State=Focused` | `1510:30416` |
+| `State=Current` | `1510:30411` |
+
+#### `_Asset Left` — `392:40268`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Show Left Leading Icon#398:124` | `BOOLEAN` | `false` |
+| `Property 1` | `VARIANT` | `Default` |
+
+Variants (1):
+
+| Variant | Node ID |
+| --- | --- |
+| `Property 1=Default` | `392:40267` |
+
+#### `Context Menu` — `2011:33232`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Default` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `2011:33231` |
+| `State=Hover` | `2011:33233` |
+| `State=Open` | `2011:33256` |
+
+#### `Context Menu Item` — `2071:42249`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Default` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `2011:33186` |
+| `State=Hover` | `2071:42250` |
+
+#### `_Network` — `2771:36893`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Network` | `VARIANT` | `USDC` |
+
+Variants (5):
+
+| Variant | Node ID |
+| --- | --- |
+| `Network=USDC` | `2771:36892` |
+| `Network=ZEC` | `2771:36891` |
+| `Network=ETH` | `2865:120648` |
+| `Network=NEAR` | `2865:120663` |
+| `Network=Solana` | `2865:120666` |
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `Context Menu` | `2011:33204` | — |
+| `Table Paginantion` | `1439:28156` | — |
+| `_Asset Right` | `398:40774` | — |
+| `Context Menu Divider` | `2011:33208` | — |
+
+### Supporting showroom or source material
+
+- `Showroom Dark` (`SECTION`)
+- `Showroom Light` (`SECTION`)
+- `ZCASH` (`FRAME`)
+- `ETH` (`FRAME`)
+
+## [Cards](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=400-42053&m=dev)
+
+Page ID: `400:42053`. Top-level children: 15. Reusable assets found: 7 component sets and 3 standalone components.
+
+### Component sets
+
+#### `_Pagination Item` — `400:42495`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Active` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Active` | `400:42483` |
+| `State=Default` | `400:42499` |
+
+#### `Seed Card` — `1764:53297`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Show Birthday Height#1764:8` | `BOOLEAN` | `false` |
+| `State` | `VARIANT` | `Default` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `1510:30936` |
+| `State=Warning` | `1764:53298` |
+
+#### `Full Width Card` — `4018:54553`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Type` | `VARIANT` | `Default` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Default` | `4018:54541` |
+| `Type=Transparent` | `4063:318424` |
+| `Type=Importing` | `4018:54600` |
+
+#### `Password Card` — `4080:388821`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Default` |
+
+Variants (4):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `4080:388775` |
+| `State=Typing` | `4080:388822` |
+| `State=Filled` | `4080:388849` |
+| `State=Error` | `4080:388888` |
+
+#### `Review Card` — `4083:434671`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Type` | `VARIANT` | `Default` |
+
+Variants (5):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Default` | `4083:430947` |
+| `Type=Success` | `4199:1094600` |
+| `Type=Failed` | `4083:434672` |
+| `Type=Swap` | `4091:500296` |
+| `Type=Type4` | `4091:532220` |
+
+#### `Custom Endpoint` — `4083:458266`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Property 1` | `VARIANT` | `Default` |
+
+Variants (1):
+
+| Variant | Node ID |
+| --- | --- |
+| `Property 1=Default` | `4083:457642` |
+
+#### `_Reivew Info` — `4265:59168`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Title#4265:0` | `TEXT` | `You’re sending` |
+| `Large Text#4265:4` | `TEXT` | `123 ZEC` |
+| `Bottom Leading Icon#4265:6` | `BOOLEAN` | `false` |
+| `Bottom Trailing Icon#4265:8` | `BOOLEAN` | `false` |
+| `Bottom Text#4265:10` | `TEXT` | `Shielded` |
+| `Bottom Copy#4265:12` | `BOOLEAN` | `false` |
+| `Property 1` | `VARIANT` | `Default` |
+
+Variants (1):
+
+| Variant | Node ID |
+| --- | --- |
+| `Property 1=Default` | `4265:59147` |
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `Pagination` | `400:42501` | — |
+| `Seed Card  Settings` | `1764:52509` | — |
+| `Review Info` | `4265:59314` | — |
+
+### Supporting showroom or source material
+
+- `image 1` (`RECTANGLE`)
+- `image 3` (`RECTANGLE`)
+- `image 5` (`RECTANGLE`)
+- `Reivew` (`FRAME`)
+
+## [Lists](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=970-72935&m=dev)
+
+Page ID: `970:72935`. Top-level children: 4. Reusable assets found: 0 component sets and 2 standalone components.
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `Unordered List` | `970:73010` | — |
+| `List Item` | `970:72989` | — |
+
+### Supporting showroom or source material
+
+- `List Item` (`FRAME`)

--- a/figma-ai-fix/12-swap-components.md
+++ b/figma-ai-fix/12-swap-components.md
@@ -1,0 +1,110 @@
+# Swap components
+
+This document covers only reusable assets on the Swap UI design-system page. It intentionally excludes swap business logic, routing, transaction states outside the component variants, and product-screen layouts.
+
+## [Swap UI](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=2788-43761&m=dev)
+
+Page ID: `2788:43761`. Top-level children: 7. Reusable assets found: 6 component sets and 1 standalone components.
+
+### Component sets
+
+#### `Swap Card` — `2771:37005`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Default` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `2771:36919` |
+| `State=Active` | `2771:37006` |
+
+#### `Swap Currency Picker` — `2771:37425`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Type` | `VARIANT` | `Non-Selectable` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Non-Selectable` | `2771:37424` |
+| `Type=Slectable` | `2771:37433` |
+
+#### `Slippage` — `2774:37766`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Default` |
+
+Variants (4):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `2774:37760` |
+| `State=Hover` | `2774:37772` |
+| `State=Destructive` | `2774:37767` |
+| `State=Destructive Hover` | `2774:37876` |
+
+#### `_Swap Card Content_` — `2777:38264`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Type` | `VARIANT` | `Receive ZEC` |
+
+Variants (4):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Receive ZEC` | `2777:38263` |
+| `Type=Pay Zec` | `2777:38265` |
+| `Type=Pay Crypto` | `2779:38470` |
+| `Type=Receive Crypto` | `2783:61578` |
+
+#### `_Swap Card Address` — `2779:38543`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `State` | `VARIANT` | `Default` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `State=Default` | `2779:38504` |
+| `State=Hover` | `2779:38544` |
+| `State=Set` | `2779:38549` |
+
+#### `_Swap Route` — `2915:220637`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Step` | `VARIANT` | `1` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `Step=1` | `2915:220192` |
+| `Step=2` | `2915:220638` |
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `_Swap near Logo` | `2872:159543` | — |

--- a/figma-ai-fix/13-platform-and-local-utilities.md
+++ b/figma-ai-fix/13-platform-and-local-utilities.md
@@ -1,0 +1,107 @@
+# Platform and local utilities
+
+These assets support presentation and local organization. macOS backgrounds, title bars, window controls, and keyboards are operating-system context; do not treat them as app content unless native chrome is explicitly in scope.
+
+## [Utility](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=355-23650&m=dev)
+
+Page ID: `355:23650`. Top-level children: 3. Reusable assets found: 1 component sets and 0 standalone components.
+
+### Component sets
+
+#### `Scrollbar` — `2915:219497`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `scroll` | `VARIANT` | `Top` |
+
+Variants (3):
+
+| Variant | Node ID |
+| --- | --- |
+| `scroll=Top` | `452:22435` |
+| `scroll=Middle` | `2915:219498` |
+| `scroll=bottom` | `2915:219501` |
+
+### Supporting showroom or source material
+
+- `Showroom Dark` (`FRAME`)
+- `Showroom Light` (`FRAME`)
+
+## [OS Utility](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=258-3983&m=dev)
+
+Page ID: `258:3983`. Top-level children: 11. Reusable assets found: 2 component sets and 6 standalone components.
+
+### Component sets
+
+#### `Mac OS Window` — `4363:115090`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Show Sidebar#4363:17` | `BOOLEAN` | `true` |
+| `Trailing Pane#4363:18` | `SLOT` | — |
+| `Content Area#4363:19` | `SLOT` | — |
+| `Container#4363:20` | `SLOT` | — |
+| `Show Modal#4363:21` | `BOOLEAN` | `false` |
+| `Show Scroll#4363:22` | `BOOLEAN` | `false` |
+| `Full Page BG#4363:23` | `BOOLEAN` | `false` |
+| `Type` | `VARIANT` | `Default` |
+
+Variants (2):
+
+| Variant | Node ID |
+| --- | --- |
+| `Type=Default` | `4031:51503` |
+| `Type=Full Page` | `4363:115091` |
+
+#### `Keyboard` — `4638:76169`
+
+Properties:
+
+| Property | Type | Default |
+| --- | --- | --- |
+| `Property 1` | `VARIANT` | `Light Default` |
+
+Variants (6):
+
+| Variant | Node ID |
+| --- | --- |
+| `Property 1=Light Default` | `4638:76168` |
+| `Property 1=Dark Default` | `4638:76167` |
+| `Property 1=Light Numpad` | `4638:76165` |
+| `Property 1=Dark Numpad` | `4638:76166` |
+| `Property 1=Dark Radial` | `5434:127045` |
+| `Property 1=Light Radial` | `5434:127251` |
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `_MacOS Light Mode` | `258:4369` | — |
+| `_MacOS Dark Mode` | `258:4699` | — |
+| `_MacOS Dock` | `258:4314` | — |
+| `_ MacOS Menu Bar` | `258:4212` | — |
+| `_ OS Titlebar` | `378:33632` | — |
+| `_ MacOS Window` | `414:45401` | — |
+
+### Supporting showroom or source material
+
+- `Menubar Menu` (`FRAME`)
+
+## [Local Utility](https://www.figma.com/design/HJxo289BJD7R6tz0OoGSQu/Vizor--Design-System--AI-Test-?node-id=10-650&m=dev)
+
+Page ID: `10:650`. Top-level children: 6. Reusable assets found: 0 component sets and 1 standalone components.
+
+### Standalone components
+
+| Component | Node ID | Description |
+| --- | --- | --- |
+| `Utility Org Badge` | `504:39524` | — |
+
+### Supporting showroom or source material
+
+- `Home` (`FRAME`)
+- `Frame` (`FRAME`)

--- a/lib/figma_compare.dart
+++ b/lib/figma_compare.dart
@@ -9,22 +9,9 @@ import 'package:window_manager/window_manager.dart';
 
 import 'figma_compare/figma_compare_app.dart';
 import 'figma_compare/figma_compare_capture.dart';
-import 'figma_compare/figma_compare_scenarios.dart';
+import 'figma_compare/figma_compare_configuration.dart';
 import 'src/core/layout/app_layout.dart';
 
-const _scenarioId = String.fromEnvironment(
-  'FIGMA_COMPARE_SCENARIO',
-  defaultValue: 'pay-recipient',
-);
-const _themeName = String.fromEnvironment(
-  'FIGMA_COMPARE_THEME',
-  defaultValue: 'dark',
-);
-const _outputPath = String.fromEnvironment('FIGMA_COMPARE_OUTPUT');
-const _pixelRatioText = String.fromEnvironment(
-  'FIGMA_COMPARE_PIXEL_RATIO',
-  defaultValue: '1',
-);
 const _settleDelayMs = int.fromEnvironment(
   'FIGMA_COMPARE_SETTLE_MS',
   defaultValue: 350,
@@ -38,24 +25,11 @@ const _startMinimized = bool.fromEnvironment('FIGMA_COMPARE_START_MINIMIZED');
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  final scenario = findFigmaCompareScenario(_scenarioId);
-  if (scenario == null) {
-    final available = figmaCompareScenarios.map((item) => item.id).join(', ');
-    throw ArgumentError.value(
-      _scenarioId,
-      'FIGMA_COMPARE_SCENARIO',
-      'Unknown scenario. Available: $available',
-    );
-  }
-  if (kAppFormFactor == AppFormFactor.desktop && !scenario.desktop) {
-    throw StateError('Scenario ${scenario.id} does not support desktop.');
-  }
-  if (kAppFormFactor == AppFormFactor.mobile && !scenario.mobile) {
-    throw StateError('Scenario ${scenario.id} does not support mobile.');
-  }
+  final configuration = FigmaCompareConfiguration.fromEnvironment();
+  final scenario = configuration.resolveScenario(kAppFormFactor);
 
   // Match the production macOS bootstrap. The comparison entry point omits
-  // only Rust, wallet, storage, sync, and network initialization.
+  // Rust runtime, wallet, storage, sync, and network initialization.
   await initializeDesktopWindow();
   if (isDesktopLayoutPlatform) {
     await DesktopWindowBootstrap.initialize(
@@ -68,12 +42,12 @@ Future<void> main() async {
   runApp(
     FigmaCompareApp(
       scenario: scenario,
-      themeMode: _themeName == 'light' ? ThemeMode.light : ThemeMode.dark,
+      themeMode: configuration.themeMode,
       captureBoundaryKey: captureBoundaryKey,
     ),
   );
 
-  if (_outputPath.isEmpty) {
+  if (configuration.outputPath.isEmpty) {
     debugPrint(
       'Figma comparison ready: ${scenario.id} (${scenario.description})',
     );
@@ -100,18 +74,10 @@ Future<void> main() async {
   final captureController = FigmaCompareCaptureController(
     captureBoundaryKey: captureBoundaryKey,
   );
-  final outputPath = resolveFigmaCompareOutputPath(_outputPath);
-  final pixelRatio = double.tryParse(_pixelRatioText);
-  if (pixelRatio == null || pixelRatio <= 0) {
-    throw ArgumentError.value(
-      _pixelRatioText,
-      'FIGMA_COMPARE_PIXEL_RATIO',
-      'Expected a positive number.',
-    );
-  }
+  final outputPath = resolveFigmaCompareOutputPath(configuration.outputPath);
   await captureController.capture(
     contentOutputPath: outputPath,
-    pixelRatio: pixelRatio,
+    pixelRatio: configuration.pixelRatio,
     settleDelay: Duration(milliseconds: _settleDelayMs),
   );
   debugPrint('Figma comparison content: $outputPath');

--- a/lib/figma_compare.dart
+++ b/lib/figma_compare.dart
@@ -1,0 +1,125 @@
+// ignore_for_file: depend_on_referenced_packages
+// This is a dev-only entry point and is not reachable from lib/main.dart.
+
+import 'dart:io';
+
+import 'package:desktop_window_bootstrap/desktop_window_bootstrap.dart';
+import 'package:flutter/material.dart';
+import 'package:window_manager/window_manager.dart';
+
+import 'figma_compare/figma_compare_app.dart';
+import 'figma_compare/figma_compare_capture.dart';
+import 'figma_compare/figma_compare_scenarios.dart';
+import 'src/core/layout/app_layout.dart';
+
+const _scenarioId = String.fromEnvironment(
+  'FIGMA_COMPARE_SCENARIO',
+  defaultValue: 'pay-recipient',
+);
+const _themeName = String.fromEnvironment(
+  'FIGMA_COMPARE_THEME',
+  defaultValue: 'dark',
+);
+const _outputPath = String.fromEnvironment('FIGMA_COMPARE_OUTPUT');
+const _pixelRatioText = String.fromEnvironment(
+  'FIGMA_COMPARE_PIXEL_RATIO',
+  defaultValue: '1',
+);
+const _settleDelayMs = int.fromEnvironment(
+  'FIGMA_COMPARE_SETTLE_MS',
+  defaultValue: 350,
+);
+const _exitAfterCapture = bool.fromEnvironment(
+  'FIGMA_COMPARE_EXIT_AFTER_CAPTURE',
+  defaultValue: true,
+);
+const _startMinimized = bool.fromEnvironment('FIGMA_COMPARE_START_MINIMIZED');
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final scenario = findFigmaCompareScenario(_scenarioId);
+  if (scenario == null) {
+    final available = figmaCompareScenarios.map((item) => item.id).join(', ');
+    throw ArgumentError.value(
+      _scenarioId,
+      'FIGMA_COMPARE_SCENARIO',
+      'Unknown scenario. Available: $available',
+    );
+  }
+  if (kAppFormFactor == AppFormFactor.desktop && !scenario.desktop) {
+    throw StateError('Scenario ${scenario.id} does not support desktop.');
+  }
+  if (kAppFormFactor == AppFormFactor.mobile && !scenario.mobile) {
+    throw StateError('Scenario ${scenario.id} does not support mobile.');
+  }
+
+  // Match the production macOS bootstrap. The comparison entry point omits
+  // only Rust, wallet, storage, sync, and network initialization.
+  await initializeDesktopWindow();
+  if (isDesktopLayoutPlatform) {
+    await DesktopWindowBootstrap.initialize(
+      visualStyle: DesktopWindowVisualStyle.opaque,
+    );
+    if (!Platform.isWindows) await showDesktopWindow();
+  }
+
+  final captureBoundaryKey = GlobalKey();
+  runApp(
+    FigmaCompareApp(
+      scenario: scenario,
+      themeMode: _themeName == 'light' ? ThemeMode.light : ThemeMode.dark,
+      captureBoundaryKey: captureBoundaryKey,
+    ),
+  );
+
+  if (_outputPath.isEmpty) {
+    debugPrint(
+      'Figma comparison ready: ${scenario.id} (${scenario.description})',
+    );
+    return;
+  }
+
+  if (_startMinimized && Platform.isMacOS) {
+    await WidgetsBinding.instance.endOfFrame;
+    // AppThemeHost may still be synchronizing native light/dark appearance and
+    // restoring the production frame during the first 120 ms after launch.
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+    await windowManager.minimize();
+    var minimized = false;
+    for (var attempt = 0; attempt < 40; attempt += 1) {
+      minimized = await windowManager.isMinimized();
+      if (minimized) break;
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+    }
+    if (!minimized) {
+      throw StateError('The comparison window did not minimize for testing.');
+    }
+  }
+
+  final captureController = FigmaCompareCaptureController(
+    captureBoundaryKey: captureBoundaryKey,
+  );
+  final outputPath = resolveFigmaCompareOutputPath(_outputPath);
+  final pixelRatio = double.tryParse(_pixelRatioText);
+  if (pixelRatio == null || pixelRatio <= 0) {
+    throw ArgumentError.value(
+      _pixelRatioText,
+      'FIGMA_COMPARE_PIXEL_RATIO',
+      'Expected a positive number.',
+    );
+  }
+  await captureController.capture(
+    contentOutputPath: outputPath,
+    pixelRatio: pixelRatio,
+    settleDelay: Duration(milliseconds: _settleDelayMs),
+  );
+  debugPrint('Figma comparison content: $outputPath');
+  if (Platform.isMacOS) {
+    debugPrint(
+      'Figma comparison window: ${figmaCompareWindowCapturePath(outputPath)}',
+    );
+  }
+
+  if (_exitAfterCapture) exit(0);
+}

--- a/lib/figma_compare/figma_compare_app.dart
+++ b/lib/figma_compare/figma_compare_app.dart
@@ -1,0 +1,54 @@
+// ignore_for_file: depend_on_referenced_packages
+// Figma comparison tooling is dev-only and may reuse Widgetbook fixtures.
+
+import 'package:flutter/material.dart';
+
+import '../src/core/theme/app_theme.dart';
+import '../src/core/theme/app_theme_host.dart';
+import '../src/core/theme/legacy_material_theme.dart';
+import 'figma_compare_scenarios.dart';
+
+class FigmaCompareApp extends StatelessWidget {
+  const FigmaCompareApp({
+    required this.scenario,
+    required this.themeMode,
+    required this.captureBoundaryKey,
+    super.key,
+  });
+
+  final FigmaCompareScenario scenario;
+  final ThemeMode themeMode;
+  final GlobalKey captureBoundaryKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final appTheme = themeMode == ThemeMode.light
+        ? AppThemeData.light
+        : AppThemeData.dark;
+
+    return MaterialApp(
+      title: 'Vizor Figma comparison',
+      debugShowCheckedModeBanner: false,
+      theme: buildLegacyLightTheme(),
+      darkTheme: buildLegacyDarkTheme(),
+      themeMode: themeMode,
+      home: Scaffold(
+        body: RepaintBoundary(
+          key: captureBoundaryKey,
+          child: Focus(
+            canRequestFocus: false,
+            descendantsAreFocusable: false,
+            child: IgnorePointer(child: Builder(builder: scenario.builder)),
+          ),
+        ),
+      ),
+      builder: (context, child) => AppThemeHost(
+        themeMode: themeMode,
+        child: ColoredBox(
+          color: appTheme.colors.background.window,
+          child: child!,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/figma_compare/figma_compare_capture.dart
+++ b/lib/figma_compare/figma_compare_capture.dart
@@ -1,0 +1,114 @@
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+const _platformChannel = MethodChannel(
+  'com.zcash.wallet/figma_compare_capture',
+);
+
+String resolveFigmaCompareOutputPath(String configuredPath) {
+  if (File(configuredPath).isAbsolute) return configuredPath;
+  return Directory.systemTemp.uri
+      .resolve('vizor-figma-compare/$configuredPath')
+      .toFilePath();
+}
+
+String figmaCompareWindowCapturePath(String contentPath) {
+  final dot = contentPath.lastIndexOf('.');
+  if (dot <= contentPath.lastIndexOf(Platform.pathSeparator)) {
+    return '$contentPath.window.png';
+  }
+  return '${contentPath.substring(0, dot)}.window${contentPath.substring(dot)}';
+}
+
+class FigmaCompareCaptureController {
+  const FigmaCompareCaptureController({
+    required this.captureBoundaryKey,
+    MethodChannel channel = _platformChannel,
+  }) : _channel = channel;
+
+  final GlobalKey captureBoundaryKey;
+  final MethodChannel _channel;
+
+  Future<void> capture({
+    required String contentOutputPath,
+    double pixelRatio = 1,
+    Duration settleDelay = const Duration(milliseconds: 350),
+  }) async {
+    if (!kDebugMode) {
+      throw StateError('Figma comparison capture is available in debug only.');
+    }
+
+    await Directory(
+      File(contentOutputPath).parent.path,
+    ).create(recursive: true);
+
+    String? captureToken;
+    try {
+      if (Platform.isMacOS) {
+        final response = await _channel.invokeMapMethod<String, Object?>(
+          'beginCapture',
+        );
+        captureToken = response?['token'] as String?;
+        if (captureToken == null) {
+          throw StateError('macOS capture preparation returned no token.');
+        }
+      }
+
+      await _waitForStableFrame(settleDelay);
+      await _captureFlutterContent(contentOutputPath, pixelRatio);
+
+      if (Platform.isMacOS) {
+        await _channel.invokeMethod<void>('captureWindow', {
+          'token': captureToken,
+          'path': figmaCompareWindowCapturePath(contentOutputPath),
+        });
+      }
+    } finally {
+      if (Platform.isMacOS && captureToken != null) {
+        final restored = await _channel.invokeMapMethod<String, Object?>(
+          'endCapture',
+          {'token': captureToken},
+        );
+        debugPrint(
+          'Figma comparison window restored: '
+          'minimized=${restored?['windowMiniaturized']}, '
+          'visible=${restored?['windowVisible']}, '
+          'appHidden=${restored?['appHidden']}',
+        );
+      }
+    }
+  }
+
+  Future<void> _waitForStableFrame(Duration settleDelay) async {
+    await WidgetsBinding.instance.endOfFrame;
+    await WidgetsBinding.instance.endOfFrame;
+    if (settleDelay > Duration.zero) await Future<void>.delayed(settleDelay);
+    await WidgetsBinding.instance.endOfFrame;
+  }
+
+  Future<void> _captureFlutterContent(String path, double pixelRatio) async {
+    final renderObject = captureBoundaryKey.currentContext?.findRenderObject();
+    if (renderObject is! RenderRepaintBoundary) {
+      throw StateError('Figma comparison capture boundary is unavailable.');
+    }
+    if (renderObject.debugNeedsPaint) {
+      await WidgetsBinding.instance.endOfFrame;
+    }
+
+    final image = await renderObject.toImage(pixelRatio: pixelRatio);
+    try {
+      final data = await image.toByteData(format: ui.ImageByteFormat.png);
+      if (data == null) {
+        throw StateError('Flutter did not encode the comparison image.');
+      }
+      await File(path).writeAsBytes(data.buffer.asUint8List(), flush: true);
+    } finally {
+      image.dispose();
+    }
+  }
+}

--- a/lib/figma_compare/figma_compare_configuration.dart
+++ b/lib/figma_compare/figma_compare_configuration.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+
+import '../src/core/layout/app_form_factor.dart';
+import 'figma_compare_scenarios.dart';
+
+class FigmaCompareConfiguration {
+  const FigmaCompareConfiguration({
+    required this.scenarioId,
+    required this.themeMode,
+    required this.outputPath,
+    required this.logicalSize,
+    required this.pixelRatio,
+  });
+
+  factory FigmaCompareConfiguration.fromEnvironment({
+    Size defaultLogicalSize = const Size(1080, 720),
+    double defaultPixelRatio = 1,
+  }) {
+    const scenarioId = String.fromEnvironment(
+      'FIGMA_COMPARE_SCENARIO',
+      defaultValue: 'pay-recipient',
+    );
+    const themeName = String.fromEnvironment(
+      'FIGMA_COMPARE_THEME',
+      defaultValue: 'dark',
+    );
+    const outputPath = String.fromEnvironment('FIGMA_COMPARE_OUTPUT');
+    const widthText = String.fromEnvironment('FIGMA_COMPARE_WIDTH');
+    const heightText = String.fromEnvironment('FIGMA_COMPARE_HEIGHT');
+    const pixelRatioText = String.fromEnvironment('FIGMA_COMPARE_PIXEL_RATIO');
+
+    final themeMode = switch (themeName) {
+      'dark' => ThemeMode.dark,
+      'light' => ThemeMode.light,
+      _ => throw ArgumentError.value(
+        themeName,
+        'FIGMA_COMPARE_THEME',
+        'Expected dark or light.',
+      ),
+    };
+    final width = widthText.isEmpty
+        ? defaultLogicalSize.width
+        : _positiveDouble(widthText, 'FIGMA_COMPARE_WIDTH');
+    final height = heightText.isEmpty
+        ? defaultLogicalSize.height
+        : _positiveDouble(heightText, 'FIGMA_COMPARE_HEIGHT');
+    final pixelRatio = pixelRatioText.isEmpty
+        ? defaultPixelRatio
+        : _positiveDouble(pixelRatioText, 'FIGMA_COMPARE_PIXEL_RATIO');
+
+    return FigmaCompareConfiguration(
+      scenarioId: scenarioId,
+      themeMode: themeMode,
+      outputPath: outputPath,
+      logicalSize: Size(width, height),
+      pixelRatio: pixelRatio,
+    );
+  }
+
+  final String scenarioId;
+  final ThemeMode themeMode;
+  final String outputPath;
+  final Size logicalSize;
+  final double pixelRatio;
+
+  FigmaCompareScenario resolveScenario(AppFormFactor formFactor) {
+    final scenario = findFigmaCompareScenario(scenarioId);
+    if (scenario == null) {
+      final available = figmaCompareScenarios.map((item) => item.id).join(', ');
+      throw ArgumentError.value(
+        scenarioId,
+        'FIGMA_COMPARE_SCENARIO',
+        'Unknown scenario. Available: $available',
+      );
+    }
+
+    final supported = switch (formFactor) {
+      AppFormFactor.desktop => scenario.desktop,
+      AppFormFactor.mobile => scenario.mobile,
+    };
+    if (!supported) {
+      throw StateError(
+        'Scenario ${scenario.id} does not support ${formFactor.name}.',
+      );
+    }
+    return scenario;
+  }
+
+  static double _positiveDouble(String value, String name) {
+    final parsed = double.tryParse(value);
+    if (parsed == null || parsed <= 0) {
+      throw ArgumentError.value(value, name, 'Expected a positive number.');
+    }
+    return parsed;
+  }
+}

--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -1,0 +1,65 @@
+// ignore_for_file: depend_on_referenced_packages
+// Figma comparison tooling is dev-only and may reuse Widgetbook fixtures.
+
+import 'package:flutter/widgets.dart';
+
+import '../widgetbook/pay_use_cases.dart';
+
+typedef FigmaCompareScenarioBuilder = Widget Function(BuildContext context);
+
+@immutable
+class FigmaCompareScenario {
+  const FigmaCompareScenario({
+    required this.id,
+    required this.description,
+    required this.builder,
+    this.desktop = true,
+    this.mobile = false,
+  });
+
+  final String id;
+  final String description;
+  final FigmaCompareScenarioBuilder builder;
+  final bool desktop;
+  final bool mobile;
+}
+
+/// Deterministic previews for the screens changed on the current branch.
+///
+/// Add a scenario here only when its builder is isolated from production
+/// storage, network, wallet, and Rust state. Widgetbook fixtures are preferred
+/// because they are already used to review the same UI states.
+const figmaCompareScenarios = <FigmaCompareScenario>[
+  FigmaCompareScenario(
+    id: 'pay-recipient',
+    description: 'Pay recipient selection with recent contacts',
+    builder: buildPayRecipientUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'pay-recipient-new-address',
+    description: 'Pay recipient with a valid newly typed address',
+    builder: buildPayRecipientNewAddressUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'pay-add-contact',
+    description: 'Pay recipient add-contact modal',
+    builder: buildPayAddContactUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'pay-in-progress',
+    description: 'Pay activity in-progress state',
+    builder: buildPayInProgressUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'pay-completed',
+    description: 'Pay activity completed state',
+    builder: buildPayCompletedUseCase,
+  ),
+];
+
+FigmaCompareScenario? findFigmaCompareScenario(String id) {
+  for (final scenario in figmaCompareScenarios) {
+    if (scenario.id == id) return scenario;
+  }
+  return null;
+}

--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../widgetbook/pay_use_cases.dart';
+import '../widgetbook/screen_use_cases.dart';
 
 typedef FigmaCompareScenarioBuilder = Widget Function(BuildContext context);
 
@@ -54,6 +55,13 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     id: 'pay-completed',
     description: 'Pay activity completed state',
     builder: buildPayCompletedUseCase,
+  ),
+  FigmaCompareScenario(
+    id: 'mobile-home-default',
+    description: 'Mobile home with deterministic balance and activity',
+    builder: buildMobileHomeDefaultUseCase,
+    desktop: false,
+    mobile: true,
   ),
 ];
 

--- a/lib/src/features/pay/screens/pay_screen.dart
+++ b/lib/src/features/pay/screens/pay_screen.dart
@@ -63,6 +63,8 @@ class _PayScreenState extends ConsumerState<PayScreen> {
   _PayModalSurface? _payModal;
   var _wizardStep = _PayWizardStep.amount;
   var _startingIntent = false;
+  var _saveRecipientToContacts = false;
+  var _openReviewAfterContactSave = false;
   var _reviewRequestGeneration = 0;
   Timer? _expiryTimer;
   DateTime? _expiryDeadline;
@@ -97,7 +99,10 @@ class _PayScreenState extends ConsumerState<PayScreen> {
 
   void _closePayModal() {
     if (_payModal == null) return;
-    setState(() => _payModal = null);
+    setState(() {
+      _payModal = null;
+      _openReviewAfterContactSave = false;
+    });
   }
 
   void _syncController(TextEditingController controller, String value) {
@@ -119,8 +124,27 @@ class _PayScreenState extends ConsumerState<PayScreen> {
   }
 
   void _handleAddressScanned(String value) {
-    ref.read(swapStateProvider.notifier).updateDestination(value);
+    _updateRecipientDestination(value);
     _closePayModal();
+  }
+
+  void _updateRecipientDestination(String value) {
+    final current = ref.read(swapStateProvider).destinationText;
+    if (_saveRecipientToContacts && value != current) {
+      setState(() => _saveRecipientToContacts = false);
+    }
+    ref.read(swapStateProvider.notifier).updateDestination(value);
+  }
+
+  void _selectRecipient({required bool canSaveContact}) {
+    if (_saveRecipientToContacts && canSaveContact) {
+      setState(() {
+        _openReviewAfterContactSave = true;
+        _payModal = _PayModalSurface.addContact;
+      });
+      return;
+    }
+    unawaited(_openReview());
   }
 
   Future<void> _openReview() async {
@@ -187,7 +211,15 @@ class _PayScreenState extends ConsumerState<PayScreen> {
           profilePictureId: profilePictureId,
         );
     if (!mounted) return;
-    _closePayModal();
+    final openReview = _openReviewAfterContactSave;
+    setState(() {
+      _payModal = null;
+      _saveRecipientToContacts = false;
+      _openReviewAfterContactSave = false;
+    });
+    if (openReview) {
+      await _openReview();
+    }
   }
 
   /// Keeps the review countdown aligned with the active quote; a new quote
@@ -313,10 +345,13 @@ class _PayScreenState extends ConsumerState<PayScreen> {
       busy: swapState.quoteLoading,
       enabled: swapState.externalAssetIsSupported,
       quoteError: swapState.externalAssetSupportError ?? swapState.quoteError,
-      onSelectRecipient: () => unawaited(_openReview()),
-      onAddToContacts: network == null
-          ? () {}
-          : () => setState(() => _payModal = _PayModalSurface.addContact),
+      onSelectRecipient: () => _selectRecipient(
+        canSaveContact: network != null && recipientContact == null,
+      ),
+      saveAddressToContacts: _saveRecipientToContacts,
+      onSaveAddressToContactsChanged: network == null
+          ? null
+          : (value) => setState(() => _saveRecipientToContacts = value),
     );
     final actions = switch (_wizardStep) {
       _PayWizardStep.amount => PayAmountAction(
@@ -396,11 +431,11 @@ class _PayScreenState extends ConsumerState<PayScreen> {
                   contacts: contacts,
                   recents: recents,
                   busy: swapState.quoteLoading,
-                  onAddressChanged: swapNotifier.updateDestination,
+                  onAddressChanged: _updateRecipientDestination,
                   onOpenScanner: () => setState(
                     () => _payModal = _PayModalSurface.addressScanner,
                   ),
-                  onChooseRecipient: swapNotifier.updateDestination,
+                  onChooseRecipient: _updateRecipientDestination,
                 ),
                 _PayWizardStep.review =>
                   quote == null
@@ -445,6 +480,7 @@ class _PayScreenState extends ConsumerState<PayScreen> {
                       assets: swapState.supportedExternalAssets,
                       selected: swapState.externalAsset,
                       onSelected: (asset) {
+                        setState(() => _saveRecipientToContacts = false);
                         ref
                             .read(swapStateProvider.notifier)
                             .selectPayExternalAsset(

--- a/lib/src/features/pay/widgets/pay_add_contact_modal.dart
+++ b/lib/src/features/pay/widgets/pay_add_contact_modal.dart
@@ -3,13 +3,13 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
-import '../../../core/profile_pictures.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_modal_card.dart';
 import '../../../core/widgets/app_profile_picture.dart';
 import '../../../core/widgets/app_profile_picture_picker_modal.dart';
 import '../../../core/widgets/app_text_field.dart';
+import '../../address_book/contact_label_generator.dart';
 import '../../address_book/models/address_book_contact.dart';
 import '../../address_book/widgets/address_book_network_icon.dart';
 import '../../swap/models/swap_address_formatting.dart';
@@ -40,7 +40,8 @@ class PayAddContactModal extends StatefulWidget {
 
 class _PayAddContactModalState extends State<PayAddContactModal> {
   late final TextEditingController _labelController;
-  var _profilePictureId = kDefaultProfilePictureId;
+  late final FocusNode _labelFocusNode;
+  late String _profilePictureId;
   var _pickingPicture = false;
   var _saving = false;
   String? _saveError;
@@ -48,14 +49,34 @@ class _PayAddContactModalState extends State<PayAddContactModal> {
   @override
   void initState() {
     super.initState();
+    _profilePictureId = randomContactProfilePictureId();
     _labelController = TextEditingController();
+    _labelFocusNode = FocusNode();
     _labelController.addListener(() => setState(() {}));
+    _requestLabelFocus();
   }
 
   @override
   void dispose() {
     _labelController.dispose();
+    _labelFocusNode.dispose();
     super.dispose();
+  }
+
+  void _requestLabelFocus() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _labelFocusNode.requestFocus();
+    });
+  }
+
+  void _closePicturePicker([String? profilePictureId]) {
+    setState(() {
+      if (profilePictureId != null) {
+        _profilePictureId = profilePictureId;
+      }
+      _pickingPicture = false;
+    });
+    _requestLabelFocus();
   }
 
   bool get _canSave {
@@ -91,13 +112,8 @@ class _PayAddContactModalState extends State<PayAddContactModal> {
       return AppProfilePicturePickerModal(
         title: 'Select contact picture',
         currentProfilePictureId: _profilePictureId,
-        onCancel: () => setState(() => _pickingPicture = false),
-        onUpdate: (id) async {
-          setState(() {
-            _profilePictureId = id;
-            _pickingPicture = false;
-          });
-        },
+        onCancel: _closePicturePicker,
+        onUpdate: (id) async => _closePicturePicker(id),
       );
     }
     return AppModalCard(
@@ -151,6 +167,7 @@ class _PayAddContactModalState extends State<PayAddContactModal> {
             key: const ValueKey('pay_add_contact_label_field'),
             label: 'Address label',
             controller: _labelController,
+            focusNode: _labelFocusNode,
             hintText: 'Add label 1-20 characters',
             autofocus: true,
             inputFormatters: [LengthLimitingTextInputFormatter(20)],
@@ -162,12 +179,17 @@ class _PayAddContactModalState extends State<PayAddContactModal> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(
-                  'Chain & address',
-                  style: AppTypography.labelLarge.copyWith(
-                    color: colors.text.secondary,
+                Expanded(
+                  child: Text(
+                    'Chain & address',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.labelLarge.copyWith(
+                      color: colors.text.secondary,
+                    ),
                   ),
                 ),
+                const SizedBox(width: AppSpacing.xs),
                 Row(
                   children: [
                     AddressBookNetworkIcon(network: widget.network, size: 16),

--- a/lib/src/features/pay/widgets/pay_recipient_step.dart
+++ b/lib/src/features/pay/widgets/pay_recipient_step.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../../core/theme/app_theme.dart';
@@ -10,6 +11,11 @@ import '../../address_book/models/address_book_contact.dart';
 import '../../address_book/models/address_book_label_lookup.dart';
 import '../../swap/models/swap_address_formatting.dart';
 import '../models/pay_recent_recipients.dart';
+
+const _payCheckboxActivationShortcuts = <ShortcutActivator, Intent>{
+  SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+  SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
+};
 
 /// Step 2 "Select Recipient" of the desktop pay wizard — Figma 6241:85245
 /// plus the 2B1/2B2/2B3 field states (85845 / 104834 / 86376).
@@ -235,7 +241,8 @@ class PayRecipientActions extends StatelessWidget {
     required this.busy,
     required this.quoteError,
     required this.onSelectRecipient,
-    required this.onAddToContacts,
+    required this.saveAddressToContacts,
+    required this.onSaveAddressToContactsChanged,
     this.enabled = true,
     super.key,
   });
@@ -247,7 +254,8 @@ class PayRecipientActions extends StatelessWidget {
   final bool enabled;
   final String? quoteError;
   final VoidCallback onSelectRecipient;
-  final VoidCallback onAddToContacts;
+  final bool saveAddressToContacts;
+  final ValueChanged<bool>? onSaveAddressToContactsChanged;
 
   bool get visible {
     final typed = typedAddress.trim();
@@ -258,7 +266,8 @@ class PayRecipientActions extends StatelessWidget {
   Widget build(BuildContext context) {
     final typed = typedAddress.trim();
     final contact = payRecipientContactForAddress(contacts, typed);
-    final canAddContact = contact == null;
+    final canSaveContact =
+        contact == null && onSaveAddressToContactsChanged != null;
 
     return Column(
       key: const ValueKey('pay_recipient_actions'),
@@ -280,14 +289,10 @@ class PayRecipientActions extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.s),
         ],
-        if (canAddContact) ...[
-          AppButton(
-            key: const ValueKey('pay_add_to_contacts_button'),
-            variant: AppButtonVariant.ghost,
-            size: AppButtonSize.large,
-            minWidth: PayWizardActionMetrics.width,
-            onPressed: busy ? null : onAddToContacts,
-            child: const Text('Add to contacts'),
+        if (canSaveContact) ...[
+          _PaySaveAddressCheckbox(
+            value: saveAddressToContacts,
+            onChanged: busy ? null : onSaveAddressToContactsChanged,
           ),
           const SizedBox(height: AppSpacing.s),
         ],
@@ -297,6 +302,9 @@ class PayRecipientActions extends StatelessWidget {
           size: AppButtonSize.large,
           minWidth: PayWizardActionMetrics.width,
           onPressed: busy || !enabled ? null : onSelectRecipient,
+          leading: busy
+              ? const AppIcon(AppIcons.loader, semanticLabel: 'Fetching quote')
+              : null,
           child: Text(busy ? 'Fetching quote' : 'Select recipient'),
         ),
       ],
@@ -304,8 +312,141 @@ class PayRecipientActions extends StatelessWidget {
   }
 }
 
+class _PaySaveAddressCheckbox extends StatefulWidget {
+  const _PaySaveAddressCheckbox({required this.value, required this.onChanged});
+
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+
+  @override
+  State<_PaySaveAddressCheckbox> createState() =>
+      _PaySaveAddressCheckboxState();
+}
+
+class _PaySaveAddressCheckboxState extends State<_PaySaveAddressCheckbox> {
+  var _hovered = false;
+  var _focused = false;
+
+  bool get _enabled => widget.onChanged != null;
+
+  void _activate() {
+    if (!_enabled) return;
+    widget.onChanged!(!widget.value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final transparent = colors.background.ground.withValues(alpha: 0);
+    final labelColor = _enabled
+        ? colors.text.accent
+        : colors.button.disabled.label;
+
+    return Semantics(
+      key: const ValueKey('pay_save_address_checkbox'),
+      checked: widget.value,
+      enabled: _enabled,
+      label: 'Save address to contacts',
+      child: ExcludeSemantics(
+        child: MouseRegion(
+          cursor: _enabled
+              ? SystemMouseCursors.click
+              : SystemMouseCursors.basic,
+          onEnter: _enabled ? (_) => setState(() => _hovered = true) : null,
+          onExit: _enabled ? (_) => setState(() => _hovered = false) : null,
+          child: FocusableActionDetector(
+            enabled: _enabled,
+            mouseCursor: _enabled
+                ? SystemMouseCursors.click
+                : SystemMouseCursors.basic,
+            onShowFocusHighlight: (value) => setState(() => _focused = value),
+            shortcuts: _payCheckboxActivationShortcuts,
+            actions: <Type, Action<Intent>>{
+              ActivateIntent: CallbackAction<Intent>(
+                onInvoke: (_) {
+                  _activate();
+                  return null;
+                },
+              ),
+            },
+            child: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onTap: _enabled ? _activate : null,
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 140),
+                curve: Curves.easeOut,
+                width: PayWizardActionMetrics.saveContactWidth,
+                height: 44,
+                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xxs),
+                decoration: BoxDecoration(
+                  color: _hovered ? colors.state.hover : transparent,
+                  border: Border.all(
+                    color: _focused ? colors.state.focusRing : transparent,
+                    width: 2,
+                  ),
+                  borderRadius: BorderRadius.circular(AppRadii.small),
+                ),
+                child: Center(
+                  child: FittedBox(
+                    key: const ValueKey('pay_save_address_checkbox_content'),
+                    fit: BoxFit.scaleDown,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        AnimatedContainer(
+                          key: const ValueKey(
+                            'pay_save_address_checkbox_indicator',
+                          ),
+                          duration: const Duration(milliseconds: 140),
+                          curve: Curves.easeOut,
+                          width: 20,
+                          height: 20,
+                          alignment: Alignment.center,
+                          decoration: BoxDecoration(
+                            color: widget.value
+                                ? colors.background.inverse
+                                : transparent,
+                            border: Border.all(
+                              color: widget.value
+                                  ? colors.border.strong
+                                  : colors.border.regular,
+                              width: 1.5,
+                            ),
+                            borderRadius: BorderRadius.circular(
+                              AppRadii.xSmall,
+                            ),
+                          ),
+                          child: widget.value
+                              ? AppIcon(
+                                  AppIcons.check,
+                                  size: 13,
+                                  color: colors.icon.inverse,
+                                )
+                              : null,
+                        ),
+                        const SizedBox(width: AppSpacing.xs),
+                        Text(
+                          'Save address to contacts',
+                          style: AppTypography.labelLarge.copyWith(
+                            color: labelColor,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 abstract final class PayWizardActionMetrics {
   static const double width = 196;
+  static const double saveContactWidth = 240;
 }
 
 class _PayRecipientListCard extends StatelessWidget {

--- a/lib/src/features/swap/widgets/pay_activity_status_content.dart
+++ b/lib/src/features/swap/widgets/pay_activity_status_content.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
 import '../../../core/widgets/app_profile_picture.dart';
 import '../../../core/widgets/review_info_row.dart';
@@ -23,6 +24,7 @@ class PayActivityStatusContent extends StatelessWidget {
     required this.amountFiatText,
     required this.recipientAddress,
     required this.onShowFullAddress,
+    required this.onGoHome,
     this.recipientContact,
     this.onOpenExplorer,
     super.key,
@@ -35,13 +37,18 @@ class PayActivityStatusContent extends StatelessWidget {
   final String recipientAddress;
   final AddressBookContact? recipientContact;
   final VoidCallback onShowFullAddress;
+  final VoidCallback onGoHome;
   final VoidCallback? onOpenExplorer;
 
-  static const Size contentSize = Size(396, 549);
+  static const Size inProgressContentSize = Size(396, 713);
+  static const Size completedContentSize = Size(396, 549);
   static const double reviewInfoHeight = 204;
   static const double detailCardHeight = 257;
+  static const double inProgressFooterHeight = 140;
 
   bool get _completed => status.phase == PayActivityStatusPhase.completed;
+  Size get contentSize =>
+      _completed ? completedContentSize : inProgressContentSize;
 
   @override
   Widget build(BuildContext context) {
@@ -64,6 +71,38 @@ class PayActivityStatusContent extends StatelessWidget {
           _reviewInfo(context),
           const SizedBox(height: AppSpacing.base),
           _detailCard(context),
+          if (!_completed) ...[
+            const SizedBox(height: AppSpacing.md),
+            _inProgressFooter(context),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _inProgressFooter(BuildContext context) {
+    return SizedBox(
+      key: const ValueKey('pay_status_in_progress_footer'),
+      height: inProgressFooterHeight,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          Text(
+            'Your swap is in progress. You can check its status at any time '
+            'from the Activity tab.',
+            key: const ValueKey('pay_status_in_progress_message'),
+            textAlign: TextAlign.center,
+            style: AppTypography.bodyMedium.copyWith(
+              color: context.colors.text.secondary,
+            ),
+          ),
+          const SizedBox(height: AppSpacing.s),
+          AppButton(
+            key: const ValueKey('pay_status_go_home_button'),
+            onPressed: onGoHome,
+            minWidth: 196,
+            child: const Text('Go home'),
+          ),
         ],
       ),
     );

--- a/lib/src/features/swap/widgets/swap_activity_panel.dart
+++ b/lib/src/features/swap/widgets/swap_activity_panel.dart
@@ -879,6 +879,7 @@ class _SwapStatusForIntentState extends ConsumerState<_SwapStatusForIntent> {
           recipientAddress,
           recipientContact,
         ),
+        onGoHome: () => context.go('/home'),
         onOpenExplorer: txIdUri == null
             ? null
             : () => unawaited(

--- a/lib/widgetbook/pay_use_cases.dart
+++ b/lib/widgetbook/pay_use_cases.dart
@@ -180,6 +180,8 @@ class _PayRecipientPreview extends StatefulWidget {
 class _PayRecipientPreviewState extends State<_PayRecipientPreview> {
   late final TextEditingController _controller;
   late String _typedAddress;
+  var _saveAddressToContacts = false;
+  var _addContactOpen = false;
 
   @override
   void initState() {
@@ -197,6 +199,7 @@ class _PayRecipientPreviewState extends State<_PayRecipientPreview> {
   void _selectAddress(String address) {
     setState(() {
       _typedAddress = address;
+      _saveAddressToContacts = false;
       _controller.value = TextEditingValue(
         text: address,
         selection: TextSelection.collapsed(offset: address.length),
@@ -215,27 +218,56 @@ class _PayRecipientPreviewState extends State<_PayRecipientPreview> {
       contacts: _previewContacts,
       busy: false,
       quoteError: null,
-      onSelectRecipient: () {},
-      onAddToContacts: () {},
+      onSelectRecipient: () {
+        if (_saveAddressToContacts) {
+          setState(() => _addContactOpen = true);
+        }
+      },
+      saveAddressToContacts: _saveAddressToContacts,
+      onSaveAddressToContactsChanged: (value) =>
+          setState(() => _saveAddressToContacts = value),
     );
-    return PayWizardPage(
-      title: 'Select Recipient',
-      currentIndex: 1,
-      backLabel: 'Amount',
-      onBack: () {},
-      actions: actions.visible ? actions : null,
-      onStepSelected: (_) {},
-      child: PayRecipientStep(
-        controller: _controller,
-        typedAddress: _typedAddress,
-        addressError: issue,
-        contacts: _previewContacts,
-        recents: _previewRecents,
-        busy: false,
-        onAddressChanged: (value) => setState(() => _typedAddress = value),
-        onOpenScanner: () {},
-        onChooseRecipient: _selectAddress,
-      ),
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        PayWizardPage(
+          title: 'Select Recipient',
+          currentIndex: 1,
+          backLabel: 'Amount',
+          onBack: () {},
+          actions: actions.visible ? actions : null,
+          onStepSelected: (_) {},
+          child: PayRecipientStep(
+            controller: _controller,
+            typedAddress: _typedAddress,
+            addressError: issue,
+            contacts: _previewContacts,
+            recents: _previewRecents,
+            busy: false,
+            onAddressChanged: (value) => setState(() {
+              _typedAddress = value;
+              _saveAddressToContacts = false;
+            }),
+            onOpenScanner: () {},
+            onChooseRecipient: _selectAddress,
+          ),
+        ),
+        if (_addContactOpen)
+          AppPaneModalOverlay(
+            onDismiss: () => setState(() => _addContactOpen = false),
+            child: PayAddContactModal(
+              network: AddressBookNetwork.ethereum,
+              address: _typedAddress,
+              onCancel: () => setState(() => _addContactOpen = false),
+              onSave: (_, _) async {
+                setState(() {
+                  _addContactOpen = false;
+                  _saveAddressToContacts = false;
+                });
+              },
+            ),
+          ),
+      ],
     );
   }
 }
@@ -356,6 +388,7 @@ class _PayStatusPreview extends StatelessWidget {
           amountFiatText: r'$990.12',
           recipientAddress: _newRecipientAddress,
           onShowFullAddress: () {},
+          onGoHome: () {},
           onOpenExplorer: () {},
         ),
       ),

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -3,6 +3,9 @@ import FlutterMacOS
 import LocalAuthentication
 import Security
 import desktop_window_bootstrap
+#if DEBUG
+import ScreenCaptureKit
+#endif
 
 private func appWindowBackgroundColor(for brightness: String) -> NSColor {
   if brightness == "dark" {
@@ -494,6 +497,331 @@ final class PrivacyExposureChannel: NSObject, FlutterStreamHandler {
   }
 }
 
+#if DEBUG
+/// Development-only capture bridge used by `lib/figma_compare.dart`.
+///
+/// Capture is a transaction: the bridge records the current app/window state,
+/// restores and activates a minimized window, captures that exact NSWindow,
+/// and then returns focus and visibility to their prior state.
+final class FigmaComparisonCaptureChannel {
+  private static var shared: FigmaComparisonCaptureChannel?
+  private static let readyTimeout = DispatchTimeInterval.seconds(3)
+
+  private struct CaptureSession {
+    let token: String
+    let wasHidden: Bool
+    let wasVisible: Bool
+    let wasMiniaturized: Bool
+    let animationBehavior: NSWindow.AnimationBehavior
+    let previousFrontmostApplication: NSRunningApplication?
+  }
+
+  private weak var window: NSWindow?
+  private let channel: FlutterMethodChannel
+  private var session: CaptureSession?
+
+  private init(window: NSWindow, messenger: FlutterBinaryMessenger) {
+    self.window = window
+    channel = FlutterMethodChannel(
+      name: "com.zcash.wallet/figma_compare_capture",
+      binaryMessenger: messenger
+    )
+    channel.setMethodCallHandler { [weak self] call, result in
+      self?.handle(call, result: result)
+    }
+  }
+
+  static func register(window: NSWindow, messenger: FlutterBinaryMessenger) {
+    shared = FigmaComparisonCaptureChannel(window: window, messenger: messenger)
+  }
+
+  private func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "beginCapture":
+      beginCapture(result: result)
+    case "captureWindow":
+      guard
+        let arguments = call.arguments as? [String: Any],
+        let token = arguments["token"] as? String,
+        let path = arguments["path"] as? String
+      else {
+        result(captureError("bad_args", "Expected capture token and output path."))
+        return
+      }
+      captureWindow(token: token, path: path, result: result)
+    case "endCapture":
+      guard
+        let arguments = call.arguments as? [String: Any],
+        let token = arguments["token"] as? String
+      else {
+        result(captureError("bad_args", "Expected capture token."))
+        return
+      }
+      endCapture(token: token, result: result)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func beginCapture(result: @escaping FlutterResult) {
+    guard session == nil else {
+      result(captureError("capture_in_progress", "A comparison capture is already active."))
+      return
+    }
+    guard let window else {
+      result(captureError("missing_window", "The comparison window is unavailable."))
+      return
+    }
+
+    let currentProcessIdentifier = ProcessInfo.processInfo.processIdentifier
+    let previousFrontmostApplication = NSWorkspace.shared.frontmostApplication
+    let captureSession = CaptureSession(
+      token: UUID().uuidString,
+      wasHidden: NSApp.isHidden,
+      wasVisible: window.isVisible,
+      wasMiniaturized: window.isMiniaturized,
+      animationBehavior: window.animationBehavior,
+      previousFrontmostApplication:
+        previousFrontmostApplication?.processIdentifier == currentProcessIdentifier
+          ? nil
+          : previousFrontmostApplication
+    )
+    session = captureSession
+
+    window.animationBehavior = .none
+    if NSApp.isHidden {
+      NSApp.unhide(nil)
+    }
+    if window.isMiniaturized {
+      window.deminiaturize(nil)
+    }
+    window.setIsVisible(true)
+
+    // `activate()` is the current API but cooperative activation is not
+    // guaranteed. The debug-only fallback matches window_manager's macOS
+    // implementation and makes automated comparison capture deterministic.
+    if #available(macOS 14.0, *) {
+      NSApp.activate()
+    } else {
+      NSApp.activate(ignoringOtherApps: true)
+    }
+    if !NSApp.isActive {
+      NSApp.activate(ignoringOtherApps: true)
+    }
+    window.makeKeyAndOrderFront(nil)
+    window.orderFrontRegardless()
+
+    waitUntilReady(
+      token: captureSession.token,
+      deadline: DispatchTime.now() + Self.readyTimeout,
+      result: result
+    )
+  }
+
+  private func waitUntilReady(
+    token: String,
+    deadline: DispatchTime,
+    result: @escaping FlutterResult
+  ) {
+    guard let session, session.token == token, let window else {
+      result(captureError("capture_cancelled", "The comparison capture was cancelled."))
+      return
+    }
+
+    let ready =
+      NSApp.isActive &&
+      !NSApp.isHidden &&
+      window.isKeyWindow &&
+      window.isVisible &&
+      !window.isMiniaturized &&
+      window.occlusionState.contains(.visible)
+    if ready {
+      result([
+        "token": token,
+        "windowNumber": window.windowNumber,
+        "backingScaleFactor": window.backingScaleFactor,
+      ])
+      return
+    }
+
+    if DispatchTime.now() >= deadline {
+      restoreSession(session)
+      self.session = nil
+      result(
+        captureError(
+          "window_not_ready",
+          "The comparison window did not become active, key, and visible."
+        )
+      )
+      return
+    }
+
+    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) { [weak self] in
+      self?.waitUntilReady(token: token, deadline: deadline, result: result)
+    }
+  }
+
+  private func captureWindow(
+    token: String,
+    path: String,
+    result: @escaping FlutterResult
+  ) {
+    guard let session, session.token == token else {
+      result(captureError("invalid_token", "The comparison capture token is invalid."))
+      return
+    }
+    guard let window else {
+      result(captureError("missing_window", "The comparison window is unavailable."))
+      return
+    }
+
+    if #available(macOS 14.0, *) {
+      captureWithScreenCaptureKit(window: window, path: path, result: result)
+    } else {
+      captureWithCoreGraphics(window: window, path: path, result: result)
+    }
+  }
+
+  @available(macOS 14.0, *)
+  private func captureWithScreenCaptureKit(
+    window: NSWindow,
+    path: String,
+    result: @escaping FlutterResult
+  ) {
+    let windowID = CGWindowID(window.windowNumber)
+    SCShareableContent.getExcludingDesktopWindows(
+      false,
+      onScreenWindowsOnly: false
+    ) { [weak self] content, error in
+      guard let self else { return }
+      if let error {
+        result(self.captureError("shareable_content_failed", error.localizedDescription))
+        return
+      }
+      guard
+        let capturedWindow = content?.windows.first(where: { $0.windowID == windowID })
+      else {
+        result(self.captureError("window_not_shareable", "The comparison window was not shareable."))
+        return
+      }
+
+      let filter = SCContentFilter(desktopIndependentWindow: capturedWindow)
+      let configuration = SCStreamConfiguration()
+      let scale = window.backingScaleFactor
+      configuration.width = Int(window.frame.width * scale)
+      configuration.height = Int(window.frame.height * scale)
+      configuration.showsCursor = false
+      configuration.ignoreShadowsSingleWindow = true
+
+      SCScreenshotManager.captureImage(
+        contentFilter: filter,
+        configuration: configuration
+      ) { image, captureError in
+        if let captureError {
+          result(self.captureError("window_capture_failed", captureError.localizedDescription))
+          return
+        }
+        guard let image else {
+          result(self.captureError("window_capture_failed", "ScreenCaptureKit returned no image."))
+          return
+        }
+        self.write(image: image, path: path, backend: "ScreenCaptureKit", result: result)
+      }
+    }
+  }
+
+  private func captureWithCoreGraphics(
+    window: NSWindow,
+    path: String,
+    result: @escaping FlutterResult
+  ) {
+    guard
+      let image = CGWindowListCreateImage(
+        .null,
+        .optionIncludingWindow,
+        CGWindowID(window.windowNumber),
+        [.boundsIgnoreFraming, .bestResolution]
+      )
+    else {
+      result(captureError("window_capture_failed", "Core Graphics returned no image."))
+      return
+    }
+    write(image: image, path: path, backend: "CoreGraphics", result: result)
+  }
+
+  private func write(
+    image: CGImage,
+    path: String,
+    backend: String,
+    result: @escaping FlutterResult
+  ) {
+    let representation = NSBitmapImageRep(cgImage: image)
+    guard let data = representation.representation(using: .png, properties: [:]) else {
+      result(captureError("png_encoding_failed", "The window image could not be encoded."))
+      return
+    }
+
+    do {
+      try data.write(to: URL(fileURLWithPath: path), options: .atomic)
+      result([
+        "path": path,
+        "width": image.width,
+        "height": image.height,
+        "backend": backend,
+      ])
+    } catch {
+      result(captureError("png_write_failed", error.localizedDescription))
+    }
+  }
+
+  private func endCapture(token: String, result: @escaping FlutterResult) {
+    guard let session, session.token == token else {
+      result(captureError("invalid_token", "The comparison capture token is invalid."))
+      return
+    }
+    restoreSession(session)
+    self.session = nil
+    // AppKit publishes minimize/hide state on the next run-loop turns. Do not
+    // let a capture-and-exit caller terminate before that restoration settles.
+    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(150)) { [weak self] in
+      result([
+        "windowMiniaturized": self?.window?.isMiniaturized ?? false,
+        "windowVisible": self?.window?.isVisible ?? false,
+        "appHidden": NSApp.isHidden,
+      ])
+    }
+  }
+
+  private func restoreSession(_ session: CaptureSession) {
+    guard let window else { return }
+
+    window.animationBehavior = .none
+    if session.wasHidden {
+      NSApp.hide(nil)
+    } else if session.wasMiniaturized {
+      window.miniaturize(nil)
+    } else if !session.wasVisible {
+      window.orderOut(nil)
+    }
+    window.animationBehavior = session.animationBehavior
+
+    guard
+      let previousApplication = session.previousFrontmostApplication,
+      !previousApplication.isTerminated,
+      NSWorkspace.shared.frontmostApplication?.processIdentifier ==
+        ProcessInfo.processInfo.processIdentifier
+    else {
+      return
+    }
+    _ = previousApplication.activate(options: [])
+  }
+
+  private func captureError(_ code: String, _ message: String) -> FlutterError {
+    FlutterError(code: code, message: message, details: nil)
+  }
+}
+#endif
+
 final class CameraPermissionSettingsChannel {
   private static var channel: FlutterMethodChannel?
 
@@ -629,6 +957,12 @@ class MainFlutterWindow: NSWindow {
       window: self,
       messenger: flutterViewController.engine.binaryMessenger
     )
+#if DEBUG
+    FigmaComparisonCaptureChannel.register(
+      window: self,
+      messenger: flutterViewController.engine.binaryMessenger
+    )
+#endif
     CameraPermissionSettingsChannel.register(
       messenger: flutterViewController.engine.binaryMessenger
     )

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -589,27 +589,7 @@ final class FigmaComparisonCaptureChannel {
     session = captureSession
 
     window.animationBehavior = .none
-    if NSApp.isHidden {
-      NSApp.unhide(nil)
-    }
-    if window.isMiniaturized {
-      window.deminiaturize(nil)
-    }
-    window.setIsVisible(true)
-
-    // `activate()` is the current API but cooperative activation is not
-    // guaranteed. The debug-only fallback matches window_manager's macOS
-    // implementation and makes automated comparison capture deterministic.
-    if #available(macOS 14.0, *) {
-      NSApp.activate()
-    } else {
-      NSApp.activate(ignoringOtherApps: true)
-    }
-    if !NSApp.isActive {
-      NSApp.activate(ignoringOtherApps: true)
-    }
-    window.makeKeyAndOrderFront(nil)
-    window.orderFrontRegardless()
+    presentForCapture(window)
 
     waitUntilReady(
       token: captureSession.token,
@@ -644,6 +624,12 @@ final class FigmaComparisonCaptureChannel {
       return
     }
 
+    // Activation is asynchronous and another app can win focus between the
+    // first request and AppKit publishing the new state. Reassert the entire
+    // debug-only capture state on every poll instead of merely waiting for a
+    // one-shot activation that may already have been superseded.
+    presentForCapture(window)
+
     if DispatchTime.now() >= deadline {
       restoreSession(session)
       self.session = nil
@@ -659,6 +645,28 @@ final class FigmaComparisonCaptureChannel {
     DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) { [weak self] in
       self?.waitUntilReady(token: token, deadline: deadline, result: result)
     }
+  }
+
+  private func presentForCapture(_ window: NSWindow) {
+    if NSApp.isHidden {
+      NSApp.unhide(nil)
+    }
+    if window.isMiniaturized {
+      window.deminiaturize(nil)
+    }
+    window.setIsVisible(true)
+
+    // `activate()` is cooperative on current macOS releases. This bridge is
+    // DEBUG-only and must put the exact comparison window in the foreground
+    // before collecting evidence, so retain the force-activation fallback.
+    if #available(macOS 14.0, *) {
+      NSApp.activate()
+    }
+    if !NSApp.isActive || !window.isKeyWindow {
+      NSApp.activate(ignoringOtherApps: true)
+    }
+    window.makeKeyAndOrderFront(nil)
+    window.orderFrontRegardless()
   }
 
   private func captureWindow(

--- a/scripts/figma-compare.sh
+++ b/scripts/figma-compare.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/figma-compare.sh widget [options]
+  scripts/figma-compare.sh native [options]
+
+Options:
+  --scenario <id>          Registered scenario (default: pay-recipient)
+  --theme <dark|light>     Theme (default: dark)
+  --form-factor <value>    desktop or mobile (default: desktop)
+  --width <logical-px>     Widget-test logical width
+  --height <logical-px>    Widget-test logical height
+  --pixel-ratio <ratio>    Widget simulated DPR / native content scale
+  --output <absolute-path> Override the generated PNG path
+  --start-minimized        Native macOS restoration check only
+  -h, --help               Show this help
+
+`widget` is the normal code-to-Figma comparison path. `native` launches the
+real macOS window for final window-shell and restoration verification.
+EOF
+}
+
+fail() {
+  echo "fail: $*" >&2
+  exit 2
+}
+
+take_value() {
+  local flag="$1"
+  local value="${2:-}"
+  [[ -n "$value" ]] || fail "missing value for $flag"
+  printf '%s' "$value"
+}
+
+MODE="${1:-}"
+case "$MODE" in
+  widget|native) shift ;;
+  -h|--help) usage; exit 0 ;;
+  '') usage >&2; exit 2 ;;
+  *) fail "unknown mode $MODE" ;;
+esac
+
+SCENARIO="pay-recipient"
+THEME="dark"
+FORM_FACTOR="desktop"
+WIDTH=""
+HEIGHT=""
+PIXEL_RATIO=""
+OUTPUT=""
+START_MINIMIZED="false"
+
+while (($# > 0)); do
+  case "$1" in
+    --scenario) SCENARIO="$(take_value "$1" "${2:-}")"; shift 2 ;;
+    --theme) THEME="$(take_value "$1" "${2:-}")"; shift 2 ;;
+    --form-factor) FORM_FACTOR="$(take_value "$1" "${2:-}")"; shift 2 ;;
+    --width) WIDTH="$(take_value "$1" "${2:-}")"; shift 2 ;;
+    --height) HEIGHT="$(take_value "$1" "${2:-}")"; shift 2 ;;
+    --pixel-ratio) PIXEL_RATIO="$(take_value "$1" "${2:-}")"; shift 2 ;;
+    --output) OUTPUT="$(take_value "$1" "${2:-}")"; shift 2 ;;
+    --start-minimized) START_MINIMIZED="true"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "unknown option $1" ;;
+  esac
+done
+
+[[ "$THEME" == "dark" || "$THEME" == "light" ]] || \
+  fail "--theme must be dark or light"
+[[ "$FORM_FACTOR" == "desktop" || "$FORM_FACTOR" == "mobile" ]] || \
+  fail "--form-factor must be desktop or mobile"
+
+OUTPUT_ROOT="$HOME/Library/Containers/com.keplr.vizor/Data/tmp/vizor-figma-compare"
+if [[ -z "$OUTPUT" ]]; then
+  if [[ "$MODE" == "widget" ]]; then
+    OUTPUT="$OUTPUT_ROOT/$SCENARIO/content.widget.png"
+  else
+    OUTPUT="$OUTPUT_ROOT/$SCENARIO/content.png"
+  fi
+fi
+[[ "$OUTPUT" == /* ]] || fail "--output must be an absolute path"
+
+DEFINES=(
+  "--dart-define=FIGMA_COMPARE_SCENARIO=$SCENARIO"
+  "--dart-define=FIGMA_COMPARE_THEME=$THEME"
+  "--dart-define=FIGMA_COMPARE_OUTPUT=$OUTPUT"
+)
+[[ -z "$WIDTH" ]] || DEFINES+=("--dart-define=FIGMA_COMPARE_WIDTH=$WIDTH")
+[[ -z "$HEIGHT" ]] || DEFINES+=("--dart-define=FIGMA_COMPARE_HEIGHT=$HEIGHT")
+[[ -z "$PIXEL_RATIO" ]] || \
+  DEFINES+=("--dart-define=FIGMA_COMPARE_PIXEL_RATIO=$PIXEL_RATIO")
+
+cd "$ROOT_DIR"
+
+if [[ "$MODE" == "widget" ]]; then
+  if [[ "$START_MINIMIZED" == "true" ]]; then
+    fail "--start-minimized is available only in native mode"
+  fi
+
+  TEST_FILE="test/figma_compare/figma_compare_capture_desktop_test.dart"
+  if [[ "$FORM_FACTOR" == "mobile" ]]; then
+    TEST_FILE="test/figma_compare/figma_compare_capture_mobile_test.dart"
+    DEFINES+=("--dart-define=VIZOR_FORM_FACTOR=mobile")
+  fi
+
+  fvm flutter test --no-pub --update-goldens \
+    --tags figma-capture --run-skipped \
+    "${DEFINES[@]}" \
+    "$TEST_FILE"
+  echo "ok: $OUTPUT"
+  exit 0
+fi
+
+[[ "$FORM_FACTOR" == "desktop" ]] || \
+  fail "native mode currently verifies macOS only; use the iOS Simulator workflow for mobile"
+[[ -z "$WIDTH" && -z "$HEIGHT" ]] || \
+  fail "native macOS size comes from production window bootstrap; omit --width/--height"
+
+DEFINES+=("--dart-define=FIGMA_COMPARE_START_MINIMIZED=$START_MINIMIZED")
+fvm flutter run --no-pub -d macos -t lib/figma_compare.dart "${DEFINES[@]}"

--- a/test/features/pay/pay_wizard_steps_test.dart
+++ b/test/features/pay/pay_wizard_steps_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart' show Material, MaterialApp, TextField;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon_hover_button.dart';
+import 'package:zcash_wallet/src/core/widgets/app_profile_picture.dart';
 import 'package:zcash_wallet/src/features/address_book/models/address_book_contact.dart';
 import 'package:zcash_wallet/src/features/pay/models/pay_recent_recipients.dart';
 import 'package:zcash_wallet/src/features/pay/widgets/pay_add_contact_modal.dart';
@@ -59,9 +61,11 @@ Widget _recipientStep({
   List<PayRecentRecipient> recents = const [],
   ValueChanged<String>? onChooseRecipient,
   VoidCallback? onSelectRecipient,
-  VoidCallback? onAddToContacts,
+  ValueChanged<bool>? onSaveAddressToContactsChanged,
   String? quoteError,
   bool actionsEnabled = true,
+  bool busy = false,
+  bool saveAddressToContacts = false,
 }) {
   final step = PayRecipientStep(
     controller: TextEditingController(text: typedAddress),
@@ -69,7 +73,7 @@ Widget _recipientStep({
     addressError: addressError,
     contacts: contacts,
     recents: recents,
-    busy: false,
+    busy: busy,
     onAddressChanged: (_) {},
     onOpenScanner: () {},
     onChooseRecipient: onChooseRecipient ?? (_) {},
@@ -78,11 +82,12 @@ Widget _recipientStep({
     typedAddress: typedAddress,
     addressError: addressError,
     contacts: contacts,
-    busy: false,
+    busy: busy,
     enabled: actionsEnabled,
     quoteError: quoteError,
     onSelectRecipient: onSelectRecipient ?? () {},
-    onAddToContacts: onAddToContacts ?? () {},
+    saveAddressToContacts: saveAddressToContacts,
+    onSaveAddressToContactsChanged: onSaveAddressToContactsChanged ?? (_) {},
   );
   return Column(
     crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -125,15 +130,60 @@ void main() {
     );
 
     expect(
-      payRecipientContactForAddress(
-        [contact],
-        _solanaAddress.replaceFirst('N', 'n'),
-      ),
+      payRecipientContactForAddress([
+        contact,
+      ], _solanaAddress.replaceFirst('N', 'n')),
       isNull,
     );
   });
 
   group('PayAddContactModal', () {
+    testWidgets('starts with a random avatar and focuses the address label', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          PayAddContactModal(
+            network: AddressBookNetwork.ethereum,
+            address: _unknownAddress,
+            onCancel: () {},
+            onSave: (_, _) async {},
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final labelField = find.byKey(
+        const ValueKey('pay_add_contact_label_field'),
+      );
+      final editable = find.descendant(
+        of: labelField,
+        matching: find.byType(TextField),
+      );
+      expect(tester.widget<TextField>(editable).focusNode!.hasFocus, isTrue);
+
+      final avatar = tester.widget<AppProfilePicture>(
+        find.descendant(
+          of: find.byKey(const ValueKey('pay_add_contact_modal')),
+          matching: find.byType(AppProfilePicture),
+        ),
+      );
+      expect(
+        kProfilePictureOptions.map((option) => option.id),
+        contains(avatar.profilePictureId),
+      );
+
+      await tester.enterText(labelField, 'Mike');
+      await tester.pump();
+      final rebuiltAvatar = tester.widget<AppProfilePicture>(
+        find.descendant(
+          of: find.byKey(const ValueKey('pay_add_contact_modal')),
+          matching: find.byType(AppProfilePicture),
+        ),
+      );
+      expect(rebuiltAvatar.profilePictureId, avatar.profilePictureId);
+    });
+
     testWidgets('waits for persistence and recovers from a save failure', (
       tester,
     ) async {
@@ -469,7 +519,7 @@ void main() {
         findsNothing,
       );
       expect(
-        find.byKey(const ValueKey('pay_add_to_contacts_button')),
+        find.byKey(const ValueKey('pay_save_address_checkbox')),
         findsNothing,
       );
     });
@@ -493,7 +543,7 @@ void main() {
         findsNothing,
       );
       expect(
-        find.byKey(const ValueKey('pay_add_to_contacts_button')),
+        find.byKey(const ValueKey('pay_save_address_checkbox')),
         findsNothing,
       );
       expect(
@@ -521,7 +571,7 @@ void main() {
       );
       expect(find.byKey(const ValueKey('pay_contacts_card')), findsNothing);
       expect(
-        find.byKey(const ValueKey('pay_add_to_contacts_button')),
+        find.byKey(const ValueKey('pay_save_address_checkbox')),
         findsOneWidget,
       );
     });
@@ -584,7 +634,7 @@ void main() {
       );
       expect(find.byKey(const ValueKey('pay_contacts_card')), findsNothing);
       expect(
-        find.byKey(const ValueKey('pay_add_to_contacts_button')),
+        find.byKey(const ValueKey('pay_save_address_checkbox')),
         findsNothing,
       );
       expect(
@@ -596,12 +646,19 @@ void main() {
     testWidgets('unknown valid address shows the new-address notice', (
       tester,
     ) async {
+      var saveAddress = false;
       await tester.pumpWidget(
         _harness(
-          _recipientStep(
-            typedAddress: _unknownAddress,
-            contacts: [_contact],
-            recents: const [PayRecentRecipient(address: _recentAddress)],
+          StatefulBuilder(
+            builder: (context, setState) => _recipientStep(
+              typedAddress: _unknownAddress,
+              contacts: [_contact],
+              recents: const [PayRecentRecipient(address: _recentAddress)],
+              saveAddressToContacts: saveAddress,
+              onSaveAddressToContactsChanged: (value) {
+                setState(() => saveAddress = value);
+              },
+            ),
           ),
         ),
       );
@@ -616,11 +673,77 @@ void main() {
         findsOneWidget,
       );
       expect(
-        find.byKey(const ValueKey('pay_add_to_contacts_button')),
+        find.byKey(const ValueKey('pay_save_address_checkbox')),
         findsOneWidget,
       );
       expect(
         find.byKey(const ValueKey('pay_select_recipient_button')),
+        findsOneWidget,
+      );
+      expect(find.text('Save address to contacts'), findsOneWidget);
+
+      final selectButton = find.byKey(
+        const ValueKey('pay_select_recipient_button'),
+      );
+      final saveCheckbox = find.byKey(
+        const ValueKey('pay_save_address_checkbox'),
+      );
+      final saveCheckboxContent = find.byKey(
+        const ValueKey('pay_save_address_checkbox_content'),
+      );
+      expect(
+        tester.getTopLeft(saveCheckbox).dy,
+        lessThan(tester.getTopLeft(selectButton).dy),
+      );
+      expect(
+        tester.getCenter(saveCheckboxContent).dx,
+        closeTo(tester.getCenter(selectButton).dx, 0.5),
+      );
+      await tester.tap(saveCheckbox);
+      await tester.pump();
+      expect(saveAddress, isTrue);
+      expect(
+        find.descendant(
+          of: saveCheckbox,
+          matching: find.byWidgetPredicate(
+            (widget) => widget is AppIcon && widget.name == AppIcons.check,
+          ),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('quote loading disables actions and shows a spinner', (
+      tester,
+    ) async {
+      var saveChanged = false;
+      await tester.pumpWidget(
+        _harness(
+          _recipientStep(
+            typedAddress: _unknownAddress,
+            busy: true,
+            onSaveAddressToContactsChanged: (_) => saveChanged = true,
+          ),
+        ),
+      );
+
+      final selectButton = find.byKey(
+        const ValueKey('pay_select_recipient_button'),
+      );
+      final saveCheckbox = find.byKey(
+        const ValueKey('pay_save_address_checkbox'),
+      );
+      expect(find.text('Fetching quote'), findsOneWidget);
+      expect(tester.widget<AppButton>(selectButton).onPressed, isNull);
+      await tester.tap(saveCheckbox);
+      expect(saveChanged, isFalse);
+      expect(
+        find.descendant(
+          of: selectButton,
+          matching: find.byWidgetPredicate(
+            (widget) => widget is AppIcon && widget.name == AppIcons.loader,
+          ),
+        ),
         findsOneWidget,
       );
     });

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -49,10 +49,12 @@ import 'package:zcash_wallet/src/features/activity/screens/activity_screen.dart'
 import 'package:zcash_wallet/src/features/activity/screens/activity_transaction_status_screen.dart';
 import 'package:zcash_wallet/src/features/activity/screens/swap_activity_detail_screen.dart';
 import 'package:zcash_wallet/src/features/pay/screens/pay_screen.dart';
+import 'package:zcash_wallet/src/features/pay/widgets/pay_add_contact_modal.dart';
 import 'package:zcash_wallet/src/features/swap/screens/swap_review_screen.dart';
 import 'package:zcash_wallet/src/features/swap/screens/swap_screen.dart';
 import 'package:zcash_wallet/src/features/swap/widgets/swap_amount_text.dart';
 import 'package:zcash_wallet/src/features/address_scan/widgets/address_qr_scan_modal.dart';
+import 'package:zcash_wallet/src/features/swap/widgets/pay_activity_status_content.dart';
 import 'package:zcash_wallet/src/features/swap/widgets/swap_asset_icon.dart';
 import 'package:zcash_wallet/src/features/swap/widgets/swap_deposit_tokens_page_content.dart';
 import 'package:zcash_wallet/src/features/swap/widgets/swap_review_page_content.dart';
@@ -975,6 +977,71 @@ void main() {
     );
   });
 
+  testWidgets(
+    'Pay saves an unknown recipient from the checkbox before review',
+    (tester) async {
+      await _setDesktopViewport(tester);
+      final addressBookRepository = _FakeAddressBookRepository();
+
+      await tester.pumpWidget(
+        _routerHarness(
+          GoRouter(
+            initialLocation: '/pay',
+            routes: [_payRoute(), _swapActivityRoute()],
+          ),
+          addressBookRepository: addressBookRepository,
+          seedSwapActivityFixtures: false,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byKey(const ValueKey('pay_amount_input')),
+        '10',
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(
+        find.byKey(const ValueKey('pay_amount_continue_button')),
+      );
+      await tester.pumpAndSettle();
+
+      const recipient = '0x2222222222222222222222222222222222222222';
+      await tester.enterText(
+        find.byKey(const ValueKey('pay_recipient_search_field')),
+        recipient,
+      );
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('pay_save_address_checkbox')));
+      await tester.pump();
+      await tester.tap(
+        find.byKey(const ValueKey('pay_select_recipient_button')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(PayAddContactModal), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('pay_add_contact_modal')),
+        findsOneWidget,
+      );
+
+      await tester.enterText(
+        find.byKey(const ValueKey('pay_add_contact_label_field')),
+        'Treasury',
+      );
+      await tester.pump();
+      await tester.tap(
+        find.byKey(const ValueKey('pay_add_contact_save_button')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(addressBookRepository.contacts, hasLength(1));
+      expect(addressBookRepository.contacts.single.label, 'Treasury');
+      expect(addressBookRepository.contacts.single.address, recipient);
+      expect(find.text('Review Payment'), findsOneWidget);
+      expect(find.byType(PayAddContactModal), findsNothing);
+    },
+  );
+
   testWidgets('swap status summary shows the captured fiat from the mapper', (
     tester,
   ) async {
@@ -1459,7 +1526,14 @@ void main() {
         _routerHarness(
           GoRouter(
             initialLocation: '/activity/swap/pay-progress?from=activity',
-            routes: [_swapRoute(), _swapActivityRoute()],
+            routes: [
+              _swapRoute(),
+              _swapActivityRoute(),
+              GoRoute(
+                path: '/home',
+                builder: (_, _) => const Text('Home destination'),
+              ),
+            ],
           ),
           seedSwapActivityFixtures: false,
           sessionStore: _FakeSwapPersistenceStore(initialIntents: [payIntent]),
@@ -1493,6 +1567,14 @@ void main() {
       expect(find.text('2.45125 ZEC'), findsOneWidget);
       expect(find.text('Tx fee'), findsOneWidget);
       expect(find.text('Not reported'), findsOneWidget);
+      expect(
+        find.text(
+          'Your swap is in progress. You can check its status at any time '
+          'from the Activity tab.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Go home'), findsOneWidget);
       expect(find.byKey(const ValueKey('swap_status_tabs')), findsNothing);
       expect(find.byKey(const ValueKey('swap_review_info')), findsNothing);
       expect(find.byKey(const ValueKey('pay_status_summary')), findsNothing);
@@ -1501,7 +1583,7 @@ void main() {
         tester.getSize(
           find.byKey(const ValueKey('pay_activity_status_content')),
         ),
-        const Size(396, 549),
+        PayActivityStatusContent.inProgressContentSize,
       );
       expect(
         tester.getSize(find.byKey(const ValueKey('pay_status_review_info'))),
@@ -1527,6 +1609,17 @@ void main() {
         find.byKey(const ValueKey('verify_address_close_button')),
         findsOneWidget,
       );
+
+      await tester.tap(
+        find.byKey(const ValueKey('verify_address_close_button')),
+      );
+      await tester.pumpAndSettle();
+      await tester.ensureVisible(
+        find.byKey(const ValueKey('pay_status_go_home_button')),
+      );
+      await tester.tap(find.byKey(const ValueKey('pay_status_go_home_button')));
+      await tester.pumpAndSettle();
+      expect(find.text('Home destination'), findsOneWidget);
     },
   );
 
@@ -3305,9 +3398,7 @@ void main() {
     expect(restored.slippageBps, 200);
   });
 
-  testWidgets('pay restores its saved payout asset on startup', (
-    tester,
-  ) async {
+  testWidgets('pay restores its saved payout asset on startup', (tester) async {
     await _setDesktopViewport(tester);
     final sessionStore = _FakeSwapPersistenceStore(
       initialPayAsset: SwapAsset.sol,

--- a/test/figma_compare/figma_compare_capture_desktop_test.dart
+++ b/test/figma_compare/figma_compare_capture_desktop_test.dart
@@ -1,0 +1,16 @@
+@Tags(['figma-capture'])
+library;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart' show Tags;
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
+
+import 'figma_compare_capture_support.dart';
+
+void main() {
+  runFigmaCompareCaptureTest(
+    expectedFormFactor: AppFormFactor.desktop,
+    defaultLogicalSize: const Size(1080, 720),
+    defaultPixelRatio: 1,
+  );
+}

--- a/test/figma_compare/figma_compare_capture_mobile_test.dart
+++ b/test/figma_compare/figma_compare_capture_mobile_test.dart
@@ -1,0 +1,16 @@
+@Tags(['mobile', 'figma-capture'])
+library;
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart' show Tags;
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
+
+import 'figma_compare_capture_support.dart';
+
+void main() {
+  runFigmaCompareCaptureTest(
+    expectedFormFactor: AppFormFactor.mobile,
+    defaultLogicalSize: const Size(393, 852),
+    defaultPixelRatio: 3,
+  );
+}

--- a/test/figma_compare/figma_compare_capture_support.dart
+++ b/test/figma_compare/figma_compare_capture_support.dart
@@ -1,0 +1,130 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/figma_compare/figma_compare_app.dart';
+import 'package:zcash_wallet/figma_compare/figma_compare_configuration.dart';
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
+
+const _windowAppearanceChannel = MethodChannel(
+  'com.zcash.wallet/window_appearance',
+);
+
+void runFigmaCompareCaptureTest({
+  required AppFormFactor expectedFormFactor,
+  required Size defaultLogicalSize,
+  required double defaultPixelRatio,
+}) {
+  testWidgets('captures the configured Figma comparison scenario', (
+    tester,
+  ) async {
+    expect(
+      kAppFormFactor,
+      expectedFormFactor,
+      reason:
+          'The capture test was compiled with the wrong form factor. Use '
+          'scripts/figma-compare.sh so the required define is always passed.',
+    );
+
+    final configuration = FigmaCompareConfiguration.fromEnvironment(
+      defaultLogicalSize: defaultLogicalSize,
+      defaultPixelRatio: defaultPixelRatio,
+    );
+    final scenario = configuration.resolveScenario(expectedFormFactor);
+    final output = File(
+      configuration.outputPath.isEmpty
+          ? '${Directory.systemTemp.path}/vizor-figma-compare/'
+                '${scenario.id}/content.widget.png'
+          : configuration.outputPath,
+    ).absolute;
+    output.parent.createSync(recursive: true);
+
+    tester.view.devicePixelRatio = configuration.pixelRatio;
+    tester.view.physicalSize = Size(
+      configuration.logicalSize.width * configuration.pixelRatio,
+      configuration.logicalSize.height * configuration.pixelRatio,
+    );
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(
+      _windowAppearanceChannel,
+      (_) async => null,
+    );
+    addTearDown(
+      () => messenger.setMockMethodCallHandler(_windowAppearanceChannel, null),
+    );
+
+    await _loadAppFonts();
+    final captureBoundaryKey = GlobalKey();
+    await tester.pumpWidget(
+      FigmaCompareApp(
+        scenario: scenario,
+        themeMode: configuration.themeMode,
+        captureBoundaryKey: captureBoundaryKey,
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    await _precacheRenderedImages(tester);
+    await tester.pump();
+
+    await expectLater(
+      find.byKey(captureBoundaryKey),
+      matchesGoldenFile(output.uri),
+    );
+    debugPrint(
+      'Figma comparison widget: ${output.path} '
+      '(${configuration.logicalSize.width.toInt()}x'
+      '${configuration.logicalSize.height.toInt()} logical PNG, simulated '
+      'DPR ${configuration.pixelRatio})',
+    );
+  });
+}
+
+Future<void> _precacheRenderedImages(WidgetTester tester) async {
+  final cachedProviders = <ImageProvider<Object>>{};
+  final images = [
+    for (final element in find.byType(Image).evaluate())
+      (image: element.widget as Image, context: element),
+  ];
+  await tester.runAsync(() async {
+    for (final entry in images) {
+      if (!cachedProviders.add(entry.image.image)) continue;
+      await precacheImage(entry.image.image, entry.context);
+    }
+  });
+}
+
+Future<void> _loadAppFonts() async {
+  const fonts = <String, List<String>>{
+    'Inter': [
+      'assets/fonts/Inter-Regular.ttf',
+      'assets/fonts/Inter-Medium.ttf',
+      'assets/fonts/Inter-SemiBold.ttf',
+      'assets/fonts/Inter-Bold.ttf',
+    ],
+    'Geist': [
+      'assets/fonts/Geist-Regular.ttf',
+      'assets/fonts/Geist-Medium.ttf',
+      'assets/fonts/Geist-SemiBold.ttf',
+      'assets/fonts/Geist-Bold.ttf',
+    ],
+    'Geist Mono': [
+      'assets/fonts/GeistMono-Regular.ttf',
+      'assets/fonts/GeistMono-Medium.ttf',
+    ],
+    'Young Serif': ['assets/fonts/YoungSerif-Regular.ttf'],
+  };
+
+  for (final entry in fonts.entries) {
+    final loader = FontLoader(entry.key);
+    for (final asset in entry.value) {
+      loader.addFont(rootBundle.load(asset));
+    }
+    await loader.load();
+  }
+}

--- a/test/figma_compare/figma_compare_test.dart
+++ b/test/figma_compare/figma_compare_test.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zcash_wallet/figma_compare/figma_compare_app.dart';
 import 'package:zcash_wallet/figma_compare/figma_compare_capture.dart';
+import 'package:zcash_wallet/figma_compare/figma_compare_configuration.dart';
 import 'package:zcash_wallet/figma_compare/figma_compare_scenarios.dart';
+import 'package:zcash_wallet/src/core/layout/app_form_factor.dart';
 
 void main() {
   test('comparison scenarios have stable unique IDs', () {
@@ -17,6 +19,7 @@ void main() {
         'pay-add-contact',
         'pay-in-progress',
         'pay-completed',
+        'mobile-home-default',
       ]),
     );
   });
@@ -32,7 +35,53 @@ void main() {
     );
   });
 
-  for (final scenario in figmaCompareScenarios) {
+  test(
+    'configuration resolves only scenarios supported by its form factor',
+    () {
+      const desktopConfiguration = FigmaCompareConfiguration(
+        scenarioId: 'pay-recipient',
+        themeMode: ThemeMode.dark,
+        outputPath: '/tmp/content.png',
+        logicalSize: Size(1080, 720),
+        pixelRatio: 1,
+      );
+
+      expect(
+        desktopConfiguration.resolveScenario(AppFormFactor.desktop).id,
+        'pay-recipient',
+      );
+      expect(
+        () => desktopConfiguration.resolveScenario(AppFormFactor.mobile),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('does not support mobile'),
+          ),
+        ),
+      );
+
+      const mobileConfiguration = FigmaCompareConfiguration(
+        scenarioId: 'mobile-home-default',
+        themeMode: ThemeMode.dark,
+        outputPath: '/tmp/content.png',
+        logicalSize: Size(393, 852),
+        pixelRatio: 3,
+      );
+      expect(
+        mobileConfiguration.resolveScenario(AppFormFactor.mobile).id,
+        'mobile-home-default',
+      );
+      expect(
+        () => mobileConfiguration.resolveScenario(AppFormFactor.desktop),
+        throwsStateError,
+      );
+    },
+  );
+
+  for (final scenario in figmaCompareScenarios.where(
+    (scenario) => scenario.desktop,
+  )) {
     testWidgets('${scenario.id} renders at the desktop comparison viewport', (
       tester,
     ) async {

--- a/test/figma_compare/figma_compare_test.dart
+++ b/test/figma_compare/figma_compare_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zcash_wallet/figma_compare/figma_compare_app.dart';
+import 'package:zcash_wallet/figma_compare/figma_compare_capture.dart';
+import 'package:zcash_wallet/figma_compare/figma_compare_scenarios.dart';
+
+void main() {
+  test('comparison scenarios have stable unique IDs', () {
+    final ids = figmaCompareScenarios.map((scenario) => scenario.id).toList();
+
+    expect(ids.toSet(), hasLength(ids.length));
+    expect(
+      ids,
+      containsAll(<String>[
+        'pay-recipient',
+        'pay-recipient-new-address',
+        'pay-add-contact',
+        'pay-in-progress',
+        'pay-completed',
+      ]),
+    );
+  });
+
+  test('window capture path stays beside the Flutter content capture', () {
+    expect(
+      figmaCompareWindowCapturePath('/tmp/pay-recipient/content.png'),
+      '/tmp/pay-recipient/content.window.png',
+    );
+    expect(
+      figmaCompareWindowCapturePath('/tmp/pay-recipient/content'),
+      '/tmp/pay-recipient/content.window.png',
+    );
+  });
+
+  for (final scenario in figmaCompareScenarios) {
+    testWidgets('${scenario.id} renders at the desktop comparison viewport', (
+      tester,
+    ) async {
+      await tester.binding.setSurfaceSize(const Size(1080, 720));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+      final boundaryKey = GlobalKey();
+
+      await tester.pumpWidget(
+        FigmaCompareApp(
+          scenario: scenario,
+          themeMode: ThemeMode.dark,
+          captureBoundaryKey: boundaryKey,
+        ),
+      );
+      await tester.pump();
+
+      expect(boundaryKey.currentContext, isNotNull);
+      expect(tester.takeException(), isNull);
+    });
+  }
+}

--- a/test/widgetbook/pay_use_cases_test.dart
+++ b/test/widgetbook/pay_use_cases_test.dart
@@ -62,8 +62,14 @@ void main() {
 
     expect(tester.takeException(), isNull);
     expect(find.text('New address detected.'), findsOneWidget);
-    expect(find.text('Add to contacts'), findsOneWidget);
+    expect(find.text('Save address to contacts'), findsOneWidget);
     expect(find.text('Select recipient'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('pay_save_address_checkbox')));
+    await tester.pump();
+    await tester.tap(find.byKey(const ValueKey('pay_select_recipient_button')));
+    await tester.pumpAndSettle();
+    expect(find.byType(PayAddContactModal), findsOneWidget);
+    expect(find.byKey(const ValueKey('pay_add_contact_modal')), findsOneWidget);
   });
 
   testWidgets('Pay review use case renders a live quote and confirm action', (
@@ -134,13 +140,21 @@ void main() {
     expect(content.status.phase, PayActivityStatusPhase.inProgress);
     expect(
       tester.getSize(find.byKey(const ValueKey('pay_activity_status_content'))),
-      PayActivityStatusContent.contentSize,
+      PayActivityStatusContent.inProgressContentSize,
     );
     expect(find.text('Pay in progress...'), findsOneWidget);
     expect(find.text('990 USDC'), findsOneWidget);
     expect(find.text(r'$990.12'), findsOneWidget);
     expect(find.text('New address'), findsOneWidget);
     expect(find.text('In progress'), findsOneWidget);
+    expect(
+      find.text(
+        'Your swap is in progress. You can check its status at any time from '
+        'the Activity tab.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Go home'), findsOneWidget);
     _expectPayStatusDetails();
   });
 
@@ -157,6 +171,11 @@ void main() {
     expect(find.text('Paid successfully'), findsOneWidget);
     expect(find.text('Completed'), findsOneWidget);
     expect(find.text('In progress'), findsNothing);
+    expect(find.text('Go home'), findsNothing);
+    expect(
+      tester.getSize(find.byKey(const ValueKey('pay_activity_status_content'))),
+      PayActivityStatusContent.completedContentSize,
+    );
     _expectPayStatusDetails();
   });
 }


### PR DESCRIPTION
## Summary

- replace the secondary add-to-contacts action with a centered, keyboard-accessible “Save address to contacts” checkbox that opens the existing contact modal before review
- randomize the initial contact avatar, autofocus the address-label field, and preserve the selected avatar while the modal is open
- add the Pay progress guidance, Go home action, and loading treatment covered by VZR-117 and VZR-118
- update Widgetbook fixtures and focused widget/integration coverage

## Why

This brings the desktop Pay recipient and progress flows in line with VZR-116, VZR-117, and VZR-118, including the follow-up interaction and layout refinements made during local review.

## Validation

- `fvm flutter test test/features/pay/pay_wizard_steps_test.dart test/features/swap/swap_screen_test.dart test/widgetbook/pay_use_cases_test.dart test/features/address_book/contact_label_generator_test.dart` (190 tests passed)
- `fvm flutter analyze` across all nine changed source/test files (no issues)
- `fvm flutter build macos --debug`

## Review status

Draft only. Waiting for the remaining Figma changes before marking this R4R.