### PR TITLE
Fix iOS migration preparation notifications

### DIFF
--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -37,11 +37,20 @@ func migrationPreparationCancellationResult(
   return .needsAction
 }
 
-func migrationPreparationExpirationNeedsForegroundAction(
+func migrationPreparationExpirationRequiresBackgroundRecovery(
   taskExpired: Bool,
-  willRecoverInProcessing: Bool
+  resumeTarget: BackgroundMigrationPreparationResumeTarget
 ) -> Bool {
-  taskExpired && !willRecoverInProcessing
+  guard taskExpired else { return false }
+  return resumeTarget == .continuedProcessing
+    || resumeTarget == .backgroundProcessing
+}
+
+func migrationPreparationExpirationRequiresForegroundContinuation(
+  taskExpired: Bool,
+  resumeTarget: BackgroundMigrationPreparationResumeTarget
+) -> Bool {
+  taskExpired && resumeTarget == .idle
 }
 
 func migrationPreparationPassCompleted(
@@ -49,6 +58,22 @@ func migrationPreparationPassCompleted(
   terminalAfterExpiration: Bool
 ) -> Bool {
   result == .completed || terminalAfterExpiration
+}
+
+func migrationPreparationPassResultAfterHandoff(
+  _ result: BackgroundMigrationPreparationPassResult,
+  handoffScheduled: Bool,
+  interruptionRequested: Bool
+) -> BackgroundMigrationPreparationPassResult {
+  guard case .deferred = result, !handoffScheduled else { return result }
+  if interruptionRequested { return .cancelled }
+  return .needsAction
+}
+
+func migrationPreparationNeedsActionNotificationScope(
+  manifestScope: String?
+) -> String {
+  manifestScope ?? "global"
 }
 
 func shouldPostMigrationPreparationNeedsActionNotification(
@@ -866,14 +891,21 @@ final class BackgroundMigrationPreparationManager {
         BackgroundMigrationManager.shared.schedulePreparationHandoff(
           after: retryDelay
         ) { deferredToProcessing in
-          if !deferredToProcessing {
+          let interruptionRequested =
+            self.preparationHandoffInterruptionRequested
+          if !deferredToProcessing && !interruptionRequested {
             self.postNeedsActionNotification(
               reason: "processing-handoff-failed"
             )
           }
+          let completionResult = migrationPreparationPassResultAfterHandoff(
+            passResult,
+            handoffScheduled: deferredToProcessing,
+            interruptionRequested: interruptionRequested
+          )
           self.finishAuthorizedTask(
             task,
-            passResult: passResult,
+            passResult: completionResult,
             deferredToProcessing: deferredToProcessing
           )
         }
@@ -908,11 +940,12 @@ final class BackgroundMigrationPreparationManager {
         )
       }
     let resumeTarget = preparationResumeTarget()
-    let shouldRecoverInProcessing =
-      didExpire && !handedOff && !quiescedForMutation
-      && !disabledForNotifications
-      && (resumeTarget == .continuedProcessing
-        || resumeTarget == .backgroundProcessing)
+    // BGContinuedProcessingTask uses the same expiration handler for a
+    // system expiration and a person stopping the task in system UI, without
+    // exposing the cause. Never turn expiration into a needs-action alert.
+    // Preserve terminal completion and hand resumable work to the existing
+    // discretionary BGProcessingTask lane so resource expiration does not
+    // strand preparation until the next foreground visit.
     let terminalAfterExpiration =
       passResult == .cancelled && didExpire
       && resumeTarget == .terminal
@@ -920,21 +953,26 @@ final class BackgroundMigrationPreparationManager {
       passResult,
       terminalAfterExpiration: terminalAfterExpiration
     )
-    let expirationNeedsForegroundAction =
+    let expirationRequiresBackgroundRecovery =
       passResult == .cancelled && !handedOff && !quiescedForMutation
       && !disabledForNotifications
-      && resumeTarget != .terminal
-      && migrationPreparationExpirationNeedsForegroundAction(
+      && migrationPreparationExpirationRequiresBackgroundRecovery(
         taskExpired: didExpire,
-        willRecoverInProcessing: shouldRecoverInProcessing
+        resumeTarget: resumeTarget
+      )
+    let expirationRequiresForegroundContinuation =
+      passResult == .cancelled && !handedOff && !quiescedForMutation
+      && !disabledForNotifications
+      && migrationPreparationExpirationRequiresForegroundContinuation(
+        taskExpired: didExpire,
+        resumeTarget: resumeTarget
       )
     let needsForegroundAction =
       migrationPreparationPassNeedsForegroundAction(passResult)
-      || expirationNeedsForegroundAction
-    if expirationNeedsForegroundAction {
-      postNeedsActionNotification(reason: "preparation-expired")
-    }
-    if passCompleted || needsForegroundAction || deferredToProcessing {
+    if passCompleted || needsForegroundAction || deferredToProcessing
+      || expirationRequiresBackgroundRecovery
+      || expirationRequiresForegroundContinuation
+    {
       updateProgress(1000)
     }
     if handedOff {
@@ -943,21 +981,27 @@ final class BackgroundMigrationPreparationManager {
       markForegroundContinuationsReady()
     } else if needsForegroundAction {
       markForegroundContinuationsReady()
+    } else if expirationRequiresForegroundContinuation {
+      markForegroundContinuationsReady()
     }
     stateLock.withPreparationLock {
       taskRunning = false
       taskProgress = nil
       foregroundHandoffRequested = false
     }
-    if shouldRecoverInProcessing {
+    if expirationRequiresBackgroundRecovery {
       BackgroundMigrationManager.shared.schedulePreparationHandoff(after: 60) {
         recoveredInProcessing in
+        if !recoveredInProcessing {
+          self.markForegroundContinuationsReady()
+        }
         self.completeAuthorizedTask(
           task,
           passCompleted: passCompleted,
           needsForegroundAction: needsForegroundAction,
           deferredToProcessing: deferredToProcessing,
           recoveredInProcessing: recoveredInProcessing,
+          expirationFallbackToForeground: !recoveredInProcessing,
           handedOff: handedOff,
           quiescedForMutation: quiescedForMutation,
           disabledForNotifications: disabledForNotifications
@@ -971,6 +1015,8 @@ final class BackgroundMigrationPreparationManager {
       needsForegroundAction: needsForegroundAction,
       deferredToProcessing: deferredToProcessing,
       recoveredInProcessing: false,
+      expirationFallbackToForeground:
+        expirationRequiresForegroundContinuation,
       handedOff: handedOff,
       quiescedForMutation: quiescedForMutation,
       disabledForNotifications: disabledForNotifications
@@ -983,6 +1029,7 @@ final class BackgroundMigrationPreparationManager {
     needsForegroundAction: Bool,
     deferredToProcessing: Bool,
     recoveredInProcessing: Bool,
+    expirationFallbackToForeground: Bool,
     handedOff: Bool,
     quiescedForMutation: Bool,
     disabledForNotifications: Bool
@@ -996,7 +1043,8 @@ final class BackgroundMigrationPreparationManager {
     }
     let success =
       passCompleted || needsForegroundAction
-      || deferredToProcessing || recoveredInProcessing
+      || deferredToProcessing
+      || recoveredInProcessing || expirationFallbackToForeground
       || handedOff || quiescedForMutation || disabledForNotifications
     if success {
       BGTaskScheduler.shared.cancel(
@@ -1015,11 +1063,14 @@ final class BackgroundMigrationPreparationManager {
     } else if needsForegroundAction {
       recordSchedulingState("needs_action")
       cancelWatchdog()
-    } else if deferredToProcessing {
-      recordSchedulingState("handed_off_to_processing")
-      cancelWatchdog()
     } else if recoveredInProcessing {
       recordSchedulingState("expired_handed_off_to_processing")
+      cancelWatchdog()
+    } else if expirationFallbackToForeground {
+      recordSchedulingState("expired_waiting_for_foreground")
+      cancelWatchdog()
+    } else if deferredToProcessing {
+      recordSchedulingState("handed_off_to_processing")
       cancelWatchdog()
     } else {
       recordSchedulingState(success ? "completed" : "failed")
@@ -1420,14 +1471,6 @@ final class BackgroundMigrationPreparationManager {
     }
   }
 
-  private var isExpired: Bool {
-    stateLock.withPreparationLock { expired }
-  }
-
-  private var isForegroundHandoffRequested: Bool {
-    stateLock.withPreparationLock { foregroundHandoffRequested }
-  }
-
   private var preparationCancellationResult: BackgroundMigrationPreparationPassResult {
     stateLock.withPreparationLock {
       migrationPreparationCancellationResult(
@@ -1436,6 +1479,13 @@ final class BackgroundMigrationPreparationManager {
         mutationQuiesced: mutationQuiesced,
         notificationsDisabled: notificationAuthorization.isDisabled
       )
+    }
+  }
+
+  private var preparationHandoffInterruptionRequested: Bool {
+    stateLock.withPreparationLock {
+      expired || foregroundHandoffRequested || mutationQuiesced
+        || notificationAuthorization.isDisabled
     }
   }
 
@@ -1530,10 +1580,14 @@ final class BackgroundMigrationPreparationManager {
     }
     if let manifest {
       guard let scope = Self.preparationScope(for: manifest) else { return }
+      let notificationScope =
+        migrationPreparationNeedsActionNotificationScope(
+          manifestScope: scope
+        )
       postNeedsActionNotification(
-        scope: scope,
+        scope: notificationScope,
         fingerprint: needsActionFingerprint(
-          scope: scope,
+          scope: notificationScope,
           reason: reason,
           progress: progress
         )
@@ -1541,28 +1595,16 @@ final class BackgroundMigrationPreparationManager {
       return
     }
 
-    let manifests =
-      IronwoodMigrationBackgroundCredentialStore.loadAll()?.filter {
-        $0.expectedRunId != nil
-      } ?? []
-    if manifests.isEmpty {
-      postNeedsActionNotification(
-        scope: "global",
-        fingerprint: "global:\(reason)"
+    let notificationScope =
+      migrationPreparationNeedsActionNotificationScope(manifestScope: nil)
+    postNeedsActionNotification(
+      scope: notificationScope,
+      fingerprint: needsActionFingerprint(
+        scope: notificationScope,
+        reason: reason,
+        progress: nil
       )
-      return
-    }
-    for manifest in manifests {
-      guard let scope = Self.preparationScope(for: manifest) else { continue }
-      postNeedsActionNotification(
-        scope: scope,
-        fingerprint: needsActionFingerprint(
-          scope: scope,
-          reason: reason,
-          progress: nil
-        )
-      )
-    }
+    )
   }
 
   private func postNeedsActionNotification(
@@ -1613,13 +1655,22 @@ final class BackgroundMigrationPreparationManager {
   }
 
   private func clearNeedsActionNotification(scope: String) {
-    let identifier = Self.needsActionNotificationIdentifier(scope: scope)
+    let scopes = Set([scope, "global"])
+    stateLock.withPreparationLock {
+      for scope in scopes {
+        needsActionNotificationFingerprints.removeValue(forKey: scope)
+      }
+      persistNeedsActionNotificationFingerprintsLocked()
+    }
+    let identifiers = scopes.map {
+      Self.needsActionNotificationIdentifier(scope: $0)
+    }
     let center = UNUserNotificationCenter.current()
     center.removePendingNotificationRequests(
-      withIdentifiers: [identifier, Self.needsActionIdentifier]
+      withIdentifiers: identifiers + [Self.needsActionIdentifier]
     )
     center.removeDeliveredNotifications(
-      withIdentifiers: [identifier, Self.needsActionIdentifier]
+      withIdentifiers: identifiers + [Self.needsActionIdentifier]
     )
   }
 

--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -23,6 +23,34 @@ func migrationPreparationBackgroundWakeSucceeded(
   result != .cancelled
 }
 
+func migrationPreparationCancellationResult(
+  taskExpired: Bool,
+  foregroundHandoffRequested: Bool,
+  mutationQuiesced: Bool,
+  notificationsDisabled: Bool
+) -> BackgroundMigrationPreparationPassResult {
+  if taskExpired || foregroundHandoffRequested || mutationQuiesced
+    || notificationsDisabled
+  {
+    return .cancelled
+  }
+  return .needsAction
+}
+
+func migrationPreparationExpirationNeedsForegroundAction(
+  taskExpired: Bool,
+  willRecoverInProcessing: Bool
+) -> Bool {
+  taskExpired && !willRecoverInProcessing
+}
+
+func migrationPreparationPassCompleted(
+  _ result: BackgroundMigrationPreparationPassResult,
+  terminalAfterExpiration: Bool
+) -> Bool {
+  result == .completed || terminalAfterExpiration
+}
+
 func shouldPostMigrationPreparationNeedsActionNotification(
   previousFingerprint: String?,
   fingerprint: String
@@ -48,6 +76,7 @@ enum BackgroundMigrationPreparationRuntimeState: String, Equatable {
 
 enum BackgroundMigrationPreparationResumeTarget: Equatable {
   case idle
+  case terminal
   case continuedProcessing
   case backgroundProcessing
 }
@@ -61,6 +90,9 @@ func migrationPreparationResumeTarget(
   }
   if inspectionFailed || states.contains(5) {
     return .backgroundProcessing
+  }
+  if states.isEmpty || states.allSatisfy({ $0 == 4 }) {
+    return .terminal
   }
   return .idle
 }
@@ -98,7 +130,12 @@ func migrationPreparationPassResult(
   states: [UInt8]
 ) -> BackgroundMigrationPreparationPassResult {
   if states.contains(2) { return .needsAction }
-  if states.contains(3) { return .cancelled }
+  // A persisted cancellation is not, by itself, an expected cancellation of
+  // the iOS task. The user must reopen the app to recover the preparation.
+  // Task-originated cancellations (foreground handoff, mutation quiescence,
+  // and notification revocation) are classified at the point where the
+  // manager's runtime state is available.
+  if states.contains(3) { return .needsAction }
   if states.contains(0) {
     return .waitingForConfirmations
   }
@@ -604,7 +641,7 @@ final class BackgroundMigrationPreparationManager {
       mutationQuiesced = false
     }
     switch preparationResumeTarget() {
-    case .idle:
+    case .idle, .terminal:
       BGTaskScheduler.shared.cancel(
         taskRequestWithIdentifier: Self.taskIdentifier
       )
@@ -856,12 +893,6 @@ final class BackgroundMigrationPreparationManager {
     deferredToProcessing: Bool
   ) {
     stopAuthorizationMonitoring()
-    let passCompleted = passResult == .completed
-    let needsForegroundAction =
-      migrationPreparationPassNeedsForegroundAction(passResult)
-    if passCompleted || needsForegroundAction || deferredToProcessing {
-      updateProgress(1000)
-    }
     let (
       handedOff,
       didExpire,
@@ -876,6 +907,36 @@ final class BackgroundMigrationPreparationManager {
           notificationAuthorization.isDisabled
         )
       }
+    let resumeTarget = preparationResumeTarget()
+    let shouldRecoverInProcessing =
+      didExpire && !handedOff && !quiescedForMutation
+      && !disabledForNotifications
+      && (resumeTarget == .continuedProcessing
+        || resumeTarget == .backgroundProcessing)
+    let terminalAfterExpiration =
+      passResult == .cancelled && didExpire
+      && resumeTarget == .terminal
+    let passCompleted = migrationPreparationPassCompleted(
+      passResult,
+      terminalAfterExpiration: terminalAfterExpiration
+    )
+    let expirationNeedsForegroundAction =
+      passResult == .cancelled && !handedOff && !quiescedForMutation
+      && !disabledForNotifications
+      && resumeTarget != .terminal
+      && migrationPreparationExpirationNeedsForegroundAction(
+        taskExpired: didExpire,
+        willRecoverInProcessing: shouldRecoverInProcessing
+      )
+    let needsForegroundAction =
+      migrationPreparationPassNeedsForegroundAction(passResult)
+      || expirationNeedsForegroundAction
+    if expirationNeedsForegroundAction {
+      postNeedsActionNotification(reason: "preparation-expired")
+    }
+    if passCompleted || needsForegroundAction || deferredToProcessing {
+      updateProgress(1000)
+    }
     if handedOff {
       // Publish the continuation before clearing the running flag so a
       // foreground state read cannot observe an idle gap between the two.
@@ -888,10 +949,6 @@ final class BackgroundMigrationPreparationManager {
       taskProgress = nil
       foregroundHandoffRequested = false
     }
-    let shouldRecoverInProcessing =
-      didExpire && !handedOff && !quiescedForMutation
-      && !disabledForNotifications
-      && hasResumablePreparation()
     if shouldRecoverInProcessing {
       BackgroundMigrationManager.shared.schedulePreparationHandoff(after: 60) {
         recoveredInProcessing in
@@ -974,7 +1031,8 @@ final class BackgroundMigrationPreparationManager {
   }
 
   func hasResumablePreparation() -> Bool {
-    preparationResumeTarget() != .idle
+    let target = preparationResumeTarget()
+    return target == .continuedProcessing || target == .backgroundProcessing
   }
 
   private func preparationResumeTarget()
@@ -1152,14 +1210,15 @@ final class BackgroundMigrationPreparationManager {
         )
         return .needsAction
       case 3:
-        if !isExpired && !isForegroundHandoffRequested {
+        let result = preparationCancellationResult
+        if result == .needsAction {
           postNeedsActionNotification(
             reason: "preparation-cancelled",
             manifest: manifest,
             progress: preparation
           )
         }
-        return .cancelled
+        return result
       case 0, 5:
         break
       default:
@@ -1369,6 +1428,17 @@ final class BackgroundMigrationPreparationManager {
     stateLock.withPreparationLock { foregroundHandoffRequested }
   }
 
+  private var preparationCancellationResult: BackgroundMigrationPreparationPassResult {
+    stateLock.withPreparationLock {
+      migrationPreparationCancellationResult(
+        taskExpired: expired,
+        foregroundHandoffRequested: foregroundHandoffRequested,
+        mutationQuiesced: mutationQuiesced,
+        notificationsDisabled: notificationAuthorization.isDisabled
+      )
+    }
+  }
+
   private var isStopRequested: Bool {
     stateLock.withPreparationLock {
       expired || foregroundHandoffRequested
@@ -1513,7 +1583,7 @@ final class BackgroundMigrationPreparationManager {
     guard shouldPost else { return }
 
     let content = UNMutableNotificationContent()
-    content.title = "Continue preparing your migration"
+    content.title = "User action needed"
     content.body = "Open and unlock Vizor to continue."
     content.sound = .default
     addNotificationIfEnabled(

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -337,6 +337,13 @@ class RunnerTests: XCTestCase {
       ),
       .idle
     )
+    XCTAssertEqual(
+      migrationPreparationResumeTarget(
+        states: [4],
+        inspectionFailed: false
+      ),
+      .terminal
+    )
   }
 
   func testMigrationPreparationCompletesOnlyTerminalBackgroundStates() {
@@ -354,7 +361,7 @@ class RunnerTests: XCTestCase {
     )
     XCTAssertEqual(
       migrationPreparationPassResult(states: [3]),
-      .cancelled
+      .needsAction
     )
   }
 
@@ -367,6 +374,66 @@ class RunnerTests: XCTestCase {
     )
     XCTAssertFalse(
       migrationPreparationBackgroundWakeSucceeded(.cancelled)
+    )
+  }
+
+  func testUnexpectedPreparationCancellationNeedsForegroundAction() {
+    XCTAssertEqual(
+      migrationPreparationCancellationResult(
+        taskExpired: false,
+        foregroundHandoffRequested: false,
+        mutationQuiesced: false,
+        notificationsDisabled: false
+      ),
+      .needsAction
+    )
+    XCTAssertEqual(
+      migrationPreparationCancellationResult(
+        taskExpired: false,
+        foregroundHandoffRequested: true,
+        mutationQuiesced: false,
+        notificationsDisabled: false
+      ),
+      .cancelled
+    )
+    XCTAssertEqual(
+      migrationPreparationCancellationResult(
+        taskExpired: true,
+        foregroundHandoffRequested: false,
+        mutationQuiesced: false,
+        notificationsDisabled: false
+      ),
+      .cancelled
+    )
+  }
+
+  func testExpiredPreparationUsesForegroundActionOnlyWithoutRecovery() {
+    XCTAssertTrue(
+      migrationPreparationExpirationNeedsForegroundAction(
+        taskExpired: true,
+        willRecoverInProcessing: false
+      )
+    )
+    XCTAssertFalse(
+      migrationPreparationExpirationNeedsForegroundAction(
+        taskExpired: true,
+        willRecoverInProcessing: true
+      )
+    )
+  }
+
+  func testTerminalPreparationCancellationCompletesExpiredTask() {
+    XCTAssertTrue(
+      migrationPreparationPassCompleted(
+        .cancelled,
+        terminalAfterExpiration: true
+      )
+    )
+    XCTAssertFalse(
+      migrationPreparationPassCompleted(
+        .cancelled,
+        terminalAfterExpiration: false
+      )
     )
   }
 

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -407,18 +407,107 @@ class RunnerTests: XCTestCase {
     )
   }
 
-  func testExpiredPreparationUsesForegroundActionOnlyWithoutRecovery() {
+  func testExpiredPreparationRecoversInBackgroundWithoutNeedsAction() {
     XCTAssertTrue(
-      migrationPreparationExpirationNeedsForegroundAction(
+      migrationPreparationExpirationRequiresBackgroundRecovery(
         taskExpired: true,
-        willRecoverInProcessing: false
+        resumeTarget: .continuedProcessing
+      )
+    )
+    XCTAssertTrue(
+      migrationPreparationExpirationRequiresBackgroundRecovery(
+        taskExpired: true,
+        resumeTarget: .backgroundProcessing
       )
     )
     XCTAssertFalse(
-      migrationPreparationExpirationNeedsForegroundAction(
+      migrationPreparationExpirationRequiresBackgroundRecovery(
         taskExpired: true,
-        willRecoverInProcessing: true
+        resumeTarget: .terminal
       )
+    )
+    XCTAssertFalse(
+      migrationPreparationExpirationRequiresBackgroundRecovery(
+        taskExpired: true,
+        resumeTarget: .idle
+      )
+    )
+    XCTAssertFalse(
+      migrationPreparationExpirationRequiresBackgroundRecovery(
+        taskExpired: false,
+        resumeTarget: .continuedProcessing
+      )
+    )
+    XCTAssertTrue(
+      migrationPreparationExpirationRequiresForegroundContinuation(
+        taskExpired: true,
+        resumeTarget: .idle
+      )
+    )
+    XCTAssertFalse(
+      migrationPreparationExpirationRequiresForegroundContinuation(
+        taskExpired: true,
+        resumeTarget: .continuedProcessing
+      )
+    )
+    XCTAssertFalse(
+      migrationPreparationExpirationRequiresForegroundContinuation(
+        taskExpired: true,
+        resumeTarget: .terminal
+      )
+    )
+    XCTAssertFalse(
+      migrationPreparationPassNeedsForegroundAction(.cancelled)
+    )
+  }
+
+  func testFailedPreparationHandoffRequiresForegroundAction() {
+    XCTAssertEqual(
+      migrationPreparationPassResultAfterHandoff(
+        .deferred(60),
+        handoffScheduled: false,
+        interruptionRequested: false
+      ),
+      .needsAction
+    )
+    XCTAssertEqual(
+      migrationPreparationPassResultAfterHandoff(
+        .deferred(60),
+        handoffScheduled: true,
+        interruptionRequested: false
+      ),
+      .deferred(60)
+    )
+    XCTAssertEqual(
+      migrationPreparationPassResultAfterHandoff(
+        .deferred(60),
+        handoffScheduled: false,
+        interruptionRequested: true
+      ),
+      .cancelled
+    )
+    XCTAssertEqual(
+      migrationPreparationPassResultAfterHandoff(
+        .completed,
+        handoffScheduled: false,
+        interruptionRequested: false
+      ),
+      .completed
+    )
+  }
+
+  func testGlobalPreparationFailureUsesSingleNotificationScope() {
+    XCTAssertEqual(
+      migrationPreparationNeedsActionNotificationScope(
+        manifestScope: nil
+      ),
+      "global"
+    )
+    XCTAssertEqual(
+      migrationPreparationNeedsActionNotificationScope(
+        manifestScope: "main:account-1:run-1"
+      ),
+      "main:account-1:run-1"
     )
   }
 


### PR DESCRIPTION
## Summary

- prevent iOS migration preparation expiration from surfacing both a system task failure and a local completion notification
- use `User action needed` only for genuine failures that require foreground recovery
- route resumable expiration states to background processing and preserve a foreground fallback when scheduling fails
- coalesce global needs-action notifications and clear their persisted fingerprints when acknowledged
- handle expiration, foreground handoff, notification revocation, and mutation quiescence races consistently

## Root cause

`BGContinuedProcessingTask` expiration and deferred handoff failures were treated as foreground-action failures even when work had completed, was resumable elsewhere, or had been intentionally interrupted. This allowed iOS to display `Task failed` while Vizor also reported that the device could continue being used.

## Validation

- `xcrun swiftc -parse ios/Runner/BackgroundMigrationPreparationManager.swift ios/Runner/BackgroundMigrationManager.swift ios/RunnerTests/RunnerTests.swift`
- iOS `RunnerTests`: 70 tests passed, 0 failures
- `git diff --check`