### PR TITLE
Refine Ironwood migration copy

### DIFF
--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -187,7 +187,7 @@ class _MigrationStatusContentState extends State<_MigrationStatusContent> {
             child: Column(
               children: [
                 Text(
-                  'Migration in Progress',
+                  'Ironwood Migration',
                   style: AppTypography.headlineSmall.copyWith(
                     color: context.colors.text.accent,
                   ),
@@ -307,7 +307,7 @@ class _MigrationPreparingStatusContent extends StatelessWidget {
             child: Column(
               children: [
                 Text(
-                  'Migration in Progress',
+                  'Ironwood Migration',
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   textAlign: TextAlign.center,

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_intro_options.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_intro_options.dart
@@ -212,7 +212,7 @@ class _MobileMigrationOptionsState
             title: 'Private',
             body:
                 'Splits transactions into multiple parts to minimize '
-                'traceability, but takes longer.',
+                'traceability but will take several hours to days.',
             selected: privateSelected,
             icon: _MigrationChoiceIcon.private,
             recommended: true,
@@ -224,7 +224,7 @@ class _MobileMigrationOptionsState
             title: 'Immediate',
             body: widget.immediateEnabled
                 ? 'Migrates your entire balance in one batch. '
-                      'Fast, but less private.'
+                      'Fast (~10 mins) but less private.'
                 : 'Not available with Keystone.',
             selected: immediateSelected,
             icon: _MigrationChoiceIcon.immediate,

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_live_states.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_live_states.dart
@@ -51,7 +51,7 @@ class _MobileMigrationPreparing extends StatelessWidget {
               child: Column(
                 children: [
                   Text(
-                    'Migration in Progress',
+                    'Ironwood Migration',
                     key: const ValueKey(
                       'mobile_ironwood_migration_preparing_title',
                     ),
@@ -226,7 +226,7 @@ class _MobileMigrationMigratingState
       children: [
         SizedBox(height: compact ? 20 : 46),
         Text(
-          'Migration in Progress',
+          'Ironwood Migration',
           textAlign: TextAlign.center,
           style: AppTypography.headlineLarge.copyWith(
             color: colors.text.accent,

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -704,6 +704,7 @@ class _MigrationProgressPreview extends StatelessWidget {
     this.totalParts = 24,
     this.completedBatches,
     this.totalBatches,
+    this.currentBatchNumber = 1,
     this.currentBatchStartIndex,
     this.currentBatchPartCount,
     this.completedRingSegments,
@@ -728,6 +729,7 @@ class _MigrationProgressPreview extends StatelessWidget {
   final int totalParts;
   final int? completedBatches;
   final int? totalBatches;
+  final int currentBatchNumber;
   final int? currentBatchStartIndex;
   final int? currentBatchPartCount;
   final Set<int>? completedRingSegments;
@@ -832,6 +834,7 @@ class _MigrationProgressPreview extends StatelessWidget {
                 _MigrationProgressSummary(
                   completedParts: resolvedCompletedParts,
                   state: state,
+                  currentBatchNumber: currentBatchNumber,
                   availableAmountText: availableAmountText,
                   statusValueOverride: statusValueOverride,
                 ),
@@ -847,6 +850,7 @@ class _MigrationProgressPreview extends StatelessWidget {
                 else
                   _MigrationProgressStatus(
                     state: state,
+                    currentBatchNumber: currentBatchNumber,
                     bodyOverride: nextActionText,
                   ),
               ],
@@ -1227,12 +1231,14 @@ class _MigrationProgressSummary extends StatelessWidget {
   const _MigrationProgressSummary({
     required this.completedParts,
     required this.state,
+    required this.currentBatchNumber,
     this.availableAmountText,
     this.statusValueOverride,
   });
 
   final int completedParts;
   final _MigrationProgressState state;
+  final int currentBatchNumber;
   final String? availableAmountText;
   final String? statusValueOverride;
 
@@ -1254,7 +1260,7 @@ class _MigrationProgressSummary extends StatelessWidget {
             switch (state) {
               _MigrationProgressState.syncing => 'Syncing',
               _MigrationProgressState.broadcasting =>
-                'All is well. Broadcasting notes…',
+                'All clear. Processing batch #$currentBatchNumber',
               _MigrationProgressState.confirming => 'Waiting for confirmations',
               _MigrationProgressState.needsInput =>
                 'Waiting for your confirmation',
@@ -1287,9 +1293,14 @@ class _MigrationSummaryRows extends StatelessWidget {
 }
 
 class _MigrationProgressStatus extends StatelessWidget {
-  const _MigrationProgressStatus({required this.state, this.bodyOverride});
+  const _MigrationProgressStatus({
+    required this.state,
+    required this.currentBatchNumber,
+    this.bodyOverride,
+  });
 
   final _MigrationProgressState state;
+  final int currentBatchNumber;
   final String? bodyOverride;
 
   @override
@@ -1314,13 +1325,13 @@ class _MigrationProgressStatus extends StatelessWidget {
       ),
       _MigrationProgressState.broadcasting => (
         AppIcons.notificationBell,
-        'All is well. Broadcasting notes…',
+        'All clear. Processing batch #$currentBatchNumber',
         '~2 hrs 15 mins.\nWe will notify you when it’s ready.',
       ),
       _MigrationProgressState.confirming => (
         AppIcons.migrationTimer,
         'Waiting for confirmations',
-        'Confirmations are still arriving. You can leave Vizor and check '
+        'Confirmations are still arriving.\nYou can leave Vizor and check '
             'again later.',
       ),
       _MigrationProgressState.needsInput => (
@@ -1505,9 +1516,11 @@ class _PreparationCompleteModalBody extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.s),
           Text(
-            'What’s Next?',
+            'Preparation is complete, but we are waiting for the next '
+            'available signing window.\nWe\'ll let you know when it\'s time '
+            'to take action.',
             textAlign: TextAlign.center,
-            style: AppTypography.headlineSmall.copyWith(
+            style: AppTypography.bodyMedium.copyWith(
               color: context.colors.text.secondary,
             ),
           ),

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -496,6 +496,7 @@ class _MobileMigrationRedesignedStatusState
       totalParts: _totalParts(widget.status),
       completedBatches: batchProgress.completedBatches,
       totalBatches: batchProgress.totalBatches,
+      currentBatchNumber: batchProgress.currentBatchNumber,
       currentBatchStartIndex: batchProgress.currentBatchStartIndex,
       currentBatchPartCount: batchProgress.currentBatchPartCount,
       completedRingSegments: _completedRingSegments(widget.status),
@@ -618,7 +619,7 @@ class _MobileMigrationRedesignedStatusState
           'continue because notifications are disabled.';
     }
     if (state == _MigrationProgressState.confirming) {
-      return 'Confirmations are still arriving. You can leave Vizor and '
+      return 'Confirmations are still arriving.\nYou can leave Vizor and '
           'check again later.';
     }
     return '$timing.\nWe will notify you when it’s ready.';

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -238,7 +238,7 @@ void main() {
 
     expect(startedAccountUuid, 'account-1');
     expect(startedSchedule, _privatePlan().scheduledTransfers);
-    expect(find.text('Migration in Progress'), findsOneWidget);
+    expect(find.text('Ironwood Migration'), findsOneWidget);
   });
 
   testWidgets(
@@ -313,7 +313,7 @@ void main() {
     await tester.tap(find.widgetWithText(AppButton, 'Start migration'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Migration in Progress'), findsOneWidget);
+    expect(find.text('Ironwood Migration'), findsOneWidget);
     expect(
       find.text("Couldn't broadcast the migration transaction. Try again."),
       findsNothing,
@@ -475,7 +475,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Migration in Progress'), findsOneWidget);
+    expect(find.text('Ironwood Migration'), findsOneWidget);
     expect(find.text('Note split'), findsOneWidget);
     expect(find.text('Split notes into 1 migration part'), findsOneWidget);
     expect(find.text('Wait 1 block for confirmation'), findsOneWidget);
@@ -754,7 +754,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
-    expect(find.text('Migration in Progress'), findsOneWidget);
+    expect(find.text('Ironwood Migration'), findsOneWidget);
     expect(find.text('intro-route'), findsNothing);
   });
 
@@ -769,7 +769,7 @@ void main() {
     final cases = [
       _StatusUiCase(
         status: _status(),
-        title: 'Migration in Progress',
+        title: 'Ironwood Migration',
         buttonLabel: 'Go home',
         buttonEnabled: true,
       ),
@@ -778,7 +778,7 @@ void main() {
           phase: kIronwoodMigrationReadyToMigratePhase,
           activeRunId: 'run-1',
         ),
-        title: 'Migration in Progress',
+        title: 'Ironwood Migration',
         buttonLabel: 'Go home',
         buttonEnabled: true,
       ),
@@ -787,7 +787,7 @@ void main() {
           phase: kIronwoodMigrationBroadcastScheduledPhase,
           activeRunId: 'run-1',
         ),
-        title: 'Migration in Progress',
+        title: 'Ironwood Migration',
         buttonLabel: 'Go home',
         buttonEnabled: true,
       ),
@@ -796,7 +796,7 @@ void main() {
           phase: kIronwoodMigrationBroadcastingPhase,
           activeRunId: 'run-1',
         ),
-        title: 'Migration in Progress',
+        title: 'Ironwood Migration',
         buttonLabel: 'Go home',
         buttonEnabled: true,
       ),
@@ -805,7 +805,7 @@ void main() {
           phase: kIronwoodMigrationWaitingConfirmationsPhase,
           activeRunId: 'run-1',
         ),
-        title: 'Migration in Progress',
+        title: 'Ironwood Migration',
         buttonLabel: 'Go home',
         buttonEnabled: true,
       ),
@@ -823,7 +823,7 @@ void main() {
           phase: kIronwoodMigrationCompletePhase,
           activeRunId: 'run-1',
         ),
-        title: 'Migration in Progress',
+        title: 'Ironwood Migration',
         buttonLabel: 'Go home',
         buttonEnabled: true,
       ),
@@ -912,7 +912,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Migration in Progress'), findsOneWidget);
+    expect(find.text('Ironwood Migration'), findsOneWidget);
     expect(find.text('Migration Complete'), findsNothing);
     expect(find.text('Back home'), findsNothing);
     expect(find.text('Migrating...'), findsNothing);

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -903,8 +903,8 @@ void main() {
     );
     expect(
       find.text(
-        'Splits transactions into multiple parts to minimize traceability, '
-        'but takes longer.',
+        'Splits transactions into multiple parts to minimize traceability '
+        'but will take several hours to days.',
       ),
       findsOneWidget,
     );
@@ -915,7 +915,8 @@ void main() {
     );
     expect(
       find.text(
-        'Migrates your entire balance in one batch. Fast, but less private.',
+        'Migrates your entire balance in one batch. '
+        'Fast (~10 mins) but less private.',
       ),
       findsOneWidget,
     );
@@ -938,7 +939,7 @@ void main() {
           .widget<Text>(
             find.text(
               'Migrates your entire balance in one batch. '
-              'Fast, but less private.',
+              'Fast (~10 mins) but less private.',
             ),
           )
           .style
@@ -2303,7 +2304,7 @@ void main() {
     await tester.pumpWidget(_app(step: MobileIronwoodMigrationStep.preparing));
     await tester.pumpAndSettle();
 
-    expect(find.text('Migration in Progress'), findsOneWidget);
+    expect(find.text('Ironwood Migration'), findsOneWidget);
     expect(
       find.text(
         'Preparing your balance for migration. This step usually takes '
@@ -2376,7 +2377,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('Migration in Progress'), findsOneWidget);
+    expect(find.text('Ironwood Migration'), findsOneWidget);
     expect(find.text('Migration 12 notes'), findsOneWidget);
     expect(find.text('142.20 ZEC'), findsOneWidget);
     expect(find.text('Part 1'), findsOneWidget);
@@ -3535,6 +3536,14 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Preparation is done'), findsOneWidget);
+      expect(
+        find.text(
+          'Preparation is complete, but we are waiting for the next '
+          'available signing window.\nWe\'ll let you know when it\'s time '
+          'to take action.',
+        ),
+        findsOneWidget,
+      );
 
       syncNotifier.emit(
         SyncState(
@@ -3728,7 +3737,10 @@ void main() {
     expect(find.text('Available in Ironwood'), findsOneWidget);
     expect(find.text('Waiting for confirmations'), findsWidgets);
     expect(
-      find.textContaining('Confirmations are still arriving'),
+      find.text(
+        'Confirmations are still arriving.\nYou can leave Vizor and check '
+        'again later.',
+      ),
       findsOneWidget,
     );
     expect(find.textContaining('Signing window expected'), findsNothing);
@@ -3900,7 +3912,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('All is well. Broadcasting notes…'), findsWidgets);
+    expect(find.text('All clear. Processing batch #1'), findsWidgets);
     expect(find.textContaining('Signing window expected'), findsOneWidget);
     expect(
       find.textContaining('We will notify you when it’s ready.'),


### PR DESCRIPTION
## What changed
- Clarify Ironwood migration titles, timing, batch progress, and confirmation messaging.
- Update mobile migration status copy and matching widget tests.

## Validation
- fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/migration/mobile_ironwood_migration_flow_screen_test.dart (passed: 83 tests)
- Desktop focused test run has one unrelated existing failure: expected ~3 hrs at test/features/migration/ironwood_migration_flow_screen_test.dart:170.