### PR TITLE
Update mobile sync keep-awake copy

### DIFF
--- a/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
+++ b/lib/src/core/widgets/mobile/sync_keep_awake_privacy_lock_host.dart
@@ -373,8 +373,8 @@ class _SyncKeepAwakeStatusScreen extends ConsumerWidget {
       SyncKeepAwakePrivacyLockMode.done => const _SyncKeepAwakeStatusLockup(
         iconName: AppIcons.checkCircle,
         iconKey: ValueKey('sync_keep_awake_privacy_done_check'),
-        title: 'Synced',
-        body: 'Synced successfully.\nYou can unlock Vizor.',
+        title: 'Sync Complete',
+        body: 'Unlock Vizor to continue',
         success: true,
       ),
       SyncKeepAwakePrivacyLockMode.interrupted =>
@@ -703,8 +703,7 @@ class _SyncKeepAwakePasscodeConfirmScreen extends ConsumerWidget {
       SyncKeepAwakePrivacyLockMode.interrupted =>
         'Sync paused. Unlock Vizor to continue.',
       SyncKeepAwakePrivacyLockMode.hidden ||
-      SyncKeepAwakePrivacyLockMode.syncing =>
-        'Vizor is syncing, stick around ...',
+      SyncKeepAwakePrivacyLockMode.syncing => 'Unlock to continue',
     };
   }
 }
@@ -829,7 +828,7 @@ class _SyncKeepAwakeProgressLockup extends StatelessWidget {
                   child: SizedBox(
                     width: SyncKeepAwakePrivacyLockScreen._bodyWidth,
                     child: Text(
-                      'Vizor is syncing,\nstick around ...',
+                      'Vizor is syncing',
                       textAlign: TextAlign.center,
                       style: AppTypography.bodyMediumStrong.copyWith(
                         color: colors.text.primary,

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -247,7 +247,7 @@ class _SyncKeepAwakePromptSheet extends StatelessWidget {
 
     return MobileModalScaffold(
       key: const ValueKey('mobile_sync_keep_awake_prompt_sheet'),
-      title: 'Keep screen awake during sync?',
+      title: 'Stay awake to sync?',
       onClose: onMaybeLater,
       bodyGap: AppSpacing.xxs,
       bottomPadding: AppSpacing.base,
@@ -256,7 +256,8 @@ class _SyncKeepAwakePromptSheet extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Text(
-            'This will make long syncs much easier.',
+            'Your phone pauses syncing when screen is off. This allows sync '
+            'to finish faster.',
             style: AppTypography.bodyMedium.copyWith(
               color: colors.text.secondary,
             ),
@@ -266,18 +267,17 @@ class _SyncKeepAwakePromptSheet extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               _SyncKeepAwakePromptBullet(
-                iconName: AppIcons.cog,
-                text: 'You can turn it on and off in settings anytime.',
-                textStyle: bodyStyle.copyWith(fontWeight: FontWeight.w500),
+                iconName: AppIcons.lock,
+                text:
+                    'The app locks after 1 minute of inactivity. Syncing '
+                    'continues behind the lock.',
+                textStyle: bodyStyle,
               ),
               const SizedBox(height: AppSpacing.xs),
               _SyncKeepAwakePromptBullet(
-                iconName: AppIcons.lock,
-                text:
-                    'After 1 minute of inactivity, the screen will be locked '
-                    'with the passcode while syncing continues in the '
-                    'background.',
-                textStyle: bodyStyle,
+                iconName: AppIcons.cog,
+                text: 'You can change this anytime in the Settings.',
+                textStyle: bodyStyle.copyWith(fontWeight: FontWeight.w500),
               ),
             ],
           ),

--- a/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
+++ b/lib/src/features/settings/screens/mobile/mobile_settings_screen.dart
@@ -501,9 +501,8 @@ class _SyncKeepAwakeSettingsCard extends StatelessWidget {
   final VoidCallback onToggle;
 
   static const _description =
-      'Keep the screen active while Vizor is syncing. This will make long '
-      'syncs easier. For security, the screen will lock with passcode after '
-      '1 minute of inactivity.';
+      'Prevents your phone from sleeping so sync can finish faster. The app '
+      'still locks after 1 minute of inactivity.';
 
   @override
   Widget build(BuildContext context) {

--- a/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
+++ b/test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart
@@ -102,7 +102,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 60));
     await tester.pump();
 
-    expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+    expect(find.text('Vizor is syncing'), findsOneWidget);
     expect(find.text('25%'), findsOneWidget);
     expect(find.text('Unlock Vizor'), findsOneWidget);
   });
@@ -127,7 +127,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 80));
     await tester.pump();
 
-    expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
+    expect(find.text('Vizor is syncing'), findsNothing);
   });
 
   testWidgets('recent interaction delays the privacy screen', (tester) async {
@@ -147,12 +147,12 @@ void main() {
     await tester.pump(const Duration(milliseconds: 30));
     await tester.pump();
 
-    expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
+    expect(find.text('Vizor is syncing'), findsNothing);
 
     await tester.pump(const Duration(milliseconds: 30));
     await tester.pump();
 
-    expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+    expect(find.text('Vizor is syncing'), findsOneWidget);
   });
 
   testWidgets(
@@ -174,17 +174,17 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(minutes: 5));
 
-      expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
+      expect(find.text('Vizor is syncing'), findsNothing);
 
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
       await tester.pump();
 
-      expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
+      expect(find.text('Vizor is syncing'), findsNothing);
 
       await tester.pump(const Duration(milliseconds: 60));
       await tester.pump();
 
-      expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+      expect(find.text('Vizor is syncing'), findsOneWidget);
     },
   );
 
@@ -203,14 +203,14 @@ void main() {
     await tester.pump(const Duration(milliseconds: 60));
     await tester.pump();
 
-    expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+    expect(find.text('Vizor is syncing'), findsOneWidget);
 
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
     await tester.pump(const Duration(minutes: 5));
     tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
     await tester.pump();
 
-    expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+    expect(find.text('Vizor is syncing'), findsOneWidget);
   });
 
   testWidgets('passcode confirmation clears the virtual privacy lock', (
@@ -248,7 +248,7 @@ void main() {
 
     expect(find.text('Welcome Back'), findsOneWidget);
     expect(find.text('25% Syncing...'), findsOneWidget);
-    expect(find.text('Vizor is syncing, stick around ...'), findsOneWidget);
+    expect(find.text('Unlock to continue'), findsOneWidget);
     expect(find.byType(PasscodeNumpad), findsOneWidget);
     expect(find.bySemanticsLabel('Passcode help'), findsNothing);
     expect(container.read(syncKeepAwakePrivacyLockProvider).isLocked, isTrue);
@@ -501,7 +501,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 60));
     await tester.pump();
 
-    expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+    expect(find.text('Vizor is syncing'), findsOneWidget);
 
     syncNotifier.emit(
       _sync(
@@ -520,12 +520,9 @@ void main() {
       container.read(syncKeepAwakePrivacyLockModeProvider),
       SyncKeepAwakePrivacyLockMode.done,
     );
-    expect(find.text('Vizor is syncing,\nstick around ...'), findsNothing);
-    expect(find.text('Synced'), findsOneWidget);
-    expect(
-      find.text('Synced successfully.\nYou can unlock Vizor.'),
-      findsOneWidget,
-    );
+    expect(find.text('Vizor is syncing'), findsNothing);
+    expect(find.text('Sync Complete'), findsOneWidget);
+    expect(find.text('Unlock Vizor to continue'), findsOneWidget);
     expect(find.text('Unlock Vizor'), findsOneWidget);
   });
 
@@ -565,7 +562,7 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.text('Synced'), findsOneWidget);
+    expect(find.text('Sync Complete'), findsOneWidget);
 
     syncNotifier.emit(
       _sync(
@@ -583,9 +580,9 @@ void main() {
       container.read(syncKeepAwakePrivacyLockModeProvider),
       SyncKeepAwakePrivacyLockMode.syncing,
     );
-    expect(find.text('Synced'), findsNothing);
+    expect(find.text('Sync Complete'), findsNothing);
     expect(find.text('0%'), findsOneWidget);
-    expect(find.text('Vizor is syncing,\nstick around ...'), findsOneWidget);
+    expect(find.text('Vizor is syncing'), findsOneWidget);
 
     syncNotifier.emit(
       _sync(
@@ -603,7 +600,7 @@ void main() {
       container.read(syncKeepAwakePrivacyLockModeProvider),
       SyncKeepAwakePrivacyLockMode.done,
     );
-    expect(find.text('Synced'), findsOneWidget);
+    expect(find.text('Sync Complete'), findsOneWidget);
     expect(find.text('Unlock Vizor'), findsOneWidget);
   });
 
@@ -649,11 +646,8 @@ void main() {
         container.read(syncKeepAwakePrivacyLockModeProvider),
         SyncKeepAwakePrivacyLockMode.interrupted,
       );
-      expect(find.text('Synced'), findsNothing);
-      expect(
-        find.text('Synced successfully.\nYou can unlock Vizor.'),
-        findsNothing,
-      );
+      expect(find.text('Sync Complete'), findsNothing);
+      expect(find.text('Unlock Vizor to continue'), findsNothing);
       expect(find.text('Sync paused'), findsOneWidget);
       expect(find.text('Unlock Vizor to continue.'), findsOneWidget);
       expect(find.text('Unlock Vizor'), findsOneWidget);
@@ -684,7 +678,7 @@ void main() {
     final checkRect = tester.getRect(
       find.byKey(const ValueKey('sync_keep_awake_privacy_done_check')),
     );
-    final titleRect = tester.getRect(find.text('Synced'));
+    final titleRect = tester.getRect(find.text('Sync Complete'));
     final buttonRect = tester.getRect(
       find.byKey(const ValueKey('sync_keep_awake_privacy_unlock_button')),
     );

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -20,6 +20,7 @@ import 'package:zcash_wallet/src/features/swap/providers/pay_selected_asset_stor
 import 'package:zcash_wallet/src/features/swap/providers/swap_state_provider.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/privacy_mode_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_keep_awake_provider.dart';
 import 'package:zcash_wallet/src/providers/sync_provider.dart';
 import 'package:zcash_wallet/src/providers/zec_price_change_provider.dart';
 import 'package:zcash_wallet/src/rust/api/sync.dart' as rust_sync;
@@ -76,6 +77,17 @@ class _FakePaySelectedAssetStore implements PaySelectedAssetStore {
   }) async {}
 }
 
+class _FakeSyncKeepAwakeNotifier extends SyncKeepAwakeNotifier {
+  @override
+  SyncKeepAwakeSettings build() =>
+      const SyncKeepAwakeSettings(enabled: false, promptSeen: false);
+
+  @override
+  Future<void> markPromptSeen() async {
+    state = state.copyWith(promptSeen: true);
+  }
+}
+
 TextStyle _effectiveTextStyle(WidgetTester tester, Finder finder) {
   final text = tester.widget<Text>(finder);
   final defaultStyle = DefaultTextStyle.of(tester.element(finder)).style;
@@ -115,6 +127,7 @@ Widget _app(
     change24hPct: 13.12,
   ),
   FakeSyncNotifier? syncNotifier,
+  SyncKeepAwakeNotifier? syncKeepAwakeNotifier,
   bool? swapEnabled,
   PayIntroductionBadgeStore? badgeStore,
 }) {
@@ -147,6 +160,8 @@ Widget _app(
     overrides: [
       appBootstrapProvider.overrideWithValue(_bootstrap()),
       syncProvider.overrideWith(() => effectiveSyncNotifier),
+      if (syncKeepAwakeNotifier != null)
+        syncKeepAwakeProvider.overrideWith(() => syncKeepAwakeNotifier),
       privacyModeProvider.overrideWith(_FakePrivacyModeNotifier.new),
       zecMarketDataSourceProvider.overrideWithValue(
         _FakeMarketDataSource(marketData),
@@ -202,6 +217,58 @@ rust_sync.TransactionInfo _tx(int index) {
 }
 
 void main() {
+  testWidgets('shows the Figma sync keep-awake prompt copy', (tester) async {
+    await tester.binding.setSurfaceSize(const Size(393, 852));
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    await tester.pumpWidget(
+      _app(
+        SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          isSyncing: true,
+          percentage: 0.25,
+          displayPercentage: 0.25,
+          scannedHeight: 50,
+          chainTipHeight: 200,
+          lastSyncStartedAt: DateTime.now().subtract(
+            const Duration(minutes: 2),
+          ),
+        ),
+        syncKeepAwakeNotifier: _FakeSyncKeepAwakeNotifier(),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    const lockCopy =
+        'The app locks after 1 minute of inactivity. Syncing continues behind '
+        'the lock.';
+    const settingsCopy = 'You can change this anytime in the Settings.';
+    expect(find.text('Stay awake to sync?'), findsOneWidget);
+    expect(
+      find.text(
+        'Your phone pauses syncing when screen is off. This allows sync to '
+        'finish faster.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text(lockCopy), findsOneWidget);
+    expect(find.text(settingsCopy), findsOneWidget);
+    expect(
+      tester.getTopLeft(find.text(lockCopy)).dy,
+      lessThan(tester.getTopLeft(find.text(settingsCopy)).dy),
+    );
+    expect(find.text('Keep screen awake'), findsOneWidget);
+    expect(find.text('Maybe later'), findsOneWidget);
+
+    await tester.tap(find.text('Maybe later'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+  });
+
   testWidgets('shows the importing state before account data exists', (
     tester,
   ) async {

--- a/test/features/settings/mobile_settings_screen_test.dart
+++ b/test/features/settings/mobile_settings_screen_test.dart
@@ -193,7 +193,10 @@ void main() {
       findsOneWidget,
     );
     expect(
-      find.textContaining('Keep the screen active while Vizor is syncing'),
+      find.text(
+        'Prevents your phone from sleeping so sync can finish faster. The app '
+        'still locks after 1 minute of inactivity.',
+      ),
       findsOneWidget,
     );
     // The About entry stays hidden until the legal documents are ready.


### PR DESCRIPTION
## Summary

- align the mobile keep-awake prompt and Settings description with the latest text QA
- update syncing, completion, and passcode copy while preserving the canonical `Vizor` spelling
- add prompt copy/order coverage and update the existing privacy-lock and Settings widget tests

## User impact

The keep-awake flow now explains screen sleep, the one-minute privacy lock, and unlock states using the reviewed Figma copy.

## Validation

- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/home/mobile_home_screen_test.dart test/features/settings/mobile_settings_screen_test.dart test/core/widgets/sync_keep_awake_privacy_lock_host_test.dart` (50 tests passed)
- `fvm flutter analyze`