### PR TITLE
Fix private migration draft timing

### DIFF
--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_intro_options.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_intro_options.dart
@@ -171,6 +171,7 @@ class _MobileMigrationOptionsState
       _continueError = null;
     });
     rust_sync.OrchardMigrationPrivatePlan? plan;
+    String? accountUuid;
     try {
       plan = await ref.read(ironwoodMigrationPrivatePlanProvider.future);
       if (!mounted) return;
@@ -179,7 +180,7 @@ class _MobileMigrationOptionsState
       }
       final accountState = await ref.read(accountProvider.future);
       if (!mounted) return;
-      final accountUuid = accountState.activeAccountUuid;
+      accountUuid = accountState.activeAccountUuid;
       if (accountUuid == null) {
         throw StateError('No active account is selected.');
       }
@@ -191,17 +192,8 @@ class _MobileMigrationOptionsState
           );
         }
       }
-      await ref
-          .read(ironwoodMigrationServiceProvider)
-          .savePrivateMigrationDraft(
-            accountUuid: accountUuid,
-            approvedSchedule: plan.scheduledTransfers,
-          );
-      ref.invalidate(ironwoodMigrationRouteCtaProvider);
-      ref.invalidate(ironwoodHomeMigrationCtaProvider);
-      ref.invalidate(ironwoodPostMigrationStateProvider);
     } catch (error) {
-      debugPrint('Failed to save private migration draft: $error');
+      debugPrint('Failed to prepare private migration choice: $error');
       if (!mounted) return;
       setState(() {
         _continueError = "Couldn't prepare the migration plan. Try again.";
@@ -228,6 +220,15 @@ class _MobileMigrationOptionsState
         context.go('/migration/private/notifications', extra: plan);
         return;
       }
+      await ref
+          .read(ironwoodMigrationServiceProvider)
+          .savePrivateMigrationDraft(
+            accountUuid: accountUuid,
+            approvedSchedule: plan.scheduledTransfers,
+          );
+      if (!mounted) return;
+      await _refreshPrivateMigrationDraftPresentation(ref);
+      if (!mounted) return;
       await _continuePrivateMigrationAfterNotificationGate(ref, plan);
       if (!mounted) return;
       context.go(
@@ -312,6 +313,19 @@ class _MobileMigrationOptionsState
         ],
       ),
     );
+  }
+}
+
+Future<void> _refreshPrivateMigrationDraftPresentation(WidgetRef ref) async {
+  ref.invalidate(ironwoodMigrationRouteCtaProvider);
+  ref.invalidate(ironwoodHomeMigrationCtaProvider);
+  ref.invalidate(ironwoodPostMigrationStateProvider);
+  try {
+    await ref.read(ironwoodHomeMigrationCtaProvider.future);
+  } catch (error) {
+    // The durable draft is already saved. Let the destination screen reconcile
+    // it rather than trapping the user on the option picker for a stale read.
+    debugPrint('Failed to refresh private migration presentation: $error');
   }
 }
 

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -291,15 +291,30 @@ class _MobileMigrationNotificationPermissionScreenState
 
   Future<void> _continueAfterNotificationGate() async {
     final plan = widget.privatePlan;
-    if (plan == null || plan.denominationSplitStageCount != 0) {
-      if (mounted) {
-        context.go('/migration/private/start', extra: plan);
-      }
-      return;
-    }
-
     if (!_busy && mounted) setState(() => _busy = true);
     try {
+      if (plan == null) {
+        throw StateError('Migration plan is unavailable.');
+      }
+      final accountState = await ref.read(accountProvider.future);
+      if (!mounted) return;
+      final accountUuid = accountState.activeAccountUuid;
+      if (accountUuid == null) {
+        throw StateError('No active account is selected.');
+      }
+      await ref
+          .read(ironwoodMigrationServiceProvider)
+          .savePrivateMigrationDraft(
+            accountUuid: accountUuid,
+            approvedSchedule: plan.scheduledTransfers,
+          );
+      if (!mounted) return;
+      await _refreshPrivateMigrationDraftPresentation(ref);
+      if (!mounted) return;
+      if (plan.denominationSplitStageCount != 0) {
+        context.go('/migration/private/start', extra: plan);
+        return;
+      }
       await _continuePrivateMigrationAfterNotificationGate(ref, plan);
       if (!mounted) return;
       context.go('/migration/private/status', extra: plan);

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -1313,7 +1313,7 @@ void main() {
   });
 
   testWidgets(
-    'saves a software private draft before leaving migration options',
+    'saves a software private draft only after the notification gate',
     (tester) async {
       _useMobileViewport(tester);
       var savedDraftCount = 0;
@@ -1339,8 +1339,16 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(savedDraftCount, 1);
+      expect(savedDraftCount, 0);
       expect(find.text('Keep your migration on schedule'), findsOneWidget);
+
+      await tester.tap(find.text('Not now'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Continue without notifications'));
+      await tester.pumpAndSettle();
+
+      expect(savedDraftCount, 1);
+      expect(find.text('Keep your migration on schedule'), findsNothing);
     },
   );
 


### PR DESCRIPTION
## Problem

Selecting Private persisted an awaiting_preparation migration draft before the notification decision was final. A user could return from the notification screen and choose Immediate while the private run already existed, or briefly see the stale start CTA after leaving the preparation screen.

## Solution

- Defer private draft creation until notification permission is granted or the user explicitly confirms continuing without notifications.
- Refresh migration CTA presentation after the durable draft is saved before entering preparation.
- Keep the refresh best-effort so a transient status read cannot trap the user on the option picker after the draft already exists.
- Cover the persistence boundary with a mobile flow test.

## Validation

- Mobile Ironwood migration flow suite: 82 tests passed.
- Focused private-draft timing test passed.
- Targeted Flutter analyze: no issues.