### PR TITLE
[mobile] Shorten iOS migration task and notification titles

### DIFF
--- a/ios/Runner/BackgroundMigrationManager.swift
+++ b/ios/Runner/BackgroundMigrationManager.swift
@@ -974,7 +974,7 @@ final class BackgroundMigrationManager {
   private func postNeedsUserActionNotification() {
     guard !isNotificationWorkDisabled else { return }
     let content = UNMutableNotificationContent()
-    content.title = "Ironwood migration needs attention"
+    content.title = "Needs attention"
     content.body = "Open Vizor to review and continue your migration."
     content.sound = .default
     addNotificationIfEnabled(
@@ -1048,9 +1048,8 @@ final class BackgroundMigrationManager {
     completion: @escaping (Bool) -> Void
   ) {
     let content = UNMutableNotificationContent()
-    content.title = "Migration transfers sent"
-    content.body =
-      "All scheduled transfers were submitted. Open Vizor to check the status."
+    content.title = "All transfers sent"
+    content.body = "Open Vizor to check the status."
     content.sound = .default
     addNotificationIfEnabled(
       UNNotificationRequest(
@@ -1069,7 +1068,7 @@ final class BackgroundMigrationManager {
     completion: @escaping (Bool) -> Void
   ) {
     let content = UNMutableNotificationContent()
-    content.title = "Continue your Ironwood migration"
+    content.title = "Ready to sign"
     content.body = "Open Vizor to prepare the next migration transfer."
     content.sound = .default
     addNotificationIfEnabled(

--- a/ios/Runner/BackgroundMigrationPreparationManager.swift
+++ b/ios/Runner/BackgroundMigrationPreparationManager.swift
@@ -521,8 +521,8 @@ final class BackgroundMigrationPreparationManager {
         self.scheduleWatchdog()
         let request = BGContinuedProcessingTaskRequest(
           identifier: Self.taskIdentifier,
-          title: "Preparing migration",
-          subtitle: "You can continue using your device"
+          title: "Preparing",
+          subtitle: "Migration"
         )
         request.strategy = .fail
         let submission = self.stateLock.withPreparationLock {
@@ -1540,7 +1540,7 @@ final class BackgroundMigrationPreparationManager {
       return
     }
     let content = UNMutableNotificationContent()
-    content.title = "Migration preparation paused"
+    content.title = "Paused"
     content.body = "Open Vizor to continue preparing your migration."
     content.sound = .default
     let request = UNNotificationRequest(
@@ -1706,7 +1706,7 @@ final class BackgroundMigrationPreparationManager {
       return
     }
     let content = UNMutableNotificationContent()
-    content.title = "Continue your Ironwood migration"
+    content.title = "Ready to sign"
     content.body = "Open Vizor to continue your migration."
     content.sound = .default
     addNotificationIfEnabled(


### PR DESCRIPTION
## What changed

Ironwood migration's iOS surfaces had long, overlapping titles — three different events asked the user to continue with nearly identical wording. This replaces them with short, glanceable state labels. Copy-only: no control-flow, scheduling, notification-identifier, or retry changes.

| State (trigger) | Dynamic Island (task UI) | Notification |
|---|---|---|
| Preparation running | `Preparing` / `Migration` + system progress bar | — |
| Preparation stalled 15 min (watchdog) | — (island gone with the task) | `Paused` — Open Vizor to continue preparing your migration. |
| Preparation blocked on user | — | `Needs attention` — Open and unlock Vizor to continue your migration. |
| Preparation proof ready | — | `Ready to sign` — Open Vizor to continue your migration. |
| Outbox blocked on user | — | `Needs attention` — Open Vizor to review and continue your migration. |
| Outbox proof ready | — | `Ready to sign` — Open Vizor to prepare the next migration transfer. |
| All transfers broadcast | — | `All transfers sent` — Open Vizor to check the status. |

## Why the notable calls

- **Watchdog is titled `Paused`, not `Preparing`**: `scheduleWatchdog()` is a dead-man's switch — the notification is pre-scheduled 15 min out, pushed forward on every progress advance, and cancelled on every clean exit. It is delivered *only* when preparation has silently stopped, so a "Preparing" title would claim active work exactly when there is none.
- **Task subtitle is `Migration`**: the title carries the state, the system progress bar carries the progress; the subtitle's job is the subject. Dynamic Island space is tight, so one word per slot.
- **`All transfers sent`**: folds completeness into the title and drops the body sentence that restated it; body keeps only the action.
- **Needs-action body regains "your migration"**: with the title shortened to a generic state label, the body is the only place the notification names its subject (Vizor also sends sync/tx notifications).

## Reviewer notes

- **Open question**: the outbox proof-ready pair is title `Ready to sign` / body "prepare the next migration transfer" — these describe different states. Left as-is pending confirmation of what's actually true at that trigger; align the pair once known.
- The app's Live Activity (`DynamicIslandManager`) only renders sync and tx-track modes; the migration island presence is entirely the system `BGContinuedProcessingTask` UI.
- Verification: focused grep for stale references to the old literals (none in Swift/Dart tests) and `git diff --check`. Copy-only, no test run required.