### PR TITLE
Make desktop Pay introduction one-shot

### DIFF
--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -379,7 +379,7 @@ class _HomePaneState extends ConsumerState<_HomePane> {
     final selectedAssetFuture = swapNotifier.resolvePaySelectedAssetForEntry(
       accountUuid: accountUuid,
     );
-    ref.read(payIntroductionBadgeClickedProvider.notifier).markClicked();
+    ref.read(desktopPayIntroductionVisibleProvider.notifier).dismiss();
 
     final selectedAsset = await selectedAssetFuture;
     if (!mounted ||

--- a/lib/src/features/home/services/pay_introduction_badge_store.dart
+++ b/lib/src/features/home/services/pay_introduction_badge_store.dart
@@ -2,7 +2,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// Stable, install-local record that the desktop Pay button was activated.
+/// Stable, install-local record that the Pay introduction was completed.
+///
+/// This key shipped with the v0.0.37 click-gated treatment. Keep the exact
+/// value so users whose decoration already disappeared never see it again.
 const payIntroductionButtonClickedStorageKey = 'vizor_pay_button_clicked';
 
 abstract interface class PayIntroductionBadgeStore {
@@ -81,6 +84,51 @@ final payIntroductionBadgeClickedProvider =
     AsyncNotifierProvider<PayIntroductionBadgeClickedNotifier, bool>(
       PayIntroductionBadgeClickedNotifier.new,
     );
+
+/// Desktop-only visibility for the one-shot Pay introduction.
+///
+/// The existing click record is claimed before the decoration is shown, while
+/// the returned state keeps it visible for the current Home visit. This makes
+/// the introduction install-wide and account-independent without reviving it
+/// for users who already completed the v0.0.37 treatment.
+class DesktopPayIntroductionVisibleNotifier extends AsyncNotifier<bool> {
+  var _dismissedInSession = false;
+
+  @override
+  Future<bool> build() async {
+    if (_dismissedInSession) return false;
+    if (!ref.watch(payIntroductionBadgePersistenceEnabledProvider)) {
+      return true;
+    }
+
+    try {
+      final store = ref.watch(payIntroductionBadgeStoreProvider);
+      if (await store.hasClickedPay()) return false;
+
+      // Persist before rendering so an app exit or account-driven rebuild
+      // cannot turn this into a repeated introduction.
+      await store.markPayClicked();
+      return !_dismissedInSession;
+    } catch (error) {
+      // Fail closed: a storage failure must not create a decoration that can
+      // reappear on every launch.
+      debugPrint('Desktop Pay introduction persistence failed: $error');
+      return false;
+    }
+  }
+
+  void dismiss() {
+    if (_dismissedInSession) return;
+    _dismissedInSession = true;
+    state = const AsyncData(false);
+  }
+}
+
+final desktopPayIntroductionVisibleProvider =
+    AsyncNotifierProvider.autoDispose<
+      DesktopPayIntroductionVisibleNotifier,
+      bool
+    >(DesktopPayIntroductionVisibleNotifier.new);
 
 /// Test seam for full-app suites that rely on `pumpAndSettle`: the coin bob
 /// loops forever in production, which never settles. Reduce motion at runtime

--- a/lib/src/features/home/widgets/pay_floating_badge.dart
+++ b/lib/src/features/home/widgets/pay_floating_badge.dart
@@ -10,8 +10,8 @@ const _payIntroductionFadeOutDuration = Duration(milliseconds: 120);
 
 /// Wraps the desktop Pay button with its floating introduction.
 ///
-/// Before the first Pay activation, the full treatment is always visible.
-/// Afterwards it returns only while the Pay button is hovered.
+/// The full treatment is shown during the first eligible Home visit, then
+/// disappears permanently after Pay is activated or Home is left.
 class PayIntroductionBadgeTarget extends ConsumerStatefulWidget {
   const PayIntroductionBadgeTarget({
     super.key,
@@ -29,56 +29,64 @@ class PayIntroductionBadgeTarget extends ConsumerStatefulWidget {
 
 class _PayIntroductionBadgeTargetState
     extends ConsumerState<PayIntroductionBadgeTarget> {
-  var _hovered = false;
+  bool? _routeWasCurrent;
+  var _dismissedForRoute = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final routeIsCurrent = ModalRoute.of(context)?.isCurrent ?? true;
+    if (_routeWasCurrent == true && !routeIsCurrent) {
+      _dismissedForRoute = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        ref.read(desktopPayIntroductionVisibleProvider.notifier).dismiss();
+      });
+    }
+    _routeWasCurrent = routeIsCurrent;
+  }
 
   @override
   Widget build(BuildContext context) {
-    final clicked = ref.watch(payIntroductionBadgeClickedProvider).value;
+    final visible = ref.watch(desktopPayIntroductionVisibleProvider).value;
     final showIntroduction =
-        widget.enabled && (clicked == false || (clicked == true && _hovered));
-    return MouseRegion(
-      key: const ValueKey('pay_introduction_badge_hover_target'),
-      onEnter: (_) => setState(() => _hovered = true),
-      onExit: (_) => setState(() => _hovered = false),
-      child: Stack(
-        key: const ValueKey('pay_introduction_badge_target'),
-        clipBehavior: Clip.none,
-        children: [
-          Positioned(
-            left: 0,
-            top: 0,
-            width: 60,
-            height: 44,
-            child: _PayIntroductionFade(
-              key: const ValueKey('pay_introduction_glow_fade'),
-              visible: showIntroduction,
-              child: const IgnorePointer(child: _PayFloatingGlow()),
-            ),
+        widget.enabled && !_dismissedForRoute && visible == true;
+    return Stack(
+      key: const ValueKey('pay_introduction_badge_target'),
+      clipBehavior: Clip.none,
+      children: [
+        Positioned(
+          left: 0,
+          top: 0,
+          width: 60,
+          height: 44,
+          child: _PayIntroductionFade(
+            key: const ValueKey('pay_introduction_glow_fade'),
+            visible: showIntroduction,
+            child: const IgnorePointer(child: _PayFloatingGlow()),
           ),
-          widget.child,
-          Positioned(
-            // In the Home frame (5407:152492), the 169px badge frame starts
-            // at the Pay button's left edge and overflows to its right.
-            left: 0,
-            top: -65,
-            child: _PayIntroductionFade(
-              key: const ValueKey('pay_introduction_badge_fade'),
-              visible: showIntroduction,
-              child: IgnorePointer(
-                child: ExcludeSemantics(
-                  child: PayFloatingBadge(
-                    animate: ref.watch(
-                      payIntroductionBadgeMotionEnabledProvider,
-                    ),
-                    showGlow: false,
-                    showNew: true,
-                  ),
+        ),
+        widget.child,
+        Positioned(
+          // In the Home frame (5407:152492), the 169px badge frame starts
+          // at the Pay button's left edge and overflows to its right.
+          left: 0,
+          top: -65,
+          child: _PayIntroductionFade(
+            key: const ValueKey('pay_introduction_badge_fade'),
+            visible: showIntroduction,
+            child: IgnorePointer(
+              child: ExcludeSemantics(
+                child: PayFloatingBadge(
+                  animate: ref.watch(payIntroductionBadgeMotionEnabledProvider),
+                  showGlow: false,
+                  showNew: true,
                 ),
               ),
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/test/features/home/home_desktop_screen_test.dart
+++ b/test/features/home/home_desktop_screen_test.dart
@@ -394,77 +394,132 @@ void main() {
     expect(badgeStore.markCount, 0);
   });
 
-  testWidgets(
-    'home hides the treatment after Pay click and restores it on hover',
-    (tester) async {
-      final badgeStore = _FakePayIntroductionBadgeStore();
-      await tester.pumpWidget(
-        _appHarness(
-          '/home',
-          payIntroductionBadgeStore: badgeStore,
-          syncState: SyncState(
-            accountUuid: 'account-1',
-            hasAccountScopedData: true,
-            orchardBalance: BigInt.from(14_312_000_000),
-            spendableBalance: BigInt.from(14_312_000_000),
-            totalBalance: BigInt.from(14_312_000_000),
-          ),
+  testWidgets('home does not consume the treatment without a Pay button', (
+    tester,
+  ) async {
+    final badgeStore = _FakePayIntroductionBadgeStore();
+    await tester.pumpWidget(
+      _appHarness(
+        '/home',
+        payIntroductionBadgeStore: badgeStore,
+        syncState: SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
         ),
-      );
-      await _pumpUntilPresent(tester, find.text('NEW'));
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      expect(find.byType(PayFloatingBadge), findsOneWidget);
-      expect(find.text('NEW'), findsOneWidget);
-      expect(badgeStore.markCount, 0);
+    expect(find.byKey(const ValueKey('home_desktop_pay_button')), findsNothing);
+    expect(find.byType(PayIntroductionBadgeTarget), findsNothing);
+    expect(badgeStore.markCount, 0);
+  });
 
-      await tester.tap(find.byKey(const ValueKey('home_desktop_pay_button')));
-      await _pumpUntilPresent(tester, find.byType(PayScreen));
-      expect(badgeStore.markCount, 1);
-      await tester.tap(find.byKey(const ValueKey('pay_wizard_back_link')));
-      for (
-        var i = 0;
-        i < 20 && find.byType(PayScreen).evaluate().isNotEmpty;
-        i++
-      ) {
-        await tester.pump(const Duration(milliseconds: 50));
-      }
+  testWidgets('home shows the treatment once and keeps it hidden after Pay', (
+    tester,
+  ) async {
+    final badgeStore = _FakePayIntroductionBadgeStore();
+    await tester.pumpWidget(
+      _appHarness(
+        '/home',
+        payIntroductionBadgeStore: badgeStore,
+        syncState: SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          orchardBalance: BigInt.from(14_312_000_000),
+          spendableBalance: BigInt.from(14_312_000_000),
+          totalBalance: BigInt.from(14_312_000_000),
+        ),
+      ),
+    );
+    await _pumpUntilPresent(tester, find.text('NEW'));
 
-      expect(find.byType(PayScreen), findsNothing);
-      expect(find.byType(PayFloatingBadge), findsNothing);
-      expect(find.text('Pay in USDC'), findsNothing);
-      expect(find.text('NEW'), findsNothing);
-      expect(badgeStore.markCount, 1);
+    expect(find.byType(PayFloatingBadge), findsOneWidget);
+    expect(find.text('NEW'), findsOneWidget);
+    expect(badgeStore.clicked, isTrue);
+    expect(badgeStore.markCount, 1);
 
-      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
-      await mouse.addPointer();
-      await mouse.moveTo(
-        tester.getCenter(find.byKey(const ValueKey('home_desktop_pay_button'))),
-      );
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 180));
+    await tester.tap(find.byKey(const ValueKey('home_desktop_pay_button')));
+    await _pumpUntilPresent(tester, find.byType(PayScreen));
+    expect(badgeStore.markCount, 1);
+    await tester.tap(find.byKey(const ValueKey('pay_wizard_back_link')));
+    for (
+      var i = 0;
+      i < 20 && find.byType(PayScreen).evaluate().isNotEmpty;
+      i++
+    ) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
 
-      expect(find.byType(PayFloatingBadge), findsOneWidget);
-      expect(
-        find.byKey(const ValueKey('pay_floating_badge_glow')),
-        findsOneWidget,
-      );
-      expect(
-        find.byKey(const ValueKey('pay_floating_badge_coin')),
-        findsOneWidget,
-      );
-      expect(find.text('Pay in USDC'), findsOneWidget);
-      expect(find.text('NEW'), findsOneWidget);
+    expect(find.byType(PayScreen), findsNothing);
+    expect(find.byType(PayFloatingBadge), findsNothing);
+    expect(find.text('Pay in USDC'), findsNothing);
+    expect(find.text('NEW'), findsNothing);
+    expect(badgeStore.markCount, 1);
 
-      await mouse.moveTo(Offset.zero);
-      await tester.pump();
-      await tester.pump(const Duration(milliseconds: 121));
-      await tester.pump();
+    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await mouse.addPointer();
+    await mouse.moveTo(
+      tester.getCenter(find.byKey(const ValueKey('home_desktop_pay_button'))),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 180));
 
-      expect(find.byType(PayFloatingBadge), findsNothing);
-      expect(find.text('Pay in USDC'), findsNothing);
-      expect(find.text('NEW'), findsNothing);
-    },
-  );
+    expect(find.byType(PayFloatingBadge), findsNothing);
+    expect(find.byKey(const ValueKey('pay_floating_badge_glow')), findsNothing);
+    expect(find.byKey(const ValueKey('pay_floating_badge_coin')), findsNothing);
+    expect(find.text('Pay in USDC'), findsNothing);
+    expect(find.text('NEW'), findsNothing);
+
+    await mouse.moveTo(Offset.zero);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 121));
+    await tester.pump();
+
+    expect(find.byType(PayFloatingBadge), findsNothing);
+    expect(find.text('Pay in USDC'), findsNothing);
+    expect(find.text('NEW'), findsNothing);
+  });
+
+  testWidgets('home keeps the treatment hidden after visiting another page', (
+    tester,
+  ) async {
+    final badgeStore = _FakePayIntroductionBadgeStore();
+    await tester.pumpWidget(
+      _appHarness(
+        '/home',
+        payIntroductionBadgeStore: badgeStore,
+        syncState: SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          orchardBalance: BigInt.from(14_312_000_000),
+          spendableBalance: BigInt.from(14_312_000_000),
+          totalBalance: BigInt.from(14_312_000_000),
+        ),
+      ),
+    );
+    await _pumpUntilPresent(tester, find.text('NEW'));
+
+    expect(find.byType(PayFloatingBadge), findsOneWidget);
+    expect(badgeStore.markCount, 1);
+
+    await tester.tap(find.byKey(const ValueKey('home_desktop_send_button')));
+    await _pumpUntilPresent(tester, find.byType(SendScreen));
+    await tester.tap(find.byKey(const ValueKey('send_pane_back_button')));
+    for (
+      var i = 0;
+      i < 20 && find.byType(SendScreen).evaluate().isNotEmpty;
+      i++
+    ) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+
+    expect(find.byType(SendScreen), findsNothing);
+    expect(find.byType(PayFloatingBadge), findsNothing);
+    expect(find.text('Pay in USDC'), findsNothing);
+    expect(find.text('NEW'), findsNothing);
+    expect(badgeStore.markCount, 1);
+  });
 
   testWidgets('home desktop see all action opens activity screen', (
     tester,

--- a/test/features/home/pay_floating_badge_test.dart
+++ b/test/features/home/pay_floating_badge_test.dart
@@ -85,7 +85,7 @@ void main() {
     expect(_coinTranslationY(tester), 0);
   });
 
-  testWidgets('target keeps the full treatment until Pay is clicked', (
+  testWidgets('target claims the existing record before showing once', (
     tester,
   ) async {
     final store = _FakePayIntroductionBadgeStore();
@@ -102,7 +102,8 @@ void main() {
     );
     expect(find.text('Pay in USDC'), findsOneWidget);
     expect(find.text('NEW'), findsOneWidget);
-    expect(store.markCount, 0);
+    expect(store.clicked, isTrue);
+    expect(store.markCount, 1);
     final targetRect = tester.getRect(
       find.byKey(const ValueKey('pay_introduction_badge_target')),
     );
@@ -120,7 +121,7 @@ void main() {
       tester.element(find.byType(PayIntroductionBadgeTarget)),
       listen: false,
     );
-    container.read(payIntroductionBadgeClickedProvider.notifier).markClicked();
+    container.read(desktopPayIntroductionVisibleProvider.notifier).dismiss();
     await tester.pumpAndSettle();
 
     expect(find.byType(PayFloatingBadge), findsNothing);
@@ -131,13 +132,14 @@ void main() {
     expect(store.markCount, 1);
   });
 
-  testWidgets('clicked target shows the full treatment only while hovered', (
+  testWidgets('completed v0.0.37 target never returns on hover', (
     tester,
   ) async {
     final store = _FakePayIntroductionBadgeStore()..clicked = true;
     await _pumpTarget(tester, store, persistenceEnabled: true);
 
     expect(find.byType(PayFloatingBadge), findsNothing);
+    expect(store.markCount, 0);
 
     final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await mouse.addPointer();
@@ -146,21 +148,6 @@ void main() {
         find.byKey(const ValueKey('pay_introduction_badge_target')),
       ),
     );
-    await tester.pump();
-
-    expect(find.byType(PayFloatingBadge), findsOneWidget);
-    expect(
-      find.byKey(const ValueKey('pay_floating_badge_glow')),
-      findsOneWidget,
-    );
-    expect(
-      find.byKey(const ValueKey('pay_floating_badge_coin')),
-      findsOneWidget,
-    );
-    expect(find.text('Pay in USDC'), findsOneWidget);
-    expect(find.text('NEW'), findsOneWidget);
-
-    await mouse.moveTo(Offset.zero);
     await tester.pump();
 
     expect(find.byType(PayFloatingBadge), findsNothing);
@@ -170,33 +157,54 @@ void main() {
     expect(find.text('NEW'), findsNothing);
   });
 
-  testWidgets('clicked target fades the treatment on hover transitions', (
+  testWidgets('claimed target stays hidden in a fresh provider scope', (
     tester,
   ) async {
-    final store = _FakePayIntroductionBadgeStore()..clicked = true;
+    final store = _FakePayIntroductionBadgeStore();
+    await _pumpTarget(tester, store, persistenceEnabled: true);
+
+    expect(find.byType(PayFloatingBadge), findsOneWidget);
+    expect(store.markCount, 1);
+
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump();
+    await _pumpTarget(tester, store, persistenceEnabled: true);
+
+    expect(find.byType(PayFloatingBadge), findsNothing);
+    expect(find.text('Pay in USDC'), findsNothing);
+    expect(find.text('NEW'), findsNothing);
+    expect(store.markCount, 1);
+  });
+
+  testWidgets('target fails closed when its completion cannot be stored', (
+    tester,
+  ) async {
+    final store = _FakePayIntroductionBadgeStore(failMark: true);
+    await _pumpTarget(tester, store, persistenceEnabled: true);
+
+    expect(find.byType(PayFloatingBadge), findsNothing);
+    expect(find.text('Pay in USDC'), findsNothing);
+    expect(find.text('NEW'), findsNothing);
+  });
+
+  testWidgets('target fades the treatment when it is dismissed', (
+    tester,
+  ) async {
+    final store = _FakePayIntroductionBadgeStore();
     await _pumpTarget(
       tester,
       store,
       persistenceEnabled: true,
       disableAnimations: false,
     );
+    expect(find.byType(PayFloatingBadge), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 180));
 
-    final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await mouse.addPointer();
-    await mouse.moveTo(
-      tester.getCenter(
-        find.byKey(const ValueKey('pay_introduction_badge_target')),
-      ),
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(PayIntroductionBadgeTarget)),
+      listen: false,
     );
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 90));
-
-    expect(_badgeFadeOpacity(tester), inExclusiveRange(0, 1));
-
-    await tester.pump(const Duration(milliseconds: 90));
-    expect(_badgeFadeOpacity(tester), 1);
-
-    await mouse.moveTo(Offset.zero);
+    container.read(desktopPayIntroductionVisibleProvider.notifier).dismiss();
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 60));
 
@@ -226,7 +234,7 @@ void main() {
     },
   );
 
-  testWidgets('navigation without a Pay click keeps the full treatment', (
+  testWidgets('navigation away permanently dismisses the treatment', (
     tester,
   ) async {
     final store = _FakePayIntroductionBadgeStore();
@@ -250,10 +258,10 @@ void main() {
       find.byKey(const ValueKey('pay_introduction_badge_target')),
       findsOneWidget,
     );
-    expect(find.byType(PayFloatingBadge), findsOneWidget);
-    expect(find.text('Pay in USDC'), findsOneWidget);
-    expect(find.text('NEW'), findsOneWidget);
-    expect(store.markCount, 0);
+    expect(find.byType(PayFloatingBadge), findsNothing);
+    expect(find.text('Pay in USDC'), findsNothing);
+    expect(find.text('NEW'), findsNothing);
+    expect(store.markCount, 1);
   });
 }
 
@@ -339,7 +347,7 @@ Future<void> _pumpNavigableTarget(
     ProviderScope(
       overrides: [
         payIntroductionBadgeStoreProvider.overrideWithValue(store),
-        payIntroductionBadgePersistenceEnabledProvider.overrideWithValue(false),
+        payIntroductionBadgePersistenceEnabledProvider.overrideWithValue(true),
       ],
       child: MaterialApp(
         home: MediaQuery(
@@ -360,6 +368,9 @@ Future<void> _pumpNavigableTarget(
 }
 
 class _FakePayIntroductionBadgeStore implements PayIntroductionBadgeStore {
+  _FakePayIntroductionBadgeStore({this.failMark = false});
+
+  final bool failMark;
   bool clicked = false;
   int markCount = 0;
 
@@ -368,6 +379,9 @@ class _FakePayIntroductionBadgeStore implements PayIntroductionBadgeStore {
 
   @override
   Future<void> markPayClicked() async {
+    if (failMark) {
+      throw StateError('test persistence failure');
+    }
     markCount += 1;
     clicked = true;
   }


### PR DESCRIPTION
## Summary

- preserve the existing `vizor_pay_button_clicked` record so users who already dismissed the v0.0.37 treatment never see it again
- show the desktop Pay introduction only during the first eligible Home visit
- dismiss it permanently after Pay is selected or Home is left, without reviving it on hover
- keep the mobile Pay introduction behavior unchanged

## Why

The desktop callout was keyed only to Pay activation and returned on hover after dismissal. The intended behavior is a single attention cue across all accounts: once the user sees it and either opens Pay or navigates elsewhere, the Pay button becomes a regular UI control permanently.

## Validation

- `fvm flutter test test/features/home/pay_floating_badge_test.dart test/features/home/home_desktop_screen_test.dart`
- `fvm flutter test test/features/home/mobile_home_screen_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
- `fvm flutter analyze`

The full desktop test lane also ran; it remains red in two unrelated tests that reproduce independently: the Receive widgetbook modal size expectation and the Settings uninstall off-screen tap.