### PR TITLE
Persist transparent enhancement progress

### DIFF
--- a/rust/src/wallet/sync_engine/enhance.rs
+++ b/rust/src/wallet/sync_engine/enhance.rs
@@ -23,7 +23,10 @@
 //! (e.g. a newly-decrypted transaction may reveal additional parent
 //! transactions to enhance).
 
-use std::collections::{BTreeMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt::Display,
+};
 
 use tonic::{transport::Channel, Code, Status};
 use transparent::bundle::OutPoint;
@@ -229,7 +232,23 @@ pub(super) async fn run_enhancement(
                                             }
                                         }
                                     }
-                                    Ok(None) => break,
+                                    Ok(None) => {
+                                        notify_completed_address_check(
+                                            end_height,
+                                            |as_of_height| {
+                                                with_wallet_db_write_lock(
+                                                    "sync_engine.enhance.notify_address_checked",
+                                                    || {
+                                                        db.notify_address_checked(
+                                                            req.clone(),
+                                                            as_of_height,
+                                                        )
+                                                    },
+                                                )
+                                            },
+                                        )?;
+                                        break;
+                                    }
                                     Err(e) => return Err(e),
                                 }
                             }
@@ -241,6 +260,17 @@ pub(super) async fn run_enhancement(
         }
     }
     Ok(())
+}
+
+fn notify_completed_address_check<E: Display>(
+    end_height: BlockHeight,
+    notify: impl FnOnce(BlockHeight) -> Result<(), E>,
+) -> Result<(), SyncError> {
+    let as_of_height = u32::from(end_height)
+        .checked_sub(1)
+        .map(BlockHeight::from_u32)
+        .ok_or_else(|| SyncError::parse("transparent address range ends at height zero"))?;
+    notify(as_of_height).map_err(|e| SyncError::db(format!("notify_address_checked failed: {e}")))
 }
 
 async fn fill_missing_transparent_fee(
@@ -578,5 +608,39 @@ mod tests {
             mined_height_from_raw_height(u32::MAX as u64 + 1),
             Err(SyncError::Parse(_)),
         ));
+    }
+
+    #[test]
+    fn completed_address_check_notifies_at_inclusive_end_height() {
+        let mut notified_at = None;
+
+        notify_completed_address_check(BlockHeight::from_u32(41), |height| {
+            notified_at = Some(height);
+            Ok::<_, &'static str>(())
+        })
+        .unwrap();
+
+        assert_eq!(notified_at, Some(BlockHeight::from_u32(40)));
+    }
+
+    #[test]
+    fn completed_address_check_propagates_notification_failure() {
+        let result = notify_completed_address_check(BlockHeight::from_u32(41), |_| {
+            Err::<(), _>("database write failed")
+        });
+
+        assert!(matches!(result, Err(SyncError::Db(_))));
+    }
+
+    #[test]
+    fn completed_address_check_rejects_zero_end_without_notifying() {
+        let mut called = false;
+        let result = notify_completed_address_check(BlockHeight::from_u32(0), |_| {
+            called = true;
+            Ok::<_, &'static str>(())
+        });
+
+        assert!(matches!(result, Err(SyncError::Parse(_))));
+        assert!(!called);
     }
 }


### PR DESCRIPTION
## Summary

- persist completed transparent-address enhancement ranges in the wallet DB
- advance the checked-height cursor only after the lightwalletd stream
  completes successfully
- cover the exclusive range-end conversion and notification failures

## Root cause

`TransactionsInvolvingAddress` requests were serviced without calling
`WalletWrite::notify_address_checked` when the requested range completed.
The wallet DB therefore kept generating the same transparent history requests
on later syncs, causing established wallets to repeatedly download and process
historical transactions after restart or resync.

## Impact

Completed transparent-history ranges are now recorded, so subsequent syncs
continue incrementally instead of reprocessing the same history. Partial or
failed streams do not advance the cursor and remain safe to retry.

## Validation

- `cargo fmt -- --check`
- `cargo test sync_engine::enhance::tests` (12 passed)
- `cargo test` (438 passed, 1 ignored; Docker regtests ignored as designed)

No Rust or Dart API surface changes.
