### PR TITLE
Recover stalled Ironwood migration broadcasts

### DIFF
--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationOutbox.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationOutbox.kt
@@ -108,6 +108,32 @@ internal class IronwoodMigrationOutboxRepository(
 }
 
 internal object IronwoodOutboxState {
+    fun hasBatch(
+        snapshot: IronwoodOutboxSnapshot,
+        batchId: String,
+        network: String,
+        accountUuid: String,
+        runId: String,
+        expectedTxids: Set<String>,
+        requiredTxids: Set<String>,
+    ): Boolean {
+        val batch = snapshot.batches.firstOrNull { it.batchId == batchId }
+            ?: return false
+        require(
+            batch.network == network &&
+                batch.accountUuid == accountUuid &&
+                batch.runId == runId &&
+                expectedTxids.isNotEmpty() &&
+                requiredTxids.isNotEmpty() &&
+                batch.items.isNotEmpty() &&
+                batch.items.all { it.txidHex in expectedTxids } &&
+                requiredTxids.all { required ->
+                    batch.items.any { it.txidHex == required }
+                },
+        ) { "Conflicting outbox batch." }
+        return true
+    }
+
     fun recoverInterrupted(snapshot: IronwoodOutboxSnapshot, nowMs: Long) {
         snapshot.batches.flatMap { it.items }
             .filter { it.status == IronwoodOutboxItemStatus.SUBMITTING }
@@ -147,9 +173,9 @@ internal object IronwoodOutboxState {
         endpoint: String,
         remoteHeight: Long,
         nowMs: Long,
-    ): Boolean {
+    ): String? {
         val canonicalExpiry = canonicalExpiryHeight(remoteHeight)
-        var needsUserAction = false
+        var needsUserActionAccountUuid: String? = null
         snapshot.batches.filter { it.lightwalletdUrl == endpoint }.forEach { batch ->
             var terminal = false
             batch.items.filter { it.status == IronwoodOutboxItemStatus.ARMED }.forEach { item ->
@@ -180,14 +206,15 @@ internal object IronwoodOutboxState {
                 )
                 batch.needsUserActionNotificationPending = true
                 terminal = true
-                needsUserAction = true
+                needsUserActionAccountUuid =
+                    needsUserActionAccountUuid ?: batch.accountUuid
             }
             if (terminal) {
                 batch.armedAtMs = null
                 batch.nextProofHeight = null
             }
         }
-        return needsUserAction
+        return needsUserActionAccountUuid
     }
 
     fun markProofReadyIfNeeded(
@@ -406,6 +433,22 @@ internal object IronwoodOutboxState {
                 }
             }
             .minOrNull()
+
+    fun nextActionAccountUuid(
+        snapshot: IronwoodOutboxSnapshot,
+        endpoint: String,
+        height: Long,
+    ): String? = snapshot.batches.filter { batch ->
+        if (batch.lightwalletdUrl != endpoint) return@filter false
+        val hasTransaction = batch.items.any {
+            it.status == IronwoodOutboxItemStatus.ARMED &&
+                it.scheduledHeight == height
+        }
+        val hasProof = batch.armedAtMs != null &&
+            batch.proofReadyObservedHeight == null &&
+            batch.nextProofHeight == height
+        hasTransaction || hasProof
+    }.minByOrNull { it.batchId }?.accountUuid
 
     fun hasDeliveryWork(snapshot: IronwoodOutboxSnapshot): Boolean =
         snapshot.batches.any { batch ->

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationOutboxWorker.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationOutboxWorker.kt
@@ -45,6 +45,7 @@ internal data class IronwoodMigrationOutboxRunResult(
     val observedHeight: Long? = null,
     val delayMs: Long? = null,
     val proofReadyBatchId: String? = null,
+    val transportAccountUuid: String? = null,
 )
 
 internal enum class IronwoodMigrationNotificationDelivery {
@@ -172,13 +173,15 @@ internal class IronwoodMigrationOutboxRunner(
             )
         }
 
-        var needsUserAction = false
+        var needsUserActionAccountUuid: String? = null
         var proofReadyBatchId = pendingProofReadyBatchId
         var selectedBatchId: String? = null
+        var selectedAccountUuid: String? = null
         val submission = try {
             repository.update { snapshot ->
                 val now = clockMs()
-                needsUserAction = IronwoodOutboxState.expireAndMarkNoncanonical(
+                needsUserActionAccountUuid =
+                    IronwoodOutboxState.expireAndMarkNoncanonical(
                     snapshot,
                     endpoint,
                     remoteHeight,
@@ -198,6 +201,7 @@ internal class IronwoodMigrationOutboxRunner(
                 )
                 selected?.let { (batch, item) ->
                     selectedBatchId = batch.batchId
+                    selectedAccountUuid = batch.accountUuid
                     IronwoodOutboxState.validateReschedulingAfterAcceptance(
                         batch,
                         item.itemId,
@@ -216,13 +220,15 @@ internal class IronwoodMigrationOutboxRunner(
             return result(
                 IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION,
                 proofReadyBatchId,
+                selectedAccountUuid,
             )
         }
         if (submission == null) {
-            if (needsUserAction) {
+            if (needsUserActionAccountUuid != null) {
                 return result(
                     IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION,
                     proofReadyBatchId,
+                    needsUserActionAccountUuid,
                 )
             }
             return waiting(endpoint, remoteHeight, proofReadyBatchId)
@@ -232,6 +238,7 @@ internal class IronwoodMigrationOutboxRunner(
             return result(
                 IronwoodMigrationOutboxOutcome.CANCELLED,
                 proofReadyBatchId,
+                selectedAccountUuid,
             )
         }
 
@@ -243,11 +250,13 @@ internal class IronwoodMigrationOutboxRunner(
                 result(
                     IronwoodMigrationOutboxOutcome.CANCELLED,
                     proofReadyBatchId,
+                    selectedAccountUuid,
                 )
             } else {
                 result(
                     IronwoodMigrationOutboxOutcome.RETRY,
                     proofReadyBatchId,
+                    selectedAccountUuid,
                 )
             }
         } finally {
@@ -288,6 +297,7 @@ internal class IronwoodMigrationOutboxRunner(
                         observedHeight = remoteHeight,
                         delayMs = delay,
                         proofReadyBatchId = proofReadyBatchId,
+                        transportAccountUuid = batch.accountUuid,
                     )
                 } else {
                     IronwoodOutboxState.recordRejected(
@@ -302,6 +312,7 @@ internal class IronwoodMigrationOutboxRunner(
                     result(
                         IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION,
                         proofReadyBatchId,
+                        batch.accountUuid,
                     )
                 }
             }
@@ -310,6 +321,7 @@ internal class IronwoodMigrationOutboxRunner(
             result(
                 IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION,
                 proofReadyBatchId,
+                selectedAccountUuid,
             )
         }
     }
@@ -335,6 +347,9 @@ internal class IronwoodMigrationOutboxRunner(
             observedHeight = remoteHeight,
             delayMs = delay,
             proofReadyBatchId = proofReadyBatchId,
+            transportAccountUuid = next?.let {
+                IronwoodOutboxState.nextActionAccountUuid(snapshot, endpoint, it)
+            },
         )
     }
 
@@ -370,9 +385,11 @@ internal class IronwoodMigrationOutboxRunner(
     private fun result(
         outcome: IronwoodMigrationOutboxOutcome,
         proofReadyBatchId: String? = null,
+        transportAccountUuid: String? = null,
     ) = IronwoodMigrationOutboxRunResult(
         outcome = outcome,
         proofReadyBatchId = proofReadyBatchId,
+        transportAccountUuid = transportAccountUuid,
     )
 
     private companion object {

--- a/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreChannel.kt
+++ b/android/app/src/main/kotlin/com/keplr/vizor/IronwoodMigrationSecureStoreChannel.kt
@@ -249,6 +249,30 @@ internal class IronwoodMigrationSecureStoreChannel(
                     recovered
                 }
             }
+            "hasOutboxBatch" -> {
+                {
+                    val arguments = arguments(call)
+                    val batchId = string(arguments, "batchId")
+                    val expectedTxids = stringList(
+                        arguments["expectedTxids"],
+                        "expectedTxids",
+                    ).map(String::lowercase).toSet()
+                    val requiredTxids = stringList(
+                        arguments["requiredTxids"],
+                        "requiredTxids",
+                    ).map(String::lowercase).toSet()
+                    val snapshot = outboxRepository.read()
+                    IronwoodOutboxState.hasBatch(
+                        snapshot = snapshot,
+                        batchId = batchId,
+                        network = network(arguments),
+                        accountUuid = string(arguments, "accountUuid"),
+                        runId = string(arguments, "runId"),
+                        expectedTxids = expectedTxids,
+                        requiredTxids = requiredTxids,
+                    )
+                }
+            }
             "listOutboxReceipts" -> {
                 {
                     outboxRepository.read().receipts.map(::receiptMap)
@@ -708,6 +732,7 @@ internal class IronwoodMigrationSecureStoreChannel(
             "nextHeight" to nextHeight,
             "observedHeight" to observedHeight,
             "delaySeconds" to delayMs?.div(1_000.0),
+            "accountUuid" to transportAccountUuid,
         )
 
     private fun arguments(call: MethodCall): Map<String, Any?> =

--- a/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationOutboxTest.kt
+++ b/android/app/src/test/kotlin/com/keplr/vizor/IronwoodMigrationOutboxTest.kt
@@ -50,6 +50,7 @@ class IronwoodMigrationOutboxTest {
         ).runOnce()
 
         assertEquals(IronwoodMigrationOutboxOutcome.WAITING, result.outcome)
+        assertEquals("account-1", result.transportAccountUuid)
         val recovered = repository.read().batches.single().items.single()
         assertEquals(IronwoodOutboxItemStatus.ARMED, recovered.status)
         assertEquals(1, recovered.attemptCount)
@@ -74,6 +75,7 @@ class IronwoodMigrationOutboxTest {
         ).runOnce()
 
         assertEquals(IronwoodMigrationOutboxOutcome.NEEDS_USER_ACTION, result.outcome)
+        assertEquals("account-1", result.transportAccountUuid)
         val snapshot = repository.read()
         assertEquals(
             IronwoodOutboxItemStatus.NEEDS_RESIGN_AWAITING_RECONCILIATION,
@@ -97,6 +99,36 @@ class IronwoodMigrationOutboxTest {
         assertNull(
             IronwoodOutboxState.pendingNeedsUserActionBatchId(repository.read()),
         )
+    }
+
+    @Test
+    fun hasBatchRequiresEveryScheduledTransaction() {
+        val batch = batch(item(expiryHeight = 69_120))
+        val snapshot = IronwoodOutboxSnapshot(batches = mutableListOf(batch))
+        val expectedTxids = batch.items.map { it.txidHex }.toSet()
+
+        assertTrue(
+            IronwoodOutboxState.hasBatch(
+                snapshot = snapshot,
+                batchId = batch.batchId,
+                network = batch.network,
+                accountUuid = batch.accountUuid,
+                runId = batch.runId,
+                expectedTxids = expectedTxids,
+                requiredTxids = expectedTxids,
+            ),
+        )
+        org.junit.Assert.assertThrows(IllegalArgumentException::class.java) {
+            IronwoodOutboxState.hasBatch(
+                snapshot = snapshot,
+                batchId = batch.batchId,
+                network = batch.network,
+                accountUuid = batch.accountUuid,
+                runId = batch.runId,
+                expectedTxids = expectedTxids + "missing-txid",
+                requiredTxids = setOf("missing-txid"),
+            )
+        }
     }
 
     @Test

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -164,6 +164,12 @@ import UIKit
         } catch {
           result(self.backgroundMigrationFlutterError(error))
         }
+      case "hasOutboxBatch":
+        do {
+          result(try BackgroundMigrationOutboxChannel.hasBatch(arguments: call.arguments))
+        } catch {
+          result(self.backgroundMigrationFlutterError(error))
+        }
       case "listOutboxReceipts":
         do {
           result(try BackgroundMigrationOutboxChannel.listReceipts())
@@ -447,6 +453,7 @@ import UIKit
     let transport = backgroundTransportResult(runResult.transport)
     var result = transport
     result["transport"] = transport
+    result["accountUuid"] = runResult.transportAccountUuid
     if let proofReady = runResult.proofReady {
       result["proofReady"] = [
         "batchId": proofReady.batchId,

--- a/ios/Runner/BackgroundMigrationOutbox.swift
+++ b/ios/Runner/BackgroundMigrationOutbox.swift
@@ -122,6 +122,7 @@ struct BackgroundMigrationOutboxReceipt: Codable, Equatable {
 
 struct BackgroundMigrationOutboxSelection: Equatable {
   let batchId: String
+  let accountUuid: String
   let scopeKey: String
   let lightwalletdUrl: String
   let item: BackgroundMigrationOutboxItem
@@ -149,15 +150,18 @@ struct BackgroundMigrationOutboxRunResult: Equatable {
   let transport: BackgroundMigrationTransportOutcome
   let proofReady: BackgroundMigrationProofReadyMetadata?
   let broadcastComplete: BackgroundMigrationBroadcastCompleteMetadata?
+  let transportAccountUuid: String?
 
   init(
     transport: BackgroundMigrationTransportOutcome,
     proofReady: BackgroundMigrationProofReadyMetadata?,
-    broadcastComplete: BackgroundMigrationBroadcastCompleteMetadata? = nil
+    broadcastComplete: BackgroundMigrationBroadcastCompleteMetadata? = nil,
+    transportAccountUuid: String? = nil
   ) {
     self.transport = transport
     self.proofReady = proofReady
     self.broadcastComplete = broadcastComplete
+    self.transportAccountUuid = transportAccountUuid
   }
 }
 
@@ -325,6 +329,35 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
     return true
   }
 
+  func hasBatch(
+    batchId: String,
+    network: String,
+    accountUuid: String,
+    runId: String,
+    expectedTxids: Set<String>,
+    requiredTxids: Set<String>
+  ) throws -> Bool {
+    guard !expectedTxids.isEmpty, !requiredTxids.isEmpty else {
+      throw BackgroundMigrationOutboxError.invalidArmRequest
+    }
+    guard let batch = batches.first(where: { $0.batchId == batchId }) else {
+      return false
+    }
+    let normalizedExpectedTxids = Set(expectedTxids.map { $0.lowercased() })
+    let normalizedRequiredTxids = Set(requiredTxids.map { $0.lowercased() })
+    let batchTxids = Set(batch.items.map(\.txidHex))
+    guard batch.network == network,
+      batch.accountUuid == accountUuid,
+      batch.runId == runId,
+      !batch.items.isEmpty,
+      batchTxids.isSubset(of: normalizedExpectedTxids),
+      normalizedRequiredTxids.isSubset(of: batchTxids)
+    else {
+      throw BackgroundMigrationOutboxError.conflictingBatch
+    }
+    return true
+  }
+
   mutating func recoverInterruptedSubmissions(at date: Date) {
     for batchIndex in batches.indices {
       for itemIndex in batches[batchIndex].items.indices
@@ -376,6 +409,25 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
         && $0.proofReadyNotificationPendingAt == nil
     }.compactMap(\.nextProofHeight).min()
     return [transactionHeight, proofHeight].compactMap { $0 }.min()
+  }
+
+  func nextActionAccountUuid(endpoint: String, height: UInt64) -> String? {
+    return batches
+      .filter { batch in
+        guard batch.lightwalletdUrl == endpoint else { return false }
+        let hasTransaction = batch.items.contains {
+          $0.status == .armed && $0.scheduledHeight == height
+        }
+        let hasProof =
+          batch.armedAt != nil
+          && batch.proofReadyNotifiedAt == nil
+          && batch.proofReadyNotificationPendingAt == nil
+          && batch.nextProofHeight == height
+        return hasTransaction || hasProof
+      }
+      .sorted(by: { $0.batchId < $1.batchId })
+      .first?
+      .accountUuid
   }
 
   mutating func markProofReadyIfNeeded(
@@ -585,6 +637,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
     lastAttemptedScopeKey = selectedScope
     return BackgroundMigrationOutboxSelection(
       batchId: batch.batchId,
+      accountUuid: batch.accountUuid,
       scopeKey: batch.scopeKey,
       lightwalletdUrl: batch.lightwalletdUrl,
       item: item

--- a/ios/Runner/BackgroundMigrationOutboxChannel.swift
+++ b/ios/Runner/BackgroundMigrationOutboxChannel.swift
@@ -59,6 +59,27 @@ enum BackgroundMigrationOutboxChannel {
     return recovered
   }
 
+  static func hasBatch(
+    arguments: Any?,
+    store: BackgroundMigrationOutboxStore = .shared
+  ) throws -> Bool {
+    let arguments = try dictionary(arguments)
+    guard let expectedTxids = arguments["expectedTxids"] as? [String] else {
+      throw BackgroundMigrationOutboxChannelError.invalidArguments("expectedTxids")
+    }
+    guard let requiredTxids = arguments["requiredTxids"] as? [String] else {
+      throw BackgroundMigrationOutboxChannelError.invalidArguments("requiredTxids")
+    }
+    return try store.read().hasBatch(
+      batchId: string(arguments, "batchId"),
+      network: string(arguments, "network"),
+      accountUuid: string(arguments, "accountUuid"),
+      runId: string(arguments, "runId"),
+      expectedTxids: Set(expectedTxids),
+      requiredTxids: Set(requiredTxids)
+    )
+  }
+
   static func listReceipts(
     store: BackgroundMigrationOutboxStore = .shared
   ) throws -> [[String: Any]] {

--- a/ios/Runner/BackgroundMigrationOutboxRunner.swift
+++ b/ios/Runner/BackgroundMigrationOutboxRunner.swift
@@ -111,6 +111,7 @@ enum BackgroundMigrationOutboxRunner {
     }
 
     var proofReady: BackgroundMigrationProofReadyMetadata?
+    var attemptedAccountUuid: String?
     let selection: BackgroundMigrationOutboxSelection
     do {
       var selected: BackgroundMigrationOutboxSelection?
@@ -132,6 +133,7 @@ enum BackgroundMigrationOutboxRunner {
           at: now
         )
         if let selected {
+          attemptedAccountUuid = selected.accountUuid
           try snapshot.validateReschedulingAfterAcceptance(
             itemId: selected.item.itemId,
             remoteHeight: remoteHeight
@@ -148,10 +150,15 @@ enum BackgroundMigrationOutboxRunner {
           ($0.outcome == .expired || $0.outcome == .needsResign)
             && $0.remoteHeight == remoteHeight
         }) {
+          let accountUuid = snapshot.receipts.first(where: {
+            ($0.outcome == .expired || $0.outcome == .needsResign)
+              && $0.remoteHeight == remoteHeight
+          })?.accountUuid
           return BackgroundMigrationOutboxRunResult(
             transport: .needsUserAction,
             proofReady: proofReady,
-            broadcastComplete: broadcastComplete
+            broadcastComplete: broadcastComplete,
+            transportAccountUuid: accountUuid
           )
         }
         let nextHeight = snapshot.nextActionHeight(endpoint: endpoint)
@@ -171,7 +178,10 @@ enum BackgroundMigrationOutboxRunner {
         return BackgroundMigrationOutboxRunResult(
           transport: transport,
           proofReady: proofReady,
-          broadcastComplete: broadcastComplete
+          broadcastComplete: broadcastComplete,
+          transportAccountUuid: nextHeight.flatMap {
+            snapshot.nextActionAccountUuid(endpoint: endpoint, height: $0)
+          }
         )
       }
       selection = selected
@@ -179,7 +189,8 @@ enum BackgroundMigrationOutboxRunner {
       return BackgroundMigrationOutboxRunResult(
         transport: .needsUserAction,
         proofReady: nil,
-        broadcastComplete: broadcastComplete
+        broadcastComplete: broadcastComplete,
+        transportAccountUuid: attemptedAccountUuid
       )
     } catch BackgroundMigrationOutboxStoreError.temporarilyUnavailable {
       return BackgroundMigrationOutboxRunResult(
@@ -191,7 +202,8 @@ enum BackgroundMigrationOutboxRunner {
       return BackgroundMigrationOutboxRunResult(
         transport: .needsUserAction,
         proofReady: proofReady,
-        broadcastComplete: broadcastComplete
+        broadcastComplete: broadcastComplete,
+        transportAccountUuid: attemptedAccountUuid
       )
     }
 
@@ -205,7 +217,8 @@ enum BackgroundMigrationOutboxRunner {
       return BackgroundMigrationOutboxRunResult(
         transport: .cancelled,
         proofReady: proofReady,
-        broadcastComplete: broadcastComplete
+        broadcastComplete: broadcastComplete,
+        transportAccountUuid: selection.accountUuid
       )
     }
 
@@ -224,7 +237,8 @@ enum BackgroundMigrationOutboxRunner {
       return BackgroundMigrationOutboxRunResult(
         transport: error == .cancelled ? .cancelled : .temporarilyUnavailable,
         proofReady: proofReady,
-        broadcastComplete: broadcastComplete
+        broadcastComplete: broadcastComplete,
+        transportAccountUuid: selection.accountUuid
       )
     case .success(let response):
       do {
@@ -257,7 +271,8 @@ enum BackgroundMigrationOutboxRunner {
               )
             ),
             proofReady: proofReady,
-            broadcastComplete: broadcastComplete
+            broadcastComplete: broadcastComplete,
+            transportAccountUuid: selection.accountUuid
           )
         }
         _ = try store.update { snapshot in
@@ -272,19 +287,22 @@ enum BackgroundMigrationOutboxRunner {
         return BackgroundMigrationOutboxRunResult(
           transport: .needsUserAction,
           proofReady: nil,
-          broadcastComplete: broadcastComplete
+          broadcastComplete: broadcastComplete,
+          transportAccountUuid: selection.accountUuid
         )
       } catch BackgroundMigrationOutboxStoreError.temporarilyUnavailable {
         return BackgroundMigrationOutboxRunResult(
           transport: .temporarilyUnavailable,
           proofReady: proofReady,
-          broadcastComplete: broadcastComplete
+          broadcastComplete: broadcastComplete,
+          transportAccountUuid: selection.accountUuid
         )
       } catch {
         return BackgroundMigrationOutboxRunResult(
           transport: .needsUserAction,
           proofReady: proofReady,
-          broadcastComplete: broadcastComplete
+          broadcastComplete: broadcastComplete,
+          transportAccountUuid: selection.accountUuid
         )
       }
     }

--- a/ios/RunnerTests/BackgroundMigrationOutboxTests.swift
+++ b/ios/RunnerTests/BackgroundMigrationOutboxTests.swift
@@ -80,6 +80,34 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     }
   }
 
+  func testHasBatchRequiresEveryScheduledTransaction() throws {
+    var snapshot = BackgroundMigrationOutboxSnapshot()
+    let batch = makeBatch(batchId: "batch-a", account: "account-a")
+    try snapshot.stage(batch)
+    let expectedTxids = Set(batch.items.map(\.txidHex))
+
+    XCTAssertTrue(
+      try snapshot.hasBatch(
+        batchId: batch.batchId,
+        network: batch.network,
+        accountUuid: batch.accountUuid,
+        runId: batch.runId,
+        expectedTxids: expectedTxids,
+        requiredTxids: [batch.items[0].txidHex]
+      )
+    )
+    XCTAssertThrowsError(
+      try snapshot.hasBatch(
+        batchId: batch.batchId,
+        network: batch.network,
+        accountUuid: batch.accountUuid,
+        runId: batch.runId,
+        expectedTxids: expectedTxids.union(["missing-txid"]),
+        requiredTxids: ["missing-txid"]
+      )
+    )
+  }
+
   func testRestagingMovesAnIdleBatchToTheCurrentEndpoint() throws {
     let original = makeBatch(
       batchId: "batch-a",
@@ -718,6 +746,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
       outcome.transport,
       .waiting(nextHeight: 300, observedHeight: 200, delay: 600)
     )
+    XCTAssertEqual(outcome.transportAccountUuid, "account-a")
     XCTAssertNil(outcome.proofReady)
   }
 
@@ -762,6 +791,7 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
 
     XCTAssertEqual(sendCount, 0)
     XCTAssertEqual(outcome.transport, .needsUserAction)
+    XCTAssertEqual(outcome.transportAccountUuid, "account-a")
     let snapshot = try harness.store.read()
     XCTAssertNil(snapshot.batches.first?.armedAt)
     XCTAssertEqual(

--- a/lib/src/features/migration/models/ironwood_migration_presentation.dart
+++ b/lib/src/features/migration/models/ironwood_migration_presentation.dart
@@ -5,6 +5,19 @@ const _estimatedSecondsPerBlock = 75;
 const _preparationConfirmationBlocks = 3;
 const _preparationBroadcastBufferBlocks = 1;
 
+bool migrationHasDueScheduledBroadcast(
+  rust_sync.MigrationStatus status, {
+  required int currentHeight,
+}) {
+  if (currentHeight <= 0) return false;
+  return status.scheduledBroadcasts.any(
+    (broadcast) =>
+        broadcast.status.toLowerCase() == 'scheduled' &&
+        broadcast.scheduledHeight > 0 &&
+        broadcast.scheduledHeight <= currentHeight,
+  );
+}
+
 bool migrationHasDueProofBatch(
   rust_sync.MigrationStatus status, {
   required int currentHeight,
@@ -353,7 +366,7 @@ String migrationHeightTimingLabel(
   required int currentHeight,
   DateTime? now,
 }) {
-  if (targetHeight <= currentHeight) return 'soon';
+  if (targetHeight <= currentHeight) return 'ready now';
 
   final localNow = (now ?? DateTime.now()).toLocal();
   final nextTime = localNow.add(
@@ -374,7 +387,7 @@ String migrationHeightRemainingDurationLabel(
   int targetHeight, {
   required int currentHeight,
 }) {
-  if (targetHeight <= currentHeight) return 'soon';
+  if (targetHeight <= currentHeight) return 'ready now';
   final remainingBlocks = targetHeight - currentHeight;
   final seconds = remainingBlocks * _estimatedSecondsPerBlock;
   final minutes = (seconds / Duration.secondsPerMinute).ceil();

--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -12,13 +12,13 @@ import '../../../providers/app_security_provider.dart';
 import '../../../providers/rpc_endpoint_failover_provider.dart';
 import '../../../providers/sync_provider.dart';
 import '../../../rust/api/sync.dart' as rust_sync;
+import '../models/ironwood_migration_presentation.dart';
 import '../services/ironwood_migration_service.dart';
 import 'ironwood_migration_announcement_provider.dart';
 
 const _migrationStatusPollInterval = Duration(seconds: 5);
 const _migrationAdvanceInterval = Duration(
-  seconds:
-      String.fromEnvironment('ZCASH_DEFAULT_NETWORK') == 'regtest'
+  seconds: String.fromEnvironment('ZCASH_DEFAULT_NETWORK') == 'regtest'
       ? 1
       : kZcashFastTestnetMigration
       ? 5
@@ -77,6 +77,8 @@ class IronwoodMigrationCoordinator
   bool _hasObservedInitialAccountList = false;
   Future<void>? _backgroundPreparationRecovery;
   final Map<String, DateTime> _lastAdvanceAt = {};
+  final Map<String, ({String progressKey, DateTime retryAt})>
+  _outboxRecoveryWindows = {};
   final Map<String, String> _lastAdvanceProgressKeys = {};
   final Map<String, Future<void>> _advanceOperations = {};
 
@@ -357,6 +359,42 @@ class IronwoodMigrationCoordinator
         nextStatuses[account.uuid] = status;
         nextErrors.remove(account.uuid);
 
+        if (_shouldRecoverDueNativeOutbox(
+          status,
+          usesNativeOutbox: service.supportsBackgroundMigrationRetry,
+          accountUuid: account.uuid,
+        )) {
+          final recovery = await service.recoverDueMigrationOutbox(
+            network: endpoint.networkName,
+            accountUuid: account.uuid,
+          );
+          if (!ref.mounted) return;
+          status = await service.status(
+            network: endpoint.networkName,
+            accountUuid: account.uuid,
+          );
+          if (!ref.mounted) return;
+          nextStatuses[account.uuid] = status;
+          final stillDue = migrationHasDueScheduledBroadcast(
+            status,
+            currentHeight: _safelyObservedHeight(),
+          );
+          if (stillDue) {
+            _validateDueOutboxRecovery(recovery, accountUuid: account.uuid);
+          }
+          if (!stillDue ||
+              _outboxRecoveryCanWait(recovery, accountUuid: account.uuid)) {
+            if (stillDue) {
+              _outboxRecoveryWindows[account.uuid] = (
+                progressKey: _outboxRecoveryProgressKey(status),
+                retryAt: DateTime.now().add(_outboxRecoveryDelay(recovery)),
+              );
+            } else {
+              _outboxRecoveryWindows.remove(account.uuid);
+            }
+          }
+        }
+
         if (_shouldAdvance(
           status,
           isHardware: account.isHardware,
@@ -384,6 +422,98 @@ class IronwoodMigrationCoordinator
     if (!ref.mounted) return;
     state = state.copyWith(statuses: nextStatuses, errors: nextErrors);
     _invalidateMigrationProviders(accountState.activeAccountUuid);
+  }
+
+  bool _shouldRecoverDueNativeOutbox(
+    rust_sync.MigrationStatus status, {
+    required bool usesNativeOutbox,
+    required String accountUuid,
+  }) {
+    final due =
+        kAppFormFactor == AppFormFactor.mobile &&
+        usesNativeOutbox &&
+        migrationHasDueScheduledBroadcast(
+          status,
+          currentHeight: _safelyObservedHeight(),
+        );
+    if (!due) {
+      _outboxRecoveryWindows.remove(accountUuid);
+      return false;
+    }
+    final window = _outboxRecoveryWindows[accountUuid];
+    final progressKey = _outboxRecoveryProgressKey(status);
+    if (window == null || window.progressKey != progressKey) {
+      _outboxRecoveryWindows.remove(accountUuid);
+      return true;
+    }
+    return !DateTime.now().isBefore(window.retryAt);
+  }
+
+  void _validateDueOutboxRecovery(
+    IronwoodMigrationOutboxRunResult result, {
+    required String accountUuid,
+  }) {
+    switch (result.outcome) {
+      case IronwoodMigrationOutboxRunOutcome.accepted:
+        return;
+      case IronwoodMigrationOutboxRunOutcome.waiting:
+        if (result.accountUuid != accountUuid ||
+            _outboxRecoveryCanWait(result, accountUuid: accountUuid)) {
+          return;
+        }
+        throw StateError('Scheduled migration submission is waiting to retry.');
+      case IronwoodMigrationOutboxRunOutcome.noWork:
+        throw StateError(
+          'The scheduled migration transaction is not available in the '
+          'background outbox.',
+        );
+      case IronwoodMigrationOutboxRunOutcome.needsUserAction:
+        if (result.accountUuid == accountUuid) {
+          throw StateError('Scheduled migration submission needs user action.');
+        }
+        return;
+      case IronwoodMigrationOutboxRunOutcome.temporarilyUnavailable:
+        return;
+      case IronwoodMigrationOutboxRunOutcome.cancelled:
+        return;
+    }
+  }
+
+  bool _outboxRecoveryCanWait(
+    IronwoodMigrationOutboxRunResult result, {
+    required String accountUuid,
+  }) {
+    if (result.outcome != IronwoodMigrationOutboxRunOutcome.waiting ||
+        result.accountUuid != accountUuid) {
+      return false;
+    }
+    final observedHeight = result.observedHeight;
+    final nextHeight = result.nextHeight;
+    return (result.retryDelay?.inMilliseconds ?? 0) > 0 ||
+        (observedHeight != null &&
+            nextHeight != null &&
+            nextHeight > observedHeight);
+  }
+
+  Duration _outboxRecoveryDelay(IronwoodMigrationOutboxRunResult result) {
+    final nativeDelay = result.retryDelay;
+    if (nativeDelay == null || nativeDelay < _migrationAdvanceInterval) {
+      return _migrationAdvanceInterval;
+    }
+    return nativeDelay;
+  }
+
+  String _outboxRecoveryProgressKey(rust_sync.MigrationStatus status) {
+    final scheduled =
+        status.scheduledBroadcasts
+            .where((broadcast) => broadcast.status.toLowerCase() == 'scheduled')
+            .map(
+              (broadcast) =>
+                  '${broadcast.txidHex.toLowerCase()}:${broadcast.scheduledHeight}',
+            )
+            .toList()
+          ..sort();
+    return '${status.activeRunId}:${scheduled.join(',')}';
   }
 
   bool _shouldAdvance(

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -968,6 +968,7 @@ enum _MigrationProgressState {
   waitingNotificationsOn,
   waitingNotificationsOff,
   needsInput,
+  readyToSubmit,
   broadcasting,
   confirming,
 }
@@ -1063,6 +1064,7 @@ class _MigrationProgressPreview extends StatelessWidget {
       backgroundDecoration: switch (state) {
         _MigrationProgressState.waitingNotificationsOn ||
         _MigrationProgressState.waitingNotificationsOff ||
+        _MigrationProgressState.readyToSubmit ||
         _MigrationProgressState.broadcasting ||
         _MigrationProgressState.confirming => const BoxDecoration(
           gradient: LinearGradient(
@@ -1517,7 +1519,9 @@ class _MigrationProgressSummary extends StatelessWidget {
               _MigrationProgressState.confirming => 'Waiting for confirmations',
               _MigrationProgressState.needsInput =>
                 'Waiting for your confirmation',
-              _ => 'Waiting for signing window',
+              _MigrationProgressState.readyToSubmit =>
+                'Scheduled transaction ready',
+              _ => 'Waiting for next migration step',
             },
       ),
     );
@@ -1562,19 +1566,26 @@ class _MigrationProgressStatus extends StatelessWidget {
       _MigrationProgressState.waitingNotificationsOn => (
         AppIcons.notificationBell,
         '~2 hrs 15 mins',
-        'Signing window expected in this time.\n'
-            'We will notify you when it’s ready.',
+        'Next migration step expected in this time.\n'
+            'Notifications are on. You can leave Vizor and check back later.',
       ),
       _MigrationProgressState.waitingNotificationsOff => (
         AppIcons.warningCircle,
-        'Waiting for signing window',
+        'Waiting for next migration step',
         'Notifications are disabled. Open Vizor after block 123456 '
             '(~1 hr 30 mins) and approve the next migration batch.',
+      ),
+      _MigrationProgressState.readyToSubmit => (
+        AppIcons.migrationTimer,
+        'Ready now',
+        'The scheduled transaction is ready for automatic submission. '
+            'Keep Vizor open.',
       ),
       _MigrationProgressState.broadcasting => (
         AppIcons.notificationBell,
         'All is well. Broadcasting notes…',
-        '~2 hrs 15 mins.\nWe will notify you when it’s ready.',
+        '~2 hrs 15 mins.\n'
+            'Notifications are on. You can leave Vizor and check back later.',
       ),
       _MigrationProgressState.confirming => (
         AppIcons.migrationTimer,
@@ -1635,9 +1646,9 @@ class _MigrationProgressStatus extends StatelessWidget {
             )
           else if (broadcasting)
             Text(
-              'Signing window expected in\n'
+              'Next migration step expected in\n'
               '${_migrationTimingFromBody(bodyOverride) ?? '~2 hrs 15 mins'}.\n'
-              'We will notify you when it’s ready.',
+              'Notifications are on. You can leave Vizor and check back later.',
               textAlign: TextAlign.center,
               style: AppTypography.bodyMediumStrong.copyWith(
                 color: context.colors.text.accent,

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -583,6 +583,12 @@ class _MobileMigrationRedesignedStatusState
     if (confirming) return _MigrationProgressState.confirming;
     final broadcasting = status.phase == kIronwoodMigrationBroadcastingPhase;
     if (broadcasting) return _MigrationProgressState.broadcasting;
+    if (migrationHasDueScheduledBroadcast(
+      status,
+      currentHeight: _currentHeight(),
+    )) {
+      return _MigrationProgressState.readyToSubmit;
+    }
     return _notificationsAuthorized
         ? _MigrationProgressState.waitingNotificationsOn
         : _MigrationProgressState.waitingNotificationsOff;
@@ -648,16 +654,25 @@ class _MobileMigrationRedesignedStatusState
     }
     if (state == _MigrationProgressState.broadcasting) {
       if (_notificationsAuthorized) {
-        return '$timing.\nWe will notify you when it’s ready.';
+        return '$timing until the next migration step. Notifications are on; '
+            'you can leave Vizor and check back later.';
       }
       return '$timing until the next migration step. Open Vizor again to '
           'continue because notifications are disabled.';
+    }
+    if (state == _MigrationProgressState.readyToSubmit) {
+      return 'The scheduled transaction is ready for automatic submission. '
+          'Keep Vizor open while Vizor continues trying.';
     }
     if (state == _MigrationProgressState.confirming) {
       return 'Confirmations are still arriving. You can leave Vizor and '
           'check again later.';
     }
-    return '$timing.\nWe will notify you when it’s ready.';
+    if (timing == 'ready now') {
+      return 'The next migration step is ready. Keep Vizor open to continue.';
+    }
+    return '$timing until the next migration step.\n'
+        'Notifications are on; you can leave Vizor and check back later.';
   }
 
   Future<void> _continuePreparation(String accountUuid) async {

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -209,12 +209,26 @@ typedef IronwoodMigrationOutboxBatchRecoverer =
       required String lightwalletdUrl,
       required List<String> expectedTxids,
     });
+typedef IronwoodMigrationOutboxBatchChecker =
+    Future<bool> Function({
+      required String batchId,
+      required String network,
+      required String accountUuid,
+      required String runId,
+      required List<String> expectedTxids,
+      required List<String> requiredTxids,
+    });
 typedef IronwoodMigrationOutboxReceiptLister =
     Future<List<Map<Object?, Object?>>> Function();
 typedef IronwoodMigrationOutboxReceiptAcknowledger =
     Future<void> Function(List<String> receiptIds);
 typedef IronwoodMigrationOutboxForegroundRunner =
     Future<IronwoodMigrationOutboxRunResult> Function();
+typedef IronwoodMigrationDueOutboxRecoveryRunner =
+    Future<IronwoodMigrationOutboxRunResult> Function({
+      required String network,
+      required String accountUuid,
+    });
 
 enum IronwoodMigrationOutboxRunOutcome {
   noWork,
@@ -230,6 +244,8 @@ class IronwoodMigrationOutboxRunResult {
     required this.outcome,
     this.nextHeight,
     this.observedHeight,
+    this.accountUuid,
+    this.retryDelay,
   });
 
   factory IronwoodMigrationOutboxRunResult.fromMap(
@@ -251,12 +267,21 @@ class IronwoodMigrationOutboxRunResult {
       outcome: outcome,
       nextHeight: (values['nextHeight'] as num?)?.toInt(),
       observedHeight: (values['observedHeight'] as num?)?.toInt(),
+      accountUuid: values['accountUuid'] as String?,
+      retryDelay: switch (values['delaySeconds']) {
+        final num seconds when seconds > 0 => Duration(
+          milliseconds: (seconds * Duration.millisecondsPerSecond).ceil(),
+        ),
+        _ => null,
+      },
     );
   }
 
   final IronwoodMigrationOutboxRunOutcome outcome;
   final int? nextHeight;
   final int? observedHeight;
+  final String? accountUuid;
+  final Duration? retryDelay;
 }
 
 typedef IronwoodMigrationKeystoneDenominationPreparer =
@@ -404,10 +429,12 @@ class IronwoodMigrationService {
     IronwoodMigrationOutboxBatchStager? stageMigrationOutboxBatch,
     IronwoodMigrationOutboxBatchArmer? armMigrationOutboxBatch,
     IronwoodMigrationOutboxBatchRecoverer? recoverMigrationOutboxBatch,
+    IronwoodMigrationOutboxBatchChecker? hasMigrationOutboxBatch,
     IronwoodMigrationOutboxReceiptLister? listMigrationOutboxReceipts,
     IronwoodMigrationOutboxReceiptAcknowledger?
     acknowledgeMigrationOutboxReceipts,
     IronwoodMigrationOutboxForegroundRunner? runMigrationOutboxOnceNow,
+    IronwoodMigrationDueOutboxRecoveryRunner? recoverDueMigrationOutbox,
     IronwoodMigrationKeystoneDenominationPreparer?
     prepareKeystoneDenominationMigration,
     IronwoodMigrationKeystoneDenominationCompleter?
@@ -484,6 +511,8 @@ class IronwoodMigrationService {
            armMigrationOutboxBatch ?? _defaultArmMigrationOutboxBatch,
        recoverMigrationOutboxBatch =
            recoverMigrationOutboxBatch ?? _defaultRecoverMigrationOutboxBatch,
+       hasMigrationOutboxBatch =
+           hasMigrationOutboxBatch ?? _defaultHasMigrationOutboxBatch,
        listMigrationOutboxReceipts =
            listMigrationOutboxReceipts ?? _defaultListMigrationOutboxReceipts,
        acknowledgeMigrationOutboxReceipts =
@@ -491,6 +520,7 @@ class IronwoodMigrationService {
            _defaultAcknowledgeMigrationOutboxReceipts,
        runMigrationOutboxOnceNow =
            runMigrationOutboxOnceNow ?? _defaultRunMigrationOutboxOnceNow,
+       _recoverDueMigrationOutboxOverride = recoverDueMigrationOutbox,
        prepareKeystoneDenominationMigration =
            prepareKeystoneDenominationMigration ??
            rust_sync.prepareOrchardMigrationDenominationsPczt,
@@ -551,10 +581,13 @@ class IronwoodMigrationService {
   final IronwoodMigrationOutboxBatchStager stageMigrationOutboxBatch;
   final IronwoodMigrationOutboxBatchArmer armMigrationOutboxBatch;
   final IronwoodMigrationOutboxBatchRecoverer recoverMigrationOutboxBatch;
+  final IronwoodMigrationOutboxBatchChecker hasMigrationOutboxBatch;
   final IronwoodMigrationOutboxReceiptLister listMigrationOutboxReceipts;
   final IronwoodMigrationOutboxReceiptAcknowledger
   acknowledgeMigrationOutboxReceipts;
   final IronwoodMigrationOutboxForegroundRunner runMigrationOutboxOnceNow;
+  final IronwoodMigrationDueOutboxRecoveryRunner?
+  _recoverDueMigrationOutboxOverride;
   final IronwoodMigrationKeystoneDenominationPreparer
   prepareKeystoneDenominationMigration;
   final IronwoodMigrationKeystoneDenominationCompleter
@@ -686,6 +719,58 @@ class IronwoodMigrationService {
           return status;
         });
       },
+    );
+  }
+
+  /// Runs only the already-armed native transaction outbox and reconciles this
+  /// account's receipts. The native runner is global and may service a
+  /// different account; callers must re-read this account's status before
+  /// interpreting the result. This never creates proofs or signs another
+  /// migration batch, so it is safe to use without a signing permit.
+  Future<IronwoodMigrationOutboxRunResult> recoverDueMigrationOutbox({
+    required String network,
+    required String accountUuid,
+  }) async {
+    final override = _recoverDueMigrationOutboxOverride;
+    if (override != null) {
+      return override(network: network, accountUuid: accountUuid);
+    }
+    if (!_usesNativeMigrationOutbox) {
+      throw UnsupportedError(
+        'Native migration outbox recovery is not available.',
+      );
+    }
+
+    final dbPath = await getWalletDbPath();
+    final context = _MigrationCredentialContext(
+      dbPath: dbPath,
+      network: network,
+      accountUuid: accountUuid,
+    );
+    return operationRegistry.run(
+      network: network,
+      accountUuid: accountUuid,
+      operation: () => _serializeCredentialState(context, () async {
+        await _reconcileMigrationOutboxReceipts(context: context);
+        final status = await _getStatusForContext(context);
+        if (status.scheduledBroadcasts.any(
+          (broadcast) => broadcast.status.toLowerCase() == 'scheduled',
+        )) {
+          final available = await _hasPersistedMigrationOutboxBatch(
+            context: context,
+            status: status,
+          );
+          if (!available) {
+            throw StateError(
+              'The scheduled migration transaction is not available in the '
+              'background outbox.',
+            );
+          }
+        }
+        final result = await runMigrationOutboxOnceNow();
+        await _reconcileMigrationOutboxReceipts(context: context);
+        return result;
+      }),
     );
   }
 
@@ -1407,6 +1492,22 @@ class IronwoodMigrationService {
     required _MigrationCredentialContext context,
     required rust_sync.MigrationStatus status,
   }) async {
+    if (!await _recoverPersistedMigrationOutboxBatch(
+      context: context,
+      status: status,
+    )) {
+      return false;
+    }
+
+    await runMigrationOutboxOnceNow();
+    await _reconcileMigrationOutboxReceipts(context: context);
+    return true;
+  }
+
+  Future<bool> _recoverPersistedMigrationOutboxBatch({
+    required _MigrationCredentialContext context,
+    required rust_sync.MigrationStatus status,
+  }) async {
     final runId = status.activeRunId;
     final lightwalletdUrl = context.lightwalletdUrl;
     if (!_usesNativeMigrationOutbox ||
@@ -1415,13 +1516,7 @@ class IronwoodMigrationService {
       return false;
     }
 
-    final expectedTxids = <String>{
-      for (final part in status.parts)
-        if (part.txidHex case final txid? when txid.isNotEmpty)
-          txid.toLowerCase(),
-      for (final scheduled in status.scheduledBroadcasts)
-        if (scheduled.txidHex.isNotEmpty) scheduled.txidHex.toLowerCase(),
-    }.toList(growable: false);
+    final expectedTxids = _migrationOutboxExpectedTxids(status);
     if (expectedTxids.isEmpty) return false;
 
     final recovered = await recoverMigrationOutboxBatch(
@@ -1435,9 +1530,45 @@ class IronwoodMigrationService {
     if (!recovered) return false;
 
     _scheduledBackgroundMigrations.add(_credentialKey(context));
-    await runMigrationOutboxOnceNow();
-    await _reconcileMigrationOutboxReceipts(context: context);
     return true;
+  }
+
+  Future<bool> _hasPersistedMigrationOutboxBatch({
+    required _MigrationCredentialContext context,
+    required rust_sync.MigrationStatus status,
+  }) async {
+    final runId = status.activeRunId;
+    if (!_usesNativeMigrationOutbox || runId == null) return false;
+
+    final expectedTxids = _migrationOutboxExpectedTxids(status);
+    final requiredTxids = status.scheduledBroadcasts
+        .where(
+          (broadcast) =>
+              broadcast.status.toLowerCase() == 'scheduled' &&
+              broadcast.txidHex.isNotEmpty,
+        )
+        .map((broadcast) => broadcast.txidHex.toLowerCase())
+        .toSet()
+        .toList(growable: false);
+    if (expectedTxids.isEmpty || requiredTxids.isEmpty) return false;
+    return hasMigrationOutboxBatch(
+      batchId: _migrationOutboxBatchId(context, runId),
+      network: context.network,
+      accountUuid: context.accountUuid,
+      runId: runId,
+      expectedTxids: expectedTxids,
+      requiredTxids: requiredTxids,
+    );
+  }
+
+  List<String> _migrationOutboxExpectedTxids(rust_sync.MigrationStatus status) {
+    return <String>{
+      for (final part in status.parts)
+        if (part.txidHex case final txid? when txid.isNotEmpty)
+          txid.toLowerCase(),
+      for (final scheduled in status.scheduledBroadcasts)
+        if (scheduled.txidHex.isNotEmpty) scheduled.txidHex.toLowerCase(),
+    }.toList(growable: false);
   }
 
   _MigrationCredentialContext _contextWithCurrentEndpoint(
@@ -1991,6 +2122,26 @@ Future<bool> _defaultRecoverMigrationOutboxBatch({
             'runId': runId,
             'lightwalletdUrl': lightwalletdUrl,
             'expectedTxids': expectedTxids,
+          }) ??
+      false;
+}
+
+Future<bool> _defaultHasMigrationOutboxBatch({
+  required String batchId,
+  required String network,
+  required String accountUuid,
+  required String runId,
+  required List<String> expectedTxids,
+  required List<String> requiredTxids,
+}) async {
+  return await _backgroundMigrationChannel
+          .invokeMethod<bool>('hasOutboxBatch', {
+            'batchId': batchId,
+            'network': network,
+            'accountUuid': accountUuid,
+            'runId': runId,
+            'expectedTxids': expectedTxids,
+            'requiredTxids': requiredTxids,
           }) ??
       false;
 }

--- a/test/features/migration/ironwood_migration_coordinator_provider_test.dart
+++ b/test/features/migration/ironwood_migration_coordinator_provider_test.dart
@@ -448,6 +448,512 @@ void main() {
     expect(broadcasts, [_hardwareUuid]);
   });
 
+  test(
+    'due native outbox recovers in foreground without a signing permit',
+    () async {
+      final statuses = {
+        _softwareUuid: _status('broadcast_scheduled', scheduledHeight: 1_000),
+        _hardwareUuid: _status('complete', activeRunId: null),
+      };
+      final outboxRecoveries = <String>[];
+      final broadcasts = <String>[];
+      final container = _container(
+        statuses: statuses,
+        softwareStarts: [],
+        broadcasts: broadcasts,
+        outboxRecoveries: outboxRecoveries,
+        recoverOutbox: (accountUuid) async {
+          statuses[accountUuid] = _status('waiting_migration_confirmations');
+          return const IronwoodMigrationOutboxRunResult(
+            outcome: IronwoodMigrationOutboxRunOutcome.accepted,
+            observedHeight: 1_000,
+          );
+        },
+        syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_000),
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        ironwoodMigrationCoordinatorProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+
+      await container
+          .read(ironwoodMigrationCoordinatorProvider.notifier)
+          .refreshNow();
+
+      expect(outboxRecoveries, [_softwareUuid]);
+      expect(broadcasts, isEmpty);
+      expect(
+        container
+            .read(ironwoodMigrationCoordinatorProvider)
+            .foregroundProgressPermits,
+        isEmpty,
+      );
+      expect(
+        container
+            .read(ironwoodMigrationCoordinatorProvider)
+            .statuses[_softwareUuid]
+            ?.phase,
+        'waiting_migration_confirmations',
+      );
+    },
+  );
+
+  test(
+    'global outbox acceptance for another account retries the due account',
+    () async {
+      final statuses = {
+        _softwareUuid: _status('broadcast_scheduled', scheduledHeight: 1_000),
+        _hardwareUuid: _status('complete', activeRunId: null),
+      };
+      final recoveries = <String>[];
+      final container = _container(
+        statuses: statuses,
+        softwareStarts: [],
+        broadcasts: [],
+        outboxRecoveries: recoveries,
+        recoverOutbox: (_) async => const IronwoodMigrationOutboxRunResult(
+          outcome: IronwoodMigrationOutboxRunOutcome.accepted,
+          observedHeight: 1_000,
+        ),
+        syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_000),
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        ironwoodMigrationCoordinatorProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+      final coordinator = container.read(
+        ironwoodMigrationCoordinatorProvider.notifier,
+      );
+
+      await coordinator.refreshNow();
+      await coordinator.refreshNow();
+
+      expect(recoveries, [_softwareUuid, _softwareUuid]);
+      expect(
+        container
+            .read(ironwoodMigrationCoordinatorProvider)
+            .errors[_softwareUuid],
+        isNull,
+      );
+    },
+  );
+
+  test(
+    'noWork is successful when reconciliation cleared the due status',
+    () async {
+      final statuses = {
+        _softwareUuid: _status('broadcast_scheduled', scheduledHeight: 1_000),
+        _hardwareUuid: _status('complete', activeRunId: null),
+      };
+      final container = _container(
+        statuses: statuses,
+        softwareStarts: [],
+        broadcasts: [],
+        recoverOutbox: (accountUuid) async {
+          statuses[accountUuid] = _status('waiting_migration_confirmations');
+          return const IronwoodMigrationOutboxRunResult(
+            outcome: IronwoodMigrationOutboxRunOutcome.noWork,
+            observedHeight: 1_000,
+          );
+        },
+        syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_000),
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        ironwoodMigrationCoordinatorProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+
+      await container
+          .read(ironwoodMigrationCoordinatorProvider.notifier)
+          .refreshNow();
+
+      expect(
+        container
+            .read(ironwoodMigrationCoordinatorProvider)
+            .errors[_softwareUuid],
+        isNull,
+      );
+      expect(
+        container
+            .read(ironwoodMigrationCoordinatorProvider)
+            .statuses[_softwareUuid]
+            ?.phase,
+        'waiting_migration_confirmations',
+      );
+    },
+  );
+
+  test(
+    'temporary native contention retries without showing an error',
+    () async {
+      final statuses = {
+        _softwareUuid: _status('broadcast_scheduled', scheduledHeight: 1_000),
+        _hardwareUuid: _status('complete', activeRunId: null),
+      };
+      final recoveries = <String>[];
+      final container = _container(
+        statuses: statuses,
+        softwareStarts: [],
+        broadcasts: [],
+        outboxRecoveries: recoveries,
+        recoverOutbox: (_) async => const IronwoodMigrationOutboxRunResult(
+          outcome: IronwoodMigrationOutboxRunOutcome.temporarilyUnavailable,
+        ),
+        syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_000),
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        ironwoodMigrationCoordinatorProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+      final coordinator = container.read(
+        ironwoodMigrationCoordinatorProvider.notifier,
+      );
+
+      await coordinator.refreshNow();
+      await coordinator.refreshNow();
+
+      expect(recoveries, [_softwareUuid, _softwareUuid]);
+      expect(
+        container
+            .read(ironwoodMigrationCoordinatorProvider)
+            .errors[_softwareUuid],
+        isNull,
+      );
+    },
+  );
+
+  test(
+    'global needs-user-action outcome is not attached to the due account',
+    () async {
+      final statuses = {
+        _softwareUuid: _status('broadcast_scheduled', scheduledHeight: 1_000),
+        _hardwareUuid: _status('complete', activeRunId: null),
+      };
+      final recoveries = <String>[];
+      final container = _container(
+        statuses: statuses,
+        softwareStarts: [],
+        broadcasts: [],
+        outboxRecoveries: recoveries,
+        recoverOutbox: (_) async => const IronwoodMigrationOutboxRunResult(
+          outcome: IronwoodMigrationOutboxRunOutcome.needsUserAction,
+          accountUuid: _hardwareUuid,
+        ),
+        syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_000),
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        ironwoodMigrationCoordinatorProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+      final coordinator = container.read(
+        ironwoodMigrationCoordinatorProvider.notifier,
+      );
+
+      await coordinator.refreshNow();
+      await coordinator.refreshNow();
+
+      expect(recoveries, [_softwareUuid, _softwareUuid]);
+      expect(
+        container
+            .read(ironwoodMigrationCoordinatorProvider)
+            .errors[_softwareUuid],
+        isNull,
+      );
+    },
+  );
+
+  test(
+    'matching needs-user-action outcome becomes immediately actionable',
+    () async {
+      final statuses = {
+        _softwareUuid: _status('broadcast_scheduled', scheduledHeight: 1_000),
+        _hardwareUuid: _status('complete', activeRunId: null),
+      };
+      final container = _container(
+        statuses: statuses,
+        softwareStarts: [],
+        broadcasts: [],
+        recoverOutbox: (_) async => const IronwoodMigrationOutboxRunResult(
+          outcome: IronwoodMigrationOutboxRunOutcome.needsUserAction,
+          accountUuid: _softwareUuid,
+        ),
+        syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_000),
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        ironwoodMigrationCoordinatorProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+
+      await container
+          .read(ironwoodMigrationCoordinatorProvider.notifier)
+          .refreshNow();
+
+      expect(
+        container
+            .read(ironwoodMigrationCoordinatorProvider)
+            .errors[_softwareUuid],
+        contains('needs user action'),
+      );
+    },
+  );
+
+  test('global waiting outcome does not throttle the due account', () async {
+    final statuses = {
+      _softwareUuid: _status('broadcast_scheduled', scheduledHeight: 1_000),
+      _hardwareUuid: _status('complete', activeRunId: null),
+    };
+    final recoveries = <String>[];
+    final container = _container(
+      statuses: statuses,
+      softwareStarts: [],
+      broadcasts: [],
+      outboxRecoveries: recoveries,
+      recoverOutbox: (_) async => const IronwoodMigrationOutboxRunResult(
+        outcome: IronwoodMigrationOutboxRunOutcome.waiting,
+        nextHeight: 1_001,
+        observedHeight: 1_000,
+        accountUuid: _hardwareUuid,
+      ),
+      syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_000),
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      ironwoodMigrationCoordinatorProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+    await container.read(syncProvider.future);
+    final coordinator = container.read(
+      ironwoodMigrationCoordinatorProvider.notifier,
+    );
+
+    await coordinator.refreshNow();
+    await coordinator.refreshNow();
+
+    expect(recoveries, [_softwareUuid, _softwareUuid]);
+    expect(
+      container
+          .read(ironwoodMigrationCoordinatorProvider)
+          .errors[_softwareUuid],
+      isNull,
+    );
+  });
+
+  test('matching waiting outcome throttles the due account', () async {
+    final statuses = {
+      _softwareUuid: _status('broadcast_scheduled', scheduledHeight: 1_000),
+      _hardwareUuid: _status('complete', activeRunId: null),
+    };
+    final recoveries = <String>[];
+    final container = _container(
+      statuses: statuses,
+      softwareStarts: [],
+      broadcasts: [],
+      outboxRecoveries: recoveries,
+      recoverOutbox: (_) async => const IronwoodMigrationOutboxRunResult(
+        outcome: IronwoodMigrationOutboxRunOutcome.waiting,
+        nextHeight: 1_001,
+        observedHeight: 1_000,
+        accountUuid: _softwareUuid,
+      ),
+      syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_000),
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      ironwoodMigrationCoordinatorProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+    await container.read(syncProvider.future);
+    final coordinator = container.read(
+      ironwoodMigrationCoordinatorProvider.notifier,
+    );
+
+    await coordinator.refreshNow();
+    await coordinator.refreshNow();
+
+    expect(recoveries, [_softwareUuid]);
+    expect(
+      container
+          .read(ironwoodMigrationCoordinatorProvider)
+          .errors[_softwareUuid],
+      isNull,
+    );
+  });
+
+  test(
+    'matching native retry delay does not become a due-account error',
+    () async {
+      final statuses = {
+        _softwareUuid: _status('broadcast_scheduled', scheduledHeight: 1_000),
+        _hardwareUuid: _status('complete', activeRunId: null),
+      };
+      final recoveries = <String>[];
+      final container = _container(
+        statuses: statuses,
+        softwareStarts: [],
+        broadcasts: [],
+        outboxRecoveries: recoveries,
+        recoverOutbox: (_) async => const IronwoodMigrationOutboxRunResult(
+          outcome: IronwoodMigrationOutboxRunOutcome.waiting,
+          nextHeight: 1_000,
+          observedHeight: 1_000,
+          accountUuid: _softwareUuid,
+          retryDelay: Duration(minutes: 1),
+        ),
+        syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_000),
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        ironwoodMigrationCoordinatorProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+      final coordinator = container.read(
+        ironwoodMigrationCoordinatorProvider.notifier,
+      );
+
+      await coordinator.refreshNow();
+      await coordinator.refreshNow();
+
+      expect(recoveries, [_softwareUuid]);
+      expect(
+        container
+            .read(ironwoodMigrationCoordinatorProvider)
+            .errors[_softwareUuid],
+        isNull,
+      );
+    },
+  );
+
+  test(
+    'a new scheduled batch is not throttled by the previous batch',
+    () async {
+      final statuses = {
+        _softwareUuid: _status(
+          'broadcast_scheduled',
+          scheduledHeight: 1_000,
+          scheduledTxid: 'scheduled-tx-1',
+        ),
+        _hardwareUuid: _status('complete', activeRunId: null),
+      };
+      final recoveries = <String>[];
+      final container = _container(
+        statuses: statuses,
+        softwareStarts: [],
+        broadcasts: [],
+        outboxRecoveries: recoveries,
+        recoverOutbox: (_) async => const IronwoodMigrationOutboxRunResult(
+          outcome: IronwoodMigrationOutboxRunOutcome.waiting,
+          nextHeight: 1_000,
+          observedHeight: 1_000,
+          accountUuid: _softwareUuid,
+          retryDelay: Duration(minutes: 10),
+        ),
+        syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_000),
+      );
+      addTearDown(container.dispose);
+      final subscription = container.listen(
+        ironwoodMigrationCoordinatorProvider,
+        (_, _) {},
+        fireImmediately: true,
+      );
+      addTearDown(subscription.close);
+      await container.read(syncProvider.future);
+      final coordinator = container.read(
+        ironwoodMigrationCoordinatorProvider.notifier,
+      );
+
+      await coordinator.refreshNow();
+      statuses[_softwareUuid] = _status(
+        'broadcast_scheduled',
+        scheduledHeight: 1_000,
+        scheduledTxid: 'scheduled-tx-2',
+      );
+      await coordinator.refreshNow();
+
+      expect(recoveries, [_softwareUuid, _softwareUuid]);
+    },
+  );
+
+  test('due native outbox failure becomes immediately actionable', () async {
+    final statuses = {
+      _softwareUuid: _status('broadcast_scheduled', scheduledHeight: 1_000),
+      _hardwareUuid: _status('complete', activeRunId: null),
+    };
+    final recoveries = <String>[];
+    final container = _container(
+      statuses: statuses,
+      softwareStarts: [],
+      broadcasts: [],
+      outboxRecoveries: recoveries,
+      recoverOutbox: (_) async => const IronwoodMigrationOutboxRunResult(
+        outcome: IronwoodMigrationOutboxRunOutcome.noWork,
+        observedHeight: 1_000,
+      ),
+      syncState: SyncState(scannedHeight: 1_000, chainTipHeight: 1_000),
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      ironwoodMigrationCoordinatorProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+    await container.read(syncProvider.future);
+
+    await container
+        .read(ironwoodMigrationCoordinatorProvider.notifier)
+        .refreshNow();
+
+    expect(
+      container
+          .read(ironwoodMigrationCoordinatorProvider)
+          .errors[_softwareUuid],
+      contains('not available in the background outbox'),
+    );
+
+    await container
+        .read(ironwoodMigrationCoordinatorProvider.notifier)
+        .refreshNow();
+
+    expect(recoveries, [_softwareUuid, _softwareUuid]);
+    expect(
+      container
+          .read(ironwoodMigrationCoordinatorProvider)
+          .errors[_softwareUuid],
+      contains('not available in the background outbox'),
+    );
+  });
+
   test('one account failure does not block another account recovery', () async {
     final statuses = {
       _softwareUuid: _status('broadcast_scheduled', scheduledHeight: 1_000),
@@ -794,6 +1300,9 @@ ProviderContainer _container({
   Future<rust_sync.MigrationStatus> Function(String accountUuid)? loadStatus,
   Future<rust_sync.IronwoodMigrationResult> Function(String accountUuid)?
   broadcast,
+  Future<IronwoodMigrationOutboxRunResult> Function(String accountUuid)?
+  recoverOutbox,
+  List<String>? outboxRecoveries,
   bool usesNativeOutbox = true,
   SyncState? syncState,
   bool isIOS = false,
@@ -828,6 +1337,17 @@ ProviderContainer _container({
             return true;
           },
     scheduleBackgroundMigration: () async => true,
+    recoverDueMigrationOutbox:
+        ({required network, required accountUuid}) async {
+          outboxRecoveries?.add(accountUuid);
+          if (recoverOutbox != null) return recoverOutbox(accountUuid);
+          return IronwoodMigrationOutboxRunResult(
+            outcome: IronwoodMigrationOutboxRunOutcome.waiting,
+            nextHeight: 1_001,
+            observedHeight: 1_000,
+            accountUuid: accountUuid,
+          );
+        },
     broadcastDueMigration:
         ({
           required dbPath,
@@ -871,8 +1391,9 @@ ProviderContainer _container({
         appSecurityProvider.overrideWith(
           () => _MutableSecurityNotifier(initialSecurityState),
         ),
-      if (syncState != null)
-        syncProvider.overrideWith(() => FakeSyncNotifier(syncState)),
+      syncProvider.overrideWith(
+        () => FakeSyncNotifier(syncState ?? SyncState()),
+      ),
       ironwoodMigrationServiceProvider.overrideWithValue(service),
     ],
   );
@@ -992,6 +1513,7 @@ rust_sync.MigrationStatus _status(
   String? activeRunId = 'run-1',
   int confirmedTxCount = 0,
   int? scheduledHeight,
+  String scheduledTxid = 'scheduled-tx',
   int signedChildPcztCount = 0,
   int? nextActionHeight,
 }) {
@@ -1019,7 +1541,7 @@ rust_sync.MigrationStatus _status(
         ? const []
         : [
             rust_sync.MigrationScheduledBroadcast(
-              txidHex: 'scheduled-tx',
+              txidHex: scheduledTxid,
               valueZatoshi: BigInt.from(100000000),
               scheduledAtMs: 0,
               scheduledHeight: scheduledHeight,

--- a/test/features/migration/ironwood_migration_presentation_test.dart
+++ b/test/features/migration/ironwood_migration_presentation_test.dart
@@ -338,7 +338,25 @@ void main() {
     );
     expect(
       migrationHeightRemainingDurationLabel(1_000, currentHeight: 1_000),
-      'soon',
+      'ready now',
+    );
+  });
+
+  test('detects a scheduled broadcast as soon as its height is due', () {
+    final status = _status(
+      phase: 'broadcast_scheduled',
+      broadcasts: [
+        _broadcast('scheduled', DateTime(2026), scheduledHeight: 1_000),
+      ],
+    );
+
+    expect(
+      migrationHasDueScheduledBroadcast(status, currentHeight: 999),
+      isFalse,
+    );
+    expect(
+      migrationHasDueScheduledBroadcast(status, currentHeight: 1_000),
+      isTrue,
     );
   });
 }

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -53,6 +53,19 @@ void main() {
     },
   );
 
+  test('outbox result parses native account scope and retry delay', () {
+    final result = IronwoodMigrationOutboxRunResult.fromMap({
+      'outcome': 'waiting',
+      'nextHeight': 1_000,
+      'observedHeight': 1_000,
+      'accountUuid': 'account-1',
+      'delaySeconds': 60.5,
+    });
+
+    expect(result.accountUuid, 'account-1');
+    expect(result.retryDelay, const Duration(milliseconds: 60_500));
+  });
+
   test(
     'Android reads preparation runtime state from the native worker',
     () async {
@@ -119,6 +132,195 @@ void main() {
       expect(seenDbPath, '/tmp/wallet.db');
       expect(seenNetwork, 'test');
       expect(seenAccountUuid, 'account-1');
+    },
+  );
+
+  test(
+    'foreground due-outbox recovery runs only native outbox reconciliation',
+    () async {
+      final events = <String>[];
+      var receiptReadCount = 0;
+      final service = IronwoodMigrationService(
+        getWalletDbPath: () async => '/tmp/wallet.db',
+        getStatus:
+            ({required dbPath, required network, required accountUuid}) async =>
+                _migrationStatus(
+                  phase: 'broadcast_scheduled',
+                  activeRunId: 'run-1',
+                  parts: [_migrationPart(txidHex: 'tx-1')],
+                  scheduledBroadcasts: [_scheduledBroadcast(txidHex: 'tx-1')],
+                ),
+        getPrivatePlan:
+            ({required dbPath, required network, required accountUuid}) async =>
+                null,
+        secureStore: AppSecureStore.testing(
+          storage: const FlutterSecureStorage(),
+        ),
+        getEndpoint: _testEndpoint,
+        isMobile: () => true,
+        isIOS: () => true,
+        hasMigrationOutboxBatch:
+            ({
+              required batchId,
+              required network,
+              required accountUuid,
+              required runId,
+              required expectedTxids,
+              required requiredTxids,
+            }) async {
+              events.add('has');
+              expect(requiredTxids, ['tx-1']);
+              return true;
+            },
+        listMigrationOutboxReceipts: () async {
+          events.add('list');
+          receiptReadCount++;
+          return receiptReadCount == 1
+              ? const []
+              : [_outboxReceipt(receiptId: 'receipt-1', txidHex: 'tx-1')];
+        },
+        reconcileMigrationOutboxReceipt:
+            ({
+              required dbPath,
+              required network,
+              required accountUuid,
+              required runId,
+              required txidHex,
+              required outcome,
+              required remoteHeight,
+              responseMessage,
+              required scheduleUpdates,
+              acceptedRawTransaction,
+            }) async {
+              events.add('receipt');
+            },
+        acknowledgeMigrationOutboxReceipts: (_) async {
+          events.add('ack');
+        },
+        runMigrationOutboxOnceNow: () async {
+          events.add('run');
+          return const IronwoodMigrationOutboxRunResult(
+            outcome: IronwoodMigrationOutboxRunOutcome.accepted,
+            observedHeight: 1_000,
+          );
+        },
+      );
+
+      final result = await service.recoverDueMigrationOutbox(
+        network: 'test',
+        accountUuid: 'account-1',
+      );
+
+      expect(result.outcome, IronwoodMigrationOutboxRunOutcome.accepted);
+      expect(events, ['list', 'has', 'run', 'list', 'receipt', 'ack']);
+    },
+  );
+
+  test(
+    'foreground recovery allows the global outbox to accept another account',
+    () async {
+      final service = IronwoodMigrationService(
+        getWalletDbPath: () async => '/tmp/wallet.db',
+        getStatus:
+            ({required dbPath, required network, required accountUuid}) async =>
+                _migrationStatus(
+                  phase: 'broadcast_scheduled',
+                  activeRunId: 'run-1',
+                  parts: [_migrationPart(txidHex: 'tx-1')],
+                  scheduledBroadcasts: [_scheduledBroadcast(txidHex: 'tx-1')],
+                ),
+        getPrivatePlan:
+            ({required dbPath, required network, required accountUuid}) async =>
+                null,
+        secureStore: AppSecureStore.testing(
+          storage: const FlutterSecureStorage(),
+        ),
+        getEndpoint: _testEndpoint,
+        isMobile: () => true,
+        isIOS: () => true,
+        hasMigrationOutboxBatch:
+            ({
+              required batchId,
+              required network,
+              required accountUuid,
+              required runId,
+              required expectedTxids,
+              required requiredTxids,
+            }) async => true,
+        listMigrationOutboxReceipts: () async => const [],
+        runMigrationOutboxOnceNow: () async =>
+            const IronwoodMigrationOutboxRunResult(
+              outcome: IronwoodMigrationOutboxRunOutcome.accepted,
+              observedHeight: 1_000,
+            ),
+      );
+
+      final result = await service.recoverDueMigrationOutbox(
+        network: 'test',
+        accountUuid: 'account-1',
+      );
+
+      expect(result.outcome, IronwoodMigrationOutboxRunOutcome.accepted);
+    },
+  );
+
+  test(
+    'foreground recovery rejects a missing requested-account outbox batch',
+    () async {
+      var foregroundRuns = 0;
+      final service = IronwoodMigrationService(
+        getWalletDbPath: () async => '/tmp/wallet.db',
+        getStatus:
+            ({required dbPath, required network, required accountUuid}) async =>
+                _migrationStatus(
+                  phase: 'broadcast_scheduled',
+                  activeRunId: 'run-1',
+                  parts: [_migrationPart(txidHex: 'tx-1')],
+                  scheduledBroadcasts: [_scheduledBroadcast(txidHex: 'tx-1')],
+                ),
+        getPrivatePlan:
+            ({required dbPath, required network, required accountUuid}) async =>
+                null,
+        secureStore: AppSecureStore.testing(
+          storage: const FlutterSecureStorage(),
+        ),
+        getEndpoint: _testEndpoint,
+        isMobile: () => true,
+        isIOS: () => true,
+        listMigrationOutboxReceipts: () async => const [],
+        hasMigrationOutboxBatch:
+            ({
+              required batchId,
+              required network,
+              required accountUuid,
+              required runId,
+              required expectedTxids,
+              required requiredTxids,
+            }) async => false,
+        runMigrationOutboxOnceNow: () async {
+          foregroundRuns++;
+          return const IronwoodMigrationOutboxRunResult(
+            outcome: IronwoodMigrationOutboxRunOutcome.waiting,
+            nextHeight: 1_001,
+            observedHeight: 1_000,
+          );
+        },
+      );
+
+      await expectLater(
+        service.recoverDueMigrationOutbox(
+          network: 'test',
+          accountUuid: 'account-1',
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('not available in the background outbox'),
+          ),
+        ),
+      );
+      expect(foregroundRuns, 0);
     },
   );
 
@@ -2916,6 +3118,7 @@ rust_sync.MigrationStatus _migrationStatus({
   String phase = 'ready_to_prepare',
   String? activeRunId,
   List<rust_sync.MigrationPartStatus> parts = const [],
+  List<rust_sync.MigrationScheduledBroadcast> scheduledBroadcasts = const [],
 }) {
   return rust_sync.MigrationStatus(
     phase: phase,
@@ -2936,8 +3139,20 @@ rust_sync.MigrationStatus _migrationStatus({
     signingBatchLimit: 35,
     scheduleMeanDelayBlocks: 144,
     scheduleMaxDelayBlocks: 576,
-    scheduledBroadcasts: const [],
+    scheduledBroadcasts: scheduledBroadcasts,
     parts: parts,
+  );
+}
+
+rust_sync.MigrationScheduledBroadcast _scheduledBroadcast({
+  required String txidHex,
+}) {
+  return rust_sync.MigrationScheduledBroadcast(
+    txidHex: txidHex,
+    valueZatoshi: BigInt.from(100000),
+    scheduledAtMs: 0,
+    scheduledHeight: 1_000,
+    status: 'scheduled',
   );
 }
 

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -4840,7 +4840,7 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('We will notify you'), findsOneWidget);
+      expect(find.textContaining('Notifications are on'), findsOneWidget);
       authorizationLookupFails = true;
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
@@ -4853,7 +4853,7 @@ void main() {
       expect(coordinator.synchronizeCount, 0);
       expect(find.text("Couldn't update migration"), findsNothing);
       expect(find.textContaining('Notifications are disabled'), findsWidgets);
-      expect(find.textContaining('We will notify you'), findsNothing);
+      expect(find.textContaining('Notifications are on'), findsNothing);
     },
   );
 
@@ -4921,7 +4921,7 @@ void main() {
     },
   );
 
-  testWidgets('shows the next signing window while broadcasting', (
+  testWidgets('shows the next migration step while broadcasting', (
     tester,
   ) async {
     _useMobileViewport(tester);
@@ -4935,11 +4935,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('All is well. Broadcasting notes…'), findsWidgets);
-    expect(find.textContaining('Signing window expected'), findsOneWidget);
-    expect(
-      find.textContaining('We will notify you when it’s ready.'),
-      findsOneWidget,
-    );
+    expect(find.textContaining('Next migration step expected'), findsOneWidget);
+    expect(find.textContaining('Notifications are on'), findsOneWidget);
   });
 
   testWidgets('keeps coordinator errors on the redesigned retry surface', (
@@ -5128,6 +5125,41 @@ void main() {
     expect(find.text('0/1 Batch'), findsOneWidget);
   });
 
+  testWidgets('shows a due scheduled transaction as ready, never Soon', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/private/status',
+        migrationService: _migrationService(),
+        status: _status(
+          phase: kIronwoodMigrationBroadcastScheduledPhase,
+          broadcastStatuses: const ['scheduled'],
+          nextActionHeight: 3_000_000,
+          nextActionPartIndex: 0,
+        ),
+        syncState: SyncState(
+          accountUuid: 'account-1',
+          hasAccountScopedData: true,
+          scannedHeight: 3_000_000,
+          chainTipHeight: 3_000_000,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Scheduled transaction ready'), findsOneWidget);
+    expect(find.text('Ready now'), findsOneWidget);
+    expect(
+      find.textContaining('ready for automatic submission'),
+      findsOneWidget,
+    );
+    expect(find.text('soon'), findsNothing);
+    expect(find.text('Soon'), findsNothing);
+    expect(find.text('Waiting for signing window'), findsNothing);
+  });
+
   testWidgets('shows safe-block timing without a proof label', (tester) async {
     _useMobileViewport(tester);
     await tester.pumpWidget(
@@ -5156,7 +5188,7 @@ void main() {
     expect(find.textContaining('~25 minutes'), findsOneWidget);
     expect(find.textContaining('Proof'), findsNothing);
     expect(find.text('Sign batch #2'), findsNothing);
-    expect(find.text('Waiting for signing window'), findsOneWidget);
+    expect(find.text('Waiting for next migration step'), findsOneWidget);
   });
 
   testWidgets('shows the real next block when notifications are disabled', (


### PR DESCRIPTION
## Summary

- recover due mobile migration broadcasts from the persisted native outbox whenever the app returns to the foreground
- validate that every scheduled transaction is present before attempting recovery
- scope native waiting and user-action outcomes to the correct account and honor native retry delays per batch
- replace the ambiguous `Soon` state with explicit ready, waiting, and recovery guidance

## Root cause

A scheduled migration could remain in `broadcast_scheduled` when OS background execution did not run. Foreground status refreshes did not directly reconcile and execute the native outbox, so reopening Vizor could continue showing an indefinite timing label without making progress. Global native results also lacked enough account and retry metadata for safe multi-account recovery.

## User impact

Reopening an unlocked mobile wallet now actively retries an intact due outbox without requiring another signing action. Missing or inconsistent outbox state is surfaced as actionable instead of remaining in an indefinite waiting state, and the UI no longer claims an imprecise `Soon` or an unverified in-flight submission.

## Validation

- `fvm flutter analyze lib/src/features/migration test/features/migration`
- migration service tests: 55 passed
- mobile coordinator and migration flow tests: 127 passed
- Android `IronwoodMigrationOutboxTest`: passed
- iOS `BackgroundMigrationOutboxTests`: 30 passed
- rebased onto current `origin/main` without conflicts
