### PR TITLE
Add Android background Ironwood migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,13 +434,16 @@ rust/src/
 │                        # decode_accounts_ur. Keystone UX is QR-only.
 │                        # Re-exports KeystoneAccountInfo, UrDecodeResult from
 │                        # crate::wallet::keystone via `pub use`.
-├── ffi.rs              # C FFI for Swift Ironwood migration preparation:
-│                        # inspect, operation begin/end, preparation-only sync,
-│                        # advance, cancel, and shared sync-running inspection.
-│                        # Preparation owns a private cancel token and desired mode
-│                        # across sync → advance; only SYNC_RUNNING is shared while
-│                        # the actual sync engine is active.
-│                        # Located outside api/ to avoid FRB codegen picking it up.
+├── ffi.rs              # Thin C adapter for Swift Ironwood migration preparation.
+│                        # Validates native pointers, converts C values, preserves
+│                        # the iOS ABI, and delegates to migration_preparation.rs.
+├── migration_preparation.rs
+│                       # Platform-neutral mobile preparation execution core:
+│                       # operation begin/end/cancel, preparation-only sync,
+│                       # inspect/advance, progress state interpretation, and
+│                       # shared foreground-sync exclusion. Future Android JNI
+│                       # adapters must delegate here instead of duplicating it.
+│                       # Located outside api/ to avoid FRB codegen picking it up.
 ├── wallet/
 │   ├── mod.rs          # pub mod keys, sync, sync_engine, keystone
 │   ├── keys.rs         # Key derivation, mnemonic, account creation (Derived + Imported),
@@ -496,13 +499,14 @@ iOS Ironwood denomination preparation has a separate native path because its
 Swift BackgroundMigrationPreparationManager
     → begin preparation operation
     → wait until foreground sync releases SYNC_RUNNING
-    → preparation-only C FFI sync
-    → inspect / advance denomination preparation
+    → thin C FFI adapter
+    → platform-neutral Rust preparation sync / inspect / advance
     → end preparation operation
 ```
 
-- `MigrationPreparationOperation` owns a private cancel token and desired mode
-  for the whole native operation, including both sync and advance calls.
+- `rust/src/migration_preparation.rs` owns the operation's private cancel token
+  and desired mode for the whole native operation, including both sync and
+  advance calls. The same core is the required entry point for Android JNI.
 - Foreground `cancelFullSync()` cannot cancel migration preparation.
 - The two paths share only `SYNC_RUNNING` while the sync engine is actually
   active, preventing concurrent access to the wallet sync pipeline.
@@ -517,7 +521,8 @@ Swift BackgroundMigrationPreparationManager
   submitted by older builds; no handler is registered for it.
 
 Key files:
-- `rust/src/ffi.rs` — migration-preparation-only C FFI
+- `rust/src/migration_preparation.rs` — platform-neutral preparation core
+- `rust/src/ffi.rs` — migration-preparation-only iOS C adapter
 - `ios/Runner/zcash_sync.h` — matching C header
 - `ios/Runner/BackgroundMigrationPreparationManager.swift` — native task owner
 - `lib/src/providers/wallet_mutation_guard.dart` — mutation ordering fence

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -79,4 +79,5 @@ flutter {
 dependencies {
     // Biometric passcode escrow (BiometricPrompt + Keystore-bound key).
     implementation("androidx.biometric:biometric:1.1.0")
+    testImplementation("junit:junit:4.13.2")
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -79,5 +79,8 @@ flutter {
 dependencies {
     // Biometric passcode escrow (BiometricPrompt + Keystore-bound key).
     implementation("androidx.biometric:biometric:1.1.0")
+    implementation("androidx.work:work-runtime-ktx:2.10.1")
+    implementation("com.google.guava:guava:33.4.8-android")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("org.json:json:20180813")
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,11 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <application
         android:label="Vizor"
         android:name="${applicationName}"
@@ -36,6 +40,10 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationNativeBridge.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationNativeBridge.kt
@@ -1,0 +1,302 @@
+package com.keplr.vizor
+
+import androidx.annotation.Keep
+
+internal enum class IronwoodMigrationNativePreparationState(val nativeValue: Long) {
+    WAITING_FOR_DENOMINATION_PREPARATION(0),
+    PROOF_READY(1),
+    NEEDS_USER_ACTION(2),
+    CANCELLED(3),
+    INACTIVE(4),
+    WAITING_FOR_PREPARED_NOTE_ANCHOR(5);
+
+    companion object {
+        fun fromNative(value: Long): IronwoodMigrationNativePreparationState =
+            entries.firstOrNull { it.nativeValue == value }
+                ?: throw IronwoodMigrationNativeException(
+                    IronwoodMigrationNativeError.INVALID_RESPONSE,
+                    "Unknown migration preparation state: $value",
+                )
+    }
+}
+
+internal data class IronwoodMigrationNativePreparationProgress(
+    val state: IronwoodMigrationNativePreparationState,
+    val confirmationCount: Long,
+    val confirmationTarget: Long,
+    val completedStageCount: Long,
+    val totalStageCount: Long,
+)
+
+internal data class IronwoodMigrationNativeSyncProgress(
+    val scannedHeight: Long,
+    val chainTipHeight: Long,
+    val percentage: Double,
+    val displayTargetPercentage: Double,
+    val displayTargetBlocks: Long,
+    val isSyncing: Boolean,
+    val isComplete: Boolean,
+    val hasNewTx: Boolean,
+)
+
+internal enum class IronwoodMigrationNativeError(val nativeCode: Int) {
+    NO_ACTIVE_OPERATION(1),
+    SYNC_ALREADY_RUNNING(2),
+    INVALID_CREDENTIAL(3),
+    EXECUTION(4),
+    CALLBACK(5),
+    PANIC(6),
+    INVALID_ARGUMENT(7),
+    INVALID_RESPONSE(-1);
+
+    companion object {
+        fun fromNative(value: Int): IronwoodMigrationNativeError =
+            entries.firstOrNull { it.nativeCode == value } ?: INVALID_RESPONSE
+    }
+}
+
+internal class IronwoodMigrationNativeException(
+    val reason: IronwoodMigrationNativeError,
+    message: String,
+) : Exception(message)
+
+/**
+ * JNI result envelope. The field layout is part of the Rust/Kotlin JNI ABI.
+ */
+@Keep
+internal class IronwoodMigrationNativeCallResult(
+    @JvmField val code: Int,
+    @JvmField val message: String?,
+    @JvmField val progress: LongArray?,
+)
+
+@Keep
+internal fun interface IronwoodMigrationNativeSyncCallback {
+    @Suppress("LongParameterList")
+    fun onProgress(
+        scannedHeight: Long,
+        chainTipHeight: Long,
+        percentage: Double,
+        displayTargetPercentage: Double,
+        displayTargetBlocks: Long,
+        isSyncing: Boolean,
+        isComplete: Boolean,
+        hasNewTx: Boolean,
+    )
+}
+
+internal interface IronwoodMigrationNativeBindings {
+    fun nativeBeginOperation(): Boolean
+    fun nativeEndOperation()
+    fun nativeCancelOperation(): Boolean
+    fun nativeIsSyncRunning(): Boolean
+
+    fun nativeInspect(
+        dbPath: String,
+        network: String,
+        accountUuid: String,
+        expectedRunId: String,
+    ): IronwoodMigrationNativeCallResult
+
+    @Suppress("LongParameterList")
+    fun nativeAdvance(
+        dbPath: String,
+        lightwalletdUrl: String,
+        network: String,
+        accountUuid: String,
+        expectedRunId: String,
+        credential: ByteArray,
+        saltBase64: String,
+    ): IronwoodMigrationNativeCallResult
+
+    fun nativeRunSync(
+        dbPath: String,
+        lightwalletdUrl: String,
+        network: String,
+        callback: IronwoodMigrationNativeSyncCallback,
+    ): IronwoodMigrationNativeCallResult
+}
+
+@Keep
+internal object IronwoodMigrationJniBindings : IronwoodMigrationNativeBindings {
+    init {
+        System.loadLibrary("rust_lib_zcash_wallet")
+    }
+
+    external override fun nativeBeginOperation(): Boolean
+    external override fun nativeEndOperation()
+    external override fun nativeCancelOperation(): Boolean
+    external override fun nativeIsSyncRunning(): Boolean
+
+    external override fun nativeInspect(
+        dbPath: String,
+        network: String,
+        accountUuid: String,
+        expectedRunId: String,
+    ): IronwoodMigrationNativeCallResult
+
+    @Suppress("LongParameterList")
+    external override fun nativeAdvance(
+        dbPath: String,
+        lightwalletdUrl: String,
+        network: String,
+        accountUuid: String,
+        expectedRunId: String,
+        credential: ByteArray,
+        saltBase64: String,
+    ): IronwoodMigrationNativeCallResult
+
+    external override fun nativeRunSync(
+        dbPath: String,
+        lightwalletdUrl: String,
+        network: String,
+        callback: IronwoodMigrationNativeSyncCallback,
+    ): IronwoodMigrationNativeCallResult
+}
+
+internal class IronwoodMigrationNativeBridge(
+    private val bindings: IronwoodMigrationNativeBindings = IronwoodMigrationJniBindings,
+) {
+    fun beginOperation(): Boolean = bindings.nativeBeginOperation()
+
+    fun endOperation() {
+        bindings.nativeEndOperation()
+    }
+
+    fun cancelOperation(): Boolean = bindings.nativeCancelOperation()
+
+    fun isSyncRunning(): Boolean = bindings.nativeIsSyncRunning()
+
+    fun inspect(
+        dbPath: String,
+        network: String,
+        accountUuid: String,
+        expectedRunId: String,
+    ): IronwoodMigrationNativePreparationProgress =
+        decodeProgress(
+            bindings.nativeInspect(dbPath, network, accountUuid, expectedRunId),
+            "inspect",
+        )
+
+    @Suppress("LongParameterList")
+    fun advance(
+        dbPath: String,
+        lightwalletdUrl: String,
+        network: String,
+        accountUuid: String,
+        expectedRunId: String,
+        credential: ByteArray,
+        saltBase64: String,
+    ): IronwoodMigrationNativePreparationProgress =
+        decodeProgress(
+            bindings.nativeAdvance(
+                dbPath,
+                lightwalletdUrl,
+                network,
+                accountUuid,
+                expectedRunId,
+                credential,
+                saltBase64,
+            ),
+            "advance",
+        )
+
+    fun runSync(
+        dbPath: String,
+        lightwalletdUrl: String,
+        network: String,
+        onProgress: (IronwoodMigrationNativeSyncProgress) -> Unit,
+    ) {
+        val result = bindings.nativeRunSync(
+            dbPath,
+            lightwalletdUrl,
+            network,
+            IronwoodMigrationNativeSyncCallback {
+                    scannedHeight,
+                    chainTipHeight,
+                    percentage,
+                    displayTargetPercentage,
+                    displayTargetBlocks,
+                    isSyncing,
+                    isComplete,
+                    hasNewTx,
+                ->
+                onProgress(
+                    IronwoodMigrationNativeSyncProgress(
+                        scannedHeight = requireNonNegative(
+                            scannedHeight,
+                            "scannedHeight",
+                        ),
+                        chainTipHeight = requireNonNegative(
+                            chainTipHeight,
+                            "chainTipHeight",
+                        ),
+                        percentage = percentage,
+                        displayTargetPercentage = displayTargetPercentage,
+                        displayTargetBlocks = requireNonNegative(
+                            displayTargetBlocks,
+                            "displayTargetBlocks",
+                        ),
+                        isSyncing = isSyncing,
+                        isComplete = isComplete,
+                        hasNewTx = hasNewTx,
+                    ),
+                )
+            },
+        )
+        requireSuccess(result, "sync")
+        if (result.progress != null) {
+            throw invalidResponse("sync returned unexpected preparation progress")
+        }
+    }
+
+    private fun decodeProgress(
+        result: IronwoodMigrationNativeCallResult,
+        operation: String,
+    ): IronwoodMigrationNativePreparationProgress {
+        requireSuccess(result, operation)
+        val values = result.progress
+            ?: throw invalidResponse("$operation returned no preparation progress")
+        if (values.size != PROGRESS_FIELD_COUNT) {
+            throw invalidResponse(
+                "$operation returned ${values.size} preparation progress fields",
+            )
+        }
+        return IronwoodMigrationNativePreparationProgress(
+            state = IronwoodMigrationNativePreparationState.fromNative(values[0]),
+            confirmationCount = requireNonNegative(values[1], "confirmationCount"),
+            confirmationTarget = requireNonNegative(values[2], "confirmationTarget"),
+            completedStageCount = requireNonNegative(values[3], "completedStageCount"),
+            totalStageCount = requireNonNegative(values[4], "totalStageCount"),
+        )
+    }
+
+    private fun requireSuccess(
+        result: IronwoodMigrationNativeCallResult,
+        operation: String,
+    ) {
+        if (result.code == RESULT_SUCCESS) return
+        val reason = IronwoodMigrationNativeError.fromNative(result.code)
+        throw IronwoodMigrationNativeException(
+            reason,
+            result.message ?: "$operation failed with native code ${result.code}",
+        )
+    }
+
+    private fun requireNonNegative(value: Long, name: String): Long {
+        if (value < 0) {
+            throw invalidResponse("$name is negative")
+        }
+        return value
+    }
+
+    private fun invalidResponse(message: String) = IronwoodMigrationNativeException(
+        IronwoodMigrationNativeError.INVALID_RESPONSE,
+        message,
+    )
+
+    private companion object {
+        const val RESULT_SUCCESS = 0
+        const val PROGRESS_FIELD_COUNT = 5
+    }
+}

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationNativeBridge.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationNativeBridge.kt
@@ -154,20 +154,51 @@ internal object IronwoodMigrationJniBindings : IronwoodMigrationNativeBindings {
     ): IronwoodMigrationNativeCallResult
 }
 
+internal interface IronwoodMigrationPreparationNative {
+    fun beginOperation(): Boolean
+    fun endOperation()
+    fun cancelOperation(): Boolean
+    fun isSyncRunning(): Boolean
+    fun inspect(
+        dbPath: String,
+        network: String,
+        accountUuid: String,
+        expectedRunId: String,
+    ): IronwoodMigrationNativePreparationProgress
+
+    @Suppress("LongParameterList")
+    fun advance(
+        dbPath: String,
+        lightwalletdUrl: String,
+        network: String,
+        accountUuid: String,
+        expectedRunId: String,
+        credential: ByteArray,
+        saltBase64: String,
+    ): IronwoodMigrationNativePreparationProgress
+
+    fun runSync(
+        dbPath: String,
+        lightwalletdUrl: String,
+        network: String,
+        onProgress: (IronwoodMigrationNativeSyncProgress) -> Unit,
+    )
+}
+
 internal class IronwoodMigrationNativeBridge(
     private val bindings: IronwoodMigrationNativeBindings = IronwoodMigrationJniBindings,
-) {
-    fun beginOperation(): Boolean = bindings.nativeBeginOperation()
+) : IronwoodMigrationPreparationNative {
+    override fun beginOperation(): Boolean = bindings.nativeBeginOperation()
 
-    fun endOperation() {
+    override fun endOperation() {
         bindings.nativeEndOperation()
     }
 
-    fun cancelOperation(): Boolean = bindings.nativeCancelOperation()
+    override fun cancelOperation(): Boolean = bindings.nativeCancelOperation()
 
-    fun isSyncRunning(): Boolean = bindings.nativeIsSyncRunning()
+    override fun isSyncRunning(): Boolean = bindings.nativeIsSyncRunning()
 
-    fun inspect(
+    override fun inspect(
         dbPath: String,
         network: String,
         accountUuid: String,
@@ -179,7 +210,7 @@ internal class IronwoodMigrationNativeBridge(
         )
 
     @Suppress("LongParameterList")
-    fun advance(
+    override fun advance(
         dbPath: String,
         lightwalletdUrl: String,
         network: String,
@@ -201,7 +232,7 @@ internal class IronwoodMigrationNativeBridge(
             "advance",
         )
 
-    fun runSync(
+    override fun runSync(
         dbPath: String,
         lightwalletdUrl: String,
         network: String,

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationNativeBridge.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationNativeBridge.kt
@@ -71,6 +71,14 @@ internal class IronwoodMigrationNativeCallResult(
 )
 
 @Keep
+internal class IronwoodMigrationOutboxNativeCallResult(
+    @JvmField val code: Int,
+    @JvmField val message: String?,
+    @JvmField val height: Long,
+    @JvmField val responseCode: Int,
+)
+
+@Keep
 internal fun interface IronwoodMigrationNativeSyncCallback {
     @Suppress("LongParameterList")
     fun onProgress(
@@ -115,6 +123,17 @@ internal interface IronwoodMigrationNativeBindings {
         network: String,
         callback: IronwoodMigrationNativeSyncCallback,
     ): IronwoodMigrationNativeCallResult
+
+    fun nativeLatestBlockHeight(
+        lightwalletdUrl: String,
+    ): IronwoodMigrationOutboxNativeCallResult =
+        throw UnsupportedOperationException("Outbox transport is not implemented.")
+
+    fun nativeSendTransaction(
+        lightwalletdUrl: String,
+        rawTransaction: ByteArray,
+    ): IronwoodMigrationOutboxNativeCallResult =
+        throw UnsupportedOperationException("Outbox transport is not implemented.")
 }
 
 @Keep
@@ -152,6 +171,15 @@ internal object IronwoodMigrationJniBindings : IronwoodMigrationNativeBindings {
         network: String,
         callback: IronwoodMigrationNativeSyncCallback,
     ): IronwoodMigrationNativeCallResult
+
+    external override fun nativeLatestBlockHeight(
+        lightwalletdUrl: String,
+    ): IronwoodMigrationOutboxNativeCallResult
+
+    external override fun nativeSendTransaction(
+        lightwalletdUrl: String,
+        rawTransaction: ByteArray,
+    ): IronwoodMigrationOutboxNativeCallResult
 }
 
 internal interface IronwoodMigrationPreparationNative {
@@ -183,6 +211,59 @@ internal interface IronwoodMigrationPreparationNative {
         network: String,
         onProgress: (IronwoodMigrationNativeSyncProgress) -> Unit,
     )
+}
+
+internal data class IronwoodMigrationSendResponse(
+    val errorCode: Int,
+    val errorMessage: String,
+)
+
+internal interface IronwoodMigrationOutboxTransport {
+    fun latestBlockHeight(lightwalletdUrl: String): Long
+    fun sendTransaction(
+        lightwalletdUrl: String,
+        rawTransaction: ByteArray,
+    ): IronwoodMigrationSendResponse
+}
+
+internal class IronwoodMigrationOutboxNativeBridge(
+    private val bindings: IronwoodMigrationNativeBindings = IronwoodMigrationJniBindings,
+) : IronwoodMigrationOutboxTransport {
+    override fun latestBlockHeight(lightwalletdUrl: String): Long {
+        val result = bindings.nativeLatestBlockHeight(lightwalletdUrl)
+        checkOutboxResult(result, "latest block height")
+        if (result.height < 0) {
+            throw IronwoodMigrationNativeException(
+                IronwoodMigrationNativeError.INVALID_RESPONSE,
+                "Invalid latest block height.",
+            )
+        }
+        return result.height
+    }
+
+    override fun sendTransaction(
+        lightwalletdUrl: String,
+        rawTransaction: ByteArray,
+    ): IronwoodMigrationSendResponse {
+        val result = bindings.nativeSendTransaction(lightwalletdUrl, rawTransaction)
+        checkOutboxResult(result, "send transaction")
+        return IronwoodMigrationSendResponse(
+            errorCode = result.responseCode,
+            errorMessage = result.message.orEmpty(),
+        )
+    }
+
+    private fun checkOutboxResult(
+        result: IronwoodMigrationOutboxNativeCallResult,
+        action: String,
+    ) {
+        if (result.code != 0) {
+            throw IronwoodMigrationNativeException(
+                IronwoodMigrationNativeError.fromNative(result.code),
+                result.message ?: "Failed to $action.",
+            )
+        }
+    }
 }
 
 internal class IronwoodMigrationNativeBridge(

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationOutbox.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationOutbox.kt
@@ -1,0 +1,751 @@
+package com.keplr.vizor
+
+import java.security.MessageDigest
+import java.util.UUID
+import kotlin.math.ceil
+import kotlin.math.exp
+import kotlin.math.ln
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.random.Random
+
+internal enum class IronwoodOutboxItemStatus {
+    STAGED,
+    ARMED,
+    SUBMITTING,
+    ACCEPTED_AWAITING_RECONCILIATION,
+    REJECTED_AWAITING_RECONCILIATION,
+    EXPIRED_AWAITING_RECONCILIATION,
+    NEEDS_RESIGN_AWAITING_RECONCILIATION,
+}
+
+internal data class IronwoodOutboxItem(
+    val itemId: String,
+    val partIndex: Long,
+    val txidHex: String,
+    val rawTransaction: ByteArray,
+    val payloadDigestHex: String,
+    val anchorBoundaryHeight: Long,
+    var scheduledHeight: Long,
+    var scheduleStartHeight: Long,
+    val expiryHeight: Long,
+    var status: IronwoodOutboxItemStatus = IronwoodOutboxItemStatus.STAGED,
+    var attemptCount: Int = 0,
+    var attemptId: String? = null,
+    var attemptStartedAtMs: Long? = null,
+    var nextAttemptAtMs: Long? = null,
+    var lastError: String? = null,
+)
+
+internal data class IronwoodOutboxBatch(
+    val batchId: String,
+    val network: String,
+    val accountUuid: String,
+    val runId: String,
+    var lightwalletdUrl: String,
+    val timingMeanBlocks: Long,
+    val timingMaxBlocks: Long,
+    val createdAtMs: Long,
+    var armedAtMs: Long? = null,
+    var nextProofHeight: Long? = null,
+    var proofReadyObservedHeight: Long? = null,
+    var proofReadyNotificationAcknowledged: Boolean = false,
+    var needsUserActionNotificationPending: Boolean = false,
+    var broadcastCompletePending: Boolean = false,
+    val items: MutableList<IronwoodOutboxItem>,
+) {
+    val scopeKey: String get() = "$network:$accountUuid"
+}
+
+internal data class IronwoodOutboxScheduleUpdate(
+    val itemId: String,
+    val scheduledHeight: Long,
+    val scheduleStartHeight: Long,
+)
+
+internal data class IronwoodOutboxReceipt(
+    val receiptId: String,
+    val batchId: String,
+    val itemId: String,
+    val network: String,
+    val accountUuid: String,
+    val runId: String,
+    val txidHex: String,
+    val outcome: String,
+    val remoteHeight: Long,
+    val responseCode: Int?,
+    val responseMessage: String?,
+    val recordedAtMs: Long,
+    val scheduleUpdates: List<IronwoodOutboxScheduleUpdate>,
+    val rawTransaction: ByteArray?,
+)
+
+internal data class IronwoodOutboxSnapshot(
+    val batches: MutableList<IronwoodOutboxBatch> = mutableListOf(),
+    val receipts: MutableList<IronwoodOutboxReceipt> = mutableListOf(),
+    var lastAttemptedScopeKey: String? = null,
+    var lastInspectedEndpoint: String? = null,
+)
+
+internal class IronwoodMigrationOutboxRepository(
+    private val store: IronwoodMigrationSecureStore,
+) {
+    fun <T> update(block: (IronwoodOutboxSnapshot) -> T): T {
+        var result: T? = null
+        store.updateOutboxSnapshot { encoded ->
+            val snapshot = encoded?.let(IronwoodOutboxCodec::decode)
+                ?: IronwoodOutboxSnapshot()
+            result = block(snapshot)
+            IronwoodOutboxCodec.encode(snapshot)
+        }
+        @Suppress("UNCHECKED_CAST")
+        return result as T
+    }
+
+    fun read(): IronwoodOutboxSnapshot =
+        store.readOutboxSnapshot()?.let(IronwoodOutboxCodec::decode)
+            ?: IronwoodOutboxSnapshot()
+}
+
+internal object IronwoodOutboxState {
+    fun recoverInterrupted(snapshot: IronwoodOutboxSnapshot, nowMs: Long) {
+        snapshot.batches.flatMap { it.items }
+            .filter { it.status == IronwoodOutboxItemStatus.SUBMITTING }
+            .forEach { item ->
+                item.status = IronwoodOutboxItemStatus.ARMED
+                item.attemptCount += 1
+                item.nextAttemptAtMs = nowMs + retryDelayMs(item.attemptCount)
+                item.lastError = "The previous submission outcome is unknown."
+                item.attemptId = null
+                item.attemptStartedAtMs = null
+            }
+    }
+
+    fun nextEndpoint(snapshot: IronwoodOutboxSnapshot): String? {
+        val endpoints = snapshot.batches
+            .filter { batch ->
+                batch.armedAtMs != null &&
+                    (
+                        batch.items.any { it.status == IronwoodOutboxItemStatus.ARMED } ||
+                            (
+                                batch.nextProofHeight != null &&
+                                    batch.proofReadyObservedHeight == null
+                                )
+                        )
+            }
+            .map { it.lightwalletdUrl }
+            .distinct()
+            .sorted()
+        if (endpoints.isEmpty()) return null
+        val lastIndex = endpoints.indexOf(snapshot.lastInspectedEndpoint)
+        return endpoints[if (lastIndex < 0) 0 else (lastIndex + 1) % endpoints.size]
+            .also { snapshot.lastInspectedEndpoint = it }
+    }
+
+    fun expireAndMarkNoncanonical(
+        snapshot: IronwoodOutboxSnapshot,
+        endpoint: String,
+        remoteHeight: Long,
+        nowMs: Long,
+    ): Boolean {
+        val canonicalExpiry = canonicalExpiryHeight(remoteHeight)
+        var needsUserAction = false
+        snapshot.batches.filter { it.lightwalletdUrl == endpoint }.forEach { batch ->
+            var terminal = false
+            batch.items.filter { it.status == IronwoodOutboxItemStatus.ARMED }.forEach { item ->
+                val outcome = when {
+                    remoteHeight >= item.expiryHeight -> "expired"
+                    item.scheduledHeight <= remoteHeight &&
+                        canonicalExpiry != null &&
+                        item.expiryHeight != canonicalExpiry -> "needsResign"
+                    else -> null
+                } ?: return@forEach
+                item.status = if (outcome == "expired") {
+                    IronwoodOutboxItemStatus.EXPIRED_AWAITING_RECONCILIATION
+                } else {
+                    IronwoodOutboxItemStatus.NEEDS_RESIGN_AWAITING_RECONCILIATION
+                }
+                snapshot.receipts += receipt(
+                    batch = batch,
+                    item = item,
+                    outcome = outcome,
+                    remoteHeight = remoteHeight,
+                    responseCode = null,
+                    responseMessage = if (outcome == "needsResign") {
+                        "Broadcast height crossed a ZIP 318 expiry boundary."
+                    } else {
+                        null
+                    },
+                    nowMs = nowMs,
+                )
+                batch.needsUserActionNotificationPending = true
+                terminal = true
+                needsUserAction = true
+            }
+            if (terminal) {
+                batch.armedAtMs = null
+                batch.nextProofHeight = null
+            }
+        }
+        return needsUserAction
+    }
+
+    fun markProofReadyIfNeeded(
+        snapshot: IronwoodOutboxSnapshot,
+        endpoint: String,
+        remoteHeight: Long,
+    ): String? {
+        val batch = snapshot.batches.filter {
+            it.lightwalletdUrl == endpoint &&
+                it.armedAtMs != null &&
+                it.proofReadyObservedHeight == null &&
+                it.nextProofHeight != null &&
+                it.nextProofHeight!! <= remoteHeight
+        }.minWithOrNull(compareBy<IronwoodOutboxBatch> { it.nextProofHeight }.thenBy { it.batchId })
+            ?: return null
+        batch.proofReadyObservedHeight = remoteHeight
+        return batch.batchId
+    }
+
+    fun pendingProofReadyBatchId(snapshot: IronwoodOutboxSnapshot): String? =
+        snapshot.batches.filter {
+            it.proofReadyObservedHeight != null &&
+                !it.proofReadyNotificationAcknowledged
+        }.minByOrNull { it.batchId }?.batchId
+
+    fun acknowledgeProofReadyNotification(
+        snapshot: IronwoodOutboxSnapshot,
+        batchId: String,
+    ): Boolean {
+        val batch = snapshot.batches.firstOrNull { it.batchId == batchId }
+            ?: return false
+        if (batch.proofReadyObservedHeight == null) return false
+        batch.proofReadyNotificationAcknowledged = true
+        return true
+    }
+
+    fun pendingNeedsUserActionBatchId(snapshot: IronwoodOutboxSnapshot): String? =
+        snapshot.batches.filter {
+            it.needsUserActionNotificationPending
+        }.minByOrNull { it.batchId }?.batchId
+
+    fun markNeedsUserActionNotificationPending(
+        snapshot: IronwoodOutboxSnapshot,
+        batchId: String,
+    ) {
+        snapshot.batches.firstOrNull { it.batchId == batchId }
+            ?.needsUserActionNotificationPending = true
+    }
+
+    fun acknowledgeNeedsUserActionNotification(
+        snapshot: IronwoodOutboxSnapshot,
+        batchId: String,
+    ): Boolean {
+        val batch = snapshot.batches.firstOrNull { it.batchId == batchId }
+            ?: return false
+        if (!batch.needsUserActionNotificationPending) return false
+        batch.needsUserActionNotificationPending = false
+        return true
+    }
+
+    fun pendingBroadcastCompleteBatchId(snapshot: IronwoodOutboxSnapshot): String? =
+        snapshot.batches.filter {
+            it.broadcastCompletePending
+        }.minByOrNull { it.batchId }?.batchId
+
+    fun acknowledgeBroadcastCompleteNotification(
+        snapshot: IronwoodOutboxSnapshot,
+        batchId: String,
+    ): Boolean {
+        val batch = snapshot.batches.firstOrNull { it.batchId == batchId }
+            ?: return false
+        if (!batch.broadcastCompletePending) return false
+        batch.broadcastCompletePending = false
+        if (batch.items.isEmpty() && batch.nextProofHeight == null) {
+            snapshot.batches.remove(batch)
+        }
+        return true
+    }
+
+    fun selectDue(
+        snapshot: IronwoodOutboxSnapshot,
+        endpoint: String,
+        remoteHeight: Long,
+        nowMs: Long,
+    ): Pair<IronwoodOutboxBatch, IronwoodOutboxItem>? {
+        val candidates = snapshot.batches.filter { batch ->
+            batch.lightwalletdUrl == endpoint &&
+                batch.armedAtMs != null &&
+                batch.items.any { it.isDue(remoteHeight, nowMs) }
+        }
+        if (candidates.isEmpty()) return null
+        val scopes = candidates.map { it.scopeKey }.distinct().sorted()
+        val lastIndex = scopes.indexOf(snapshot.lastAttemptedScopeKey)
+        val selectedScope = scopes[if (lastIndex < 0) 0 else (lastIndex + 1) % scopes.size]
+        val batch = candidates.first { it.scopeKey == selectedScope }
+        val item = batch.items.filter { it.isDue(remoteHeight, nowMs) }
+            .minWith(compareBy<IronwoodOutboxItem> { it.scheduledHeight }.thenBy { it.txidHex })
+        snapshot.lastAttemptedScopeKey = selectedScope
+        return batch to item
+    }
+
+    fun beginSubmission(item: IronwoodOutboxItem, nowMs: Long) {
+        check(item.status == IronwoodOutboxItemStatus.ARMED)
+        item.status = IronwoodOutboxItemStatus.SUBMITTING
+        item.attemptId = UUID.randomUUID().toString()
+        item.attemptStartedAtMs = nowMs
+    }
+
+    fun validateReschedulingAfterAcceptance(
+        batch: IronwoodOutboxBatch,
+        excludingItemId: String,
+        remoteHeight: Long,
+    ) {
+        var nextHeight = remoteHeight
+        batch.items.filter {
+            it.itemId != excludingItemId &&
+                it.status == IronwoodOutboxItemStatus.ARMED &&
+                it.scheduledHeight <= remoteHeight
+        }.map { it.expiryHeight }.sorted().forEach { expiryHeight ->
+            nextHeight = Math.addExact(nextHeight, 1)
+            require(nextHeight < expiryHeight) { "Invalid outbox rescheduling window." }
+        }
+    }
+
+    fun recordUncertain(item: IronwoodOutboxItem, message: String, nowMs: Long) {
+        check(item.status == IronwoodOutboxItemStatus.SUBMITTING)
+        item.status = IronwoodOutboxItemStatus.ARMED
+        item.attemptCount += 1
+        item.nextAttemptAtMs = nowMs + retryDelayMs(item.attemptCount)
+        item.lastError = message
+        item.attemptId = null
+        item.attemptStartedAtMs = null
+    }
+
+    fun recordAccepted(
+        snapshot: IronwoodOutboxSnapshot,
+        batch: IronwoodOutboxBatch,
+        item: IronwoodOutboxItem,
+        equivalent: Boolean,
+        remoteHeight: Long,
+        responseCode: Int,
+        responseMessage: String,
+        nowMs: Long,
+        random: Random,
+    ) {
+        check(item.status == IronwoodOutboxItemStatus.SUBMITTING)
+        item.status = IronwoodOutboxItemStatus.ACCEPTED_AWAITING_RECONCILIATION
+        item.attemptId = null
+        item.attemptStartedAtMs = null
+        item.nextAttemptAtMs = null
+        val updates = rescheduleOverdue(batch, item.itemId, remoteHeight, random)
+        snapshot.receipts += receipt(
+            batch = batch,
+            item = item,
+            outcome = if (equivalent) "acceptedEquivalent" else "accepted",
+            remoteHeight = remoteHeight,
+            responseCode = responseCode,
+            responseMessage = responseMessage,
+            scheduleUpdates = updates,
+            rawTransaction = item.rawTransaction,
+            nowMs = nowMs,
+        )
+        if (
+            batch.nextProofHeight == null &&
+            batch.items.isNotEmpty() &&
+            batch.items.all {
+                it.status == IronwoodOutboxItemStatus.ACCEPTED_AWAITING_RECONCILIATION
+            }
+        ) {
+            batch.broadcastCompletePending = true
+        }
+    }
+
+    fun recordRejected(
+        snapshot: IronwoodOutboxSnapshot,
+        batch: IronwoodOutboxBatch,
+        item: IronwoodOutboxItem,
+        remoteHeight: Long,
+        responseCode: Int,
+        responseMessage: String,
+        nowMs: Long,
+    ) {
+        check(item.status == IronwoodOutboxItemStatus.SUBMITTING)
+        item.status = IronwoodOutboxItemStatus.REJECTED_AWAITING_RECONCILIATION
+        item.attemptId = null
+        item.attemptStartedAtMs = null
+        item.nextAttemptAtMs = null
+        batch.armedAtMs = null
+        batch.nextProofHeight = null
+        batch.needsUserActionNotificationPending = true
+        snapshot.receipts += receipt(
+            batch = batch,
+            item = item,
+            outcome = "rejected",
+            remoteHeight = remoteHeight,
+            responseCode = responseCode,
+            responseMessage = responseMessage,
+            nowMs = nowMs,
+        )
+    }
+
+    fun nextActionHeight(snapshot: IronwoodOutboxSnapshot, endpoint: String): Long? =
+        snapshot.batches.filter { it.lightwalletdUrl == endpoint }
+            .flatMap { batch ->
+                buildList {
+                    addAll(
+                        batch.items.filter { it.status == IronwoodOutboxItemStatus.ARMED }
+                            .map { it.scheduledHeight },
+                    )
+                    if (
+                        batch.armedAtMs != null &&
+                        batch.proofReadyObservedHeight == null
+                    ) {
+                        batch.nextProofHeight?.let(::add)
+                    }
+                }
+            }
+            .minOrNull()
+
+    fun hasDeliveryWork(snapshot: IronwoodOutboxSnapshot): Boolean =
+        snapshot.batches.any { batch ->
+            batch.armedAtMs != null &&
+                (
+                    batch.items.any { it.status == IronwoodOutboxItemStatus.ARMED } ||
+                        (
+                            batch.nextProofHeight != null &&
+                                batch.proofReadyObservedHeight == null
+                            )
+                    )
+        }
+
+    fun hasDeliveryWorkForOtherEndpoint(
+        snapshot: IronwoodOutboxSnapshot,
+        endpoint: String,
+    ): Boolean =
+        snapshot.batches.any { batch ->
+            batch.lightwalletdUrl != endpoint &&
+                batch.armedAtMs != null &&
+                (
+                    batch.items.any { it.status == IronwoodOutboxItemStatus.ARMED } ||
+                        (
+                            batch.nextProofHeight != null &&
+                                batch.proofReadyObservedHeight == null
+                            )
+                    )
+        }
+
+    fun hasRunnableWork(snapshot: IronwoodOutboxSnapshot): Boolean =
+        hasDeliveryWork(snapshot) ||
+            hasPendingNotifications(snapshot)
+
+    fun hasPendingNotifications(snapshot: IronwoodOutboxSnapshot): Boolean =
+        snapshot.batches.any {
+            it.needsUserActionNotificationPending ||
+                it.broadcastCompletePending ||
+                (
+                    it.proofReadyObservedHeight != null &&
+                        !it.proofReadyNotificationAcknowledged
+                    )
+        }
+
+    fun acknowledgeReceipts(
+        snapshot: IronwoodOutboxSnapshot,
+        receiptIds: Set<String>,
+    ) {
+        val acknowledged = snapshot.receipts.filter { it.receiptId in receiptIds }
+        val acknowledgedItems = acknowledged.map { it.itemId }.toSet()
+        val terminalBatches = acknowledged.filter {
+            it.outcome in setOf("rejected", "expired", "needsResign")
+        }.map { it.batchId }.toSet()
+        snapshot.receipts.removeAll { it.receiptId in receiptIds }
+        snapshot.batches.forEach { batch ->
+            batch.items.removeAll { it.itemId in acknowledgedItems }
+        }
+        snapshot.batches.removeAll { batch ->
+            (
+                batch.items.isEmpty() &&
+                    batch.nextProofHeight == null &&
+                    !batch.broadcastCompletePending
+                ) ||
+                (
+                    batch.batchId in terminalBatches &&
+                        snapshot.receipts.none { it.batchId == batch.batchId }
+                    )
+        }
+    }
+
+    fun canonicalExpiryHeight(height: Long): Long? {
+        if (height < 0) return null
+        val modulus = 34_560L
+        val boundary = height - height % modulus
+        return try {
+            Math.addExact(boundary, Math.multiplyExact(modulus, 2))
+        } catch (_: ArithmeticException) {
+            null
+        }
+    }
+
+    fun retryDelayMs(attemptCount: Int): Long = when (attemptCount) {
+        0, 1 -> 60_000
+        2 -> 5 * 60_000
+        3 -> 15 * 60_000
+        else -> 60 * 60_000
+    }
+
+    fun nextCheckDelayMs(remoteHeight: Long, nextHeight: Long?): Long? {
+        nextHeight ?: return null
+        if (nextHeight <= remoteHeight) return 60_000
+        val estimated = Math.multiplyExact(nextHeight - remoteHeight, 75_000L)
+        return min(10 * 60_000L, max(60_000L, estimated - 10 * 60_000L))
+    }
+
+    private fun IronwoodOutboxItem.isDue(remoteHeight: Long, nowMs: Long): Boolean =
+        status == IronwoodOutboxItemStatus.ARMED &&
+            scheduledHeight <= remoteHeight &&
+            remoteHeight < expiryHeight &&
+            (nextAttemptAtMs == null || nextAttemptAtMs!! <= nowMs)
+
+    private fun rescheduleOverdue(
+        batch: IronwoodOutboxBatch,
+        excludingItemId: String,
+        remoteHeight: Long,
+        random: Random,
+    ): List<IronwoodOutboxScheduleUpdate> {
+        val overdue = batch.items.filter {
+            it.itemId != excludingItemId &&
+                it.status == IronwoodOutboxItemStatus.ARMED &&
+                it.scheduledHeight <= remoteHeight
+        }.shuffled(random).sortedBy { it.expiryHeight }
+        var elapsed = 0L
+        return overdue.mapIndexed { index, item ->
+            val remaining = overdue.size - index - 1L
+            val latest = item.expiryHeight - remaining - 1
+            val current = Math.addExact(remoteHeight, elapsed)
+            require(latest > current) { "Invalid outbox rescheduling window." }
+            val boundedMax = min(batch.timingMaxBlocks, latest - current)
+            elapsed = Math.addExact(
+                elapsed,
+                sampleDelay(batch.timingMeanBlocks, boundedMax, random),
+            )
+            item.scheduledHeight = Math.addExact(remoteHeight, elapsed)
+            item.scheduleStartHeight = remoteHeight
+            IronwoodOutboxScheduleUpdate(
+                item.itemId,
+                item.scheduledHeight,
+                item.scheduleStartHeight,
+            )
+        }
+    }
+
+    private fun sampleDelay(mean: Long, maximum: Long, random: Random): Long {
+        require(mean > 0 && maximum > 0)
+        val lowerBound = exp(-maximum.toDouble() / mean.toDouble())
+        val uniform = lowerBound + (1 - lowerBound) * random.nextDouble()
+        return min(maximum, max(1, ceil(-ln(uniform) * mean).toLong()))
+    }
+
+    private fun receipt(
+        batch: IronwoodOutboxBatch,
+        item: IronwoodOutboxItem,
+        outcome: String,
+        remoteHeight: Long,
+        responseCode: Int?,
+        responseMessage: String?,
+        scheduleUpdates: List<IronwoodOutboxScheduleUpdate> = emptyList(),
+        rawTransaction: ByteArray? = null,
+        nowMs: Long,
+    ) = IronwoodOutboxReceipt(
+        receiptId = "${batch.batchId}:${item.itemId}:$outcome",
+        batchId = batch.batchId,
+        itemId = item.itemId,
+        network = batch.network,
+        accountUuid = batch.accountUuid,
+        runId = batch.runId,
+        txidHex = item.txidHex,
+        outcome = outcome,
+        remoteHeight = remoteHeight,
+        responseCode = responseCode,
+        responseMessage = responseMessage,
+        recordedAtMs = nowMs,
+        scheduleUpdates = scheduleUpdates,
+        rawTransaction = rawTransaction,
+    )
+}
+
+internal object IronwoodOutboxCodec {
+    fun encode(snapshot: IronwoodOutboxSnapshot): ByteArray =
+        encodeIronwoodOutboxMap(
+            mapOf(
+                "version" to 1,
+                "batches" to snapshot.batches.map(::encodeBatch),
+                "receipts" to snapshot.receipts.map(::encodeReceipt),
+                "lastAttemptedScopeKey" to snapshot.lastAttemptedScopeKey,
+                "lastInspectedEndpoint" to snapshot.lastInspectedEndpoint,
+            ),
+        )
+
+    fun decode(encoded: ByteArray): IronwoodOutboxSnapshot {
+        val root = decodeIronwoodOutboxMap(encoded)
+        require(number(root, "version") == 1L) { "Unsupported outbox snapshot." }
+        return IronwoodOutboxSnapshot(
+            batches = maps(root["batches"]).map(::decodeBatch).toMutableList(),
+            receipts = maps(root["receipts"]).map(::decodeReceipt).toMutableList(),
+            lastAttemptedScopeKey = root["lastAttemptedScopeKey"] as? String,
+            lastInspectedEndpoint = root["lastInspectedEndpoint"] as? String,
+        )
+    }
+
+    private fun encodeBatch(batch: IronwoodOutboxBatch) = mapOf(
+        "batchId" to batch.batchId,
+        "network" to batch.network,
+        "accountUuid" to batch.accountUuid,
+        "runId" to batch.runId,
+        "lightwalletdUrl" to batch.lightwalletdUrl,
+        "timingMeanBlocks" to batch.timingMeanBlocks,
+        "timingMaxBlocks" to batch.timingMaxBlocks,
+        "createdAtMs" to batch.createdAtMs,
+        "armedAtMs" to batch.armedAtMs,
+        "nextProofHeight" to batch.nextProofHeight,
+        "proofReadyObservedHeight" to batch.proofReadyObservedHeight,
+        "proofReadyNotificationAcknowledged" to
+            batch.proofReadyNotificationAcknowledged,
+        "needsUserActionNotificationPending" to
+            batch.needsUserActionNotificationPending,
+        "broadcastCompletePending" to batch.broadcastCompletePending,
+        "items" to batch.items.map(::encodeItem),
+    )
+
+    private fun encodeItem(item: IronwoodOutboxItem) = mapOf(
+        "itemId" to item.itemId,
+        "partIndex" to item.partIndex,
+        "txidHex" to item.txidHex,
+        "rawTransaction" to item.rawTransaction,
+        "payloadDigestHex" to item.payloadDigestHex,
+        "anchorBoundaryHeight" to item.anchorBoundaryHeight,
+        "scheduledHeight" to item.scheduledHeight,
+        "scheduleStartHeight" to item.scheduleStartHeight,
+        "expiryHeight" to item.expiryHeight,
+        "status" to item.status.name,
+        "attemptCount" to item.attemptCount,
+        "attemptId" to item.attemptId,
+        "attemptStartedAtMs" to item.attemptStartedAtMs,
+        "nextAttemptAtMs" to item.nextAttemptAtMs,
+        "lastError" to item.lastError,
+    )
+
+    private fun encodeReceipt(receipt: IronwoodOutboxReceipt) = mapOf(
+        "receiptId" to receipt.receiptId,
+        "batchId" to receipt.batchId,
+        "itemId" to receipt.itemId,
+        "network" to receipt.network,
+        "accountUuid" to receipt.accountUuid,
+        "runId" to receipt.runId,
+        "txidHex" to receipt.txidHex,
+        "outcome" to receipt.outcome,
+        "remoteHeight" to receipt.remoteHeight,
+        "responseCode" to receipt.responseCode,
+        "responseMessage" to receipt.responseMessage,
+        "recordedAtMs" to receipt.recordedAtMs,
+        "scheduleUpdates" to receipt.scheduleUpdates.map {
+            mapOf(
+                "itemId" to it.itemId,
+                "scheduledHeight" to it.scheduledHeight,
+                "scheduleStartHeight" to it.scheduleStartHeight,
+            )
+        },
+        "rawTransaction" to receipt.rawTransaction,
+    )
+
+    private fun decodeBatch(value: Map<String, Any?>) = IronwoodOutboxBatch(
+        batchId = text(value, "batchId"),
+        network = text(value, "network"),
+        accountUuid = text(value, "accountUuid"),
+        runId = text(value, "runId"),
+        lightwalletdUrl = text(value, "lightwalletdUrl"),
+        timingMeanBlocks = number(value, "timingMeanBlocks"),
+        timingMaxBlocks = number(value, "timingMaxBlocks"),
+        createdAtMs = number(value, "createdAtMs"),
+        armedAtMs = optionalNumber(value, "armedAtMs"),
+        nextProofHeight = optionalNumber(value, "nextProofHeight"),
+        proofReadyObservedHeight = optionalNumber(value, "proofReadyObservedHeight"),
+        proofReadyNotificationAcknowledged =
+            value["proofReadyNotificationAcknowledged"] as? Boolean ?: false,
+        needsUserActionNotificationPending =
+            value["needsUserActionNotificationPending"] as? Boolean ?: false,
+        broadcastCompletePending = value["broadcastCompletePending"] as? Boolean ?: false,
+        items = maps(value["items"]).map(::decodeItem).toMutableList(),
+    )
+
+    private fun decodeItem(value: Map<String, Any?>): IronwoodOutboxItem {
+        val raw = value["rawTransaction"] as? ByteArray
+            ?: throw IllegalArgumentException("Invalid outbox transaction.")
+        val digest = sha256Hex(raw)
+        require(digest == text(value, "payloadDigestHex")) {
+            "Outbox transaction digest mismatch."
+        }
+        return IronwoodOutboxItem(
+            itemId = text(value, "itemId"),
+            partIndex = number(value, "partIndex"),
+            txidHex = text(value, "txidHex"),
+            rawTransaction = raw,
+            payloadDigestHex = digest,
+            anchorBoundaryHeight = number(value, "anchorBoundaryHeight"),
+            scheduledHeight = number(value, "scheduledHeight"),
+            scheduleStartHeight = number(value, "scheduleStartHeight"),
+            expiryHeight = number(value, "expiryHeight"),
+            status = IronwoodOutboxItemStatus.valueOf(text(value, "status")),
+            attemptCount = number(value, "attemptCount").toInt(),
+            attemptId = value["attemptId"] as? String,
+            attemptStartedAtMs = optionalNumber(value, "attemptStartedAtMs"),
+            nextAttemptAtMs = optionalNumber(value, "nextAttemptAtMs"),
+            lastError = value["lastError"] as? String,
+        )
+    }
+
+    private fun decodeReceipt(value: Map<String, Any?>) = IronwoodOutboxReceipt(
+        receiptId = text(value, "receiptId"),
+        batchId = text(value, "batchId"),
+        itemId = text(value, "itemId"),
+        network = text(value, "network"),
+        accountUuid = text(value, "accountUuid"),
+        runId = text(value, "runId"),
+        txidHex = text(value, "txidHex"),
+        outcome = text(value, "outcome"),
+        remoteHeight = number(value, "remoteHeight"),
+        responseCode = optionalNumber(value, "responseCode")?.toInt(),
+        responseMessage = value["responseMessage"] as? String,
+        recordedAtMs = number(value, "recordedAtMs"),
+        scheduleUpdates = maps(value["scheduleUpdates"]).map {
+            IronwoodOutboxScheduleUpdate(
+                text(it, "itemId"),
+                number(it, "scheduledHeight"),
+                number(it, "scheduleStartHeight"),
+            )
+        },
+        rawTransaction = value["rawTransaction"] as? ByteArray,
+    )
+
+    private fun maps(value: Any?): List<Map<String, Any?>> =
+        (value as? List<*>)?.map { entry ->
+            val map = entry as? Map<*, *>
+                ?: throw IllegalArgumentException("Invalid outbox list.")
+            require(map.keys.all { it is String }) { "Invalid outbox map." }
+            @Suppress("UNCHECKED_CAST")
+            map as Map<String, Any?>
+        } ?: throw IllegalArgumentException("Invalid outbox list.")
+
+    private fun text(value: Map<String, Any?>, key: String): String =
+        value[key] as? String ?: throw IllegalArgumentException("Invalid outbox $key.")
+
+    private fun number(value: Map<String, Any?>, key: String): Long =
+        (value[key] as? Number)?.toLong()
+            ?: throw IllegalArgumentException("Invalid outbox $key.")
+
+    private fun optionalNumber(value: Map<String, Any?>, key: String): Long? =
+        (value[key] as? Number)?.toLong()
+
+    private fun sha256Hex(value: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(value)
+            .joinToString("") { "%02x".format(it.toInt() and 0xff) }
+}

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationOutboxWorker.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationOutboxWorker.kt
@@ -98,13 +98,23 @@ internal object IronwoodMigrationOutboxExecutionCoordinator {
     }
 
     fun cancelAndDrain(block: () -> Unit) {
-        quiescing.set(true)
+        val wasQuiescing = quiescing.getAndSet(true)
         cancellationEpoch.incrementAndGet()
         try {
             runLock.withLock(block)
         } finally {
-            quiescing.set(false)
+            if (!wasQuiescing) quiescing.set(false)
         }
+    }
+
+    fun quiesceAndDrain() {
+        quiescing.set(true)
+        cancellationEpoch.incrementAndGet()
+        runLock.withLock { }
+    }
+
+    fun resume() {
+        quiescing.set(false)
     }
 }
 
@@ -122,9 +132,10 @@ internal class IronwoodMigrationOutboxRunner(
     }
 
     fun runOnceWaitingForActiveRun(): IronwoodMigrationOutboxRunResult =
-        IronwoodMigrationOutboxExecutionCoordinator.runExclusive {
-            runOnceLocked(isStopped)
-        }
+        IronwoodMigrationOutboxExecutionCoordinator.runWhenAvailable {
+            coordinatorCancelled ->
+            runOnceLocked { isStopped() || coordinatorCancelled() }
+        } ?: result(IronwoodMigrationOutboxOutcome.RETRY)
 
     private fun runOnceLocked(cancelled: () -> Boolean): IronwoodMigrationOutboxRunResult {
         if (cancelled()) return result(IronwoodMigrationOutboxOutcome.CANCELLED)
@@ -404,15 +415,25 @@ internal object IronwoodMigrationOutboxScheduler {
     }
 
     fun enqueueContinuation(context: Context, delayMs: Long) {
-        WorkManager.getInstance(context).enqueueUniqueWork(
-            UNIQUE_WORK_NAME,
-            ExistingWorkPolicy.APPEND_OR_REPLACE,
-            request(delayMs),
-        )
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork(
+                UNIQUE_WORK_NAME,
+                ExistingWorkPolicy.APPEND_OR_REPLACE,
+                request(delayMs),
+            )
+            .result
+            .get()
     }
 
     fun cancel(context: Context) {
         WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_WORK_NAME)
+    }
+
+    fun cancelAndWait(context: Context) {
+        WorkManager.getInstance(context)
+            .cancelUniqueWork(UNIQUE_WORK_NAME)
+            .result
+            .get()
     }
 
     internal fun request(delayMs: Long = 0): OneTimeWorkRequest =

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationOutboxWorker.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationOutboxWorker.kt
@@ -1,0 +1,739 @@
+package com.keplr.vizor
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.Worker
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.math.min
+import kotlin.random.Random
+
+internal enum class IronwoodMigrationOutboxOutcome {
+    NO_WORK,
+    WAITING,
+    ACCEPTED,
+    NEEDS_USER_ACTION,
+    RETRY,
+    CANCELLED,
+}
+
+internal data class IronwoodMigrationOutboxRunResult(
+    val outcome: IronwoodMigrationOutboxOutcome,
+    val nextHeight: Long? = null,
+    val observedHeight: Long? = null,
+    val delayMs: Long? = null,
+    val proofReadyBatchId: String? = null,
+)
+
+internal enum class IronwoodMigrationNotificationDelivery {
+    DELIVERED,
+    DISABLED,
+    RETRY,
+}
+
+private data class IronwoodOutboxSubmission(
+    val batchId: String,
+    val itemId: String,
+    val rawTransaction: ByteArray,
+)
+
+internal object IronwoodMigrationOutboxExecutionCoordinator {
+    private val runLock = ReentrantLock()
+    private val cancellationEpoch = AtomicLong()
+    private val quiescing = AtomicBoolean()
+
+    fun <T> tryRun(block: (isCancelled: () -> Boolean) -> T): T? {
+        if (quiescing.get()) return null
+        if (!runLock.tryLock()) return null
+        val epoch = cancellationEpoch.get()
+        if (quiescing.get()) {
+            runLock.unlock()
+            return null
+        }
+        return try {
+            block { cancellationEpoch.get() != epoch }
+        } finally {
+            runLock.unlock()
+        }
+    }
+
+    fun <T> runExclusive(block: () -> T): T = runLock.withLock(block)
+
+    fun <T> runWhenAvailable(
+        block: (isCancelled: () -> Boolean) -> T,
+    ): T? {
+        if (quiescing.get()) return null
+        runLock.lock()
+        return try {
+            if (quiescing.get()) return null
+            val epoch = cancellationEpoch.get()
+            block {
+                quiescing.get() || cancellationEpoch.get() != epoch
+            }
+        } finally {
+            runLock.unlock()
+        }
+    }
+
+    fun cancelAndDrain(block: () -> Unit) {
+        quiescing.set(true)
+        cancellationEpoch.incrementAndGet()
+        try {
+            runLock.withLock(block)
+        } finally {
+            quiescing.set(false)
+        }
+    }
+}
+
+internal class IronwoodMigrationOutboxRunner(
+    private val repository: IronwoodMigrationOutboxRepository,
+    private val transport: IronwoodMigrationOutboxTransport,
+    private val isStopped: () -> Boolean = { false },
+    private val clockMs: () -> Long = System::currentTimeMillis,
+    private val random: Random = Random.Default,
+) {
+    fun runOnce(): IronwoodMigrationOutboxRunResult {
+        return IronwoodMigrationOutboxExecutionCoordinator.tryRun { isCancelled ->
+            runOnceLocked { isStopped() || isCancelled() }
+        } ?: result(IronwoodMigrationOutboxOutcome.RETRY)
+    }
+
+    fun runOnceWaitingForActiveRun(): IronwoodMigrationOutboxRunResult =
+        IronwoodMigrationOutboxExecutionCoordinator.runExclusive {
+            runOnceLocked(isStopped)
+        }
+
+    private fun runOnceLocked(cancelled: () -> Boolean): IronwoodMigrationOutboxRunResult {
+        if (cancelled()) return result(IronwoodMigrationOutboxOutcome.CANCELLED)
+        var pendingProofReadyBatchId: String? = null
+        val endpoint = repository.update { snapshot ->
+            IronwoodOutboxState.recoverInterrupted(snapshot, clockMs())
+            pendingProofReadyBatchId =
+                IronwoodOutboxState.pendingProofReadyBatchId(snapshot)
+            IronwoodOutboxState.nextEndpoint(snapshot)
+        } ?: return result(
+            IronwoodMigrationOutboxOutcome.NO_WORK,
+            pendingProofReadyBatchId,
+        )
+
+        val remoteHeight = try {
+            transport.latestBlockHeight(endpoint)
+        } catch (_: IronwoodMigrationNativeException) {
+            return if (cancelled()) {
+                result(
+                    IronwoodMigrationOutboxOutcome.CANCELLED,
+                    pendingProofReadyBatchId,
+                )
+            } else {
+                result(
+                    IronwoodMigrationOutboxOutcome.RETRY,
+                    pendingProofReadyBatchId,
+                )
+            }
+        }
+        if (cancelled()) {
+            return result(
+                IronwoodMigrationOutboxOutcome.CANCELLED,
+                pendingProofReadyBatchId,
+            )
+        }
+
+        var needsUserAction = false
+        var proofReadyBatchId = pendingProofReadyBatchId
+        var selectedBatchId: String? = null
+        val submission = try {
+            repository.update { snapshot ->
+                val now = clockMs()
+                needsUserAction = IronwoodOutboxState.expireAndMarkNoncanonical(
+                    snapshot,
+                    endpoint,
+                    remoteHeight,
+                    now,
+                )
+                val newlyProofReadyBatchId = IronwoodOutboxState.markProofReadyIfNeeded(
+                    snapshot,
+                    endpoint,
+                    remoteHeight,
+                )
+                proofReadyBatchId = proofReadyBatchId ?: newlyProofReadyBatchId
+                val selected = IronwoodOutboxState.selectDue(
+                    snapshot,
+                    endpoint,
+                    remoteHeight,
+                    now,
+                )
+                selected?.let { (batch, item) ->
+                    selectedBatchId = batch.batchId
+                    IronwoodOutboxState.validateReschedulingAfterAcceptance(
+                        batch,
+                        item.itemId,
+                        remoteHeight,
+                    )
+                    IronwoodOutboxState.beginSubmission(item, now)
+                    IronwoodOutboxSubmission(
+                        batch.batchId,
+                        item.itemId,
+                        item.rawTransaction.copyOf(),
+                    )
+                }
+            }
+        } catch (_: IllegalArgumentException) {
+            selectedBatchId?.let(::markNeedsUserActionNotificationPending)
+            return result(
+                IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION,
+                proofReadyBatchId,
+            )
+        }
+        if (submission == null) {
+            if (needsUserAction) {
+                return result(
+                    IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION,
+                    proofReadyBatchId,
+                )
+            }
+            return waiting(endpoint, remoteHeight, proofReadyBatchId)
+        }
+        if (cancelled()) {
+            recordUncertain(submission, "The outbox worker was stopped.")
+            return result(
+                IronwoodMigrationOutboxOutcome.CANCELLED,
+                proofReadyBatchId,
+            )
+        }
+
+        val response = try {
+            transport.sendTransaction(endpoint, submission.rawTransaction)
+        } catch (error: IronwoodMigrationNativeException) {
+            recordUncertain(submission, error.message ?: "Transaction submission failed.")
+            return if (cancelled()) {
+                result(
+                    IronwoodMigrationOutboxOutcome.CANCELLED,
+                    proofReadyBatchId,
+                )
+            } else {
+                result(
+                    IronwoodMigrationOutboxOutcome.RETRY,
+                    proofReadyBatchId,
+                )
+            }
+        } finally {
+            submission.rawTransaction.fill(0)
+        }
+
+        return try {
+            repository.update { snapshot ->
+                val batch = snapshot.batches.first { it.batchId == submission.batchId }
+                val item = batch.items.first { it.itemId == submission.itemId }
+                if (response.errorCode == 0 || isAcceptedEquivalent(response.errorMessage)) {
+                    IronwoodOutboxState.recordAccepted(
+                        snapshot = snapshot,
+                        batch = batch,
+                        item = item,
+                        equivalent = response.errorCode != 0,
+                        remoteHeight = remoteHeight,
+                        responseCode = response.errorCode,
+                        responseMessage = response.errorMessage,
+                        nowMs = clockMs(),
+                        random = random,
+                    )
+                    val next = IronwoodOutboxState.nextActionHeight(snapshot, endpoint)
+                    var delay = IronwoodOutboxState.nextCheckDelayMs(remoteHeight, next)
+                        ?: 0L.takeIf { IronwoodOutboxState.hasRunnableWork(snapshot) }
+                    if (
+                        delay != null &&
+                        IronwoodOutboxState.hasDeliveryWorkForOtherEndpoint(
+                            snapshot,
+                            endpoint,
+                        )
+                    ) {
+                        delay = min(delay, OTHER_ENDPOINT_CHECK_DELAY_MS)
+                    }
+                    IronwoodMigrationOutboxRunResult(
+                        outcome = IronwoodMigrationOutboxOutcome.ACCEPTED,
+                        nextHeight = next,
+                        observedHeight = remoteHeight,
+                        delayMs = delay,
+                        proofReadyBatchId = proofReadyBatchId,
+                    )
+                } else {
+                    IronwoodOutboxState.recordRejected(
+                        snapshot,
+                        batch,
+                        item,
+                        remoteHeight,
+                        response.errorCode,
+                        response.errorMessage,
+                        clockMs(),
+                    )
+                    result(
+                        IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION,
+                        proofReadyBatchId,
+                    )
+                }
+            }
+        } catch (_: Exception) {
+            markNeedsUserActionNotificationPending(submission.batchId)
+            result(
+                IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION,
+                proofReadyBatchId,
+            )
+        }
+    }
+
+    private fun waiting(
+        endpoint: String,
+        remoteHeight: Long,
+        proofReadyBatchId: String?,
+    ): IronwoodMigrationOutboxRunResult {
+        val snapshot = repository.read()
+        val next = IronwoodOutboxState.nextActionHeight(snapshot, endpoint)
+        var delay = IronwoodOutboxState.nextCheckDelayMs(remoteHeight, next)
+            ?: 0L.takeIf { IronwoodOutboxState.hasRunnableWork(snapshot) }
+        if (
+            delay != null &&
+            IronwoodOutboxState.hasDeliveryWorkForOtherEndpoint(snapshot, endpoint)
+        ) {
+            delay = min(delay, OTHER_ENDPOINT_CHECK_DELAY_MS)
+        }
+        return IronwoodMigrationOutboxRunResult(
+            outcome = IronwoodMigrationOutboxOutcome.WAITING,
+            nextHeight = next,
+            observedHeight = remoteHeight,
+            delayMs = delay,
+            proofReadyBatchId = proofReadyBatchId,
+        )
+    }
+
+    private fun recordUncertain(
+        submission: IronwoodOutboxSubmission,
+        message: String,
+    ) {
+        runCatching {
+            repository.update { snapshot ->
+                val item = snapshot.batches.first { it.batchId == submission.batchId }
+                    .items.first { it.itemId == submission.itemId }
+                IronwoodOutboxState.recordUncertain(item, message, clockMs())
+            }
+        }
+    }
+
+    private fun markNeedsUserActionNotificationPending(batchId: String) {
+        runCatching {
+            repository.update { snapshot ->
+                IronwoodOutboxState.markNeedsUserActionNotificationPending(
+                    snapshot,
+                    batchId,
+                )
+            }
+        }
+    }
+
+    private fun isAcceptedEquivalent(message: String): Boolean {
+        val normalized = message.lowercase()
+        return ACCEPTED_EQUIVALENT_MESSAGES.any(normalized::contains)
+    }
+
+    private fun result(
+        outcome: IronwoodMigrationOutboxOutcome,
+        proofReadyBatchId: String? = null,
+    ) = IronwoodMigrationOutboxRunResult(
+        outcome = outcome,
+        proofReadyBatchId = proofReadyBatchId,
+    )
+
+    private companion object {
+        const val OTHER_ENDPOINT_CHECK_DELAY_MS = 60_000L
+        val ACCEPTED_EQUIVALENT_MESSAGES = listOf(
+            "transaction was committed to the best chain",
+            "already in mempool",
+            "already have transaction",
+            "transaction already in block chain",
+            "transaction is already in state",
+            "transaction already exists",
+            "txn-already-known",
+            "txn-already-in-mempool",
+            "already known",
+        )
+    }
+}
+
+internal object IronwoodMigrationOutboxScheduler {
+    const val UNIQUE_WORK_NAME = "ironwood-migration-outbox"
+    const val WORK_TAG = "ironwood-migration-outbox"
+    private const val RETRY_DELAY_MINUTES = 1L
+
+    fun enqueue(context: Context, delayMs: Long = 0) {
+        // A newly armed batch must supersede an older height-based wake-up;
+        // otherwise KEEP can leave immediately due transactions behind a
+        // continuation that was scheduled several minutes earlier. Waiting
+        // for the execution coordinator ensures REPLACE cannot cancel a
+        // transaction submission that is already in progress.
+        IronwoodMigrationOutboxExecutionCoordinator.runExclusive {
+            WorkManager.getInstance(context)
+                .enqueueUniqueWork(
+                    UNIQUE_WORK_NAME,
+                    ExistingWorkPolicy.REPLACE,
+                    request(delayMs),
+                )
+                .result
+                .get()
+        }
+    }
+
+    fun enqueueContinuation(context: Context, delayMs: Long) {
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            UNIQUE_WORK_NAME,
+            ExistingWorkPolicy.APPEND_OR_REPLACE,
+            request(delayMs),
+        )
+    }
+
+    fun cancel(context: Context) {
+        WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_WORK_NAME)
+    }
+
+    internal fun request(delayMs: Long = 0): OneTimeWorkRequest =
+        OneTimeWorkRequestBuilder<IronwoodMigrationOutboxWorker>()
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build(),
+            )
+            .setBackoffCriteria(
+                BackoffPolicy.LINEAR,
+                RETRY_DELAY_MINUTES,
+                TimeUnit.MINUTES,
+            )
+            .setInitialDelay(delayMs, TimeUnit.MILLISECONDS)
+            .addTag(WORK_TAG)
+            .build()
+}
+
+class IronwoodMigrationOutboxWorker(
+    appContext: Context,
+    workerParams: WorkerParameters,
+) : Worker(appContext, workerParams) {
+    override fun doWork(): Result = try {
+        setForegroundAsync(createForegroundInfo()).get()
+        val repository = IronwoodMigrationOutboxRepository(
+            IronwoodMigrationSecureStore(applicationContext),
+        )
+        IronwoodMigrationOutboxExecutionCoordinator.runWhenAvailable { coordinatorCancelled ->
+            val result = IronwoodMigrationOutboxRunner(
+                repository = repository,
+                transport = IronwoodMigrationOutboxNativeBridge(),
+                isStopped = { isStopped },
+            ).runOnce()
+            processRunResult(
+                repository = repository,
+                result = result,
+                cancelled = { isStopped || coordinatorCancelled() },
+            )
+        } ?: if (isStopped) Result.failure() else Result.retry()
+    } catch (error: IllegalArgumentException) {
+        Result.failure(workDataOf(OUTPUT_ERROR to (error.message ?: "Invalid outbox.")))
+    } catch (error: IronwoodMigrationSecureStoreException) {
+        Result.failure(
+            workDataOf(
+                OUTPUT_ERROR to
+                    (error.message ?: "The migration outbox could not be opened."),
+            ),
+        )
+    } catch (_: Exception) {
+        if (isStopped) Result.failure() else Result.retry()
+    }
+
+    private fun processRunResult(
+        repository: IronwoodMigrationOutboxRepository,
+        result: IronwoodMigrationOutboxRunResult,
+        cancelled: () -> Boolean,
+    ): Result {
+        if (cancelled() || result.outcome == IronwoodMigrationOutboxOutcome.CANCELLED) {
+            return Result.failure()
+        }
+        val notificationDeliveries =
+            mutableListOf<IronwoodMigrationNotificationDelivery>()
+        if (!cancelled()) {
+            result.proofReadyBatchId?.let { batchId ->
+                notificationDeliveries +=
+                    deliverProofReadyNotification(repository, batchId)
+            }
+            if (!cancelled()) {
+                repository.read().let(
+                    IronwoodOutboxState::pendingNeedsUserActionBatchId,
+                )?.let { batchId ->
+                    notificationDeliveries +=
+                        deliverNeedsUserActionNotification(repository, batchId)
+                }
+            }
+            if (!cancelled()) {
+                repository.read().let(
+                    IronwoodOutboxState::pendingBroadcastCompleteBatchId,
+                )?.let { batchId ->
+                    notificationDeliveries +=
+                        deliverBroadcastCompleteNotification(repository, batchId)
+                }
+            }
+        }
+        if (cancelled()) return Result.failure()
+        val currentSnapshot = repository.read()
+        val hasRemainingDeliveryWork =
+            IronwoodOutboxState.hasDeliveryWork(currentSnapshot)
+        val hasPendingNotifications =
+            IronwoodOutboxState.hasPendingNotifications(currentSnapshot)
+        val notificationRetryRequired = notificationDeliveries.any {
+            it == IronwoodMigrationNotificationDelivery.RETRY
+        }
+        val notificationsDisabled = notificationDeliveries.any {
+            it == IronwoodMigrationNotificationDelivery.DISABLED
+        }
+        val continuationDelayMs = when {
+            hasRemainingDeliveryWork &&
+                result.outcome == IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION ->
+                0L
+            notificationRetryRequired ->
+                NOTIFICATION_RETRY_DELAY_MS
+            hasPendingNotifications && !notificationsDisabled -> 0L
+            else -> result.delayMs
+        }
+        return when (result.outcome) {
+            IronwoodMigrationOutboxOutcome.NO_WORK -> {
+                continuationDelayMs?.let(::enqueueContinuation)
+                Result.success()
+            }
+            IronwoodMigrationOutboxOutcome.WAITING,
+            IronwoodMigrationOutboxOutcome.ACCEPTED,
+            -> {
+                continuationDelayMs?.let(::enqueueContinuation)
+                Result.success()
+            }
+            IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION -> {
+                continuationDelayMs?.let(::enqueueContinuation)
+                if (continuationDelayMs == null) {
+                    Result.failure(workDataOf(OUTPUT_ERROR to "needs_user_action"))
+                } else {
+                    Result.success(workDataOf(OUTPUT_ERROR to "needs_user_action"))
+                }
+            }
+            IronwoodMigrationOutboxOutcome.RETRY -> Result.retry()
+            IronwoodMigrationOutboxOutcome.CANCELLED -> Result.failure()
+        }
+    }
+
+    private fun deliverProofReadyNotification(
+        repository: IronwoodMigrationOutboxRepository,
+        batchId: String,
+    ): IronwoodMigrationNotificationDelivery {
+        val delivery = IronwoodMigrationOutboxNotifier(applicationContext).notifyProofReady()
+        if (delivery != IronwoodMigrationNotificationDelivery.DELIVERED) {
+            return delivery
+        }
+        return runCatching {
+            repository.update { snapshot ->
+                IronwoodOutboxState.acknowledgeProofReadyNotification(snapshot, batchId)
+            }
+            IronwoodMigrationNotificationDelivery.DELIVERED
+        }.getOrDefault(IronwoodMigrationNotificationDelivery.RETRY)
+    }
+
+    private fun deliverNeedsUserActionNotification(
+        repository: IronwoodMigrationOutboxRepository,
+        batchId: String,
+    ): IronwoodMigrationNotificationDelivery {
+        val delivery =
+            IronwoodMigrationOutboxNotifier(applicationContext).notifyNeedsUserAction()
+        if (delivery != IronwoodMigrationNotificationDelivery.DELIVERED) {
+            return delivery
+        }
+        return runCatching {
+            repository.update { snapshot ->
+                IronwoodOutboxState.acknowledgeNeedsUserActionNotification(
+                    snapshot,
+                    batchId,
+                )
+            }
+            IronwoodMigrationNotificationDelivery.DELIVERED
+        }.getOrDefault(IronwoodMigrationNotificationDelivery.RETRY)
+    }
+
+    private fun deliverBroadcastCompleteNotification(
+        repository: IronwoodMigrationOutboxRepository,
+        batchId: String,
+    ): IronwoodMigrationNotificationDelivery {
+        val delivery =
+            IronwoodMigrationOutboxNotifier(applicationContext).notifyBroadcastComplete()
+        if (delivery != IronwoodMigrationNotificationDelivery.DELIVERED) {
+            return delivery
+        }
+        return runCatching {
+            repository.update { snapshot ->
+                IronwoodOutboxState.acknowledgeBroadcastCompleteNotification(
+                    snapshot,
+                    batchId,
+                )
+            }
+            IronwoodMigrationNotificationDelivery.DELIVERED
+        }.getOrDefault(IronwoodMigrationNotificationDelivery.RETRY)
+    }
+
+    private fun enqueueContinuation(delayMs: Long) {
+        IronwoodMigrationOutboxScheduler.enqueueContinuation(
+            applicationContext,
+            delayMs,
+        )
+    }
+
+    private fun createForegroundInfo(): ForegroundInfo {
+        val manager = applicationContext.getSystemService(
+            Service.NOTIFICATION_SERVICE,
+        ) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    NOTIFICATION_CHANNEL_ID,
+                    "Wallet migration",
+                    NotificationManager.IMPORTANCE_LOW,
+                ),
+            )
+        }
+        val notification: Notification = NotificationCompat.Builder(
+            applicationContext,
+            NOTIFICATION_CHANNEL_ID,
+        )
+            .setSmallIcon(applicationContext.applicationInfo.icon)
+            .setContentTitle("Completing wallet migration")
+            .setContentText("Vizor is securely submitting a scheduled migration transaction.")
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .build()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            ForegroundInfo(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private companion object {
+        const val NOTIFICATION_CHANNEL_ID = "ironwood_migration_outbox"
+        const val NOTIFICATION_ID = 319
+        const val OUTPUT_ERROR = "error"
+        const val NOTIFICATION_RETRY_DELAY_MS = 10 * 60_000L
+    }
+}
+
+internal class IronwoodMigrationOutboxNotifier(
+    private val context: Context,
+) {
+    fun notifyProofReady(): IronwoodMigrationNotificationDelivery = notifyMigrationStatus(
+        notificationId = PROOF_READY_NOTIFICATION_ID,
+        title = "Wallet migration is ready to continue",
+        body = "Open Vizor to continue securing your wallet.",
+    )
+
+    fun notifyNeedsUserAction(): IronwoodMigrationNotificationDelivery = notifyMigrationStatus(
+        notificationId = NEEDS_USER_ACTION_NOTIFICATION_ID,
+        title = "Ironwood migration needs attention",
+        body = "Open Vizor to review and continue your migration.",
+    )
+
+    fun notifyBroadcastComplete(): IronwoodMigrationNotificationDelivery =
+        notifyMigrationStatus(
+            notificationId = BROADCAST_COMPLETE_NOTIFICATION_ID,
+            title = "Migration transfers sent",
+            body = "All scheduled transfers were submitted. Open Vizor to check the status.",
+        )
+
+    fun cancelAll() {
+        NotificationManagerCompat.from(context).let { notifications ->
+            notifications.cancel(PROOF_READY_NOTIFICATION_ID)
+            notifications.cancel(NEEDS_USER_ACTION_NOTIFICATION_ID)
+            notifications.cancel(BROADCAST_COMPLETE_NOTIFICATION_ID)
+        }
+    }
+
+    private fun notifyMigrationStatus(
+        notificationId: Int,
+        title: String,
+        body: String,
+    ): IronwoodMigrationNotificationDelivery {
+        val notifications = NotificationManagerCompat.from(context)
+        if (!notifications.areNotificationsEnabled()) {
+            return IronwoodMigrationNotificationDelivery.DISABLED
+        }
+        val manager = context.getSystemService(Service.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    CHANNEL_ID,
+                    "Wallet migration updates",
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ),
+            )
+            if (manager.getNotificationChannel(CHANNEL_ID).importance ==
+                NotificationManager.IMPORTANCE_NONE
+            ) {
+                return IronwoodMigrationNotificationDelivery.DISABLED
+            }
+        }
+        val launchIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)
+            ?: Intent(context, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            launchIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(context.applicationInfo.icon)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_STATUS)
+            .build()
+        return try {
+            notifications.notify(notificationId, notification)
+            IronwoodMigrationNotificationDelivery.DELIVERED
+        } catch (_: SecurityException) {
+            IronwoodMigrationNotificationDelivery.DISABLED
+        } catch (_: RuntimeException) {
+            IronwoodMigrationNotificationDelivery.RETRY
+        }
+    }
+
+    private companion object {
+        const val CHANNEL_ID = "ironwood_migration_updates"
+        const val PROOF_READY_NOTIFICATION_ID = 320
+        const val NEEDS_USER_ACTION_NOTIFICATION_ID = 321
+        const val BROADCAST_COMPLETE_NOTIFICATION_ID = 322
+    }
+}

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationPreparationWorker.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationPreparationWorker.kt
@@ -1,0 +1,403 @@
+package com.keplr.vizor
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.Worker
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import java.util.concurrent.TimeUnit
+import org.json.JSONObject
+
+internal data class IronwoodMigrationPreparationManifest(
+    val network: String,
+    val accountUuid: String,
+    val dbPath: String,
+    val lightwalletdUrl: String,
+    val credentialHex: String,
+    val saltBase64: String,
+    val expectedRunId: String?,
+) {
+    val syncContext: String
+        get() = "$dbPath\u0000$lightwalletdUrl\u0000$network"
+
+    companion object {
+        fun decode(encoded: String): IronwoodMigrationPreparationManifest {
+            val json = JSONObject(encoded)
+            require(json.keys().asSequence().toSet() == MANIFEST_FIELDS) {
+                "Invalid migration manifest fields."
+            }
+            require(json.getInt("version") == MANIFEST_VERSION) {
+                "Unsupported migration manifest version."
+            }
+            val expectedRunId = if (json.isNull("expectedRunId")) {
+                null
+            } else {
+                json.getString("expectedRunId").requireNotBlank("expectedRunId")
+            }
+            return IronwoodMigrationPreparationManifest(
+                network = json.getString("network").also {
+                    require(it in SUPPORTED_NETWORKS) { "Unsupported network." }
+                },
+                accountUuid = json.getString("accountUuid").requireNotBlank("accountUuid"),
+                dbPath = json.getString("dbPath").requireNotBlank("dbPath"),
+                lightwalletdUrl =
+                    json.getString("lightwalletdUrl").requireNotBlank("lightwalletdUrl"),
+                credentialHex = json.getString("credentialHex").also {
+                    require(CREDENTIAL.matches(it)) {
+                        "Invalid migration credential."
+                    }
+                },
+                saltBase64 = json.getString("saltBase64").also {
+                    require(SALT.matches(it)) { "Invalid migration salt." }
+                },
+                expectedRunId = expectedRunId,
+            )
+        }
+
+        private fun String.requireNotBlank(name: String): String = also {
+            require(isNotBlank() && trim() == this) { "Invalid $name." }
+        }
+
+        private val SUPPORTED_NETWORKS = setOf("main", "test", "regtest")
+        private val CREDENTIAL = Regex("^[0-9a-f]{64}$")
+        private val SALT = Regex("^[A-Za-z0-9+/]{22}==$")
+        private const val MANIFEST_VERSION = 1
+        private val MANIFEST_FIELDS = setOf(
+            "version",
+            "network",
+            "accountUuid",
+            "dbPath",
+            "lightwalletdUrl",
+            "credentialHex",
+            "saltBase64",
+            "expectedRunId",
+        )
+    }
+}
+
+internal enum class IronwoodMigrationPreparationOutcome {
+    COMPLETED,
+    WAITING,
+    BUSY,
+    NEEDS_USER_ACTION,
+    CANCELLED,
+    RETRY,
+}
+
+/**
+ * Executes one resumable preparation pass. WorkManager owns retry timing while
+ * the Rust core owns cancellation and foreground-sync exclusion.
+ */
+internal class IronwoodMigrationPreparationRunner(
+    private val native: IronwoodMigrationPreparationNative,
+    private val isStopped: () -> Boolean = { false },
+    private val onOperationStarted: () -> Unit = {},
+    private val onOperationEnded: () -> Unit = {},
+) {
+    fun run(
+        manifests: List<IronwoodMigrationPreparationManifest>,
+        onSyncProgress: (IronwoodMigrationNativeSyncProgress) -> Unit = {},
+    ): IronwoodMigrationPreparationOutcome {
+        val active = manifests.filter { it.expectedRunId != null }
+        if (active.isEmpty()) return IronwoodMigrationPreparationOutcome.COMPLETED
+        if (!native.beginOperation()) return IronwoodMigrationPreparationOutcome.BUSY
+        onOperationStarted()
+
+        return try {
+            runActive(active, onSyncProgress)
+        } finally {
+            try {
+                onOperationEnded()
+            } finally {
+                native.endOperation()
+            }
+        }
+    }
+
+    private fun runActive(
+        manifests: List<IronwoodMigrationPreparationManifest>,
+        onSyncProgress: (IronwoodMigrationNativeSyncProgress) -> Unit,
+    ): IronwoodMigrationPreparationOutcome {
+        val syncedContexts = mutableSetOf<String>()
+        var isWaiting = false
+        for (manifest in manifests) {
+            if (isStopped()) return IronwoodMigrationPreparationOutcome.CANCELLED
+            val outcome = runManifest(manifest, syncedContexts, onSyncProgress)
+            when (outcome) {
+                IronwoodMigrationPreparationOutcome.COMPLETED -> Unit
+                IronwoodMigrationPreparationOutcome.WAITING -> isWaiting = true
+                else -> return outcome
+            }
+        }
+        return if (isWaiting) {
+            IronwoodMigrationPreparationOutcome.WAITING
+        } else {
+            IronwoodMigrationPreparationOutcome.COMPLETED
+        }
+    }
+
+    private fun runManifest(
+        manifest: IronwoodMigrationPreparationManifest,
+        syncedContexts: MutableSet<String>,
+        onSyncProgress: (IronwoodMigrationNativeSyncProgress) -> Unit,
+    ): IronwoodMigrationPreparationOutcome {
+        val runId = checkNotNull(manifest.expectedRunId)
+        var progress = try {
+            native.inspect(
+                manifest.dbPath,
+                manifest.network,
+                manifest.accountUuid,
+                runId,
+            )
+        } catch (error: IronwoodMigrationNativeException) {
+            return error.toOutcome()
+        }
+        if (!progress.state.needsSync) return progress.state.toOutcome()
+        if (isStopped()) return IronwoodMigrationPreparationOutcome.CANCELLED
+
+        if (syncedContexts.add(manifest.syncContext)) {
+            if (native.isSyncRunning()) return IronwoodMigrationPreparationOutcome.BUSY
+            try {
+                native.runSync(
+                    manifest.dbPath,
+                    manifest.lightwalletdUrl,
+                    manifest.network,
+                    onSyncProgress,
+                )
+            } catch (error: IronwoodMigrationNativeException) {
+                return error.toOutcome()
+            }
+        }
+        if (isStopped()) return IronwoodMigrationPreparationOutcome.CANCELLED
+
+        if (
+            progress.state ==
+            IronwoodMigrationNativePreparationState.WAITING_FOR_PREPARED_NOTE_ANCHOR
+        ) {
+            progress = try {
+                native.inspect(
+                    manifest.dbPath,
+                    manifest.network,
+                    manifest.accountUuid,
+                    runId,
+                )
+            } catch (error: IronwoodMigrationNativeException) {
+                return error.toOutcome()
+            }
+        } else {
+            val credential = manifest.credentialHex.toByteArray(Charsets.US_ASCII)
+            progress = try {
+                native.advance(
+                    manifest.dbPath,
+                    manifest.lightwalletdUrl,
+                    manifest.network,
+                    manifest.accountUuid,
+                    runId,
+                    credential,
+                    manifest.saltBase64,
+                )
+            } catch (error: IronwoodMigrationNativeException) {
+                return error.toOutcome()
+            } finally {
+                credential.fill(0)
+            }
+        }
+        return progress.state.toOutcome()
+    }
+
+    private val IronwoodMigrationNativePreparationState.needsSync: Boolean
+        get() =
+            this ==
+                IronwoodMigrationNativePreparationState
+                    .WAITING_FOR_DENOMINATION_PREPARATION ||
+                this ==
+                IronwoodMigrationNativePreparationState
+                    .WAITING_FOR_PREPARED_NOTE_ANCHOR
+
+    private fun IronwoodMigrationNativePreparationState.toOutcome() = when (this) {
+        IronwoodMigrationNativePreparationState.PROOF_READY,
+        IronwoodMigrationNativePreparationState.INACTIVE,
+        -> IronwoodMigrationPreparationOutcome.COMPLETED
+        IronwoodMigrationNativePreparationState.WAITING_FOR_DENOMINATION_PREPARATION,
+        IronwoodMigrationNativePreparationState.WAITING_FOR_PREPARED_NOTE_ANCHOR,
+        -> IronwoodMigrationPreparationOutcome.WAITING
+        IronwoodMigrationNativePreparationState.NEEDS_USER_ACTION ->
+            IronwoodMigrationPreparationOutcome.NEEDS_USER_ACTION
+        IronwoodMigrationNativePreparationState.CANCELLED ->
+            IronwoodMigrationPreparationOutcome.CANCELLED
+    }
+
+    private fun IronwoodMigrationNativeException.toOutcome() = when (reason) {
+        IronwoodMigrationNativeError.INVALID_CREDENTIAL,
+        IronwoodMigrationNativeError.INVALID_ARGUMENT,
+        IronwoodMigrationNativeError.INVALID_RESPONSE,
+        -> IronwoodMigrationPreparationOutcome.NEEDS_USER_ACTION
+        IronwoodMigrationNativeError.SYNC_ALREADY_RUNNING ->
+            IronwoodMigrationPreparationOutcome.BUSY
+        IronwoodMigrationNativeError.NO_ACTIVE_OPERATION,
+        IronwoodMigrationNativeError.EXECUTION,
+        IronwoodMigrationNativeError.CALLBACK,
+        IronwoodMigrationNativeError.PANIC,
+        -> if (isStopped()) {
+            IronwoodMigrationPreparationOutcome.CANCELLED
+        } else {
+            IronwoodMigrationPreparationOutcome.RETRY
+        }
+    }
+}
+
+internal object IronwoodMigrationPreparationScheduler {
+    const val UNIQUE_WORK_NAME = "ironwood-migration-preparation"
+    const val WORK_TAG = "ironwood-migration-preparation"
+    private const val RETRY_DELAY_MINUTES = 1L
+
+    fun enqueue(context: Context) {
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            UNIQUE_WORK_NAME,
+            ExistingWorkPolicy.KEEP,
+            request(),
+        )
+    }
+
+    fun enqueueContinuation(context: Context) {
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            UNIQUE_WORK_NAME,
+            ExistingWorkPolicy.APPEND_OR_REPLACE,
+            request(initialDelayMinutes = RETRY_DELAY_MINUTES),
+        )
+    }
+
+    fun cancel(context: Context) {
+        WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_WORK_NAME)
+    }
+
+    internal fun request(initialDelayMinutes: Long = 0): OneTimeWorkRequest =
+        OneTimeWorkRequestBuilder<IronwoodMigrationPreparationWorker>()
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build(),
+            )
+            .setBackoffCriteria(
+                BackoffPolicy.LINEAR,
+                RETRY_DELAY_MINUTES,
+                TimeUnit.MINUTES,
+            )
+            .setInitialDelay(initialDelayMinutes, TimeUnit.MINUTES)
+            .addTag(WORK_TAG)
+            .build()
+}
+
+class IronwoodMigrationPreparationWorker(
+    appContext: Context,
+    workerParams: WorkerParameters,
+) : Worker(appContext, workerParams) {
+    @Volatile
+    private var native: IronwoodMigrationPreparationNative? = null
+
+    override fun doWork(): Result {
+        val bridge = IronwoodMigrationNativeBridge()
+        return try {
+            setForegroundAsync(createForegroundInfo()).get()
+            val manifests = IronwoodMigrationSecureStore(applicationContext)
+                .readAllManifests()
+                .map(IronwoodMigrationPreparationManifest::decode)
+            val outcome = IronwoodMigrationPreparationRunner(
+                native = bridge,
+                isStopped = { isStopped },
+                onOperationStarted = { native = bridge },
+                onOperationEnded = { native = null },
+            ).run(manifests)
+            outcome.toWorkerResult()
+        } catch (error: IllegalArgumentException) {
+            Result.failure(workDataOf(OUTPUT_ERROR to (error.message ?: "Invalid manifest.")))
+        } catch (error: Exception) {
+            if (isStopped) {
+                Result.failure()
+            } else {
+                Result.retry()
+            }
+        } finally {
+            native = null
+        }
+    }
+
+    override fun onStopped() {
+        native?.cancelOperation()
+        super.onStopped()
+    }
+
+    private fun IronwoodMigrationPreparationOutcome.toWorkerResult() = when (this) {
+        IronwoodMigrationPreparationOutcome.COMPLETED -> Result.success()
+        IronwoodMigrationPreparationOutcome.WAITING,
+        IronwoodMigrationPreparationOutcome.BUSY,
+        -> {
+            // Expected confirmation waits and foreground-sync contention are
+            // not failed attempts. Append fresh work so WorkManager backoff
+            // does not grow without bound.
+            IronwoodMigrationPreparationScheduler.enqueueContinuation(
+                applicationContext,
+            )
+            Result.success()
+        }
+        IronwoodMigrationPreparationOutcome.RETRY -> Result.retry()
+        IronwoodMigrationPreparationOutcome.NEEDS_USER_ACTION ->
+            Result.failure(workDataOf(OUTPUT_ERROR to "needs_user_action"))
+        IronwoodMigrationPreparationOutcome.CANCELLED -> Result.failure()
+    }
+
+    private fun createForegroundInfo(): ForegroundInfo {
+        val manager = applicationContext.getSystemService(
+            Service.NOTIFICATION_SERVICE,
+        ) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    NOTIFICATION_CHANNEL_ID,
+                    "Wallet migration",
+                    NotificationManager.IMPORTANCE_LOW,
+                ),
+            )
+        }
+        val notification: Notification = NotificationCompat.Builder(
+            applicationContext,
+            NOTIFICATION_CHANNEL_ID,
+        )
+            .setSmallIcon(applicationContext.applicationInfo.icon)
+            .setContentTitle("Preparing wallet migration")
+            .setContentText("Vizor is securely preparing your wallet in the background.")
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_PROGRESS)
+            .build()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            ForegroundInfo(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private companion object {
+        const val NOTIFICATION_CHANNEL_ID = "ironwood_migration_preparation"
+        const val NOTIFICATION_ID = 318
+        const val OUTPUT_ERROR = "error"
+    }
+}

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationPreparationWorker.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationPreparationWorker.kt
@@ -15,11 +15,16 @@ import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
 import androidx.work.Worker
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 import org.json.JSONObject
 
 internal data class IronwoodMigrationPreparationManifest(
@@ -96,6 +101,66 @@ internal enum class IronwoodMigrationPreparationOutcome {
     NEEDS_USER_ACTION,
     CANCELLED,
     RETRY,
+}
+
+internal object IronwoodMigrationPreparationExecutionCoordinator {
+    private val runLock = ReentrantLock()
+    private val quiescing = AtomicBoolean()
+    private val activeCancellation = AtomicReference<(() -> Unit)?>(null)
+
+    val isQuiescing: Boolean
+        get() = quiescing.get()
+
+    fun <T> tryRun(
+        cancel: () -> Unit,
+        block: (isCancelled: () -> Boolean) -> T,
+    ): T? {
+        if (quiescing.get() || !runLock.tryLock()) return null
+        if (quiescing.get()) {
+            runLock.unlock()
+            return null
+        }
+        activeCancellation.set(cancel)
+        if (quiescing.get()) {
+            activeCancellation.compareAndSet(cancel, null)
+            runLock.unlock()
+            return null
+        }
+        return try {
+            block { quiescing.get() }
+        } finally {
+            activeCancellation.compareAndSet(cancel, null)
+            runLock.unlock()
+        }
+    }
+
+    fun quiesceAndDrain() {
+        quiescing.set(true)
+        val cancellation = runCatching {
+            activeCancellation.get()?.invoke()
+        }
+        runLock.withLock { }
+        cancellation.getOrThrow()
+    }
+
+    fun <T> runQuiesced(block: () -> T): T {
+        val wasQuiescing = quiescing.getAndSet(true)
+        val cancellation = runCatching {
+            activeCancellation.get()?.invoke()
+        }
+        return try {
+            runLock.withLock {
+                cancellation.getOrThrow()
+                block()
+            }
+        } finally {
+            if (!wasQuiescing) quiescing.set(false)
+        }
+    }
+
+    fun resume() {
+        quiescing.set(false)
+    }
 }
 
 /**
@@ -266,23 +331,61 @@ internal object IronwoodMigrationPreparationScheduler {
     private const val RETRY_DELAY_MINUTES = 1L
 
     fun enqueue(context: Context) {
-        WorkManager.getInstance(context).enqueueUniqueWork(
-            UNIQUE_WORK_NAME,
-            ExistingWorkPolicy.KEEP,
-            request(),
-        )
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork(
+                UNIQUE_WORK_NAME,
+                ExistingWorkPolicy.KEEP,
+                request(),
+            )
+            .result
+            .get()
     }
 
     fun enqueueContinuation(context: Context) {
-        WorkManager.getInstance(context).enqueueUniqueWork(
-            UNIQUE_WORK_NAME,
-            ExistingWorkPolicy.APPEND_OR_REPLACE,
-            request(initialDelayMinutes = RETRY_DELAY_MINUTES),
-        )
+        WorkManager.getInstance(context)
+            .enqueueUniqueWork(
+                UNIQUE_WORK_NAME,
+                ExistingWorkPolicy.APPEND_OR_REPLACE,
+                request(initialDelayMinutes = RETRY_DELAY_MINUTES),
+            )
+            .result
+            .get()
     }
 
     fun cancel(context: Context) {
         WorkManager.getInstance(context).cancelUniqueWork(UNIQUE_WORK_NAME)
+    }
+
+    fun cancelAndWait(context: Context) {
+        WorkManager.getInstance(context)
+            .cancelUniqueWork(UNIQUE_WORK_NAME)
+            .result
+            .get()
+    }
+
+    fun runtimeState(context: Context): String {
+        val states = WorkManager.getInstance(context)
+            .getWorkInfosForUniqueWork(UNIQUE_WORK_NAME)
+            .get()
+            .map { it.state }
+        return runtimeState(states)
+    }
+
+    internal fun runtimeState(states: Iterable<WorkInfo.State>): String {
+        var scheduled = false
+        states.forEach { state ->
+            when (state) {
+                WorkInfo.State.RUNNING -> return "running"
+                WorkInfo.State.ENQUEUED,
+                WorkInfo.State.BLOCKED,
+                -> scheduled = true
+                WorkInfo.State.SUCCEEDED,
+                WorkInfo.State.FAILED,
+                WorkInfo.State.CANCELLED,
+                -> Unit
+            }
+        }
+        return if (scheduled) "scheduled" else "idle"
     }
 
     internal fun request(initialDelayMinutes: Long = 0): OneTimeWorkRequest =
@@ -316,13 +419,17 @@ class IronwoodMigrationPreparationWorker(
             val manifests = IronwoodMigrationSecureStore(applicationContext)
                 .readAllManifests()
                 .map(IronwoodMigrationPreparationManifest::decode)
-            val outcome = IronwoodMigrationPreparationRunner(
-                native = bridge,
-                isStopped = { isStopped },
-                onOperationStarted = { native = bridge },
-                onOperationEnded = { native = null },
-            ).run(manifests)
-            outcome.toWorkerResult()
+            IronwoodMigrationPreparationExecutionCoordinator.tryRun(
+                cancel = { bridge.cancelOperation() },
+            ) { isCoordinatorCancelled ->
+                val outcome = IronwoodMigrationPreparationRunner(
+                    native = bridge,
+                    isStopped = { isStopped || isCoordinatorCancelled() },
+                    onOperationStarted = { native = bridge },
+                    onOperationEnded = { native = null },
+                ).run(manifests)
+                outcome.toWorkerResult()
+            } ?: Result.success()
         } catch (error: IllegalArgumentException) {
             Result.failure(workDataOf(OUTPUT_ERROR to (error.message ?: "Invalid manifest.")))
         } catch (error: Exception) {

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStore.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStore.kt
@@ -1,0 +1,412 @@
+package com.keplr.vizor
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.security.KeyStore
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.concurrent.locks.ReentrantLock
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import kotlin.concurrent.withLock
+
+internal interface IronwoodMigrationKeyProvider {
+    fun getOrCreate(): SecretKey
+    fun delete()
+}
+
+internal class AndroidKeystoreIronwoodMigrationKeyProvider(
+    private val alias: String = KEY_ALIAS,
+) : IronwoodMigrationKeyProvider {
+    override fun getOrCreate(): SecretKey = KEYSTORE_LOCK.withLock {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        (keyStore.getKey(alias, null) as? SecretKey)?.let { return it }
+
+        val generator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            ANDROID_KEYSTORE,
+        )
+        generator.init(
+            KeyGenParameterSpec.Builder(
+                alias,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(KEY_SIZE_BITS)
+                .setRandomizedEncryptionRequired(true)
+                .setUserAuthenticationRequired(false)
+                .build(),
+        )
+        generator.generateKey()
+    }
+
+    override fun delete() = KEYSTORE_LOCK.withLock {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        if (keyStore.containsAlias(alias)) {
+            keyStore.deleteEntry(alias)
+        }
+    }
+
+    private companion object {
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        const val KEY_ALIAS = "com.keplr.vizor.ironwood-migration-native.v1"
+        const val KEY_SIZE_BITS = 256
+        val KEYSTORE_LOCK = ReentrantLock()
+    }
+}
+
+internal class IronwoodMigrationAesGcm(
+    private val keyProvider: IronwoodMigrationKeyProvider,
+    private val random: SecureRandom = SecureRandom(),
+) {
+    fun seal(plaintext: ByteArray, recordId: String): ByteArray {
+        val nonce = ByteArray(NONCE_SIZE).also(random::nextBytes)
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(
+            Cipher.ENCRYPT_MODE,
+            keyProvider.getOrCreate(),
+            GCMParameterSpec(TAG_SIZE_BITS, nonce),
+        )
+        cipher.updateAAD(associatedData(recordId))
+        val ciphertext = cipher.doFinal(plaintext)
+
+        return ByteArrayOutputStream().use { bytes ->
+            DataOutputStream(bytes).use { output ->
+                output.writeInt(MAGIC)
+                output.writeByte(FORMAT_VERSION)
+                output.writeByte(nonce.size)
+                output.writeInt(ciphertext.size)
+                output.write(nonce)
+                output.write(ciphertext)
+            }
+            bytes.toByteArray()
+        }
+    }
+
+    fun open(envelope: ByteArray, recordId: String): ByteArray {
+        val input = DataInputStream(ByteArrayInputStream(envelope))
+        if (input.readInt() != MAGIC || input.readUnsignedByte() != FORMAT_VERSION) {
+            throw IronwoodMigrationSecureStoreException("Unsupported encrypted record.")
+        }
+        val nonceSize = input.readUnsignedByte()
+        val ciphertextSize = input.readInt()
+        if (
+            nonceSize != NONCE_SIZE ||
+            ciphertextSize < TAG_SIZE_BYTES ||
+            ciphertextSize > MAX_RECORD_BYTES ||
+            input.available() != nonceSize + ciphertextSize
+        ) {
+            throw IronwoodMigrationSecureStoreException("Invalid encrypted record.")
+        }
+        val nonce = ByteArray(nonceSize).also(input::readFully)
+        val ciphertext = ByteArray(ciphertextSize).also(input::readFully)
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(
+            Cipher.DECRYPT_MODE,
+            keyProvider.getOrCreate(),
+            GCMParameterSpec(TAG_SIZE_BITS, nonce),
+        )
+        cipher.updateAAD(associatedData(recordId))
+        return try {
+            cipher.doFinal(ciphertext)
+        } catch (error: Exception) {
+            throw IronwoodMigrationSecureStoreException(
+                "Failed to authenticate encrypted migration data.",
+                error,
+            )
+        }
+    }
+
+    private fun associatedData(recordId: String): ByteArray =
+        "$ASSOCIATED_DATA_PREFIX:$recordId".toByteArray(Charsets.UTF_8)
+
+    private companion object {
+        const val TRANSFORMATION = "AES/GCM/NoPadding"
+        const val FORMAT_VERSION = 1
+        const val MAGIC = 0x56494D31 // VIM1
+        const val NONCE_SIZE = 12
+        const val TAG_SIZE_BITS = 128
+        const val TAG_SIZE_BYTES = TAG_SIZE_BITS / 8
+        const val MAX_RECORD_BYTES = 64 * 1024 * 1024
+        const val ASSOCIATED_DATA_PREFIX = "vizor-ironwood-native-store-v1"
+    }
+}
+
+internal class IronwoodMigrationSecureStoreException(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause)
+
+/**
+ * Encrypted, account-scoped storage for native Ironwood migration work.
+ *
+ * Each file name is a SHA-256 digest of its logical record key. The encrypted
+ * plaintext repeats that key and is bound to the file name through AES-GCM AAD,
+ * allowing safe prefix revocation without exposing wallet scope in file names.
+ */
+internal class IronwoodMigrationSecureStore(
+    private val keyProvider: IronwoodMigrationKeyProvider =
+        AndroidKeystoreIronwoodMigrationKeyProvider(),
+    directory: File,
+    private val cipher: IronwoodMigrationAesGcm = IronwoodMigrationAesGcm(keyProvider),
+) {
+    constructor(context: Context) : this(
+        directory = File(context.noBackupFilesDir, DIRECTORY_NAME),
+    )
+
+    private val lock = STORE_LOCK
+    private val directory = directory.apply {
+        if ((!exists() && !mkdirs()) || !isDirectory) {
+            throw IronwoodMigrationSecureStoreException(
+                "Failed to create the native migration storage directory.",
+            )
+        }
+    }
+
+    init {
+        lock.withLock {
+            recoverInterruptedWrites()
+        }
+    }
+
+    fun writeManifest(
+        network: String,
+        accountUuid: String,
+        manifestJson: String,
+    ) {
+        put(manifestKey(network, accountUuid), manifestJson.toByteArray(Charsets.UTF_8))
+    }
+
+    fun readManifest(network: String, accountUuid: String): String? =
+        get(manifestKey(network, accountUuid))?.toString(Charsets.UTF_8)
+
+    fun deleteManifest(network: String, accountUuid: String) {
+        remove(manifestKey(network, accountUuid))
+    }
+
+    fun writeOutboxBatch(
+        network: String,
+        accountUuid: String,
+        batchId: String,
+        encodedBatch: ByteArray,
+    ) {
+        put(outboxKey(network, accountUuid, batchId), encodedBatch)
+    }
+
+    fun readOutboxBatch(
+        network: String,
+        accountUuid: String,
+        batchId: String,
+    ): ByteArray? = get(outboxKey(network, accountUuid, batchId))
+
+    fun revokeAccount(network: String, accountUuid: String) {
+        remove(manifestKey(network, accountUuid))
+        removePrefix("$RECORD_VERSION:outbox:$network:$accountUuid:")
+    }
+
+    fun revokeAll() = lock.withLock {
+        directory.listFiles()
+            ?.filter {
+                it.isFile &&
+                    (
+                        it.name.endsWith(RECORD_SUFFIX) ||
+                            it.name.endsWith(TEMP_SUFFIX) ||
+                            it.name.endsWith(BACKUP_SUFFIX)
+                        )
+            }
+            ?.forEach { file ->
+                if (!file.delete() && file.exists()) {
+                    throw IronwoodMigrationSecureStoreException(
+                        "Failed to remove native migration data.",
+                    )
+                }
+            }
+        keyProvider.delete()
+    }
+
+    private fun put(recordKey: String, payload: ByteArray) = lock.withLock {
+        require(payload.size <= MAX_PAYLOAD_BYTES) { "Migration record is too large." }
+        val recordId = recordId(recordKey)
+        val plaintext = encodeRecord(recordKey, payload)
+        val encrypted = cipher.seal(plaintext, recordId)
+        atomicWrite(fileFor(recordId), encrypted)
+    }
+
+    private fun get(recordKey: String): ByteArray? = lock.withLock {
+        val recordId = recordId(recordKey)
+        val file = fileFor(recordId)
+        if (!file.exists()) return null
+        val record = decodeRecord(cipher.open(file.readBytes(), recordId))
+        if (record.first != recordKey) {
+            throw IronwoodMigrationSecureStoreException(
+                "Encrypted migration record scope does not match its file.",
+            )
+        }
+        record.second
+    }
+
+    private fun remove(recordKey: String) = lock.withLock {
+        val file = fileFor(recordId(recordKey))
+        if (file.exists() && !file.delete()) {
+            throw IronwoodMigrationSecureStoreException(
+                "Failed to remove native migration data.",
+            )
+        }
+    }
+
+    private fun removePrefix(prefix: String) = lock.withLock {
+        recoverInterruptedWrites()
+        directory.listFiles()
+            ?.filter { it.isFile && it.name.endsWith(RECORD_SUFFIX) }
+            ?.forEach { file ->
+                val recordId = file.name.removeSuffix(RECORD_SUFFIX)
+                val recordKey = decodeRecord(cipher.open(file.readBytes(), recordId)).first
+                if (recordKey.startsWith(prefix)) {
+                    if (!file.delete()) {
+                        throw IronwoodMigrationSecureStoreException(
+                            "Failed to revoke native migration account data.",
+                        )
+                    }
+                }
+            }
+    }
+
+    private fun fileFor(recordId: String): File {
+        // A previous atomic write can leave the last committed value in a
+        // backup even while this store instance remains alive.
+        recoverInterruptedWrites()
+        return File(directory, "$recordId$RECORD_SUFFIX")
+    }
+
+    private fun recoverInterruptedWrites() {
+        directory.listFiles()
+            ?.filter { it.isFile && it.name.endsWith("$RECORD_SUFFIX$BACKUP_SUFFIX") }
+            ?.forEach { backup ->
+                val destination = File(directory, backup.name.removeSuffix(BACKUP_SUFFIX))
+                val recovered = if (destination.exists()) {
+                    backup.delete()
+                } else {
+                    backup.renameTo(destination)
+                }
+                if (!recovered) {
+                    throw IronwoodMigrationSecureStoreException(
+                        "Failed to recover native migration data.",
+                    )
+                }
+            }
+        directory.listFiles()
+            ?.filter { it.isFile && it.name.endsWith("$RECORD_SUFFIX$TEMP_SUFFIX") }
+            ?.forEach { temporary ->
+                if (!temporary.delete()) {
+                    throw IronwoodMigrationSecureStoreException(
+                        "Failed to clear interrupted native migration data.",
+                    )
+                }
+            }
+    }
+
+    private fun atomicWrite(destination: File, bytes: ByteArray) {
+        val temporary = File(directory, "${destination.name}$TEMP_SUFFIX")
+        val backup = File(directory, "${destination.name}$BACKUP_SUFFIX")
+        try {
+            FileOutputStream(temporary).use { output ->
+                output.write(bytes)
+                output.flush()
+                output.fd.sync()
+            }
+            if (backup.exists() && !backup.delete()) {
+                throw IronwoodMigrationSecureStoreException(
+                    "Failed to clear a stale native migration backup.",
+                )
+            }
+            if (destination.exists() && !destination.renameTo(backup)) {
+                throw IronwoodMigrationSecureStoreException(
+                    "Failed to back up native migration data.",
+                )
+            }
+            if (!temporary.renameTo(destination)) {
+                if (backup.exists() && !backup.renameTo(destination)) {
+                    throw IronwoodMigrationSecureStoreException(
+                        "Failed to commit or restore native migration data.",
+                    )
+                }
+                throw IronwoodMigrationSecureStoreException(
+                    "Failed to commit native migration data.",
+                )
+            }
+            backup.delete()
+        } finally {
+            temporary.delete()
+        }
+    }
+
+    private fun encodeRecord(recordKey: String, payload: ByteArray): ByteArray {
+        val keyBytes = recordKey.toByteArray(Charsets.UTF_8)
+        return ByteArrayOutputStream().use { bytes ->
+            DataOutputStream(bytes).use { output ->
+                output.writeInt(RECORD_MAGIC)
+                output.writeInt(keyBytes.size)
+                output.writeInt(payload.size)
+                output.write(keyBytes)
+                output.write(payload)
+            }
+            bytes.toByteArray()
+        }
+    }
+
+    private fun decodeRecord(plaintext: ByteArray): Pair<String, ByteArray> {
+        val input = DataInputStream(ByteArrayInputStream(plaintext))
+        if (input.readInt() != RECORD_MAGIC) {
+            throw IronwoodMigrationSecureStoreException("Invalid migration record.")
+        }
+        val keySize = input.readInt()
+        val payloadSize = input.readInt()
+        if (
+            keySize <= 0 ||
+            keySize > MAX_KEY_BYTES ||
+            payloadSize < 0 ||
+            payloadSize > MAX_PAYLOAD_BYTES ||
+            input.available() != keySize + payloadSize
+        ) {
+            throw IronwoodMigrationSecureStoreException("Invalid migration record lengths.")
+        }
+        val key = ByteArray(keySize).also(input::readFully).toString(Charsets.UTF_8)
+        val payload = ByteArray(payloadSize).also(input::readFully)
+        return key to payload
+    }
+
+    private fun manifestKey(network: String, accountUuid: String) =
+        "$RECORD_VERSION:manifest:$network:$accountUuid"
+
+    private fun outboxKey(network: String, accountUuid: String, batchId: String) =
+        "$RECORD_VERSION:outbox:$network:$accountUuid:$batchId"
+
+    private fun recordId(recordKey: String): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(recordKey.toByteArray(Charsets.UTF_8))
+            .joinToString(separator = "") { byte ->
+                "%02x".format(byte.toInt() and 0xff)
+            }
+
+    private companion object {
+        const val DIRECTORY_NAME = "ironwood-migration-native-v1"
+        const val RECORD_VERSION = "v1"
+        const val RECORD_SUFFIX = ".bin"
+        const val TEMP_SUFFIX = ".tmp"
+        const val BACKUP_SUFFIX = ".bak"
+        const val RECORD_MAGIC = 0x56495231 // VIR1
+        const val MAX_KEY_BYTES = 4 * 1024
+        const val MAX_PAYLOAD_BYTES = 48 * 1024 * 1024
+        val STORE_LOCK = ReentrantLock()
+    }
+}

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStore.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStore.kt
@@ -183,15 +183,57 @@ internal class IronwoodMigrationSecureStore(
         network: String,
         accountUuid: String,
         manifestJson: String,
-    ) {
-        put(manifestKey(network, accountUuid), manifestJson.toByteArray(Charsets.UTF_8))
+    ) = lock.withLock {
+        val recordKey = manifestKey(network, accountUuid)
+        val manifestKeys = readManifestKeysLocked()
+        val addedToIndex = manifestKeys.add(recordKey)
+        if (addedToIndex) {
+            writeManifestKeysLocked(manifestKeys)
+        }
+        try {
+            put(recordKey, manifestJson.toByteArray(Charsets.UTF_8))
+        } catch (error: Exception) {
+            if (addedToIndex) {
+                manifestKeys.remove(recordKey)
+                try {
+                    writeManifestKeysLocked(manifestKeys)
+                } catch (rollbackError: Exception) {
+                    error.addSuppressed(rollbackError)
+                }
+            }
+            throw error
+        }
     }
 
     fun readManifest(network: String, accountUuid: String): String? =
         get(manifestKey(network, accountUuid))?.toString(Charsets.UTF_8)
 
-    fun deleteManifest(network: String, accountUuid: String) {
-        remove(manifestKey(network, accountUuid))
+    fun readAllManifests(): List<String> = lock.withLock {
+        val manifestKeys = readManifestKeysLocked()
+        val staleKeys = mutableSetOf<String>()
+        val manifests = manifestKeys.mapNotNull { recordKey ->
+            val payload = get(recordKey)
+            if (payload == null) {
+                staleKeys.add(recordKey)
+                null
+            } else {
+                payload.toString(Charsets.UTF_8)
+            }
+        }
+        if (staleKeys.isNotEmpty()) {
+            manifestKeys.removeAll(staleKeys)
+            writeManifestKeysLocked(manifestKeys)
+        }
+        manifests
+    }
+
+    fun deleteManifest(network: String, accountUuid: String) = lock.withLock {
+        val recordKey = manifestKey(network, accountUuid)
+        val manifestKeys = readManifestKeysLocked()
+        remove(recordKey)
+        if (manifestKeys.remove(recordKey)) {
+            writeManifestKeysLocked(manifestKeys)
+        }
     }
 
     fun writeOutboxBatch(
@@ -209,8 +251,13 @@ internal class IronwoodMigrationSecureStore(
         batchId: String,
     ): ByteArray? = get(outboxKey(network, accountUuid, batchId))
 
-    fun revokeAccount(network: String, accountUuid: String) {
-        remove(manifestKey(network, accountUuid))
+    fun revokeAccount(network: String, accountUuid: String) = lock.withLock {
+        val recordKey = manifestKey(network, accountUuid)
+        val manifestKeys = readManifestKeysLocked()
+        remove(recordKey)
+        if (manifestKeys.remove(recordKey)) {
+            writeManifestKeysLocked(manifestKeys)
+        }
         removePrefix("$RECORD_VERSION:outbox:$network:$accountUuid:")
     }
 
@@ -262,6 +309,90 @@ internal class IronwoodMigrationSecureStore(
                 "Failed to remove native migration data.",
             )
         }
+    }
+
+    private fun readManifestKeysLocked(): MutableSet<String> {
+        get(MANIFEST_INDEX_KEY)?.let {
+            return decodeManifestIndex(it)
+        }
+
+        // Upgrade path for stores created before the encrypted index existed.
+        // This is the only path that opens non-manifest records.
+        recoverInterruptedWrites()
+        val recordFiles = directory.listFiles()
+            ?.filter { it.isFile && it.name.endsWith(RECORD_SUFFIX) }
+            .orEmpty()
+        val manifestKeys = recordFiles
+            .mapNotNull { file ->
+                val recordId = file.name.removeSuffix(RECORD_SUFFIX)
+                val record = decodeRecord(cipher.open(file.readBytes(), recordId))
+                record.first.takeIf { it.startsWith(MANIFEST_PREFIX) }
+            }
+            .toMutableSet()
+        if (recordFiles.isNotEmpty()) {
+            writeManifestKeysLocked(manifestKeys)
+        }
+        return manifestKeys
+    }
+
+    private fun writeManifestKeysLocked(manifestKeys: Set<String>) {
+        put(MANIFEST_INDEX_KEY, encodeManifestIndex(manifestKeys))
+    }
+
+    private fun encodeManifestIndex(manifestKeys: Set<String>): ByteArray =
+        ByteArrayOutputStream().use { bytes ->
+            DataOutputStream(bytes).use { output ->
+                output.writeInt(MANIFEST_INDEX_MAGIC)
+                output.writeInt(MANIFEST_INDEX_VERSION)
+                output.writeInt(manifestKeys.size)
+                manifestKeys.sorted().forEach { recordKey ->
+                    val keyBytes = recordKey.toByteArray(Charsets.UTF_8)
+                    output.writeInt(keyBytes.size)
+                    output.write(keyBytes)
+                }
+            }
+            bytes.toByteArray()
+        }
+
+    private fun decodeManifestIndex(payload: ByteArray): MutableSet<String> {
+        val input = DataInputStream(ByteArrayInputStream(payload))
+        if (
+            input.readInt() != MANIFEST_INDEX_MAGIC ||
+            input.readInt() != MANIFEST_INDEX_VERSION
+        ) {
+            throw IronwoodMigrationSecureStoreException(
+                "Unsupported migration manifest index.",
+            )
+        }
+        val count = input.readInt()
+        if (count < 0 || count > MAX_MANIFEST_COUNT) {
+            throw IronwoodMigrationSecureStoreException(
+                "Invalid migration manifest index count.",
+            )
+        }
+        val manifestKeys = linkedSetOf<String>()
+        repeat(count) {
+            val keySize = input.readInt()
+            if (keySize <= 0 || keySize > MAX_KEY_BYTES || input.available() < keySize) {
+                throw IronwoodMigrationSecureStoreException(
+                    "Invalid migration manifest index entry.",
+                )
+            }
+            val recordKey = ByteArray(keySize)
+                .also(input::readFully)
+                .toString(Charsets.UTF_8)
+            if (!recordKey.startsWith(MANIFEST_PREFIX) || !manifestKeys.add(recordKey)) {
+                throw IronwoodMigrationSecureStoreException(
+                    "Invalid migration manifest index scope.",
+                )
+            }
+        }
+        if (input.available() != 0) {
+            throw IronwoodMigrationSecureStoreException(
+                "Invalid migration manifest index length.",
+            )
+        }
+        return manifestKeys
     }
 
     private fun removePrefix(prefix: String) = lock.withLock {
@@ -386,7 +517,7 @@ internal class IronwoodMigrationSecureStore(
     }
 
     private fun manifestKey(network: String, accountUuid: String) =
-        "$RECORD_VERSION:manifest:$network:$accountUuid"
+        "$MANIFEST_PREFIX$network:$accountUuid"
 
     private fun outboxKey(network: String, accountUuid: String, batchId: String) =
         "$RECORD_VERSION:outbox:$network:$accountUuid:$batchId"
@@ -405,8 +536,13 @@ internal class IronwoodMigrationSecureStore(
         const val TEMP_SUFFIX = ".tmp"
         const val BACKUP_SUFFIX = ".bak"
         const val RECORD_MAGIC = 0x56495231 // VIR1
+        const val MANIFEST_INDEX_MAGIC = 0x56494D49 // VIMI
+        const val MANIFEST_INDEX_VERSION = 1
+        const val MAX_MANIFEST_COUNT = 10_000
         const val MAX_KEY_BYTES = 4 * 1024
         const val MAX_PAYLOAD_BYTES = 48 * 1024 * 1024
+        const val MANIFEST_PREFIX = "$RECORD_VERSION:manifest:"
+        const val MANIFEST_INDEX_KEY = "$RECORD_VERSION:index:manifests"
         val STORE_LOCK = ReentrantLock()
     }
 }

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStore.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStore.kt
@@ -251,6 +251,20 @@ internal class IronwoodMigrationSecureStore(
         batchId: String,
     ): ByteArray? = get(outboxKey(network, accountUuid, batchId))
 
+    fun updateOutboxSnapshot(
+        transform: (ByteArray?) -> ByteArray?,
+    ): ByteArray? = lock.withLock {
+        val updated = transform(get(OUTBOX_SNAPSHOT_KEY))
+        if (updated == null) {
+            remove(OUTBOX_SNAPSHOT_KEY)
+        } else {
+            put(OUTBOX_SNAPSHOT_KEY, updated)
+        }
+        updated
+    }
+
+    fun readOutboxSnapshot(): ByteArray? = get(OUTBOX_SNAPSHOT_KEY)
+
     fun revokeAccount(network: String, accountUuid: String) = lock.withLock {
         val recordKey = manifestKey(network, accountUuid)
         val manifestKeys = readManifestKeysLocked()
@@ -543,6 +557,7 @@ internal class IronwoodMigrationSecureStore(
         const val MAX_PAYLOAD_BYTES = 48 * 1024 * 1024
         const val MANIFEST_PREFIX = "$RECORD_VERSION:manifest:"
         const val MANIFEST_INDEX_KEY = "$RECORD_VERSION:index:manifests"
+        const val OUTBOX_SNAPSHOT_KEY = "$RECORD_VERSION:outbox-snapshot"
         val STORE_LOCK = ReentrantLock()
     }
 }

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStore.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStore.kt
@@ -147,6 +147,10 @@ internal class IronwoodMigrationSecureStoreException(
     cause: Throwable? = null,
 ) : Exception(message, cause)
 
+internal data class IronwoodMigrationBackgroundWorkResumeState(
+    val preparationWasScheduled: Boolean,
+)
+
 /**
  * Encrypted, account-scoped storage for native Ironwood migration work.
  *
@@ -264,6 +268,38 @@ internal class IronwoodMigrationSecureStore(
     }
 
     fun readOutboxSnapshot(): ByteArray? = get(OUTBOX_SNAPSHOT_KEY)
+
+    fun writeBackgroundWorkResumeState(
+        state: IronwoodMigrationBackgroundWorkResumeState,
+    ) {
+        put(
+            BACKGROUND_WORK_RESUME_STATE_KEY,
+            byteArrayOf(
+                BACKGROUND_WORK_RESUME_STATE_VERSION.toByte(),
+                if (state.preparationWasScheduled) 1 else 0,
+            ),
+        )
+    }
+
+    fun readBackgroundWorkResumeState(): IronwoodMigrationBackgroundWorkResumeState? {
+        val payload = get(BACKGROUND_WORK_RESUME_STATE_KEY) ?: return null
+        if (
+            payload.size != 2 ||
+            payload[0].toInt() != BACKGROUND_WORK_RESUME_STATE_VERSION ||
+            payload[1].toInt() !in 0..1
+        ) {
+            throw IronwoodMigrationSecureStoreException(
+                "Invalid background work resume state.",
+            )
+        }
+        return IronwoodMigrationBackgroundWorkResumeState(
+            preparationWasScheduled = payload[1].toInt() == 1,
+        )
+    }
+
+    fun clearBackgroundWorkResumeState() {
+        remove(BACKGROUND_WORK_RESUME_STATE_KEY)
+    }
 
     fun revokeAccount(network: String, accountUuid: String) = lock.withLock {
         val recordKey = manifestKey(network, accountUuid)
@@ -558,6 +594,9 @@ internal class IronwoodMigrationSecureStore(
         const val MANIFEST_PREFIX = "$RECORD_VERSION:manifest:"
         const val MANIFEST_INDEX_KEY = "$RECORD_VERSION:index:manifests"
         const val OUTBOX_SNAPSHOT_KEY = "$RECORD_VERSION:outbox-snapshot"
+        const val BACKGROUND_WORK_RESUME_STATE_KEY =
+            "$RECORD_VERSION:background-work-resume-state"
+        const val BACKGROUND_WORK_RESUME_STATE_VERSION = 1
         val STORE_LOCK = ReentrantLock()
     }
 }

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreChannel.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreChannel.kt
@@ -1,0 +1,396 @@
+package com.keplr.vizor
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Base64
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.StandardMessageCodec
+import org.json.JSONObject
+import java.nio.ByteBuffer
+import java.security.MessageDigest
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+internal class IronwoodMigrationSecureStoreChannel(
+    context: Context,
+    private val store: IronwoodMigrationSecureStore = IronwoodMigrationSecureStore(context),
+    private val executor: ExecutorService = Executors.newSingleThreadExecutor(),
+    private val mainHandler: Handler = Handler(Looper.getMainLooper()),
+) {
+    fun handle(call: MethodCall, result: MethodChannel.Result): Boolean {
+        val action: () -> Any? = when (call.method) {
+            "stageCredentialManifest" -> {
+                {
+                    val arguments = arguments(call)
+                    val network = network(arguments)
+                    val accountUuid = string(arguments, "accountUuid")
+                    val manifestJson = string(arguments, "manifestJson")
+                    validateManifest(manifestJson, network, accountUuid)
+                    store.writeManifest(network, accountUuid, manifestJson)
+                    true
+                }
+            }
+            "readCredentialManifest" -> {
+                {
+                    val arguments = arguments(call)
+                    store.readManifest(
+                        network(arguments),
+                        string(arguments, "accountUuid"),
+                    )
+                }
+            }
+            "deleteCredentialManifest" -> {
+                {
+                    val arguments = arguments(call)
+                    store.deleteManifest(
+                        network(arguments),
+                        string(arguments, "accountUuid"),
+                    )
+                    true
+                }
+            }
+            "stageOutboxBatch" -> {
+                {
+                    val incoming = validateOutboxBatch(arguments(call))
+                    val existing = store.readOutboxBatch(
+                        incoming.network,
+                        incoming.accountUuid,
+                        incoming.batchId,
+                    )?.let(::decodeIronwoodOutboxMap)
+                    val merged = mergeOutboxBatch(existing, incoming.payload)
+                    store.writeOutboxBatch(
+                        incoming.network,
+                        incoming.accountUuid,
+                        incoming.batchId,
+                        encodeIronwoodOutboxMap(merged),
+                    )
+                    incoming.digests
+                }
+            }
+            "revokeAccount" -> {
+                {
+                    val arguments = arguments(call)
+                    store.revokeAccount(
+                        network(arguments),
+                        string(arguments, "accountUuid"),
+                    )
+                    true
+                }
+            }
+            "revokeAll" -> {
+                {
+                    store.revokeAll()
+                    true
+                }
+            }
+            else -> return false
+        }
+
+        executor.execute {
+            try {
+                val value = action()
+                mainHandler.post { result.success(value) }
+            } catch (error: IllegalArgumentException) {
+                mainHandler.post {
+                    result.error("invalid_arguments", error.message, null)
+                }
+            } catch (error: Exception) {
+                mainHandler.post {
+                    result.error("ironwood_secure_store_error", error.message, null)
+                }
+            }
+        }
+        return true
+    }
+
+    fun close() {
+        executor.shutdown()
+    }
+
+    private fun validateManifest(
+        manifestJson: String,
+        expectedNetwork: String,
+        expectedAccountUuid: String,
+    ) {
+        val manifest = try {
+            JSONObject(manifestJson)
+        } catch (error: Exception) {
+            throw IllegalArgumentException("Invalid Ironwood migration manifest.", error)
+        }
+        val exactKeys = setOf(
+            "version",
+            "network",
+            "accountUuid",
+            "dbPath",
+            "lightwalletdUrl",
+            "credentialHex",
+            "saltBase64",
+            "expectedRunId",
+        )
+        if (manifest.keys().asSequence().toSet() != exactKeys) {
+            throw IllegalArgumentException("Invalid Ironwood migration manifest fields.")
+        }
+        val version = manifest.get("version")
+        val network = manifest.get("network")
+        val accountUuid = manifest.get("accountUuid")
+        val dbPath = manifest.get("dbPath")
+        val lightwalletdUrl = manifest.get("lightwalletdUrl")
+        val credentialHex = manifest.get("credentialHex")
+        val saltBase64 = manifest.get("saltBase64")
+        val expectedRunId = manifest.get("expectedRunId")
+        if (
+            version !is Int ||
+            version != 1 ||
+            network !is String ||
+            network != expectedNetwork ||
+            accountUuid !is String ||
+            accountUuid != expectedAccountUuid ||
+            dbPath !is String ||
+            dbPath.isBlank() ||
+            lightwalletdUrl !is String ||
+            lightwalletdUrl.isBlank() ||
+            credentialHex !is String ||
+            !LOWERCASE_CREDENTIAL.matches(credentialHex) ||
+            saltBase64 !is String ||
+            !CANONICAL_SALT.matches(saltBase64) ||
+            (
+                expectedRunId !== JSONObject.NULL &&
+                    (expectedRunId !is String || expectedRunId.isBlank())
+                )
+        ) {
+            throw IllegalArgumentException("Invalid Ironwood migration manifest values.")
+        }
+        val salt = try {
+            Base64.decode(saltBase64, Base64.DEFAULT)
+        } catch (error: IllegalArgumentException) {
+            throw IllegalArgumentException("Invalid Ironwood migration salt.", error)
+        }
+        if (
+            salt.size != 16 ||
+            Base64.encodeToString(salt, Base64.NO_WRAP) != saltBase64
+        ) {
+            throw IllegalArgumentException("Invalid Ironwood migration salt.")
+        }
+    }
+
+    private data class ValidatedOutboxBatch(
+        val network: String,
+        val accountUuid: String,
+        val batchId: String,
+        val payload: Map<String, Any?>,
+        val digests: Map<String, String>,
+    )
+
+    private fun validateOutboxBatch(arguments: Map<String, Any?>): ValidatedOutboxBatch {
+        val batchId = string(arguments, "batchId")
+        val network = network(arguments)
+        val accountUuid = string(arguments, "accountUuid")
+        string(arguments, "runId")
+        string(arguments, "lightwalletdUrl")
+        val timingMean = positiveLong(arguments, "timingMeanBlocks")
+        val timingMax = positiveLong(arguments, "timingMaxBlocks")
+        if (timingMean > timingMax) {
+            throw IllegalArgumentException("Invalid outbox timing policy.")
+        }
+        nonNegativeLong(arguments, "createdAtMs")
+        optionalNonNegativeLong(arguments, "nextProofHeight")
+        val items = arguments["items"] as? List<*>
+            ?: throw IllegalArgumentException("Missing items.")
+        if (items.isEmpty() && arguments["nextProofHeight"] == null) {
+            throw IllegalArgumentException("Outbox batch has no work.")
+        }
+
+        val itemIds = mutableSetOf<String>()
+        val txids = mutableSetOf<String>()
+        val partIndexes = mutableSetOf<Long>()
+        val digests = linkedMapOf<String, String>()
+        items.forEach { rawItem ->
+            val item = stringMap(rawItem, "items")
+            val itemId = string(item, "itemId")
+            val txid = string(item, "txidHex").lowercase()
+            val partIndex = nonNegativeLong(item, "partIndex")
+            val rawTransaction = item["rawTransaction"] as? ByteArray
+                ?: throw IllegalArgumentException("Invalid rawTransaction.")
+            val scheduledHeight = nonNegativeLong(item, "scheduledHeight")
+            val expiryHeight = nonNegativeLong(item, "expiryHeight")
+            nonNegativeLong(item, "anchorBoundaryHeight")
+            nonNegativeLong(item, "scheduleStartHeight")
+            if (
+                rawTransaction.isEmpty() ||
+                scheduledHeight >= expiryHeight ||
+                !itemIds.add(itemId) ||
+                !txids.add(txid) ||
+                !partIndexes.add(partIndex)
+            ) {
+                throw IllegalArgumentException("Invalid outbox item.")
+            }
+            digests[itemId] = sha256Hex(rawTransaction)
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        return ValidatedOutboxBatch(
+            network = network,
+            accountUuid = accountUuid,
+            batchId = batchId,
+            payload = LinkedHashMap(arguments),
+            digests = digests,
+        )
+    }
+
+    private fun mergeOutboxBatch(
+        existing: Map<String, Any?>?,
+        incoming: Map<String, Any?>,
+    ): Map<String, Any?> {
+        if (existing == null) return incoming
+        for (key in listOf(
+            "batchId",
+            "network",
+            "accountUuid",
+            "runId",
+            "timingMeanBlocks",
+            "timingMaxBlocks",
+        )) {
+            if (existing[key] != incoming[key]) {
+                throw IllegalArgumentException("Conflicting outbox batch.")
+            }
+        }
+
+        val existingItems = listOfMaps(existing["items"], "items").toMutableList()
+        val incomingItems = listOfMaps(incoming["items"], "items")
+        for (incomingItem in incomingItems) {
+            val incomingId = string(incomingItem, "itemId")
+            val incomingTxid = string(incomingItem, "txidHex").lowercase()
+            val incomingPart = nonNegativeLong(incomingItem, "partIndex")
+            val matchingId = existingItems.firstOrNull {
+                string(it, "itemId") == incomingId
+            }
+            if (matchingId != null) {
+                if (!sameOutboxIdentity(matchingId, incomingItem)) {
+                    throw IllegalArgumentException("Conflicting outbox item.")
+                }
+                continue
+            }
+            if (existingItems.any {
+                    string(it, "txidHex").lowercase() == incomingTxid ||
+                        nonNegativeLong(it, "partIndex") == incomingPart
+                }) {
+                throw IllegalArgumentException("Conflicting outbox item identity.")
+            }
+            existingItems += incomingItem
+        }
+
+        return LinkedHashMap(existing).apply {
+            this["lightwalletdUrl"] = incoming["lightwalletdUrl"]
+            this["nextProofHeight"] = incoming["nextProofHeight"]
+            this["items"] = existingItems
+        }
+    }
+
+    private fun sameOutboxIdentity(
+        left: Map<String, Any?>,
+        right: Map<String, Any?>,
+    ): Boolean {
+        for (key in listOf(
+            "itemId",
+            "partIndex",
+            "txidHex",
+            "anchorBoundaryHeight",
+            "expiryHeight",
+        )) {
+            if (left[key] != right[key]) return false
+        }
+        val leftRaw = left["rawTransaction"] as? ByteArray ?: return false
+        val rightRaw = right["rawTransaction"] as? ByteArray ?: return false
+        return MessageDigest.isEqual(leftRaw, rightRaw)
+    }
+
+    private fun arguments(call: MethodCall): Map<String, Any?> =
+        stringMap(call.arguments, "arguments")
+
+    private fun stringMap(value: Any?, name: String): Map<String, Any?> {
+        val raw = value as? Map<*, *>
+            ?: throw IllegalArgumentException("Invalid $name.")
+        if (raw.keys.any { it !is String }) {
+            throw IllegalArgumentException("Invalid $name keys.")
+        }
+        @Suppress("UNCHECKED_CAST")
+        return raw as Map<String, Any?>
+    }
+
+    private fun listOfMaps(value: Any?, name: String): List<Map<String, Any?>> {
+        val raw = value as? List<*> ?: throw IllegalArgumentException("Invalid $name.")
+        return raw.map { stringMap(it, name) }
+    }
+
+    private fun network(arguments: Map<String, Any?>): String =
+        string(arguments, "network").also {
+            if (it !in SUPPORTED_NETWORKS) {
+                throw IllegalArgumentException("Unsupported network.")
+            }
+        }
+
+    private fun string(arguments: Map<String, Any?>, key: String): String {
+        val value = arguments[key] as? String
+            ?: throw IllegalArgumentException("Missing $key.")
+        if (value.isBlank() || value.trim() != value) {
+            throw IllegalArgumentException("Invalid $key.")
+        }
+        return value
+    }
+
+    private fun positiveLong(arguments: Map<String, Any?>, key: String): Long =
+        nonNegativeLong(arguments, key).also {
+            if (it == 0L) throw IllegalArgumentException("Invalid $key.")
+        }
+
+    private fun nonNegativeLong(arguments: Map<String, Any?>, key: String): Long {
+        val value = (arguments[key] as? Number)?.toLong()
+            ?: throw IllegalArgumentException("Missing $key.")
+        if (value < 0) throw IllegalArgumentException("Invalid $key.")
+        return value
+    }
+
+    private fun optionalNonNegativeLong(
+        arguments: Map<String, Any?>,
+        key: String,
+    ): Long? {
+        val value = arguments[key] ?: return null
+        if (value !is Number || value.toLong() < 0) {
+            throw IllegalArgumentException("Invalid $key.")
+        }
+        return value.toLong()
+    }
+
+    private fun sha256Hex(value: ByteArray): String =
+        MessageDigest.getInstance("SHA-256")
+            .digest(value)
+            .joinToString(separator = "") { byte ->
+                "%02x".format(byte.toInt() and 0xff)
+            }
+
+    private companion object {
+        val SUPPORTED_NETWORKS = setOf("main", "test", "regtest")
+        val LOWERCASE_CREDENTIAL = Regex("^[0-9a-f]{64}$")
+        val CANONICAL_SALT = Regex("^[A-Za-z0-9+/]{22}==$")
+    }
+}
+
+internal fun encodeIronwoodOutboxMap(value: Map<String, Any?>): ByteArray {
+    val buffer = StandardMessageCodec.INSTANCE.encodeMessage(value)
+        ?: throw IronwoodMigrationSecureStoreException("Failed to encode outbox batch.")
+    buffer.flip()
+    return ByteArray(buffer.remaining()).also(buffer::get)
+}
+
+internal fun decodeIronwoodOutboxMap(value: ByteArray): Map<String, Any?> {
+    val decoded = StandardMessageCodec.INSTANCE.decodeMessage(ByteBuffer.wrap(value))
+    val raw = decoded as? Map<*, *>
+        ?: throw IllegalArgumentException("Invalid storedOutboxBatch.")
+    if (raw.keys.any { it !is String }) {
+        throw IllegalArgumentException("Invalid storedOutboxBatch keys.")
+    }
+    @Suppress("UNCHECKED_CAST")
+    return raw as Map<String, Any?>
+}

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreChannel.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreChannel.kt
@@ -14,11 +14,13 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 internal class IronwoodMigrationSecureStoreChannel(
-    context: Context,
+    private val context: Context,
     private val store: IronwoodMigrationSecureStore = IronwoodMigrationSecureStore(context),
     private val executor: ExecutorService = Executors.newSingleThreadExecutor(),
     private val mainHandler: Handler = Handler(Looper.getMainLooper()),
 ) {
+    private val outboxRepository = IronwoodMigrationOutboxRepository(store)
+
     fun handle(call: MethodCall, result: MethodChannel.Result): Boolean {
         val action: () -> Any? = when (call.method) {
             "stageCredentialManifest" -> {
@@ -54,34 +56,157 @@ internal class IronwoodMigrationSecureStoreChannel(
             "stageOutboxBatch" -> {
                 {
                     val incoming = validateOutboxBatch(arguments(call))
-                    val existing = store.readOutboxBatch(
-                        incoming.network,
-                        incoming.accountUuid,
-                        incoming.batchId,
-                    )?.let(::decodeIronwoodOutboxMap)
-                    val merged = mergeOutboxBatch(existing, incoming.payload)
-                    store.writeOutboxBatch(
-                        incoming.network,
-                        incoming.accountUuid,
-                        incoming.batchId,
-                        encodeIronwoodOutboxMap(merged),
-                    )
+                    outboxRepository.update { snapshot -> stage(snapshot, incoming) }
                     incoming.digests
+                }
+            }
+            "armOutboxBatch" -> {
+                {
+                    val arguments = arguments(call)
+                    val batchId = string(arguments, "batchId")
+                    val expectedDigests = stringStringMap(
+                        arguments["expectedDigests"],
+                        "expectedDigests",
+                    )
+                    outboxRepository.update { snapshot ->
+                        val batch = snapshot.batches.firstOrNull { it.batchId == batchId }
+                            ?: throw IllegalArgumentException("Outbox batch not found.")
+                        if (
+                            expectedDigests.isEmpty() &&
+                            batch.nextProofHeight == null
+                        ) {
+                            throw IllegalArgumentException("Invalid outbox arm request.")
+                        }
+                        if (expectedDigests.any { (itemId, digest) ->
+                                batch.items.none {
+                                    it.itemId == itemId &&
+                                        it.payloadDigestHex == digest
+                                }
+                            }) {
+                            throw IllegalArgumentException("Invalid outbox arm request.")
+                        }
+                        batch.armedAtMs = batch.armedAtMs ?: System.currentTimeMillis()
+                        batch.items.filter {
+                            it.itemId in expectedDigests &&
+                                it.status == IronwoodOutboxItemStatus.STAGED
+                        }.forEach { it.status = IronwoodOutboxItemStatus.ARMED }
+                    }
+                    scheduleOutbox()
+                    true
+                }
+            }
+            "recoverOutboxBatch" -> {
+                {
+                    val arguments = arguments(call)
+                    val batchId = string(arguments, "batchId")
+                    val expectedTxids = stringList(
+                        arguments["expectedTxids"],
+                        "expectedTxids",
+                    ).map(String::lowercase).toSet()
+                    val recovered = IronwoodMigrationOutboxExecutionCoordinator.runExclusive {
+                        outboxRepository.update { snapshot ->
+                            val batch = snapshot.batches.firstOrNull { it.batchId == batchId }
+                                ?: return@update false
+                            if (
+                                batch.network != network(arguments) ||
+                                batch.accountUuid != string(arguments, "accountUuid") ||
+                                batch.runId != string(arguments, "runId") ||
+                                expectedTxids.isEmpty() ||
+                                batch.items.isEmpty() ||
+                                batch.items.any { it.txidHex !in expectedTxids }
+                            ) {
+                                throw IllegalArgumentException("Conflicting outbox batch.")
+                            }
+                            batch.lightwalletdUrl = string(arguments, "lightwalletdUrl")
+                            val now = System.currentTimeMillis()
+                            batch.items.forEach { item ->
+                                when (item.status) {
+                                    IronwoodOutboxItemStatus.SUBMITTING -> {
+                                        item.status = IronwoodOutboxItemStatus.ARMED
+                                        item.attemptCount += 1
+                                        item.nextAttemptAtMs = now +
+                                            IronwoodOutboxState.retryDelayMs(item.attemptCount)
+                                        item.lastError =
+                                            "The previous submission outcome is unknown."
+                                        item.attemptId = null
+                                        item.attemptStartedAtMs = null
+                                    }
+                                    IronwoodOutboxItemStatus.STAGED ->
+                                        item.status = IronwoodOutboxItemStatus.ARMED
+                                    else -> Unit
+                                }
+                            }
+                            if (batch.items.any {
+                                    it.status == IronwoodOutboxItemStatus.ARMED
+                                }) {
+                                batch.armedAtMs = batch.armedAtMs ?: now
+                            }
+                            true
+                        }
+                    }
+                    if (recovered) scheduleOutbox()
+                    recovered
+                }
+            }
+            "listOutboxReceipts" -> {
+                {
+                    outboxRepository.read().receipts.map(::receiptMap)
+                }
+            }
+            "ackOutboxReceipts" -> {
+                {
+                    val receiptIds = stringList(
+                        arguments(call)["receiptIds"],
+                        "receiptIds",
+                    ).toSet()
+                    outboxRepository.update { snapshot ->
+                        IronwoodOutboxState.acknowledgeReceipts(snapshot, receiptIds)
+                    }
+                    null
+                }
+            }
+            "runOutboxOnceNow" -> {
+                {
+                    IronwoodMigrationOutboxRunner(
+                        repository = outboxRepository,
+                        transport = IronwoodMigrationOutboxNativeBridge(),
+                    ).runOnceWaitingForActiveRun().toChannelMap()
                 }
             }
             "revokeAccount" -> {
                 {
                     val arguments = arguments(call)
-                    store.revokeAccount(
-                        network(arguments),
-                        string(arguments, "accountUuid"),
-                    )
+                    val network = network(arguments)
+                    val accountUuid = string(arguments, "accountUuid")
+                    IronwoodMigrationOutboxScheduler.cancel(context)
+                    var hasRemainingWork = false
+                    IronwoodMigrationOutboxExecutionCoordinator.cancelAndDrain {
+                        hasRemainingWork = outboxRepository.update { snapshot ->
+                            val batchIds = snapshot.batches.filter {
+                                it.network == network && it.accountUuid == accountUuid
+                            }.map { it.batchId }.toSet()
+                            snapshot.batches.removeAll { it.batchId in batchIds }
+                            snapshot.receipts.removeAll { it.batchId in batchIds }
+                            if (snapshot.lastAttemptedScopeKey == "$network:$accountUuid") {
+                                snapshot.lastAttemptedScopeKey = null
+                            }
+                            IronwoodOutboxState.hasRunnableWork(snapshot)
+                        }
+                        store.revokeAccount(network, accountUuid)
+                    }
+                    if (hasRemainingWork) {
+                        IronwoodMigrationOutboxScheduler.enqueueContinuation(context, 0)
+                    }
                     true
                 }
             }
             "revokeAll" -> {
                 {
-                    store.revokeAll()
+                    IronwoodMigrationOutboxScheduler.cancel(context)
+                    IronwoodMigrationOutboxExecutionCoordinator.cancelAndDrain {
+                        store.revokeAll()
+                    }
+                    IronwoodMigrationOutboxNotifier(context).cancelAll()
                     true
                 }
             }
@@ -105,8 +230,26 @@ internal class IronwoodMigrationSecureStoreChannel(
         return true
     }
 
+    private fun scheduleOutbox() {
+        IronwoodMigrationOutboxScheduler.enqueue(context)
+    }
+
     fun close() {
         executor.shutdown()
+    }
+
+    fun resumePendingNotifications() {
+        executor.execute {
+            runCatching {
+                if (
+                    outboxRepository.read().let(
+                        IronwoodOutboxState::hasPendingNotifications,
+                    )
+                ) {
+                    scheduleOutbox()
+                }
+            }
+        }
     }
 
     private fun validateManifest(
@@ -239,72 +382,130 @@ internal class IronwoodMigrationSecureStoreChannel(
         )
     }
 
-    private fun mergeOutboxBatch(
-        existing: Map<String, Any?>?,
-        incoming: Map<String, Any?>,
-    ): Map<String, Any?> {
-        if (existing == null) return incoming
-        for (key in listOf(
-            "batchId",
-            "network",
-            "accountUuid",
-            "runId",
-            "timingMeanBlocks",
-            "timingMaxBlocks",
-        )) {
-            if (existing[key] != incoming[key]) {
-                throw IllegalArgumentException("Conflicting outbox batch.")
-            }
+    private fun stage(
+        snapshot: IronwoodOutboxSnapshot,
+        incoming: ValidatedOutboxBatch,
+    ) {
+        val payload = incoming.payload
+        val incomingItems = listOfMaps(payload["items"], "items").map { item ->
+            val rawTransaction = item["rawTransaction"] as ByteArray
+            IronwoodOutboxItem(
+                itemId = string(item, "itemId"),
+                partIndex = nonNegativeLong(item, "partIndex"),
+                txidHex = string(item, "txidHex").lowercase(),
+                rawTransaction = rawTransaction.copyOf(),
+                payloadDigestHex = sha256Hex(rawTransaction),
+                anchorBoundaryHeight = nonNegativeLong(item, "anchorBoundaryHeight"),
+                scheduledHeight = nonNegativeLong(item, "scheduledHeight"),
+                scheduleStartHeight = nonNegativeLong(item, "scheduleStartHeight"),
+                expiryHeight = nonNegativeLong(item, "expiryHeight"),
+            )
         }
-
-        val existingItems = listOfMaps(existing["items"], "items").toMutableList()
-        val incomingItems = listOfMaps(incoming["items"], "items")
-        for (incomingItem in incomingItems) {
-            val incomingId = string(incomingItem, "itemId")
-            val incomingTxid = string(incomingItem, "txidHex").lowercase()
-            val incomingPart = nonNegativeLong(incomingItem, "partIndex")
-            val matchingId = existingItems.firstOrNull {
-                string(it, "itemId") == incomingId
-            }
-            if (matchingId != null) {
-                if (!sameOutboxIdentity(matchingId, incomingItem)) {
+        val existing = snapshot.batches.firstOrNull { it.batchId == incoming.batchId }
+        if (existing == null) {
+            snapshot.batches += IronwoodOutboxBatch(
+                batchId = incoming.batchId,
+                network = incoming.network,
+                accountUuid = incoming.accountUuid,
+                runId = string(payload, "runId"),
+                lightwalletdUrl = string(payload, "lightwalletdUrl"),
+                timingMeanBlocks = positiveLong(payload, "timingMeanBlocks"),
+                timingMaxBlocks = positiveLong(payload, "timingMaxBlocks"),
+                createdAtMs = nonNegativeLong(payload, "createdAtMs"),
+                nextProofHeight = optionalNonNegativeLong(payload, "nextProofHeight"),
+                items = incomingItems.toMutableList(),
+            )
+            return
+        }
+        if (
+            existing.network != incoming.network ||
+            existing.accountUuid != incoming.accountUuid ||
+            existing.runId != string(payload, "runId") ||
+            existing.timingMeanBlocks != positiveLong(payload, "timingMeanBlocks") ||
+            existing.timingMaxBlocks != positiveLong(payload, "timingMaxBlocks")
+        ) {
+            throw IllegalArgumentException("Conflicting outbox batch.")
+        }
+        val endpoint = string(payload, "lightwalletdUrl")
+        if (
+            existing.lightwalletdUrl != endpoint &&
+            existing.items.any { it.status == IronwoodOutboxItemStatus.SUBMITTING }
+        ) {
+            throw IllegalArgumentException("Conflicting outbox batch.")
+        }
+        existing.lightwalletdUrl = endpoint
+        var addedItem = false
+        incomingItems.forEach { item ->
+            val sameId = existing.items.firstOrNull { it.itemId == item.itemId }
+            if (sameId != null) {
+                if (
+                    sameId.partIndex != item.partIndex ||
+                    sameId.txidHex != item.txidHex ||
+                    sameId.payloadDigestHex != item.payloadDigestHex ||
+                    sameId.anchorBoundaryHeight != item.anchorBoundaryHeight ||
+                    sameId.expiryHeight != item.expiryHeight
+                ) {
                     throw IllegalArgumentException("Conflicting outbox item.")
                 }
-                continue
+            } else {
+                if (existing.items.any {
+                        it.txidHex == item.txidHex || it.partIndex == item.partIndex
+                    }) {
+                    throw IllegalArgumentException("Conflicting outbox item identity.")
+                }
+                existing.items += item
+                addedItem = true
             }
-            if (existingItems.any {
-                    string(it, "txidHex").lowercase() == incomingTxid ||
-                        nonNegativeLong(it, "partIndex") == incomingPart
-                }) {
-                throw IllegalArgumentException("Conflicting outbox item identity.")
-            }
-            existingItems += incomingItem
         }
-
-        return LinkedHashMap(existing).apply {
-            this["lightwalletdUrl"] = incoming["lightwalletdUrl"]
-            this["nextProofHeight"] = incoming["nextProofHeight"]
-            this["items"] = existingItems
+        val nextProofHeight = optionalNonNegativeLong(payload, "nextProofHeight")
+        val proofHeightChanged = existing.nextProofHeight != nextProofHeight
+        if (proofHeightChanged) {
+            existing.nextProofHeight = nextProofHeight
+            existing.proofReadyObservedHeight = null
+            existing.proofReadyNotificationAcknowledged = false
+        }
+        if (addedItem || proofHeightChanged) {
+            existing.broadcastCompletePending = false
         }
     }
 
-    private fun sameOutboxIdentity(
-        left: Map<String, Any?>,
-        right: Map<String, Any?>,
-    ): Boolean {
-        for (key in listOf(
-            "itemId",
-            "partIndex",
-            "txidHex",
-            "anchorBoundaryHeight",
-            "expiryHeight",
-        )) {
-            if (left[key] != right[key]) return false
-        }
-        val leftRaw = left["rawTransaction"] as? ByteArray ?: return false
-        val rightRaw = right["rawTransaction"] as? ByteArray ?: return false
-        return MessageDigest.isEqual(leftRaw, rightRaw)
-    }
+    private fun receiptMap(receipt: IronwoodOutboxReceipt): Map<String, Any?> = mapOf(
+        "receiptId" to receipt.receiptId,
+        "batchId" to receipt.batchId,
+        "itemId" to receipt.itemId,
+        "network" to receipt.network,
+        "accountUuid" to receipt.accountUuid,
+        "runId" to receipt.runId,
+        "txidHex" to receipt.txidHex,
+        "outcome" to receipt.outcome,
+        "remoteHeight" to receipt.remoteHeight,
+        "responseCode" to receipt.responseCode,
+        "responseMessage" to receipt.responseMessage,
+        "recordedAtMs" to receipt.recordedAtMs,
+        "scheduleUpdates" to receipt.scheduleUpdates.map {
+            mapOf(
+                "itemId" to it.itemId,
+                "scheduledHeight" to it.scheduledHeight,
+                "scheduleStartHeight" to it.scheduleStartHeight,
+            )
+        },
+        "rawTransaction" to receipt.rawTransaction,
+    )
+
+    private fun IronwoodMigrationOutboxRunResult.toChannelMap(): Map<String, Any?> =
+        mapOf(
+            "outcome" to when (outcome) {
+                IronwoodMigrationOutboxOutcome.NO_WORK -> "noWork"
+                IronwoodMigrationOutboxOutcome.WAITING -> "waiting"
+                IronwoodMigrationOutboxOutcome.ACCEPTED -> "accepted"
+                IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION -> "needsUserAction"
+                IronwoodMigrationOutboxOutcome.RETRY -> "temporarilyUnavailable"
+                IronwoodMigrationOutboxOutcome.CANCELLED -> "cancelled"
+            },
+            "nextHeight" to nextHeight,
+            "observedHeight" to observedHeight,
+            "delaySeconds" to delayMs?.div(1_000.0),
+        )
 
     private fun arguments(call: MethodCall): Map<String, Any?> =
         stringMap(call.arguments, "arguments")
@@ -322,6 +523,24 @@ internal class IronwoodMigrationSecureStoreChannel(
     private fun listOfMaps(value: Any?, name: String): List<Map<String, Any?>> {
         val raw = value as? List<*> ?: throw IllegalArgumentException("Invalid $name.")
         return raw.map { stringMap(it, name) }
+    }
+
+    private fun stringStringMap(value: Any?, name: String): Map<String, String> {
+        val raw = value as? Map<*, *> ?: throw IllegalArgumentException("Invalid $name.")
+        if (raw.any { it.key !is String || it.value !is String }) {
+            throw IllegalArgumentException("Invalid $name.")
+        }
+        @Suppress("UNCHECKED_CAST")
+        return raw as Map<String, String>
+    }
+
+    private fun stringList(value: Any?, name: String): List<String> {
+        val raw = value as? List<*> ?: throw IllegalArgumentException("Invalid $name.")
+        if (raw.any { it !is String || it.isBlank() }) {
+            throw IllegalArgumentException("Invalid $name.")
+        }
+        @Suppress("UNCHECKED_CAST")
+        return raw as List<String>
     }
 
     private fun network(arguments: Map<String, Any?>): String =

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreChannel.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreChannel.kt
@@ -12,6 +12,35 @@ import java.nio.ByteBuffer
 import java.security.MessageDigest
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+internal object IronwoodMigrationQuiescenceLeases {
+    private val lock = ReentrantLock()
+    private val activeLeaseIds = linkedSetOf<String>()
+
+    fun acquire(leaseId: String): Boolean = lock.withLock {
+        if (!activeLeaseIds.add(leaseId)) return false
+        activeLeaseIds.size == 1
+    }
+
+    fun contains(leaseId: String): Boolean = lock.withLock {
+        leaseId in activeLeaseIds
+    }
+
+    fun isLast(leaseId: String): Boolean = lock.withLock {
+        activeLeaseIds.size == 1 && leaseId in activeLeaseIds
+    }
+
+    fun release(leaseId: String): Boolean = lock.withLock {
+        activeLeaseIds.remove(leaseId)
+        activeLeaseIds.isEmpty()
+    }
+
+    fun hasActiveLeases(): Boolean = lock.withLock {
+        activeLeaseIds.isNotEmpty()
+    }
+}
 
 internal class IronwoodMigrationSecureStoreChannel(
     private val context: Context,
@@ -51,6 +80,78 @@ internal class IronwoodMigrationSecureStoreChannel(
                         string(arguments, "accountUuid"),
                     )
                     true
+                }
+            }
+            "startPreparation" -> {
+                {
+                    if (IronwoodMigrationPreparationExecutionCoordinator.isQuiescing) {
+                        false
+                    } else {
+                        IronwoodMigrationPreparationScheduler.enqueue(context)
+                        true
+                    }
+                }
+            }
+            "cancel" -> {
+                {
+                    val shouldResume = hasScheduledPreparation()
+                    IronwoodMigrationPreparationExecutionCoordinator.runQuiesced {
+                        IronwoodMigrationPreparationScheduler.cancelAndWait(context)
+                    }
+                    if (shouldResume) resumeRemainingPreparation()
+                    true
+                }
+            }
+            "quiesce" -> {
+                {
+                    val leaseId = quiescenceLeaseId(call)
+                    val firstLease = IronwoodMigrationQuiescenceLeases.acquire(leaseId)
+                    if (firstLease) {
+                        val previousState = store.readBackgroundWorkResumeState()
+                        try {
+                            store.writeBackgroundWorkResumeState(
+                                IronwoodMigrationBackgroundWorkResumeState(
+                                    preparationWasScheduled =
+                                        previousState?.preparationWasScheduled == true ||
+                                        hasScheduledPreparation(),
+                                ),
+                            )
+                        } catch (error: Exception) {
+                            IronwoodMigrationQuiescenceLeases.release(leaseId)
+                            throw error
+                        }
+                        IronwoodMigrationPreparationExecutionCoordinator
+                            .quiesceAndDrain()
+                        IronwoodMigrationOutboxExecutionCoordinator.quiesceAndDrain()
+                        IronwoodMigrationPreparationScheduler.cancelAndWait(context)
+                        IronwoodMigrationOutboxScheduler.cancelAndWait(context)
+                    }
+                    true
+                }
+            }
+            "resume" -> {
+                {
+                    resumeQuiescedWork(optionalQuiescenceLeaseId(call))
+                }
+            }
+            "getPreparationRuntimeState" -> {
+                {
+                    val arguments = arguments(call)
+                    val network = network(arguments)
+                    val accountUuid = string(arguments, "accountUuid")
+                    val runId = string(arguments, "runId")
+                    val manifest = store.readManifest(network, accountUuid)
+                        ?.let(IronwoodMigrationPreparationManifest::decode)
+                    if (
+                        manifest == null ||
+                        manifest.network != network ||
+                        manifest.accountUuid != accountUuid ||
+                        manifest.expectedRunId != runId
+                    ) {
+                        "idle"
+                    } else {
+                        IronwoodMigrationPreparationScheduler.runtimeState(context)
+                    }
                 }
             }
             "stageOutboxBatch" -> {
@@ -178,22 +279,35 @@ internal class IronwoodMigrationSecureStoreChannel(
                     val arguments = arguments(call)
                     val network = network(arguments)
                     val accountUuid = string(arguments, "accountUuid")
-                    IronwoodMigrationOutboxScheduler.cancel(context)
+                    val shouldResumePreparation =
+                        !IronwoodMigrationPreparationExecutionCoordinator
+                            .isQuiescing &&
+                            hasScheduledPreparation()
                     var hasRemainingWork = false
-                    IronwoodMigrationOutboxExecutionCoordinator.cancelAndDrain {
-                        hasRemainingWork = outboxRepository.update { snapshot ->
-                            val batchIds = snapshot.batches.filter {
-                                it.network == network && it.accountUuid == accountUuid
-                            }.map { it.batchId }.toSet()
-                            snapshot.batches.removeAll { it.batchId in batchIds }
-                            snapshot.receipts.removeAll { it.batchId in batchIds }
-                            if (snapshot.lastAttemptedScopeKey == "$network:$accountUuid") {
-                                snapshot.lastAttemptedScopeKey = null
+                    IronwoodMigrationPreparationExecutionCoordinator.runQuiesced {
+                        IronwoodMigrationOutboxExecutionCoordinator.cancelAndDrain {
+                            IronwoodMigrationPreparationScheduler
+                                .cancelAndWait(context)
+                            IronwoodMigrationOutboxScheduler.cancelAndWait(context)
+                            hasRemainingWork = outboxRepository.update { snapshot ->
+                                val batchIds = snapshot.batches.filter {
+                                    it.network == network &&
+                                        it.accountUuid == accountUuid
+                                }.map { it.batchId }.toSet()
+                                snapshot.batches.removeAll { it.batchId in batchIds }
+                                snapshot.receipts.removeAll { it.batchId in batchIds }
+                                if (
+                                    snapshot.lastAttemptedScopeKey ==
+                                    "$network:$accountUuid"
+                                ) {
+                                    snapshot.lastAttemptedScopeKey = null
+                                }
+                                IronwoodOutboxState.hasRunnableWork(snapshot)
                             }
-                            IronwoodOutboxState.hasRunnableWork(snapshot)
+                            store.revokeAccount(network, accountUuid)
                         }
-                        store.revokeAccount(network, accountUuid)
                     }
+                    if (shouldResumePreparation) resumeRemainingPreparation()
                     if (hasRemainingWork) {
                         IronwoodMigrationOutboxScheduler.enqueueContinuation(context, 0)
                     }
@@ -202,9 +316,13 @@ internal class IronwoodMigrationSecureStoreChannel(
             }
             "revokeAll" -> {
                 {
-                    IronwoodMigrationOutboxScheduler.cancel(context)
-                    IronwoodMigrationOutboxExecutionCoordinator.cancelAndDrain {
-                        store.revokeAll()
+                    IronwoodMigrationPreparationExecutionCoordinator.runQuiesced {
+                        IronwoodMigrationOutboxExecutionCoordinator.cancelAndDrain {
+                            IronwoodMigrationPreparationScheduler
+                                .cancelAndWait(context)
+                            IronwoodMigrationOutboxScheduler.cancelAndWait(context)
+                            store.revokeAll()
+                        }
                     }
                     IronwoodMigrationOutboxNotifier(context).cancelAll()
                     true
@@ -234,13 +352,38 @@ internal class IronwoodMigrationSecureStoreChannel(
         IronwoodMigrationOutboxScheduler.enqueue(context)
     }
 
+    private fun hasScheduledPreparation(): Boolean =
+        IronwoodMigrationPreparationScheduler.runtimeState(context) != "idle"
+
+    private fun resumeRemainingPreparation(immediate: Boolean = false) {
+        if (IronwoodMigrationPreparationExecutionCoordinator.isQuiescing) return
+        val hasActiveManifest = store.readAllManifests().any { encoded ->
+            runCatching {
+                IronwoodMigrationPreparationManifest.decode(encoded).expectedRunId != null
+            }.getOrDefault(false)
+        }
+        if (hasActiveManifest) {
+            if (immediate) {
+                IronwoodMigrationPreparationScheduler.enqueue(context)
+            } else {
+                IronwoodMigrationPreparationScheduler.enqueueContinuation(context)
+            }
+        }
+    }
+
     fun close() {
         executor.shutdown()
     }
 
-    fun resumePendingNotifications() {
+    fun resumePendingWork() {
         executor.execute {
             runCatching {
+                if (
+                    !IronwoodMigrationQuiescenceLeases.hasActiveLeases() &&
+                    store.readBackgroundWorkResumeState() != null
+                ) {
+                    resumeQuiescedWork(leaseId = null)
+                }
                 if (
                     outboxRepository.read().let(
                         IronwoodOutboxState::hasPendingNotifications,
@@ -250,6 +393,66 @@ internal class IronwoodMigrationSecureStoreChannel(
                 }
             }
         }
+    }
+
+    private fun resumeQuiescedWork(leaseId: String?): Boolean {
+        if (leaseId != null && !IronwoodMigrationQuiescenceLeases.contains(leaseId)) {
+            return true
+        }
+        if (
+            leaseId != null &&
+            !IronwoodMigrationQuiescenceLeases.isLast(leaseId)
+        ) {
+            IronwoodMigrationQuiescenceLeases.release(leaseId)
+            return true
+        }
+        if (leaseId == null && IronwoodMigrationQuiescenceLeases.hasActiveLeases()) {
+            return false
+        }
+
+        val resumeState = store.readBackgroundWorkResumeState()
+        IronwoodMigrationPreparationExecutionCoordinator.resume()
+        IronwoodMigrationOutboxExecutionCoordinator.resume()
+        try {
+            if (resumeState?.preparationWasScheduled == true) {
+                resumeRemainingPreparation(immediate = true)
+            }
+            if (
+                outboxRepository.read().let(
+                    IronwoodOutboxState::hasRunnableWork,
+                )
+            ) {
+                IronwoodMigrationOutboxScheduler.enqueueContinuation(context, 0)
+            }
+            store.clearBackgroundWorkResumeState()
+        } catch (error: Exception) {
+            val requiesceError = runCatching {
+                IronwoodMigrationPreparationExecutionCoordinator.quiesceAndDrain()
+                IronwoodMigrationOutboxExecutionCoordinator.quiesceAndDrain()
+                IronwoodMigrationPreparationScheduler.cancelAndWait(context)
+                IronwoodMigrationOutboxScheduler.cancelAndWait(context)
+            }.exceptionOrNull()
+            if (requiesceError != null) error.addSuppressed(requiesceError)
+            throw error
+        }
+        if (leaseId != null) {
+            IronwoodMigrationQuiescenceLeases.release(leaseId)
+        }
+        return true
+    }
+
+    private fun quiescenceLeaseId(call: MethodCall): String =
+        optionalQuiescenceLeaseId(call)
+            ?: throw IllegalArgumentException("Missing quiescence lease ID.")
+
+    private fun optionalQuiescenceLeaseId(call: MethodCall): String? {
+        val arguments = call.arguments ?: return null
+        if (arguments !is Map<*, *>) {
+            throw IllegalArgumentException("Invalid quiescence arguments.")
+        }
+        return (arguments["leaseId"] as? String)
+            ?.takeIf { it.isNotBlank() }
+            ?: throw IllegalArgumentException("Missing quiescence lease ID.")
     }
 
     private fun validateManifest(

--- a/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
@@ -13,6 +13,8 @@ import io.flutter.plugin.common.MethodChannel
 // FlutterFragmentActivity: BiometricPrompt requires a FragmentActivity host.
 class MainActivity : FlutterFragmentActivity() {
     private lateinit var deviceOwnerAuthHandler: DeviceOwnerAuthHandler
+    private lateinit var ironwoodMigrationSecureStoreChannel:
+        IronwoodMigrationSecureStoreChannel
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -85,6 +87,16 @@ class MainActivity : FlutterFragmentActivity() {
                 else -> result.notImplemented()
             }
         }
+        ironwoodMigrationSecureStoreChannel =
+            IronwoodMigrationSecureStoreChannel(applicationContext)
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            BACKGROUND_MIGRATION_CHANNEL
+        ).setMethodCallHandler { call, result ->
+            if (!ironwoodMigrationSecureStoreChannel.handle(call, result)) {
+                result.notImplemented()
+            }
+        }
     }
 
     /** REJECT is the platform's error haptic; older APIs report
@@ -126,6 +138,13 @@ class MainActivity : FlutterFragmentActivity() {
         super.onActivityResult(requestCode, resultCode, data)
     }
 
+    override fun onDestroy() {
+        if (::ironwoodMigrationSecureStoreChannel.isInitialized) {
+            ironwoodMigrationSecureStoreChannel.close()
+        }
+        super.onDestroy()
+    }
+
     private fun openAppSettings(): Boolean {
         return try {
             val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
@@ -159,6 +178,8 @@ class MainActivity : FlutterFragmentActivity() {
     }
 
     companion object {
+        private const val BACKGROUND_MIGRATION_CHANNEL =
+            "com.zcash.wallet/background_migration"
         private const val CAMERA_PERMISSION_CHANNEL = "com.zcash.wallet/camera_permission"
         private const val HAPTICS_CHANNEL = "com.zcash.wallet/haptics"
         private const val PRIVACY_SHIELD_CHANNEL = "com.zcash.wallet/privacy_shield"

--- a/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
@@ -174,7 +174,7 @@ class MainActivity : FlutterFragmentActivity() {
             ::ironwoodMigrationSecureStoreChannel.isInitialized &&
             notificationAuthorizationStatus() == NOTIFICATION_AUTHORIZED
         ) {
-            ironwoodMigrationSecureStoreChannel.resumePendingNotifications()
+            ironwoodMigrationSecureStoreChannel.resumePendingWork()
         }
     }
 
@@ -191,7 +191,7 @@ class MainActivity : FlutterFragmentActivity() {
                 status == NOTIFICATION_AUTHORIZED &&
                 ::ironwoodMigrationSecureStoreChannel.isInitialized
             ) {
-                ironwoodMigrationSecureStoreChannel.resumePendingNotifications()
+                ironwoodMigrationSecureStoreChannel.resumePendingWork()
             }
             result?.success(status)
             return

--- a/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/MainActivity.kt
@@ -1,11 +1,17 @@
 package com.keplr.vizor
 
+import android.Manifest
+import android.app.NotificationManager
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import android.view.HapticFeedbackConstants
 import android.view.WindowManager
+import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
@@ -15,6 +21,7 @@ class MainActivity : FlutterFragmentActivity() {
     private lateinit var deviceOwnerAuthHandler: DeviceOwnerAuthHandler
     private lateinit var ironwoodMigrationSecureStoreChannel:
         IronwoodMigrationSecureStoreChannel
+    private var pendingNotificationPermissionResult: MethodChannel.Result? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -93,8 +100,18 @@ class MainActivity : FlutterFragmentActivity() {
             flutterEngine.dartExecutor.binaryMessenger,
             BACKGROUND_MIGRATION_CHANNEL
         ).setMethodCallHandler { call, result ->
-            if (!ironwoodMigrationSecureStoreChannel.handle(call, result)) {
-                result.notImplemented()
+            when (call.method) {
+                "requestNotificationAuthorization" ->
+                    requestNotificationAuthorization(result)
+                "getNotificationAuthorizationStatus" ->
+                    result.success(notificationAuthorizationStatus())
+                "openNotificationSettings" ->
+                    result.success(openNotificationSettings())
+                else -> {
+                    if (!ironwoodMigrationSecureStoreChannel.handle(call, result)) {
+                        result.notImplemented()
+                    }
+                }
             }
         }
     }
@@ -139,10 +156,122 @@ class MainActivity : FlutterFragmentActivity() {
     }
 
     override fun onDestroy() {
+        pendingNotificationPermissionResult?.error(
+            "activity_destroyed",
+            "Notification permission request was interrupted.",
+            null,
+        )
+        pendingNotificationPermissionResult = null
         if (::ironwoodMigrationSecureStoreChannel.isInitialized) {
             ironwoodMigrationSecureStoreChannel.close()
         }
         super.onDestroy()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (
+            ::ironwoodMigrationSecureStoreChannel.isInitialized &&
+            notificationAuthorizationStatus() == NOTIFICATION_AUTHORIZED
+        ) {
+            ironwoodMigrationSecureStoreChannel.resumePendingNotifications()
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+    ) {
+        if (requestCode == NOTIFICATION_PERMISSION_REQUEST_CODE) {
+            val result = pendingNotificationPermissionResult
+            pendingNotificationPermissionResult = null
+            val status = notificationAuthorizationStatus()
+            if (
+                status == NOTIFICATION_AUTHORIZED &&
+                ::ironwoodMigrationSecureStoreChannel.isInitialized
+            ) {
+                ironwoodMigrationSecureStoreChannel.resumePendingNotifications()
+            }
+            result?.success(status)
+            return
+        }
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+    }
+
+    private fun requestNotificationAuthorization(result: MethodChannel.Result) {
+        if (
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            result.success(notificationAuthorizationStatus())
+            return
+        }
+        if (pendingNotificationPermissionResult != null) {
+            result.error(
+                "request_in_progress",
+                "A notification permission request is already active.",
+                null,
+            )
+            return
+        }
+        pendingNotificationPermissionResult = result
+        getSharedPreferences(NOTIFICATION_PERMISSION_PREFERENCES, MODE_PRIVATE)
+            .edit()
+            .putBoolean(NOTIFICATION_PERMISSION_REQUESTED_KEY, true)
+            .apply()
+        ActivityCompat.requestPermissions(
+            this,
+            arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+            NOTIFICATION_PERMISSION_REQUEST_CODE,
+        )
+    }
+
+    private fun notificationAuthorizationStatus(): String {
+        if (!NotificationManagerCompat.from(this).areNotificationsEnabled()) {
+            if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                !getSharedPreferences(
+                    NOTIFICATION_PERMISSION_PREFERENCES,
+                    MODE_PRIVATE,
+                ).getBoolean(NOTIFICATION_PERMISSION_REQUESTED_KEY, false)
+            ) {
+                return NOTIFICATION_NOT_DETERMINED
+            }
+            return NOTIFICATION_DENIED
+        }
+        if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            return NOTIFICATION_DENIED
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = getSystemService(NotificationManager::class.java)
+                .getNotificationChannel(MIGRATION_UPDATES_NOTIFICATION_CHANNEL_ID)
+            if (channel?.importance == NotificationManager.IMPORTANCE_NONE) {
+                return NOTIFICATION_DENIED
+            }
+        }
+        return NOTIFICATION_AUTHORIZED
+    }
+
+    private fun openNotificationSettings(): Boolean {
+        return try {
+            val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+            }
+            startActivity(intent)
+            true
+        } catch (_: Exception) {
+            openAppSettings()
+        }
     }
 
     private fun openAppSettings(): Boolean {
@@ -184,5 +313,14 @@ class MainActivity : FlutterFragmentActivity() {
         private const val HAPTICS_CHANNEL = "com.zcash.wallet/haptics"
         private const val PRIVACY_SHIELD_CHANNEL = "com.zcash.wallet/privacy_shield"
         private const val SCREEN_AWAKE_CHANNEL = "com.zcash.wallet/screen_awake"
+        private const val NOTIFICATION_PERMISSION_REQUEST_CODE = 0x319
+        private const val NOTIFICATION_PERMISSION_PREFERENCES =
+            "ironwood_migration_notifications"
+        private const val NOTIFICATION_PERMISSION_REQUESTED_KEY = "permission_requested"
+        private const val MIGRATION_UPDATES_NOTIFICATION_CHANNEL_ID =
+            "ironwood_migration_updates"
+        private const val NOTIFICATION_NOT_DETERMINED = "notDetermined"
+        private const val NOTIFICATION_DENIED = "denied"
+        private const val NOTIFICATION_AUTHORIZED = "authorized"
     }
 }

--- a/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationNativeBridgeTest.kt
+++ b/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationNativeBridgeTest.kt
@@ -1,0 +1,153 @@
+package com.keplr.vizor
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IronwoodMigrationNativeBridgeTest {
+    @Test
+    fun preparationProgressIsDecodedFromNativeEnvelope() {
+        val bindings = FakeBindings().apply {
+            inspectResult = IronwoodMigrationNativeCallResult(
+                0,
+                null,
+                longArrayOf(5, 2, 10, 3, 4),
+            )
+        }
+
+        val progress = IronwoodMigrationNativeBridge(bindings).inspect(
+            "/tmp/wallet.db",
+            "test",
+            "account-1",
+            "run-1",
+        )
+
+        assertEquals(
+            IronwoodMigrationNativePreparationState.WAITING_FOR_PREPARED_NOTE_ANCHOR,
+            progress.state,
+        )
+        assertEquals(2, progress.confirmationCount)
+        assertEquals(10, progress.confirmationTarget)
+        assertEquals(3, progress.completedStageCount)
+        assertEquals(4, progress.totalStageCount)
+    }
+
+    @Test
+    fun nativeErrorCodesRemainTyped() {
+        val bindings = FakeBindings().apply {
+            inspectResult = IronwoodMigrationNativeCallResult(
+                2,
+                "Another wallet sync is already running",
+                null,
+            )
+        }
+
+        val error = assertThrows(IronwoodMigrationNativeException::class.java) {
+            IronwoodMigrationNativeBridge(bindings).inspect(
+                "/tmp/wallet.db",
+                "test",
+                "account-1",
+                "run-1",
+            )
+        }
+
+        assertEquals(IronwoodMigrationNativeError.SYNC_ALREADY_RUNNING, error.reason)
+    }
+
+    @Test
+    fun malformedNativeProgressFailsClosed() {
+        val bindings = FakeBindings().apply {
+            inspectResult = IronwoodMigrationNativeCallResult(
+                0,
+                null,
+                longArrayOf(1, -1, 0, 0, 0),
+            )
+        }
+
+        val error = assertThrows(IronwoodMigrationNativeException::class.java) {
+            IronwoodMigrationNativeBridge(bindings).inspect(
+                "/tmp/wallet.db",
+                "test",
+                "account-1",
+                "run-1",
+            )
+        }
+
+        assertEquals(IronwoodMigrationNativeError.INVALID_RESPONSE, error.reason)
+    }
+
+    @Test
+    fun syncProgressIsForwardedAndValidated() {
+        val bindings = FakeBindings()
+        var progress: IronwoodMigrationNativeSyncProgress? = null
+
+        IronwoodMigrationNativeBridge(bindings).runSync(
+            "/tmp/wallet.db",
+            "https://lwd.example:443",
+            "test",
+        ) {
+            progress = it
+        }
+
+        assertEquals(100L, progress?.scannedHeight)
+        assertEquals(120L, progress?.chainTipHeight)
+        assertEquals(0.5, progress?.percentage)
+        assertTrue(progress?.isSyncing == true)
+        assertFalse(progress?.isComplete == true)
+        assertTrue(progress?.hasNewTx == true)
+    }
+
+    private class FakeBindings : IronwoodMigrationNativeBindings {
+        var inspectResult = IronwoodMigrationNativeCallResult(
+            0,
+            null,
+            longArrayOf(4, 0, 0, 0, 0),
+        )
+
+        override fun nativeBeginOperation(): Boolean = true
+
+        override fun nativeEndOperation() = Unit
+
+        override fun nativeCancelOperation(): Boolean = true
+
+        override fun nativeIsSyncRunning(): Boolean = false
+
+        override fun nativeInspect(
+            dbPath: String,
+            network: String,
+            accountUuid: String,
+            expectedRunId: String,
+        ): IronwoodMigrationNativeCallResult = inspectResult
+
+        override fun nativeAdvance(
+            dbPath: String,
+            lightwalletdUrl: String,
+            network: String,
+            accountUuid: String,
+            expectedRunId: String,
+            credential: ByteArray,
+            saltBase64: String,
+        ): IronwoodMigrationNativeCallResult = inspectResult
+
+        override fun nativeRunSync(
+            dbPath: String,
+            lightwalletdUrl: String,
+            network: String,
+            callback: IronwoodMigrationNativeSyncCallback,
+        ): IronwoodMigrationNativeCallResult {
+            callback.onProgress(
+                100,
+                120,
+                0.5,
+                0.75,
+                20,
+                true,
+                false,
+                true,
+            )
+            return IronwoodMigrationNativeCallResult(0, null, null)
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationOutboxTest.kt
+++ b/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationOutboxTest.kt
@@ -1,0 +1,552 @@
+package com.keplr.vizor
+
+import java.nio.file.Files
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+import kotlin.random.Random
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class IronwoodMigrationOutboxTest {
+    private lateinit var directory: java.io.File
+    private lateinit var repository: IronwoodMigrationOutboxRepository
+
+    @Before
+    fun setUp() {
+        directory = Files.createTempDirectory("ironwood-outbox").toFile()
+        repository = IronwoodMigrationOutboxRepository(
+            IronwoodMigrationSecureStore(
+                keyProvider = TestKeyProvider(),
+                directory = directory,
+            ),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        directory.deleteRecursively()
+    }
+
+    @Test
+    fun interruptedSubmissionIsRecoveredBeforeNetworkInspection() {
+        val item = item(
+            status = IronwoodOutboxItemStatus.SUBMITTING,
+            expiryHeight = 69_120,
+        )
+        repository.update { it.batches += batch(item) }
+
+        val result = IronwoodMigrationOutboxRunner(
+            repository = repository,
+            transport = FakeTransport(height = 50),
+            clockMs = { 1_000 },
+        ).runOnce()
+
+        assertEquals(IronwoodMigrationOutboxOutcome.WAITING, result.outcome)
+        val recovered = repository.read().batches.single().items.single()
+        assertEquals(IronwoodOutboxItemStatus.ARMED, recovered.status)
+        assertEquals(1, recovered.attemptCount)
+        assertEquals(61_000L, recovered.nextAttemptAtMs)
+    }
+
+    @Test
+    fun dueTransactionWithDifferentCanonicalExpiryRequiresResigning() {
+        repository.update {
+            it.batches += batch(
+                item(
+                    scheduledHeight = 100,
+                    expiryHeight = 34_560,
+                ),
+            )
+        }
+
+        val result = IronwoodMigrationOutboxRunner(
+            repository = repository,
+            transport = FakeTransport(height = 100),
+            clockMs = { 2_000 },
+        ).runOnce()
+
+        assertEquals(IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION, result.outcome)
+        val snapshot = repository.read()
+        assertEquals(
+            IronwoodOutboxItemStatus.NEEDS_RESIGN_AWAITING_RECONCILIATION,
+            snapshot.batches.single().items.single().status,
+        )
+        assertEquals("needsResign", snapshot.receipts.single().outcome)
+        assertEquals(
+            "batch-1",
+            IronwoodOutboxState.pendingNeedsUserActionBatchId(snapshot),
+        )
+        assertTrue(IronwoodOutboxState.hasRunnableWork(snapshot))
+
+        repository.update {
+            assertTrue(
+                IronwoodOutboxState.acknowledgeNeedsUserActionNotification(
+                    it,
+                    "batch-1",
+                ),
+            )
+        }
+        assertNull(
+            IronwoodOutboxState.pendingNeedsUserActionBatchId(repository.read()),
+        )
+    }
+
+    @Test
+    fun acceptedSubmissionCreatesReceiptWithRawTransaction() {
+        val raw = byteArrayOf(1, 2, 3)
+        repository.update {
+            it.batches += batch(
+                item(
+                    raw = raw,
+                    scheduledHeight = 100,
+                    expiryHeight = 69_120,
+                ),
+            )
+        }
+        val transport = FakeTransport(height = 100)
+
+        val result = IronwoodMigrationOutboxRunner(
+            repository = repository,
+            transport = transport,
+            clockMs = { 3_000 },
+            random = Random(7),
+        ).runOnce()
+
+        assertEquals(IronwoodMigrationOutboxOutcome.ACCEPTED, result.outcome)
+        assertArrayEquals(raw, transport.sent.single())
+        val snapshot = repository.read()
+        assertEquals(
+            IronwoodOutboxItemStatus.ACCEPTED_AWAITING_RECONCILIATION,
+            snapshot.batches.single().items.single().status,
+        )
+        assertEquals("accepted", snapshot.receipts.single().outcome)
+        assertArrayEquals(raw, snapshot.receipts.single().rawTransaction)
+        assertTrue(snapshot.batches.single().broadcastCompletePending)
+    }
+
+    @Test
+    fun uncertainSubmissionReturnsToArmedWithBackoff() {
+        repository.update {
+            it.batches += batch(item(scheduledHeight = 100, expiryHeight = 69_120))
+        }
+
+        val result = IronwoodMigrationOutboxRunner(
+            repository = repository,
+            transport = FakeTransport(
+                height = 100,
+                sendError = IronwoodMigrationNativeException(
+                    IronwoodMigrationNativeError.EXECUTION,
+                    "network lost",
+                ),
+            ),
+            clockMs = { 5_000 },
+        ).runOnce()
+
+        assertEquals(IronwoodMigrationOutboxOutcome.RETRY, result.outcome)
+        val item = repository.read().batches.single().items.single()
+        assertEquals(IronwoodOutboxItemStatus.ARMED, item.status)
+        assertEquals(1, item.attemptCount)
+        assertEquals(65_000L, item.nextAttemptAtMs)
+        assertEquals("network lost", item.lastError)
+    }
+
+    @Test
+    fun proofWatchStopsSchedulingAfterHeightIsObserved() {
+        repository.update {
+            it.batches += batch(
+                item = null,
+                nextProofHeight = 120,
+            )
+        }
+
+        val result = IronwoodMigrationOutboxRunner(
+            repository = repository,
+            transport = FakeTransport(height = 120),
+        ).runOnce()
+
+        assertEquals(IronwoodMigrationOutboxOutcome.WAITING, result.outcome)
+        assertEquals("batch-1", result.proofReadyBatchId)
+        assertNull(result.nextHeight)
+        assertEquals(120L, repository.read().batches.single().proofReadyObservedHeight)
+
+        val pending = IronwoodMigrationOutboxRunner(
+            repository = repository,
+            transport = FakeTransport(height = 120),
+        ).runOnce()
+        assertEquals(IronwoodMigrationOutboxOutcome.NO_WORK, pending.outcome)
+        assertEquals("batch-1", pending.proofReadyBatchId)
+        assertTrue(IronwoodOutboxState.hasRunnableWork(repository.read()))
+
+        repository.update {
+            assertTrue(
+                IronwoodOutboxState.acknowledgeProofReadyNotification(it, "batch-1"),
+            )
+        }
+        val acknowledged = IronwoodMigrationOutboxRunner(
+            repository = repository,
+            transport = FakeTransport(height = 120),
+        ).runOnce()
+        assertEquals(IronwoodMigrationOutboxOutcome.NO_WORK, acknowledged.outcome)
+        assertNull(acknowledged.proofReadyBatchId)
+        assertTrue(!IronwoodOutboxState.hasRunnableWork(repository.read()))
+    }
+
+    @Test
+    fun terminalReceiptDoesNotAbandonAnotherDueSubmission() {
+        repository.update {
+            it.batches += batch(
+                item(
+                    scheduledHeight = 100,
+                    expiryHeight = 34_560,
+                ),
+                batchId = "terminal",
+                accountUuid = "account-1",
+            )
+            it.batches += batch(
+                item(
+                    scheduledHeight = 100,
+                    expiryHeight = 69_120,
+                ),
+                batchId = "sendable",
+                accountUuid = "account-2",
+            )
+        }
+
+        val result = IronwoodMigrationOutboxRunner(
+            repository = repository,
+            transport = FakeTransport(height = 100),
+            clockMs = { 2_000 },
+        ).runOnce()
+
+        assertEquals(IronwoodMigrationOutboxOutcome.ACCEPTED, result.outcome)
+        val snapshot = repository.read()
+        assertEquals("needsResign", snapshot.receipts.first { it.batchId == "terminal" }.outcome)
+        assertEquals("accepted", snapshot.receipts.first { it.batchId == "sendable" }.outcome)
+    }
+
+    @Test
+    fun finalItemForOneEndpointContinuesWorkOnAnotherEndpoint() {
+        repository.update {
+            it.batches += batch(
+                item(scheduledHeight = 100, expiryHeight = 69_120),
+                batchId = "first",
+                accountUuid = "account-1",
+                endpoint = "https://a.example",
+            )
+            it.batches += batch(
+                item(scheduledHeight = 200, expiryHeight = 69_120),
+                batchId = "second",
+                accountUuid = "account-2",
+                endpoint = "https://b.example",
+            )
+        }
+
+        val result = IronwoodMigrationOutboxRunner(
+            repository = repository,
+            transport = FakeTransport(height = 100),
+        ).runOnce()
+
+        assertEquals(IronwoodMigrationOutboxOutcome.ACCEPTED, result.outcome)
+        assertEquals(0L, result.delayMs)
+        assertEquals(
+            IronwoodOutboxItemStatus.ARMED,
+            repository.read().batches.first { it.batchId == "second" }.items.single().status,
+        )
+    }
+
+    @Test
+    fun acceptedItemChecksAnotherEndpointBeforeItsOwnFutureWork() {
+        repository.update {
+            it.batches += batch(
+                item(scheduledHeight = 100, expiryHeight = 69_120),
+                batchId = "accepted",
+                accountUuid = "account-1",
+                endpoint = "https://a.example",
+            )
+            it.batches += batch(
+                item(scheduledHeight = 1_000, expiryHeight = 69_120),
+                batchId = "future",
+                accountUuid = "account-1",
+                endpoint = "https://a.example",
+            )
+            it.batches += batch(
+                item(scheduledHeight = 100, expiryHeight = 69_120),
+                batchId = "other-due",
+                accountUuid = "account-2",
+                endpoint = "https://b.example",
+            )
+        }
+
+        val result = IronwoodMigrationOutboxRunner(
+            repository = repository,
+            transport = FakeTransport(height = 100),
+        ).runOnce()
+
+        assertEquals(IronwoodMigrationOutboxOutcome.ACCEPTED, result.outcome)
+        assertEquals(60_000L, result.delayMs)
+    }
+
+    @Test
+    fun waitingEndpointChecksAnotherEndpointWithinOneMinute() {
+        repository.update {
+            it.batches += batch(
+                item(scheduledHeight = 1_000, expiryHeight = 69_120),
+                batchId = "future",
+                accountUuid = "account-1",
+                endpoint = "https://a.example",
+            )
+            it.batches += batch(
+                item(scheduledHeight = 100, expiryHeight = 69_120),
+                batchId = "due",
+                accountUuid = "account-2",
+                endpoint = "https://b.example",
+            )
+        }
+        val transport = FakeTransport(height = 100)
+
+        val result = IronwoodMigrationOutboxRunner(
+            repository = repository,
+            transport = transport,
+        ).runOnce()
+
+        assertEquals(IronwoodMigrationOutboxOutcome.WAITING, result.outcome)
+        assertEquals(60_000L, result.delayMs)
+        assertTrue(transport.sent.isEmpty())
+    }
+
+    @Test
+    fun acknowledgingLastReceiptPreservesPendingCompletion() {
+        val accepted = item(
+            expiryHeight = 69_120,
+            status = IronwoodOutboxItemStatus.ACCEPTED_AWAITING_RECONCILIATION,
+        )
+        val batch = batch(accepted).copy(broadcastCompletePending = true)
+        val receipt = IronwoodOutboxReceipt(
+            receiptId = "receipt-1",
+            batchId = batch.batchId,
+            itemId = accepted.itemId,
+            network = batch.network,
+            accountUuid = batch.accountUuid,
+            runId = batch.runId,
+            txidHex = accepted.txidHex,
+            outcome = "accepted",
+            remoteHeight = 100,
+            responseCode = 0,
+            responseMessage = "",
+            recordedAtMs = 0,
+            scheduleUpdates = emptyList(),
+            rawTransaction = accepted.rawTransaction,
+        )
+        val snapshot = IronwoodOutboxSnapshot(
+            batches = mutableListOf(batch),
+            receipts = mutableListOf(receipt),
+        )
+
+        IronwoodOutboxState.acknowledgeReceipts(snapshot, setOf(receipt.receiptId))
+
+        assertTrue(snapshot.receipts.isEmpty())
+        assertTrue(snapshot.batches.single().items.isEmpty())
+        assertTrue(snapshot.batches.single().broadcastCompletePending)
+
+        assertTrue(
+            IronwoodOutboxState.acknowledgeBroadcastCompleteNotification(
+                snapshot,
+                batch.batchId,
+            ),
+        )
+        assertTrue(snapshot.batches.isEmpty())
+        assertTrue(!IronwoodOutboxState.hasRunnableWork(snapshot))
+    }
+
+    @Test
+    fun cancellationEpochIsVisibleBeforeDrainCompletes() {
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val drained = CountDownLatch(1)
+        var cancellationObserved = false
+        val runner = Thread {
+            IronwoodMigrationOutboxExecutionCoordinator.tryRun { isCancelled ->
+                started.countDown()
+                release.await(5, TimeUnit.SECONDS)
+                cancellationObserved = isCancelled()
+            }
+        }.apply { start() }
+        assertTrue(started.await(5, TimeUnit.SECONDS))
+        val canceller = Thread {
+            IronwoodMigrationOutboxExecutionCoordinator.cancelAndDrain {
+                drained.countDown()
+            }
+        }.apply { start() }
+
+        assertTrue(!drained.await(100, TimeUnit.MILLISECONDS))
+        release.countDown()
+        runner.join(5_000)
+        canceller.join(5_000)
+
+        assertTrue(cancellationObserved)
+        assertEquals(0L, drained.count)
+    }
+
+    @Test
+    fun exclusiveMutationWaitsForActiveRun() {
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val mutationCompleted = CountDownLatch(1)
+        val runner = Thread {
+            IronwoodMigrationOutboxExecutionCoordinator.tryRun {
+                started.countDown()
+                release.await(5, TimeUnit.SECONDS)
+            }
+        }.apply { start() }
+        assertTrue(started.await(5, TimeUnit.SECONDS))
+        val mutator = Thread {
+            IronwoodMigrationOutboxExecutionCoordinator.runExclusive {
+                mutationCompleted.countDown()
+            }
+        }.apply { start() }
+
+        assertTrue(!mutationCompleted.await(100, TimeUnit.MILLISECONDS))
+        release.countDown()
+        runner.join(5_000)
+        mutator.join(5_000)
+
+        assertEquals(0L, mutationCompleted.count)
+    }
+
+    @Test
+    fun blockingWorkerEntryWaitsForExclusiveMutation() {
+        val mutationStarted = CountDownLatch(1)
+        val releaseMutation = CountDownLatch(1)
+        val workerCompleted = CountDownLatch(1)
+        val mutation = Thread {
+            IronwoodMigrationOutboxExecutionCoordinator.runExclusive {
+                mutationStarted.countDown()
+                releaseMutation.await(5, TimeUnit.SECONDS)
+            }
+        }.apply { start() }
+        assertTrue(mutationStarted.await(5, TimeUnit.SECONDS))
+        val worker = Thread {
+            IronwoodMigrationOutboxExecutionCoordinator.runWhenAvailable {
+                workerCompleted.countDown()
+            }
+        }.apply { start() }
+
+        assertTrue(!workerCompleted.await(100, TimeUnit.MILLISECONDS))
+        releaseMutation.countDown()
+        mutation.join(5_000)
+        worker.join(5_000)
+
+        assertEquals(0L, workerCompleted.count)
+    }
+
+    @Test
+    fun foregroundRunWaitsForActiveWorkerInsteadOfReturningRetry() {
+        repository.update {
+            it.batches += batch(item(scheduledHeight = 100, expiryHeight = 69_120))
+        }
+        val workerStarted = CountDownLatch(1)
+        val releaseWorker = CountDownLatch(1)
+        val foregroundCompleted = CountDownLatch(1)
+        val foregroundResult =
+            AtomicReference<IronwoodMigrationOutboxRunResult>()
+        val worker = Thread {
+            IronwoodMigrationOutboxExecutionCoordinator.tryRun {
+                workerStarted.countDown()
+                releaseWorker.await(5, TimeUnit.SECONDS)
+            }
+        }.apply { start() }
+        assertTrue(workerStarted.await(5, TimeUnit.SECONDS))
+        val foreground = Thread {
+            foregroundResult.set(
+                IronwoodMigrationOutboxRunner(
+                    repository = repository,
+                    transport = FakeTransport(height = 100),
+                ).runOnceWaitingForActiveRun(),
+            )
+            foregroundCompleted.countDown()
+        }.apply { start() }
+
+        assertTrue(!foregroundCompleted.await(100, TimeUnit.MILLISECONDS))
+        releaseWorker.countDown()
+        worker.join(5_000)
+        foreground.join(5_000)
+
+        assertEquals(0L, foregroundCompleted.count)
+        assertEquals(
+            IronwoodMigrationOutboxOutcome.ACCEPTED,
+            foregroundResult.get().outcome,
+        )
+    }
+
+    private fun batch(
+        item: IronwoodOutboxItem?,
+        nextProofHeight: Long? = null,
+        batchId: String = "batch-1",
+        accountUuid: String = "account-1",
+        endpoint: String = "https://lightwalletd.example",
+    ) = IronwoodOutboxBatch(
+        batchId = batchId,
+        network = "test",
+        accountUuid = accountUuid,
+        runId = "run-1",
+        lightwalletdUrl = endpoint,
+        timingMeanBlocks = 10,
+        timingMaxBlocks = 20,
+        createdAtMs = 0,
+        armedAtMs = 1,
+        nextProofHeight = nextProofHeight,
+        items = item?.let { mutableListOf(it) } ?: mutableListOf(),
+    )
+
+    private fun item(
+        raw: ByteArray = byteArrayOf(1, 2, 3),
+        scheduledHeight: Long = 100,
+        expiryHeight: Long,
+        status: IronwoodOutboxItemStatus = IronwoodOutboxItemStatus.ARMED,
+    ) = IronwoodOutboxItem(
+        itemId = "item-1",
+        partIndex = 0,
+        txidHex = "abcd",
+        rawTransaction = raw,
+        payloadDigestHex = java.security.MessageDigest.getInstance("SHA-256")
+            .digest(raw)
+            .joinToString("") { "%02x".format(it.toInt() and 0xff) },
+        anchorBoundaryHeight = 0,
+        scheduledHeight = scheduledHeight,
+        scheduleStartHeight = 0,
+        expiryHeight = expiryHeight,
+        status = status,
+    )
+
+    private class FakeTransport(
+        private val height: Long,
+        private val sendError: IronwoodMigrationNativeException? = null,
+    ) : IronwoodMigrationOutboxTransport {
+        val sent = mutableListOf<ByteArray>()
+
+        override fun latestBlockHeight(lightwalletdUrl: String): Long = height
+
+        override fun sendTransaction(
+            lightwalletdUrl: String,
+            rawTransaction: ByteArray,
+        ): IronwoodMigrationSendResponse {
+            sendError?.let { throw it }
+            sent += rawTransaction.copyOf()
+            return IronwoodMigrationSendResponse(0, "")
+        }
+    }
+
+    private class TestKeyProvider : IronwoodMigrationKeyProvider {
+        private val key = SecretKeySpec(ByteArray(32) { it.toByte() }, "AES")
+        override fun getOrCreate(): SecretKey = key
+        override fun delete() = Unit
+    }
+}

--- a/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationOutboxTest.kt
+++ b/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationOutboxTest.kt
@@ -486,6 +486,27 @@ class IronwoodMigrationOutboxTest {
         )
     }
 
+    @Test
+    fun foregroundRunDoesNotSubmitWhileMutationIsQuiesced() {
+        repository.update {
+            it.batches += batch(item(scheduledHeight = 100, expiryHeight = 69_120))
+        }
+        val transport = FakeTransport(height = 100)
+        IronwoodMigrationOutboxExecutionCoordinator.quiesceAndDrain()
+
+        val result = try {
+            IronwoodMigrationOutboxRunner(
+                repository = repository,
+                transport = transport,
+            ).runOnceWaitingForActiveRun()
+        } finally {
+            IronwoodMigrationOutboxExecutionCoordinator.resume()
+        }
+
+        assertEquals(IronwoodMigrationOutboxOutcome.RETRY, result.outcome)
+        assertTrue(transport.sent.isEmpty())
+    }
+
     private fun batch(
         item: IronwoodOutboxItem?,
         nextProofHeight: Long? = null,

--- a/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationPreparationRunnerTest.kt
+++ b/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationPreparationRunnerTest.kt
@@ -1,0 +1,247 @@
+package com.keplr.vizor
+
+import androidx.work.NetworkType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class IronwoodMigrationPreparationRunnerTest {
+    @Test
+    fun schedulerRequestRequiresNetworkAndUsesOneGlobalTag() {
+        val request = IronwoodMigrationPreparationScheduler.request()
+
+        assertEquals(
+            NetworkType.CONNECTED,
+            request.workSpec.constraints.requiredNetworkType,
+        )
+        assertTrue(request.tags.contains(IronwoodMigrationPreparationScheduler.WORK_TAG))
+        assertEquals(0, request.workSpec.initialDelay)
+    }
+
+    @Test
+    fun manifestDecoderRejectsUnexpectedFields() {
+        val encoded = """
+            {
+              "version": 1,
+              "network": "test",
+              "accountUuid": "account",
+              "dbPath": "/tmp/wallet.db",
+              "lightwalletdUrl": "https://example.test",
+              "credentialHex": "${"ab".repeat(32)}",
+              "saltBase64": "AAAAAAAAAAAAAAAAAAAAAA==",
+              "expectedRunId": "run",
+              "unexpected": true
+            }
+        """.trimIndent()
+
+        val error = org.junit.Assert.assertThrows(IllegalArgumentException::class.java) {
+            IronwoodMigrationPreparationManifest.decode(encoded)
+        }
+
+        assertEquals("Invalid migration manifest fields.", error.message)
+    }
+
+    @Test
+    fun waitingPreparationSyncsAdvancesAndClearsCredentialBytes() {
+        val native = FakeNative(
+            inspectResults = ArrayDeque(listOf(progress(WAITING))),
+            advanceResult = progress(PROOF_READY),
+        )
+
+        val outcome = IronwoodMigrationPreparationRunner(native).run(listOf(manifest()))
+
+        assertEquals(IronwoodMigrationPreparationOutcome.COMPLETED, outcome)
+        assertEquals(1, native.syncCalls)
+        assertEquals(1, native.advanceCalls)
+        assertTrue(native.credentialReference!!.all { it == 0.toByte() })
+        assertEquals(1, native.endCalls)
+    }
+
+    @Test
+    fun proofAnchorWaitOnlyReinspectsAfterSync() {
+        val native = FakeNative(
+            inspectResults = ArrayDeque(
+                listOf(progress(WAITING_ANCHOR), progress(WAITING_ANCHOR)),
+            ),
+        )
+
+        val outcome = IronwoodMigrationPreparationRunner(native).run(listOf(manifest()))
+
+        assertEquals(IronwoodMigrationPreparationOutcome.WAITING, outcome)
+        assertEquals(1, native.syncCalls)
+        assertEquals(0, native.advanceCalls)
+        assertEquals(2, native.inspectCalls)
+    }
+
+    @Test
+    fun accountsSharingSyncContextSyncOnlyOnce() {
+        val native = FakeNative(
+            inspectResults = ArrayDeque(listOf(progress(WAITING), progress(WAITING))),
+            advanceResult = progress(PROOF_READY),
+        )
+
+        val outcome = IronwoodMigrationPreparationRunner(native).run(
+            listOf(manifest(accountUuid = "one"), manifest(accountUuid = "two")),
+        )
+
+        assertEquals(IronwoodMigrationPreparationOutcome.COMPLETED, outcome)
+        assertEquals(1, native.syncCalls)
+        assertEquals(2, native.advanceCalls)
+    }
+
+    @Test
+    fun foregroundSyncContentionDefersWithoutAdvancing() {
+        val native = FakeNative(
+            inspectResults = ArrayDeque(listOf(progress(WAITING))),
+            syncRunning = true,
+        )
+
+        val outcome = IronwoodMigrationPreparationRunner(native).run(listOf(manifest()))
+
+        assertEquals(IronwoodMigrationPreparationOutcome.BUSY, outcome)
+        assertEquals(0, native.syncCalls)
+        assertEquals(0, native.advanceCalls)
+        assertEquals(1, native.endCalls)
+    }
+
+    @Test
+    fun preparationOperationContentionUsesFixedDelayOutcome() {
+        val native = FakeNative(
+            inspectResults = ArrayDeque(),
+            beginOperationResult = false,
+        )
+
+        val outcome = IronwoodMigrationPreparationRunner(native).run(listOf(manifest()))
+
+        assertEquals(IronwoodMigrationPreparationOutcome.BUSY, outcome)
+        assertEquals(0, native.inspectCalls)
+        assertEquals(0, native.endCalls)
+    }
+
+    @Test
+    fun nativeSyncContentionUsesFixedDelayOutcome() {
+        val native = FakeNative(
+            inspectResults = ArrayDeque(listOf(progress(WAITING))),
+            syncError = IronwoodMigrationNativeError.SYNC_ALREADY_RUNNING,
+        )
+
+        val outcome = IronwoodMigrationPreparationRunner(native).run(listOf(manifest()))
+
+        assertEquals(IronwoodMigrationPreparationOutcome.BUSY, outcome)
+        assertEquals(1, native.syncCalls)
+        assertEquals(0, native.advanceCalls)
+    }
+
+    @Test
+    fun cancellationEndsTheOwnedOperation() {
+        val native = FakeNative(
+            inspectResults = ArrayDeque(listOf(progress(WAITING))),
+        )
+
+        val outcome = IronwoodMigrationPreparationRunner(
+            native = native,
+            isStopped = { true },
+        ).run(listOf(manifest()))
+
+        assertEquals(IronwoodMigrationPreparationOutcome.CANCELLED, outcome)
+        assertEquals(1, native.endCalls)
+        assertFalse(native.operationActive)
+    }
+
+    private fun manifest(accountUuid: String = "account") =
+        IronwoodMigrationPreparationManifest(
+            network = "test",
+            accountUuid = accountUuid,
+            dbPath = "/tmp/wallet.db",
+            lightwalletdUrl = "https://example.test",
+            credentialHex = "ab".repeat(32),
+            saltBase64 = "AAAAAAAAAAAAAAAAAAAAAA==",
+            expectedRunId = "run",
+        )
+
+    private fun progress(
+        state: IronwoodMigrationNativePreparationState,
+    ) = IronwoodMigrationNativePreparationProgress(state, 0, 10, 0, 1)
+
+    private class FakeNative(
+        private val inspectResults:
+            ArrayDeque<IronwoodMigrationNativePreparationProgress>,
+        private val advanceResult: IronwoodMigrationNativePreparationProgress =
+            IronwoodMigrationNativePreparationProgress(
+                PROOF_READY,
+                0,
+                10,
+                0,
+                1,
+            ),
+        private val syncRunning: Boolean = false,
+        private val beginOperationResult: Boolean = true,
+        private val syncError: IronwoodMigrationNativeError? = null,
+    ) : IronwoodMigrationPreparationNative {
+        var operationActive = false
+        var inspectCalls = 0
+        var syncCalls = 0
+        var advanceCalls = 0
+        var endCalls = 0
+        var credentialReference: ByteArray? = null
+
+        override fun beginOperation(): Boolean {
+            operationActive = beginOperationResult
+            return beginOperationResult
+        }
+
+        override fun endOperation() {
+            operationActive = false
+            endCalls += 1
+        }
+
+        override fun cancelOperation(): Boolean = true
+
+        override fun isSyncRunning(): Boolean = syncRunning
+
+        override fun inspect(
+            dbPath: String,
+            network: String,
+            accountUuid: String,
+            expectedRunId: String,
+        ): IronwoodMigrationNativePreparationProgress {
+            inspectCalls += 1
+            return inspectResults.removeFirst()
+        }
+
+        override fun advance(
+            dbPath: String,
+            lightwalletdUrl: String,
+            network: String,
+            accountUuid: String,
+            expectedRunId: String,
+            credential: ByteArray,
+            saltBase64: String,
+        ): IronwoodMigrationNativePreparationProgress {
+            advanceCalls += 1
+            credentialReference = credential
+            return advanceResult
+        }
+
+        override fun runSync(
+            dbPath: String,
+            lightwalletdUrl: String,
+            network: String,
+            onProgress: (IronwoodMigrationNativeSyncProgress) -> Unit,
+        ) {
+            syncCalls += 1
+            syncError?.let {
+                throw IronwoodMigrationNativeException(it, "sync contention")
+            }
+        }
+    }
+
+    private companion object {
+        val WAITING =
+            IronwoodMigrationNativePreparationState.WAITING_FOR_DENOMINATION_PREPARATION
+        val WAITING_ANCHOR =
+            IronwoodMigrationNativePreparationState.WAITING_FOR_PREPARED_NOTE_ANCHOR
+        val PROOF_READY = IronwoodMigrationNativePreparationState.PROOF_READY
+    }
+}

--- a/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationPreparationRunnerTest.kt
+++ b/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationPreparationRunnerTest.kt
@@ -1,10 +1,14 @@
 package com.keplr.vizor
 
 import androidx.work.NetworkType
+import androidx.work.WorkInfo
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class IronwoodMigrationPreparationRunnerTest {
     @Test
@@ -17,6 +21,105 @@ class IronwoodMigrationPreparationRunnerTest {
         )
         assertTrue(request.tags.contains(IronwoodMigrationPreparationScheduler.WORK_TAG))
         assertEquals(0, request.workSpec.initialDelay)
+    }
+
+    @Test
+    fun schedulerRuntimeStatePrioritizesRunningWork() {
+        assertEquals(
+            "running",
+            IronwoodMigrationPreparationScheduler.runtimeState(
+                listOf(WorkInfo.State.ENQUEUED, WorkInfo.State.RUNNING),
+            ),
+        )
+    }
+
+    @Test
+    fun schedulerRuntimeStateReportsQueuedWorkAsScheduled() {
+        assertEquals(
+            "scheduled",
+            IronwoodMigrationPreparationScheduler.runtimeState(
+                listOf(WorkInfo.State.BLOCKED, WorkInfo.State.ENQUEUED),
+            ),
+        )
+    }
+
+    @Test
+    fun schedulerRuntimeStateIgnoresTerminalWork() {
+        assertEquals(
+            "idle",
+            IronwoodMigrationPreparationScheduler.runtimeState(
+                listOf(
+                    WorkInfo.State.SUCCEEDED,
+                    WorkInfo.State.FAILED,
+                    WorkInfo.State.CANCELLED,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun preparationQuiesceCancelsAndDrainsTheActiveRun() {
+        val started = CountDownLatch(1)
+        val cancelled = CountDownLatch(1)
+        val finished = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val run = executor.submit {
+                IronwoodMigrationPreparationExecutionCoordinator.tryRun(
+                    cancel = { cancelled.countDown() },
+                ) { isCancelled ->
+                    started.countDown()
+                    while (!isCancelled()) Thread.yield()
+                    finished.countDown()
+                }
+            }
+            assertTrue(started.await(1, TimeUnit.SECONDS))
+
+            IronwoodMigrationPreparationExecutionCoordinator.quiesceAndDrain()
+
+            assertTrue(cancelled.await(1, TimeUnit.SECONDS))
+            assertTrue(finished.await(1, TimeUnit.SECONDS))
+            run.get(1, TimeUnit.SECONDS)
+            assertTrue(
+                IronwoodMigrationPreparationExecutionCoordinator.isQuiescing,
+            )
+        } finally {
+            IronwoodMigrationPreparationExecutionCoordinator.resume()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun nestedPreparationRevocationPreservesOuterQuiescence() {
+        try {
+            IronwoodMigrationPreparationExecutionCoordinator.quiesceAndDrain()
+
+            IronwoodMigrationPreparationExecutionCoordinator.runQuiesced { }
+
+            assertTrue(
+                IronwoodMigrationPreparationExecutionCoordinator.isQuiescing,
+            )
+        } finally {
+            IronwoodMigrationPreparationExecutionCoordinator.resume()
+        }
+    }
+
+    @Test
+    fun onlyTheLastAndroidQuiescenceLeaseAllowsResume() {
+        val firstLease = "test-first-lease"
+        val secondLease = "test-second-lease"
+        try {
+            assertTrue(IronwoodMigrationQuiescenceLeases.acquire(firstLease))
+            assertFalse(IronwoodMigrationQuiescenceLeases.acquire(secondLease))
+            assertFalse(IronwoodMigrationQuiescenceLeases.isLast(firstLease))
+
+            assertFalse(IronwoodMigrationQuiescenceLeases.release(firstLease))
+            assertTrue(IronwoodMigrationQuiescenceLeases.isLast(secondLease))
+            assertTrue(IronwoodMigrationQuiescenceLeases.release(secondLease))
+        } finally {
+            IronwoodMigrationQuiescenceLeases.release(firstLease)
+            IronwoodMigrationQuiescenceLeases.release(secondLease)
+        }
     }
 
     @Test

--- a/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreTest.kt
+++ b/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreTest.kt
@@ -1,0 +1,134 @@
+package com.keplr.vizor
+
+import java.nio.file.Files
+import javax.crypto.SecretKey
+import javax.crypto.spec.SecretKeySpec
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class IronwoodMigrationSecureStoreTest {
+    private lateinit var directory: java.io.File
+    private lateinit var keyProvider: TestKeyProvider
+    private lateinit var store: IronwoodMigrationSecureStore
+
+    @Before
+    fun setUp() {
+        directory = Files.createTempDirectory("ironwood-secure-store").toFile()
+        keyProvider = TestKeyProvider()
+        store = IronwoodMigrationSecureStore(
+            keyProvider = keyProvider,
+            directory = directory,
+        )
+    }
+
+    @After
+    fun tearDown() {
+        directory.deleteRecursively()
+    }
+
+    @Test
+    fun manifestAndOutboxRoundTripWithoutPlaintextOnDisk() {
+        val manifest = """{"network":"test","credentialHex":"super-secret"}"""
+        val outbox = byteArrayOf(1, 3, 3, 7, 9)
+
+        store.writeManifest("test", "account-1", manifest)
+        store.writeOutboxBatch("test", "account-1", "batch-1", outbox)
+
+        assertEquals(manifest, store.readManifest("test", "account-1"))
+        assertArrayEquals(
+            outbox,
+            store.readOutboxBatch("test", "account-1", "batch-1"),
+        )
+        val diskBytes = directory.listFiles()!!.flatMap { it.readBytes().asIterable() }
+            .toByteArray()
+        assertFalse(
+            diskBytes.toString(Charsets.UTF_8).contains("super-secret"),
+        )
+    }
+
+    @Test
+    fun authenticatedEncryptionRejectsTamperedCiphertext() {
+        store.writeManifest("test", "account-1", """{"value":"one"}""")
+        val file = directory.listFiles()!!.single { it.name.endsWith(".bin") }
+        val tampered = file.readBytes()
+        tampered[tampered.lastIndex] = (tampered.last().toInt() xor 1).toByte()
+        file.writeBytes(tampered)
+
+        assertThrows(IronwoodMigrationSecureStoreException::class.java) {
+            store.readManifest("test", "account-1")
+        }
+    }
+
+    @Test
+    fun accountRevocationRemovesOnlyTheExactScope() {
+        store.writeManifest("test", "account-1", """{"value":"one"}""")
+        store.writeOutboxBatch("test", "account-1", "batch-1", byteArrayOf(1))
+        store.writeManifest("test", "account-10", """{"value":"ten"}""")
+        store.writeOutboxBatch("main", "account-1", "batch-2", byteArrayOf(2))
+
+        store.revokeAccount("test", "account-1")
+
+        assertNull(store.readManifest("test", "account-1"))
+        assertNull(store.readOutboxBatch("test", "account-1", "batch-1"))
+        assertEquals("""{"value":"ten"}""", store.readManifest("test", "account-10"))
+        assertArrayEquals(
+            byteArrayOf(2),
+            store.readOutboxBatch("main", "account-1", "batch-2"),
+        )
+    }
+
+    @Test
+    fun revokeAllDeletesRecordsAndCryptographicKey() {
+        store.writeManifest("test", "account-1", """{"value":"one"}""")
+
+        store.revokeAll()
+
+        assertTrue(directory.listFiles().isNullOrEmpty())
+        assertTrue(keyProvider.deleted)
+    }
+
+    @Test
+    fun liveStoreRecoversInterruptedBackupBeforeAccountRevocation() {
+        store.writeOutboxBatch("test", "account-1", "batch-1", byteArrayOf(1))
+        val record = directory.listFiles()!!.single { it.name.endsWith(".bin") }
+        assertTrue(record.renameTo(java.io.File(directory, "${record.name}.bak")))
+
+        store.revokeAccount("test", "account-1")
+
+        assertTrue(directory.listFiles().isNullOrEmpty())
+    }
+
+    @Test
+    fun outboxCodecPreservesBinaryPayload() {
+        val encoded = encodeIronwoodOutboxMap(
+            mapOf(
+                "batchId" to "batch-1",
+                "items" to listOf(mapOf("rawTransaction" to byteArrayOf(1, 2, 3))),
+            ),
+        )
+
+        assertTrue(encoded.isNotEmpty())
+        val decoded = decodeIronwoodOutboxMap(encoded)
+        val items = decoded["items"] as List<*>
+        val item = items.single() as Map<*, *>
+        assertArrayEquals(byteArrayOf(1, 2, 3), item["rawTransaction"] as ByteArray)
+    }
+
+    private class TestKeyProvider : IronwoodMigrationKeyProvider {
+        private val key = SecretKeySpec(ByteArray(32) { it.toByte() }, "AES")
+        var deleted = false
+
+        override fun getOrCreate(): SecretKey = key
+
+        override fun delete() {
+            deleted = true
+        }
+    }
+}

--- a/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreTest.kt
+++ b/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreTest.kt
@@ -1,6 +1,7 @@
 package com.keplr.vizor
 
 import java.nio.file.Files
+import java.security.MessageDigest
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
 import org.junit.After
@@ -54,16 +55,61 @@ class IronwoodMigrationSecureStoreTest {
     }
 
     @Test
+    fun manifestEnumerationExcludesOutboxRecords() {
+        store.writeManifest("test", "account-1", """{"value":"one"}""")
+        store.writeManifest("main", "account-2", """{"value":"two"}""")
+        store.writeOutboxBatch("test", "account-1", "batch-1", byteArrayOf(1))
+
+        assertEquals(
+            setOf("""{"value":"one"}""", """{"value":"two"}"""),
+            store.readAllManifests().toSet(),
+        )
+    }
+
+    @Test
     fun authenticatedEncryptionRejectsTamperedCiphertext() {
         store.writeManifest("test", "account-1", """{"value":"one"}""")
-        val file = directory.listFiles()!!.single { it.name.endsWith(".bin") }
-        val tampered = file.readBytes()
-        tampered[tampered.lastIndex] = (tampered.last().toInt() xor 1).toByte()
-        file.writeBytes(tampered)
+        directory.listFiles()!!
+            .filter { it.name.endsWith(".bin") }
+            .forEach { file ->
+                val tampered = file.readBytes()
+                tampered[tampered.lastIndex] =
+                    (tampered.last().toInt() xor 1).toByte()
+                file.writeBytes(tampered)
+            }
 
         assertThrows(IronwoodMigrationSecureStoreException::class.java) {
             store.readManifest("test", "account-1")
         }
+    }
+
+    @Test
+    fun indexedManifestEnumerationDoesNotOpenOutboxCiphertext() {
+        val manifest = """{"value":"one"}"""
+        store.writeManifest("test", "account-1", manifest)
+        store.writeOutboxBatch("test", "account-1", "batch-1", byteArrayOf(1, 2, 3))
+        val outboxFile = recordFile("v1:outbox:test:account-1:batch-1")
+        val tampered = outboxFile.readBytes()
+        tampered[tampered.lastIndex] = (tampered.last().toInt() xor 1).toByte()
+        outboxFile.writeBytes(tampered)
+
+        assertEquals(listOf(manifest), store.readAllManifests())
+        assertThrows(IronwoodMigrationSecureStoreException::class.java) {
+            store.readOutboxBatch("test", "account-1", "batch-1")
+        }
+    }
+
+    @Test
+    fun staleIndexedManifestIsPrunedAndCanBeRegisteredAgain() {
+        val manifest = """{"value":"one"}"""
+        store.writeManifest("test", "account-1", manifest)
+        val manifestFile = recordFile("v1:manifest:test:account-1")
+        assertTrue(manifestFile.delete())
+
+        assertTrue(store.readAllManifests().isEmpty())
+
+        store.writeManifest("test", "account-1", manifest)
+        assertEquals(listOf(manifest), store.readAllManifests())
     }
 
     @Test
@@ -102,7 +148,8 @@ class IronwoodMigrationSecureStoreTest {
 
         store.revokeAccount("test", "account-1")
 
-        assertTrue(directory.listFiles().isNullOrEmpty())
+        assertNull(store.readOutboxBatch("test", "account-1", "batch-1"))
+        assertTrue(store.readAllManifests().isEmpty())
     }
 
     @Test
@@ -130,5 +177,14 @@ class IronwoodMigrationSecureStoreTest {
         override fun delete() {
             deleted = true
         }
+    }
+
+    private fun recordFile(recordKey: String): java.io.File {
+        val recordId = MessageDigest.getInstance("SHA-256")
+            .digest(recordKey.toByteArray(Charsets.UTF_8))
+            .joinToString(separator = "") { byte ->
+                "%02x".format(byte.toInt() and 0xff)
+            }
+        return java.io.File(directory, "$recordId.bin")
     }
 }

--- a/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreTest.kt
+++ b/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreTest.kt
@@ -67,6 +67,29 @@ class IronwoodMigrationSecureStoreTest {
     }
 
     @Test
+    fun backgroundWorkResumeStateSurvivesStoreRecreation() {
+        store.writeBackgroundWorkResumeState(
+            IronwoodMigrationBackgroundWorkResumeState(
+                preparationWasScheduled = true,
+            ),
+        )
+
+        val reopened = IronwoodMigrationSecureStore(
+            keyProvider = keyProvider,
+            directory = directory,
+        )
+
+        assertEquals(
+            IronwoodMigrationBackgroundWorkResumeState(
+                preparationWasScheduled = true,
+            ),
+            reopened.readBackgroundWorkResumeState(),
+        )
+        reopened.clearBackgroundWorkResumeState()
+        assertNull(reopened.readBackgroundWorkResumeState())
+    }
+
+    @Test
     fun authenticatedEncryptionRejectsTamperedCiphertext() {
         store.writeManifest("test", "account-1", """{"value":"one"}""")
         directory.listFiles()!!

--- a/lib/src/features/migration/services/ironwood_migration_background_credential_store.dart
+++ b/lib/src/features/migration/services/ironwood_migration_background_credential_store.dart
@@ -209,19 +209,33 @@ class IronwoodMigrationBackgroundCredentialStore {
   IronwoodMigrationBackgroundCredentialStore({
     FlutterSecureStorage? storage,
     IronwoodMigrationSecureRandomBytes? randomBytes,
+    MethodChannel? channel,
+    bool? isAndroid,
   }) : _storage = storage ?? _defaultStorage(),
-       _randomBytes = randomBytes ?? _defaultRandomBytes;
+       _randomBytes = randomBytes ?? _defaultRandomBytes,
+       _channel =
+           channel ??
+           const MethodChannel('com.zcash.wallet/background_migration'),
+       _isAndroid = isAndroid ?? Platform.isAndroid;
 
   IronwoodMigrationBackgroundCredentialStore.testing({
     required FlutterSecureStorage storage,
     required IronwoodMigrationSecureRandomBytes randomBytes,
+    MethodChannel? channel,
+    bool isAndroid = false,
   }) : _storage = storage,
-       _randomBytes = randomBytes;
+       _randomBytes = randomBytes,
+       _channel =
+           channel ??
+           const MethodChannel('com.zcash.wallet/background_migration'),
+       _isAndroid = isAndroid;
 
   static final instance = IronwoodMigrationBackgroundCredentialStore();
 
   final FlutterSecureStorage _storage;
   final IronwoodMigrationSecureRandomBytes _randomBytes;
+  final MethodChannel _channel;
+  final bool _isAndroid;
 
   static String storageKey({
     required String network,
@@ -232,16 +246,38 @@ class IronwoodMigrationBackgroundCredentialStore {
     required String network,
     required String accountUuid,
   }) async {
-    final raw = await _storage.read(
-      key: storageKey(network: network, accountUuid: accountUuid),
-    );
+    final key = storageKey(network: network, accountUuid: accountUuid);
+    String? raw;
+    if (_isAndroid) {
+      raw = await _channel.invokeMethod<String>('readCredentialManifest', {
+        'network': network,
+        'accountUuid': accountUuid,
+      });
+      if (raw == null) {
+        // One-time upgrade path from the old flutter_secure_storage-backed
+        // Android manifest. Native workers must never depend on decoding that
+        // plugin's private encrypted SharedPreferences format.
+        final legacy = await _storage.read(key: key);
+        if (legacy != null) {
+          final manifest = IronwoodMigrationBackgroundCredentialManifest.decode(
+            legacy,
+          );
+          _validateStoredScope(
+            manifest,
+            network: network,
+            accountUuid: accountUuid,
+          );
+          await _stageNativeManifest(manifest);
+          await _storage.delete(key: key);
+          return manifest;
+        }
+      }
+    } else {
+      raw = await _storage.read(key: key);
+    }
     if (raw == null) return null;
     final manifest = IronwoodMigrationBackgroundCredentialManifest.decode(raw);
-    if (manifest.network != network || manifest.accountUuid != accountUuid) {
-      throw const FormatException(
-        'Ironwood migration manifest does not match its storage scope.',
-      );
-    }
+    _validateStoredScope(manifest, network: network, accountUuid: accountUuid);
     return manifest;
   }
 
@@ -312,22 +348,88 @@ class IronwoodMigrationBackgroundCredentialStore {
     return updated;
   }
 
-  Future<void> delete({required String network, required String accountUuid}) {
-    return _storage.delete(
+  Future<void> delete({
+    required String network,
+    required String accountUuid,
+  }) async {
+    if (_isAndroid) {
+      final deleted = await _channel.invokeMethod<bool>(
+        'deleteCredentialManifest',
+        {'network': network, 'accountUuid': accountUuid},
+      );
+      if (deleted != true) {
+        throw StateError(
+          'Failed to delete the native Ironwood migration manifest.',
+        );
+      }
+    }
+    await _deleteLegacy(network: network, accountUuid: accountUuid);
+  }
+
+  Future<void> _deleteLegacy({
+    required String network,
+    required String accountUuid,
+  }) async {
+    await _storage.delete(
       key: storageKey(network: network, accountUuid: accountUuid),
     );
   }
 
-  Future<void> deleteAll() => _storage.deleteAll();
+  Future<void> deleteAll() async {
+    if (_isAndroid) {
+      final deleted = await _channel.invokeMethod<bool>('revokeAll');
+      if (deleted != true) {
+        throw StateError('Failed to delete native Ironwood migration data.');
+      }
+    }
+    await _deleteAllLegacy();
+  }
 
-  Future<void> _write(IronwoodMigrationBackgroundCredentialManifest manifest) {
-    return _storage.write(
-      key: storageKey(
-        network: manifest.network,
-        accountUuid: manifest.accountUuid,
-      ),
-      value: manifest.encode(),
+  Future<void> _deleteAllLegacy() async {
+    await _storage.deleteAll();
+  }
+
+  Future<void> _write(
+    IronwoodMigrationBackgroundCredentialManifest manifest,
+  ) async {
+    final key = storageKey(
+      network: manifest.network,
+      accountUuid: manifest.accountUuid,
     );
+    if (_isAndroid) {
+      await _stageNativeManifest(manifest);
+      await _storage.delete(key: key);
+      return;
+    }
+    await _storage.write(key: key, value: manifest.encode());
+  }
+
+  Future<void> _stageNativeManifest(
+    IronwoodMigrationBackgroundCredentialManifest manifest,
+  ) async {
+    final staged = await _channel
+        .invokeMethod<bool>('stageCredentialManifest', {
+          'network': manifest.network,
+          'accountUuid': manifest.accountUuid,
+          'manifestJson': manifest.encode(),
+        });
+    if (staged != true) {
+      throw StateError(
+        'Failed to stage the native Ironwood migration manifest.',
+      );
+    }
+  }
+
+  static void _validateStoredScope(
+    IronwoodMigrationBackgroundCredentialManifest manifest, {
+    required String network,
+    required String accountUuid,
+  }) {
+    if (manifest.network != network || manifest.accountUuid != accountUuid) {
+      throw const FormatException(
+        'Ironwood migration manifest does not match its storage scope.',
+      );
+    }
   }
 
   static FlutterSecureStorage _defaultStorage() {
@@ -441,7 +543,19 @@ class IronwoodMigrationBackgroundLifecycle {
       return;
     }
     if (_isAndroid) {
-      await _credentialStore.delete(network: network, accountUuid: accountUuid);
+      final revoked = await _channel.invokeMethod<bool>('revokeAccount', {
+        'network': network,
+        'accountUuid': accountUuid,
+      });
+      if (revoked != true) {
+        throw StateError(
+          'Failed to revoke native Ironwood migration account data.',
+        );
+      }
+      await _credentialStore._deleteLegacy(
+        network: network,
+        accountUuid: accountUuid,
+      );
     }
   }
 
@@ -456,7 +570,11 @@ class IronwoodMigrationBackgroundLifecycle {
       return;
     }
     if (_isAndroid) {
-      await _credentialStore.deleteAll();
+      final revoked = await _channel.invokeMethod<bool>('revokeAll');
+      if (revoked != true) {
+        throw StateError('Failed to revoke native Ironwood migration data.');
+      }
+      await _credentialStore._deleteAllLegacy();
     }
   }
 }

--- a/lib/src/features/migration/services/ironwood_migration_background_credential_store.dart
+++ b/lib/src/features/migration/services/ironwood_migration_background_credential_store.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
@@ -484,6 +485,7 @@ class IronwoodMigrationBackgroundLifecycle {
   final bool _isIOS;
   final bool _isAndroid;
   final List<Duration> _resumeRetryDelays;
+  final Queue<String> _androidQuiescenceLeaseIds = Queue<String>();
 
   bool get isQuiescenceManagedByCaller =>
       Zone.current[_callerManagedQuiescenceZoneKey] == true;
@@ -496,8 +498,13 @@ class IronwoodMigrationBackgroundLifecycle {
   }
 
   Future<void> quiesce() async {
-    if (!_isIOS) return;
-    final quiesced = await _channel.invokeMethod<bool>('quiesce');
+    if (!_isIOS && !_isAndroid) return;
+    final leaseId = _isAndroid ? _newAndroidQuiescenceLeaseId() : null;
+    if (leaseId != null) _androidQuiescenceLeaseIds.addLast(leaseId);
+    final quiesced = await _channel.invokeMethod<bool>(
+      'quiesce',
+      leaseId == null ? null : {'leaseId': leaseId},
+    );
     if (quiesced != true) {
       throw StateError(
         'Failed to pause Ironwood migration before wallet data changed.',
@@ -506,13 +513,26 @@ class IronwoodMigrationBackgroundLifecycle {
   }
 
   Future<void> resumeAfterMutation() async {
-    if (!_isIOS) return;
+    if (!_isIOS && !_isAndroid) return;
+    final leaseId = _isAndroid && _androidQuiescenceLeaseIds.isNotEmpty
+        ? _androidQuiescenceLeaseIds.first
+        : null;
     Object? lastError;
     for (final delay in _resumeRetryDelays) {
       if (delay != Duration.zero) await Future<void>.delayed(delay);
       try {
-        final resumed = await _channel.invokeMethod<bool>('resume');
-        if (resumed == true) return;
+        final resumed = await _channel.invokeMethod<bool>(
+          'resume',
+          leaseId == null ? null : {'leaseId': leaseId},
+        );
+        if (resumed == true) {
+          if (leaseId != null &&
+              _androidQuiescenceLeaseIds.isNotEmpty &&
+              _androidQuiescenceLeaseIds.first == leaseId) {
+            _androidQuiescenceLeaseIds.removeFirst();
+          }
+          return;
+        }
         lastError = StateError('Native migration resume returned false.');
       } catch (error) {
         lastError = error;
@@ -525,6 +545,15 @@ class IronwoodMigrationBackgroundLifecycle {
   }
 
   Future<void> resumeAfterFailedMutation() => resumeAfterMutation();
+
+  static String _newAndroidQuiescenceLeaseId() {
+    final bytes = Uint8List(16);
+    final random = Random.secure();
+    for (var index = 0; index < bytes.length; index++) {
+      bytes[index] = random.nextInt(256);
+    }
+    return base64UrlEncode(bytes).replaceAll('=', '');
+  }
 
   Future<void> revokeAccount({
     required String network,

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -573,6 +573,7 @@ class IronwoodMigrationService {
       isMobile() && supportsBackgroundMigration();
 
   bool get _usesNativeMigrationOutbox => isIOS() || isAndroid();
+  bool get _usesNativePreparation => isIOS() || isAndroid();
 
   Future<IronwoodMigrationNotificationAuthorizationStatus>
   notificationAuthorizationStatus() {
@@ -602,7 +603,7 @@ class IronwoodMigrationService {
     required String accountUuid,
     required String runId,
   }) {
-    if (!isIOS()) {
+    if (!_usesNativePreparation) {
       return Future.value(IronwoodMigrationPreparationRuntimeState.idle);
     }
     return getPreparationRuntimeState(
@@ -675,7 +676,7 @@ class IronwoodMigrationService {
     required String network,
     required String accountUuid,
   }) async {
-    if (!isIOS() || !isMobile()) return;
+    if (!_usesNativePreparation || !isMobile()) return;
 
     final dbPath = await getWalletDbPath();
     final context = _MigrationCredentialContext(
@@ -1743,7 +1744,7 @@ class IronwoodMigrationService {
   Future<void> _reconcileBackgroundPreparationBestEffort(
     rust_sync.MigrationStatus status,
   ) async {
-    if (!isIOS() || !isMobile()) return;
+    if (!_usesNativePreparation || !isMobile()) return;
     if (status.phase != kIronwoodMigrationWaitingDenomConfirmationsPhase) {
       return;
     }
@@ -1854,7 +1855,7 @@ Future<bool> _defaultScheduleBackgroundMigration() async {
 }
 
 Future<bool> _defaultStartBackgroundPreparation() async {
-  if (!Platform.isIOS) return false;
+  if (!Platform.isIOS && !Platform.isAndroid) return false;
   return await _backgroundMigrationChannel.invokeMethod<bool>(
         'startPreparation',
       ) ??
@@ -1862,7 +1863,7 @@ Future<bool> _defaultStartBackgroundPreparation() async {
 }
 
 Future<void> _defaultCancelBackgroundMigration() async {
-  if (!Platform.isIOS) return;
+  if (!Platform.isIOS && !Platform.isAndroid) return;
   await _backgroundMigrationChannel.invokeMethod<void>('cancel');
 }
 
@@ -1872,7 +1873,9 @@ _defaultGetPreparationRuntimeState({
   required String accountUuid,
   required String runId,
 }) async {
-  if (!Platform.isIOS) return IronwoodMigrationPreparationRuntimeState.idle;
+  if (!Platform.isIOS && !Platform.isAndroid) {
+    return IronwoodMigrationPreparationRuntimeState.idle;
+  }
   final value = await _backgroundMigrationChannel.invokeMethod<String>(
     'getPreparationRuntimeState',
     {'network': network, 'accountUuid': accountUuid, 'runId': runId},

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -377,6 +377,7 @@ class IronwoodMigrationService {
     IronwoodMigrationPlatformCheck? isMacOS,
     IronwoodMigrationPlatformCheck? isMobile,
     IronwoodMigrationPlatformCheck? isIOS,
+    IronwoodMigrationPlatformCheck? isAndroid,
     IronwoodMigrationPlatformCheck? supportsBackgroundMigration,
     IronwoodMigrationHardwareAccountCheck? isHardwareAccount,
     IronwoodMigrationBackgroundScheduler? scheduleBackgroundMigration,
@@ -426,9 +427,12 @@ class IronwoodMigrationService {
        isMacOS = isMacOS ?? _defaultIsMacOS,
        isMobile = isMobile ?? _defaultIsMobile,
        isIOS = isIOS ?? _defaultIsIOS,
+       isAndroid = isAndroid ?? _defaultIsAndroid,
        supportsBackgroundMigration =
            supportsBackgroundMigration ??
-           (scheduleBackgroundMigration == null ? _defaultIsIOS : _alwaysTrue),
+           (scheduleBackgroundMigration == null
+               ? _defaultSupportsNativeMigrationOutbox
+               : _alwaysTrue),
        isHardwareAccount = isHardwareAccount ?? _defaultIsHardwareAccount,
        scheduleBackgroundMigration =
            scheduleBackgroundMigration ?? _defaultScheduleBackgroundMigration,
@@ -519,6 +523,7 @@ class IronwoodMigrationService {
   final IronwoodMigrationPlatformCheck isMacOS;
   final IronwoodMigrationPlatformCheck isMobile;
   final IronwoodMigrationPlatformCheck isIOS;
+  final IronwoodMigrationPlatformCheck isAndroid;
   final IronwoodMigrationPlatformCheck supportsBackgroundMigration;
   final IronwoodMigrationHardwareAccountCheck isHardwareAccount;
   final IronwoodMigrationBackgroundScheduler scheduleBackgroundMigration;
@@ -567,9 +572,11 @@ class IronwoodMigrationService {
   bool get supportsBackgroundMigrationRetry =>
       isMobile() && supportsBackgroundMigration();
 
+  bool get _usesNativeMigrationOutbox => isIOS() || isAndroid();
+
   Future<IronwoodMigrationNotificationAuthorizationStatus>
   notificationAuthorizationStatus() {
-    if (!isIOS()) {
+    if (!_usesNativeMigrationOutbox) {
       return Future.value(
         IronwoodMigrationNotificationAuthorizationStatus.denied,
       );
@@ -579,7 +586,7 @@ class IronwoodMigrationService {
 
   Future<IronwoodMigrationNotificationAuthorizationStatus>
   requestNotificationPermission() async {
-    if (!isIOS()) {
+    if (!_usesNativeMigrationOutbox) {
       return IronwoodMigrationNotificationAuthorizationStatus.denied;
     }
     await _requestNotificationAuthorization();
@@ -587,7 +594,7 @@ class IronwoodMigrationService {
   }
 
   Future<bool> openNotificationSystemSettings() async {
-    if (!isIOS()) return false;
+    if (!_usesNativeMigrationOutbox) return false;
     return _openNotificationSettings();
   }
 
@@ -635,7 +642,7 @@ class IronwoodMigrationService {
 
         return _serializeCredentialState(context, () async {
           var status = await _getStatusForContext(context);
-          if (isIOS() && status.activeRunId != null) {
+          if (_usesNativeMigrationOutbox && status.activeRunId != null) {
             final manifest = await backgroundCredentialStore.read(
               network: context.network,
               accountUuid: context.accountUuid,
@@ -862,7 +869,7 @@ class IronwoodMigrationService {
     );
 
     final rust_sync.IronwoodMigrationResult broadcastResult;
-    if (isIOS() && isMobile()) {
+    if (_usesNativeMigrationOutbox) {
       broadcastResult = await _runCredentialOperation(
         context: context,
         mayCreateRun: false,
@@ -978,7 +985,7 @@ class IronwoodMigrationService {
           expectedRunId: activeRunId,
         );
 
-        if (isIOS()) {
+        if (_usesNativeMigrationOutbox) {
           final credential = _MigrationCredential(
             password: manifest.credentialHex,
             saltBase64: manifest.saltBase64,
@@ -1004,10 +1011,10 @@ class IronwoodMigrationService {
   Future<void> recoverSoftwarePrivateMigration({
     required String accountUuid,
   }) async {
-    if (!isIOS() || !isMobile() || isHardwareAccount(accountUuid)) {
+    if (!_usesNativeMigrationOutbox || isHardwareAccount(accountUuid)) {
       throw StateError(
         'Ironwood migration credential recovery is only available for '
-        'software accounts on iOS.',
+        'software accounts on mobile.',
       );
     }
 
@@ -1238,7 +1245,7 @@ class IronwoodMigrationService {
             status: initialStatus,
             mayCreateRun: mayCreateRun,
           );
-          if (isIOS()) {
+          if (_usesNativeMigrationOutbox) {
             await _reconcileMigrationOutboxReceipts(context: context);
           }
 
@@ -1252,7 +1259,7 @@ class IronwoodMigrationService {
             operationStackTrace = stackTrace;
           }
 
-          if (isIOS()) {
+          if (_usesNativeMigrationOutbox) {
             try {
               await _reconcileMigrationOutboxReceipts(context: context);
             } catch (error, stackTrace) {
@@ -1288,7 +1295,7 @@ class IronwoodMigrationService {
           final waitingForDenominationConfirmations =
               currentStatus.phase ==
               kIronwoodMigrationWaitingDenomConfirmationsPhase;
-          if (isIOS() &&
+          if (_usesNativeMigrationOutbox &&
               currentStatus.activeRunId != null &&
               !waitingForDenominationConfirmations) {
             try {
@@ -1334,7 +1341,7 @@ class IronwoodMigrationService {
         accountUuid: context.accountUuid,
       );
       if (manifest == null) {
-        if (isIOS()) {
+        if (_usesNativeMigrationOutbox) {
           await _recoverPersistedMigrationOutbox(
             context: context,
             status: status,
@@ -1343,7 +1350,7 @@ class IronwoodMigrationService {
         throw StateError(
           '$_credentialRecoveryRequiredError '
           'Vizor will only continue transactions preserved in the verified '
-          'iOS outbox.',
+          'native migration outbox.',
         );
       }
       final resolvedManifest = await _resolveManifestContext(manifest, context);
@@ -1378,7 +1385,11 @@ class IronwoodMigrationService {
   }) async {
     final runId = status.activeRunId;
     final lightwalletdUrl = context.lightwalletdUrl;
-    if (!isIOS() || runId == null || lightwalletdUrl == null) return false;
+    if (!_usesNativeMigrationOutbox ||
+        runId == null ||
+        lightwalletdUrl == null) {
+      return false;
+    }
 
     final expectedTxids = <String>{
       for (final part in status.parts)
@@ -1826,6 +1837,9 @@ Future<List<int>?> _missingMnemonicBytesForAccount(String accountUuid) {
 bool _defaultIsMacOS() => Platform.isMacOS;
 bool _defaultIsMobile() => Platform.isIOS || Platform.isAndroid;
 bool _defaultIsIOS() => Platform.isIOS;
+bool _defaultIsAndroid() => Platform.isAndroid;
+bool _defaultSupportsNativeMigrationOutbox() =>
+    Platform.isIOS || Platform.isAndroid;
 bool _alwaysTrue() => true;
 bool _defaultIsHardwareAccount(String _) => false;
 
@@ -1879,6 +1893,7 @@ Future<void> _defaultAcknowledgePreparationForegroundContinuation({
 }
 
 Future<bool> _defaultRequestNotificationAuthorization() async {
+  if (!Platform.isIOS && !Platform.isAndroid) return false;
   final status = await _backgroundMigrationChannel.invokeMethod<String>(
     'requestNotificationAuthorization',
   );
@@ -1889,6 +1904,9 @@ Future<bool> _defaultRequestNotificationAuthorization() async {
 
 Future<IronwoodMigrationNotificationAuthorizationStatus>
 _defaultGetNotificationAuthorizationStatus() async {
+  if (!Platform.isIOS && !Platform.isAndroid) {
+    return IronwoodMigrationNotificationAuthorizationStatus.denied;
+  }
   final status = await _backgroundMigrationChannel.invokeMethod<String>(
     'getNotificationAuthorizationStatus',
   );
@@ -1896,6 +1914,7 @@ _defaultGetNotificationAuthorizationStatus() async {
 }
 
 Future<bool> _defaultOpenNotificationSettings() async {
+  if (!Platform.isIOS && !Platform.isAndroid) return false;
   return await _backgroundMigrationChannel.invokeMethod<bool>(
         'openNotificationSettings',
       ) ??

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -471,6 +471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +543,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1854,6 +1870,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,7 +1968,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2965,6 +3025,7 @@ dependencies = [
  "futures",
  "hex",
  "incrementalmerkletree",
+ "jni",
  "jubjub",
  "log",
  "minicbor",
@@ -3093,6 +3154,15 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "sapling-crypto"
@@ -4041,6 +4111,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4203,6 +4283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4210,11 +4299,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4223,7 +4321,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4237,19 +4335,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4259,9 +4378,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4277,9 +4408,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4289,9 +4432,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -137,6 +137,9 @@ features = ["std"]
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "3.7", features = ["OSX_10_15"] }
 
+[target.'cfg(target_os = "android")'.dependencies]
+jni = "0.21.1"
+
 [dev-dependencies]
 tempfile = "3"
 hex = "0.4"

--- a/rust/src/android_jni.rs
+++ b/rust/src/android_jni.rs
@@ -1,0 +1,441 @@
+//! JNI adapter for Android Ironwood migration preparation.
+//!
+//! This module performs JNI conversion only. Operation ownership, sync
+//! exclusion, cancellation, and preparation state interpretation remain in
+//! `crate::migration_preparation`.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::{Arc, Mutex};
+
+use jni::objects::{JByteArray, JObject, JString, JValue};
+use jni::sys::{jboolean, jobject, JNI_FALSE, JNI_TRUE};
+use jni::{JNIEnv, JavaVM};
+use zeroize::Zeroizing;
+
+use crate::migration_preparation::{self, MigrationPreparationError, MigrationPreparationProgress};
+use crate::wallet::network::WalletNetwork;
+
+const RESULT_CLASS: &str = "com/keplr/vizor/IronwoodMigrationNativeCallResult";
+const RESULT_SIGNATURE: &str = "(ILjava/lang/String;[J)V";
+const SYNC_CALLBACK_METHOD: &str = "onProgress";
+const SYNC_CALLBACK_SIGNATURE: &str = "(JJDDJZZZ)V";
+
+const RESULT_SUCCESS: i32 = 0;
+const RESULT_NO_ACTIVE_OPERATION: i32 = 1;
+const RESULT_SYNC_ALREADY_RUNNING: i32 = 2;
+const RESULT_INVALID_CREDENTIAL: i32 = 3;
+const RESULT_EXECUTION: i32 = 4;
+const RESULT_CALLBACK: i32 = 5;
+const RESULT_PANIC: i32 = 6;
+const RESULT_INVALID_ARGUMENT: i32 = 7;
+
+struct NativeOutcome {
+    code: i32,
+    message: Option<String>,
+    progress: Option<MigrationPreparationProgress>,
+}
+
+impl NativeOutcome {
+    fn success() -> Self {
+        Self {
+            code: RESULT_SUCCESS,
+            message: None,
+            progress: None,
+        }
+    }
+
+    fn progress(progress: MigrationPreparationProgress) -> Self {
+        Self {
+            code: RESULT_SUCCESS,
+            message: None,
+            progress: Some(progress),
+        }
+    }
+
+    fn invalid_argument(message: impl Into<String>) -> Self {
+        Self {
+            code: RESULT_INVALID_ARGUMENT,
+            message: Some(message.into()),
+            progress: None,
+        }
+    }
+
+    fn callback(message: impl Into<String>) -> Self {
+        Self {
+            code: RESULT_CALLBACK,
+            message: Some(message.into()),
+            progress: None,
+        }
+    }
+
+    fn panic(context: &str, panic: Box<dyn std::any::Any + Send>) -> Self {
+        let detail = if let Some(message) = panic.downcast_ref::<&str>() {
+            (*message).to_string()
+        } else if let Some(message) = panic.downcast_ref::<String>() {
+            message.clone()
+        } else {
+            "Unknown panic".to_string()
+        };
+        log::error!("android_jni: panic during {context}: {detail}");
+        Self {
+            code: RESULT_PANIC,
+            message: Some(format!("{context}: {detail}")),
+            progress: None,
+        }
+    }
+}
+
+impl From<MigrationPreparationError> for NativeOutcome {
+    fn from(error: MigrationPreparationError) -> Self {
+        let code = match error {
+            MigrationPreparationError::NoActiveOperation => RESULT_NO_ACTIVE_OPERATION,
+            MigrationPreparationError::SyncAlreadyRunning => RESULT_SYNC_ALREADY_RUNNING,
+            MigrationPreparationError::InvalidCredential => RESULT_INVALID_CREDENTIAL,
+            MigrationPreparationError::Execution(_) => RESULT_EXECUTION,
+        };
+        Self {
+            code,
+            message: Some(error.to_string()),
+            progress: None,
+        }
+    }
+}
+
+fn parse_string(
+    env: &mut JNIEnv<'_>,
+    value: JString<'_>,
+    name: &str,
+) -> Result<String, NativeOutcome> {
+    let value: String = env
+        .get_string(&value)
+        .map_err(|error| NativeOutcome::invalid_argument(format!("Read {name}: {error}")))?
+        .into();
+    if value.is_empty() {
+        return Err(NativeOutcome::invalid_argument(format!("{name} is empty")));
+    }
+    Ok(value)
+}
+
+fn parse_network(value: &str) -> Result<WalletNetwork, NativeOutcome> {
+    WalletNetwork::from_str(value)
+        .ok_or_else(|| NativeOutcome::invalid_argument("Unsupported wallet network"))
+}
+
+fn encode_outcome(env: &mut JNIEnv<'_>, outcome: NativeOutcome) -> jobject {
+    let message = match outcome.message {
+        Some(message) => match env.new_string(message) {
+            Ok(message) => JObject::from(message),
+            Err(error) => return throw_encoding_error(env, error),
+        },
+        None => JObject::null(),
+    };
+    let progress = match outcome.progress {
+        Some(progress) => {
+            let values = [
+                progress.state as u8 as i64,
+                i64::from(progress.confirmation_count),
+                i64::from(progress.confirmation_target),
+                i64::from(progress.completed_stage_count),
+                i64::from(progress.total_stage_count),
+            ];
+            let array = match env.new_long_array(values.len() as i32) {
+                Ok(array) => array,
+                Err(error) => return throw_encoding_error(env, error),
+            };
+            if let Err(error) = env.set_long_array_region(&array, 0, &values) {
+                return throw_encoding_error(env, error);
+            }
+            JObject::from(array)
+        }
+        None => JObject::null(),
+    };
+    match env.new_object(
+        RESULT_CLASS,
+        RESULT_SIGNATURE,
+        &[
+            JValue::Int(outcome.code),
+            JValue::Object(&message),
+            JValue::Object(&progress),
+        ],
+    ) {
+        Ok(result) => result.into_raw(),
+        Err(error) => throw_encoding_error(env, error),
+    }
+}
+
+fn throw_encoding_error(env: &mut JNIEnv<'_>, error: jni::errors::Error) -> jobject {
+    let _ = env.throw_new(
+        "java/lang/IllegalStateException",
+        format!("Encode Ironwood JNI result: {error}"),
+    );
+    JObject::null().into_raw()
+}
+
+fn run_outcome(
+    env: &mut JNIEnv<'_>,
+    context: &str,
+    action: impl FnOnce(&mut JNIEnv<'_>) -> NativeOutcome,
+) -> jobject {
+    let outcome = match catch_unwind(AssertUnwindSafe(|| action(env))) {
+        Ok(outcome) => outcome,
+        Err(panic) => NativeOutcome::panic(context, panic),
+    };
+    encode_outcome(env, outcome)
+}
+
+fn report_sync_progress(
+    java_vm: &JavaVM,
+    callback: &jni::objects::GlobalRef,
+    progress: crate::wallet::sync_engine::SyncProgressEvent,
+) -> Result<(), String> {
+    let mut env = java_vm
+        .attach_current_thread()
+        .map_err(|error| format!("Attach sync callback thread: {error}"))?;
+    let result = env.call_method(
+        callback.as_obj(),
+        SYNC_CALLBACK_METHOD,
+        SYNC_CALLBACK_SIGNATURE,
+        &[
+            JValue::Long(progress.scanned_height as i64),
+            JValue::Long(progress.chain_tip_height as i64),
+            JValue::Double(progress.percentage),
+            JValue::Double(progress.display_target_percentage),
+            JValue::Long(progress.display_target_blocks as i64),
+            JValue::Bool(if progress.is_syncing {
+                JNI_TRUE
+            } else {
+                JNI_FALSE
+            }),
+            JValue::Bool(if progress.is_complete {
+                JNI_TRUE
+            } else {
+                JNI_FALSE
+            }),
+            JValue::Bool(if progress.has_new_tx {
+                JNI_TRUE
+            } else {
+                JNI_FALSE
+            }),
+        ],
+    );
+    match result {
+        Ok(_) => Ok(()),
+        Err(error) => {
+            if env.exception_check().unwrap_or(false) {
+                let _ = env.exception_clear();
+            }
+            Err(format!("Deliver sync progress: {error}"))
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_keplr_vizor_IronwoodMigrationJniBindings_nativeBeginOperation(
+    _env: JNIEnv<'_>,
+    _this: JObject<'_>,
+) -> jboolean {
+    match catch_unwind(migration_preparation::begin_operation) {
+        Ok(true) => JNI_TRUE,
+        Ok(false) | Err(_) => JNI_FALSE,
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_keplr_vizor_IronwoodMigrationJniBindings_nativeEndOperation(
+    _env: JNIEnv<'_>,
+    _this: JObject<'_>,
+) {
+    if let Err(panic) = catch_unwind(migration_preparation::end_operation) {
+        let _ = NativeOutcome::panic("end operation", panic);
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_keplr_vizor_IronwoodMigrationJniBindings_nativeCancelOperation(
+    _env: JNIEnv<'_>,
+    _this: JObject<'_>,
+) -> jboolean {
+    match catch_unwind(migration_preparation::cancel_operation) {
+        Ok(true) => JNI_TRUE,
+        Ok(false) | Err(_) => JNI_FALSE,
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_keplr_vizor_IronwoodMigrationJniBindings_nativeIsSyncRunning(
+    _env: JNIEnv<'_>,
+    _this: JObject<'_>,
+) -> jboolean {
+    match catch_unwind(migration_preparation::is_sync_running) {
+        Ok(true) => JNI_TRUE,
+        Ok(false) | Err(_) => JNI_FALSE,
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_keplr_vizor_IronwoodMigrationJniBindings_nativeInspect(
+    mut env: JNIEnv<'_>,
+    _this: JObject<'_>,
+    db_path: JString<'_>,
+    network: JString<'_>,
+    account_uuid: JString<'_>,
+    expected_run_id: JString<'_>,
+) -> jobject {
+    run_outcome(&mut env, "inspect preparation", |env| {
+        let db_path = match parse_string(env, db_path, "dbPath") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let network =
+            match parse_string(env, network, "network").and_then(|value| parse_network(&value)) {
+                Ok(value) => value,
+                Err(error) => return error,
+            };
+        let account_uuid = match parse_string(env, account_uuid, "accountUuid") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let expected_run_id = match parse_string(env, expected_run_id, "expectedRunId") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        match migration_preparation::inspect(&db_path, network, &account_uuid, &expected_run_id) {
+            Ok(progress) => NativeOutcome::progress(progress),
+            Err(error) => error.into(),
+        }
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_keplr_vizor_IronwoodMigrationJniBindings_nativeAdvance(
+    mut env: JNIEnv<'_>,
+    _this: JObject<'_>,
+    db_path: JString<'_>,
+    lightwalletd_url: JString<'_>,
+    network: JString<'_>,
+    account_uuid: JString<'_>,
+    expected_run_id: JString<'_>,
+    credential: JByteArray<'_>,
+    salt_base64: JString<'_>,
+) -> jobject {
+    run_outcome(&mut env, "advance preparation", |env| {
+        let db_path = match parse_string(env, db_path, "dbPath") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let lightwalletd_url = match parse_string(env, lightwalletd_url, "lightwalletdUrl") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let network =
+            match parse_string(env, network, "network").and_then(|value| parse_network(&value)) {
+                Ok(value) => value,
+                Err(error) => return error,
+            };
+        let account_uuid = match parse_string(env, account_uuid, "accountUuid") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let expected_run_id = match parse_string(env, expected_run_id, "expectedRunId") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let credential = match env.convert_byte_array(&credential) {
+            Ok(value) if !value.is_empty() => Zeroizing::new(value),
+            Ok(_) => return NativeOutcome::invalid_argument("credential is empty"),
+            Err(error) => {
+                return NativeOutcome::invalid_argument(format!("Read credential: {error}"));
+            }
+        };
+        let salt_base64 = match parse_string(env, salt_base64, "saltBase64") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        match migration_preparation::advance(
+            &db_path,
+            &lightwalletd_url,
+            network,
+            &account_uuid,
+            &expected_run_id,
+            credential,
+            &salt_base64,
+        ) {
+            Ok(progress) => NativeOutcome::progress(progress),
+            Err(error) => error.into(),
+        }
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_keplr_vizor_IronwoodMigrationJniBindings_nativeRunSync(
+    mut env: JNIEnv<'_>,
+    _this: JObject<'_>,
+    db_path: JString<'_>,
+    lightwalletd_url: JString<'_>,
+    network: JString<'_>,
+    callback: JObject<'_>,
+) -> jobject {
+    run_outcome(&mut env, "run preparation sync", |env| {
+        let db_path = match parse_string(env, db_path, "dbPath") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let lightwalletd_url = match parse_string(env, lightwalletd_url, "lightwalletdUrl") {
+            Ok(value) => value,
+            Err(error) => return error,
+        };
+        let network =
+            match parse_string(env, network, "network").and_then(|value| parse_network(&value)) {
+                Ok(value) => value,
+                Err(error) => return error,
+            };
+        if callback.is_null() {
+            return NativeOutcome::invalid_argument("progress callback is null");
+        }
+        let java_vm = match env.get_java_vm() {
+            Ok(value) => Arc::new(value),
+            Err(error) => {
+                return NativeOutcome::callback(format!("Get Java VM: {error}"));
+            }
+        };
+        let callback = match env.new_global_ref(callback) {
+            Ok(value) => value,
+            Err(error) => {
+                return NativeOutcome::callback(format!("Retain progress callback: {error}"));
+            }
+        };
+        let callback_error = Arc::new(Mutex::new(None::<String>));
+        let callback_error_for_sync = callback_error.clone();
+        let sync_result = migration_preparation::run_sync(
+            &db_path,
+            &lightwalletd_url,
+            network,
+            move |progress| {
+                if callback_error_for_sync
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .is_some()
+                {
+                    return;
+                }
+                if let Err(error) = report_sync_progress(&java_vm, &callback, progress) {
+                    *callback_error_for_sync
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(error);
+                    migration_preparation::cancel_operation();
+                }
+            },
+        );
+        let callback_error = callback_error
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(error) = callback_error {
+            return NativeOutcome::callback(error);
+        }
+        match sync_result {
+            Ok(()) => NativeOutcome::success(),
+            Err(error) => error.into(),
+        }
+    })
+}

--- a/rust/src/android_jni.rs
+++ b/rust/src/android_jni.rs
@@ -17,6 +17,8 @@ use crate::wallet::network::WalletNetwork;
 
 const RESULT_CLASS: &str = "com/keplr/vizor/IronwoodMigrationNativeCallResult";
 const RESULT_SIGNATURE: &str = "(ILjava/lang/String;[J)V";
+const OUTBOX_RESULT_CLASS: &str = "com/keplr/vizor/IronwoodMigrationOutboxNativeCallResult";
+const OUTBOX_RESULT_SIGNATURE: &str = "(ILjava/lang/String;JI)V";
 const SYNC_CALLBACK_METHOD: &str = "onProgress";
 const SYNC_CALLBACK_SIGNATURE: &str = "(JJDDJZZZ)V";
 
@@ -181,6 +183,52 @@ fn run_outcome(
         Err(panic) => NativeOutcome::panic(context, panic),
     };
     encode_outcome(env, outcome)
+}
+
+fn encode_outbox_outcome(
+    env: &mut JNIEnv<'_>,
+    code: i32,
+    message: Option<String>,
+    height: i64,
+    response_code: i32,
+) -> jobject {
+    let message = match message {
+        Some(message) => match env.new_string(message) {
+            Ok(message) => JObject::from(message),
+            Err(error) => return throw_encoding_error(env, error),
+        },
+        None => JObject::null(),
+    };
+    match env.new_object(
+        OUTBOX_RESULT_CLASS,
+        OUTBOX_RESULT_SIGNATURE,
+        &[
+            JValue::Int(code),
+            JValue::Object(&message),
+            JValue::Long(height),
+            JValue::Int(response_code),
+        ],
+    ) {
+        Ok(result) => result.into_raw(),
+        Err(error) => throw_encoding_error(env, error),
+    }
+}
+
+fn run_outbox_call(
+    env: &mut JNIEnv<'_>,
+    context: &str,
+    action: impl FnOnce(&mut JNIEnv<'_>) -> Result<(Option<String>, i64, i32), NativeOutcome>,
+) -> jobject {
+    match catch_unwind(AssertUnwindSafe(|| action(env))) {
+        Ok(Ok((message, height, response_code))) => {
+            encode_outbox_outcome(env, RESULT_SUCCESS, message, height, response_code)
+        }
+        Ok(Err(outcome)) => encode_outbox_outcome(env, outcome.code, outcome.message, -1, 0),
+        Err(panic) => {
+            let outcome = NativeOutcome::panic(context, panic);
+            encode_outbox_outcome(env, outcome.code, outcome.message, -1, 0)
+        }
+    }
 }
 
 fn report_sync_progress(
@@ -436,6 +484,72 @@ pub extern "system" fn Java_com_keplr_vizor_IronwoodMigrationJniBindings_nativeR
         match sync_result {
             Ok(()) => NativeOutcome::success(),
             Err(error) => error.into(),
+        }
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_keplr_vizor_IronwoodMigrationJniBindings_nativeLatestBlockHeight(
+    mut env: JNIEnv<'_>,
+    _this: JObject<'_>,
+    lightwalletd_url: JString<'_>,
+) -> jobject {
+    run_outbox_call(&mut env, "get outbox block height", |env| {
+        let lightwalletd_url = parse_string(env, lightwalletd_url, "lightwalletdUrl")?;
+        let runtime = tokio::runtime::Runtime::new().map_err(|error| {
+            NativeOutcome::from(MigrationPreparationError::Execution(format!(
+                "Create outbox runtime: {error}"
+            )))
+        })?;
+        let height = runtime.block_on(async {
+            let mut client = crate::wallet::sync_engine::open_lwd_channel(&lightwalletd_url)
+                .await
+                .map_err(|error| error.to_string())?;
+            crate::wallet::sync_engine::get_latest_block(&mut client)
+                .await
+                .map(|block| block.height)
+                .map_err(|error| error.to_string())
+        });
+        match height {
+            Ok(height) => i64::try_from(height)
+                .map(|height| (None, height, 0))
+                .map_err(|_| NativeOutcome::invalid_argument("Block height exceeds JNI range")),
+            Err(error) => Err(MigrationPreparationError::Execution(error).into()),
+        }
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_keplr_vizor_IronwoodMigrationJniBindings_nativeSendTransaction(
+    mut env: JNIEnv<'_>,
+    _this: JObject<'_>,
+    lightwalletd_url: JString<'_>,
+    raw_transaction: JByteArray<'_>,
+) -> jobject {
+    run_outbox_call(&mut env, "send outbox transaction", |env| {
+        let lightwalletd_url = parse_string(env, lightwalletd_url, "lightwalletdUrl")?;
+        let raw_transaction = env.convert_byte_array(&raw_transaction).map_err(|error| {
+            NativeOutcome::invalid_argument(format!("Read rawTransaction: {error}"))
+        })?;
+        if raw_transaction.is_empty() {
+            return Err(NativeOutcome::invalid_argument("rawTransaction is empty"));
+        }
+        let runtime = tokio::runtime::Runtime::new().map_err(|error| {
+            NativeOutcome::from(MigrationPreparationError::Execution(format!(
+                "Create outbox runtime: {error}"
+            )))
+        })?;
+        let response = runtime.block_on(async {
+            let mut client = crate::wallet::sync_engine::open_lwd_channel(&lightwalletd_url)
+                .await
+                .map_err(|error| error.to_string())?;
+            crate::wallet::sync_engine::send_transaction_with_status(&mut client, &raw_transaction)
+                .await
+                .map_err(|error| error.to_string())
+        });
+        match response {
+            Ok(response) => Ok((Some(response.error_message), -1, response.error_code)),
+            Err(error) => Err(MigrationPreparationError::Execution(error).into()),
         }
     })
 }

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -1,89 +1,14 @@
-//! C FFI interface for iOS Ironwood migration background work.
+//! C adapter for iOS Ironwood migration background work.
+//!
+//! The platform-neutral execution and state machine live in
+//! `crate::migration_preparation`; this module only validates C inputs,
+//! converts native values, and preserves the existing iOS ABI.
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
-use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
-use std::sync::{Arc, Mutex};
 
-use crate::api::sync::SYNC_RUNNING;
-use crate::wallet::{keys, sync, sync_engine};
-
-struct MigrationPreparationControl {
-    cancel: Arc<AtomicBool>,
-    desired_sync_mode: AtomicU8,
-}
-
-impl MigrationPreparationControl {
-    fn new() -> Self {
-        Self {
-            cancel: Arc::new(AtomicBool::new(false)),
-            desired_sync_mode: AtomicU8::new(2),
-        }
-    }
-
-    fn cancel(&self) {
-        self.cancel.store(true, Ordering::Relaxed);
-        self.desired_sync_mode.store(0, Ordering::SeqCst);
-    }
-}
-
-struct MigrationPreparationOperation {
-    active: Mutex<Option<Arc<MigrationPreparationControl>>>,
-}
-
-impl MigrationPreparationOperation {
-    const fn new() -> Self {
-        Self {
-            active: Mutex::new(None),
-        }
-    }
-
-    fn begin(&self) -> bool {
-        let mut active = self
-            .active
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if active.is_some() {
-            return false;
-        }
-        *active = Some(Arc::new(MigrationPreparationControl::new()));
-        true
-    }
-
-    fn cancel(&self) -> bool {
-        let active = self
-            .active
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let Some(control) = active.as_ref() else {
-            return false;
-        };
-        control.cancel();
-        true
-    }
-
-    fn end(&self) {
-        let control = self
-            .active
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .take();
-        if let Some(control) = control {
-            control.cancel();
-        }
-    }
-
-    fn control(&self) -> Option<Arc<MigrationPreparationControl>> {
-        self.active
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .as_ref()
-            .cloned()
-    }
-}
-
-static MIGRATION_PREPARATION_OPERATION: MigrationPreparationOperation =
-    MigrationPreparationOperation::new();
+use crate::migration_preparation::{self, MigrationPreparationError, MigrationPreparationProgress};
+use crate::wallet::keys;
 
 #[repr(C)]
 pub struct CMigrationPreparationProgress {
@@ -95,6 +20,18 @@ pub struct CMigrationPreparationProgress {
     pub confirmation_target: u32,
     pub completed_stage_count: u32,
     pub total_stage_count: u32,
+}
+
+impl From<MigrationPreparationProgress> for CMigrationPreparationProgress {
+    fn from(progress: MigrationPreparationProgress) -> Self {
+        Self {
+            state: progress.state as u8,
+            confirmation_count: progress.confirmation_count,
+            confirmation_target: progress.confirmation_target,
+            completed_stage_count: progress.completed_stage_count,
+            total_stage_count: progress.total_stage_count,
+        }
+    }
 }
 
 /// Progress data passed to the C callback.
@@ -120,9 +57,27 @@ unsafe fn c_str_to_str<'a>(ptr: *const c_char) -> Option<&'a str> {
         return None;
     }
     match CStr::from_ptr(ptr).to_str() {
-        Ok(s) if !s.is_empty() => Some(s),
+        Ok(value) if !value.is_empty() => Some(value),
         _ => None,
     }
+}
+
+unsafe fn credential_bytes<'a>(ptr: *const u8, len: usize) -> Option<&'a [u8]> {
+    if ptr.is_null() || len == 0 {
+        return None;
+    }
+    Some(std::slice::from_raw_parts(ptr, len))
+}
+
+fn log_panic(context: &str, panic: Box<dyn std::any::Any + Send>) {
+    let message = if let Some(message) = panic.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = panic.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "Unknown".to_string()
+    };
+    log::error!("ffi: panic during {context}: {message}");
 }
 
 /// Run one sync pass for an active migration preparation task. Pending wallet
@@ -135,67 +90,62 @@ pub extern "C" fn zcash_run_full_sync_for_migration_preparation(
     network: *const c_char,
     progress_callback: SyncProgressCallback,
 ) -> i32 {
-    let Some(control) = MIGRATION_PREPARATION_OPERATION.control() else {
-        log::warn!("ffi: migration preparation sync has no active operation");
-        return 4;
-    };
-    if SYNC_RUNNING
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_err()
-    {
-        log::warn!("ffi: migration preparation sync already running");
-        return 3;
-    }
-    let code = run_migration_preparation_sync_after_acquire(
-        db_path,
-        lightwalletd_url,
-        network,
-        progress_callback,
-        control.cancel.clone(),
-        &control.desired_sync_mode,
-    );
-    SYNC_RUNNING.store(false, Ordering::SeqCst);
-    code
-}
+    let result = std::panic::catch_unwind(|| {
+        let Some(db_path) = (unsafe { c_str_to_str(db_path) }) else {
+            log::error!("ffi: invalid or null db_path");
+            return 1;
+        };
+        let Some(lightwalletd_url) = (unsafe { c_str_to_str(lightwalletd_url) }) else {
+            log::error!("ffi: invalid or null lightwalletd_url");
+            return 1;
+        };
+        let Some(network_str) = (unsafe { c_str_to_str(network) }) else {
+            log::error!("ffi: invalid or null network string");
+            return 1;
+        };
+        let network = match keys::parse_network(network_str) {
+            Ok(network) => network,
+            Err(error) => {
+                log::error!("ffi: parse migration preparation network: {error}");
+                return 1;
+            }
+        };
 
-unsafe fn credential_bytes<'a>(ptr: *const u8, len: usize) -> Option<&'a [u8]> {
-    if ptr.is_null() || len == 0 {
-        return None;
-    }
-    Some(std::slice::from_raw_parts(ptr, len))
-}
-
-fn fill_migration_preparation_progress(
-    output: &mut CMigrationPreparationProgress,
-    status: &sync::MigrationStatus,
-    scanned_height: u32,
-) {
-    if status.active_run_id.is_none() {
-        output.state = 4;
-        output.confirmation_count = 0;
-        output.confirmation_target = 0;
-        output.completed_stage_count = 0;
-        output.total_stage_count = 0;
-        return;
-    }
-    output.state = match status.phase.as_str() {
-        "waiting_denom_confirmations" => 0,
-        "ready_to_migrate" if status.signed_child_pczt_count > 0 => {
-            match status.next_action_height {
-                Some(height) if height <= scanned_height => 1,
-                Some(_) => 5,
-                None => 2,
+        match migration_preparation::run_sync(db_path, lightwalletd_url, network, |progress| {
+            progress_callback(CSyncProgress {
+                scanned_height: progress.scanned_height,
+                chain_tip_height: progress.chain_tip_height,
+                percentage: progress.percentage,
+                display_target_percentage: progress.display_target_percentage,
+                display_target_blocks: progress.display_target_blocks,
+                is_syncing: progress.is_syncing,
+                is_complete: progress.is_complete,
+                has_new_tx: progress.has_new_tx,
+            });
+        }) {
+            Ok(()) => 0,
+            Err(MigrationPreparationError::NoActiveOperation) => {
+                log::warn!("ffi: migration preparation sync has no active operation");
+                4
+            }
+            Err(MigrationPreparationError::SyncAlreadyRunning) => {
+                log::warn!("ffi: migration preparation sync already running");
+                3
+            }
+            Err(error) => {
+                log::error!("ffi: migration preparation sync failed: {error}");
+                1
             }
         }
-        "broadcast_scheduled" | "broadcasting" | "waiting_migration_confirmations" | "complete" => {
-            4
+    });
+
+    match result {
+        Ok(code) => code,
+        Err(panic) => {
+            log_panic("migration preparation sync", panic);
+            2
         }
-        _ => 2,
-    };
-    output.confirmation_count = status.denomination_confirmation_count;
-    output.confirmation_target = status.denomination_confirmation_target;
-    output.completed_stage_count = status.denomination_split_completed_count;
-    output.total_stage_count = status.denomination_split_total_count;
+    }
 }
 
 /// Inspect local migration preparation state without syncing or loading a
@@ -232,37 +182,25 @@ pub extern "C" fn zcash_inspect_migration_preparation(
                 return 1;
             }
         };
-        let status = match sync::migration_status(db_path, network, account_uuid, 0, 0, 0, 0) {
-            Ok(status) => status,
+
+        match migration_preparation::inspect(db_path, network, account_uuid, expected_run_id) {
+            Ok(progress) => {
+                *output = progress.into();
+                0
+            }
             Err(error) => {
                 log::error!("ffi: inspect migration preparation: {error}");
-                return 1;
+                1
             }
-        };
-        if status.active_run_id.as_deref() != Some(expected_run_id) {
-            output.state = 4;
-            output.confirmation_count = 0;
-            output.confirmation_target = 0;
-            output.completed_stage_count = 0;
-            output.total_stage_count = 0;
-            return 0;
         }
-        let scanned_height = match sync::get_sync_progress(db_path, network).and_then(|progress| {
-            u32::try_from(progress.scanned_height)
-                .map_err(|_| "Migration scanned height exceeds u32".to_string())
-        }) {
-            Ok(height) => height,
-            Err(error) => {
-                log::error!("ffi: inspect migration preparation height: {error}");
-                return 1;
-            }
-        };
-        fill_migration_preparation_progress(output, &status, scanned_height);
-        0
     });
+
     match result {
         Ok(code) => code,
-        Err(_) => 2,
+        Err(panic) => {
+            log_panic("migration preparation inspection", panic);
+            2
+        }
     }
 }
 
@@ -281,10 +219,6 @@ pub extern "C" fn zcash_advance_migration_preparation(
     output: *mut CMigrationPreparationProgress,
 ) -> i32 {
     let result = std::panic::catch_unwind(|| {
-        let Some(control) = MIGRATION_PREPARATION_OPERATION.control() else {
-            log::error!("ffi: migration preparation advance has no active operation");
-            return 1;
-        };
         let Some(db_path) = (unsafe { c_str_to_str(db_path) }) else {
             return 1;
         };
@@ -306,10 +240,6 @@ pub extern "C" fn zcash_advance_migration_preparation(
         let Some(credential) = (unsafe { credential_bytes(credential, credential_len) }) else {
             return 1;
         };
-        if credential.len() != 64 || !credential.iter().all(u8::is_ascii_hexdigit) {
-            log::error!("ffi: migration preparation credential must be 64 hexadecimal bytes");
-            return 1;
-        }
         let Some(output) = (unsafe { output.as_mut() }) else {
             return 1;
         };
@@ -320,17 +250,8 @@ pub extern "C" fn zcash_advance_migration_preparation(
                 return 1;
             }
         };
-        let runtime = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(runtime) => runtime,
-            Err(error) => {
-                log::error!("ffi: migration preparation runtime: {error}");
-                return 1;
-            }
-        };
-        let advance = runtime.block_on(sync::advance_orchard_migration_preparation_for_run(
+
+        match migration_preparation::advance(
             db_path,
             lightwalletd_url,
             network,
@@ -338,128 +259,13 @@ pub extern "C" fn zcash_advance_migration_preparation(
             expected_run_id,
             zeroize::Zeroizing::new(credential.to_vec()),
             salt_base64,
-            control.cancel.as_ref(),
-        ));
-        if let Err(error) = advance {
-            log::error!("ffi: advance migration preparation: {error}");
-            return 1;
-        }
-        let status = match sync::migration_status(db_path, network, account_uuid, 0, 0, 0, 0) {
-            Ok(status) => status,
+        ) {
+            Ok(progress) => {
+                *output = progress.into();
+                0
+            }
             Err(error) => {
-                log::error!("ffi: inspect migration preparation: {error}");
-                return 1;
-            }
-        };
-        if status
-            .active_run_id
-            .as_deref()
-            .is_some_and(|id| id != expected_run_id)
-        {
-            return 1;
-        }
-        let scanned_height = match sync::get_sync_progress(db_path, network).and_then(|progress| {
-            u32::try_from(progress.scanned_height)
-                .map_err(|_| "Migration scanned height exceeds u32".to_string())
-        }) {
-            Ok(height) => height,
-            Err(error) => {
-                log::error!("ffi: inspect migration preparation height: {error}");
-                return 1;
-            }
-        };
-        fill_migration_preparation_progress(output, &status, scanned_height);
-        if control.cancel.load(Ordering::SeqCst) {
-            output.state = 3;
-        }
-        0
-    });
-    match result {
-        Ok(code) => code,
-        Err(_) => 2,
-    }
-}
-
-fn run_migration_preparation_sync_after_acquire(
-    db_path: *const c_char,
-    lightwalletd_url: *const c_char,
-    network: *const c_char,
-    progress_callback: SyncProgressCallback,
-    cancel: Arc<AtomicBool>,
-    desired_mode: &AtomicU8,
-) -> i32 {
-    let result = std::panic::catch_unwind(|| {
-        let db_path = match unsafe { c_str_to_str(db_path) } {
-            Some(s) => s,
-            None => {
-                log::error!("ffi: invalid or null db_path");
-                return 1;
-            }
-        };
-        let lightwalletd_url = match unsafe { c_str_to_str(lightwalletd_url) } {
-            Some(s) => s,
-            None => {
-                log::error!("ffi: invalid or null lightwalletd_url");
-                return 1;
-            }
-        };
-        let network_str = match unsafe { c_str_to_str(network) } {
-            Some(s) => s,
-            None => {
-                log::error!("ffi: invalid or null network string");
-                return 1;
-            }
-        };
-
-        let network = match keys::parse_network(network_str) {
-            Ok(n) => n,
-            Err(e) => {
-                log::error!("ffi: parse_network failed: {e}");
-                return 1;
-            }
-        };
-
-        // current_thread runtime — inherits .utility QoS from iOS dispatch queue
-        let rt = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                log::error!("ffi: tokio runtime failed: {e}");
-                return 1;
-            }
-        };
-
-        let result = rt.block_on(async {
-            sync_engine::run_sync_inner(
-                db_path,
-                lightwalletd_url,
-                network,
-                cancel,
-                2,
-                desired_mode,
-                false,
-                |progress| {
-                    progress_callback(CSyncProgress {
-                        scanned_height: progress.scanned_height,
-                        chain_tip_height: progress.chain_tip_height,
-                        percentage: progress.percentage,
-                        display_target_percentage: progress.display_target_percentage,
-                        display_target_blocks: progress.display_target_blocks,
-                        is_syncing: progress.is_syncing,
-                        is_complete: progress.is_complete,
-                        has_new_tx: progress.has_new_tx,
-                    });
-                },
-            )
-            .await
-        });
-
-        match result {
-            Ok(()) => 0,
-            Err(e) => {
-                log::error!("ffi: sync failed: {e}");
+                log::error!("ffi: advance migration preparation: {error}");
                 1
             }
         }
@@ -467,15 +273,8 @@ fn run_migration_preparation_sync_after_acquire(
 
     match result {
         Ok(code) => code,
-        Err(e) => {
-            let msg = if let Some(s) = e.downcast_ref::<&str>() {
-                s.to_string()
-            } else if let Some(s) = e.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "Unknown".to_string()
-            };
-            log::error!("ffi: panic during sync: {msg}");
+        Err(panic) => {
+            log_panic("migration preparation advancement", panic);
             2
         }
     }
@@ -485,62 +284,25 @@ fn run_migration_preparation_sync_after_acquire(
 /// call made by the Swift task.
 #[no_mangle]
 pub extern "C" fn zcash_begin_migration_preparation_operation() -> bool {
-    MIGRATION_PREPARATION_OPERATION.begin()
+    migration_preparation::begin_operation()
 }
 
 /// End the current migration preparation operation after its serial Swift work
 /// has returned.
 #[no_mangle]
 pub extern "C" fn zcash_end_migration_preparation_operation() {
-    MIGRATION_PREPARATION_OPERATION.end();
+    migration_preparation::end_operation();
 }
 
 /// Cancel the active migration preparation operation without touching the
 /// foreground sync cancellation token.
 #[no_mangle]
 pub extern "C" fn zcash_cancel_migration_preparation_sync() -> bool {
-    MIGRATION_PREPARATION_OPERATION.cancel()
+    migration_preparation::cancel_operation()
 }
 
 /// Check if a sync is currently running.
 #[no_mangle]
 pub extern "C" fn zcash_is_sync_running() -> bool {
-    SYNC_RUNNING.load(Ordering::SeqCst)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn migration_preparation_operation_owns_cancel_across_sync_and_advance() {
-        let operation = MigrationPreparationOperation::new();
-        assert!(operation.begin());
-        assert!(!operation.begin());
-
-        let sync_control = operation.control().unwrap();
-        let advance_control = operation.control().unwrap();
-        assert!(Arc::ptr_eq(&sync_control, &advance_control));
-        assert!(!sync_control.cancel.load(Ordering::Relaxed));
-        assert_eq!(sync_control.desired_sync_mode.load(Ordering::SeqCst), 2);
-
-        let unrelated_sync_cancel = AtomicBool::new(false);
-        unrelated_sync_cancel.store(true, Ordering::Relaxed);
-        assert!(!sync_control.cancel.load(Ordering::Relaxed));
-
-        assert!(operation.cancel());
-        assert!(sync_control.cancel.load(Ordering::Relaxed));
-        assert!(advance_control.cancel.load(Ordering::Relaxed));
-        assert_eq!(sync_control.desired_sync_mode.load(Ordering::SeqCst), 0);
-
-        operation.end();
-        assert!(operation.control().is_none());
-        assert!(!operation.cancel());
-
-        assert!(operation.begin());
-        let next_control = operation.control().unwrap();
-        assert!(!Arc::ptr_eq(&sync_control, &next_control));
-        assert!(!next_control.cancel.load(Ordering::Relaxed));
-        operation.end();
-    }
+    migration_preparation::is_sync_running()
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(target_os = "android")]
+mod android_jni;
 pub mod api;
 pub mod ffi;
 mod frb_generated;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
 pub mod ffi;
 mod frb_generated;
+pub mod migration_preparation;
 pub mod wallet;

--- a/rust/src/migration_preparation.rs
+++ b/rust/src/migration_preparation.rs
@@ -1,0 +1,437 @@
+//! Platform-neutral execution core for mobile Ironwood migration preparation.
+//!
+//! Platform adapters are responsible only for converting their native inputs
+//! and outputs. Operation ownership, foreground-sync exclusion, state
+//! interpretation, sync execution, and denomination advancement live here so
+//! iOS and Android use the same state machine.
+
+use std::fmt;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::{Arc, Mutex};
+
+use zeroize::Zeroizing;
+
+use crate::api::sync::SYNC_RUNNING;
+use crate::wallet::network::WalletNetwork;
+use crate::wallet::sync_engine::SyncProgressEvent;
+use crate::wallet::{sync, sync_engine};
+
+const MIGRATION_PREPARATION_SYNC_MODE: u8 = 2;
+const STOPPED_SYNC_MODE: u8 = 0;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum MigrationPreparationState {
+    WaitingForDenominationPreparation = 0,
+    ProofReady = 1,
+    NeedsUserAction = 2,
+    Cancelled = 3,
+    Inactive = 4,
+    WaitingForPreparedNoteAnchor = 5,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MigrationPreparationProgress {
+    pub state: MigrationPreparationState,
+    pub confirmation_count: u32,
+    pub confirmation_target: u32,
+    pub completed_stage_count: u32,
+    pub total_stage_count: u32,
+}
+
+impl MigrationPreparationProgress {
+    fn inactive() -> Self {
+        Self {
+            state: MigrationPreparationState::Inactive,
+            confirmation_count: 0,
+            confirmation_target: 0,
+            completed_stage_count: 0,
+            total_stage_count: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MigrationPreparationError {
+    NoActiveOperation,
+    SyncAlreadyRunning,
+    InvalidCredential,
+    Execution(String),
+}
+
+impl fmt::Display for MigrationPreparationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoActiveOperation => {
+                formatter.write_str("Migration preparation has no active operation")
+            }
+            Self::SyncAlreadyRunning => {
+                formatter.write_str("Another wallet sync is already running")
+            }
+            Self::InvalidCredential => {
+                formatter.write_str("Migration preparation credential must be 64 hexadecimal bytes")
+            }
+            Self::Execution(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl std::error::Error for MigrationPreparationError {}
+
+struct MigrationPreparationControl {
+    cancel: Arc<AtomicBool>,
+    desired_sync_mode: AtomicU8,
+}
+
+impl MigrationPreparationControl {
+    fn new() -> Self {
+        Self {
+            cancel: Arc::new(AtomicBool::new(false)),
+            desired_sync_mode: AtomicU8::new(MIGRATION_PREPARATION_SYNC_MODE),
+        }
+    }
+
+    fn cancel(&self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        self.desired_sync_mode
+            .store(STOPPED_SYNC_MODE, Ordering::SeqCst);
+    }
+}
+
+struct MigrationPreparationOperation {
+    active: Mutex<Option<Arc<MigrationPreparationControl>>>,
+}
+
+impl MigrationPreparationOperation {
+    const fn new() -> Self {
+        Self {
+            active: Mutex::new(None),
+        }
+    }
+
+    fn begin(&self) -> bool {
+        let mut active = self
+            .active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if active.is_some() {
+            return false;
+        }
+        *active = Some(Arc::new(MigrationPreparationControl::new()));
+        true
+    }
+
+    fn cancel(&self) -> bool {
+        let active = self
+            .active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let Some(control) = active.as_ref() else {
+            return false;
+        };
+        control.cancel();
+        true
+    }
+
+    fn end(&self) {
+        let control = self
+            .active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take();
+        if let Some(control) = control {
+            control.cancel();
+        }
+    }
+
+    fn control(&self) -> Option<Arc<MigrationPreparationControl>> {
+        self.active
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .as_ref()
+            .cloned()
+    }
+}
+
+static MIGRATION_PREPARATION_OPERATION: MigrationPreparationOperation =
+    MigrationPreparationOperation::new();
+
+struct SyncRunningGuard;
+
+impl SyncRunningGuard {
+    fn acquire() -> Result<Self, MigrationPreparationError> {
+        SYNC_RUNNING
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .map(|_| Self)
+            .map_err(|_| MigrationPreparationError::SyncAlreadyRunning)
+    }
+}
+
+impl Drop for SyncRunningGuard {
+    fn drop(&mut self) {
+        SYNC_RUNNING.store(false, Ordering::SeqCst);
+    }
+}
+
+pub fn begin_operation() -> bool {
+    MIGRATION_PREPARATION_OPERATION.begin()
+}
+
+pub fn cancel_operation() -> bool {
+    MIGRATION_PREPARATION_OPERATION.cancel()
+}
+
+pub fn end_operation() {
+    MIGRATION_PREPARATION_OPERATION.end();
+}
+
+pub fn is_sync_running() -> bool {
+    SYNC_RUNNING.load(Ordering::SeqCst)
+}
+
+pub fn run_sync(
+    db_path: &str,
+    lightwalletd_url: &str,
+    network: WalletNetwork,
+    progress_callback: impl Fn(SyncProgressEvent) + Send + Sync,
+) -> Result<(), MigrationPreparationError> {
+    let control = MIGRATION_PREPARATION_OPERATION
+        .control()
+        .ok_or(MigrationPreparationError::NoActiveOperation)?;
+    let _sync_guard = SyncRunningGuard::acquire()?;
+    let runtime = current_thread_runtime()?;
+
+    runtime
+        .block_on(sync_engine::run_sync_inner(
+            db_path,
+            lightwalletd_url,
+            network,
+            control.cancel.clone(),
+            MIGRATION_PREPARATION_SYNC_MODE,
+            &control.desired_sync_mode,
+            false,
+            progress_callback,
+        ))
+        .map_err(MigrationPreparationError::Execution)
+}
+
+pub fn inspect(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    expected_run_id: &str,
+) -> Result<MigrationPreparationProgress, MigrationPreparationError> {
+    let status = sync::migration_status(db_path, network, account_uuid, 0, 0, 0, 0)
+        .map_err(MigrationPreparationError::Execution)?;
+    if status.active_run_id.as_deref() != Some(expected_run_id) {
+        return Ok(MigrationPreparationProgress::inactive());
+    }
+    progress_for_status(db_path, network, &status)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn advance(
+    db_path: &str,
+    lightwalletd_url: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    expected_run_id: &str,
+    credential: Zeroizing<Vec<u8>>,
+    salt_base64: &str,
+) -> Result<MigrationPreparationProgress, MigrationPreparationError> {
+    let control = MIGRATION_PREPARATION_OPERATION
+        .control()
+        .ok_or(MigrationPreparationError::NoActiveOperation)?;
+    if !is_valid_credential(&credential) {
+        return Err(MigrationPreparationError::InvalidCredential);
+    }
+    let runtime = current_thread_runtime()?;
+    runtime
+        .block_on(sync::advance_orchard_migration_preparation_for_run(
+            db_path,
+            lightwalletd_url,
+            network,
+            account_uuid,
+            expected_run_id,
+            credential,
+            salt_base64,
+            control.cancel.as_ref(),
+        ))
+        .map_err(MigrationPreparationError::Execution)?;
+
+    let status = sync::migration_status(db_path, network, account_uuid, 0, 0, 0, 0)
+        .map_err(MigrationPreparationError::Execution)?;
+    if status
+        .active_run_id
+        .as_deref()
+        .is_some_and(|id| id != expected_run_id)
+    {
+        return Err(MigrationPreparationError::Execution(
+            "Ironwood migration preparation run changed".to_string(),
+        ));
+    }
+
+    let mut progress = progress_for_status(db_path, network, &status)?;
+    if control.cancel.load(Ordering::SeqCst) {
+        progress.state = MigrationPreparationState::Cancelled;
+    }
+    Ok(progress)
+}
+
+fn current_thread_runtime() -> Result<tokio::runtime::Runtime, MigrationPreparationError> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| {
+            MigrationPreparationError::Execution(format!(
+                "Create migration preparation runtime: {error}"
+            ))
+        })
+}
+
+fn is_valid_credential(credential: &[u8]) -> bool {
+    credential.len() == 64 && credential.iter().all(u8::is_ascii_hexdigit)
+}
+
+fn progress_for_status(
+    db_path: &str,
+    network: WalletNetwork,
+    status: &sync::MigrationStatus,
+) -> Result<MigrationPreparationProgress, MigrationPreparationError> {
+    if status.active_run_id.is_none() {
+        return Ok(MigrationPreparationProgress::inactive());
+    }
+    let scanned_height = sync::get_sync_progress(db_path, network)
+        .and_then(|progress| {
+            u32::try_from(progress.scanned_height)
+                .map_err(|_| "Migration scanned height exceeds u32".to_string())
+        })
+        .map_err(MigrationPreparationError::Execution)?;
+
+    Ok(MigrationPreparationProgress {
+        state: classify_state(
+            &status.phase,
+            status.signed_child_pczt_count,
+            status.next_action_height,
+            scanned_height,
+        ),
+        confirmation_count: status.denomination_confirmation_count,
+        confirmation_target: status.denomination_confirmation_target,
+        completed_stage_count: status.denomination_split_completed_count,
+        total_stage_count: status.denomination_split_total_count,
+    })
+}
+
+fn classify_state(
+    phase: &str,
+    signed_child_pczt_count: u32,
+    next_action_height: Option<u32>,
+    scanned_height: u32,
+) -> MigrationPreparationState {
+    match phase {
+        "waiting_denom_confirmations" => {
+            MigrationPreparationState::WaitingForDenominationPreparation
+        }
+        "ready_to_migrate" if signed_child_pczt_count > 0 => match next_action_height {
+            Some(height) if height <= scanned_height => MigrationPreparationState::ProofReady,
+            Some(_) => MigrationPreparationState::WaitingForPreparedNoteAnchor,
+            None => MigrationPreparationState::NeedsUserAction,
+        },
+        "broadcast_scheduled" | "broadcasting" | "waiting_migration_confirmations" | "complete" => {
+            MigrationPreparationState::Inactive
+        }
+        _ => MigrationPreparationState::NeedsUserAction,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operation_owns_cancel_across_sync_and_advance() {
+        let operation = MigrationPreparationOperation::new();
+        assert!(operation.begin());
+        assert!(!operation.begin());
+
+        let sync_control = operation.control().unwrap();
+        let advance_control = operation.control().unwrap();
+        assert!(Arc::ptr_eq(&sync_control, &advance_control));
+        assert!(!sync_control.cancel.load(Ordering::Relaxed));
+        assert_eq!(
+            sync_control.desired_sync_mode.load(Ordering::SeqCst),
+            MIGRATION_PREPARATION_SYNC_MODE
+        );
+
+        let unrelated_sync_cancel = AtomicBool::new(false);
+        unrelated_sync_cancel.store(true, Ordering::Relaxed);
+        assert!(!sync_control.cancel.load(Ordering::Relaxed));
+
+        assert!(operation.cancel());
+        assert!(sync_control.cancel.load(Ordering::Relaxed));
+        assert!(advance_control.cancel.load(Ordering::Relaxed));
+        assert_eq!(
+            sync_control.desired_sync_mode.load(Ordering::SeqCst),
+            STOPPED_SYNC_MODE
+        );
+
+        operation.end();
+        assert!(operation.control().is_none());
+        assert!(!operation.cancel());
+
+        assert!(operation.begin());
+        let next_control = operation.control().unwrap();
+        assert!(!Arc::ptr_eq(&sync_control, &next_control));
+        assert!(!next_control.cancel.load(Ordering::Relaxed));
+        operation.end();
+    }
+
+    #[test]
+    fn state_mapping_distinguishes_anchor_wait_from_proof_readiness() {
+        assert_eq!(
+            classify_state("ready_to_migrate", 1, Some(2_000), 1_999),
+            MigrationPreparationState::WaitingForPreparedNoteAnchor
+        );
+        assert_eq!(
+            classify_state("ready_to_migrate", 1, Some(2_000), 2_000),
+            MigrationPreparationState::ProofReady
+        );
+        assert_eq!(
+            classify_state("ready_to_migrate", 1, None, 2_000),
+            MigrationPreparationState::NeedsUserAction
+        );
+    }
+
+    #[test]
+    fn state_mapping_keeps_completed_or_foreground_owned_runs_inactive() {
+        for phase in [
+            "broadcast_scheduled",
+            "broadcasting",
+            "waiting_migration_confirmations",
+            "complete",
+        ] {
+            assert_eq!(
+                classify_state(phase, 0, None, 0),
+                MigrationPreparationState::Inactive
+            );
+        }
+        assert_eq!(
+            classify_state("waiting_denom_confirmations", 0, None, 0),
+            MigrationPreparationState::WaitingForDenominationPreparation
+        );
+        assert_eq!(
+            classify_state("ready_to_migrate", 0, Some(0), 0),
+            MigrationPreparationState::NeedsUserAction
+        );
+    }
+
+    #[test]
+    fn invalid_credentials_are_rejected_before_execution() {
+        assert!(!is_valid_credential(&[b'a'; 63]));
+        assert!(!is_valid_credential(&[b'a'; 65]));
+        assert!(!is_valid_credential(&[b'g'; 64]));
+        assert!(!is_valid_credential(&[0; 64]));
+        assert!(is_valid_credential(&[b'a'; 64]));
+        assert!(is_valid_credential(&[b'F'; 64]));
+    }
+}

--- a/test/features/migration/ironwood_migration_background_credential_store_test.dart
+++ b/test/features/migration/ironwood_migration_background_credential_store_test.dart
@@ -177,6 +177,106 @@ void main() {
     );
   });
 
+  test('Android uses the native encrypted manifest channel', () async {
+    const channel = MethodChannel('test/background_migration/android_store');
+    String? nativeManifest;
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          final arguments = call.arguments as Map<Object?, Object?>?;
+          switch (call.method) {
+            case 'stageCredentialManifest':
+              nativeManifest = arguments?['manifestJson'] as String?;
+              return true;
+            case 'readCredentialManifest':
+              return nativeManifest;
+            case 'deleteCredentialManifest':
+              nativeManifest = null;
+              return true;
+          }
+          return null;
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null),
+    );
+    final storage = FlutterSecureStorage();
+    final store = IronwoodMigrationBackgroundCredentialStore.testing(
+      storage: storage,
+      randomBytes: (length) => Uint8List(length),
+      channel: channel,
+      isAndroid: true,
+    );
+
+    final prepared = await store.prepare(
+      network: 'test',
+      accountUuid: 'account-1',
+      dbPath: '/tmp/wallet.db',
+      lightwalletdUrl: 'https://lwd.example:443',
+    );
+
+    expect(nativeManifest, prepared.encode());
+    expect(await storage.read(key: 'test:account-1'), isNull);
+    expect(
+      await store.read(network: 'test', accountUuid: 'account-1'),
+      prepared,
+    );
+    await store.delete(network: 'test', accountUuid: 'account-1');
+    expect(nativeManifest, isNull);
+    expect(calls.map((call) => call.method), [
+      'stageCredentialManifest',
+      'readCredentialManifest',
+      'deleteCredentialManifest',
+    ]);
+  });
+
+  test('Android migrates a legacy secure-storage manifest once', () async {
+    const channel = MethodChannel('test/background_migration/android_upgrade');
+    final legacy = IronwoodMigrationBackgroundCredentialManifest(
+      version: 1,
+      network: 'test',
+      accountUuid: 'account-1',
+      dbPath: '/tmp/wallet.db',
+      lightwalletdUrl: 'https://lwd.example:443',
+      credentialHex: List.filled(32, 'ab').join(),
+      saltBase64: base64Encode(List<int>.filled(16, 7)),
+      expectedRunId: 'run-1',
+    );
+    FlutterSecureStorage.setMockInitialValues({
+      'test:account-1': legacy.encode(),
+    });
+    String? nativeManifest;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          switch (call.method) {
+            case 'readCredentialManifest':
+              return nativeManifest;
+            case 'stageCredentialManifest':
+              nativeManifest =
+                  (call.arguments as Map<Object?, Object?>)['manifestJson']
+                      as String;
+              return true;
+          }
+          return null;
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null),
+    );
+    final storage = FlutterSecureStorage();
+    final store = IronwoodMigrationBackgroundCredentialStore.testing(
+      storage: storage,
+      randomBytes: (length) => Uint8List(length),
+      channel: channel,
+      isAndroid: true,
+    );
+
+    expect(await store.read(network: 'test', accountUuid: 'account-1'), legacy);
+    expect(nativeManifest, legacy.encode());
+    expect(await storage.read(key: 'test:account-1'), isNull);
+  });
+
   test(
     'iOS account revocation waits for native lifecycle completion',
     () async {
@@ -278,6 +378,17 @@ void main() {
   test(
     'Android quiesce retains the credential until revocation commits',
     () async {
+      const channel = MethodChannel('test/background_migration/android_revoke');
+      final calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            calls.add(call);
+            return true;
+          });
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null),
+      );
       final storage = FlutterSecureStorage();
       final store = IronwoodMigrationBackgroundCredentialStore.testing(
         storage: storage,
@@ -285,6 +396,7 @@ void main() {
       );
       final lifecycle = IronwoodMigrationBackgroundLifecycle(
         credentialStore: store,
+        channel: channel,
         isIOS: false,
         isAndroid: true,
       );
@@ -306,6 +418,7 @@ void main() {
         await store.read(network: 'test', accountUuid: 'account-1'),
         isNull,
       );
+      expect(calls.single.method, 'revokeAccount');
     },
   );
 

--- a/test/features/migration/ironwood_migration_background_credential_store_test.dart
+++ b/test/features/migration/ironwood_migration_background_credential_store_test.dart
@@ -360,6 +360,46 @@ void main() {
     expect(resumeCalls, 2);
   });
 
+  test(
+    'Android migration resume retries a transient channel failure',
+    () async {
+      const channel = MethodChannel(
+        'test/background_migration/android_resume_retry',
+      );
+      var resumeCalls = 0;
+      final resumeLeaseIds = <String?>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            if (call.method != 'resume') return true;
+            resumeCalls += 1;
+            resumeLeaseIds.add(
+              (call.arguments as Map<Object?, Object?>?)?['leaseId'] as String?,
+            );
+            if (resumeCalls == 1) {
+              throw PlatformException(code: 'temporarily_unavailable');
+            }
+            return true;
+          });
+      addTearDown(
+        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, null),
+      );
+      final lifecycle = IronwoodMigrationBackgroundLifecycle(
+        channel: channel,
+        isIOS: false,
+        isAndroid: true,
+        resumeRetryDelays: const [Duration.zero, Duration.zero],
+      );
+
+      await lifecycle.quiesce();
+      await lifecycle.resumeAfterMutation();
+
+      expect(resumeCalls, 2);
+      expect(resumeLeaseIds.first, isNotEmpty);
+      expect(resumeLeaseIds.toSet(), hasLength(1));
+    },
+  );
+
   test('caller-managed quiescence stays scoped to its async action', () async {
     final lifecycle = IronwoodMigrationBackgroundLifecycle(
       isIOS: false,
@@ -418,9 +458,79 @@ void main() {
         await store.read(network: 'test', accountUuid: 'account-1'),
         isNull,
       );
-      expect(calls.single.method, 'revokeAccount');
+      expect(calls.map((call) => call.method), ['quiesce', 'revokeAccount']);
     },
   );
+
+  test('Android quiesce and resume use native lifecycle steps', () async {
+    const channel = MethodChannel(
+      'test/background_migration/android_quiesce_resume',
+    );
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return true;
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null),
+    );
+    final lifecycle = IronwoodMigrationBackgroundLifecycle(
+      channel: channel,
+      isIOS: false,
+      isAndroid: true,
+    );
+
+    await lifecycle.quiesce();
+    await lifecycle.resumeAfterMutation();
+
+    expect(calls.map((call) => call.method), ['quiesce', 'resume']);
+    final quiesceLeaseId =
+        (calls.first.arguments as Map<Object?, Object?>)['leaseId'];
+    final resumeLeaseId =
+        (calls.last.arguments as Map<Object?, Object?>)['leaseId'];
+    expect(quiesceLeaseId, isA<String>());
+    expect(resumeLeaseId, quiesceLeaseId);
+  });
+
+  test('overlapping Android quiescence uses distinct native leases', () async {
+    const channel = MethodChannel(
+      'test/background_migration/android_overlapping_quiescence',
+    );
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return true;
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null),
+    );
+    final lifecycle = IronwoodMigrationBackgroundLifecycle(
+      channel: channel,
+      isIOS: false,
+      isAndroid: true,
+    );
+
+    await lifecycle.quiesce();
+    await lifecycle.quiesce();
+    await lifecycle.resumeAfterMutation();
+    await lifecycle.resumeAfterMutation();
+
+    final quiesceLeaseIds = calls
+        .where((call) => call.method == 'quiesce')
+        .map((call) => (call.arguments as Map<Object?, Object?>)['leaseId'])
+        .toList();
+    final resumeLeaseIds = calls
+        .where((call) => call.method == 'resume')
+        .map((call) => (call.arguments as Map<Object?, Object?>)['leaseId'])
+        .toList();
+    expect(quiesceLeaseIds, hasLength(2));
+    expect(quiesceLeaseIds.toSet(), hasLength(2));
+    expect(resumeLeaseIds, quiesceLeaseIds);
+  });
 
   test('iOS wallet reset fails closed when native revocation fails', () async {
     const channel = MethodChannel('test/background_migration/revoke_all');

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -554,41 +554,44 @@ void main() {
   );
 
   test(
-    'notification APIs are invoked only by explicit service calls',
+    'iOS and Android notification APIs are invoked by explicit service calls',
     () async {
       var requestCount = 0;
       var statusCount = 0;
       var openSettingsCount = 0;
-      final service = _notificationAuthorizationService(
-        isIOS: true,
-        statuses: const [],
-        requestNotificationAuthorization: () async {
-          requestCount++;
-          return true;
-        },
-        getNotificationAuthorizationStatus: () async {
-          statusCount++;
-          return IronwoodMigrationNotificationAuthorizationStatus.authorized;
-        },
-        openNotificationSettings: () async {
-          openSettingsCount++;
-          return true;
-        },
-      );
+      for (final isAndroid in [false, true]) {
+        final service = _notificationAuthorizationService(
+          isIOS: !isAndroid,
+          isAndroid: isAndroid,
+          statuses: const [],
+          requestNotificationAuthorization: () async {
+            requestCount++;
+            return true;
+          },
+          getNotificationAuthorizationStatus: () async {
+            statusCount++;
+            return IronwoodMigrationNotificationAuthorizationStatus.authorized;
+          },
+          openNotificationSettings: () async {
+            openSettingsCount++;
+            return true;
+          },
+        );
 
-      expect(
-        await service.notificationAuthorizationStatus(),
-        IronwoodMigrationNotificationAuthorizationStatus.authorized,
-      );
-      expect(
-        await service.requestNotificationPermission(),
-        IronwoodMigrationNotificationAuthorizationStatus.authorized,
-      );
-      expect(await service.openNotificationSystemSettings(), isTrue);
+        expect(
+          await service.notificationAuthorizationStatus(),
+          IronwoodMigrationNotificationAuthorizationStatus.authorized,
+        );
+        expect(
+          await service.requestNotificationPermission(),
+          IronwoodMigrationNotificationAuthorizationStatus.authorized,
+        );
+        expect(await service.openNotificationSystemSettings(), isTrue);
+      }
 
-      expect(requestCount, 1);
-      expect(statusCount, 2);
-      expect(openSettingsCount, 1);
+      expect(requestCount, 2);
+      expect(statusCount, 4);
+      expect(openSettingsCount, 2);
     },
   );
 
@@ -2422,121 +2425,132 @@ void main() {
   );
 
   test(
-    'iOS stages and arms typed outbox payload after foreground preparation',
+    'iOS and Android stage and arm typed outbox payload after foreground preparation',
     () async {
-      const channel = MethodChannel('com.zcash.wallet/background_migration');
-      final events = <String>[];
-      Map<Object?, Object?>? stagedPayload;
-      Map<Object?, Object?>? armedPayload;
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(channel, (call) async {
-            events.add(call.method);
-            switch (call.method) {
-              case 'listOutboxReceipts':
-                return <Object?>[];
-              case 'stageOutboxBatch':
-                stagedPayload = call.arguments as Map<Object?, Object?>;
-                return <String, String>{'txid-1': 'digest-1'};
-              case 'armOutboxBatch':
-                armedPayload = call.arguments as Map<Object?, Object?>;
-                return true;
-              case 'runOutboxOnceNow':
-                return <String, Object?>{'outcome': 'waiting'};
-            }
-            throw StateError('Unexpected method ${call.method}');
-          });
-      addTearDown(
-        () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(channel, null),
-      );
-      final statuses = <rust_sync.MigrationStatus>[
-        _migrationStatus(),
-        _migrationStatus(activeRunId: 'run-1'),
-        _migrationStatus(activeRunId: 'run-1'),
-      ];
-      final service = IronwoodMigrationService(
-        getWalletDbPath: () async => '/tmp/wallet.db',
-        getStatus: ({required dbPath, required network, required accountUuid}) {
-          return Future.value(statuses.removeAt(0));
-        },
-        getPrivatePlan:
-            ({required dbPath, required network, required accountUuid}) async =>
-                null,
-        secureStore: AppSecureStore.testing(
-          storage: const FlutterSecureStorage(),
-        ),
-        backgroundCredentialStore: _backgroundCredentialStore(),
-        getEndpoint: _testEndpoint,
-        getSessionPassword: () => throw StateError('session password used'),
-        getMnemonicBytesForAccount: (_) async => Uint8List.fromList([1, 2, 3]),
-        isMobile: () => true,
-        isIOS: () => true,
-        isMacOS: () => false,
-        startSoftwareMigration:
-            ({
-              required dbPath,
-              required lightwalletdUrl,
-              required network,
-              required accountUuid,
-              required mnemonicBytes,
-              required password,
-              required saltBase64,
-              required approvedSchedule,
-            }) async {
-              events.add('credentialOperation');
-              return _migrationResult();
-            },
-        prepareMigrationOutbox:
-            ({
-              required dbPath,
-              required lightwalletdUrl,
-              required network,
-              required accountUuid,
-              required password,
-              required saltBase64,
-            }) async {
-              events.add('prepareOutbox');
-              return _migrationResult();
-            },
-        exportMigrationOutbox:
-            ({
-              required dbPath,
-              required network,
-              required accountUuid,
-              required password,
-              required saltBase64,
-            }) async {
-              events.add('exportOutbox');
-              return _outboxBatch();
-            },
-      );
+      for (final isAndroid in [false, true]) {
+        FlutterSecureStorage.setMockInitialValues({});
+        const channel = MethodChannel('com.zcash.wallet/background_migration');
+        final events = <String>[];
+        Map<Object?, Object?>? stagedPayload;
+        Map<Object?, Object?>? armedPayload;
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(channel, (call) async {
+              events.add(call.method);
+              switch (call.method) {
+                case 'listOutboxReceipts':
+                  return <Object?>[];
+                case 'stageOutboxBatch':
+                  stagedPayload = call.arguments as Map<Object?, Object?>;
+                  return <String, String>{'txid-1': 'digest-1'};
+                case 'armOutboxBatch':
+                  armedPayload = call.arguments as Map<Object?, Object?>;
+                  return true;
+                case 'runOutboxOnceNow':
+                  return <String, Object?>{'outcome': 'waiting'};
+              }
+              throw StateError('Unexpected method ${call.method}');
+            });
+        addTearDown(
+          () => TestDefaultBinaryMessengerBinding
+              .instance
+              .defaultBinaryMessenger
+              .setMockMethodCallHandler(channel, null),
+        );
+        final statuses = <rust_sync.MigrationStatus>[
+          _migrationStatus(),
+          _migrationStatus(activeRunId: 'run-1'),
+          _migrationStatus(activeRunId: 'run-1'),
+        ];
+        final service = IronwoodMigrationService(
+          getWalletDbPath: () async => '/tmp/wallet.db',
+          getStatus:
+              ({required dbPath, required network, required accountUuid}) {
+                return Future.value(statuses.removeAt(0));
+              },
+          getPrivatePlan:
+              ({
+                required dbPath,
+                required network,
+                required accountUuid,
+              }) async => null,
+          secureStore: AppSecureStore.testing(
+            storage: const FlutterSecureStorage(),
+          ),
+          backgroundCredentialStore: _backgroundCredentialStore(),
+          getEndpoint: _testEndpoint,
+          getSessionPassword: () => throw StateError('session password used'),
+          getMnemonicBytesForAccount: (_) async =>
+              Uint8List.fromList([1, 2, 3]),
+          isMobile: () => true,
+          isIOS: () => !isAndroid,
+          isAndroid: () => isAndroid,
+          isMacOS: () => false,
+          startSoftwareMigration:
+              ({
+                required dbPath,
+                required lightwalletdUrl,
+                required network,
+                required accountUuid,
+                required mnemonicBytes,
+                required password,
+                required saltBase64,
+                required approvedSchedule,
+              }) async {
+                events.add('credentialOperation');
+                return _migrationResult();
+              },
+          prepareMigrationOutbox:
+              ({
+                required dbPath,
+                required lightwalletdUrl,
+                required network,
+                required accountUuid,
+                required password,
+                required saltBase64,
+              }) async {
+                events.add('prepareOutbox');
+                return _migrationResult();
+              },
+          exportMigrationOutbox:
+              ({
+                required dbPath,
+                required network,
+                required accountUuid,
+                required password,
+                required saltBase64,
+              }) async {
+                events.add('exportOutbox');
+                return _outboxBatch();
+              },
+        );
 
-      await service.startSoftwarePrivateMigration(
-        accountUuid: 'account-1',
-        approvedSchedule: const [],
-      );
+        await service.startSoftwarePrivateMigration(
+          accountUuid: 'account-1',
+          approvedSchedule: const [],
+        );
 
-      expect(events, [
-        'listOutboxReceipts',
-        'credentialOperation',
-        'listOutboxReceipts',
-        'prepareOutbox',
-        'exportOutbox',
-        'stageOutboxBatch',
-        'armOutboxBatch',
-        'runOutboxOnceNow',
-        'listOutboxReceipts',
-      ]);
-      expect(stagedPayload?['batchId'], 'test:account-1:run-1');
-      expect(stagedPayload?['nextProofHeight'], 576);
-      final items = stagedPayload?['items'] as List<Object?>;
-      final item = items.single as Map<Object?, Object?>;
-      expect(item['rawTransaction'], isA<Uint8List>());
-      expect(item['rawTransaction'], Uint8List.fromList([1, 2, 3, 4]));
-      expect(armedPayload, {
-        'batchId': 'test:account-1:run-1',
-        'expectedDigests': {'txid-1': 'digest-1'},
-      });
+        expect(events, [
+          'listOutboxReceipts',
+          'credentialOperation',
+          'listOutboxReceipts',
+          'prepareOutbox',
+          'exportOutbox',
+          'stageOutboxBatch',
+          'armOutboxBatch',
+          'runOutboxOnceNow',
+          'listOutboxReceipts',
+        ]);
+        expect(stagedPayload?['batchId'], 'test:account-1:run-1');
+        expect(stagedPayload?['nextProofHeight'], 576);
+        final items = stagedPayload?['items'] as List<Object?>;
+        final item = items.single as Map<Object?, Object?>;
+        expect(item['rawTransaction'], isA<Uint8List>());
+        expect(item['rawTransaction'], Uint8List.fromList([1, 2, 3, 4]));
+        expect(armedPayload, {
+          'batchId': 'test:account-1:run-1',
+          'expectedDigests': {'txid-1': 'digest-1'},
+        });
+      }
     },
   );
 
@@ -2842,6 +2856,7 @@ RpcEndpointConfig _testEndpoint() => const RpcEndpointConfig(
 
 IronwoodMigrationService _notificationAuthorizationService({
   required bool isIOS,
+  bool isAndroid = false,
   required List<rust_sync.MigrationStatus> statuses,
   Future<bool> Function()? requestNotificationAuthorization,
   Future<IronwoodMigrationNotificationAuthorizationStatus> Function()?
@@ -2866,6 +2881,7 @@ IronwoodMigrationService _notificationAuthorizationService({
     isMacOS: () => false,
     isMobile: () => true,
     isIOS: () => isIOS,
+    isAndroid: () => isAndroid,
     requestNotificationAuthorization: requestNotificationAuthorization,
     getNotificationAuthorizationStatus:
         getNotificationAuthorizationStatus ??

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -54,6 +54,44 @@ void main() {
   );
 
   test(
+    'Android reads preparation runtime state from the native worker',
+    () async {
+      var getterCalls = 0;
+      final service = IronwoodMigrationService(
+        getWalletDbPath: () async => '/tmp/wallet.db',
+        getStatus:
+            ({required dbPath, required network, required accountUuid}) async =>
+                _migrationStatus(),
+        getPrivatePlan:
+            ({required dbPath, required network, required accountUuid}) async =>
+                null,
+        secureStore: AppSecureStore.testing(
+          storage: const FlutterSecureStorage(),
+        ),
+        getEndpoint: _testEndpoint,
+        isIOS: () => false,
+        isAndroid: () => true,
+        getPreparationRuntimeState:
+            ({required network, required accountUuid, required runId}) async {
+              getterCalls++;
+              expect(network, 'test');
+              expect(accountUuid, 'account-1');
+              expect(runId, 'run-1');
+              return IronwoodMigrationPreparationRuntimeState.scheduled;
+            },
+      );
+
+      final state = await service.preparationRuntimeState(
+        accountUuid: 'account-1',
+        runId: 'run-1',
+      );
+
+      expect(state, IronwoodMigrationPreparationRuntimeState.scheduled);
+      expect(getterCalls, 1);
+    },
+  );
+
+  test(
     'status resolves wallet db path before calling Rust status API',
     () async {
       String? seenDbPath;
@@ -281,6 +319,35 @@ void main() {
 
       expect(preparationStartCount, 1);
       expect(events, ['startBackgroundPreparation']);
+    },
+  );
+
+  test(
+    'Android software start hands confirmation waiting to background preparation',
+    () async {
+      var preparationStartCount = 0;
+      final service = _notificationAuthorizationService(
+        isIOS: false,
+        isAndroid: true,
+        statuses: [
+          _migrationStatus(),
+          _migrationStatus(
+            phase: 'waiting_denom_confirmations',
+            activeRunId: 'run-1',
+          ),
+        ],
+        startBackgroundPreparation: () async {
+          preparationStartCount++;
+          return true;
+        },
+      );
+
+      await service.startSoftwarePrivateMigration(
+        accountUuid: 'account-1',
+        approvedSchedule: const [],
+      );
+
+      expect(preparationStartCount, 1);
     },
   );
 
@@ -708,6 +775,43 @@ void main() {
       expect(preparationStartCount, 1);
     },
   );
+
+  test('Android lifecycle recovery restores bound preparation', () async {
+    final store = await _boundBackgroundCredentialStore();
+    var preparationStartCount = 0;
+    final service = IronwoodMigrationService(
+      getWalletDbPath: () async => '/tmp/wallet.db',
+      getStatus:
+          ({required dbPath, required network, required accountUuid}) async =>
+              _migrationStatus(
+                phase: 'waiting_denom_confirmations',
+                activeRunId: 'run-1',
+              ),
+      getPrivatePlan:
+          ({required dbPath, required network, required accountUuid}) async =>
+              null,
+      secureStore: AppSecureStore.testing(
+        storage: const FlutterSecureStorage(),
+      ),
+      backgroundCredentialStore: store,
+      isMobile: () => true,
+      isIOS: () => false,
+      isAndroid: () => true,
+      startBackgroundPreparation: () async {
+        preparationStartCount++;
+        return true;
+      },
+      getNotificationAuthorizationStatus: () async =>
+          IronwoodMigrationNotificationAuthorizationStatus.authorized,
+    );
+
+    await service.resumeBackgroundPreparationIfNeeded(
+      network: 'test',
+      accountUuid: 'account-1',
+    );
+
+    expect(preparationStartCount, 1);
+  });
 
   test('explicit recovery binds a provisional preparation manifest', () async {
     final store = _backgroundCredentialStore();

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -67,7 +67,7 @@ class _RecoveryScreenTestMigrationCoordinator
         'account-1':
             'Bad state: Ironwood migration credential is missing for the '
             'active run. Vizor will only continue transactions preserved in '
-            'the verified iOS outbox.',
+            'the verified native migration outbox.',
       },
     );
   }


### PR DESCRIPTION
## Summary

- extract Ironwood migration preparation into a Rust core shared by iOS and Android native entry points
- add Android Keystore-backed migration credentials and the JNI bridge
- run preparation through WorkManager with durable lifecycle and cancellation handling
- add a persistent migration transaction outbox and worker-based broadcast recovery
- coordinate Flutter lifecycle, wallet mutations, and native background preparation without changing the existing iOS background flow

## Why

iOS can continue migration preparation outside the Flutter isolate through `BGContinuedProcessingTask`, while Android previously had no equivalent native background path. This adds an Android implementation based on WorkManager and native secure storage, while keeping the migration execution rules in one Rust core.

## Impact

On Android, software-wallet migration preparation can continue while the app is backgrounded and recover after process restart. Credentials remain in Android Keystore-backed storage, prepared transactions are persisted before broadcast, and foreground wallet mutations quiesce native work first. iOS continues to use its existing native background manager through the same shared preparation core.

## Validation

- `fvm flutter test test/features/migration/ironwood_migration_background_credential_store_test.dart test/features/migration/ironwood_migration_service_test.dart test/providers/wallet_mutation_guard_test.dart` — passed (78 tests)
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/migration` — passed (111 tests)
- `./gradlew app:testDebugUnitTest` — passed
- `cargo test --lib migration_preparation` — passed (4 tests)
- integration was tested both as a merge and as a six-commit rebase onto current `origin/main`; both were conflict-free and produced the same Git tree
- Android Rust/JNI cross-compilation completed for ARMv7 and ARM64 during a debug APK build; the fresh x86_64/final packaging run stopped because the local disk filled

## Known upstream test issue

A full `cargo test` currently stops while compiling `rust/tests/ironwood_regtest_migration.rs`: current `main` added the `space_preparation_broadcasts` argument to `get_orchard_migration_private_plan`, but that existing regtest call was not updated. The API change and stale call both originate from `main`, not from this PR.