### PR TITLE
Fix Pay asset details and error presentation (VZR-121, VZR-122)

### DIFF
--- a/lib/src/features/pay/widgets/pay_amount_step.dart
+++ b/lib/src/features/pay/widgets/pay_amount_step.dart
@@ -338,8 +338,6 @@ class PayAmountStep extends StatelessWidget {
             Text(
               quoteError,
               key: const ValueKey('pay_amount_error'),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
               textAlign: TextAlign.center,
               style: AppTypography.bodySmall.copyWith(
                 color: colors.text.destructive,
@@ -418,7 +416,7 @@ class _PayAssetSelector extends StatelessWidget {
             ),
             const SizedBox(width: AppSpacing.xxs),
             AppIcon(
-              AppIcons.doubleArrowVertical,
+              AppIcons.expand,
               size: 16,
               color: colors.icon.regular,
             ),

--- a/lib/src/features/pay/widgets/pay_recipient_step.dart
+++ b/lib/src/features/pay/widgets/pay_recipient_step.dart
@@ -10,6 +10,7 @@ import '../../address_book/models/address_book_contact.dart';
 import '../../address_book/models/address_book_label_lookup.dart';
 import '../../swap/models/swap_address_formatting.dart';
 import '../models/pay_recent_recipients.dart';
+import 'pay_wizard_page.dart';
 
 /// Step 2 "Select Recipient" of the desktop pay wizard — Figma 6241:85245
 /// plus the 2B1/2B2/2B3 field states (85845 / 104834 / 86376).
@@ -265,16 +266,19 @@ class PayRecipientActions extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         if (quoteError != null) ...[
-          SizedBox(
-            width: PayWizardActionMetrics.width,
-            child: Text(
-              quoteError!,
-              key: const ValueKey('pay_recipient_quote_error'),
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              textAlign: TextAlign.center,
-              style: AppTypography.bodySmall.copyWith(
-                color: context.colors.text.destructive,
+          ConstrainedBox(
+            constraints: const BoxConstraints(
+              maxWidth: PayWizardPage.innerWidth,
+            ),
+            child: SizedBox(
+              width: double.infinity,
+              child: Text(
+                quoteError!,
+                key: const ValueKey('pay_recipient_quote_error'),
+                textAlign: TextAlign.center,
+                style: AppTypography.bodySmall.copyWith(
+                  color: context.colors.text.destructive,
+                ),
               ),
             ),
           ),

--- a/lib/src/features/swap/providers/swap_failure_policy.dart
+++ b/lib/src/features/swap/providers/swap_failure_policy.dart
@@ -11,6 +11,8 @@ enum SwapFailureOperation {
   sendZecDeposit,
 }
 
+enum SwapFailureSurface { swap, pay }
+
 enum SwapFailureCategory {
   unsupportedAsset,
   amountTooLow,
@@ -28,9 +30,13 @@ enum SwapFailureCategory {
   unknown,
 }
 
-String swapFailureMessage(SwapFailureOperation operation, Object error) {
+String swapFailureMessage(
+  SwapFailureOperation operation,
+  Object error, {
+  SwapFailureSurface surface = SwapFailureSurface.swap,
+}) {
   final category = swapFailureCategory(operation, error);
-  return _messageFor(operation, category);
+  return _messageFor(operation, category, surface);
 }
 
 SwapFailureCategory swapFailureCategory(
@@ -107,11 +113,14 @@ SwapFailureCategory _oneClickCategory(
 String _messageFor(
   SwapFailureOperation operation,
   SwapFailureCategory category,
+  SwapFailureSurface surface,
 ) {
   return switch (category) {
     SwapFailureCategory.unsupportedAsset => _unsupportedAssetMessage(operation),
     SwapFailureCategory.amountTooLow =>
-      'Amount is too low for this swap.\nTry a larger amount.',
+      surface == SwapFailureSurface.pay
+          ? 'Amount is too low for this payment.\nTry a larger amount.'
+          : 'Amount is too low for this swap.\nTry a larger amount.',
     SwapFailureCategory.amountPrecision =>
       'Amount has too many decimal places.\nUse fewer decimals and try again.',
     SwapFailureCategory.invalidRouteOrAddress =>

--- a/lib/src/features/swap/providers/swap_state_provider.dart
+++ b/lib/src/features/swap/providers/swap_state_provider.dart
@@ -1973,7 +1973,11 @@ class SwapNotifier extends Notifier<SwapState> {
     if (error is SwapZecStagingAddressUnavailableException) {
       return error.toString();
     }
-    return swapFailureMessage(SwapFailureOperation.quote, error);
+    return swapFailureMessage(
+      SwapFailureOperation.quote,
+      error,
+      surface: state.payMode ? SwapFailureSurface.pay : SwapFailureSurface.swap,
+    );
   }
 
   Future<SwapIntentSnapshot> _submitProviderDepositTransaction(

--- a/lib/src/features/swap/widgets/pay_activity_status_content.dart
+++ b/lib/src/features/swap/widgets/pay_activity_status_content.dart
@@ -94,7 +94,7 @@ class PayActivityStatusContent extends StatelessWidget {
               leading: SwapAssetIcon(
                 asset: amountAsset,
                 size: 32,
-                showChainBadge: false,
+                showChainBadge: true,
               ),
               bottomLeftText: amountFiatText,
             ),

--- a/lib/widgetbook/pay_use_cases.dart
+++ b/lib/widgetbook/pay_use_cases.dart
@@ -27,6 +27,9 @@ import '../src/features/swap/widgets/swap_asset_selector_modal.dart';
 const _previewWindowSize = Size(1080, 720);
 const _contactAddress = '0x52908400098527886E0F7030069857D2E4169EE7';
 const _newRecipientAddress = '0x1234567890123456789012345678901234567890';
+const _recipientQuoteError =
+    'This route or address was rejected.\n'
+    'Edit the details and request a new quote.';
 
 Widget buildPayAmountUseCase(BuildContext context) {
   return const _PayDesktopFrame(child: _PayAmountPreview());
@@ -39,6 +42,15 @@ Widget buildPayRecipientUseCase(BuildContext context) {
 Widget buildPayRecipientNewAddressUseCase(BuildContext context) {
   return const _PayDesktopFrame(
     child: _PayRecipientPreview(initialAddress: _newRecipientAddress),
+  );
+}
+
+Widget buildPayRecipientQuoteErrorUseCase(BuildContext context) {
+  return const _PayDesktopFrame(
+    child: _PayRecipientPreview(
+      initialAddress: _newRecipientAddress,
+      quoteError: _recipientQuoteError,
+    ),
   );
 }
 
@@ -169,9 +181,10 @@ class _PayAmountPreviewState extends State<_PayAmountPreview> {
 }
 
 class _PayRecipientPreview extends StatefulWidget {
-  const _PayRecipientPreview({this.initialAddress = ''});
+  const _PayRecipientPreview({this.initialAddress = '', this.quoteError});
 
   final String initialAddress;
+  final String? quoteError;
 
   @override
   State<_PayRecipientPreview> createState() => _PayRecipientPreviewState();
@@ -214,7 +227,7 @@ class _PayRecipientPreviewState extends State<_PayRecipientPreview> {
       addressError: issue,
       contacts: _previewContacts,
       busy: false,
-      quoteError: null,
+      quoteError: widget.quoteError,
       onSelectRecipient: () {},
       onAddToContacts: () {},
     );

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -510,6 +510,10 @@ class WidgetbookApp extends StatelessWidget {
                       builder: buildPayRecipientNewAddressUseCase,
                     ),
                     WidgetbookUseCase(
+                      name: 'Recipient quote error',
+                      builder: buildPayRecipientQuoteErrorUseCase,
+                    ),
+                    WidgetbookUseCase(
                       name: 'Review quote',
                       builder: buildPayReviewUseCase,
                     ),

--- a/test/features/pay/pay_wizard_steps_test.dart
+++ b/test/features/pay/pay_wizard_steps_test.dart
@@ -11,6 +11,7 @@ import 'package:zcash_wallet/src/features/pay/widgets/pay_add_contact_modal.dart
 import 'package:zcash_wallet/src/features/pay/widgets/pay_amount_step.dart';
 import 'package:zcash_wallet/src/features/pay/widgets/pay_recipient_step.dart';
 import 'package:zcash_wallet/src/features/pay/widgets/pay_review_step.dart';
+import 'package:zcash_wallet/src/features/pay/widgets/pay_wizard_page.dart';
 import 'package:zcash_wallet/src/features/pay/widgets/pay_wizard_stepper.dart';
 import 'package:zcash_wallet/src/features/swap/models/swap_models.dart';
 
@@ -352,6 +353,27 @@ void main() {
             ?.fontSize,
         AppTypography.displayLarge.fontSize,
       );
+      final assetSelector = find.byKey(const ValueKey('pay_asset_selector'));
+      expect(
+        find.descendant(
+          of: assetSelector,
+          matching: find.byWidgetPredicate(
+            (widget) => widget is AppIcon && widget.name == AppIcons.expand,
+          ),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: assetSelector,
+          matching: find.byWidgetPredicate(
+            (widget) =>
+                widget is AppIcon &&
+                widget.name == AppIcons.doubleArrowVertical,
+          ),
+        ),
+        findsNothing,
+      );
     });
 
     testWidgets('uses the fixed-width action and shared validation contract', (
@@ -379,6 +401,37 @@ void main() {
         find.byKey(const ValueKey('pay_amount_continue_button')),
       );
       expect(continued, isTrue);
+    });
+
+    testWidgets('long quote errors wrap without ellipsis', (tester) async {
+      final controller = TextEditingController(text: '25');
+      final focusNode = FocusNode();
+      addTearDown(controller.dispose);
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        _harness(
+          PayAmountStep(
+            state: _amountState.copyWith(
+              quoteError:
+                  'This route or address was rejected.\n'
+                  'Edit the details and request a new quote.',
+            ),
+            controller: controller,
+            focusNode: focusNode,
+            onAmountChanged: (_) {},
+            onFiatAmountChanged: (_) {},
+            onToggleFiatInputMode: () {},
+            onOpenAssetSelector: () {},
+          ),
+        ),
+      );
+
+      final error = tester.widget<Text>(
+        find.byKey(const ValueKey('pay_amount_error')),
+      );
+      expect(error.maxLines, isNull);
+      expect(error.overflow, isNull);
     });
   });
 
@@ -665,6 +718,29 @@ void main() {
         find.byKey(const ValueKey('pay_select_recipient_button')),
         findsOneWidget,
       );
+    });
+
+    testWidgets('long quote errors use the content width and wrap fully', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _harness(
+          _recipientStep(
+            typedAddress: _unknownAddress,
+            quoteError:
+                'This route or address was rejected.\n'
+                'Edit the details and request a new quote.',
+          ),
+        ),
+      );
+
+      final errorFinder = find.byKey(
+        const ValueKey('pay_recipient_quote_error'),
+      );
+      final error = tester.widget<Text>(errorFinder);
+      expect(tester.getSize(errorFinder).width, PayWizardPage.innerWidth);
+      expect(error.maxLines, isNull);
+      expect(error.overflow, isNull);
     });
 
     testWidgets('unsupported asset disables recipient review with an error', (

--- a/test/features/swap/support/swap_screen_test_fakes.dart
+++ b/test/features/swap/support/swap_screen_test_fakes.dart
@@ -462,6 +462,18 @@ class _FailingQuoteSwapProvider extends _FakeSwapProvider {
   }
 }
 
+class _LowAmountQuoteSwapProvider extends _FakeSwapProvider {
+  @override
+  Future<SwapQuote> quote(SwapQuoteRequest request) async {
+    requests.add(request);
+    throw const OneClickApiException(
+      'NEAR Intents quote failed (400): amount is too low',
+      statusCode: 400,
+      providerMessage: 'Amount is too low for bridge',
+    );
+  }
+}
+
 class _DeferredStatusSwapProvider extends _FakeSwapProvider {
   _DeferredStatusSwapProvider(this.snapshot);
 

--- a/test/features/swap/swap_failure_policy_test.dart
+++ b/test/features/swap/swap_failure_policy_test.dart
@@ -53,6 +53,24 @@ void main() {
     );
   });
 
+  test('pay quote amount minimum failures use payment copy', () {
+    const error = OneClickApiException(
+      'NEAR Intents quote failed (400): '
+      '{"message":"Amount is too low for bridge, try at least 74256"}',
+      statusCode: 400,
+      providerMessage: 'Amount is too low for bridge, try at least 74256',
+    );
+
+    expect(
+      swapFailureMessage(
+        SwapFailureOperation.quote,
+        error,
+        surface: SwapFailureSurface.pay,
+      ),
+      'Amount is too low for this payment.\nTry a larger amount.',
+    );
+  });
+
   test('no quotes found failures follow the low amount guidance', () {
     const error = OneClickApiException(
       'NEAR Intents quote failed (400): {"message":"No quotes found"}',

--- a/test/features/swap/swap_screen_test.dart
+++ b/test/features/swap/swap_screen_test.dart
@@ -1529,7 +1529,7 @@ void main() {
           matching: find.byType(SwapAssetIcon),
         ),
       );
-      expect(amountAssetIcon.showChainBadge, isFalse);
+      expect(amountAssetIcon.showChainBadge, isTrue);
       expect(find.text('New address'), findsOneWidget);
       expect(find.text('0x529084...e4169ee7'), findsOneWidget);
       expect(find.text('In progress'), findsOneWidget);
@@ -7248,6 +7248,40 @@ void main() {
     );
     expect(_fieldText(tester, 'swap_amount_field'), '1.5');
     expect(_destinationSummaryText(tester), '0x529084...169ee7');
+  });
+
+  testWidgets('pay quote failure uses payment-specific copy', (tester) async {
+    await _setDesktopViewport(tester);
+
+    await tester.pumpWidget(
+      _routerHarness(
+        GoRouter(initialLocation: '/pay', routes: [_payRoute()]),
+        swapProvider: _LowAmountQuoteSwapProvider(),
+        seedSwapActivityFixtures: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+      find.byKey(const ValueKey('pay_amount_input')),
+      '25',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pay_amount_continue_button')));
+    await tester.pumpAndSettle();
+    await tester.enterText(
+      find.byKey(const ValueKey('pay_recipient_search_field')),
+      '0x52908400098527886e0f7030069857d2e4169ee7',
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('pay_select_recipient_button')));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('Amount is too low for this payment.\nTry a larger amount.'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('this swap'), findsNothing);
   });
 
   testWidgets('start failure stays on review and shows an inline error', (

--- a/test/widgetbook/pay_use_cases_test.dart
+++ b/test/widgetbook/pay_use_cases_test.dart
@@ -66,6 +66,26 @@ void main() {
     expect(find.text('Select recipient'), findsOneWidget);
   });
 
+  testWidgets('Pay quote-error use case renders the full provider message', (
+    tester,
+  ) async {
+    await _pumpPayUseCase(tester, buildPayRecipientQuoteErrorUseCase);
+
+    expect(tester.takeException(), isNull);
+    expect(
+      find.text(
+        'This route or address was rejected.\n'
+        'Edit the details and request a new quote.',
+      ),
+      findsOneWidget,
+    );
+    final error = tester.widget<Text>(
+      find.byKey(const ValueKey('pay_recipient_quote_error')),
+    );
+    expect(error.maxLines, isNull);
+    expect(error.overflow, isNull);
+  });
+
   testWidgets('Pay review use case renders a live quote and confirm action', (
     tester,
   ) async {


### PR DESCRIPTION
## Problem

- [VZR-121](https://linear.app/keplrwallet/issue/VZR-121/show-destination-network-in-transaction-detail-page): the desktop Pay transaction detail showed the payout coin icon without its destination-network badge.
- [VZR-122](https://linear.app/keplrwallet/issue/VZR-122/update-currency-selection-icon-to-vertical-style): the desktop Pay currency selector used the amount/fiat toggle icon instead of the vertical selection icon.
- Pay quote failures reused swap-specific copy such as “Amount is too low for this swap.”
- Longer route/address errors were constrained to the CTA width and truncated with an ellipsis.

## Solution

- Show the chain badge on the Pay transaction-detail asset icon.
- Use the expand/vertical-selection icon in the desktop Pay asset selector while preserving the amount/fiat toggle icon.
- Make low-amount quote copy surface-aware so Pay says “payment” and Swap keeps “swap.”
- Let Pay quote errors wrap fully and use the existing 396px Pay content width.
- Add focused widget, integration, failure-policy, and Widgetbook coverage, including a quote-error preview.

## Validation

- `fvm flutter test test/features/pay/pay_wizard_steps_test.dart test/widgetbook/pay_use_cases_test.dart test/features/swap/swap_failure_policy_test.dart` — 56 passed
- `fvm flutter test test/features/swap/swap_screen_test.dart` — 154 passed
- `fvm flutter test test/features/pay/pay_wizard_steps_test.dart` — 27 passed after review cleanup
- `fvm flutter analyze` — no issues
- macOS Widgetbook visual check: network badge, vertical selector icon, and full error wrapping verified
