### PR TITLE
Improve mobile migration ring feedback

### DIFF
--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -21,25 +21,21 @@ class _MobileIronwoodMigrationPreviewSurface extends StatelessWidget {
       MobileIronwoodMigrationPreviewSurface.preparationActive =>
         const _MigrationPreparationPreview(
           state: _MigrationPreparationState.active,
-          progress: 5 / 9,
         ),
       MobileIronwoodMigrationPreviewSurface.preparationPaused =>
         _MigrationPreparationPreview(
           state: _MigrationPreparationState.paused,
-          progress: 5 / 9,
           onContinue: _noopMigrationPreviewAction,
         ),
       MobileIronwoodMigrationPreviewSurface.preparationPausedKeystone =>
         _MigrationPreparationPreview(
           state: _MigrationPreparationState.paused,
-          progress: 5 / 9,
           isKeystone: true,
           onContinue: _noopMigrationPreviewAction,
         ),
       MobileIronwoodMigrationPreviewSurface.preparationSyncing =>
         const _MigrationPreparationPreview(
           state: _MigrationPreparationState.syncing,
-          progress: 5 / 9,
         ),
       MobileIronwoodMigrationPreviewSurface.syncing =>
         const _MigrationProgressPreview(state: _MigrationProgressState.syncing),
@@ -512,14 +508,12 @@ enum _MigrationPreparationState { active, paused, syncing }
 class _MigrationPreparationPreview extends StatelessWidget {
   const _MigrationPreparationPreview({
     required this.state,
-    this.progress = 0,
     this.isKeystone = false,
     this.onBack,
     this.onContinue,
   });
 
   final _MigrationPreparationState state;
-  final double progress;
   final bool isKeystone;
   final VoidCallback? onBack;
   final VoidCallback? onContinue;
@@ -552,7 +546,7 @@ class _MigrationPreparationPreview extends StatelessWidget {
           : null,
       child: Column(
         children: [
-          _MigrationPreparationDial(state: state, progress: progress),
+          _MigrationPreparationDial(state: state),
           const SizedBox(height: AppSpacing.base),
           Opacity(
             opacity: paused ? 0.4 : 1,
@@ -565,13 +559,9 @@ class _MigrationPreparationPreview extends StatelessWidget {
 }
 
 class _MigrationPreparationDial extends StatelessWidget {
-  const _MigrationPreparationDial({
-    required this.state,
-    required this.progress,
-  });
+  const _MigrationPreparationDial({required this.state});
 
   final _MigrationPreparationState state;
-  final double progress;
 
   @override
   Widget build(BuildContext context) {
@@ -582,15 +572,9 @@ class _MigrationPreparationDial extends StatelessWidget {
       child: Stack(
         alignment: Alignment.center,
         children: [
-          CustomPaint(
-            key: const ValueKey('mobile_ironwood_preparation_progress_ring'),
-            size: const Size.square(256),
-            painter: _MigrationRingPainter(
-              trackColor: context.colors.border.subtle,
-              activeColor: const Color(0xFF00A460),
-              segments: 8,
-              progress: progress,
-            ),
+          _AnimatedMigrationPreparationRing(
+            animate: state == _MigrationPreparationState.active,
+            color: context.colors.border.subtle,
           ),
           SizedBox(
             width: 200,
@@ -629,6 +613,292 @@ class _MigrationPreparationDial extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+class _AnimatedMigrationPreparationRing extends StatefulWidget {
+  const _AnimatedMigrationPreparationRing({
+    required this.animate,
+    required this.color,
+  });
+
+  final bool animate;
+  final Color color;
+
+  @override
+  State<_AnimatedMigrationPreparationRing> createState() =>
+      _AnimatedMigrationPreparationRingState();
+}
+
+class _AnimatedMigrationPreparationRingState
+    extends State<_AnimatedMigrationPreparationRing>
+    with TickerProviderStateMixin {
+  static const _minimumWeight = 0.035;
+  static const _maximumWeight = 0.22;
+  // The nine unequal sweeps from the Figma preparation ring, normalized to 1.
+  static const _initialWeights = <double>[
+    45 / 342,
+    45 / 342,
+    18 / 342,
+    23 / 342,
+    72 / 342,
+    42 / 342,
+    45 / 342,
+    16 / 342,
+    36 / 342,
+  ];
+  static const _stepDuration = Duration(milliseconds: 390);
+  static const _stepBreather = Duration(milliseconds: 105);
+  static const _spinDuration = Duration(milliseconds: 1800);
+  static const _restBetweenBlocks = Duration(milliseconds: 900);
+
+  late final AnimationController _stepController = AnimationController(
+    vsync: this,
+    duration: _stepDuration,
+  );
+  late final AnimationController _spinController = AnimationController(
+    vsync: this,
+    duration: _spinDuration,
+  );
+  // Keep captures and motion tests reproducible while the sequence stays varied.
+  final math.Random _random = math.Random(697244909);
+
+  late List<double> _weights = List.of(_initialWeights);
+  late List<double> _fromWeights = List.of(_initialWeights);
+  late List<double> _toWeights = List.of(_initialWeights);
+  double _baseRotation = 0;
+  bool _reducedMotion = false;
+  bool _loopRunning = false;
+  bool _initialDelayPending = true;
+  int _generation = 0;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _reducedMotion = MediaQuery.disableAnimationsOf(context);
+    _syncMotion();
+  }
+
+  @override
+  void didUpdateWidget(covariant _AnimatedMigrationPreparationRing oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.animate != widget.animate) {
+      _syncMotion();
+    }
+  }
+
+  void _syncMotion() {
+    if (widget.animate && !_reducedMotion) {
+      _startLoop();
+      return;
+    }
+    _stopLoop(resetToInitial: _reducedMotion);
+  }
+
+  void _startLoop() {
+    if (_loopRunning) return;
+    _loopRunning = true;
+    final generation = ++_generation;
+    unawaited(_runLoop(generation));
+  }
+
+  void _stopLoop({required bool resetToInitial}) {
+    if (!_loopRunning &&
+        !_stepController.isAnimating &&
+        !_spinController.isAnimating &&
+        !resetToInitial) {
+      return;
+    }
+    _generation++;
+    _loopRunning = false;
+    if (resetToInitial) {
+      _weights = List.of(_initialWeights);
+      _fromWeights = List.of(_initialWeights);
+      _toWeights = List.of(_initialWeights);
+      _baseRotation = 0;
+    } else {
+      final easedStep = Curves.easeOutBack.transform(_stepController.value);
+      _weights = List.generate(
+        _fromWeights.length,
+        (index) =>
+            _fromWeights[index] +
+            (_toWeights[index] - _fromWeights[index]) * easedStep,
+      );
+      _fromWeights = List.of(_weights);
+      _toWeights = List.of(_weights);
+      _baseRotation =
+          (_baseRotation +
+              Curves.easeInOutCubic.transform(_spinController.value)) %
+          1;
+    }
+    _stepController.stop();
+    _spinController.stop();
+    _stepController.value = 0;
+    _spinController.value = 0;
+  }
+
+  bool _shouldContinue(int generation) {
+    return mounted &&
+        generation == _generation &&
+        widget.animate &&
+        !_reducedMotion;
+  }
+
+  Future<void> _runLoop(int generation) async {
+    try {
+      if (_initialDelayPending) {
+        _initialDelayPending = false;
+        await Future<void>.delayed(const Duration(milliseconds: 400));
+        if (!_shouldContinue(generation)) return;
+      }
+      while (_shouldContinue(generation)) {
+        for (var cycle = 0; cycle < 3; cycle++) {
+          await _adjustSegments(generation);
+          if (!_shouldContinue(generation)) return;
+          await _spinController.forward(from: 0).orCancel;
+          if (!_shouldContinue(generation)) return;
+          setState(() {
+            _baseRotation = (_baseRotation + 1) % 1;
+            _spinController.value = 0;
+          });
+        }
+        await Future<void>.delayed(_restBetweenBlocks);
+      }
+    } on TickerCanceled {
+      // The screen paused, reduced motion was enabled, or the widget disposed.
+    } finally {
+      if (generation == _generation) {
+        _loopRunning = false;
+      }
+    }
+  }
+
+  Future<void> _adjustSegments(int generation) async {
+    final stepCount = 3 + _random.nextInt(3);
+    for (var step = 0; step < stepCount; step++) {
+      if (!_shouldContinue(generation)) return;
+      final first = _random.nextInt(_weights.length);
+      var second = _random.nextInt(_weights.length - 1);
+      if (second >= first) second++;
+
+      final canGive = _weights[first] - _minimumWeight;
+      final canTake = _maximumWeight - _weights[first];
+      final giveRoom = math.min(canGive, _maximumWeight - _weights[second]);
+      final takeRoom = math.min(canTake, _weights[second] - _minimumWeight);
+      final give = giveRoom >= takeRoom;
+      final room = give ? giveRoom : takeRoom;
+      if (room <= 0.005) continue;
+      final amount = room * (0.4 + _random.nextDouble() * 0.6);
+
+      setState(() {
+        _fromWeights = List.of(_weights);
+        _toWeights = List.of(_weights);
+        _toWeights[first] += give ? -amount : amount;
+        _toWeights[second] += give ? amount : -amount;
+      });
+      await _stepController.forward(from: 0).orCancel;
+      if (!_shouldContinue(generation)) return;
+      setState(() {
+        _weights = List.of(_toWeights);
+        _fromWeights = List.of(_weights);
+        _toWeights = List.of(_weights);
+        _stepController.value = 0;
+      });
+      await Future<void>.delayed(_stepBreather);
+    }
+  }
+
+  @override
+  void dispose() {
+    _generation++;
+    _stepController.dispose();
+    _spinController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: Listenable.merge([_stepController, _spinController]),
+      builder: (context, _) {
+        final easedStep = Curves.easeOutBack.transform(_stepController.value);
+        final weights = List.generate(
+          _fromWeights.length,
+          (index) =>
+              _fromWeights[index] +
+              (_toWeights[index] - _fromWeights[index]) * easedStep,
+        );
+        final rotation =
+            _baseRotation +
+            Curves.easeInOutCubic.transform(_spinController.value);
+        return CustomPaint(
+          key: const ValueKey('mobile_ironwood_preparation_idle_ring'),
+          size: const Size.square(256),
+          painter: _MigrationPreparationIdleRingPainter(
+            weights: weights,
+            rotation: rotation,
+            color: widget.color,
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _MigrationPreparationIdleRingPainter extends CustomPainter {
+  const _MigrationPreparationIdleRingPainter({
+    required this.weights,
+    required this.rotation,
+    required this.color,
+  });
+
+  final List<double> weights;
+  final double rotation;
+  final Color color;
+  final double visibleSegmentGap = 4;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final radius = math.min(size.width, size.height) / 2 - 7;
+    final rect = Rect.fromCircle(center: center, radius: radius);
+    const strokeWidth = 12.0;
+    final gap = (strokeWidth + visibleSegmentGap) / radius;
+    final sweepBudget = math.pi * 2 - weights.length * gap;
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = strokeWidth
+      ..color = color;
+
+    canvas.save();
+    canvas.translate(center.dx, center.dy);
+    canvas.rotate(rotation * math.pi * 2);
+    canvas.translate(-center.dx, -center.dy);
+
+    var cursor = -math.pi / 2;
+    for (final weight in weights) {
+      final sweep = math.max(0.01, weight * sweepBudget);
+      canvas.drawArc(rect, cursor + gap / 2, sweep, false, paint);
+      cursor += sweep + gap;
+    }
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(_MigrationPreparationIdleRingPainter oldDelegate) {
+    return color != oldDelegate.color ||
+        rotation != oldDelegate.rotation ||
+        visibleSegmentGap != oldDelegate.visibleSegmentGap ||
+        !_sameWeights(weights, oldDelegate.weights);
+  }
+
+  static bool _sameWeights(List<double> first, List<double> second) {
+    if (first.length != second.length) return false;
+    for (var index = 0; index < first.length; index++) {
+      if (first[index] != second[index]) return false;
+    }
+    return true;
   }
 }
 
@@ -2085,7 +2355,6 @@ class _MigrationRingPainter extends CustomPainter {
     this.highlightedSegments = const {},
     this.highlightColor,
     this.highlightOpacity = 1,
-    this.progress,
   });
 
   final Color trackColor;
@@ -2095,7 +2364,6 @@ class _MigrationRingPainter extends CustomPainter {
   final Set<int> highlightedSegments;
   final Color? highlightColor;
   final double highlightOpacity;
-  final double? progress;
   final double visibleSegmentGap = 4;
 
   @override
@@ -2116,31 +2384,12 @@ class _MigrationRingPainter extends CustomPainter {
             segmentPitch * 0.35,
           );
     final segmentSweep = math.max(0.0, segmentPitch - gap);
-    final clampedProgress = progress?.clamp(0.0, 1.0).toDouble();
     for (var index = 0; index < segments; index++) {
       final start = -math.pi / 2 + index * segmentPitch + gap / 2;
       final paint = Paint()
         ..style = PaintingStyle.stroke
         ..strokeCap = useRoundCaps ? StrokeCap.round : StrokeCap.butt
         ..strokeWidth = strokeWidth;
-      if (clampedProgress != null) {
-        paint.color = trackColor;
-        canvas.drawArc(rect, start, segmentSweep, false, paint);
-        final segmentProgress = (clampedProgress * segments - index)
-            .clamp(0.0, 1.0)
-            .toDouble();
-        if (segmentProgress > 0) {
-          paint.color = activeColor;
-          canvas.drawArc(
-            rect,
-            start,
-            segmentSweep * segmentProgress,
-            false,
-            paint,
-          );
-        }
-        continue;
-      }
       paint.color = completedSegments.contains(index)
           ? activeColor
           : highlightedSegments.contains(index)
@@ -2159,7 +2408,6 @@ class _MigrationRingPainter extends CustomPainter {
         highlightedSegments != oldDelegate.highlightedSegments ||
         highlightColor != oldDelegate.highlightColor ||
         highlightOpacity != oldDelegate.highlightOpacity ||
-        progress != oldDelegate.progress ||
         visibleSegmentGap != oldDelegate.visibleSegmentGap;
   }
 }

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -53,18 +53,21 @@ class _MobileIronwoodMigrationPreviewSurface extends StatelessWidget {
           state: _MigrationProgressState.waitingNotificationsOff,
         ),
       MobileIronwoodMigrationPreviewSurface.migrationNeedsInput =>
-        const _MigrationProgressPreview(
+        _MigrationProgressPreview(
           state: _MigrationProgressState.needsInput,
-          currentBatchPartCount: _migrationPartsPerBatch,
+          currentSigningPartIndices: {
+            for (var index = 0; index < _migrationPartsPerBatch; index++) index,
+          },
           migratedAmountText: '777.888 ZEC',
           totalAmountText: '999.999 ZEC',
         ),
       MobileIronwoodMigrationPreviewSurface.migrationKeystoneSignAll =>
-        const _MigrationProgressPreview(
+        _MigrationProgressPreview(
           state: _MigrationProgressState.needsInput,
           totalParts: 50,
-          currentBatchPartCount: 8,
-          highlightCurrentBatch: false,
+          currentSigningPartIndices: {
+            for (var index = 0; index < 50; index++) index,
+          },
           migratedAmountText: '0 ZEC',
           totalAmountText: '50 ZEC',
           actionLabel: 'Sign migration transactions',
@@ -979,11 +982,9 @@ class _MigrationProgressPreview extends StatelessWidget {
     this.totalParts = 24,
     this.completedBatches,
     this.totalBatches,
-    this.currentBatchStartIndex,
-    this.currentBatchPartCount,
     this.completedRingSegments,
+    this.currentSigningPartIndices = const {},
     this.segmentValuesZatoshi,
-    this.highlightCurrentBatch = true,
     this.migratedAmountText,
     this.totalAmountText,
     this.availableAmountText,
@@ -1004,11 +1005,9 @@ class _MigrationProgressPreview extends StatelessWidget {
   final int totalParts;
   final int? completedBatches;
   final int? totalBatches;
-  final int? currentBatchStartIndex;
-  final int? currentBatchPartCount;
   final Set<int>? completedRingSegments;
+  final Set<int> currentSigningPartIndices;
   final List<BigInt>? segmentValuesZatoshi;
-  final bool highlightCurrentBatch;
   final String? migratedAmountText;
   final String? totalAmountText;
   final String? availableAmountText;
@@ -1040,17 +1039,6 @@ class _MigrationProgressPreview extends StatelessWidget {
         (resolvedCompletedParts >= totalParts
             ? resolvedTotalBatches
             : resolvedCompletedParts ~/ _migrationPartsPerBatch);
-    final resolvedCurrentBatchStartIndex =
-        currentBatchStartIndex ??
-        math.min(
-          math.max(0, totalParts - 1),
-          resolvedCompletedBatches * _migrationPartsPerBatch,
-        );
-    final resolvedBatchPartCount =
-        currentBatchPartCount ??
-        (state == _MigrationProgressState.needsInput
-            ? math.min(3, totalParts)
-            : math.min(_migrationPartsPerBatch, totalParts));
     final resolvedCompletedRingSegments =
         completedRingSegments ??
         {
@@ -1104,11 +1092,12 @@ class _MigrationProgressPreview extends StatelessWidget {
                   completedBatches: resolvedCompletedBatches,
                   totalBatches: resolvedTotalBatches,
                   totalParts: totalParts,
-                  currentBatchStartIndex: resolvedCurrentBatchStartIndex,
-                  currentBatchPartCount: resolvedBatchPartCount,
                   completedSegments: resolvedCompletedRingSegments,
+                  highlightedSegments:
+                      state == _MigrationProgressState.needsInput
+                      ? currentSigningPartIndices
+                      : const {},
                   segmentWeights: resolvedSegmentWeights,
-                  highlightCurrentBatch: highlightCurrentBatch,
                   dimension: compact ? 192 : 256,
                   migratedAmountText: migratedAmountText,
                   totalAmountText: totalAmountText,
@@ -1151,11 +1140,9 @@ class _MigrationBatchDial extends StatelessWidget {
     required this.completedBatches,
     required this.totalBatches,
     required this.totalParts,
-    required this.currentBatchStartIndex,
-    required this.currentBatchPartCount,
     required this.completedSegments,
+    required this.highlightedSegments,
     required this.segmentWeights,
-    this.highlightCurrentBatch = true,
     this.dimension = 256,
     this.migratedAmountText,
     this.totalAmountText,
@@ -1165,18 +1152,15 @@ class _MigrationBatchDial extends StatelessWidget {
   final int completedBatches;
   final int totalBatches;
   final int totalParts;
-  final int currentBatchStartIndex;
-  final int currentBatchPartCount;
   final Set<int> completedSegments;
+  final Set<int> highlightedSegments;
   final List<double> segmentWeights;
-  final bool highlightCurrentBatch;
   final double dimension;
   final String? migratedAmountText;
   final String? totalAmountText;
 
   @override
   Widget build(BuildContext context) {
-    final needsInput = state == _MigrationProgressState.needsInput;
     final migrated = migratedAmountText?.replaceFirst(RegExp(r'\s+ZEC$'), '');
     final total = totalAmountText ?? '100 ZEC';
     final combinedAmount = migrated == null ? '0/100 ZEC' : '$migrated/$total';
@@ -1190,21 +1174,6 @@ class _MigrationBatchDial extends StatelessWidget {
     )..layout();
     final splitAmount =
         amountPainter.width > dimension * 0.75 || combinedAmount.length >= 18;
-    final highlightedSegments = needsInput && highlightCurrentBatch
-        ? {
-            for (
-              var index = currentBatchStartIndex;
-              index <
-                  math.min(
-                    totalParts,
-                    currentBatchStartIndex +
-                        currentBatchPartCount.clamp(0, _migrationPartsPerBatch),
-                  );
-              index++
-            )
-              index,
-          }
-        : const <int>{};
     return SizedBox.square(
       dimension: dimension,
       child: Stack(
@@ -2304,11 +2273,11 @@ class _AnimatedMigrationAttentionRingState
     super.initState();
     _controller = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 1400),
-      value: 1,
+      duration: const Duration(milliseconds: 400),
+      value: 0,
     );
     _opacity = Tween<double>(
-      begin: 0.32,
+      begin: 0.40,
       end: 1,
     ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
   }
@@ -2333,6 +2302,7 @@ class _AnimatedMigrationAttentionRingState
       return;
     }
     if (!_controller.isAnimating) {
+      _controller.value = 0;
       _controller.repeat(reverse: true);
     }
   }
@@ -2348,6 +2318,7 @@ class _AnimatedMigrationAttentionRingState
     return AnimatedBuilder(
       animation: _opacity,
       builder: (context, _) => CustomPaint(
+        key: const ValueKey('mobile_ironwood_migration_attention_ring'),
         size: Size.square(widget.dimension),
         painter: _MigrationRingPainter(
           trackColor: context.colors.border.subtle,

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -72,8 +72,13 @@ class _MobileIronwoodMigrationPreviewSurface extends StatelessWidget {
           actionBatchValue: '50 ZEC (100%)',
         ),
       MobileIronwoodMigrationPreviewSurface.migrationBroadcasting =>
-        const _MigrationProgressPreview(
+        _MigrationProgressPreview(
           state: _MigrationProgressState.broadcasting,
+          totalParts: 8,
+          segmentValuesZatoshi: [
+            for (final value in const [1, 3, 2, 5, 1, 4, 2, 6])
+              BigInt.from(value),
+          ],
         ),
       MobileIronwoodMigrationPreviewSurface.migrationComplete =>
         const _MigrationCompletePreview(),
@@ -977,6 +982,7 @@ class _MigrationProgressPreview extends StatelessWidget {
     this.currentBatchStartIndex,
     this.currentBatchPartCount,
     this.completedRingSegments,
+    this.segmentValuesZatoshi,
     this.highlightCurrentBatch = true,
     this.migratedAmountText,
     this.totalAmountText,
@@ -1001,6 +1007,7 @@ class _MigrationProgressPreview extends StatelessWidget {
   final int? currentBatchStartIndex;
   final int? currentBatchPartCount;
   final Set<int>? completedRingSegments;
+  final List<BigInt>? segmentValuesZatoshi;
   final bool highlightCurrentBatch;
   final String? migratedAmountText;
   final String? totalAmountText;
@@ -1054,6 +1061,10 @@ class _MigrationProgressPreview extends StatelessWidget {
           )
             index,
         };
+    final resolvedSegmentWeights = _normalizedMigrationRingWeights(
+      segments: math.max(1, totalParts),
+      valuesZatoshi: segmentValuesZatoshi,
+    );
     final body = _MigrationPreviewPage(
       navTitle: 'Migration in progress…',
       onBack: onBack,
@@ -1082,7 +1093,10 @@ class _MigrationProgressPreview extends StatelessWidget {
         _ => null,
       },
       child: state == _MigrationProgressState.syncing
-          ? _MigrationSyncingContent(compact: compact, totalParts: totalParts)
+          ? _MigrationSyncingContent(
+              compact: compact,
+              segmentWeights: resolvedSegmentWeights,
+            )
           : Column(
               children: [
                 _MigrationBatchDial(
@@ -1093,6 +1107,7 @@ class _MigrationProgressPreview extends StatelessWidget {
                   currentBatchStartIndex: resolvedCurrentBatchStartIndex,
                   currentBatchPartCount: resolvedBatchPartCount,
                   completedSegments: resolvedCompletedRingSegments,
+                  segmentWeights: resolvedSegmentWeights,
                   highlightCurrentBatch: highlightCurrentBatch,
                   dimension: compact ? 192 : 256,
                   migratedAmountText: migratedAmountText,
@@ -1139,6 +1154,7 @@ class _MigrationBatchDial extends StatelessWidget {
     required this.currentBatchStartIndex,
     required this.currentBatchPartCount,
     required this.completedSegments,
+    required this.segmentWeights,
     this.highlightCurrentBatch = true,
     this.dimension = 256,
     this.migratedAmountText,
@@ -1152,6 +1168,7 @@ class _MigrationBatchDial extends StatelessWidget {
   final int currentBatchStartIndex;
   final int currentBatchPartCount;
   final Set<int> completedSegments;
+  final List<double> segmentWeights;
   final bool highlightCurrentBatch;
   final double dimension;
   final String? migratedAmountText;
@@ -1195,7 +1212,7 @@ class _MigrationBatchDial extends StatelessWidget {
         children: [
           _AnimatedMigrationAttentionRing(
             dimension: dimension,
-            segments: math.max(1, totalParts),
+            segmentWeights: segmentWeights,
             completedSegments: completedSegments,
             highlightedSegments: highlightedSegments,
           ),
@@ -1259,11 +1276,11 @@ class _MigrationBatchDial extends StatelessWidget {
 class _MigrationSyncingContent extends StatelessWidget {
   const _MigrationSyncingContent({
     required this.compact,
-    required this.totalParts,
+    required this.segmentWeights,
   });
 
   final bool compact;
-  final int totalParts;
+  final List<double> segmentWeights;
 
   @override
   Widget build(BuildContext context) {
@@ -1283,7 +1300,7 @@ class _MigrationSyncingContent extends StatelessWidget {
                 painter: _MigrationRingPainter(
                   trackColor: context.colors.border.subtle,
                   activeColor: context.colors.border.subtle,
-                  segments: math.max(1, totalParts),
+                  segmentWeights: segmentWeights,
                 ),
               ),
               Column(
@@ -2260,13 +2277,13 @@ class _MigrationValueRow extends StatelessWidget {
 class _AnimatedMigrationAttentionRing extends StatefulWidget {
   const _AnimatedMigrationAttentionRing({
     required this.dimension,
-    required this.segments,
+    required this.segmentWeights,
     required this.completedSegments,
     required this.highlightedSegments,
   });
 
   final double dimension;
-  final int segments;
+  final List<double> segmentWeights;
   final Set<int> completedSegments;
   final Set<int> highlightedSegments;
 
@@ -2335,7 +2352,7 @@ class _AnimatedMigrationAttentionRingState
         painter: _MigrationRingPainter(
           trackColor: context.colors.border.subtle,
           activeColor: const Color(0xFF00A460),
-          segments: widget.segments,
+          segmentWeights: widget.segmentWeights,
           completedSegments: widget.completedSegments,
           highlightedSegments: widget.highlightedSegments,
           highlightColor: context.colors.text.accent,
@@ -2350,7 +2367,7 @@ class _MigrationRingPainter extends CustomPainter {
   const _MigrationRingPainter({
     required this.trackColor,
     required this.activeColor,
-    required this.segments,
+    required this.segmentWeights,
     this.completedSegments = const {},
     this.highlightedSegments = const {},
     this.highlightColor,
@@ -2359,12 +2376,14 @@ class _MigrationRingPainter extends CustomPainter {
 
   final Color trackColor;
   final Color activeColor;
-  final int segments;
+  final List<double> segmentWeights;
   final Set<int> completedSegments;
   final Set<int> highlightedSegments;
   final Color? highlightColor;
   final double highlightOpacity;
   final double visibleSegmentGap = 4;
+
+  int get segments => segmentWeights.length;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -2383,9 +2402,11 @@ class _MigrationRingPainter extends CustomPainter {
             math.max(0, visibleSegmentGap) / radius,
             segmentPitch * 0.35,
           );
-    final segmentSweep = math.max(0.0, segmentPitch - gap);
+    final sweepBudget = math.max(0.0, math.pi * 2 - segments * gap);
+    var cursor = -math.pi / 2;
     for (var index = 0; index < segments; index++) {
-      final start = -math.pi / 2 + index * segmentPitch + gap / 2;
+      final segmentSweep = segmentWeights[index] * sweepBudget;
+      final start = cursor + gap / 2;
       final paint = Paint()
         ..style = PaintingStyle.stroke
         ..strokeCap = useRoundCaps ? StrokeCap.round : StrokeCap.butt
@@ -2396,6 +2417,7 @@ class _MigrationRingPainter extends CustomPainter {
           ? (highlightColor ?? activeColor).withValues(alpha: highlightOpacity)
           : trackColor;
       canvas.drawArc(rect, start, segmentSweep, false, paint);
+      cursor += segmentSweep + gap;
     }
   }
 
@@ -2403,13 +2425,43 @@ class _MigrationRingPainter extends CustomPainter {
   bool shouldRepaint(_MigrationRingPainter oldDelegate) {
     return trackColor != oldDelegate.trackColor ||
         activeColor != oldDelegate.activeColor ||
-        segments != oldDelegate.segments ||
+        !_sameDoubleList(segmentWeights, oldDelegate.segmentWeights) ||
         completedSegments != oldDelegate.completedSegments ||
         highlightedSegments != oldDelegate.highlightedSegments ||
         highlightColor != oldDelegate.highlightColor ||
         highlightOpacity != oldDelegate.highlightOpacity ||
         visibleSegmentGap != oldDelegate.visibleSegmentGap;
   }
+}
+
+List<double> _normalizedMigrationRingWeights({
+  required int segments,
+  required List<BigInt>? valuesZatoshi,
+}) {
+  final safeSegments = math.max(1, segments);
+  List<double> equalWeights() =>
+      List<double>.filled(safeSegments, 1 / safeSegments);
+  if (valuesZatoshi == null ||
+      valuesZatoshi.length != safeSegments ||
+      valuesZatoshi.any((value) => value <= BigInt.zero)) {
+    return equalWeights();
+  }
+  final total = valuesZatoshi.fold<BigInt>(
+    BigInt.zero,
+    (sum, value) => sum + value,
+  );
+  if (total <= BigInt.zero) return equalWeights();
+  final totalDouble = total.toDouble();
+  if (!totalDouble.isFinite || totalDouble <= 0) return equalWeights();
+  return [for (final value in valuesZatoshi) value.toDouble() / totalDouble];
+}
+
+bool _sameDoubleList(List<double> first, List<double> second) {
+  if (first.length != second.length) return false;
+  for (var index = 0; index < first.length; index++) {
+    if (first[index] != second[index]) return false;
+  }
+  return true;
 }
 
 class _MigrationWaitLoopPainter extends CustomPainter {

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -385,6 +385,7 @@ class _MobileMigrationRedesignedStatusState
         onBack: () => context.go('/home'),
         completedParts: _completedParts(widget.status),
         totalParts: _totalParts(widget.status),
+        segmentValuesZatoshi: _migrationRingSegmentValues(widget.status),
         migratedAmountText: _migratedAmountText(widget.status),
         totalAmountText: _totalAmountText(widget.status),
         availableAmountText: _availableAmountText(accountUuid),
@@ -411,6 +412,7 @@ class _MobileMigrationRedesignedStatusState
         onBack: () => context.go('/home'),
         completedParts: _completedParts(widget.status),
         totalParts: _totalParts(widget.status),
+        segmentValuesZatoshi: _migrationRingSegmentValues(widget.status),
         completedBatches: batchProgress.completedBatches,
         totalBatches: batchProgress.totalBatches,
         currentBatchStartIndex: batchProgress.currentBatchStartIndex,
@@ -456,6 +458,7 @@ class _MobileMigrationRedesignedStatusState
         onBack: () => context.go('/home'),
         completedParts: _completedParts(widget.status),
         totalParts: _totalParts(widget.status),
+        segmentValuesZatoshi: _migrationRingSegmentValues(widget.status),
         completedBatches: batchProgress.completedBatches,
         totalBatches: batchProgress.totalBatches,
         currentBatchStartIndex: batchProgress.currentBatchStartIndex,
@@ -532,6 +535,7 @@ class _MobileMigrationRedesignedStatusState
       onBack: () => context.go('/home'),
       completedParts: _completedParts(widget.status),
       totalParts: _totalParts(widget.status),
+      segmentValuesZatoshi: _migrationRingSegmentValues(widget.status),
       completedBatches: batchProgress.completedBatches,
       totalBatches: batchProgress.totalBatches,
       currentBatchStartIndex: batchProgress.currentBatchStartIndex,
@@ -1021,6 +1025,32 @@ class _MobileMigrationRedesignedStatusState
         math.max(status.parts.length, status.targetValuesZatoshi.length),
       ),
     );
+  }
+
+  List<BigInt>? _migrationRingSegmentValues(rust_sync.MigrationStatus status) {
+    final totalParts = _totalParts(status);
+    final targetValues = status.targetValuesZatoshi;
+    final values = targetValues.length == totalParts
+        ? List<BigInt>.of(targetValues)
+        : null;
+    if (status.parts.isEmpty) return values;
+
+    final orderedParts = [...status.parts]
+      ..sort((left, right) => left.partIndex.compareTo(right.partIndex));
+    final hasCompletePartValues =
+        orderedParts.length == totalParts &&
+        orderedParts.indexed.every((entry) => entry.$2.partIndex == entry.$1);
+    if (hasCompletePartValues) {
+      return [for (final part in orderedParts) part.valueZatoshi];
+    }
+    if (values == null) return null;
+
+    for (final part in status.parts) {
+      if (part.partIndex >= 0 && part.partIndex < totalParts) {
+        values[part.partIndex] = part.valueZatoshi;
+      }
+    }
+    return values;
   }
 
   String _migratedAmountText(rust_sync.MigrationStatus status) {

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -415,8 +415,6 @@ class _MobileMigrationRedesignedStatusState
         segmentValuesZatoshi: _migrationRingSegmentValues(widget.status),
         completedBatches: batchProgress.completedBatches,
         totalBatches: batchProgress.totalBatches,
-        currentBatchStartIndex: batchProgress.currentBatchStartIndex,
-        currentBatchPartCount: batchProgress.currentBatchPartCount,
         completedRingSegments: _completedRingSegments(widget.status),
         migratedAmountText: _migratedAmountText(widget.status),
         totalAmountText: _totalAmountText(widget.status),
@@ -461,8 +459,6 @@ class _MobileMigrationRedesignedStatusState
         segmentValuesZatoshi: _migrationRingSegmentValues(widget.status),
         completedBatches: batchProgress.completedBatches,
         totalBatches: batchProgress.totalBatches,
-        currentBatchStartIndex: batchProgress.currentBatchStartIndex,
-        currentBatchPartCount: batchProgress.currentBatchPartCount,
         completedRingSegments: _completedRingSegments(widget.status),
         migratedAmountText: _migratedAmountText(widget.status),
         totalAmountText: _totalAmountText(widget.status),
@@ -538,11 +534,8 @@ class _MobileMigrationRedesignedStatusState
       segmentValuesZatoshi: _migrationRingSegmentValues(widget.status),
       completedBatches: batchProgress.completedBatches,
       totalBatches: batchProgress.totalBatches,
-      currentBatchStartIndex: batchProgress.currentBatchStartIndex,
-      currentBatchPartCount: batchProgress.currentBatchPartCount,
       completedRingSegments: _completedRingSegments(widget.status),
-      highlightCurrentBatch:
-          !signingAllKeystoneTransactions && !resigningKeystoneTransactions,
+      currentSigningPartIndices: _currentSigningPartIndices(widget.status),
       migratedAmountText: _migratedAmountText(widget.status),
       totalAmountText: _totalAmountText(widget.status),
       availableAmountText: _availableAmountText(accountUuid),
@@ -1025,6 +1018,10 @@ class _MobileMigrationRedesignedStatusState
         math.max(status.parts.length, status.targetValuesZatoshi.length),
       ),
     );
+  }
+
+  Set<int> _currentSigningPartIndices(rust_sync.MigrationStatus status) {
+    return status.currentSigningPartIndices?.toSet() ?? const {};
   }
 
   List<BigInt>? _migrationRingSegmentValues(rust_sync.MigrationStatus status) {

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -535,7 +535,7 @@ class _MobileMigrationRedesignedStatusState
       completedBatches: batchProgress.completedBatches,
       totalBatches: batchProgress.totalBatches,
       completedRingSegments: _completedRingSegments(widget.status),
-      currentSigningPartIndices: _currentSigningPartIndices(widget.status),
+      currentSigningPartIndices: _currentSigningRingSegments(widget.status),
       migratedAmountText: _migratedAmountText(widget.status),
       totalAmountText: _totalAmountText(widget.status),
       availableAmountText: _availableAmountText(accountUuid),
@@ -830,12 +830,19 @@ class _MobileMigrationRedesignedStatusState
           index,
       };
     }
-    final ordered = [...status.parts]
-      ..sort((left, right) => left.partIndex.compareTo(right.partIndex));
+    final stateByPartIndex = {
+      for (final part in status.parts) part.partIndex: part.state,
+    };
+    final partOrder = _migrationRingPartOrder(status);
     return {
-      for (var index = 0; index < ordered.length; index++)
-        if (ordered[index].state == rust_sync.MigrationPartState.completed)
-          index,
+      for (
+        var displayIndex = 0;
+        displayIndex < partOrder.length;
+        displayIndex++
+      )
+        if (stateByPartIndex[partOrder[displayIndex]] ==
+            rust_sync.MigrationPartState.completed)
+          displayIndex,
     };
   }
 
@@ -1020,34 +1027,51 @@ class _MobileMigrationRedesignedStatusState
     );
   }
 
-  Set<int> _currentSigningPartIndices(rust_sync.MigrationStatus status) {
-    return status.currentSigningPartIndices?.toSet() ?? const {};
+  List<int> _migrationRingPartOrder(rust_sync.MigrationStatus status) {
+    final totalParts = _totalParts(status);
+    final orderedParts = _orderedMobileMigrationParts(status.parts);
+    final partIndices = orderedParts.map((part) => part.partIndex).toSet();
+    final hasCompletePartOrder =
+        orderedParts.length == totalParts &&
+        partIndices.length == totalParts &&
+        partIndices.every((partIndex) => partIndex < totalParts);
+    return hasCompletePartOrder
+        ? [for (final part in orderedParts) part.partIndex]
+        : List<int>.generate(totalParts, (index) => index);
+  }
+
+  Set<int> _currentSigningRingSegments(rust_sync.MigrationStatus status) {
+    final signingPartIndices =
+        status.currentSigningPartIndices?.toSet() ?? const <int>{};
+    final partOrder = _migrationRingPartOrder(status);
+    return {
+      for (
+        var displayIndex = 0;
+        displayIndex < partOrder.length;
+        displayIndex++
+      )
+        if (signingPartIndices.contains(partOrder[displayIndex])) displayIndex,
+    };
   }
 
   List<BigInt>? _migrationRingSegmentValues(rust_sync.MigrationStatus status) {
     final totalParts = _totalParts(status);
     final targetValues = status.targetValuesZatoshi;
-    final values = targetValues.length == totalParts
-        ? List<BigInt>.of(targetValues)
-        : null;
-    if (status.parts.isEmpty) return values;
-
-    final orderedParts = [...status.parts]
-      ..sort((left, right) => left.partIndex.compareTo(right.partIndex));
-    final hasCompletePartValues =
-        orderedParts.length == totalParts &&
-        orderedParts.indexed.every((entry) => entry.$2.partIndex == entry.$1);
-    if (hasCompletePartValues) {
-      return [for (final part in orderedParts) part.valueZatoshi];
-    }
-    if (values == null) return null;
-
-    for (final part in status.parts) {
-      if (part.partIndex >= 0 && part.partIndex < totalParts) {
-        values[part.partIndex] = part.valueZatoshi;
+    final valueByPartIndex = {
+      for (final part in status.parts) part.partIndex: part.valueZatoshi,
+    };
+    final values = <BigInt>[];
+    for (final partIndex in _migrationRingPartOrder(status)) {
+      final partValue = valueByPartIndex[partIndex];
+      if (partValue != null) {
+        values.add(partValue);
+      } else if (partIndex < targetValues.length) {
+        values.add(targetValues[partIndex]);
+      } else {
+        return null;
       }
     }
-    return values;
+    return values.length == totalParts ? values : null;
   }
 
   String _migratedAmountText(rust_sync.MigrationStatus status) {

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -377,7 +377,6 @@ class _MobileMigrationRedesignedStatusState
           kIronwoodMigrationWaitingDenomConfirmationsPhase) {
         return _MigrationPreparationPreview(
           state: _MigrationPreparationState.syncing,
-          progress: _preparationProgress(widget.status),
           onBack: () => context.go('/home'),
         );
       }
@@ -397,7 +396,6 @@ class _MobileMigrationRedesignedStatusState
             kIronwoodMigrationWaitingDenomConfirmationsPhase) {
       return _MigrationPreparationPreview(
         state: _MigrationPreparationState.paused,
-        progress: _preparationProgress(widget.status),
         isKeystone: widget.isHardware,
         onBack: () => context.go('/home'),
         onContinue: accountUuid == null || _actionRunning
@@ -492,7 +490,6 @@ class _MobileMigrationRedesignedStatusState
         state: needsManualResume
             ? _MigrationPreparationState.paused
             : _MigrationPreparationState.active,
-        progress: _preparationProgress(widget.status),
         isKeystone: widget.isHardware,
         onBack: () => context.go('/home'),
         onContinue: !needsManualResume || accountUuid == null
@@ -1014,23 +1011,6 @@ class _MobileMigrationRedesignedStatusState
         ? 0
         : ((needsInput * BigInt.from(100)) ~/ total).toInt();
     return '$amount ZEC ($percentage%)';
-  }
-
-  double _preparationProgress(rust_sync.MigrationStatus status) {
-    final totalStages = status.denominationSplitTotalCount;
-    if (totalStages <= 0) return 0;
-    final completedStages = status.denominationSplitCompletedCount.clamp(
-      0,
-      totalStages,
-    );
-    final confirmationTarget = status.denominationConfirmationTarget;
-    final currentStageProgress = confirmationTarget <= 0
-        ? 0.0
-        : status.denominationConfirmationCount.clamp(0, confirmationTarget) /
-              confirmationTarget;
-    return ((completedStages + currentStageProgress) / totalStages)
-        .clamp(0.0, 1.0)
-        .toDouble();
   }
 
   int _totalParts(rust_sync.MigrationStatus status) {

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_status_presentation.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_status_presentation.dart
@@ -23,6 +23,43 @@ class MobileIronwoodMigrationPartPresentation {
   final double? progress;
 }
 
+List<rust_sync.MigrationPartStatus> _orderedMobileMigrationParts(
+  Iterable<rust_sync.MigrationPartStatus> parts,
+) {
+  final orderedParts = [...parts];
+  if (orderedParts.every((part) => part.scheduledHeight != null)) {
+    orderedParts.sort((left, right) {
+      final byHeight = left.scheduledHeight!.compareTo(right.scheduledHeight!);
+      if (byHeight != 0) return byHeight;
+      final leftTxid = left.txidHex;
+      final rightTxid = right.txidHex;
+      if (leftTxid != null && rightTxid != null) {
+        final byTxid = leftTxid.compareTo(rightTxid);
+        if (byTxid != 0) return byTxid;
+      }
+      final leftOrder = left.scheduleOrder;
+      final rightOrder = right.scheduleOrder;
+      if (leftOrder != null && rightOrder != null) {
+        final bySchedule = leftOrder.compareTo(rightOrder);
+        if (bySchedule != 0) return bySchedule;
+      }
+      return left.partIndex.compareTo(right.partIndex);
+    });
+  } else if (orderedParts.every((part) => part.scheduleOrder != null)) {
+    orderedParts.sort((left, right) {
+      final bySchedule = left.scheduleOrder!.compareTo(right.scheduleOrder!);
+      return bySchedule != 0
+          ? bySchedule
+          : left.partIndex.compareTo(right.partIndex);
+    });
+  } else {
+    orderedParts.sort(
+      (left, right) => left.partIndex.compareTo(right.partIndex),
+    );
+  }
+  return orderedParts;
+}
+
 List<MobileIronwoodMigrationPartPresentation>
 _mobileMigrationPartPresentations({
   required rust_sync.MigrationStatus? status,
@@ -42,28 +79,7 @@ _mobileMigrationPartPresentations({
       for (final transfer in previewPlan?.scheduledTransfers ?? const [])
         transfer.partIndex: transfer,
     };
-    final orderedParts = [...statusParts];
-    if (orderedParts.every((part) => part.scheduleOrder != null)) {
-      orderedParts.sort((left, right) {
-        final bySchedule = left.scheduleOrder!.compareTo(right.scheduleOrder!);
-        return bySchedule != 0
-            ? bySchedule
-            : left.partIndex.compareTo(right.partIndex);
-      });
-    } else if (orderedParts.every((part) => part.scheduledHeight != null)) {
-      orderedParts.sort((left, right) {
-        final byHeight = left.scheduledHeight!.compareTo(
-          right.scheduledHeight!,
-        );
-        return byHeight != 0
-            ? byHeight
-            : left.partIndex.compareTo(right.partIndex);
-      });
-    } else {
-      orderedParts.sort(
-        (left, right) => left.partIndex.compareTo(right.partIndex),
-      );
-    }
+    final orderedParts = _orderedMobileMigrationParts(statusParts);
     return List.generate(orderedParts.length, (displayIndex) {
       final part = orderedParts[displayIndex];
       final needsAttention =

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -1475,6 +1475,7 @@ class MigrationStatus {
   final int? nextActionHeight;
   final int? estimatedCompletionHeight;
   final int? nextActionPartIndex;
+  final Uint32List? currentSigningPartIndices;
   final List<MigrationScheduledBroadcast> scheduledBroadcasts;
   final List<MigrationPartStatus> parts;
 
@@ -1501,6 +1502,7 @@ class MigrationStatus {
     this.nextActionHeight,
     this.estimatedCompletionHeight,
     this.nextActionPartIndex,
+    this.currentSigningPartIndices,
     required this.scheduledBroadcasts,
     required this.parts,
   });
@@ -1529,6 +1531,7 @@ class MigrationStatus {
       nextActionHeight.hashCode ^
       estimatedCompletionHeight.hashCode ^
       nextActionPartIndex.hashCode ^
+      currentSigningPartIndices.hashCode ^
       scheduledBroadcasts.hashCode ^
       parts.hashCode;
 
@@ -1562,6 +1565,7 @@ class MigrationStatus {
           nextActionHeight == other.nextActionHeight &&
           estimatedCompletionHeight == other.estimatedCompletionHeight &&
           nextActionPartIndex == other.nextActionPartIndex &&
+          currentSigningPartIndices == other.currentSigningPartIndices &&
           scheduledBroadcasts == other.scheduledBroadcasts &&
           parts == other.parts;
 }

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -8629,8 +8629,8 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   MigrationStatus dco_decode_migration_status(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 24)
-      throw Exception('unexpected arr length: expect 24 but see ${arr.length}');
+    if (arr.length != 25)
+      throw Exception('unexpected arr length: expect 25 but see ${arr.length}');
     return MigrationStatus(
       phase: dco_decode_String(arr[0]),
       activeRunId: dco_decode_opt_String(arr[1]),
@@ -8654,10 +8654,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       nextActionHeight: dco_decode_opt_box_autoadd_u_32(arr[19]),
       estimatedCompletionHeight: dco_decode_opt_box_autoadd_u_32(arr[20]),
       nextActionPartIndex: dco_decode_opt_box_autoadd_u_32(arr[21]),
+      currentSigningPartIndices: dco_decode_opt_list_prim_u_32_strict(arr[22]),
       scheduledBroadcasts: dco_decode_list_migration_scheduled_broadcast(
-        arr[22],
+        arr[23],
       ),
-      parts: dco_decode_list_migration_part_status(arr[23]),
+      parts: dco_decode_list_migration_part_status(arr[24]),
     );
   }
 
@@ -8763,6 +8764,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   BigInt? dco_decode_opt_box_autoadd_u_64(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_box_autoadd_u_64(raw);
+  }
+
+  @protected
+  Uint32List? dco_decode_opt_list_prim_u_32_strict(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_list_prim_u_32_strict(raw);
   }
 
   @protected
@@ -11190,6 +11197,9 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       deserializer,
     );
     var var_nextActionPartIndex = sse_decode_opt_box_autoadd_u_32(deserializer);
+    var var_currentSigningPartIndices = sse_decode_opt_list_prim_u_32_strict(
+      deserializer,
+    );
     var var_scheduledBroadcasts = sse_decode_list_migration_scheduled_broadcast(
       deserializer,
     );
@@ -11217,6 +11227,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       nextActionHeight: var_nextActionHeight,
       estimatedCompletionHeight: var_estimatedCompletionHeight,
       nextActionPartIndex: var_nextActionPartIndex,
+      currentSigningPartIndices: var_currentSigningPartIndices,
       scheduledBroadcasts: var_scheduledBroadcasts,
       parts: var_parts,
     );
@@ -11382,6 +11393,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
     if (sse_decode_bool(deserializer)) {
       return (sse_decode_box_autoadd_u_64(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  Uint32List? sse_decode_opt_list_prim_u_32_strict(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_list_prim_u_32_strict(deserializer));
     } else {
       return null;
     }
@@ -13747,6 +13771,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_opt_box_autoadd_u_32(self.nextActionHeight, serializer);
     sse_encode_opt_box_autoadd_u_32(self.estimatedCompletionHeight, serializer);
     sse_encode_opt_box_autoadd_u_32(self.nextActionPartIndex, serializer);
+    sse_encode_opt_list_prim_u_32_strict(
+      self.currentSigningPartIndices,
+      serializer,
+    );
     sse_encode_list_migration_scheduled_broadcast(
       self.scheduledBroadcasts,
       serializer,
@@ -13892,6 +13920,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self != null, serializer);
     if (self != null) {
       sse_encode_box_autoadd_u_64(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_list_prim_u_32_strict(
+    Uint32List? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_list_prim_u_32_strict(self, serializer);
     }
   }
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -508,6 +508,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt? dco_decode_opt_box_autoadd_u_64(dynamic raw);
 
   @protected
+  Uint32List? dco_decode_opt_list_prim_u_32_strict(dynamic raw);
+
+  @protected
   Uint8List? dco_decode_opt_list_prim_u_8_strict(dynamic raw);
 
   @protected
@@ -1300,6 +1303,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   BigInt? sse_decode_opt_box_autoadd_u_64(SseDeserializer deserializer);
+
+  @protected
+  Uint32List? sse_decode_opt_list_prim_u_32_strict(
+    SseDeserializer deserializer,
+  );
 
   @protected
   Uint8List? sse_decode_opt_list_prim_u_8_strict(SseDeserializer deserializer);
@@ -2269,6 +2277,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_box_autoadd_u_64(BigInt? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_list_prim_u_32_strict(
+    Uint32List? self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_opt_list_prim_u_8_strict(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -510,6 +510,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   BigInt? dco_decode_opt_box_autoadd_u_64(dynamic raw);
 
   @protected
+  Uint32List? dco_decode_opt_list_prim_u_32_strict(dynamic raw);
+
+  @protected
   Uint8List? dco_decode_opt_list_prim_u_8_strict(dynamic raw);
 
   @protected
@@ -1302,6 +1305,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   BigInt? sse_decode_opt_box_autoadd_u_64(SseDeserializer deserializer);
+
+  @protected
+  Uint32List? sse_decode_opt_list_prim_u_32_strict(
+    SseDeserializer deserializer,
+  );
 
   @protected
   Uint8List? sse_decode_opt_list_prim_u_8_strict(SseDeserializer deserializer);
@@ -2271,6 +2279,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_opt_box_autoadd_u_64(BigInt? self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_opt_list_prim_u_32_strict(
+    Uint32List? self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_opt_list_prim_u_8_strict(

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -775,6 +775,7 @@ pub struct MigrationStatus {
     pub next_action_height: Option<u32>,
     pub estimated_completion_height: Option<u32>,
     pub next_action_part_index: Option<u32>,
+    pub current_signing_part_indices: Option<Vec<u32>>,
     pub scheduled_broadcasts: Vec<MigrationScheduledBroadcast>,
     pub parts: Vec<MigrationPartStatus>,
 }
@@ -1178,6 +1179,7 @@ pub fn get_orchard_migration_status(
             next_action_height: status.next_action_height,
             estimated_completion_height: status.estimated_completion_height,
             next_action_part_index: status.next_action_part_index,
+            current_signing_part_indices: Some(status.current_signing_part_indices),
             scheduled_broadcasts: status
                 .scheduled_broadcasts
                 .into_iter()

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -7797,6 +7797,7 @@ impl SseDecode for crate::api::sync::MigrationStatus {
         let mut var_nextActionHeight = <Option<u32>>::sse_decode(deserializer);
         let mut var_estimatedCompletionHeight = <Option<u32>>::sse_decode(deserializer);
         let mut var_nextActionPartIndex = <Option<u32>>::sse_decode(deserializer);
+        let mut var_currentSigningPartIndices = <Option<Vec<u32>>>::sse_decode(deserializer);
         let mut var_scheduledBroadcasts =
             <Vec<crate::api::sync::MigrationScheduledBroadcast>>::sse_decode(deserializer);
         let mut var_parts = <Vec<crate::api::sync::MigrationPartStatus>>::sse_decode(deserializer);
@@ -7823,6 +7824,7 @@ impl SseDecode for crate::api::sync::MigrationStatus {
             next_action_height: var_nextActionHeight,
             estimated_completion_height: var_estimatedCompletionHeight,
             next_action_part_index: var_nextActionPartIndex,
+            current_signing_part_indices: var_currentSigningPartIndices,
             scheduled_broadcasts: var_scheduledBroadcasts,
             parts: var_parts,
         };
@@ -7976,6 +7978,17 @@ impl SseDecode for Option<u64> {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         if (<bool>::sse_decode(deserializer)) {
             return Some(<u64>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<Vec<u32>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<Vec<u32>>::sse_decode(deserializer));
         } else {
             return None;
         }
@@ -10278,6 +10291,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::sync::MigrationStatus {
                 .into_into_dart()
                 .into_dart(),
             self.next_action_part_index.into_into_dart().into_dart(),
+            self.current_signing_part_indices
+                .into_into_dart()
+                .into_dart(),
             self.scheduled_broadcasts.into_into_dart().into_dart(),
             self.parts.into_into_dart().into_dart(),
         ]
@@ -12622,6 +12638,7 @@ impl SseEncode for crate::api::sync::MigrationStatus {
         <Option<u32>>::sse_encode(self.next_action_height, serializer);
         <Option<u32>>::sse_encode(self.estimated_completion_height, serializer);
         <Option<u32>>::sse_encode(self.next_action_part_index, serializer);
+        <Option<Vec<u32>>>::sse_encode(self.current_signing_part_indices, serializer);
         <Vec<crate::api::sync::MigrationScheduledBroadcast>>::sse_encode(
             self.scheduled_broadcasts,
             serializer,
@@ -12747,6 +12764,16 @@ impl SseEncode for Option<u64> {
         <bool>::sse_encode(self.is_some(), serializer);
         if let Some(value) = self {
             <u64>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<Vec<u32>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <Vec<u32>>::sse_encode(value, serializer);
         }
     }
 }

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -308,6 +308,8 @@ pub(crate) struct MigrationStatus {
     pub estimated_completion_height: Option<u32>,
     /// Part associated with `next_action_height`, when it can be identified.
     pub next_action_part_index: Option<u32>,
+    /// Exact migration parts the next signing operation will include.
+    pub current_signing_part_indices: Vec<u32>,
     pub scheduled_broadcasts: Vec<ScheduledMigrationBroadcast>,
     pub parts: Vec<MigrationPartStatus>,
 }
@@ -422,6 +424,7 @@ pub(crate) fn migration_status(
         next_action_height: None,
         estimated_completion_height: None,
         next_action_part_index: None,
+        current_signing_part_indices: Vec::new(),
         scheduled_broadcasts: Vec::new(),
         parts: Vec::new(),
     })
@@ -3499,6 +3502,18 @@ fn status_for_run(conn: &rusqlite::Connection, run: ActiveRun) -> Result<Migrati
             }
         }
     }
+    let recovery_part_indices = parts
+        .iter()
+        .filter(|part| part.state == MigrationPartState::NeedsInput)
+        .map(|part| part.part_index)
+        .collect::<Vec<_>>();
+    let current_signing_part_indices = select_migration_batch_signing_part_indices(
+        prepared_note_count,
+        pending_tx_count,
+        signed_child_pczt_count,
+        &recovery_part_indices,
+    )
+    .unwrap_or_default();
 
     Ok(MigrationStatus {
         phase,
@@ -3523,9 +3538,28 @@ fn status_for_run(conn: &rusqlite::Connection, run: ActiveRun) -> Result<Migrati
         next_action_height: timing_projection.next_action_height,
         estimated_completion_height: timing_projection.estimated_completion_height,
         next_action_part_index: timing_projection.next_action_part_index,
+        current_signing_part_indices,
         scheduled_broadcasts,
         parts,
     })
+}
+
+pub(crate) fn select_migration_batch_signing_part_indices(
+    prepared_note_count: u32,
+    pending_tx_count: u32,
+    signed_child_pczt_count: u32,
+    recovery_part_indices: &[u32],
+) -> Result<Vec<u32>, String> {
+    if !recovery_part_indices.is_empty() {
+        return Ok(recovery_part_indices.to_vec());
+    }
+    if prepared_note_count == 0 {
+        return Err("Migration run has no prepared denomination notes".to_string());
+    }
+    if pending_tx_count > 0 || signed_child_pczt_count > 0 {
+        return Err("Migration transactions are already signed and scheduled".to_string());
+    }
+    Ok((0..prepared_note_count).collect())
 }
 
 fn migration_parts_for_run(

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -3981,6 +3981,26 @@ fn ready_to_migrate_does_not_report_denomination_parts_as_completed_transfers() 
 }
 
 #[test]
+fn migration_batch_signing_selector_reports_initial_and_resign_requests_exactly() {
+    assert_eq!(
+        select_migration_batch_signing_part_indices(3, 0, 0, &[]).unwrap(),
+        vec![0, 1, 2]
+    );
+    assert_eq!(
+        select_migration_batch_signing_part_indices(2, 2, 2, &[1, 10]).unwrap(),
+        vec![1, 10]
+    );
+    assert_eq!(
+        select_migration_batch_signing_part_indices(0, 0, 0, &[]).unwrap_err(),
+        "Migration run has no prepared denomination notes"
+    );
+    assert_eq!(
+        select_migration_batch_signing_part_indices(3, 1, 0, &[]).unwrap_err(),
+        "Migration transactions are already signed and scheduled"
+    );
+}
+
+#[test]
 fn legacy_pending_parts_backfill_from_signed_child_identity() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     ensure_schema(&conn).unwrap();

--- a/rust/src/wallet/sync/send/ironwood_migration.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration.rs
@@ -606,16 +606,20 @@ pub(crate) fn prepare_orchard_migration_batch_pczt(
             .map(|recovery| recovery.selected_note.clone())
             .collect()
     };
-    if prepared_notes.is_empty() {
-        return Err("Migration run has no prepared denomination notes".to_string());
-    }
     let pending_totals = super::migration::pending_totals_for_run(db_path, &run.run_id)?;
-    if initial_signing
-        && (pending_totals.total_count > 0
-            || super::migration::signed_child_pczt_count(db_path, &run.run_id)? > 0)
-    {
-        return Err("Migration transactions are already signed and scheduled".to_string());
-    }
+    let signed_child_pczt_count =
+        super::migration::signed_child_pczt_count(db_path, &run.run_id)?;
+    let recovery_part_indices = recoveries
+        .iter()
+        .map(|recovery| recovery.part_index)
+        .collect::<Vec<_>>();
+    let signing_part_indices = super::migration::select_migration_batch_signing_part_indices(
+        u32::try_from(prepared_notes.len())
+            .map_err(|_| "Prepared migration note count exceeds u32".to_string())?,
+        pending_totals.total_count,
+        signed_child_pczt_count,
+        &recovery_part_indices,
+    )?;
     if !initial_signing && !prepared_note_spend_metadata_is_available(db_path, &run.run_id)? {
         return Err(
             "Prepared denomination notes are not spendable yet. Sync and try again.".to_string(),
@@ -633,10 +637,9 @@ pub(crate) fn prepare_orchard_migration_batch_pczt(
     let approved_schedule =
         super::migration::approved_schedule_for_run(db_path, &run.run_id)?;
     for (index, note_ref) in prepared_notes.iter().enumerate() {
-        let part_index = recoveries
+        let part_index = *signing_part_indices
             .get(index)
-            .map(|recovery| recovery.part_index)
-            .unwrap_or(index as u32);
+            .ok_or("Migration signing selector omitted a prepared note")?;
         let schedule_block_offset = super::migration::schedule_block_offset_for_part(
             &approved_schedule,
             &run.target_values_zatoshi,
@@ -646,10 +649,7 @@ pub(crate) fn prepare_orchard_migration_batch_pczt(
                 .ok_or("Migration part is outside the approved target list")?,
         )
         .ok_or("Approved migration schedule is missing a child")?;
-        let migration_index = recoveries
-            .get(index)
-            .map(|recovery| recovery.part_index + 1)
-            .unwrap_or((index + 1) as u32);
+        let migration_index = part_index + 1;
         let pczt_result = if initial_signing {
             create_deferred_orchard_to_ironwood_pczt_from_prepared_note(
                 db_path,

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -3828,7 +3828,7 @@ void main() {
   });
 
   testWidgets(
-    'maps denomination confirmation progress into the preparation ring',
+    'renders the neutral preparation idle ring when animations are disabled',
     (tester) async {
       _useMobileViewport(tester);
       await tester.pumpWidget(
@@ -3843,13 +3843,58 @@ void main() {
       await tester.pumpAndSettle();
 
       final ring = tester.widget<CustomPaint>(
-        find.byKey(const ValueKey('mobile_ironwood_preparation_progress_ring')),
+        find.byKey(const ValueKey('mobile_ironwood_preparation_idle_ring')),
       );
       final painter = ring.painter as dynamic;
-      expect(painter.progress as double, closeTo(5 / 9, 0.0001));
+      final weights = painter.weights as List<double>;
+      expect(weights, hasLength(9));
+      expect(weights.reduce((a, b) => a + b), closeTo(1, 0.0001));
+      expect(painter.rotation as double, 0);
       expect(painter.visibleSegmentGap as double, 4);
     },
   );
+
+  testWidgets('animates the preparation idle ring', (tester) async {
+    _useMobileViewport(tester);
+    await tester.pumpWidget(
+      _app(
+        step: MobileIronwoodMigrationStep.migrating,
+        previewSurface: MobileIronwoodMigrationPreviewSurface.preparationActive,
+        disableAnimations: false,
+      ),
+    );
+    await tester.pump();
+
+    final ringFinder = find.byKey(
+      const ValueKey('mobile_ironwood_preparation_idle_ring'),
+    );
+    final initialPainter =
+        tester.widget<CustomPaint>(ringFinder).painter as dynamic;
+    final initialWeights = List<double>.of(
+      initialPainter.weights as List<double>,
+    );
+    final initialRotation = initialPainter.rotation as double;
+
+    await tester.pump(const Duration(milliseconds: 400));
+    await tester.pump();
+    var didAnimate = false;
+    for (var frame = 0; frame < 12; frame++) {
+      await tester.pump(const Duration(milliseconds: 100));
+      final animatedPainter =
+          tester.widget<CustomPaint>(ringFinder).painter as dynamic;
+      final animatedWeights = animatedPainter.weights as List<double>;
+      final animatedRotation = animatedPainter.rotation as double;
+      didAnimate =
+          didAnimate ||
+          animatedWeights.asMap().entries.any(
+            (entry) => entry.value != initialWeights[entry.key],
+          ) ||
+          animatedRotation != initialRotation;
+    }
+
+    expect(didAnimate, isTrue);
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets(
     'keeps the preparation complete modal visible during wallet sync',

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -3251,11 +3251,47 @@ void main() {
     final painter = ring.painter as dynamic;
     expect(painter.segments, 10);
     expect(painter.completedSegments, {
-      for (var index = 0; index < 8; index++) index,
+      for (var index = 1; index <= 8; index++) index,
     });
-    expect(painter.highlightedSegments, {8, 9});
+    expect(painter.highlightedSegments, {0, 9});
     expect(painter.visibleSegmentGap, 4);
     expect(tester.getCenter(find.text('2 ZEC (20%)')).dx, greaterThan(250));
+  });
+
+  testWidgets('keeps action batch selection in part-index order', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    final parts = [
+      for (var index = 0; index < 10; index++)
+        rust_sync.MigrationPartStatus(
+          partIndex: index,
+          scheduleOrder: index == 8 ? 0 : index + 1,
+          valueZatoshi: BigInt.from(100_000_000),
+          state: index == 2 || index == 8
+              ? rust_sync.MigrationPartState.needsInput
+              : rust_sync.MigrationPartState.scheduled,
+          confirmationCount: 0,
+          confirmationTarget: 3,
+        ),
+    ];
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(),
+        status: _status(
+          phase: kIronwoodMigrationReadyToMigratePhase,
+          parts: parts,
+          targetValues: List<int>.filled(10, 100_000_000),
+          currentSigningPartIndices: const [2, 8],
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Batch #1'), findsOneWidget);
+    expect(find.text('8 ZEC (80%)'), findsOneWidget);
+    expect(find.text('Sign batch #1'), findsOneWidget);
   });
 
   testWidgets('highlights every part in the initial signing request', (
@@ -3446,66 +3482,73 @@ void main() {
     },
   );
 
-  testWidgets(
-    'sizes migration ring segments by note balance in part-index order',
-    (tester) async {
-      _useMobileViewport(tester);
-      final parts = [
-        rust_sync.MigrationPartStatus(
-          partIndex: 2,
-          scheduleOrder: 0,
-          valueZatoshi: BigInt.from(300_000_000),
-          state: rust_sync.MigrationPartState.completed,
-          confirmationCount: 3,
-          confirmationTarget: 3,
+  testWidgets('orders migration ring by current scheduled execution', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    final parts = [
+      rust_sync.MigrationPartStatus(
+        partIndex: 2,
+        scheduleOrder: 0,
+        scheduledHeight: 3_000_200,
+        txidHex: 'bb',
+        valueZatoshi: BigInt.from(300_000_000),
+        state: rust_sync.MigrationPartState.completed,
+        confirmationCount: 3,
+        confirmationTarget: 3,
+      ),
+      rust_sync.MigrationPartStatus(
+        partIndex: 0,
+        scheduleOrder: 2,
+        scheduledHeight: 3_000_100,
+        txidHex: 'cc',
+        valueZatoshi: BigInt.from(100_000_000),
+        state: rust_sync.MigrationPartState.scheduled,
+        confirmationCount: 0,
+        confirmationTarget: 3,
+      ),
+      rust_sync.MigrationPartStatus(
+        partIndex: 1,
+        scheduleOrder: 1,
+        scheduledHeight: 3_000_200,
+        txidHex: 'aa',
+        valueZatoshi: BigInt.from(200_000_000),
+        state: rust_sync.MigrationPartState.needsInput,
+        confirmationCount: 0,
+        confirmationTarget: 3,
+      ),
+    ];
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(),
+        status: _status(
+          phase: kIronwoodMigrationReadyToMigratePhase,
+          parts: parts,
+          targetValues: const [100_000_000, 200_000_000, 300_000_000],
+          currentSigningPartIndices: const [1],
         ),
-        rust_sync.MigrationPartStatus(
-          partIndex: 0,
-          scheduleOrder: 2,
-          valueZatoshi: BigInt.from(100_000_000),
-          state: rust_sync.MigrationPartState.scheduled,
-          confirmationCount: 0,
-          confirmationTarget: 3,
-        ),
-        rust_sync.MigrationPartStatus(
-          partIndex: 1,
-          scheduleOrder: 1,
-          valueZatoshi: BigInt.from(200_000_000),
-          state: rust_sync.MigrationPartState.needsInput,
-          confirmationCount: 0,
-          confirmationTarget: 3,
-        ),
-      ];
-      await tester.pumpWidget(
-        _productionApp(
-          initialLocation: '/migration/private/status',
-          migrationService: _migrationService(),
-          status: _status(
-            phase: kIronwoodMigrationReadyToMigratePhase,
-            parts: parts,
-            targetValues: const [100_000_000, 200_000_000, 300_000_000],
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      final ring = tester.widget<CustomPaint>(
-        find.byWidgetPredicate(
-          (widget) =>
-              widget is CustomPaint &&
-              widget.painter.runtimeType.toString() == '_MigrationRingPainter',
-        ),
-      );
-      final painter = ring.painter as dynamic;
-      final weights = painter.segmentWeights as List<double>;
-      expect(weights, hasLength(3));
-      expect(weights[0], closeTo(1 / 6, 0.000001));
-      expect(weights[1], closeTo(2 / 6, 0.000001));
-      expect(weights[2], closeTo(3 / 6, 0.000001));
-      expect(weights.reduce((sum, value) => sum + value), closeTo(1, 1e-12));
-      expect(painter.completedSegments, {2});
-    },
-  );
+    final ring = tester.widget<CustomPaint>(
+      find.byWidgetPredicate(
+        (widget) =>
+            widget is CustomPaint &&
+            widget.painter.runtimeType.toString() == '_MigrationRingPainter',
+      ),
+    );
+    final painter = ring.painter as dynamic;
+    final weights = painter.segmentWeights as List<double>;
+    expect(weights, hasLength(3));
+    expect(weights[0], closeTo(1 / 6, 0.000001));
+    expect(weights[1], closeTo(2 / 6, 0.000001));
+    expect(weights[2], closeTo(3 / 6, 0.000001));
+    expect(weights.reduce((sum, value) => sum + value), closeTo(1, 1e-12));
+    expect(painter.completedSegments, {2});
+    expect(painter.highlightedSegments, {1});
+  });
 
   testWidgets('records a Keystone signing action while status is visible', (
     tester,

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -3253,6 +3253,67 @@ void main() {
     expect(tester.getCenter(find.text('2 ZEC (20%)')).dx, greaterThan(250));
   });
 
+  testWidgets(
+    'sizes migration ring segments by note balance in part-index order',
+    (tester) async {
+      _useMobileViewport(tester);
+      final parts = [
+        rust_sync.MigrationPartStatus(
+          partIndex: 2,
+          scheduleOrder: 0,
+          valueZatoshi: BigInt.from(300_000_000),
+          state: rust_sync.MigrationPartState.completed,
+          confirmationCount: 3,
+          confirmationTarget: 3,
+        ),
+        rust_sync.MigrationPartStatus(
+          partIndex: 0,
+          scheduleOrder: 2,
+          valueZatoshi: BigInt.from(100_000_000),
+          state: rust_sync.MigrationPartState.scheduled,
+          confirmationCount: 0,
+          confirmationTarget: 3,
+        ),
+        rust_sync.MigrationPartStatus(
+          partIndex: 1,
+          scheduleOrder: 1,
+          valueZatoshi: BigInt.from(200_000_000),
+          state: rust_sync.MigrationPartState.needsInput,
+          confirmationCount: 0,
+          confirmationTarget: 3,
+        ),
+      ];
+      await tester.pumpWidget(
+        _productionApp(
+          initialLocation: '/migration/private/status',
+          migrationService: _migrationService(),
+          status: _status(
+            phase: kIronwoodMigrationReadyToMigratePhase,
+            parts: parts,
+            targetValues: const [100_000_000, 200_000_000, 300_000_000],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final ring = tester.widget<CustomPaint>(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is CustomPaint &&
+              widget.painter.runtimeType.toString() == '_MigrationRingPainter',
+        ),
+      );
+      final painter = ring.painter as dynamic;
+      final weights = painter.segmentWeights as List<double>;
+      expect(weights, hasLength(3));
+      expect(weights[0], closeTo(1 / 6, 0.000001));
+      expect(weights[1], closeTo(2 / 6, 0.000001));
+      expect(weights[2], closeTo(3 / 6, 0.000001));
+      expect(weights.reduce((sum, value) => sum + value), closeTo(1, 1e-12));
+      expect(painter.completedSegments, {2});
+    },
+  );
+
   testWidgets('records a Keystone signing action while status is visible', (
     tester,
   ) async {

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -348,6 +348,7 @@ rust_sync.MigrationStatus _status({
   int? nextActionHeight,
   int? estimatedCompletionHeight,
   int? nextActionPartIndex,
+  List<int>? currentSigningPartIndices,
   int pendingTxCount = 2,
   int signedChildPcztCount = 0,
   String? message,
@@ -375,6 +376,9 @@ rust_sync.MigrationStatus _status({
     nextActionHeight: nextActionHeight,
     estimatedCompletionHeight: estimatedCompletionHeight,
     nextActionPartIndex: nextActionPartIndex,
+    currentSigningPartIndices: currentSigningPartIndices == null
+        ? null
+        : frb.Uint32List.fromList(currentSigningPartIndices),
     message: message,
     scheduledBroadcasts:
         scheduledBroadcasts ??
@@ -3228,6 +3232,7 @@ void main() {
           phase: kIronwoodMigrationReadyToMigratePhase,
           parts: parts,
           targetValues: List<int>.filled(10, 100_000_000),
+          currentSigningPartIndices: const [8, 9],
         ),
       ),
     );
@@ -3252,6 +3257,194 @@ void main() {
     expect(painter.visibleSegmentGap, 4);
     expect(tester.getCenter(find.text('2 ZEC (20%)')).dx, greaterThan(250));
   });
+
+  testWidgets('highlights every part in the initial signing request', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    final parts = [
+      for (var index = 0; index < 10; index++)
+        rust_sync.MigrationPartStatus(
+          partIndex: index,
+          scheduleOrder: index,
+          valueZatoshi: BigInt.from(100_000_000),
+          state: rust_sync.MigrationPartState.preparing,
+          confirmationCount: 0,
+          confirmationTarget: 3,
+        ),
+    ];
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(),
+        status: _status(
+          phase: kIronwoodMigrationReadyToMigratePhase,
+          parts: parts,
+          targetValues: List<int>.filled(10, 100_000_000),
+          currentSigningPartIndices: List<int>.generate(10, (index) => index),
+        ),
+        hardware: true,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final ring = tester.widget<CustomPaint>(
+      find.byKey(const ValueKey('mobile_ironwood_migration_attention_ring')),
+    );
+    final painter = ring.painter as dynamic;
+    expect(painter.highlightedSegments, {
+      for (var index = 0; index < 10; index++) index,
+    });
+  });
+
+  testWidgets(
+    'highlights only the multiple parts marked for the signing request',
+    (tester) async {
+      _useMobileViewport(tester);
+      final parts = [
+        for (var index = 0; index < 12; index++)
+          rust_sync.MigrationPartStatus(
+            partIndex: index,
+            scheduleOrder: index,
+            valueZatoshi: BigInt.from(100_000_000),
+            state: index == 1 || index == 10
+                ? rust_sync.MigrationPartState.needsInput
+                : rust_sync.MigrationPartState.scheduled,
+            confirmationCount: 0,
+            confirmationTarget: 3,
+          ),
+      ];
+      await tester.pumpWidget(
+        _productionApp(
+          initialLocation: '/migration/private/status',
+          migrationService: _migrationService(),
+          status: _status(
+            phase: kIronwoodMigrationReadyToMigratePhase,
+            parts: parts,
+            targetValues: List<int>.filled(12, 100_000_000),
+            currentSigningPartIndices: const [1, 10],
+          ),
+          hardware: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final ring = tester.widget<CustomPaint>(
+        find.byKey(const ValueKey('mobile_ironwood_migration_attention_ring')),
+      );
+      final painter = ring.painter as dynamic;
+      expect(painter.highlightedSegments, {1, 10});
+    },
+  );
+
+  testWidgets('pulses only the current migration signing parts', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    final parts = [
+      for (var index = 0; index < 12; index++)
+        rust_sync.MigrationPartStatus(
+          partIndex: index,
+          scheduleOrder: index,
+          valueZatoshi: BigInt.from(100_000_000),
+          state: index == 1 || index == 10
+              ? rust_sync.MigrationPartState.needsInput
+              : rust_sync.MigrationPartState.scheduled,
+          confirmationCount: 0,
+          confirmationTarget: 3,
+        ),
+    ];
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(),
+        status: _status(
+          phase: kIronwoodMigrationReadyToMigratePhase,
+          parts: parts,
+          targetValues: List<int>.filled(12, 100_000_000),
+          currentSigningPartIndices: const [1, 10],
+        ),
+        hardware: true,
+        disableAnimations: false,
+      ),
+    );
+
+    final ringFinder = find.byKey(
+      const ValueKey('mobile_ironwood_migration_attention_ring'),
+    );
+    for (var attempt = 0; attempt < 20 && !tester.any(ringFinder); attempt++) {
+      await tester.pump(const Duration(milliseconds: 50));
+    }
+    ({Set<int> highlightedSegments, double highlightOpacity}) painter() {
+      final customPaint = tester.widget<CustomPaint>(ringFinder);
+      final ringPainter = customPaint.painter as dynamic;
+      return (
+        highlightedSegments: Set<int>.of(
+          ringPainter.highlightedSegments as Set<int>,
+        ),
+        highlightOpacity: ringPainter.highlightOpacity as double,
+      );
+    }
+
+    expect(painter().highlightedSegments, {1, 10});
+    expect(painter().highlightOpacity, closeTo(0.40, 0.0001));
+
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(painter().highlightOpacity, closeTo(1, 0.0001));
+
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(painter().highlightOpacity, closeTo(0.40, 0.0001));
+  });
+
+  testWidgets(
+    'keeps migration signing parts fully visible with reduced motion',
+    (tester) async {
+      _useMobileViewport(tester);
+      final parts = [
+        for (var index = 0; index < 12; index++)
+          rust_sync.MigrationPartStatus(
+            partIndex: index,
+            scheduleOrder: index,
+            valueZatoshi: BigInt.from(100_000_000),
+            state: index == 1 || index == 10
+                ? rust_sync.MigrationPartState.needsInput
+                : rust_sync.MigrationPartState.scheduled,
+            confirmationCount: 0,
+            confirmationTarget: 3,
+          ),
+      ];
+      await tester.pumpWidget(
+        _productionApp(
+          initialLocation: '/migration/private/status',
+          migrationService: _migrationService(),
+          status: _status(
+            phase: kIronwoodMigrationReadyToMigratePhase,
+            parts: parts,
+            targetValues: List<int>.filled(12, 100_000_000),
+            currentSigningPartIndices: const [1, 10],
+          ),
+          hardware: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final ringFinder = find.byKey(
+        const ValueKey('mobile_ironwood_migration_attention_ring'),
+      );
+      double opacity() {
+        final customPaint = tester.widget<CustomPaint>(ringFinder);
+        final painter = customPaint.painter as dynamic;
+        return painter.highlightOpacity as double;
+      }
+
+      final ring = tester.widget<CustomPaint>(ringFinder);
+      final ringPainter = ring.painter as dynamic;
+      expect(ringPainter.highlightedSegments, {1, 10});
+      expect(opacity(), 1);
+      await tester.pump(const Duration(milliseconds: 800));
+      expect(opacity(), 1);
+    },
+  );
 
   testWidgets(
     'sizes migration ring segments by note balance in part-index order',


### PR DESCRIPTION
## Summary

- animate the mobile migration preparation ring using the approved idle transition
- size migration ring segments proportionally to each note balance
- pulse exactly the migration parts included in the current signing request, with reduced-motion support
- order ring segments by the current persisted execution schedule while preserving existing action-batch boundaries
- expose the canonical current signing part indices from Rust so the status UI and Keystone request use the same selector

## Why

The migration ring previously used index-based ordering and equal-sized segments, and the signing state did not identify the exact parts requiring attention. This made the ring diverge from note balances, scheduled execution order, and the actual Keystone signing request.

## Validation

- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/migration/mobile_ironwood_migration_flow_screen_test.dart` — 93 passed
- targeted Flutter analysis — no issues
- focused Rust migration signing selector test — passed
- `git diff --check` — passed

## Merge status

A local merge-tree check against the latest `origin/main` reports a content conflict in `test/features/migration/mobile_ironwood_migration_flow_screen_test.dart`; this PR is intentionally left unmerged for conflict resolution.