### PR TITLE
Add a dedicated mobile Ironwood migration completion route

### DIFF
--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -321,6 +321,16 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
         ),
       ),
     ),
+    // Completion has its own destination so home does not have to route
+    // through the status screen, whose entry refresh renders a progress
+    // surface before the finished phase resolves.
+    GoRoute(
+      path: '/migration/complete',
+      pageBuilder: (context, state) => CupertinoPage(
+        key: state.pageKey,
+        child: const MobileIronwoodMigrationCompleteScreen(),
+      ),
+    ),
     GoRoute(
       path: '/migration/private/status',
       pageBuilder: (context, state) {

--- a/lib/src/features/home/screens/mobile/mobile_home_screen.dart
+++ b/lib/src/features/home/screens/mobile/mobile_home_screen.dart
@@ -236,7 +236,7 @@ class _IronwoodMigrationCompletionHostState
       }
       if (!_isOnHome()) return;
       routed.add(key);
-      context.go('/migration/private/status');
+      context.go('/migration/complete');
     });
   }
 
@@ -248,9 +248,7 @@ class _IronwoodMigrationCompletionHostState
   /// `/home` no matter where the user navigated, which made the guard vacuous.
   /// The router's current configuration is the actual location.
   bool _isOnHome() {
-    return GoRouter.of(
-          context,
-        ).routerDelegate.currentConfiguration.uri.path ==
+    return GoRouter.of(context).routerDelegate.currentConfiguration.uri.path ==
         '/home';
   }
 

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -1991,6 +1991,113 @@ class _AnimatedMigrationWaitLoopState extends State<_AnimatedMigrationWaitLoop>
   }
 }
 
+/// The amount shown on a finished migration.
+///
+/// Single rule on purpose. The dedicated completion route and the status
+/// screen's completion branch both render the same result, and the completion
+/// provider publishes its own total for routing — three places that could
+/// otherwise disagree about what the user migrated.
+String migrationCompletedAmountText(
+  rust_sync.MigrationStatus status, {
+  String? fallbackAmountText,
+}) {
+  final total = status.parts.isNotEmpty
+      ? status.parts.fold<BigInt>(
+          BigInt.zero,
+          (sum, part) => sum + part.valueZatoshi,
+        )
+      : status.targetValuesZatoshi.fold<BigInt>(
+          BigInt.zero,
+          (sum, value) => sum + value,
+        );
+  final text = total > BigInt.zero
+      ? ZecAmount.fromZatoshi(total).compactBalance.amountText
+      : fallbackAmountText;
+  return text == null ? '' : '$text ZEC';
+}
+
+/// The finished-migration result, with the behaviour that has to accompany it.
+///
+/// Owns marking the completion seen so the dedicated route and the status
+/// screen cannot drift apart on when a result stops being re-shown. The two
+/// reach this surface under different conditions — the route because home
+/// found an unseen completion, the status screen because the run it is already
+/// showing finished — but once here they must behave identically.
+class _MigrationCompleteSurface extends ConsumerStatefulWidget {
+  const _MigrationCompleteSurface({
+    required this.status,
+    required this.onDone,
+    this.fallbackAmountText,
+  });
+
+  final rust_sync.MigrationStatus status;
+  final VoidCallback onDone;
+  final String? fallbackAmountText;
+
+  @override
+  ConsumerState<_MigrationCompleteSurface> createState() =>
+      _MigrationCompleteSurfaceState();
+}
+
+class _MigrationCompleteSurfaceState
+    extends ConsumerState<_MigrationCompleteSurface> {
+  bool _seenRecorded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      unawaited(_markCompletionSeen());
+    });
+  }
+
+  Future<void> _markCompletionSeen() async {
+    if (_seenRecorded || !mounted) return;
+    _seenRecorded = true;
+    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
+    if (accountUuid == null) return;
+    // Prefer the identity the completion provider itself published. Recomputing
+    // it from this status can disagree with the status the provider read, and a
+    // key that never matches leaves the run forever unseen, so home would route
+    // back to the result on every return. Only trust it for the account on
+    // screen: a reloading provider keeps serving its previous value, so right
+    // after an account switch the published identity can still be the account
+    // the user left.
+    final publishedValue = ref.read(ironwoodMigrationCompletionProvider).value;
+    final published = publishedValue?.accountUuid == accountUuid
+        ? publishedValue
+        : null;
+    final network =
+        published?.network ?? ref.read(ironwoodMigrationInputsProvider).network;
+    final completionId =
+        published?.completionId ?? ironwoodMigrationCompletionId(widget.status);
+    try {
+      await ref
+          .read(ironwoodMigrationCompletionStoreProvider)
+          .markSeen(
+            network: network,
+            accountUuid: accountUuid,
+            completionId: completionId,
+          );
+    } catch (_) {
+      return;
+    }
+    if (!mounted) return;
+    ref.invalidate(ironwoodMigrationCompletionProvider);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _MigrationCompletePreview(
+      amountText: migrationCompletedAmountText(
+        widget.status,
+        fallbackAmountText: widget.fallbackAmountText,
+      ),
+      onDone: widget.onDone,
+    );
+  }
+}
+
 class _MigrationCompletePreview extends StatelessWidget {
   const _MigrationCompletePreview({this.amountText, this.onDone});
 

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_preview_surfaces.dart
@@ -88,7 +88,7 @@ class _MobileIronwoodMigrationPreviewSurface extends StatelessWidget {
           ],
         ),
       MobileIronwoodMigrationPreviewSurface.migrationComplete =>
-        const _MigrationCompletePreview(),
+        const _MigrationCompletePreview(amountText: '142.992 ZEC'),
       MobileIronwoodMigrationPreviewSurface.homeAttention =>
         const _MigrationHomeAttentionPreview(),
       MobileIronwoodMigrationPreviewSurface.homeAttentionModal =>
@@ -1999,7 +1999,7 @@ class _AnimatedMigrationWaitLoopState extends State<_AnimatedMigrationWaitLoop>
 /// otherwise disagree about what the user migrated.
 String migrationCompletedAmountText(
   rust_sync.MigrationStatus status, {
-  String? fallbackAmountText,
+  required String fallbackAmountText,
 }) {
   final total = status.parts.isNotEmpty
       ? status.parts.fold<BigInt>(
@@ -2013,7 +2013,7 @@ String migrationCompletedAmountText(
   final text = total > BigInt.zero
       ? ZecAmount.fromZatoshi(total).compactBalance.amountText
       : fallbackAmountText;
-  return text == null ? '' : '$text ZEC';
+  return '$text ZEC';
 }
 
 /// The finished-migration result, with the behaviour that has to accompany it.
@@ -2027,12 +2027,12 @@ class _MigrationCompleteSurface extends ConsumerStatefulWidget {
   const _MigrationCompleteSurface({
     required this.status,
     required this.onDone,
-    this.fallbackAmountText,
+    required this.fallbackAmountText,
   });
 
   final rust_sync.MigrationStatus status;
   final VoidCallback onDone;
-  final String? fallbackAmountText;
+  final String fallbackAmountText;
 
   @override
   ConsumerState<_MigrationCompleteSurface> createState() =>
@@ -2099,9 +2099,13 @@ class _MigrationCompleteSurfaceState
 }
 
 class _MigrationCompletePreview extends StatelessWidget {
-  const _MigrationCompletePreview({this.amountText, this.onDone});
+  const _MigrationCompletePreview({required this.amountText, this.onDone});
 
-  final String? amountText;
+  /// Required, and never empty. A placeholder default here would be a sample
+  /// amount rendered to a real user as their migration result; an empty one
+  /// leaves the headline with a blank line where the total belongs. Preview
+  /// call sites pass their own sample.
+  final String amountText;
   final VoidCallback? onDone;
 
   @override
@@ -2146,7 +2150,7 @@ class _MigrationCompletePreview extends StatelessWidget {
           ),
           const SizedBox(height: AppSpacing.xl),
           Text(
-            'Your\n${amountText ?? '142.992 ZEC'}\nare on Ironwood!',
+            'Your\n$amountText\nare on Ironwood!',
             textAlign: TextAlign.center,
             style: AppTypography.displayLarge.copyWith(
               color: const Color(0xFFFFFFFF),

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_redesigned_status.dart
@@ -62,7 +62,6 @@ class _MobileMigrationRedesignedStatusState
   bool _actionRunning = false;
   bool _softwarePreparationResumeAttempted = false;
   String? _softwarePreparationResumeError;
-  bool _completionSeenRecorded = false;
   String? _recordedAttentionFingerprint;
 
   @override
@@ -595,9 +594,9 @@ class _MobileMigrationRedesignedStatusState
     }
 
     if (widget.status.phase == kIronwoodMigrationCompletePhase) {
-      _recordCompletionSeen();
-      return _MigrationCompletePreview(
-        amountText: _totalAmountText(widget.status),
+      return _MigrationCompleteSurface(
+        status: widget.status,
+        fallbackAmountText: widget.data.amountText,
         onDone: () => context.go('/home'),
       );
     }
@@ -901,49 +900,6 @@ class _MobileMigrationRedesignedStatusState
   /// back here. Deliberately keyed to the screen actually rendering rather than
   /// to the navigation that brought the user here: a launch that dies before
   /// the frame is drawn should still owe the user its result.
-  void _recordCompletionSeen() {
-    if (_completionSeenRecorded) return;
-    _completionSeenRecorded = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      unawaited(_markCompletionSeen());
-    });
-  }
-
-  Future<void> _markCompletionSeen() async {
-    if (!mounted) return;
-    // Record the identity the completion provider itself published. Recomputing
-    // it here from this screen's status can disagree with the status the
-    // provider read, and a key that never matches leaves the run forever
-    // unseen, so home would route back to this screen on every return.
-    final accountUuid = ref.read(accountProvider).value?.activeAccountUuid;
-    if (accountUuid == null) return;
-    // Only when it is for the account on screen. A refresh keeps serving the
-    // previous value, so right after an account switch the published identity
-    // can still be the account the user left — marking that one seen while the
-    // account they are looking at stays unseen and keeps being routed back to.
-    final publishedValue = ref.read(ironwoodMigrationCompletionProvider).value;
-    final published = publishedValue?.accountUuid == accountUuid
-        ? publishedValue
-        : null;
-    final network =
-        published?.network ?? ref.read(ironwoodMigrationInputsProvider).network;
-    final completionId =
-        published?.completionId ?? ironwoodMigrationCompletionId(widget.status);
-    try {
-      await ref
-          .read(ironwoodMigrationCompletionStoreProvider)
-          .markSeen(
-            network: network,
-            accountUuid: accountUuid,
-            completionId: completionId,
-          );
-    } catch (_) {
-      return;
-    }
-    if (!mounted) return;
-    ref.invalidate(ironwoodMigrationCompletionProvider);
-  }
-
   void _recordVisibleAttention(String? accountUuid) {
     final runId = widget.status.activeRunId;
     if (accountUuid == null || runId == null) return;
@@ -1295,19 +1251,10 @@ class _MobileMigrationRedesignedStatusState
   }
 
   String _totalAmountText(rust_sync.MigrationStatus status) {
-    final total = status.parts.isNotEmpty
-        ? status.parts.fold<BigInt>(
-            BigInt.zero,
-            (sum, part) => sum + part.valueZatoshi,
-          )
-        : status.targetValuesZatoshi.fold<BigInt>(
-            BigInt.zero,
-            (sum, value) => sum + value,
-          );
-    final fallback = total > BigInt.zero
-        ? ZecAmount.fromZatoshi(total).compactBalance.amountText
-        : widget.data.amountText;
-    return '$fallback ZEC';
+    return migrationCompletedAmountText(
+      status,
+      fallbackAmountText: widget.data.amountText,
+    );
   }
 
   String _availableAmountText(String? accountUuid) {

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_routes.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_routes.dart
@@ -111,6 +111,80 @@ class _MobileIronwoodMigrationContent extends ConsumerWidget {
   }
 }
 
+/// Dedicated destination for a finished migration.
+///
+/// The result used to be reachable only as a branch inside the status screen,
+/// so home's completion routing had to send the user to
+/// `/migration/private/status`. That screen refreshes its own status on entry
+/// and renders its loading/progress surface until the durable phase resolves,
+/// which is why a finished migration flashed "in progress" before landing on
+/// the result. The status screen keeps its own completion branch so the result
+/// still appears when the user is already standing on it; both render the same
+/// [_MigrationCompleteSurface], which owns the amount and the seen-marking.
+class MobileIronwoodMigrationCompleteScreen extends ConsumerStatefulWidget {
+  const MobileIronwoodMigrationCompleteScreen({super.key});
+
+  @override
+  ConsumerState<MobileIronwoodMigrationCompleteScreen> createState() =>
+      _MobileIronwoodMigrationCompleteScreenState();
+}
+
+class _MobileIronwoodMigrationCompleteScreenState
+    extends ConsumerState<MobileIronwoodMigrationCompleteScreen> {
+  /// The account whose result this screen opened for, held across rebuilds.
+  ///
+  /// Marking a completion seen invalidates the provider that published it, so
+  /// `visible` flips to false moments after this screen appears. Re-deciding
+  /// from that provider on every build would redirect home and flash the
+  /// result past — the exact behaviour this route exists to remove.
+  String? _shownAccountUuid;
+
+  @override
+  Widget build(BuildContext context) {
+    final accountUuid = ref.watch(accountProvider).value?.activeAccountUuid;
+
+    // Switching accounts must not leave another account's result on screen.
+    final shownAccountUuid = _shownAccountUuid;
+    if (shownAccountUuid != null && shownAccountUuid != accountUuid) {
+      return const _MobileMigrationRedirectHome();
+    }
+
+    final ctaAsync = ref.watch(ironwoodMigrationRouteCtaProvider);
+    final data = ref.watch(ironwoodMigrationFlowDataProvider);
+    final status = ctaAsync.value?.status;
+    final completedStatus =
+        status != null && status.phase == kIronwoodMigrationCompletePhase
+        ? status
+        : null;
+
+    if (shownAccountUuid == null) {
+      final completion = ref.watch(ironwoodMigrationCompletionProvider);
+      // Never bounce off this route while either source is still settling;
+      // that flicker is what this screen exists to remove.
+      if (completion.isLoading || ctaAsync.isLoading) {
+        return const _MobileMigrationLoadingScreen();
+      }
+      final value = completion.value;
+      if (value == null ||
+          !value.visible ||
+          value.accountUuid != accountUuid ||
+          completedStatus == null) {
+        return const _MobileMigrationRedirectHome();
+      }
+      _shownAccountUuid = accountUuid;
+    }
+
+    if (completedStatus == null) {
+      return const _MobileMigrationLoadingScreen();
+    }
+    return _MigrationCompleteSurface(
+      status: completedStatus,
+      fallbackAmountText: data?.amountText,
+      onDone: () => context.go('/home'),
+    );
+  }
+}
+
 class MobileIronwoodMigrationPrivateStatusScreen extends ConsumerWidget {
   const MobileIronwoodMigrationPrivateStatusScreen({
     this.approvedPlan,

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_routes.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_routes.dart
@@ -174,12 +174,14 @@ class _MobileIronwoodMigrationCompleteScreenState
       _shownAccountUuid = accountUuid;
     }
 
-    if (completedStatus == null) {
+    // The result headline is built from a real amount or not shown at all, so
+    // wait for the flow data rather than rendering a blank total.
+    if (completedStatus == null || data == null) {
       return const _MobileMigrationLoadingScreen();
     }
     return _MigrationCompleteSurface(
       status: completedStatus,
-      fallbackAmountText: data?.amountText,
+      fallbackAmountText: data.amountText,
       onDone: () => context.go('/home'),
     );
   }

--- a/test/features/home/mobile_home_screen_test.dart
+++ b/test/features/home/mobile_home_screen_test.dart
@@ -278,6 +278,10 @@ Widget _app(
         builder: (_, _) => const Text('migration intro route'),
       ),
       GoRoute(
+        path: '/migration/complete',
+        builder: (_, _) => const Text('migration complete route'),
+      ),
+      GoRoute(
         path: '/migration/private/status',
         builder: (_, _) => const Text('migration status route'),
       ),
@@ -813,16 +817,16 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('migration status route'), findsOneWidget);
+    expect(find.text('migration complete route'), findsOneWidget);
 
     // Leaving the completion screen unmounts the host. Returning home must not
     // route back into a completion the user was already shown.
     GoRouter.of(
-      tester.element(find.text('migration status route')),
+      tester.element(find.text('migration complete route')),
     ).go('/home');
     await tester.pumpAndSettle();
 
-    expect(find.text('migration status route'), findsNothing);
+    expect(find.text('migration complete route'), findsNothing);
   });
 
   testWidgets('does not route away from the tab the user switched to', (
@@ -858,7 +862,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('migration status route'), findsNothing);
+    expect(find.text('migration complete route'), findsNothing);
     expect(find.text('shell activity route'), findsOneWidget);
   });
 
@@ -880,7 +884,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('migration status route'), findsNothing);
+    expect(find.text('migration complete route'), findsNothing);
   });
 
   testWidgets('does not route while the completion state is unsettled', (
@@ -894,7 +898,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('migration status route'), findsNothing);
+    expect(find.text('migration complete route'), findsNothing);
   });
 
   testWidgets('keeps the required migration lock while the raw CTA is hidden', (

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -707,6 +707,10 @@ Widget _productionApp({
         },
       ),
       GoRoute(
+        path: '/migration/complete',
+        builder: (_, _) => const MobileIronwoodMigrationCompleteScreen(),
+      ),
+      GoRoute(
         path: '/migration/private/status',
         builder: (_, _) => MobileIronwoodMigrationPrivateStatusScreen(
           approvedPlan: privatePlan,
@@ -3906,6 +3910,79 @@ void main() {
 
     expect(seen, hasLength(1));
     expect(seen.single, startsWith('main:account-1:'));
+  });
+
+  testWidgets('completion route keeps the result after marking it seen', (
+    tester,
+  ) async {
+    // Marking a completion seen invalidates the provider that published it, so
+    // `visible` flips to false right after this screen appears. Reading the
+    // provider on every build would redirect home and flash the result past —
+    // the behaviour this dedicated route exists to remove.
+    _useMobileViewport(tester);
+    final seen = <String>[];
+    final completion = ValueNotifier<IronwoodMigrationCompletionState>(
+      IronwoodMigrationCompletionState.visible(
+        network: 'main',
+        accountUuid: 'account-1',
+        completionId: 'completion-1',
+        transferredZatoshi: BigInt.from(412_000_000),
+      ),
+    );
+    addTearDown(completion.dispose);
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/complete',
+        migrationService: _migrationService(),
+        status: _status(
+          phase: kIronwoodMigrationCompletePhase,
+          targetValues: const [412_000_000],
+        ),
+        extraOverrides: [
+          ironwoodMigrationCompletionStoreProvider.overrideWithValue(
+            _RecordingCompletionStore(seen),
+          ),
+          ironwoodMigrationCompletionProvider.overrideWith(
+            (ref) => completion.value,
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('You’re all set!'), findsOneWidget);
+    expect(seen, hasLength(1));
+
+    completion.value = const IronwoodMigrationCompletionState.hidden();
+    await tester.pumpAndSettle();
+
+    expect(find.text('You’re all set!'), findsOneWidget);
+    expect(find.text('home route'), findsNothing);
+  });
+
+  testWidgets('completion route returns home when nothing completed', (
+    tester,
+  ) async {
+    _useMobileViewport(tester);
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/complete',
+        migrationService: _migrationService(),
+        status: _status(
+          phase: kIronwoodMigrationCompletePhase,
+          targetValues: const [412_000_000],
+        ),
+        extraOverrides: [
+          ironwoodMigrationCompletionProvider.overrideWith(
+            (ref) => const IronwoodMigrationCompletionState.hidden(),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('You’re all set!'), findsNothing);
+    expect(find.text('home route'), findsOneWidget);
   });
 
   testWidgets('returns home from the full-screen completion state', (

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -3960,6 +3960,42 @@ void main() {
     expect(find.text('home route'), findsNothing);
   });
 
+  testWidgets('completion headline never renders a placeholder amount', (
+    tester,
+  ) async {
+    // The preview gallery's sample total must not reach a real user as their
+    // migration result, and an absent amount must not leave the headline with
+    // a blank line where the total belongs.
+    _useMobileViewport(tester);
+    await tester.pumpWidget(
+      _productionApp(
+        initialLocation: '/migration/complete',
+        migrationService: _migrationService(),
+        status: _status(
+          phase: kIronwoodMigrationCompletePhase,
+          targetValues: const [412_000_000],
+        ),
+        extraOverrides: [
+          ironwoodMigrationCompletionStoreProvider.overrideWithValue(
+            _RecordingCompletionStore(<String>[]),
+          ),
+          ironwoodMigrationCompletionProvider.overrideWith(
+            (ref) => IronwoodMigrationCompletionState.visible(
+              network: 'main',
+              accountUuid: 'account-1',
+              completionId: 'completion-1',
+              transferredZatoshi: BigInt.from(412_000_000),
+            ),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('142.992'), findsNothing);
+    expect(find.textContaining('4.12 ZEC'), findsOneWidget);
+  });
+
   testWidgets('completion route returns home when nothing completed', (
     tester,
   ) async {


### PR DESCRIPTION
## Problem

After an Ironwood migration finished, Home routed back through the migration status screen. That screen refreshed the durable status on entry, so users could briefly see migration progress again before reaching the completion result.

The completion amount was also derived differently depending on whether the result was rendered from the status screen or the Home route. Sharing the completion UI exposed an additional case where a placeholder or blank amount could be presented as the user's result.

## Solution

- Add a dedicated `/migration/complete` mobile route for completed migrations.
- Reuse one completion surface and one migrated-amount rule across both entry points.
- Latch the account opened by the completion route so marking the result seen does not immediately redirect it away.
- Require a real, non-empty migrated amount before rendering the completion result.
- Keep preview-only sample values confined to preview fixtures.

## User impact

Completed migrations now open directly on a stable result screen and show the actual migrated amount without flashing an in-progress state or substituting sample data.

## Scope

This PR contains only the two commits already published on `rowan/ironwood-mobile-polish3`. The current uncommitted background-task work is intentionally excluded.

## Validation

- `fvm flutter test test/features/home/mobile_home_screen_test.dart test/features/migration/mobile_ironwood_migration_flow_screen_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile`
  - 142 tests passed from a clean detached worktree at the PR head.
- A local merge-tree check against `codex/ironwood-migration-desktop-rebased` completed without conflicts.
