### PR TITLE
Add account personalisation to mobile onboarding

### DIFF
--- a/lib/src/core/navigation/mobile_onboarding_routes.dart
+++ b/lib/src/core/navigation/mobile_onboarding_routes.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart' show CupertinoPage;
 import 'package:go_router/go_router.dart';
 
 import '../../features/onboarding/mobile/mobile_biometrics_screen.dart';
+import '../../features/onboarding/mobile/mobile_customise_account_screen.dart';
 import '../../features/onboarding/mobile/mobile_create_steps.dart';
 import '../../features/onboarding/mobile/mobile_import_birthday_screen.dart';
 import '../../features/onboarding/mobile/mobile_import_manual_screen.dart';
@@ -82,6 +83,17 @@ List<RouteBase> mobileOnboardingRoutes() => [
     pageBuilder: (context, state) => CupertinoPage(
       key: state.pageKey,
       child: MobilePasscodeScreen(args: state.extra as SetPasswordScreenArgs),
+    ),
+  ),
+  GoRoute(
+    path: '/onboarding/customise-account',
+    redirect: (_, state) =>
+        state.extra is CustomiseAccountArgs ? null : '/welcome',
+    pageBuilder: (context, state) => CupertinoPage(
+      key: state.pageKey,
+      child: MobileCustomiseAccountScreen(
+        args: state.extra as CustomiseAccountArgs,
+      ),
     ),
   ),
   GoRoute(

--- a/lib/src/features/onboarding/mobile/mobile_customise_account_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_customise_account_screen.dart
@@ -1,0 +1,455 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../main.dart' show log;
+import '../../../core/account_name_policy.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/app_button.dart';
+import '../../../core/widgets/app_icon.dart';
+import '../../../core/widgets/app_profile_picture.dart';
+import '../../../providers/account_provider.dart';
+import '../../../providers/app_security_provider.dart';
+import '../../../providers/router_refresh_provider.dart';
+import '../../../providers/wallet_mutation_guard.dart';
+import '../../accounts/widgets/mobile/account_edit_sheets.dart'
+    show showProfilePictureSheet;
+import '../create/account_persona_generator.dart';
+import '../create/onboarding_split_view.dart'
+    show clearCreateOnboardingSecretState;
+import '../shared/onboarding_error_messages.dart';
+import '../shared/onboarding_flow_args.dart';
+import 'mobile_onboarding_progress.dart';
+import 'mobile_onboarding_scaffold.dart';
+
+typedef MobileCustomiseAccountFinishCallback =
+    Future<void> Function(String accountName, String profilePictureId);
+
+/// Mobile create-account personalisation — Figma light/dark default frames
+/// 6125:117635 / 6132:117807 and keyboard/error frames 6125:117233 /
+/// 6132:117773.
+class MobileCustomiseAccountScreen extends ConsumerStatefulWidget {
+  const MobileCustomiseAccountScreen({
+    required this.args,
+    this.onFinish,
+    this.random,
+    super.key,
+  });
+
+  final CustomiseAccountArgs args;
+
+  /// Preview/test seam. Production routes own account and password mutation.
+  final MobileCustomiseAccountFinishCallback? onFinish;
+
+  /// Optional entropy source for deterministic previews and tests.
+  final Random? random;
+
+  @override
+  ConsumerState<MobileCustomiseAccountScreen> createState() =>
+      _MobileCustomiseAccountScreenState();
+}
+
+enum _SubmitPhase { idle, stoppingSync, creatingWallet }
+
+class _MobileCustomiseAccountScreenState
+    extends ConsumerState<MobileCustomiseAccountScreen> {
+  late final TextEditingController _nameController;
+  final _nameFocusNode = FocusNode();
+  late String _profilePictureId;
+  var _submitPhase = _SubmitPhase.idle;
+  String? _submitError;
+
+  String get _normalizedName => normalizeAccountName(_nameController.text);
+  int get _nameLength => accountNameCharacterLength(_nameController.text);
+  bool get _nameValid => isAccountNameLengthValid(_nameController.text);
+  bool get _isSubmitting => _submitPhase != _SubmitPhase.idle;
+  bool get _canContinue => !_isSubmitting && _nameValid;
+
+  String? get _nameMessage {
+    if (_submitError != null) return _submitError;
+    return _nameLength > kAccountNameMaxCharacters
+        ? kAccountNameLengthMessage
+        : null;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    final suggestion = generateAccountPersona(random: widget.random);
+    _nameController = TextEditingController(text: suggestion.name);
+    _profilePictureId = suggestion.profilePictureId;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _nameFocusNode.dispose();
+    super.dispose();
+  }
+
+  Future<void> _goBack() async {
+    if (_isSubmitting) return;
+    final args = widget.args;
+    final router = GoRouter.maybeOf(context);
+    if (args.configuresPassword) {
+      if (router != null) {
+        router.go(
+          '/onboarding/set-passcode',
+          extra: SetPasswordScreenArgs.create(mnemonic: args.mnemonic),
+        );
+      } else {
+        await Navigator.of(context).maybePop();
+      }
+      return;
+    }
+    final popped = await Navigator.of(context).maybePop();
+    if (!popped && mounted && router != null) {
+      router.go(
+        '/onboarding/secret-passphrase',
+        extra: CreateSecretPassphraseArgs(mnemonic: args.mnemonic),
+      );
+    }
+  }
+
+  void _handleNameChanged(String _) {
+    setState(() => _submitError = null);
+  }
+
+  Future<void> _pickProfilePicture() async {
+    if (_isSubmitting) return;
+    _nameFocusNode.unfocus();
+    final selected = await showProfilePictureSheet(
+      context,
+      selectedId: _profilePictureId,
+    );
+    if (selected != null && mounted) {
+      setState(() => _profilePictureId = selected);
+    }
+  }
+
+  Future<void> _submit() async {
+    if (!_canContinue) return;
+    _nameFocusNode.unfocus();
+    setState(() {
+      _submitPhase = _SubmitPhase.creatingWallet;
+      _submitError = null;
+    });
+
+    try {
+      final onFinish = widget.onFinish;
+      if (onFinish != null) {
+        await onFinish(_normalizedName, _profilePictureId);
+        if (mounted) setState(() => _submitPhase = _SubmitPhase.idle);
+        return;
+      }
+      await _finishSetup();
+    } catch (e, st) {
+      log('MobileCustomiseAccount._submit: ERROR: $e\n$st');
+      if (!mounted) return;
+      setState(() {
+        _submitPhase = _SubmitPhase.idle;
+        _submitError = onboardingSubmitErrorMessage(e);
+      });
+    }
+  }
+
+  Future<void> _finishSetup() async {
+    final args = widget.args;
+    final router = GoRouter.of(context);
+    final accountNotifier = ref.read(accountProvider.notifier);
+
+    Future<void> createAccount() => runWithSyncPausedForAccountMutation(
+      ref,
+      () => accountNotifier.createAccountFromMnemonic(
+        mnemonic: args.mnemonic,
+        name: _normalizedName,
+        profilePictureId: _profilePictureId,
+      ),
+      onStoppingSync: () {
+        if (mounted) {
+          setState(() => _submitPhase = _SubmitPhase.stoppingSync);
+        }
+      },
+      onSyncPaused: () {
+        if (mounted) {
+          setState(() => _submitPhase = _SubmitPhase.creatingWallet);
+        }
+      },
+    );
+
+    final pendingPassword = args.pendingPassword;
+    if (pendingPassword == null) {
+      await createAccount();
+      clearCreateOnboardingSecretState(ref.read);
+      router.go('/home');
+      return;
+    }
+
+    final securityNotifier = ref.read(appSecurityProvider.notifier);
+    final routerRefresh = ref.read(routerRefreshProvider);
+    var passwordPrepared = false;
+    var passwordCommitted = false;
+    try {
+      await routerRefresh.pauseWhile(() async {
+        await securityNotifier.preparePasswordSetup(pendingPassword);
+        passwordPrepared = true;
+        await createAccount();
+        securityNotifier.commitPasswordSetup();
+        passwordCommitted = true;
+        clearCreateOnboardingSecretState(ref.read);
+        router.go('/onboarding/biometrics');
+      });
+    } catch (_) {
+      if (passwordPrepared && !passwordCommitted) {
+        try {
+          await securityNotifier.rollbackPasswordSetup();
+        } catch (rollbackError, rollbackStack) {
+          log(
+            'MobileCustomiseAccount._finishSetup: password rollback failed: '
+            '$rollbackError\n$rollbackStack',
+          );
+        }
+      }
+      rethrow;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MobileOnboardingStepScaffold(
+      progress: mobileCreateProgress(8),
+      onBack: _isSubmitting ? null : _goBack,
+      title: 'Customise Account',
+      subtitle:
+          'Add personality to your account by setting an account name and '
+          'choosing a profile picture.',
+      bottomArea: AppButton(
+        key: const ValueKey('mobile_customise_account_continue'),
+        expand: true,
+        constrainContent: true,
+        onPressed: _canContinue ? _submit : null,
+        trailing: const AppIcon(AppIcons.chevronForward),
+        child: Text(switch (_submitPhase) {
+          _SubmitPhase.idle => 'Continue',
+          _SubmitPhase.stoppingSync => 'Stop syncing...',
+          _SubmitPhase.creatingWallet => 'Creating wallet...',
+        }),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(height: AppSpacing.xs),
+          _AccountProfileCard(
+            nameController: _nameController,
+            nameFocusNode: _nameFocusNode,
+            profilePictureId: _profilePictureId,
+            message: _nameMessage,
+            enabled: !_isSubmitting,
+            onNameChanged: _handleNameChanged,
+            onEditProfilePicture: _pickProfilePicture,
+            onSubmitted: _submit,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AccountProfileCard extends StatelessWidget {
+  const _AccountProfileCard({
+    required this.nameController,
+    required this.nameFocusNode,
+    required this.profilePictureId,
+    required this.message,
+    required this.enabled,
+    required this.onNameChanged,
+    required this.onEditProfilePicture,
+    required this.onSubmitted,
+  });
+
+  final TextEditingController nameController;
+  final FocusNode nameFocusNode;
+  final String profilePictureId;
+  final String? message;
+  final bool enabled;
+  final ValueChanged<String> onNameChanged;
+  final VoidCallback onEditProfilePicture;
+  final Future<void> Function() onSubmitted;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final cardTextColor = colors.text.homeCard;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Container(
+          key: const ValueKey('mobile_customise_account_card'),
+          height: 123,
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.md),
+          decoration: BoxDecoration(
+            color: colors.background.homeCard,
+            borderRadius: BorderRadius.circular(AppRadii.xLarge),
+          ),
+          child: Row(
+            children: [
+              _EditableProfilePicture(
+                profilePictureId: profilePictureId,
+                enabled: enabled,
+                onPressed: onEditProfilePicture,
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Account name',
+                      style: AppTypography.labelLarge.copyWith(
+                        color: cardTextColor.withValues(alpha: 0.5),
+                        fontWeight: FontWeight.w400,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    SizedBox(
+                      height: 30,
+                      child: TextField(
+                        key: const ValueKey(
+                          'mobile_customise_account_name_field',
+                        ),
+                        controller: nameController,
+                        focusNode: nameFocusNode,
+                        enabled: enabled,
+                        maxLines: 1,
+                        textInputAction: TextInputAction.done,
+                        style: AppTypography.headlineSmall.copyWith(
+                          color: cardTextColor,
+                        ),
+                        cursorColor: cardTextColor,
+                        cursorWidth: 2,
+                        cursorHeight: 22,
+                        cursorRadius: const Radius.circular(AppRadii.full),
+                        decoration: const InputDecoration(
+                          border: InputBorder.none,
+                          enabledBorder: InputBorder.none,
+                          focusedBorder: InputBorder.none,
+                          disabledBorder: InputBorder.none,
+                          contentPadding: EdgeInsets.zero,
+                          isDense: true,
+                        ),
+                        onChanged: onNameChanged,
+                        onSubmitted: (_) => onSubmitted(),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (message != null) ...[
+          const SizedBox(height: AppSpacing.sm),
+          Text(
+            message!,
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: AppTypography.bodyMediumStrong.copyWith(
+              color: colors.text.destructive,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _EditableProfilePicture extends StatelessWidget {
+  const _EditableProfilePicture({
+    required this.profilePictureId,
+    required this.enabled,
+    required this.onPressed,
+  });
+
+  final String profilePictureId;
+  final bool enabled;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    return Semantics(
+      button: true,
+      enabled: enabled,
+      label: 'Change profile picture',
+      child: GestureDetector(
+        key: const ValueKey('mobile_customise_account_avatar_button'),
+        behavior: HitTestBehavior.opaque,
+        onTap: enabled ? onPressed : null,
+        child: SizedBox(
+          width: 56,
+          height: 56,
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              AppProfilePicture(
+                profilePictureId: profilePictureId,
+                size: AppProfilePictureSize.xLarge,
+              ),
+              Positioned(
+                right: -6,
+                bottom: -6,
+                child: Container(
+                  key: const ValueKey('mobile_customise_account_edit_badge'),
+                  width: 28,
+                  height: 28,
+                  decoration: BoxDecoration(
+                    color: colors.text.homeCard,
+                    shape: BoxShape.circle,
+                    border: Border.all(
+                      color: colors.background.homeCard,
+                      width: 3,
+                    ),
+                  ),
+                  child: Center(
+                    child: _CustomiseAccountEditGlyph(
+                      color: colors.background.homeCard,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CustomiseAccountEditGlyph extends StatelessWidget {
+  const _CustomiseAccountEditGlyph({required this.color});
+
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    // Keep the dark-variant 20px edit frame, but leave more breathing room
+    // around this icon asset because its filled bounds read larger on-device.
+    return SizedBox(
+      key: const ValueKey('mobile_customise_account_edit_glyph_frame'),
+      width: 20,
+      height: 20,
+      child: Center(
+        child: AppIcon(
+          key: const ValueKey('mobile_customise_account_edit_glyph'),
+          AppIcons.editFilled,
+          size: 12,
+          color: color,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/onboarding/mobile/mobile_onboarding_progress.dart
+++ b/lib/src/features/onboarding/mobile/mobile_onboarding_progress.dart
@@ -1,9 +1,10 @@
 /// Create-flow step ordering for the steps-nav progress track:
 /// welcome -> method selection -> intro -> address types -> things to know ->
-/// secret passphrase -> passcode. Welcome itself does not show the track, but
-/// the following steps still count it so create progress starts after the
-/// user has already passed the first screen.
-const kMobileCreateStepCount = 7;
+/// secret passphrase -> passcode -> customise account. Welcome itself does not
+/// show the track, but the following steps still count it so create progress
+/// starts after the user has already passed the first screen. Biometrics is a
+/// terminal completion screen and keeps its full progress value.
+const kMobileCreateStepCount = 8;
 
 /// Import-flow step ordering:
 /// secret passphrase entry (paste or manual) -> review -> birthday -> passcode.

--- a/lib/src/features/onboarding/mobile/mobile_passcode_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_passcode_screen.dart
@@ -207,6 +207,7 @@ class _MobilePasscodeScreenState extends ConsumerState<MobilePasscodeScreen> {
     final colors = context.colors;
     final isConfirm = _phase == _PasscodePhase.confirm;
     final isSubmitting = _phase == _PasscodePhase.submitting;
+    final canNavigateBack = Navigator.of(context).canPop();
     final subtitle = isSubmitting
         ? 'Setting up your wallet...'
         : isConfirm
@@ -224,7 +225,8 @@ class _MobilePasscodeScreenState extends ConsumerState<MobilePasscodeScreen> {
           children: [
             MobileTopNav.steps(
               progress: _progressForFlow(widget.args.flow),
-              onBack: isSubmitting
+              showBackButton: canNavigateBack,
+              onBack: isSubmitting || !canNavigateBack
                   ? null
                   : () => Navigator.of(context).maybePop(),
             ),

--- a/lib/src/features/onboarding/mobile/mobile_passcode_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_passcode_screen.dart
@@ -15,8 +15,6 @@ import '../../../providers/router_refresh_provider.dart';
 import '../../../providers/wallet_mutation_guard.dart';
 import '../../address_book/providers/address_book_provider.dart';
 import '../../wallet_link/services/wallet_link_completion.dart';
-import '../create/onboarding_split_view.dart'
-    show clearCreateOnboardingSecretState;
 import '../keystone/keystone_onboarding_flow.dart'
     show keystoneOnboardingProvider;
 import '../shared/onboarding_error_messages.dart';
@@ -34,10 +32,9 @@ enum _PasscodePhase { create, confirm, submitting }
 /// Mobile passcode setup — Figma `Passcode 1` / `Passcode Confirm`
 /// (4394:82593 / 4394:82944). Two-phase entry (create → confirm); a
 /// mismatch restarts from the create phase, iOS-style. On a match the
-/// six-digit string is committed as the wallet password and the wallet
-/// is created/imported with exactly the desktop set-password sequence
-/// (prepare → account mutation under the sync pause → commit, with
-/// rollback on failure).
+/// six-digit string is forwarded to account customisation for create flows.
+/// Import flows still use the desktop set-password sequence (prepare → account
+/// mutation under the sync pause → commit, with rollback on failure).
 class MobilePasscodeScreen extends ConsumerStatefulWidget {
   const MobilePasscodeScreen({required this.args, super.key});
 
@@ -96,8 +93,9 @@ class _MobilePasscodeScreenState extends ConsumerState<MobilePasscodeScreen> {
     }
   }
 
-  /// Mirrors `SetPasswordScreen._submit` — same prepare/commit/rollback
-  /// sequence, same flow branches; only the credential UI differs.
+  /// Create continues to account customisation without persisting the pending
+  /// passcode. Import flows retain the prepare/commit/rollback sequence from
+  /// `SetPasswordScreen._submit`.
   Future<void> _submit(String passcode) async {
     final args = widget.args;
     setState(() {
@@ -106,6 +104,17 @@ class _MobilePasscodeScreenState extends ConsumerState<MobilePasscodeScreen> {
     });
 
     final router = GoRouter.of(context);
+    if (args.flow == SetPasswordFlow.create) {
+      router.go(
+        '/onboarding/customise-account',
+        extra: CustomiseAccountArgs(
+          mnemonic: args.requiredMnemonic,
+          pendingPassword: passcode,
+        ),
+      );
+      return;
+    }
+
     final securityNotifier = ref.read(appSecurityProvider.notifier);
     final accountNotifier = ref.read(accountProvider.notifier);
     final routerRefresh = ref.read(routerRefreshProvider);
@@ -122,8 +131,8 @@ class _MobilePasscodeScreenState extends ConsumerState<MobilePasscodeScreen> {
         await runWithSyncPausedForAccountMutation(ref, () async {
           switch (args.flow) {
             case SetPasswordFlow.create:
-              await accountNotifier.createAccountFromMnemonic(
-                mnemonic: args.requiredMnemonic,
+              throw StateError(
+                'Create flow must continue through account customisation.',
               );
             case SetPasswordFlow.importWallet:
               await accountNotifier.importAccount(
@@ -155,9 +164,6 @@ class _MobilePasscodeScreenState extends ConsumerState<MobilePasscodeScreen> {
         passwordCommitted = true;
         if (args.flow == SetPasswordFlow.importKeystone) {
           ref.read(keystoneOnboardingProvider.notifier).resetScan();
-        }
-        if (args.flow == SetPasswordFlow.create) {
-          clearCreateOnboardingSecretState(ref.read);
         }
         if (args.flow == SetPasswordFlow.importWalletLink) {
           final accountImportResult = walletLinkAccountImportResult;

--- a/lib/src/features/onboarding/mobile/mobile_secret_passphrase_screen.dart
+++ b/lib/src/features/onboarding/mobile/mobile_secret_passphrase_screen.dart
@@ -13,13 +13,10 @@ import '../../../core/privacy/sensitive_privacy_overlay.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_button.dart';
 import '../../../core/widgets/app_icon.dart';
-import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
-import '../../../providers/wallet_mutation_guard.dart';
 import '../../../rust/api/wallet.dart' as rust_wallet;
 import '../create/onboarding_split_view.dart'
     show
-        clearCreateOnboardingSecretState,
         createOnboardingMnemonicProvider,
         onboardingSecretPassphraseRevealedProvider;
 import '../shared/onboarding_error_messages.dart';
@@ -33,9 +30,9 @@ import 'seed_card.dart';
 /// Mobile create-flow passphrase step — Figma `Onboarding 4 Secret
 /// Phrase` (4394:81938 hidden / 4394:82007 revealed). Mirrors the
 /// desktop screen's logic: the mnemonic survives back navigation via
-/// [createOnboardingMnemonicProvider]; continue either pushes the
-/// passcode step (first wallet) or creates the account directly when a
-/// password is already configured (add-account).
+/// [createOnboardingMnemonicProvider]; continue either pushes the passcode
+/// step (first wallet) or account customisation when a password is already
+/// configured (add-account).
 class MobileSecretPassphraseScreen extends ConsumerStatefulWidget {
   const MobileSecretPassphraseScreen({
     this.args,
@@ -63,7 +60,6 @@ class _MobileSecretPassphraseScreenState
   String? _mnemonic;
   bool _revealed = false;
   bool _copied = false;
-  bool _submitting = false;
   String? _error;
   Timer? _copyResetTimer;
   StreamSubscription<void>? _screenshotSub;
@@ -132,7 +128,7 @@ class _MobileSecretPassphraseScreenState
 
   Future<void> _continue() async {
     final mnemonic = _mnemonic;
-    if (mnemonic == null || _submitting) return;
+    if (mnemonic == null) return;
     if (!_revealed) {
       unawaited(AppHaptics.privacyToggle());
       setState(() => _revealed = true);
@@ -151,32 +147,10 @@ class _MobileSecretPassphraseScreenState
       return;
     }
 
-    // Add-account path: a passcode already guards the wallet, so the
-    // account is created right here.
-    setState(() {
-      _submitting = true;
-      _error = null;
-    });
-    final router = GoRouter.of(context);
-    final accountNotifier = ref.read(accountProvider.notifier);
-    try {
-      await runWithSyncPausedForAccountMutation(
-        ref,
-        () => accountNotifier.createAccountFromMnemonic(mnemonic: mnemonic),
-      );
-    } catch (e, st) {
-      log('MobileSecretPassphrase: ERROR creating account: $e\n$st');
-      if (!mounted) return;
-      setState(() {
-        _submitting = false;
-        _error = onboardingSubmitErrorMessage(e);
-      });
-      return;
-    }
-    if (mounted) {
-      clearCreateOnboardingSecretState(ref.read);
-    }
-    router.go('/home');
+    context.push(
+      '/onboarding/customise-account',
+      extra: CustomiseAccountArgs(mnemonic: mnemonic),
+    );
   }
 
   Future<void> _onScreenshot() async {
@@ -211,7 +185,7 @@ class _MobileSecretPassphraseScreenState
       controller: _privacyController,
       child: MobileOnboardingStepScaffold(
         progress: mobileCreateProgress(6),
-        onBack: _submitting ? null : () => Navigator.of(context).maybePop(),
+        onBack: () => Navigator.of(context).maybePop(),
         title: 'Secret Passphrase',
         subtitle: 'The Master Key to your wallet.',
         bottomArea: Column(
@@ -231,15 +205,9 @@ class _MobileSecretPassphraseScreenState
             AppButton(
               key: const ValueKey('mobile_secret_passphrase_primary'),
               expand: true,
-              onPressed: _error != null || _submitting ? null : _continue,
+              onPressed: _error != null ? null : _continue,
               trailing: const AppIcon(AppIcons.chevronForward),
-              child: Text(
-                _submitting
-                    ? 'Creating wallet...'
-                    : _revealed
-                    ? 'Continue'
-                    : 'Reveal phrase',
-              ),
+              child: Text(_revealed ? 'Continue' : 'Reveal phrase'),
             ),
           ],
         ),

--- a/lib/src/features/onboarding/shared/onboarding_flow_args.dart
+++ b/lib/src/features/onboarding/shared/onboarding_flow_args.dart
@@ -9,7 +9,7 @@ class CreateSecretPassphraseArgs {
   final String mnemonic;
 }
 
-/// Ephemeral create-wallet draft passed to the final desktop onboarding step.
+/// Ephemeral create-wallet draft passed to the account-personalisation step.
 ///
 /// [pendingPassword] is present only for the first wallet, before password
 /// setup has been persisted. It stays in route memory and is intentionally not

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -40,6 +40,7 @@ import '../src/features/migration/widgets/mobile/mobile_ironwood_migration_annou
 import '../src/features/onboarding/lost_password_screen.dart';
 import '../src/features/onboarding/mobile/forgot_passcode_sheet.dart';
 import '../src/features/onboarding/mobile/mobile_biometrics_screen.dart';
+import '../src/features/onboarding/mobile/mobile_customise_account_screen.dart';
 import '../src/features/onboarding/mobile/mobile_import_manual_screen.dart';
 import '../src/features/onboarding/mobile/mobile_import_review_screen.dart';
 import '../src/features/onboarding/mobile/mobile_import_screens.dart';
@@ -211,6 +212,19 @@ Widget buildMobileCreatePasscodeUseCase(BuildContext context) {
       child: MobilePasscodeScreen(
         args: SetPasswordScreenArgs.create(mnemonic: _previewMnemonic),
       ),
+    ),
+  );
+}
+
+Widget buildMobileCustomiseAccountUseCase(BuildContext context) {
+  return _MobilePreviewFrame(
+    child: MobileCustomiseAccountScreen(
+      args: const CustomiseAccountArgs(
+        mnemonic: _previewMnemonic,
+        pendingPassword: '123456',
+      ),
+      random: Random(1234),
+      onFinish: (_, _) async {},
     ),
   );
 }

--- a/lib/widgetbook/widgetbook_app.dart
+++ b/lib/widgetbook/widgetbook_app.dart
@@ -97,6 +97,15 @@ class WidgetbookApp extends StatelessWidget {
                   ],
                 ),
                 WidgetbookComponent(
+                  name: 'Mobile customise account',
+                  useCases: [
+                    WidgetbookUseCase(
+                      name: 'Default',
+                      builder: buildMobileCustomiseAccountUseCase,
+                    ),
+                  ],
+                ),
+                WidgetbookComponent(
                   name: 'Unlock',
                   useCases: [
                     WidgetbookUseCase(

--- a/test/features/onboarding/mobile_customise_account_screen_test.dart
+++ b/test/features/onboarding/mobile_customise_account_screen_test.dart
@@ -1,0 +1,374 @@
+@Tags(['mobile'])
+library;
+
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:zcash_wallet/src/core/theme/app_theme.dart';
+import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_customise_account_screen.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_onboarding_progress.dart';
+import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args.dart';
+import 'package:zcash_wallet/src/providers/account_provider.dart';
+import 'package:zcash_wallet/src/providers/app_security_provider.dart';
+import 'package:zcash_wallet/src/providers/sync_provider.dart';
+
+const _mnemonic = 'stub mnemonic words';
+
+void main() {
+  setUp(() {
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    binding.platformDispatcher.views.first
+      ..physicalSize = const Size(393, 852)
+      ..devicePixelRatio = 1.0;
+  });
+
+  testWidgets('keeps its random persona stable and uses the eighth progress', (
+    tester,
+  ) async {
+    final random = _SequenceRandom([0, 1, 2, 3]);
+    String? submittedName;
+    String? submittedProfilePictureId;
+
+    await tester.pumpWidget(
+      _harness(
+        MobileCustomiseAccountScreen(
+          args: const CustomiseAccountArgs(mnemonic: _mnemonic),
+          random: random,
+          onFinish: (name, profilePictureId) async {
+            submittedName = name;
+            submittedProfilePictureId = profilePictureId;
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Customise Account'), findsOneWidget);
+    expect(find.text('Veiled Wardbearer'), findsOneWidget);
+    expect(_stepsProgress(tester), closeTo(mobileCreateProgress(8), 0.0001));
+    expect(random.nextIntCallCount, 3);
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('mobile_customise_account_card')),
+      ),
+      const Size(361, 123),
+    );
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('mobile_customise_account_edit_badge')),
+      ),
+      const Size(28, 28),
+    );
+    expect(
+      tester.getTopLeft(
+            find.byKey(const ValueKey('mobile_customise_account_edit_badge')),
+          ) -
+          tester.getTopLeft(
+            find.byKey(
+              const ValueKey('mobile_customise_account_avatar_button'),
+            ),
+          ),
+      const Offset(34, 34),
+    );
+    expect(
+      tester.getSize(
+        find.byKey(const ValueKey('mobile_customise_account_edit_glyph_frame')),
+      ),
+      const Size(20, 20),
+    );
+    final editGlyph = tester.widget<AppIcon>(
+      find.byKey(const ValueKey('mobile_customise_account_edit_glyph')),
+    );
+    expect(editGlyph.size, 12);
+
+    await tester.binding.setSurfaceSize(const Size(430, 932));
+    await tester.pump();
+    expect(find.text('Veiled Wardbearer'), findsOneWidget);
+    expect(random.nextIntCallCount, 3);
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_customise_account_continue')),
+    );
+    await tester.pump();
+    expect(submittedName, 'Veiled Wardbearer');
+    expect(submittedProfilePictureId, 'pfp-03');
+  });
+
+  testWidgets('uses the shared account name validation', (tester) async {
+    var submitCount = 0;
+    await tester.pumpWidget(
+      _harness(
+        MobileCustomiseAccountScreen(
+          args: const CustomiseAccountArgs(mnemonic: _mnemonic),
+          onFinish: (_, _) async => submitCount += 1,
+        ),
+      ),
+    );
+
+    final field = find.byKey(
+      const ValueKey('mobile_customise_account_name_field'),
+    );
+    await tester.enterText(field, '   ');
+    await tester.pump();
+    expect(_continueButton(tester).onPressed, isNull);
+
+    await tester.enterText(field, '123456789012345678901');
+    await tester.pump();
+    expect(find.text('Name can be up to 20 characters.'), findsOneWidget);
+    expect(_continueButton(tester).onPressed, isNull);
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_customise_account_continue')),
+    );
+    await tester.pump();
+    expect(submitCount, 0);
+  });
+
+  testWidgets('uses the existing mobile profile picture picker', (
+    tester,
+  ) async {
+    String? submittedProfilePictureId;
+    await tester.pumpWidget(
+      _harness(
+        MobileCustomiseAccountScreen(
+          args: const CustomiseAccountArgs(mnemonic: _mnemonic),
+          onFinish: (_, profilePictureId) async {
+            submittedProfilePictureId = profilePictureId;
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_customise_account_avatar_button')),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Select profile picture'), findsOneWidget);
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_account_pfp_option_pfp-02')),
+    );
+    await tester.tap(find.byKey(const ValueKey('mobile_account_pfp_update')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_customise_account_continue')),
+    );
+    await tester.pump();
+    expect(submittedProfilePictureId, 'pfp-02');
+  });
+
+  testWidgets('back is safe in the router-free Widgetbook preview', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _harness(
+        const MobileCustomiseAccountScreen(
+          args: CustomiseAccountArgs(
+            mnemonic: _mnemonic,
+            pendingPassword: '123456',
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.bySemanticsLabel('Back'));
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Customise Account'), findsOneWidget);
+  });
+
+  testWidgets('creates the initial account with the selected persona', (
+    tester,
+  ) async {
+    final accountNotifier = _RecordingAccountNotifier();
+    final securityNotifier = _RecordingSecurityNotifier();
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => MobileCustomiseAccountScreen(
+            args: const CustomiseAccountArgs(
+              mnemonic: _mnemonic,
+              pendingPassword: '123456',
+            ),
+            random: _SequenceRandom([0, 1, 2]),
+          ),
+        ),
+        GoRoute(
+          path: '/onboarding/biometrics',
+          builder: (_, _) => const Text('biometrics route'),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          accountProvider.overrideWith(() => accountNotifier),
+          appSecurityProvider.overrideWith(() => securityNotifier),
+          syncProvider.overrideWith(_NoopSyncNotifier.new),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, c) => AppTheme(data: AppThemeData.dark, child: c!),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.enterText(
+      find.byKey(const ValueKey('mobile_customise_account_name_field')),
+      '  Gentle Warden  ',
+    );
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_customise_account_continue')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(securityNotifier.preparedPassword, '123456');
+    expect(securityNotifier.committed, isTrue);
+    expect(accountNotifier.createdMnemonic, _mnemonic);
+    expect(accountNotifier.createdName, 'Gentle Warden');
+    expect(accountNotifier.createdProfilePictureId, 'pfp-03');
+    expect(find.text('biometrics route'), findsOneWidget);
+  });
+
+  testWidgets('creates an additional account without reconfiguring security', (
+    tester,
+  ) async {
+    final accountNotifier = _RecordingAccountNotifier();
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => MobileCustomiseAccountScreen(
+            args: const CustomiseAccountArgs(mnemonic: _mnemonic),
+            random: _SequenceRandom([0, 1, 2]),
+          ),
+        ),
+        GoRoute(path: '/home', builder: (_, _) => const Text('home route')),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          accountProvider.overrideWith(() => accountNotifier),
+          syncProvider.overrideWith(_NoopSyncNotifier.new),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, c) => AppTheme(data: AppThemeData.dark, child: c!),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_customise_account_continue')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(accountNotifier.createdMnemonic, _mnemonic);
+    expect(accountNotifier.createdName, 'Veiled Wardbearer');
+    expect(accountNotifier.createdProfilePictureId, 'pfp-03');
+    expect(find.text('home route'), findsOneWidget);
+  });
+}
+
+double _stepsProgress(WidgetTester tester) {
+  final fill = tester.widget<FractionallySizedBox>(
+    find.byType(FractionallySizedBox).first,
+  );
+  return fill.widthFactor!;
+}
+
+AppButton _continueButton(WidgetTester tester) => tester.widget<AppButton>(
+  find.byKey(const ValueKey('mobile_customise_account_continue')),
+);
+
+Widget _harness(Widget child) {
+  return ProviderScope(
+    child: MaterialApp(
+      builder: (_, c) => AppTheme(data: AppThemeData.dark, child: c!),
+      home: child,
+    ),
+  );
+}
+
+class _SequenceRandom implements Random {
+  _SequenceRandom(this._values);
+
+  final List<int> _values;
+  var _index = 0;
+
+  int get nextIntCallCount => _index;
+
+  @override
+  bool nextBool() => nextInt(2) == 0;
+
+  @override
+  double nextDouble() => nextInt(1 << 26) / (1 << 26);
+
+  @override
+  int nextInt(int max) {
+    final value = _values[_index++ % _values.length];
+    return value % max;
+  }
+}
+
+class _RecordingAccountNotifier extends AccountNotifier {
+  String? createdMnemonic;
+  String? createdName;
+  String? createdProfilePictureId;
+
+  @override
+  FutureOr<AccountState> build() => const AccountState();
+
+  @override
+  Future<void> createAccountFromMnemonic({
+    required String mnemonic,
+    String? name,
+    String profilePictureId = 'pfp-01',
+  }) async {
+    createdMnemonic = mnemonic;
+    createdName = name;
+    createdProfilePictureId = profilePictureId;
+  }
+}
+
+class _RecordingSecurityNotifier extends AppSecurityNotifier {
+  String? preparedPassword;
+  var committed = false;
+
+  @override
+  AppSecurityState build() =>
+      const AppSecurityState(isPasswordConfigured: false, isUnlocked: true);
+
+  @override
+  Future<void> preparePasswordSetup(String password) async {
+    preparedPassword = password;
+  }
+
+  @override
+  void commitPasswordSetup() {
+    committed = true;
+  }
+
+  @override
+  Future<void> rollbackPasswordSetup() async {}
+}
+
+class _NoopSyncNotifier extends SyncNotifier {
+  @override
+  Future<SyncState> build() async => SyncState();
+
+  @override
+  bool needsPauseForWalletMutation() => false;
+}

--- a/test/features/onboarding/mobile_customise_account_screen_test.dart
+++ b/test/features/onboarding/mobile_customise_account_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:zcash_wallet/src/core/widgets/app_button.dart';
 import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_customise_account_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_onboarding_progress.dart';
+import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_passcode_screen.dart';
 import 'package:zcash_wallet/src/features/onboarding/shared/onboarding_flow_args.dart';
 import 'package:zcash_wallet/src/providers/account_provider.dart';
 import 'package:zcash_wallet/src/providers/app_security_provider.dart';
@@ -183,6 +184,44 @@ void main() {
 
     expect(tester.takeException(), isNull);
     expect(find.text('Customise Account'), findsOneWidget);
+  });
+
+  testWidgets('returning to passcode does not reopen the phrase back stack', (
+    tester,
+  ) async {
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => const MobileCustomiseAccountScreen(
+            args: CustomiseAccountArgs(
+              mnemonic: _mnemonic,
+              pendingPassword: '123456',
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/onboarding/set-passcode',
+          builder: (_, state) =>
+              MobilePasscodeScreen(args: state.extra! as SetPasswordScreenArgs),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (_, c) => AppTheme(data: AppThemeData.dark, child: c!),
+        ),
+      ),
+    );
+
+    await tester.tap(find.bySemanticsLabel('Back'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Create Passcode'), findsOneWidget);
+    expect(find.bySemanticsLabel('Back'), findsNothing);
   });
 
   testWidgets('creates the initial account with the selected persona', (

--- a/test/features/onboarding/mobile_onboarding_progress_test.dart
+++ b/test/features/onboarding/mobile_onboarding_progress_test.dart
@@ -6,10 +6,11 @@ import 'package:zcash_wallet/src/features/onboarding/mobile/mobile_onboarding_pr
 
 void main() {
   test('create progress includes welcome before method selection', () {
-    expect(kMobileCreateStepCount, 7);
-    expect(mobileCreateProgress(1), closeTo(0.125, 0.0001));
-    expect(mobileCreateProgress(2), closeTo(0.25, 0.0001));
-    expect(mobileCreateProgress(7), closeTo(0.875, 0.0001));
+    expect(kMobileCreateStepCount, 8);
+    expect(mobileCreateProgress(1), closeTo(1 / 9, 0.0001));
+    expect(mobileCreateProgress(2), closeTo(2 / 9, 0.0001));
+    expect(mobileCreateProgress(7), closeTo(7 / 9, 0.0001));
+    expect(mobileCreateProgress(8), closeTo(8 / 9, 0.0001));
   });
 
   test('import progress includes the review step', () {

--- a/test/features/onboarding/mobile_passcode_screen_test.dart
+++ b/test/features/onboarding/mobile_passcode_screen_test.dart
@@ -59,6 +59,34 @@ Widget _importApp({required _RecordingAccountNotifier accountNotifier}) {
   );
 }
 
+Widget _createRouterApp({required _RecordingAccountNotifier accountNotifier}) {
+  final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (_, _) => const MobilePasscodeScreen(
+          args: SetPasswordScreenArgs.create(mnemonic: 'stub mnemonic words'),
+        ),
+      ),
+      GoRoute(
+        path: '/onboarding/customise-account',
+        builder: (_, state) {
+          final args = state.extra! as CustomiseAccountArgs;
+          return Text('customise ${args.mnemonic} ${args.pendingPassword}');
+        },
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: [accountProvider.overrideWith(() => accountNotifier)],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, c) => AppTheme(data: AppThemeData.light, child: c!),
+    ),
+  );
+}
+
 Future<void> _enter(WidgetTester tester, String digits) async {
   for (final d in digits.split('')) {
     await tester.tap(find.bySemanticsLabel('Digit $d'));
@@ -132,6 +160,21 @@ void main() {
     expect(find.text("Passcodes didn't match. Try again."), findsOneWidget);
   });
 
+  testWidgets('create flow forwards the passcode without creating a wallet', (
+    tester,
+  ) async {
+    final accountNotifier = _RecordingAccountNotifier();
+    await tester.pumpWidget(_createRouterApp(accountNotifier: accountNotifier));
+    await tester.pump();
+
+    await _enter(tester, '123456');
+    await _enter(tester, '123456');
+    await tester.pumpAndSettle();
+
+    expect(find.text('customise stub mnemonic words 123456'), findsOneWidget);
+    expect(accountNotifier.createdMnemonic, isNull);
+  });
+
   testWidgets('import flow forwards selected additional ZIP32 accounts', (
     tester,
   ) async {
@@ -152,6 +195,7 @@ void main() {
 }
 
 class _RecordingAccountNotifier extends AccountNotifier {
+  String? createdMnemonic;
   String? importedMnemonic;
   int? importedBirthdayHeight;
   List<int>? importedAdditionalAccountIndices;
@@ -169,6 +213,15 @@ class _RecordingAccountNotifier extends AccountNotifier {
     importedMnemonic = mnemonic;
     importedBirthdayHeight = birthdayHeight;
     importedAdditionalAccountIndices = additionalAccountIndices;
+  }
+
+  @override
+  Future<void> createAccountFromMnemonic({
+    required String mnemonic,
+    String? name,
+    String profilePictureId = 'pfp-01',
+  }) async {
+    createdMnemonic = mnemonic;
   }
 }
 

--- a/test/features/onboarding/mobile_secret_passphrase_screen_test.dart
+++ b/test/features/onboarding/mobile_secret_passphrase_screen_test.dart
@@ -38,6 +38,13 @@ class _UnconfiguredSecurityNotifier extends AppSecurityNotifier {
   }
 }
 
+class _ConfiguredSecurityNotifier extends AppSecurityNotifier {
+  @override
+  AppSecurityState build() {
+    return const AppSecurityState(isPasswordConfigured: true, isUnlocked: true);
+  }
+}
+
 Widget _app(Widget child, {bool seedCreateMnemonic = false}) {
   return ProviderScope(
     overrides: [
@@ -74,6 +81,36 @@ Widget _routerApp(Stream<void> screenshotStream) {
         _TestCreateMnemonicNotifier.new,
       ),
       appSecurityProvider.overrideWith(_UnconfiguredSecurityNotifier.new),
+    ],
+    child: MaterialApp.router(
+      routerConfig: router,
+      builder: (_, c) => AppTheme(data: AppThemeData.light, child: c!),
+    ),
+  );
+}
+
+Widget _additionalAccountRouterApp() {
+  final router = GoRouter(
+    initialLocation: '/secret',
+    routes: [
+      GoRoute(
+        path: '/secret',
+        builder: (_, _) => const MobileSecretPassphraseScreen(
+          args: CreateSecretPassphraseArgs(mnemonic: _mnemonic),
+        ),
+      ),
+      GoRoute(
+        path: '/onboarding/customise-account',
+        builder: (_, state) {
+          final args = state.extra! as CustomiseAccountArgs;
+          return Text('customise ${args.mnemonic}');
+        },
+      ),
+    ],
+  );
+  return ProviderScope(
+    overrides: [
+      appSecurityProvider.overrideWith(_ConfiguredSecurityNotifier.new),
     ],
     child: MaterialApp.router(
       routerConfig: router,
@@ -290,6 +327,18 @@ void main() {
 
     expect(find.byType(MobileSeedScreenshotWarningSheet), findsNothing);
     expect(haptics, ['HapticFeedbackType.mediumImpact']);
+  });
+
+  testWidgets('additional account continues to customisation before creation', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_additionalAccountRouterApp());
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Continue'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('customise $_mnemonic'), findsOneWidget);
   });
 
   testWidgets(


### PR DESCRIPTION
## Problem

Mobile account creation skipped the account-personalisation step. A new wallet or additional account was created before the user could review the random name and profile picture, and the create-flow progress still assumed the previous seven-step sequence.

This PR is stacked on #336 so it can reuse the shared persona generator and account-creation support introduced by the desktop flow.

## Solution

- add the mobile `Customise Account` screen for the Figma light/dark layout
- generate one stable random name and existing profile picture when the screen opens
- keep the name editable with the shared 20-character account-name policy
- reuse the existing mobile profile-picture picker
- defer first-wallet and additional-account creation until the user continues
- persist the selected name and `profilePictureId` on the created account
- carry the pending mobile passcode through customisation before committing password setup
- update create onboarding progress from seven to eight steps
- add a Widgetbook use case and production-path widget tests
- match the dark Figma edit badge geometry while keeping the smaller on-device pencil glyph

## User impact

New and additional mobile accounts now start with a suggested identity that users can accept or edit before creation. The selected name and profile picture become the account's initial metadata.

## Validation

- `fvm flutter analyze`
- focused mobile onboarding tests: 28 passed
- final integration subset on committed HEAD: 23 passed
- first commit independently validated in a detached worktree with analyzer and 9 screen/progress tests
- full mobile lane: 511 passed; the existing `mobile_activity_screen_test.dart` failed only in the parallel lane and passed when rerun alone
- iPhone 17 simulator Widgetbook review in dark mode, including profile badge placement and router-free Back behavior
