### PR TITLE
Set migration preparation expiration heights

### DIFF
--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -449,6 +449,32 @@ typedef IronwoodMigrationKeystoneProofStatusGetter =
 typedef IronwoodMigrationKeystoneRequestDiscarder =
     Future<void> Function({required String requestId});
 
+Future<rust_sync.KeystoneMigrationSigningRequest>
+_defaultPrepareKeystoneDenominationMigration({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+}) => rust_sync.prepareOrchardMigrationDenominationsPczt(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+  spacePreparationBroadcasts: kAppFormFactor == AppFormFactor.desktop,
+);
+
+Future<rust_sync.KeystoneMigrationSigningRequest>
+_defaultPrepareKeystoneSingleQrMigration({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+  required List<rust_sync.MigrationScheduledTransfer> approvedSchedule,
+}) => rust_sync.prepareOrchardMigrationSingleQrPczt(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+  approvedSchedule: approvedSchedule,
+  spacePreparationBroadcasts: kAppFormFactor == AppFormFactor.desktop,
+);
+
 Future<rust_sync.IronwoodMigrationResult> _defaultStartSoftwareMigration({
   required String dbPath,
   required String lightwalletdUrl,
@@ -510,7 +536,6 @@ _defaultCompleteKeystoneDenominationMigration({
   password: password,
   saltBase64: saltBase64,
   approvedSchedule: approvedSchedule,
-  spacePreparationBroadcasts: kAppFormFactor == AppFormFactor.desktop,
 );
 
 Future<rust_sync.IronwoodMigrationResult>
@@ -532,7 +557,6 @@ _defaultCompleteKeystoneSingleQrMigration({
   signedMessages: signedMessages,
   password: password,
   saltBase64: saltBase64,
-  spacePreparationBroadcasts: kAppFormFactor == AppFormFactor.desktop,
 );
 
 Future<String> _defaultCreatePrivateMigrationDraft({
@@ -697,10 +721,10 @@ class IronwoodMigrationService {
        _recoverDueMigrationOutboxOverride = recoverDueMigrationOutbox,
        prepareKeystoneDenominationMigration =
            prepareKeystoneDenominationMigration ??
-           rust_sync.prepareOrchardMigrationDenominationsPczt,
+           _defaultPrepareKeystoneDenominationMigration,
        prepareKeystoneSingleQrMigration =
            prepareKeystoneSingleQrMigration ??
-           rust_sync.prepareOrchardMigrationSingleQrPczt,
+           _defaultPrepareKeystoneSingleQrMigration,
        prepareKeystoneImmediateMigration =
            prepareKeystoneImmediateMigration ??
            rust_sync.prepareOrchardMigrationImmediatePczt,

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -515,15 +515,19 @@ Future<IronwoodMigrationResult> broadcastOneDueOrchardMigrationTransaction({
       saltBase64: saltBase64,
     );
 
+/// Prepares denomination PCZTs with expiry heights derived from their planned
+/// broadcast heights.
 Future<KeystoneMigrationSigningRequest>
 prepareOrchardMigrationDenominationsPczt({
   required String dbPath,
   required String network,
   required String accountUuid,
+  required bool spacePreparationBroadcasts,
 }) => RustLib.instance.api.crateApiSyncPrepareOrchardMigrationDenominationsPczt(
   dbPath: dbPath,
   network: network,
   accountUuid: accountUuid,
+  spacePreparationBroadcasts: spacePreparationBroadcasts,
 );
 
 Future<String> createOrResumePrivateMigrationDraft({
@@ -550,7 +554,6 @@ Future<IronwoodMigrationResult> completeOrchardMigrationDenominationsPczt({
   required String password,
   required String saltBase64,
   required List<MigrationScheduledTransfer> approvedSchedule,
-  required bool spacePreparationBroadcasts,
 }) =>
     RustLib.instance.api.crateApiSyncCompleteOrchardMigrationDenominationsPczt(
       dbPath: dbPath,
@@ -562,7 +565,6 @@ Future<IronwoodMigrationResult> completeOrchardMigrationDenominationsPczt({
       password: password,
       saltBase64: saltBase64,
       approvedSchedule: approvedSchedule,
-      spacePreparationBroadcasts: spacePreparationBroadcasts,
     );
 
 /// Prepares the split and migration PCZTs for one Keystone signing session.
@@ -574,11 +576,13 @@ Future<KeystoneMigrationSigningRequest> prepareOrchardMigrationSingleQrPczt({
   required String network,
   required String accountUuid,
   required List<MigrationScheduledTransfer> approvedSchedule,
+  required bool spacePreparationBroadcasts,
 }) => RustLib.instance.api.crateApiSyncPrepareOrchardMigrationSingleQrPczt(
   dbPath: dbPath,
   network: network,
   accountUuid: accountUuid,
   approvedSchedule: approvedSchedule,
+  spacePreparationBroadcasts: spacePreparationBroadcasts,
 );
 
 Future<IronwoodMigrationResult> completeOrchardMigrationSingleQrPczt({
@@ -590,7 +594,6 @@ Future<IronwoodMigrationResult> completeOrchardMigrationSingleQrPczt({
   required List<KeystoneSignedMigrationMessage> signedMessages,
   required String password,
   required String saltBase64,
-  required bool spacePreparationBroadcasts,
 }) => RustLib.instance.api.crateApiSyncCompleteOrchardMigrationSingleQrPczt(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
@@ -600,7 +603,6 @@ Future<IronwoodMigrationResult> completeOrchardMigrationSingleQrPczt({
   signedMessages: signedMessages,
   password: password,
   saltBase64: saltBase64,
-  spacePreparationBroadcasts: spacePreparationBroadcasts,
 );
 
 Future<KeystoneMigrationSigningRequest> prepareOrchardMigrationBatchPczt({

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -204,7 +204,6 @@ abstract class RustLibApi extends BaseApi {
     required String password,
     required String saltBase64,
     required List<MigrationScheduledTransfer> approvedSchedule,
-    required bool spacePreparationBroadcasts,
   });
 
   Future<IronwoodMigrationResult>
@@ -227,7 +226,6 @@ abstract class RustLibApi extends BaseApi {
     required List<KeystoneSignedMigrationMessage> signedMessages,
     required String password,
     required String saltBase64,
-    required bool spacePreparationBroadcasts,
   });
 
   Future<void> crateApiSimpleConfigureFastTestnetMigration({
@@ -816,6 +814,7 @@ abstract class RustLibApi extends BaseApi {
     required String dbPath,
     required String network,
     required String accountUuid,
+    required bool spacePreparationBroadcasts,
   });
 
   Future<KeystoneMigrationSigningRequest>
@@ -844,6 +843,7 @@ abstract class RustLibApi extends BaseApi {
     required String network,
     required String accountUuid,
     required List<MigrationScheduledTransfer> approvedSchedule,
+    required bool spacePreparationBroadcasts,
   });
 
   Future<BigInt> crateApiWalletPreviewSoftwareAccountTransparentBalance({
@@ -1787,7 +1787,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String password,
     required String saltBase64,
     required List<MigrationScheduledTransfer> approvedSchedule,
-    required bool spacePreparationBroadcasts,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1808,7 +1807,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             approvedSchedule,
             serializer,
           );
-          sse_encode_bool(spacePreparationBroadcasts, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1832,7 +1830,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           password,
           saltBase64,
           approvedSchedule,
-          spacePreparationBroadcasts,
         ],
         apiImpl: this,
       ),
@@ -1853,7 +1850,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "password",
           "saltBase64",
           "approvedSchedule",
-          "spacePreparationBroadcasts",
         ],
       );
 
@@ -1930,7 +1926,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required List<KeystoneSignedMigrationMessage> signedMessages,
     required String password,
     required String saltBase64,
-    required bool spacePreparationBroadcasts,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1947,7 +1942,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
           sse_encode_String(password, serializer);
           sse_encode_String(saltBase64, serializer);
-          sse_encode_bool(spacePreparationBroadcasts, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1969,7 +1963,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           signedMessages,
           password,
           saltBase64,
-          spacePreparationBroadcasts,
         ],
         apiImpl: this,
       ),
@@ -1989,7 +1982,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "signedMessages",
           "password",
           "saltBase64",
-          "spacePreparationBroadcasts",
         ],
       );
 
@@ -5789,6 +5781,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String dbPath,
     required String network,
     required String accountUuid,
+    required bool spacePreparationBroadcasts,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -5797,6 +5790,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(dbPath, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
+          sse_encode_bool(spacePreparationBroadcasts, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -5810,7 +5804,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         ),
         constMeta:
             kCrateApiSyncPrepareOrchardMigrationDenominationsPcztConstMeta,
-        argValues: [dbPath, network, accountUuid],
+        argValues: [dbPath, network, accountUuid, spacePreparationBroadcasts],
         apiImpl: this,
       ),
     );
@@ -5820,7 +5814,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   get kCrateApiSyncPrepareOrchardMigrationDenominationsPcztConstMeta =>
       const TaskConstMeta(
         debugName: "prepare_orchard_migration_denominations_pczt",
-        argNames: ["dbPath", "network", "accountUuid"],
+        argNames: [
+          "dbPath",
+          "network",
+          "accountUuid",
+          "spacePreparationBroadcasts",
+        ],
       );
 
   @override
@@ -5950,6 +5949,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String network,
     required String accountUuid,
     required List<MigrationScheduledTransfer> approvedSchedule,
+    required bool spacePreparationBroadcasts,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -5962,6 +5962,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             approvedSchedule,
             serializer,
           );
+          sse_encode_bool(spacePreparationBroadcasts, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -5974,7 +5975,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncPrepareOrchardMigrationSingleQrPcztConstMeta,
-        argValues: [dbPath, network, accountUuid, approvedSchedule],
+        argValues: [
+          dbPath,
+          network,
+          accountUuid,
+          approvedSchedule,
+          spacePreparationBroadcasts,
+        ],
         apiImpl: this,
       ),
     );
@@ -5983,7 +5990,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiSyncPrepareOrchardMigrationSingleQrPcztConstMeta =>
       const TaskConstMeta(
         debugName: "prepare_orchard_migration_single_qr_pczt",
-        argNames: ["dbPath", "network", "accountUuid", "approvedSchedule"],
+        argNames: [
+          "dbPath",
+          "network",
+          "accountUuid",
+          "approvedSchedule",
+          "spacePreparationBroadcasts",
+        ],
       );
 
   @override

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -1541,10 +1541,13 @@ pub fn broadcast_one_due_orchard_migration_transaction(
     })
 }
 
+/// Prepares denomination PCZTs with expiry heights derived from their planned
+/// broadcast heights.
 pub fn prepare_orchard_migration_denominations_pczt(
     db_path: String,
     network: String,
     account_uuid: String,
+    space_preparation_broadcasts: bool,
 ) -> Result<KeystoneMigrationSigningRequest, String> {
     catch(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
@@ -1552,6 +1555,9 @@ pub fn prepare_orchard_migration_denominations_pczt(
             &db_path,
             network,
             &account_uuid,
+            wallet_sync::PreparationTimingPolicy::from_spacing_enabled(
+                space_preparation_broadcasts,
+            ),
         )?;
         Ok(KeystoneMigrationSigningRequest {
             request_id: request.request_id,
@@ -1651,7 +1657,6 @@ pub async fn complete_orchard_migration_denominations_pczt(
     password: String,
     salt_base64: String,
     approved_schedule: Vec<MigrationScheduledTransfer>,
-    space_preparation_broadcasts: bool,
 ) -> Result<IronwoodMigrationResult, String> {
     let network = parse_network_and_migrate(&db_path, &network)?;
     let password = Zeroizing::new(password.into_bytes());
@@ -1666,7 +1671,6 @@ pub async fn complete_orchard_migration_denominations_pczt(
         password.as_slice(),
         &salt_base64,
         to_wallet_migration_schedule(approved_schedule),
-        wallet_sync::PreparationTimingPolicy::from_spacing_enabled(space_preparation_broadcasts),
     )
     .await?;
     Ok(IronwoodMigrationResult {
@@ -1689,6 +1693,7 @@ pub fn prepare_orchard_migration_single_qr_pczt(
     network: String,
     account_uuid: String,
     approved_schedule: Vec<MigrationScheduledTransfer>,
+    space_preparation_broadcasts: bool,
 ) -> Result<KeystoneMigrationSigningRequest, String> {
     catch(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
@@ -1697,6 +1702,9 @@ pub fn prepare_orchard_migration_single_qr_pczt(
             network,
             &account_uuid,
             to_wallet_migration_schedule(approved_schedule),
+            wallet_sync::PreparationTimingPolicy::from_spacing_enabled(
+                space_preparation_broadcasts,
+            ),
         )?;
         Ok(KeystoneMigrationSigningRequest {
             request_id: request.request_id,
@@ -1722,7 +1730,6 @@ pub async fn complete_orchard_migration_single_qr_pczt(
     signed_messages: Vec<KeystoneSignedMigrationMessage>,
     password: String,
     salt_base64: String,
-    space_preparation_broadcasts: bool,
 ) -> Result<IronwoodMigrationResult, String> {
     let network = parse_network_and_migrate(&db_path, &network)?;
     let password = Zeroizing::new(password.into_bytes());
@@ -1736,7 +1743,6 @@ pub async fn complete_orchard_migration_single_qr_pczt(
         signed_messages,
         password.as_slice(),
         &salt_base64,
-        wallet_sync::PreparationTimingPolicy::from_spacing_enabled(space_preparation_broadcasts),
     )
     .await?;
     Ok(IronwoodMigrationResult {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -602,7 +602,6 @@ fn wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(
             let api_salt_base64 = <String>::sse_decode(&mut deserializer);
             let api_approved_schedule =
                 <Vec<crate::api::sync::MigrationScheduledTransfer>>::sse_decode(&mut deserializer);
-            let api_space_preparation_broadcasts = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, String>(
@@ -618,7 +617,6 @@ fn wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(
                                 api_password,
                                 api_salt_base64,
                                 api_approved_schedule,
-                                api_space_preparation_broadcasts,
                             )
                             .await?;
                         Ok(output_ok)
@@ -715,7 +713,6 @@ fn wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(
                 );
             let api_password = <String>::sse_decode(&mut deserializer);
             let api_salt_base64 = <String>::sse_decode(&mut deserializer);
-            let api_space_preparation_broadcasts = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, String>(
@@ -730,7 +727,6 @@ fn wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(
                                 api_signed_messages,
                                 api_password,
                                 api_salt_base64,
-                                api_space_preparation_broadcasts,
                             )
                             .await?;
                         Ok(output_ok)
@@ -4444,6 +4440,7 @@ fn wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_space_preparation_broadcasts = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -4451,6 +4448,7 @@ fn wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(
                         api_db_path,
                         api_network,
                         api_account_uuid,
+                        api_space_preparation_broadcasts,
                     )?;
                     Ok(output_ok)
                 })())
@@ -4577,6 +4575,7 @@ fn wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_approved_schedule =
                 <Vec<crate::api::sync::MigrationScheduledTransfer>>::sse_decode(&mut deserializer);
+            let api_space_preparation_broadcasts = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -4585,6 +4584,7 @@ fn wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(
                         api_network,
                         api_account_uuid,
                         api_approved_schedule,
+                        api_space_preparation_broadcasts,
                     )?;
                     Ok(output_ok)
                 })())

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -575,8 +575,8 @@ fn adopt_timing_policy_for_active_run(
     }
 
     // This opt-in exists only for local Testnet validation. Before any child
-    // transaction is constructed, preserve the prepared notes and signatures
-    // while replacing the long standard schedule with the fast policy.
+    // transaction is constructed, preserve signed preparation transactions
+    // while replacing the long child schedule with the fast policy.
     let schedule = planned_transfer_schedule_with_policy(
         run.target_values_zatoshi.iter().copied(),
         network,
@@ -586,10 +586,7 @@ fn adopt_timing_policy_for_active_run(
     let schedule_json = serde_json::to_string(&schedule)
         .map_err(|e| format!("Encode fast Testnet migration schedule: {e}"))?;
     let now = now_ms()?;
-    let tx = conn
-        .unchecked_transaction()
-        .map_err(|e| format!("Begin fast Testnet migration timing adoption: {e}"))?;
-    tx.execute(
+    conn.execute(
         &format!(
             "UPDATE {RUNS_TABLE}
              SET timing_policy = ?1, schedule_json = ?2, updated_at_ms = ?3
@@ -603,9 +600,7 @@ fn adopt_timing_policy_for_active_run(
         ],
     )
     .map_err(|e| format!("Adopt fast Testnet migration timing: {e}"))?;
-    reschedule_pending_preparation_stages_with_tx(&tx, &run.run_id, network, &mut OsRng)?;
-    tx.commit()
-        .map_err(|e| format!("Commit fast Testnet migration timing adoption: {e}"))
+    Ok(())
 }
 
 pub(crate) fn active_migration_run(
@@ -1012,15 +1007,6 @@ pub(crate) fn create_run_with_staged_denominations_and_signed_children(
     .map_err(|e| format!("Create staged migration run: {e}"))?;
     insert_prepared_notes_with_tx(&tx, &run_id, prepared_notes, true)?;
     insert_denomination_stages_with_tx(&tx, &run_id, denomination_stages, password, salt_base64)?;
-    if initial_phase == PHASE_WAITING_DENOM_CONFIRMATIONS {
-        initialize_preparation_schedule_with_tx(
-            &tx,
-            &run_id,
-            network,
-            preparation_timing_policy,
-            &mut OsRng,
-        )?;
-    }
     insert_signed_child_pczts_with_tx(
         &tx,
         &run_id,
@@ -1161,21 +1147,11 @@ pub(crate) fn finalize_private_migration_draft(
     } else {
         PHASE_WAITING_DENOM_CONFIRMATIONS
     };
-    let preparation_timing_policy = preparation_timing_policy_for_run_with_conn(&conn, run_id)?;
     let tx = conn
         .unchecked_transaction()
         .map_err(|e| format!("Begin private migration draft finalization: {e}"))?;
     insert_prepared_notes_with_tx(&tx, run_id, prepared_notes, true)?;
     insert_denomination_stages_with_tx(&tx, run_id, denomination_stages, password, salt_base64)?;
-    if initial_phase == PHASE_WAITING_DENOM_CONFIRMATIONS {
-        initialize_preparation_schedule_with_tx(
-            &tx,
-            run_id,
-            network,
-            preparation_timing_policy,
-            &mut OsRng,
-        )?;
-    }
     insert_signed_child_pczts_with_tx(
         &tx,
         run_id,

--- a/rust/src/wallet/sync/migration/policy.rs
+++ b/rust/src/wallet/sync/migration/policy.rs
@@ -50,7 +50,7 @@ pub(crate) fn configure_fast_testnet_migration(enabled: bool) {
     FAST_TESTNET_MIGRATION_ENABLED.store(enabled, Ordering::Relaxed);
 }
 
-fn configured_timing_policy(network: WalletNetwork) -> MigrationTimingPolicy {
+pub(crate) fn configured_timing_policy(network: WalletNetwork) -> MigrationTimingPolicy {
     if matches!(network, WalletNetwork::Test | WalletNetwork::Regtest)
         && FAST_TESTNET_MIGRATION_ENABLED.load(Ordering::Relaxed)
     {

--- a/rust/src/wallet/sync/migration/preparation_policy.rs
+++ b/rust/src/wallet/sync/migration/preparation_policy.rs
@@ -92,31 +92,72 @@ fn preparation_delay_with_rng<R: RngCore + CryptoRng + ?Sized>(
     }
 }
 
-fn preparation_policies_for_run_with_conn(
-    conn: &rusqlite::Connection,
-    run_id: &str,
-) -> Result<(PreparationTimingPolicy, MigrationTimingPolicy), String> {
-    let (preparation_value, migration_value) = conn
-        .query_row(
-            &format!(
-                "SELECT preparation_timing_policy, timing_policy
-                 FROM {RUNS_TABLE} WHERE run_id = ?1"
-            ),
-            params![run_id],
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
-        )
-        .map_err(|e| format!("Read migration preparation policies: {e}"))?;
-    Ok((
-        PreparationTimingPolicy::from_str(&preparation_value)?,
-        MigrationTimingPolicy::from_str(&migration_value)?,
-    ))
+/// Draws and assigns every preparation transaction's broadcast height before
+/// the transaction is signed. Later layers are based past the preceding
+/// layer's schedule so their inputs have time to become spendable.
+pub(crate) fn planned_preparation_scheduled_heights<
+    R: RngCore + CryptoRng + ?Sized,
+>(
+    network: WalletNetwork,
+    preparation_policy: PreparationTimingPolicy,
+    timing_policy: MigrationTimingPolicy,
+    target_height: u32,
+    stage_layers: &[usize],
+    rng: &mut R,
+) -> Result<Vec<u32>, String> {
+    let Some(last_layer) = stage_layers.iter().copied().max() else {
+        return Ok(Vec::new());
+    };
+    let mut heights = vec![0; stage_layers.len()];
+    let mut layer_base = target_height.saturating_sub(1);
+
+    for layer_index in 0..=last_layer {
+        let mut stage_indices = stage_layers
+            .iter()
+            .enumerate()
+            .filter_map(|(stage_index, layer)| (*layer == layer_index).then_some(stage_index))
+            .collect::<Vec<_>>();
+        if stage_indices.is_empty() {
+            return Err(format!(
+                "Migration preparation schedule is missing layer {layer_index}"
+            ));
+        }
+        if preparation_policy == PreparationTimingPolicy::Zip318Spaced {
+            stage_indices.shuffle(rng);
+        }
+
+        let mut scheduled_height = layer_base;
+        for stage_index in stage_indices {
+            if preparation_policy == PreparationTimingPolicy::Zip318Spaced {
+                scheduled_height = scheduled_height
+                    .checked_add(preparation_delay_with_rng(network, timing_policy, rng))
+                    .ok_or("Migration preparation scheduled height overflow")?;
+            }
+            heights[stage_index] = scheduled_height;
+        }
+        layer_base = scheduled_height
+            .checked_add(denomination_confirmations_required())
+            .ok_or("Migration preparation layer height overflow")?;
+    }
+
+    Ok(heights)
 }
 
 fn preparation_timing_policy_for_run_with_conn(
     conn: &rusqlite::Connection,
     run_id: &str,
 ) -> Result<PreparationTimingPolicy, String> {
-    preparation_policies_for_run_with_conn(conn, run_id).map(|(policy, _)| policy)
+    let value = conn
+        .query_row(
+            &format!(
+                "SELECT preparation_timing_policy
+                 FROM {RUNS_TABLE} WHERE run_id = ?1"
+            ),
+            params![run_id],
+            |row| row.get::<_, String>(0),
+        )
+        .map_err(|e| format!("Read migration preparation timing policy: {e}"))?;
+    PreparationTimingPolicy::from_str(&value)
 }
 
 pub(crate) fn preparation_timing_policy_for_run(
@@ -126,206 +167,4 @@ pub(crate) fn preparation_timing_policy_for_run(
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
     preparation_timing_policy_for_run_with_conn(&conn, run_id)
-}
-
-fn initialize_preparation_schedule_with_tx<R: RngCore + CryptoRng + ?Sized>(
-    tx: &rusqlite::Transaction<'_>,
-    run_id: &str,
-    network: WalletNetwork,
-    policy: PreparationTimingPolicy,
-    rng: &mut R,
-) -> Result<(), String> {
-    if policy == PreparationTimingPolicy::Immediate {
-        return Ok(());
-    }
-    let (_, timing_policy) = preparation_policies_for_run_with_conn(tx, run_id)?;
-
-    let mut stmt = tx
-        .prepare_cached(&format!(
-            "SELECT stage_index, target_height
-             FROM {STAGES_TABLE}
-             WHERE run_id = ?1 AND status = 'pending'
-             ORDER BY stage_index ASC"
-        ))
-        .map_err(|e| format!("Prepare root denomination schedule query: {e}"))?;
-    let mut roots = stmt
-        .query_map(params![run_id], |row| {
-            Ok((row.get::<_, u32>(0)?, row.get::<_, u32>(1)?))
-        })
-        .map_err(|e| format!("Query root denomination schedule: {e}"))?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| format!("Read root denomination schedule: {e}"))?;
-    drop(stmt);
-    if roots.is_empty() {
-        return Err("Migration denomination plan has no broadcastable root".to_string());
-    }
-
-    roots.shuffle(rng);
-    let mut scheduled_height = roots
-        .iter()
-        .map(|(_, target_height)| target_height.saturating_sub(1))
-        .min()
-        .unwrap_or(0);
-    for (stage_index, _) in roots {
-        scheduled_height = scheduled_height
-            .checked_add(preparation_delay_with_rng(network, timing_policy, rng))
-            .ok_or("Migration preparation scheduled height overflow")?;
-        tx.execute(
-            &format!(
-                "UPDATE {STAGES_TABLE}
-                 SET scheduled_height = ?1
-                 WHERE run_id = ?2 AND stage_index = ?3 AND status = 'pending'"
-            ),
-            params![scheduled_height, run_id, stage_index],
-        )
-        .map_err(|e| format!("Schedule root denomination stage: {e}"))?;
-    }
-    Ok(())
-}
-
-fn reschedule_pending_preparation_stages_with_tx<R: RngCore + CryptoRng + ?Sized>(
-    tx: &rusqlite::Transaction<'_>,
-    run_id: &str,
-    network: WalletNetwork,
-    rng: &mut R,
-) -> Result<(), String> {
-    let (preparation_policy, timing_policy) =
-        preparation_policies_for_run_with_conn(tx, run_id)?;
-    if preparation_policy == PreparationTimingPolicy::Immediate {
-        return Ok(());
-    }
-
-    let mut stmt = tx
-        .prepare_cached(&format!(
-            "SELECT stage_index, target_height
-             FROM {STAGES_TABLE}
-             WHERE run_id = ?1 AND status = 'pending'
-             ORDER BY scheduled_height ASC, stage_index ASC"
-        ))
-        .map_err(|e| format!("Prepare denomination reschedule query: {e}"))?;
-    let pending = stmt
-        .query_map(params![run_id], |row| {
-            Ok((row.get::<_, u32>(0)?, row.get::<_, u32>(1)?))
-        })
-        .map_err(|e| format!("Query denomination stages to reschedule: {e}"))?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| format!("Read denomination stages to reschedule: {e}"))?;
-    drop(stmt);
-    if pending.is_empty() {
-        return Ok(());
-    }
-
-    let previous_scheduled_height = tx
-        .query_row(
-            &format!(
-                "SELECT MAX(scheduled_height)
-                 FROM {STAGES_TABLE}
-                 WHERE run_id = ?1 AND status != 'pending'
-                   AND scheduled_height > 0"
-            ),
-            params![run_id],
-            |row| row.get::<_, Option<u32>>(0),
-        )
-        .map_err(|e| format!("Read previous denomination schedule: {e}"))?;
-    let mut scheduled_height = previous_scheduled_height.unwrap_or_else(|| {
-        pending
-            .iter()
-            .map(|(_, target_height)| target_height.saturating_sub(1))
-            .min()
-            .unwrap_or(0)
-    });
-    for (stage_index, _) in pending {
-        scheduled_height = scheduled_height
-            .checked_add(preparation_delay_with_rng(network, timing_policy, rng))
-            .ok_or("Migration preparation scheduled height overflow")?;
-        tx.execute(
-            &format!(
-                "UPDATE {STAGES_TABLE}
-                 SET scheduled_height = ?1
-                 WHERE run_id = ?2 AND stage_index = ?3 AND status = 'pending'"
-            ),
-            params![scheduled_height, run_id, stage_index],
-        )
-        .map_err(|e| format!("Reschedule denomination stage: {e}"))?;
-    }
-    Ok(())
-}
-
-pub(crate) fn next_preparation_scheduled_height<R: RngCore + CryptoRng + ?Sized>(
-    conn: &rusqlite::Connection,
-    run_id: &str,
-    network: WalletNetwork,
-    observed_height: u32,
-    rng: &mut R,
-) -> Result<u32, String> {
-    let (preparation_policy, timing_policy) =
-        preparation_policies_for_run_with_conn(conn, run_id)?;
-    if preparation_policy == PreparationTimingPolicy::Immediate {
-        return Ok(0);
-    }
-    let last_scheduled_height = conn
-        .query_row(
-            &format!(
-                "SELECT MAX(scheduled_height)
-                 FROM {STAGES_TABLE}
-                 WHERE run_id = ?1 AND scheduled_height > 0"
-            ),
-            params![run_id],
-            |row| row.get::<_, Option<u32>>(0),
-        )
-        .map_err(|e| format!("Read latest denomination schedule: {e}"))?
-        .unwrap_or(observed_height);
-    observed_height
-        .max(last_scheduled_height)
-        .checked_add(preparation_delay_with_rng(network, timing_policy, rng))
-        .ok_or_else(|| "Migration preparation scheduled height overflow".to_string())
-}
-
-pub(crate) fn reschedule_remaining_preparation_stages<R: RngCore + CryptoRng + ?Sized>(
-    conn: &rusqlite::Connection,
-    run_id: &str,
-    network: WalletNetwork,
-    observed_height: u32,
-    rng: &mut R,
-) -> Result<(), String> {
-    let (preparation_policy, timing_policy) =
-        preparation_policies_for_run_with_conn(conn, run_id)?;
-    if preparation_policy == PreparationTimingPolicy::Immediate {
-        return Ok(());
-    }
-    let mut stmt = conn
-        .prepare_cached(&format!(
-            "SELECT stage_index
-             FROM {STAGES_TABLE}
-             WHERE run_id = ?1 AND status = 'pending'
-             ORDER BY scheduled_height ASC, stage_index ASC"
-        ))
-        .map_err(|e| format!("Prepare remaining denomination schedule query: {e}"))?;
-    let remaining = stmt
-        .query_map(params![run_id], |row| row.get::<_, u32>(0))
-        .map_err(|e| format!("Query remaining denomination schedule: {e}"))?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| format!("Read remaining denomination schedule: {e}"))?;
-    drop(stmt);
-
-    let tx = conn
-        .unchecked_transaction()
-        .map_err(|e| format!("Begin remaining denomination reschedule: {e}"))?;
-    let mut scheduled_height = observed_height;
-    for stage_index in remaining {
-        scheduled_height = scheduled_height
-            .checked_add(preparation_delay_with_rng(network, timing_policy, rng))
-            .ok_or("Migration preparation scheduled height overflow")?;
-        tx.execute(
-            &format!(
-                "UPDATE {STAGES_TABLE}
-                 SET scheduled_height = ?1
-                 WHERE run_id = ?2 AND stage_index = ?3 AND status = 'pending'"
-            ),
-            params![scheduled_height, run_id, stage_index],
-        )
-        .map_err(|e| format!("Reschedule remaining denomination stage: {e}"))?;
-    }
-    tx.commit()
-        .map_err(|e| format!("Commit remaining denomination reschedule: {e}"))
 }

--- a/rust/src/wallet/sync/migration/split_plan.rs
+++ b/rust/src/wallet/sync/migration/split_plan.rs
@@ -50,6 +50,7 @@ pub(crate) struct SplitStageOutput {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct SplitStagePlan {
+    pub layer_index: usize,
     pub inputs: Vec<SplitStageInput>,
     pub outputs: Vec<SplitStageOutput>,
     pub fee_zatoshi: u64,
@@ -364,6 +365,7 @@ fn translate_preparation_plan(
             let stage_index = stages.len();
             coordinates.insert((layer_index, transaction_index), stage_index);
             stages.push(SplitStagePlan {
+                layer_index,
                 inputs,
                 outputs,
                 fee_zatoshi: fee_per_stage_zatoshi,

--- a/rust/src/wallet/sync/migration/stages.rs
+++ b/rust/src/wallet/sync/migration/stages.rs
@@ -107,6 +107,7 @@ pub(crate) struct DenominationStageInsert {
     pub raw_tx: Option<Vec<u8>>,
     pub expected_txid_hex: String,
     pub target_height: u32,
+    pub scheduled_height: u32,
     pub expiry_height: u32,
     pub fee_zatoshi: u64,
     pub status: DenominationStageStatus,
@@ -450,7 +451,7 @@ fn insert_stage(
              (run_id, stage_index, encrypted_base_pczt, encrypted_compact_sigs,
               encrypted_raw_tx, expected_txid_hex, target_height, expiry_height,
               fee_zatoshi, status, scheduled_height)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 0)"
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)"
         ),
         params![
             run_id,
@@ -463,6 +464,7 @@ fn insert_stage(
             stage.expiry_height,
             stage.fee_zatoshi,
             stage.status.as_str(),
+            stage.scheduled_height,
         ],
     )
     .map_err(|e| format!("Insert migration denomination stage: {e}"))?;
@@ -746,7 +748,6 @@ pub(crate) fn promote_awaiting_denomination_stage(
     stage_index: u32,
     expected_txid_hex: &str,
     raw_tx: Vec<u8>,
-    scheduled_height: u32,
     password: &[u8],
     salt_base64: &str,
 ) -> Result<(), String> {
@@ -763,15 +764,13 @@ pub(crate) fn promote_awaiting_denomination_stage(
         .execute(
             &format!(
                 "UPDATE {STAGES_TABLE}
-                 SET encrypted_raw_tx = ?1, status = 'pending',
-                     scheduled_height = ?2
-                 WHERE run_id = ?3 AND stage_index = ?4
-                   AND expected_txid_hex = ?5 AND status = 'awaiting_inputs'
+                 SET encrypted_raw_tx = ?1, status = 'pending'
+                 WHERE run_id = ?2 AND stage_index = ?3
+                   AND expected_txid_hex = ?4 AND status = 'awaiting_inputs'
                    AND encrypted_raw_tx IS NULL"
             ),
             params![
                 encrypted_raw_tx,
-                scheduled_height,
                 run_id,
                 stage_index,
                 expected_txid_hex.to_ascii_lowercase(),
@@ -1443,6 +1442,7 @@ mod tests {
             raw_tx: None,
             expected_txid_hex: txid(txid_byte),
             target_height: 3_000_000 + stage_index,
+            scheduled_height: 0,
             expiry_height: 0,
             fee_zatoshi: 80_000,
             status: DenominationStageStatus::AwaitingInputs,
@@ -1550,6 +1550,8 @@ mod tests {
         let mut stage_zero = awaiting_stage(0, 0x10);
         stage_zero.raw_tx = Some(vec![0xde, 0xad, 0xbe, 0xef]);
         stage_zero.status = DenominationStageStatus::Pending;
+        stage_zero.scheduled_height = 3_000_123;
+        stage_zero.expiry_height = 3_041_280;
         stage_zero.outputs = vec![output(7, 420_000, DenominationStageOutputKind::Change)];
 
         let tx = conn.unchecked_transaction().unwrap();
@@ -1583,6 +1585,8 @@ mod tests {
         assert_eq!(stages[0].base_pczt, stage_zero.base_pczt);
         assert_eq!(stages[0].sigs, stage_zero.sigs);
         assert_eq!(stages[0].raw_tx, stage_zero.raw_tx);
+        assert_eq!(stages[0].scheduled_height, stage_zero.scheduled_height);
+        assert_eq!(stages[0].expiry_height, stage_zero.expiry_height);
         assert_eq!(stages[0].outputs, stage_zero.outputs);
         assert_eq!(stages[1].stage_index, 1);
         assert_eq!(stages[1].inputs, stage_one.inputs);
@@ -1677,7 +1681,9 @@ mod tests {
     #[test]
     fn promotion_and_state_updates_keep_recovery_material_and_locks() {
         let conn = setup();
-        let stage = awaiting_stage(0, 0x10);
+        let mut stage = awaiting_stage(0, 0x10);
+        stage.scheduled_height = 3_000_123;
+        stage.expiry_height = 3_041_280;
         let expected_txid = stage.expected_txid_hex.clone();
         let expected_input = (
             stage.inputs[0].txid_hex.clone(),
@@ -1706,7 +1712,6 @@ mod tests {
             0,
             &expected_txid,
             vec![1, 2, 3, 4],
-            0,
             PASSWORD,
             SALT_BASE64,
         )
@@ -1715,6 +1720,8 @@ mod tests {
             pending_raw_denomination_stages(&conn, "run-1", PASSWORD, SALT_BASE64).unwrap();
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].raw_tx, vec![1, 2, 3, 4]);
+        assert_eq!(pending[0].scheduled_height, 3_000_123);
+        assert_eq!(pending[0].expiry_height, 3_041_280);
 
         mark_denomination_stage_broadcasted(&conn, "run-1", &expected_txid).unwrap();
         assert_eq!(
@@ -1764,7 +1771,6 @@ mod tests {
             0,
             &expected_txid,
             vec![5, 6, 7, 8],
-            0,
             PASSWORD,
             SALT_BASE64,
         )

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -153,6 +153,7 @@ fn pending_test_stage(expected_txid_hex: &str, raw_tx: Vec<u8>) -> DenominationS
         raw_tx: Some(raw_tx),
         expected_txid_hex: expected_txid_hex.to_string(),
         target_height: 3_000_000,
+        scheduled_height: 0,
         expiry_height: 0,
         fee_zatoshi: 80_000,
         status: DenominationStageStatus::Pending,
@@ -1808,87 +1809,43 @@ fn schedule_offsets_delay_every_transfer_and_cap_each_gap() {
 }
 
 #[test]
-fn preparation_schedule_delays_every_root() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    ensure_schema(&conn).unwrap();
-    insert_preparation_policy_test_run(
-        &conn,
-        "spaced-roots",
-        PreparationTimingPolicy::Zip318Spaced,
-        8,
-        101,
-    );
-
-    let tx = conn.unchecked_transaction().unwrap();
+fn preparation_schedule_is_planned_across_dependency_layers() {
     let mut rng = StdRng::seed_from_u64(0x318);
-    initialize_preparation_schedule_with_tx(
-        &tx,
-        "spaced-roots",
+    let heights = planned_preparation_scheduled_heights(
         WalletNetwork::Main,
         PreparationTimingPolicy::Zip318Spaced,
+        MigrationTimingPolicy::Standard,
+        3_455_990,
+        &[0, 0, 1, 1],
         &mut rng,
     )
     .unwrap();
-    tx.commit().unwrap();
 
-    let mut stmt = conn
-        .prepare(&format!(
-            "SELECT scheduled_height FROM {STAGES_TABLE}
-             WHERE run_id = 'spaced-roots'
-             ORDER BY scheduled_height ASC"
-        ))
-        .unwrap();
-    let heights = stmt
-        .query_map([], |row| row.get::<_, u32>(0))
-        .unwrap()
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
-    assert_ne!(heights[0], 100);
-    assert!(heights[0] <= 100 + ZIP318_PREPARATION_MAX_DELAY_BLOCKS);
-    assert!(heights
-        .windows(2)
-        .all(|heights| { heights[1] - heights[0] <= ZIP318_PREPARATION_MAX_DELAY_BLOCKS }));
+    assert_eq!(heights.len(), 4);
+    let root_end = heights[..2].iter().copied().max().unwrap();
+    let descendant_start = heights[2..].iter().copied().min().unwrap();
+    assert!(root_end >= 3_455_989);
+    assert!(descendant_start >= root_end + denomination_confirmations_required());
+    assert!(heights.iter().all(|height| {
+        zip318_canonical_migration_expiry_height(*height)
+            .is_ok_and(|expiry_height| expiry_height > *height)
+    }));
 }
 
 #[test]
-fn descendant_preparation_schedule_follows_observed_and_existing_heights() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    ensure_schema(&conn).unwrap();
-    insert_preparation_policy_test_run(
-        &conn,
-        "spaced-descendant",
-        PreparationTimingPolicy::Zip318Spaced,
-        1,
-        101,
-    );
-    conn.execute(
-        &format!(
-            "UPDATE {STAGES_TABLE} SET scheduled_height = 140
-             WHERE run_id = 'spaced-descendant'"
-        ),
-        [],
-    )
-    .unwrap();
+fn immediate_preparation_schedule_still_serializes_dependency_layers() {
     let mut rng = StdRng::seed_from_u64(0x318);
-    let after_existing = next_preparation_scheduled_height(
-        &conn,
-        "spaced-descendant",
+    let heights = planned_preparation_scheduled_heights(
         WalletNetwork::Main,
-        100,
+        PreparationTimingPolicy::Immediate,
+        MigrationTimingPolicy::Standard,
+        101,
+        &[0, 0, 1],
         &mut rng,
     )
     .unwrap();
-    assert!((140..=140 + ZIP318_PREPARATION_MAX_DELAY_BLOCKS).contains(&after_existing));
 
-    let after_observed = next_preparation_scheduled_height(
-        &conn,
-        "spaced-descendant",
-        WalletNetwork::Main,
-        200,
-        &mut rng,
-    )
-    .unwrap();
-    assert!((200..=200 + ZIP318_PREPARATION_MAX_DELAY_BLOCKS).contains(&after_observed));
+    assert_eq!(heights, vec![100, 100, 103]);
 }
 
 #[test]
@@ -1904,43 +1861,17 @@ fn fast_testnet_uses_accelerated_preparation_delays() {
         ),
     );
 
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    ensure_schema(&conn).unwrap();
-    insert_preparation_policy_test_run(
-        &conn,
-        "fast-testnet-preparation",
-        PreparationTimingPolicy::Zip318Spaced,
-        1,
-        101,
-    );
-    conn.execute(
-        &format!(
-            "UPDATE {RUNS_TABLE} SET timing_policy = 'fast_testnet'
-             WHERE run_id = 'fast-testnet-preparation'"
-        ),
-        [],
-    )
-    .unwrap();
-    assert_eq!(
-        timing_policy_for_run_with_conn(
-            &conn,
-            "fast-testnet-preparation",
-            WalletNetwork::Regtest,
-        )
-        .unwrap(),
-        MigrationTimingPolicy::FastTestnet,
-    );
-
     let mut rng = StdRng::seed_from_u64(0x318);
     for _ in 0..32 {
-        let scheduled_height = next_preparation_scheduled_height(
-            &conn,
-            "fast-testnet-preparation",
+        let scheduled_height = planned_preparation_scheduled_heights(
             WalletNetwork::Test,
-            200,
+            PreparationTimingPolicy::Zip318Spaced,
+            MigrationTimingPolicy::FastTestnet,
+            201,
+            &[0],
             &mut rng,
         )
-        .unwrap();
+        .unwrap()[0];
         assert!((200..=200 + FAST_TESTNET_PREPARATION_MAX_DELAY_BLOCKS).contains(&scheduled_height));
     }
 }
@@ -1962,66 +1893,6 @@ fn preparation_delay_rounds_to_nearest_block() {
     assert!(delays
         .iter()
         .all(|delay| *delay <= ZIP318_PREPARATION_MAX_DELAY_BLOCKS));
-}
-
-#[test]
-fn all_remaining_preparation_stages_are_rescheduled_after_a_late_broadcast() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    ensure_schema(&conn).unwrap();
-    insert_preparation_policy_test_run(
-        &conn,
-        "spaced-overdue",
-        PreparationTimingPolicy::Zip318Spaced,
-        4,
-        101,
-    );
-    conn.execute(
-        &format!(
-            "UPDATE {STAGES_TABLE}
-             SET scheduled_height = CASE stage_index
-                     WHEN 0 THEN 100
-                     WHEN 1 THEN 150
-                     WHEN 2 THEN 250
-                     ELSE 1000
-                 END,
-                 status = CASE stage_index
-                     WHEN 0 THEN 'broadcasted'
-                     ELSE 'pending'
-                 END
-             WHERE run_id = 'spaced-overdue'"
-        ),
-        [],
-    )
-    .unwrap();
-
-    let mut rng = StdRng::seed_from_u64(0x318);
-    reschedule_remaining_preparation_stages(
-        &conn,
-        "spaced-overdue",
-        WalletNetwork::Main,
-        200,
-        &mut rng,
-    )
-    .unwrap();
-
-    let mut stmt = conn
-        .prepare(&format!(
-            "SELECT scheduled_height FROM {STAGES_TABLE}
-             WHERE run_id = 'spaced-overdue' AND status = 'pending'
-             ORDER BY scheduled_height ASC"
-        ))
-        .unwrap();
-    let heights = stmt
-        .query_map([], |row| row.get::<_, u32>(0))
-        .unwrap()
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
-    assert_eq!(heights.len(), 3);
-    assert!((200..=200 + ZIP318_PREPARATION_MAX_DELAY_BLOCKS).contains(&heights[0]));
-    assert!(heights
-        .windows(2)
-        .all(|heights| { heights[1] - heights[0] <= ZIP318_PREPARATION_MAX_DELAY_BLOCKS }));
-    assert!(heights[2] <= 200 + 3 * ZIP318_PREPARATION_MAX_DELAY_BLOCKS);
 }
 
 #[test]
@@ -2218,7 +2089,7 @@ fn fast_testnet_adopts_unstarted_run_and_replaces_schedule() {
 }
 
 #[test]
-fn fast_testnet_adoption_retimes_pending_preparation_stages() {
+fn fast_testnet_adoption_preserves_signed_preparation_schedule() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     ensure_schema(&conn).unwrap();
     insert_preparation_policy_test_run(
@@ -2233,6 +2104,7 @@ fn fast_testnet_adoption_retimes_pending_preparation_stages() {
             "UPDATE {STAGES_TABLE}
              SET scheduled_height = CASE stage_index
                  WHEN 0 THEN 100 WHEN 1 THEN 150 ELSE 200 END,
+                 expiry_height = 69120,
                  status = CASE stage_index
                      WHEN 0 THEN 'broadcasted' ELSE 'pending' END
              WHERE run_id = 'run-fast-preparation'"
@@ -2273,8 +2145,7 @@ fn fast_testnet_adoption_retimes_pending_preparation_stages() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
     assert_eq!(heights.len(), 2);
-    assert!((100..=100 + FAST_TESTNET_PREPARATION_MAX_DELAY_BLOCKS).contains(&heights[0]));
-    assert!(heights[1] - heights[0] <= FAST_TESTNET_PREPARATION_MAX_DELAY_BLOCKS);
+    assert_eq!(heights, vec![150, 200]);
 }
 
 #[test]

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -465,7 +465,6 @@ pub(crate) struct KeystoneMigrationProofStatus {
 }
 
 const SHIELDING_THRESHOLD_ZATOSHI: u64 = 100_000;
-const MIGRATION_NO_EXPIRY_HEIGHT: u32 = 0;
 const MIGRATION_ORCHARD_ACTION_COUNT: usize = 2;
 const MIGRATION_IRONWOOD_ACTION_COUNT: usize = 1;
 static ACTIVE_IRONWOOD_MIGRATIONS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
@@ -1396,8 +1395,26 @@ pub(crate) async fn migrate_orchard_to_ironwood(
         Some(run) => super::migration::approved_schedule_for_run(db_path, &run.run_id)?,
         None => approved_schedule.clone(),
     };
+    let (preparation_policy_for_build, migration_policy_for_build) = match &draft_run {
+        Some(run) => (
+            super::migration::preparation_timing_policy_for_run(db_path, &run.run_id)?,
+            super::migration::timing_policy_for_run(db_path, &run.run_id, network)?,
+        ),
+        None => (
+            preparation_timing_policy,
+            super::migration::configured_timing_policy(network),
+        ),
+    };
     let prepared = with_wallet_db_write_lock("send.migration.create_denominations", move || {
-        prepare_software_migration_run(db_path, network, account_uuid, seed, &signing_schedule)
+        prepare_software_migration_run(
+            db_path,
+            network,
+            account_uuid,
+            seed,
+            &signing_schedule,
+            preparation_policy_for_build,
+            migration_policy_for_build,
+        )
     })?;
 
     let Some(prepared) = prepared else {
@@ -2657,6 +2674,7 @@ pub(crate) fn retain_prepared_note_anchor_checkpoints_after_scan(
 fn make_orchard_split_builder_with_type(
     network: WalletNetwork,
     target_height: u32,
+    expiry_height: u32,
     orchard_anchor: orchard::Anchor,
     orchard_inputs: &[(orchard::Note, orchard::tree::MerklePath)],
     orchard_fvk: &orchard::keys::FullViewingKey,
@@ -2679,7 +2697,7 @@ fn make_orchard_split_builder_with_type(
             ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     )
-    .with_expiry_height(BlockHeight::from(MIGRATION_NO_EXPIRY_HEIGHT));
+    .with_expiry_height(BlockHeight::from(expiry_height));
 
     if network.is_nu_active(
         zcash_protocol::consensus::NetworkUpgrade::Nu6_3,
@@ -4191,20 +4209,12 @@ fn finalize_ready_denomination_stages(
         }
 
         let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
-        let scheduled_height = super::migration::next_preparation_scheduled_height(
-            &conn,
-            run_id,
-            network,
-            current_migration_scanned_height(db_path, network)?,
-            &mut OsRng,
-        )?;
         super::migration::promote_awaiting_denomination_stage(
             &conn,
             run_id,
             stage.stage_index,
             &stage.expected_txid_hex,
             extracted.raw_tx,
-            scheduled_height,
             pending_password,
             pending_salt_base64,
         )?;
@@ -4341,19 +4351,6 @@ async fn broadcast_pending_denomination_stages(
             stage.expected_txid_hex
         );
     }
-    if broadcasted_count > 0
-        && preparation_timing_policy == super::migration::PreparationTimingPolicy::Zip318Spaced
-    {
-        let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
-        super::migration::reschedule_remaining_preparation_stages(
-            &conn,
-            run_id,
-            network,
-            observed_height,
-            &mut OsRng,
-        )?;
-    }
-
     Ok(Some(CreatedBroadcastResult {
         txids,
         status: if broadcasted_count == 0 {

--- a/rust/src/wallet/sync/send/ironwood_migration.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration.rs
@@ -27,6 +27,7 @@ pub(crate) fn prepare_orchard_migration_denominations_pczt(
     db_path: &str,
     network: WalletNetwork,
     account_uuid: &str,
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
 ) -> Result<KeystoneMigrationSigningRequest, String> {
     let _migration_guard = ActiveIronwoodMigration::acquire(db_path, account_uuid)?;
     let draft_run = super::migration::active_migration_run(db_path, account_uuid, network)?;
@@ -58,8 +59,24 @@ pub(crate) fn prepare_orchard_migration_denominations_pczt(
         ensure_no_live_denomination_request(&mut request_store, account_uuid, network)?;
     }
 
+    let (preparation_policy_for_build, migration_policy_for_build) = match &draft_run {
+        Some(run) => (
+            super::migration::preparation_timing_policy_for_run(db_path, &run.run_id)?,
+            super::migration::timing_policy_for_run(db_path, &run.run_id, network)?,
+        ),
+        None => (
+            preparation_timing_policy,
+            super::migration::configured_timing_policy(network),
+        ),
+    };
     let split = with_wallet_db_write_lock("send.migration.prepare_denominations_pczt", || {
-        create_padded_orchard_denomination_pczts(db_path, network, account_uuid)
+        create_padded_orchard_denomination_pczts(
+            db_path,
+            network,
+            account_uuid,
+            preparation_policy_for_build,
+            migration_policy_for_build,
+        )
     })?;
     let Some(split) = split else {
         return Err(
@@ -107,6 +124,7 @@ pub(crate) fn prepare_orchard_migration_denominations_pczt(
         StoredDenominationPczt {
             account_uuid: account_uuid.to_string(),
             network,
+            preparation_timing_policy: preparation_policy_for_build,
             state: request_state,
             proof_error: None,
             draft_run_id: draft_run.map(|run| run.run_id),
@@ -138,7 +156,6 @@ pub(crate) async fn complete_orchard_migration_denominations_pczt(
     pending_password: &[u8],
     pending_salt_base64: &str,
     approved_schedule: Vec<super::migration::MigrationScheduleEntry>,
-    preparation_timing_policy: super::migration::PreparationTimingPolicy,
 ) -> Result<IronwoodMigrationResult, String> {
     let _migration_guard = ActiveIronwoodMigration::acquire(db_path, account_uuid)?;
     let signed_by_id = if signed_messages.is_empty() {
@@ -191,6 +208,7 @@ pub(crate) async fn complete_orchard_migration_denominations_pczt(
         stored.state = KeystoneMigrationRequestState::Completing;
         StoredDenominationCompletion {
             draft_run_id: stored.draft_run_id.clone(),
+            preparation_timing_policy: stored.preparation_timing_policy,
             split_stages: stored.split_stages.clone(),
             direct_prepared_refs: stored.direct_prepared_refs.clone(),
             total_migratable_zatoshi: stored.total_migratable_zatoshi,
@@ -235,7 +253,7 @@ pub(crate) async fn complete_orchard_migration_denominations_pczt(
                 Vec::new(),
                 denomination_stages,
                 Some(&approved_schedule),
-                preparation_timing_policy,
+                stored.preparation_timing_policy,
                 pending_password,
                 pending_salt_base64,
             )
@@ -299,6 +317,7 @@ pub(crate) fn prepare_orchard_migration_single_qr_pczt(
     network: WalletNetwork,
     account_uuid: &str,
     approved_schedule: Vec<super::migration::MigrationScheduleEntry>,
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
 ) -> Result<KeystoneMigrationSigningRequest, String> {
     let _migration_guard = ActiveIronwoodMigration::acquire(db_path, account_uuid)?;
     if super::migration::migration_reserves_orchard_inputs(db_path, account_uuid, network)? {
@@ -318,7 +337,13 @@ pub(crate) fn prepare_orchard_migration_single_qr_pczt(
     }
 
     let split = with_wallet_db_write_lock("send.migration.prepare_single_qr_pczt", || {
-        create_padded_orchard_denomination_pczts(db_path, network, account_uuid)
+        create_padded_orchard_denomination_pczts(
+            db_path,
+            network,
+            account_uuid,
+            preparation_timing_policy,
+            super::migration::configured_timing_policy(network),
+        )
     })?;
     let Some(split) = split else {
         return Err(
@@ -398,6 +423,7 @@ pub(crate) fn prepare_orchard_migration_single_qr_pczt(
         StoredSingleQrMigrationPczt {
             account_uuid: account_uuid.to_string(),
             network,
+            preparation_timing_policy,
             state: request_state,
             proof_error: None,
             split_stages: split.stages,
@@ -429,7 +455,6 @@ pub(crate) async fn complete_orchard_migration_single_qr_pczt(
     signed_messages: Vec<KeystoneSignedMigrationMessage>,
     pending_password: &[u8],
     pending_salt_base64: &str,
-    preparation_timing_policy: super::migration::PreparationTimingPolicy,
 ) -> Result<IronwoodMigrationResult, String> {
     let _migration_guard = ActiveIronwoodMigration::acquire(db_path, account_uuid)?;
     let signed_by_id = signed_migration_messages_by_id(request_id, signed_messages)?;
@@ -486,6 +511,7 @@ pub(crate) async fn complete_orchard_migration_single_qr_pczt(
         }
         stored.state = KeystoneMigrationRequestState::Completing;
         StoredSingleQrMigrationCompletion {
+            preparation_timing_policy: stored.preparation_timing_policy,
             split_stages: stored.split_stages.clone(),
             direct_prepared_refs: stored.direct_prepared_refs.clone(),
             total_migratable_zatoshi: stored.total_migratable_zatoshi,
@@ -555,7 +581,7 @@ pub(crate) async fn complete_orchard_migration_single_qr_pczt(
             signed_children,
             denomination_stages,
             Some(&stored.approved_schedule),
-            preparation_timing_policy,
+            stored.preparation_timing_policy,
             pending_password,
             pending_salt_base64,
         )

--- a/rust/src/wallet/sync/send/ironwood_migration/denomination_split.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/denomination_split.rs
@@ -68,6 +68,7 @@ fn signed_denomination_stage_inserts(
                 raw_tx,
                 expected_txid_hex: stage.expected_txid_hex.clone(),
                 target_height: stage.target_height,
+                scheduled_height: stage.scheduled_height,
                 expiry_height: stage.expiry_height,
                 fee_zatoshi: stage.fee_zatoshi,
                 status: if stage.deferred {
@@ -242,6 +243,8 @@ fn create_padded_orchard_denomination_pczts(
     db_path: &str,
     network: WalletNetwork,
     account_uuid: &str,
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
+    migration_timing_policy: super::migration::MigrationTimingPolicy,
 ) -> Result<Option<CreatedPaddedDenominationPczts>, String> {
     let mut db = open_wallet_db(db_path, network)?;
     let fee_rule = ConservativeZip317FeeRule;
@@ -325,6 +328,19 @@ fn create_padded_orchard_denomination_pczts(
         MIN_IRONWOOD_MIGRATION_OUTPUT_ZATOSHI,
     )?
     .ok_or("Insufficient spendable Orchard funds for denomination split")?;
+    let stage_layers = padded_plan
+        .stages
+        .iter()
+        .map(|stage| stage.layer_index)
+        .collect::<Vec<_>>();
+    let scheduled_heights = super::migration::planned_preparation_scheduled_heights(
+        network,
+        preparation_timing_policy,
+        migration_timing_policy,
+        target_height.into(),
+        &stage_layers,
+        &mut OsRng,
+    )?;
 
     let padded_bundle_type = orchard::builder::BundleType::Transactional {
         bundle_required: false,
@@ -374,6 +390,11 @@ fn create_padded_orchard_denomination_pczts(
     }
 
     for (stage_index, stage_plan) in padded_plan.stages.iter().enumerate() {
+        let scheduled_height = *scheduled_heights
+            .get(stage_index)
+            .ok_or("Migration preparation schedule is missing a stage")?;
+        let expiry_height =
+            super::migration::zip318_canonical_migration_expiry_height(scheduled_height)?;
         let mut stage_notes = Vec::new();
         let mut stage_input_refs = Vec::new();
         let mut root_inputs = Vec::new();
@@ -452,6 +473,7 @@ fn create_padded_orchard_denomination_pczts(
         let builder = make_orchard_split_builder_with_type(
             network,
             target_height.into(),
+            expiry_height,
             stage_anchor,
             &stage_inputs,
             &orchard_fvk,
@@ -470,7 +492,9 @@ fn create_padded_orchard_denomination_pczts(
         let build_result = builder
             .build_for_pczt(rand_core::OsRng, &fee_rule)
             .map_err(|e| format!("Build padded denomination PCZT failed: {e}"))?;
-        let expiry_height = u32::from(build_result.pczt_parts.expiry_height);
+        if u32::from(build_result.pczt_parts.expiry_height) != expiry_height {
+            return Err("Padded denomination expiry changed during PCZT construction".to_string());
+        }
         let orchard_bundle = build_result
             .pczt_parts
             .orchard
@@ -577,6 +601,7 @@ fn create_padded_orchard_denomination_pczts(
             pczt_with_proofs: None,
             expected_txid_hex,
             target_height: target_height.into(),
+            scheduled_height,
             expiry_height,
             fee_zatoshi: u64::from(split_fee),
             deferred,

--- a/rust/src/wallet/sync/send/ironwood_migration/keystone_requests.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/keystone_requests.rs
@@ -38,6 +38,7 @@ struct CreatedDenominationStagePczt {
     pczt_with_proofs: Option<Vec<u8>>,
     expected_txid_hex: String,
     target_height: u32,
+    scheduled_height: u32,
     expiry_height: u32,
     fee_zatoshi: u64,
     deferred: bool,
@@ -56,6 +57,7 @@ struct CreatedPaddedDenominationPczts {
 struct StoredDenominationPczt {
     account_uuid: String,
     network: WalletNetwork,
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
     state: KeystoneMigrationRequestState,
     proof_error: Option<String>,
     draft_run_id: Option<String>,
@@ -67,6 +69,7 @@ struct StoredDenominationPczt {
 
 struct StoredDenominationCompletion {
     draft_run_id: Option<String>,
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
     split_stages: Vec<CreatedDenominationStagePczt>,
     direct_prepared_refs: Vec<super::migration::PreparedOrchardNoteRef>,
     total_migratable_zatoshi: u64,
@@ -113,6 +116,7 @@ struct StoredMigrationBatchCompletion {
 struct StoredSingleQrMigrationPczt {
     account_uuid: String,
     network: WalletNetwork,
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
     state: KeystoneMigrationRequestState,
     proof_error: Option<String>,
     split_stages: Vec<CreatedDenominationStagePczt>,
@@ -124,6 +128,7 @@ struct StoredSingleQrMigrationPczt {
 }
 
 struct StoredSingleQrMigrationCompletion {
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
     split_stages: Vec<CreatedDenominationStagePczt>,
     direct_prepared_refs: Vec<super::migration::PreparedOrchardNoteRef>,
     total_migratable_zatoshi: u64,

--- a/rust/src/wallet/sync/send/ironwood_migration/status_advance.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/status_advance.rs
@@ -111,7 +111,6 @@ fn reconcile_mined_denomination_stages(
             stage.stage_index,
             &stage.expected_txid_hex,
             raw_tx,
-            0,
             pending_password,
             pending_salt_base64,
         )?;
@@ -309,9 +308,17 @@ fn prepare_software_migration_run(
     account_uuid: &str,
     seed: SecretVec<u8>,
     approved_schedule: &[super::migration::MigrationScheduleEntry],
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
+    migration_timing_policy: super::migration::MigrationTimingPolicy,
 ) -> Result<Option<PreparedSoftwareMigrationRun>, String> {
     let usk = derive_migration_usk(db_path, network, account_uuid, seed)?;
-    let Some(mut split) = create_padded_orchard_denomination_pczts(db_path, network, account_uuid)?
+    let Some(mut split) = create_padded_orchard_denomination_pczts(
+        db_path,
+        network,
+        account_uuid,
+        preparation_timing_policy,
+        migration_timing_policy,
+    )?
     else {
         return Ok(None);
     };

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -236,6 +236,7 @@ fn deleting_account_discards_only_its_keystone_migration_requests() {
             StoredDenominationPczt {
                 account_uuid: account_uuid.to_string(),
                 network: WalletNetwork::Test,
+                preparation_timing_policy: migration::PreparationTimingPolicy::Zip318Spaced,
                 state: KeystoneMigrationRequestState::ProofReady,
                 proof_error: None,
                 draft_run_id: None,
@@ -277,6 +278,7 @@ fn deleting_account_discards_only_its_keystone_migration_requests() {
                 StoredSingleQrMigrationPczt {
                     account_uuid: account_uuid.to_string(),
                     network: WalletNetwork::Test,
+                    preparation_timing_policy: migration::PreparationTimingPolicy::Zip318Spaced,
                     state: KeystoneMigrationRequestState::ProofReady,
                     proof_error: None,
                     split_stages: vec![],
@@ -500,6 +502,7 @@ fn migration_test_stage(
         raw_tx: Some(vec![1, 2, 3, 4]),
         expected_txid_hex: output_txid_hex.to_string(),
         target_height: 90,
+        scheduled_height: 91,
         expiry_height: 120,
         fee_zatoshi: 10_000,
         status: migration::DenominationStageStatus::Pending,
@@ -1587,6 +1590,7 @@ fn built_v6_split_pczt() -> (BuiltPczt, orchard::keys::SpendingKey) {
     crate::wallet::network::configure_regtest_nu6_3_activation_height(2).unwrap();
     let network = WalletNetwork::Regtest;
     let target_height = 120;
+    let expiry_height = 69_120;
     let sk = orchard::keys::SpendingKey::from_bytes([7; 32]).unwrap();
     let fvk = orchard::keys::FullViewingKey::from(&sk);
     let recipient_scope = orchard::keys::Scope::Internal;
@@ -1616,6 +1620,7 @@ fn built_v6_split_pczt() -> (BuiltPczt, orchard::keys::SpendingKey) {
         make_orchard_split_builder_with_type(
             network,
             target_height,
+            expiry_height,
             orchard_anchor,
             &[(note, merkle_path)],
             &fvk,
@@ -1635,6 +1640,10 @@ fn built_v6_split_pczt() -> (BuiltPczt, orchard::keys::SpendingKey) {
     let build_result = builder.build_for_pczt(rand_core::OsRng, &fee_rule).unwrap();
 
     assert_eq!(build_result.pczt_parts.version, TxVersion::V6);
+    assert_eq!(
+        u32::from(build_result.pczt_parts.expiry_height),
+        expiry_height
+    );
     let built_pczt = pczt_from_build_result(build_result, network, None, 1, 1).unwrap();
     (built_pczt, sk)
 }
@@ -1650,6 +1659,7 @@ fn padded_denomination_split_builds_exactly_sixteen_actions() {
     crate::wallet::network::configure_regtest_nu6_3_activation_height(2).unwrap();
     let network = WalletNetwork::Regtest;
     let target_height = 120;
+    let expiry_height = 69_120;
     let usk = UnifiedSpendingKey::from_seed(&network, &[9; 32], zip32::AccountId::ZERO).unwrap();
     let fvk = orchard::keys::FullViewingKey::from(usk.orchard());
     let recipient_scope = orchard::keys::Scope::Internal;
@@ -1682,6 +1692,7 @@ fn padded_denomination_split_builds_exactly_sixteen_actions() {
         make_orchard_split_builder_with_type(
             network,
             target_height,
+            expiry_height,
             anchor,
             &[(note, merkle_path)],
             &fvk,
@@ -1703,6 +1714,10 @@ fn padded_denomination_split_builds_exactly_sixteen_actions() {
         .unwrap()
         .build_for_pczt(rand_core::OsRng, &fee_rule)
         .unwrap();
+    assert_eq!(
+        u32::from(build_result.pczt_parts.expiry_height),
+        expiry_height
+    );
     assert_eq!(
         build_result
             .pczt_parts


### PR DESCRIPTION
ZIP 318 now recommends that note-preparation transactions use the canonical expiration height derived from their scheduled broadcast height. This plans the complete preparation schedule before software or Keystone signing, embeds and persists each resulting expiration height, and removes the old post-sign rescheduling path because changing a signed transaction's schedule would invalidate that commitment.

Existing in-progress preparation stages with zero expiration are intentionally not migrated and must be restarted. Validation: `cargo test --manifest-path rust/Cargo.toml --lib`, `fvm flutter test test/features/migration/ironwood_migration_service_test.dart`, and targeted Dart analysis.