### PR TITLE
Show loader while signing migration batch

### DIFF
--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -718,6 +718,7 @@ class _MigrationProgressPreview extends StatelessWidget {
     this.actionBatchLabel,
     this.actionBatchValue,
     this.onAction,
+    this.actionRunning = false,
     this.onBack,
     this.onPreparationCompleteDone,
   });
@@ -742,6 +743,7 @@ class _MigrationProgressPreview extends StatelessWidget {
   final String? actionBatchLabel;
   final String? actionBatchValue;
   final VoidCallback? onAction;
+  final bool actionRunning;
   final VoidCallback? onBack;
   final VoidCallback? onPreparationCompleteDone;
 
@@ -843,6 +845,7 @@ class _MigrationProgressPreview extends StatelessWidget {
                     batchLabel: actionBatchLabel,
                     batchValue: actionBatchValue,
                     onAction: onAction,
+                    actionRunning: actionRunning,
                   )
                 else
                   _MigrationProgressStatus(
@@ -1420,6 +1423,7 @@ class _MigrationNeedsInputCard extends StatelessWidget {
     this.batchLabel,
     this.batchValue,
     this.onAction,
+    this.actionRunning = false,
   });
 
   final String? message;
@@ -1427,6 +1431,7 @@ class _MigrationNeedsInputCard extends StatelessWidget {
   final String? batchLabel;
   final String? batchValue;
   final VoidCallback? onAction;
+  final bool actionRunning;
 
   @override
   Widget build(BuildContext context) {
@@ -1469,7 +1474,13 @@ class _MigrationNeedsInputCard extends StatelessWidget {
           expand: true,
           constrainContent: true,
           height: 50,
-          onPressed: onAction ?? () {},
+          onPressed: actionRunning ? null : onAction ?? () {},
+          leading: actionRunning
+              ? const AppIcon(
+                  AppIcons.loader,
+                  semanticLabel: 'Migration action in progress',
+                )
+              : null,
           child: FittedBox(
             fit: BoxFit.scaleDown,
             child: Text(actionLabel ?? 'Sign batch #1'),

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -566,6 +566,7 @@ class _MobileMigrationRedesignedStatusState
               widget.status,
               batchProgress.currentBatchParts,
             ),
+      actionRunning: _actionRunning,
       onAction: accountUuid == null || _actionRunning
           ? null
           : () => unawaited(_performRequiredAction(accountUuid)),

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -260,6 +260,28 @@ class _DurablePhaseRetryTestMigrationCoordinator
   }
 }
 
+class _ControlledRetryTestMigrationCoordinator
+    extends IronwoodMigrationCoordinator {
+  final retryStarted = Completer<void>();
+  final retryFinished = Completer<void>();
+  int retryCount = 0;
+
+  @override
+  IronwoodMigrationCoordinatorState build() {
+    return const IronwoodMigrationCoordinatorState();
+  }
+
+  @override
+  Future<void> retry(String accountUuid) async {
+    retryCount++;
+    retryStarted.complete();
+    await retryFinished.future;
+  }
+
+  @override
+  Future<void> refreshNow({bool forceAdvance = false}) async {}
+}
+
 class _RecordingIronwoodMigrationCompletionStore
     implements IronwoodMigrationCompletionStore {
   int markCount = 0;
@@ -3251,6 +3273,52 @@ void main() {
     expect(painter.highlightedSegments, {8, 9});
     expect(painter.visibleSegmentGap, 4);
     expect(tester.getCenter(find.text('2 ZEC (20%)')).dx, greaterThan(250));
+  });
+
+  testWidgets('shows the animated loader while a software batch is signing', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    final coordinator = _ControlledRetryTestMigrationCoordinator();
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(),
+        migrationCoordinator: () => coordinator,
+        status: _status(
+          phase: kIronwoodMigrationReadyToMigratePhase,
+          nextActionHeight: 3_000_000,
+        ),
+        syncState: SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          scannedHeight: 3_000_000,
+          chainTipHeight: 3_000_000,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final signButton = find.byKey(
+      const ValueKey('mobile_ironwood_keystone_batch_sign_button'),
+    );
+    final loader = find.byWidgetPredicate(
+      (widget) => widget is AppIcon && widget.name == AppIcons.loader,
+    );
+    await tester.ensureVisible(signButton);
+    await tester.tap(signButton);
+    await coordinator.retryStarted.future;
+    await tester.pump();
+
+    expect(coordinator.retryCount, 1);
+    expect(loader, findsOneWidget);
+    expect(tester.widget<AppButton>(signButton).onPressed, isNull);
+
+    coordinator.retryFinished.complete();
+    await tester.pumpAndSettle();
+
+    expect(loader, findsNothing);
+    expect(tester.widget<AppButton>(signButton).onPressed, isNotNull);
   });
 
   testWidgets('records a Keystone signing action while status is visible', (


### PR DESCRIPTION
## What changed

- Show the shared animated `AppIcons.loader` while a software migration batch action is running.
- Disable the batch action button until the in-flight action completes, preventing duplicate submissions.
- Restore the normal button state after completion.
- Add a widget test covering loader visibility and button interaction state.

## Why

The `Sign batch` action previously remained visually unchanged while work was in progress, making it unclear whether the tap had been accepted. The button also used an enabled-looking no-op callback during the in-flight state.

## User impact

Users now get immediate animated feedback after tapping `Sign batch`, and duplicate input is blocked until the action finishes.

## Validation

- `fvm flutter analyze` on the changed implementation and test files
- Mobile migration widget test file: 87 tests passed
- `git diff --check`