### PR TITLE
Fix sync privacy lock after app resume

### DIFF
--- a/lib/src/core/widgets/mobile/sync_keep_awake_native_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_native_host.dart
@@ -24,24 +24,57 @@ class SyncKeepAwakeNativeHost extends ConsumerStatefulWidget {
 
 class _SyncKeepAwakeNativeHostState
     extends ConsumerState<SyncKeepAwakeNativeHost> {
+  AppLifecycleListener? _lifecycleListener;
+  bool _isInForeground = true;
   bool _lastRequestedEnabled = false;
   bool _lastAppliedEnabled = false;
   Future<void> _nativeQueue = Future<void>.value();
 
   @override
+  void initState() {
+    super.initState();
+    if (kAppFormFactor != AppFormFactor.mobile) return;
+
+    final lifecycleState = WidgetsBinding.instance.lifecycleState;
+    _isInForeground =
+        lifecycleState == null || lifecycleState == AppLifecycleState.resumed;
+    _lifecycleListener = AppLifecycleListener(
+      onResume: _handleLifecycleResume,
+      onInactive: _handleLifecycleBackground,
+      onHide: _handleLifecycleBackground,
+      onPause: _handleLifecycleBackground,
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
     if (kAppFormFactor == AppFormFactor.mobile) {
-      _requestNativeState(ref.watch(syncKeepAwakeActiveProvider));
+      _requestNativeState(
+        _isInForeground && ref.watch(syncKeepAwakeActiveProvider),
+      );
     }
     return widget.child;
   }
 
   @override
   void dispose() {
+    _lifecycleListener?.dispose();
     if (_lastRequestedEnabled || _lastAppliedEnabled) {
       _requestNativeState(false, force: true);
     }
     super.dispose();
+  }
+
+  void _handleLifecycleBackground() {
+    if (!_isInForeground) return;
+    _isInForeground = false;
+    _requestNativeState(false);
+  }
+
+  void _handleLifecycleResume() {
+    if (_isInForeground) return;
+    _isInForeground = true;
+    _requestNativeState(ref.read(syncKeepAwakeActiveProvider));
   }
 
   void _requestNativeState(bool enabled, {bool force = false}) {

--- a/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
@@ -38,7 +38,25 @@ class SyncKeepAwakePrivacyLockHost extends ConsumerStatefulWidget {
 class _SyncKeepAwakePrivacyLockHostState
     extends ConsumerState<SyncKeepAwakePrivacyLockHost> {
   Timer? _idleTimer;
+  AppLifecycleListener? _lifecycleListener;
+  bool _isInForeground = true;
   bool _clearScheduled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (kAppFormFactor != AppFormFactor.mobile) return;
+
+    final lifecycleState = WidgetsBinding.instance.lifecycleState;
+    _isInForeground =
+        lifecycleState == null || lifecycleState == AppLifecycleState.resumed;
+    _lifecycleListener = AppLifecycleListener(
+      onResume: _handleLifecycleResume,
+      onInactive: _handleLifecycleBackground,
+      onHide: _handleLifecycleBackground,
+      onPause: _handleLifecycleBackground,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -62,8 +80,25 @@ class _SyncKeepAwakePrivacyLockHostState
 
   @override
   void dispose() {
+    _lifecycleListener?.dispose();
     _idleTimer?.cancel();
     super.dispose();
+  }
+
+  void _handleLifecycleBackground() {
+    if (!_isInForeground) return;
+    _isInForeground = false;
+    _idleTimer?.cancel();
+    _idleTimer = null;
+  }
+
+  void _handleLifecycleResume() {
+    if (_isInForeground) return;
+    _isInForeground = true;
+    // Returning to the app is an explicit user interaction. Reset the idle
+    // window before the provider rebuild rearms the timer so time spent while
+    // the app was not visible never causes an immediate privacy lock.
+    ref.read(syncKeepAwakeInteractionProvider.notifier).markInteraction();
   }
 
   void _syncIdleTimer({
@@ -71,7 +106,7 @@ class _SyncKeepAwakePrivacyLockHostState
     required SyncKeepAwakeInteractionState interaction,
     required bool visible,
   }) {
-    if (!active) {
+    if (!_isInForeground || !active) {
       _idleTimer?.cancel();
       _idleTimer = null;
       if (visible) return;
@@ -96,6 +131,7 @@ class _SyncKeepAwakePrivacyLockHostState
 
   void _lockIfStillIdle(int expectedRevision) {
     if (!mounted) return;
+    if (!_isInForeground) return;
     if (!ref.read(syncKeepAwakeActiveProvider)) return;
     if (ref.read(syncKeepAwakePrivacyLockProvider).isLocked) return;
 

--- a/test/core/widgets/sync_keep_awake_native_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_native_host_test.dart
@@ -76,6 +76,27 @@ void main() {
     expect(_enabledArgs(calls), [true]);
   });
 
+  testWidgets('disables native keep-awake while the app is not foreground', (
+    tester,
+  ) async {
+    final calls = _recordScreenAwakeCalls();
+    final syncNotifier = FakeSyncNotifier(
+      _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+    );
+
+    await tester.pumpWidget(_app(syncNotifier: syncNotifier));
+    await _drainNativeQueue(tester);
+    expect(_enabledArgs(calls), [true]);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    await _drainNativeQueue(tester);
+    expect(_enabledArgs(calls), [true, false]);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await _drainNativeQueue(tester);
+    expect(_enabledArgs(calls), [true, false, true]);
+  });
+
   testWidgets('does not call native API when the setting is disabled', (
     tester,
   ) async {

--- a/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
@@ -155,6 +155,64 @@ void main() {
     expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
   });
 
+  testWidgets(
+    'background time does not trigger an immediate privacy lock on resume',
+    (tester) async {
+      _setMobileViewport(tester);
+      await tester.pumpWidget(
+        _app(
+          syncNotifier: FakeSyncNotifier(
+            _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+          ),
+        ),
+      );
+      await _settleInitialSync(tester);
+
+      await tester.pump(const Duration(milliseconds: 30));
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      await tester.pump();
+      await tester.pump(const Duration(minutes: 5));
+
+      expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 49));
+
+      expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
+
+      await tester.pump(const Duration(milliseconds: 2));
+      await tester.pump();
+
+      expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+    },
+  );
+
+  testWidgets('an existing privacy lock remains latched across background', (
+    tester,
+  ) async {
+    _setMobileViewport(tester);
+    await tester.pumpWidget(
+      _app(
+        syncNotifier: FakeSyncNotifier(
+          _sync(lastSyncStartedAt: DateTime(2026, 7, 9, 12)),
+        ),
+      ),
+    );
+    await _settleInitialSync(tester);
+    await tester.pump(const Duration(milliseconds: 60));
+    await tester.pump();
+
+    expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    await tester.pump(const Duration(minutes: 5));
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+
+    expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+  });
+
   testWidgets('passcode confirmation clears the virtual privacy lock', (
     tester,
   ) async {

--- a/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
@@ -168,7 +168,8 @@ void main() {
       );
       await _settleInitialSync(tester);
 
-      await tester.pump(const Duration(milliseconds: 30));
+      await tester.tap(find.byKey(const ValueKey('home_surface')));
+      await tester.pump();
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
       await tester.pump();
       await tester.pump(const Duration(minutes: 5));
@@ -177,11 +178,10 @@ void main() {
 
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 49));
 
       expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
 
-      await tester.pump(const Duration(milliseconds: 2));
+      await tester.pump(const Duration(milliseconds: 60));
       await tester.pump();
 
       expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);


### PR DESCRIPTION
## Summary

- pause the sync keep-awake privacy timer whenever the mobile app leaves the foreground
- treat returning to the app as a fresh interaction so background time cannot trigger an immediate virtual lock
- disable the native keep-awake flag while inactive and restore it only when sync remains eligible
- preserve an already-visible virtual lock across background and resume transitions

## Root cause

The virtual privacy lock measured wall-clock time since the last pointer event but did not observe app lifecycle transitions. Time spent in another app therefore exhausted the one-minute idle window, and an overdue timer or zero-duration rearm could show the lock immediately on resume.

## Validation

- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart test/core/widgets/sync_keep_awake_native_host_test.dart test/core/widgets/sync_keep_awake_interaction_listener_test.dart test/providers/sync_keep_awake_provider_test.dart`
- `fvm flutter analyze`
- merge-tree preflight against the current `origin/main` completed without conflicts