### PR TITLE
Add migration preparation expiry and catch-up scheduling

### DIFF
--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -449,6 +449,32 @@ typedef IronwoodMigrationKeystoneProofStatusGetter =
 typedef IronwoodMigrationKeystoneRequestDiscarder =
     Future<void> Function({required String requestId});
 
+Future<rust_sync.KeystoneMigrationSigningRequest>
+_defaultPrepareKeystoneDenominationMigration({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+}) => rust_sync.prepareOrchardMigrationDenominationsPczt(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+  spacePreparationBroadcasts: kAppFormFactor == AppFormFactor.desktop,
+);
+
+Future<rust_sync.KeystoneMigrationSigningRequest>
+_defaultPrepareKeystoneSingleQrMigration({
+  required String dbPath,
+  required String network,
+  required String accountUuid,
+  required List<rust_sync.MigrationScheduledTransfer> approvedSchedule,
+}) => rust_sync.prepareOrchardMigrationSingleQrPczt(
+  dbPath: dbPath,
+  network: network,
+  accountUuid: accountUuid,
+  approvedSchedule: approvedSchedule,
+  spacePreparationBroadcasts: kAppFormFactor == AppFormFactor.desktop,
+);
+
 Future<rust_sync.IronwoodMigrationResult> _defaultStartSoftwareMigration({
   required String dbPath,
   required String lightwalletdUrl,
@@ -510,7 +536,6 @@ _defaultCompleteKeystoneDenominationMigration({
   password: password,
   saltBase64: saltBase64,
   approvedSchedule: approvedSchedule,
-  spacePreparationBroadcasts: kAppFormFactor == AppFormFactor.desktop,
 );
 
 Future<rust_sync.IronwoodMigrationResult>
@@ -532,7 +557,6 @@ _defaultCompleteKeystoneSingleQrMigration({
   signedMessages: signedMessages,
   password: password,
   saltBase64: saltBase64,
-  spacePreparationBroadcasts: kAppFormFactor == AppFormFactor.desktop,
 );
 
 Future<String> _defaultCreatePrivateMigrationDraft({
@@ -697,10 +721,10 @@ class IronwoodMigrationService {
        _recoverDueMigrationOutboxOverride = recoverDueMigrationOutbox,
        prepareKeystoneDenominationMigration =
            prepareKeystoneDenominationMigration ??
-           rust_sync.prepareOrchardMigrationDenominationsPczt,
+           _defaultPrepareKeystoneDenominationMigration,
        prepareKeystoneSingleQrMigration =
            prepareKeystoneSingleQrMigration ??
-           rust_sync.prepareOrchardMigrationSingleQrPczt,
+           _defaultPrepareKeystoneSingleQrMigration,
        prepareKeystoneImmediateMigration =
            prepareKeystoneImmediateMigration ??
            rust_sync.prepareOrchardMigrationImmediatePczt,

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -515,15 +515,19 @@ Future<IronwoodMigrationResult> broadcastOneDueOrchardMigrationTransaction({
       saltBase64: saltBase64,
     );
 
+/// Prepares denomination PCZTs with expiry heights derived from their planned
+/// broadcast heights.
 Future<KeystoneMigrationSigningRequest>
 prepareOrchardMigrationDenominationsPczt({
   required String dbPath,
   required String network,
   required String accountUuid,
+  required bool spacePreparationBroadcasts,
 }) => RustLib.instance.api.crateApiSyncPrepareOrchardMigrationDenominationsPczt(
   dbPath: dbPath,
   network: network,
   accountUuid: accountUuid,
+  spacePreparationBroadcasts: spacePreparationBroadcasts,
 );
 
 Future<String> createOrResumePrivateMigrationDraft({
@@ -550,7 +554,6 @@ Future<IronwoodMigrationResult> completeOrchardMigrationDenominationsPczt({
   required String password,
   required String saltBase64,
   required List<MigrationScheduledTransfer> approvedSchedule,
-  required bool spacePreparationBroadcasts,
 }) =>
     RustLib.instance.api.crateApiSyncCompleteOrchardMigrationDenominationsPczt(
       dbPath: dbPath,
@@ -562,7 +565,6 @@ Future<IronwoodMigrationResult> completeOrchardMigrationDenominationsPczt({
       password: password,
       saltBase64: saltBase64,
       approvedSchedule: approvedSchedule,
-      spacePreparationBroadcasts: spacePreparationBroadcasts,
     );
 
 /// Prepares the split and migration PCZTs for one Keystone signing session.
@@ -574,11 +576,13 @@ Future<KeystoneMigrationSigningRequest> prepareOrchardMigrationSingleQrPczt({
   required String network,
   required String accountUuid,
   required List<MigrationScheduledTransfer> approvedSchedule,
+  required bool spacePreparationBroadcasts,
 }) => RustLib.instance.api.crateApiSyncPrepareOrchardMigrationSingleQrPczt(
   dbPath: dbPath,
   network: network,
   accountUuid: accountUuid,
   approvedSchedule: approvedSchedule,
+  spacePreparationBroadcasts: spacePreparationBroadcasts,
 );
 
 Future<IronwoodMigrationResult> completeOrchardMigrationSingleQrPczt({
@@ -590,7 +594,6 @@ Future<IronwoodMigrationResult> completeOrchardMigrationSingleQrPczt({
   required List<KeystoneSignedMigrationMessage> signedMessages,
   required String password,
   required String saltBase64,
-  required bool spacePreparationBroadcasts,
 }) => RustLib.instance.api.crateApiSyncCompleteOrchardMigrationSingleQrPczt(
   dbPath: dbPath,
   lightwalletdUrl: lightwalletdUrl,
@@ -600,7 +603,6 @@ Future<IronwoodMigrationResult> completeOrchardMigrationSingleQrPczt({
   signedMessages: signedMessages,
   password: password,
   saltBase64: saltBase64,
-  spacePreparationBroadcasts: spacePreparationBroadcasts,
 );
 
 Future<KeystoneMigrationSigningRequest> prepareOrchardMigrationBatchPczt({

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -204,7 +204,6 @@ abstract class RustLibApi extends BaseApi {
     required String password,
     required String saltBase64,
     required List<MigrationScheduledTransfer> approvedSchedule,
-    required bool spacePreparationBroadcasts,
   });
 
   Future<IronwoodMigrationResult>
@@ -227,7 +226,6 @@ abstract class RustLibApi extends BaseApi {
     required List<KeystoneSignedMigrationMessage> signedMessages,
     required String password,
     required String saltBase64,
-    required bool spacePreparationBroadcasts,
   });
 
   Future<void> crateApiSimpleConfigureFastTestnetMigration({
@@ -816,6 +814,7 @@ abstract class RustLibApi extends BaseApi {
     required String dbPath,
     required String network,
     required String accountUuid,
+    required bool spacePreparationBroadcasts,
   });
 
   Future<KeystoneMigrationSigningRequest>
@@ -844,6 +843,7 @@ abstract class RustLibApi extends BaseApi {
     required String network,
     required String accountUuid,
     required List<MigrationScheduledTransfer> approvedSchedule,
+    required bool spacePreparationBroadcasts,
   });
 
   Future<BigInt> crateApiWalletPreviewSoftwareAccountTransparentBalance({
@@ -1787,7 +1787,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String password,
     required String saltBase64,
     required List<MigrationScheduledTransfer> approvedSchedule,
-    required bool spacePreparationBroadcasts,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1808,7 +1807,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             approvedSchedule,
             serializer,
           );
-          sse_encode_bool(spacePreparationBroadcasts, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1832,7 +1830,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           password,
           saltBase64,
           approvedSchedule,
-          spacePreparationBroadcasts,
         ],
         apiImpl: this,
       ),
@@ -1853,7 +1850,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "password",
           "saltBase64",
           "approvedSchedule",
-          "spacePreparationBroadcasts",
         ],
       );
 
@@ -1930,7 +1926,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required List<KeystoneSignedMigrationMessage> signedMessages,
     required String password,
     required String saltBase64,
-    required bool spacePreparationBroadcasts,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1947,7 +1942,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           );
           sse_encode_String(password, serializer);
           sse_encode_String(saltBase64, serializer);
-          sse_encode_bool(spacePreparationBroadcasts, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -1969,7 +1963,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           signedMessages,
           password,
           saltBase64,
-          spacePreparationBroadcasts,
         ],
         apiImpl: this,
       ),
@@ -1989,7 +1982,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           "signedMessages",
           "password",
           "saltBase64",
-          "spacePreparationBroadcasts",
         ],
       );
 
@@ -5789,6 +5781,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String dbPath,
     required String network,
     required String accountUuid,
+    required bool spacePreparationBroadcasts,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -5797,6 +5790,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_String(dbPath, serializer);
           sse_encode_String(network, serializer);
           sse_encode_String(accountUuid, serializer);
+          sse_encode_bool(spacePreparationBroadcasts, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -5810,7 +5804,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         ),
         constMeta:
             kCrateApiSyncPrepareOrchardMigrationDenominationsPcztConstMeta,
-        argValues: [dbPath, network, accountUuid],
+        argValues: [dbPath, network, accountUuid, spacePreparationBroadcasts],
         apiImpl: this,
       ),
     );
@@ -5820,7 +5814,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   get kCrateApiSyncPrepareOrchardMigrationDenominationsPcztConstMeta =>
       const TaskConstMeta(
         debugName: "prepare_orchard_migration_denominations_pczt",
-        argNames: ["dbPath", "network", "accountUuid"],
+        argNames: [
+          "dbPath",
+          "network",
+          "accountUuid",
+          "spacePreparationBroadcasts",
+        ],
       );
 
   @override
@@ -5950,6 +5949,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String network,
     required String accountUuid,
     required List<MigrationScheduledTransfer> approvedSchedule,
+    required bool spacePreparationBroadcasts,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -5962,6 +5962,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             approvedSchedule,
             serializer,
           );
+          sse_encode_bool(spacePreparationBroadcasts, serializer);
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
@@ -5974,7 +5975,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: sse_decode_String,
         ),
         constMeta: kCrateApiSyncPrepareOrchardMigrationSingleQrPcztConstMeta,
-        argValues: [dbPath, network, accountUuid, approvedSchedule],
+        argValues: [
+          dbPath,
+          network,
+          accountUuid,
+          approvedSchedule,
+          spacePreparationBroadcasts,
+        ],
         apiImpl: this,
       ),
     );
@@ -5983,7 +5990,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiSyncPrepareOrchardMigrationSingleQrPcztConstMeta =>
       const TaskConstMeta(
         debugName: "prepare_orchard_migration_single_qr_pczt",
-        argNames: ["dbPath", "network", "accountUuid", "approvedSchedule"],
+        argNames: [
+          "dbPath",
+          "network",
+          "accountUuid",
+          "approvedSchedule",
+          "spacePreparationBroadcasts",
+        ],
       );
 
   @override

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -1593,10 +1593,13 @@ pub fn broadcast_one_due_orchard_migration_transaction(
     })
 }
 
+/// Prepares denomination PCZTs with expiry heights derived from their planned
+/// broadcast heights.
 pub fn prepare_orchard_migration_denominations_pczt(
     db_path: String,
     network: String,
     account_uuid: String,
+    space_preparation_broadcasts: bool,
 ) -> Result<KeystoneMigrationSigningRequest, String> {
     catch(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
@@ -1604,6 +1607,9 @@ pub fn prepare_orchard_migration_denominations_pczt(
             &db_path,
             network,
             &account_uuid,
+            wallet_sync::PreparationTimingPolicy::from_spacing_enabled(
+                space_preparation_broadcasts,
+            ),
         )?;
         Ok(KeystoneMigrationSigningRequest {
             request_id: request.request_id,
@@ -1703,7 +1709,6 @@ pub async fn complete_orchard_migration_denominations_pczt(
     password: String,
     salt_base64: String,
     approved_schedule: Vec<MigrationScheduledTransfer>,
-    space_preparation_broadcasts: bool,
 ) -> Result<IronwoodMigrationResult, String> {
     let network = parse_network_and_migrate(&db_path, &network)?;
     let password = Zeroizing::new(password.into_bytes());
@@ -1718,7 +1723,6 @@ pub async fn complete_orchard_migration_denominations_pczt(
         password.as_slice(),
         &salt_base64,
         to_wallet_migration_schedule(approved_schedule),
-        wallet_sync::PreparationTimingPolicy::from_spacing_enabled(space_preparation_broadcasts),
     )
     .await?;
     Ok(IronwoodMigrationResult {
@@ -1741,6 +1745,7 @@ pub fn prepare_orchard_migration_single_qr_pczt(
     network: String,
     account_uuid: String,
     approved_schedule: Vec<MigrationScheduledTransfer>,
+    space_preparation_broadcasts: bool,
 ) -> Result<KeystoneMigrationSigningRequest, String> {
     catch(|| {
         let network = parse_network_and_migrate(&db_path, &network)?;
@@ -1749,6 +1754,9 @@ pub fn prepare_orchard_migration_single_qr_pczt(
             network,
             &account_uuid,
             to_wallet_migration_schedule(approved_schedule),
+            wallet_sync::PreparationTimingPolicy::from_spacing_enabled(
+                space_preparation_broadcasts,
+            ),
         )?;
         Ok(KeystoneMigrationSigningRequest {
             request_id: request.request_id,
@@ -1774,7 +1782,6 @@ pub async fn complete_orchard_migration_single_qr_pczt(
     signed_messages: Vec<KeystoneSignedMigrationMessage>,
     password: String,
     salt_base64: String,
-    space_preparation_broadcasts: bool,
 ) -> Result<IronwoodMigrationResult, String> {
     let network = parse_network_and_migrate(&db_path, &network)?;
     let password = Zeroizing::new(password.into_bytes());
@@ -1788,7 +1795,6 @@ pub async fn complete_orchard_migration_single_qr_pczt(
         signed_messages,
         password.as_slice(),
         &salt_base64,
-        wallet_sync::PreparationTimingPolicy::from_spacing_enabled(space_preparation_broadcasts),
     )
     .await?;
     Ok(IronwoodMigrationResult {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -602,7 +602,6 @@ fn wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(
             let api_salt_base64 = <String>::sse_decode(&mut deserializer);
             let api_approved_schedule =
                 <Vec<crate::api::sync::MigrationScheduledTransfer>>::sse_decode(&mut deserializer);
-            let api_space_preparation_broadcasts = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, String>(
@@ -618,7 +617,6 @@ fn wire__crate__api__sync__complete_orchard_migration_denominations_pczt_impl(
                                 api_password,
                                 api_salt_base64,
                                 api_approved_schedule,
-                                api_space_preparation_broadcasts,
                             )
                             .await?;
                         Ok(output_ok)
@@ -715,7 +713,6 @@ fn wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(
                 );
             let api_password = <String>::sse_decode(&mut deserializer);
             let api_salt_base64 = <String>::sse_decode(&mut deserializer);
-            let api_space_preparation_broadcasts = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| async move {
                 transform_result_sse::<_, String>(
@@ -730,7 +727,6 @@ fn wire__crate__api__sync__complete_orchard_migration_single_qr_pczt_impl(
                                 api_signed_messages,
                                 api_password,
                                 api_salt_base64,
-                                api_space_preparation_broadcasts,
                             )
                             .await?;
                         Ok(output_ok)
@@ -4444,6 +4440,7 @@ fn wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(
             let api_db_path = <String>::sse_decode(&mut deserializer);
             let api_network = <String>::sse_decode(&mut deserializer);
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
+            let api_space_preparation_broadcasts = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -4451,6 +4448,7 @@ fn wire__crate__api__sync__prepare_orchard_migration_denominations_pczt_impl(
                         api_db_path,
                         api_network,
                         api_account_uuid,
+                        api_space_preparation_broadcasts,
                     )?;
                     Ok(output_ok)
                 })())
@@ -4577,6 +4575,7 @@ fn wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(
             let api_account_uuid = <String>::sse_decode(&mut deserializer);
             let api_approved_schedule =
                 <Vec<crate::api::sync::MigrationScheduledTransfer>>::sse_decode(&mut deserializer);
+            let api_space_preparation_broadcasts = <bool>::sse_decode(&mut deserializer);
             deserializer.end();
             move |context| {
                 transform_result_sse::<_, String>((move || {
@@ -4585,6 +4584,7 @@ fn wire__crate__api__sync__prepare_orchard_migration_single_qr_pczt_impl(
                         api_network,
                         api_account_uuid,
                         api_approved_schedule,
+                        api_space_preparation_broadcasts,
                     )?;
                     Ok(output_ok)
                 })())

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -29,7 +29,8 @@ pub(crate) use split_plan::{
 pub(crate) use stages::{
     all_denomination_stages_confirmed, denomination_stage_chain_records,
     denomination_stage_expected_txids, denomination_stage_status, denomination_stage_status_counts,
-    denomination_stages_for_run, insert_denomination_stages_with_tx,
+    denomination_stages_for_run, expired_broadcasted_denomination_stage_count,
+    expired_unbroadcast_denomination_stage_count, insert_denomination_stages_with_tx,
     locked_denomination_stage_input_outpoints, mark_denomination_stage_broadcasted,
     mark_denomination_stage_confirmed_at, pending_raw_denomination_stages,
     promote_awaiting_denomination_stage, replace_denomination_stage_confirmation_identity,
@@ -4575,13 +4576,16 @@ fn migration_preparation_transactions_for_run(
     let chain_records = denomination_stage_chain_records(conn, run_id)?;
     let mut stmt = conn
         .prepare_cached(&format!(
-            "SELECT s.stage_index, s.scheduled_height,
+            "SELECT s.stage_index,
+                    MAX(s.scheduled_height,
+                        COALESCE(s.broadcast_not_before_height, 0)),
                     COALESCE(SUM(i.value_zatoshi), 0)
              FROM {STAGES_TABLE} s
              LEFT JOIN {STAGE_INPUTS_TABLE} i
                ON i.run_id = s.run_id AND i.stage_index = s.stage_index
              WHERE s.run_id = ?1
-             GROUP BY s.stage_index, s.scheduled_height
+             GROUP BY s.stage_index, s.scheduled_height,
+                      s.broadcast_not_before_height
              ORDER BY s.stage_index ASC"
         ))
         .map_err(|e| format!("Prepare migration preparation schedule query: {e}"))?;

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -2572,9 +2572,21 @@ pub(crate) fn reset_migration_children_for_reorged_denominations(
 /// canonical chain. This needs no seed, PCZT, or encryption password, so the
 /// normal status path can reconcile a reorg even after every child has been
 /// broadcast.
+/// A pending stage discovered on-chain and its remaining peers are updated in
+/// one transaction. The submission timing was not persisted, so a spaced run
+/// conservatively restarts its peer delays from the scanned height.
 pub(crate) fn reconcile_denomination_stage_chain_state(
     db_path: &str,
     run_id: &str,
+) -> Result<(), String> {
+    reconcile_denomination_stage_chain_state_with_rng(db_path, run_id, None, &mut OsRng)
+}
+
+fn reconcile_denomination_stage_chain_state_with_rng<R: RngCore + CryptoRng + ?Sized>(
+    db_path: &str,
+    run_id: &str,
+    recovery_observed_height: Option<u32>,
+    rng: &mut R,
 ) -> Result<(), String> {
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
@@ -2599,6 +2611,7 @@ pub(crate) fn reconcile_denomination_stage_chain_state(
     let mut affected = BTreeSet::new();
     let mut invalid_stages = BTreeSet::new();
     let mut identities_to_record = BTreeMap::new();
+    let mut recovered_pending_txids = BTreeSet::new();
 
     for record in &records {
         let txid = record.expected_txid_hex.to_ascii_lowercase();
@@ -2606,10 +2619,11 @@ pub(crate) fn reconcile_denomination_stage_chain_state(
             (DenominationStageStatus::AwaitingInputs, Some(identity)) => {
                 identities_to_record.insert(txid, identity.clone());
             }
-            (
-                DenominationStageStatus::Pending | DenominationStageStatus::Broadcasted,
-                Some(identity),
-            ) => {
+            (DenominationStageStatus::Pending, Some(identity)) => {
+                recovered_pending_txids.insert(txid.clone());
+                identities_to_record.insert(txid, identity.clone());
+            }
+            (DenominationStageStatus::Broadcasted, Some(identity)) => {
                 identities_to_record.insert(txid, identity.clone());
             }
             (DenominationStageStatus::Confirmed, None) => {
@@ -2648,7 +2662,36 @@ pub(crate) fn reconcile_denomination_stage_chain_state(
             break;
         }
     }
+    let recovery_network = if recovered_pending_txids.is_empty()
+        || preparation_timing_policy_for_run_with_conn(&conn, run_id)?
+            == PreparationTimingPolicy::Immediate
+    {
+        None
+    } else {
+        let network = conn
+            .query_row(
+                &format!("SELECT network FROM {RUNS_TABLE} WHERE run_id = ?1"),
+                params![run_id],
+                |row| row.get::<_, String>(0),
+            )
+            .map_err(|e| format!("Read recovered denomination run network: {e}"))?;
+        let network = WalletNetwork::from_str(&network)
+            .ok_or_else(|| format!("Unsupported migration run network: {network}"))?;
+        Some(network)
+    };
     drop(conn);
+
+    let recovery_context = if let Some(network) = recovery_network {
+        let observed_height = if let Some(height) = recovery_observed_height {
+            height
+        } else {
+            u32::try_from(super::get_sync_progress(db_path, network)?.scanned_height)
+                .map_err(|_| "Migration scanned height exceeds u32".to_string())?
+        };
+        Some((network, observed_height))
+    } else {
+        None
+    };
 
     if !affected.is_empty() {
         // Child cleanup comes first. If the process stops before stage state is
@@ -2659,21 +2702,56 @@ pub(crate) fn reconcile_denomination_stage_chain_state(
 
     if !invalid_stages.is_empty() || !identities_to_record.is_empty() {
         let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| format!("Begin denomination chain-state reconciliation: {e}"))?;
+        let mut recovered_pending_stage = false;
+        for txid in &recovered_pending_txids {
+            let still_pending = tx
+                .query_row(
+                    &format!(
+                        "SELECT status = 'pending' FROM {STAGES_TABLE}
+                         WHERE run_id = ?1 AND expected_txid_hex = ?2"
+                    ),
+                    params![run_id, txid],
+                    |row| row.get::<_, bool>(0),
+                )
+                .map_err(|e| format!("Check recovered denomination stage state: {e}"))?;
+            recovered_pending_stage |= still_pending;
+        }
         for txid in &invalid_stages {
-            reset_denomination_stage_exact(&conn, run_id, txid)?;
+            reset_denomination_stage_exact(&tx, run_id, txid)?;
         }
         for (txid, identity) in identities_to_record {
             if invalid_stages.contains(&txid) {
                 continue;
             }
             replace_denomination_stage_confirmation_identity(
-                &conn,
+                &tx,
                 run_id,
                 &txid,
                 identity.mined_height,
                 &identity.block_hash,
             )?;
         }
+        if let (true, Some((network, observed_height))) =
+            (recovered_pending_stage, recovery_context)
+        {
+            let rerandomized = rerandomize_remaining_preparation_broadcast_heights(
+                &tx,
+                run_id,
+                network,
+                observed_height,
+                rng,
+            )?;
+            if rerandomized > 0 {
+                log::info!(
+                    "migration: re-randomized {rerandomized} preparation stage(s) after recovering an on-chain pending stage"
+                );
+            }
+        }
+        tx.commit()
+            .map_err(|e| format!("Commit denomination chain-state reconciliation: {e}"))?;
     }
 
     if !affected.is_empty() {

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -599,8 +599,8 @@ fn adopt_timing_policy_for_active_run(
     }
 
     // This opt-in exists only for local Testnet validation. Before any child
-    // transaction is constructed, preserve the prepared notes and signatures
-    // while replacing the long standard schedule with the fast policy.
+    // transaction is constructed, preserve signed preparation transactions
+    // while replacing the long child schedule with the fast policy.
     let schedule = planned_transfer_schedule_with_policy(
         run.target_values_zatoshi.iter().copied(),
         network,
@@ -610,10 +610,7 @@ fn adopt_timing_policy_for_active_run(
     let schedule_json = serde_json::to_string(&schedule)
         .map_err(|e| format!("Encode fast Testnet migration schedule: {e}"))?;
     let now = now_ms()?;
-    let tx = conn
-        .unchecked_transaction()
-        .map_err(|e| format!("Begin fast Testnet migration timing adoption: {e}"))?;
-    tx.execute(
+    conn.execute(
         &format!(
             "UPDATE {RUNS_TABLE}
              SET timing_policy = ?1, schedule_json = ?2, updated_at_ms = ?3
@@ -627,9 +624,7 @@ fn adopt_timing_policy_for_active_run(
         ],
     )
     .map_err(|e| format!("Adopt fast Testnet migration timing: {e}"))?;
-    reschedule_pending_preparation_stages_with_tx(&tx, &run.run_id, network, &mut OsRng)?;
-    tx.commit()
-        .map_err(|e| format!("Commit fast Testnet migration timing adoption: {e}"))
+    Ok(())
 }
 
 pub(crate) fn active_migration_run(
@@ -1036,15 +1031,6 @@ pub(crate) fn create_run_with_staged_denominations_and_signed_children(
     .map_err(|e| format!("Create staged migration run: {e}"))?;
     insert_prepared_notes_with_tx(&tx, &run_id, prepared_notes, true)?;
     insert_denomination_stages_with_tx(&tx, &run_id, denomination_stages, password, salt_base64)?;
-    if initial_phase == PHASE_WAITING_DENOM_CONFIRMATIONS {
-        initialize_preparation_schedule_with_tx(
-            &tx,
-            &run_id,
-            network,
-            preparation_timing_policy,
-            &mut OsRng,
-        )?;
-    }
     insert_signed_child_pczts_with_tx(
         &tx,
         &run_id,
@@ -1185,21 +1171,11 @@ pub(crate) fn finalize_private_migration_draft(
     } else {
         PHASE_WAITING_DENOM_CONFIRMATIONS
     };
-    let preparation_timing_policy = preparation_timing_policy_for_run_with_conn(&conn, run_id)?;
     let tx = conn
         .unchecked_transaction()
         .map_err(|e| format!("Begin private migration draft finalization: {e}"))?;
     insert_prepared_notes_with_tx(&tx, run_id, prepared_notes, true)?;
     insert_denomination_stages_with_tx(&tx, run_id, denomination_stages, password, salt_base64)?;
-    if initial_phase == PHASE_WAITING_DENOM_CONFIRMATIONS {
-        initialize_preparation_schedule_with_tx(
-            &tx,
-            run_id,
-            network,
-            preparation_timing_policy,
-            &mut OsRng,
-        )?;
-    }
     insert_signed_child_pczts_with_tx(
         &tx,
         run_id,

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -2574,7 +2574,7 @@ pub(crate) fn reset_migration_children_for_reorged_denominations(
 /// broadcast.
 /// A pending stage discovered on-chain and its remaining peers are updated in
 /// one transaction. The submission timing was not persisted, so a spaced run
-/// conservatively restarts its peer delays from the scanned height.
+/// conservatively restarts its peer delays from the current chain tip.
 pub(crate) fn reconcile_denomination_stage_chain_state(
     db_path: &str,
     run_id: &str,
@@ -2585,7 +2585,7 @@ pub(crate) fn reconcile_denomination_stage_chain_state(
 fn reconcile_denomination_stage_chain_state_with_rng<R: RngCore + CryptoRng + ?Sized>(
     db_path: &str,
     run_id: &str,
-    recovery_observed_height: Option<u32>,
+    recovery_chain_tip_height: Option<u32>,
     rng: &mut R,
 ) -> Result<(), String> {
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
@@ -2682,13 +2682,13 @@ fn reconcile_denomination_stage_chain_state_with_rng<R: RngCore + CryptoRng + ?S
     drop(conn);
 
     let recovery_context = if let Some(network) = recovery_network {
-        let observed_height = if let Some(height) = recovery_observed_height {
+        let chain_tip_height = if let Some(height) = recovery_chain_tip_height {
             height
         } else {
-            u32::try_from(super::get_sync_progress(db_path, network)?.scanned_height)
-                .map_err(|_| "Migration scanned height exceeds u32".to_string())?
+            u32::try_from(super::get_sync_progress(db_path, network)?.chain_tip_height)
+                .map_err(|_| "Migration chain tip exceeds u32".to_string())?
         };
-        Some((network, observed_height))
+        Some((network, chain_tip_height))
     } else {
         None
     };
@@ -2734,14 +2734,14 @@ fn reconcile_denomination_stage_chain_state_with_rng<R: RngCore + CryptoRng + ?S
                 &identity.block_hash,
             )?;
         }
-        if let (true, Some((network, observed_height))) =
+        if let (true, Some((network, chain_tip_height))) =
             (recovered_pending_stage, recovery_context)
         {
             let rerandomized = rerandomize_remaining_preparation_broadcast_heights(
                 &tx,
                 run_id,
                 network,
-                observed_height,
+                chain_tip_height,
                 rng,
             )?;
             if rerandomized > 0 {

--- a/rust/src/wallet/sync/migration/policy.rs
+++ b/rust/src/wallet/sync/migration/policy.rs
@@ -50,7 +50,7 @@ pub(crate) fn configure_fast_testnet_migration(enabled: bool) {
     FAST_TESTNET_MIGRATION_ENABLED.store(enabled, Ordering::Relaxed);
 }
 
-fn configured_timing_policy(network: WalletNetwork) -> MigrationTimingPolicy {
+pub(crate) fn configured_timing_policy(network: WalletNetwork) -> MigrationTimingPolicy {
     if matches!(network, WalletNetwork::Test | WalletNetwork::Regtest)
         && FAST_TESTNET_MIGRATION_ENABLED.load(Ordering::Relaxed)
     {

--- a/rust/src/wallet/sync/migration/preparation_policy.rs
+++ b/rust/src/wallet/sync/migration/preparation_policy.rs
@@ -152,7 +152,7 @@ pub(crate) fn rerandomize_remaining_preparation_broadcast_heights<
     tx: &rusqlite::Transaction<'_>,
     run_id: &str,
     network: WalletNetwork,
-    observed_height: u32,
+    chain_tip_height: u32,
     rng: &mut R,
 ) -> Result<u32, String> {
     if preparation_timing_policy_for_run_with_conn(tx, run_id)?
@@ -187,7 +187,7 @@ pub(crate) fn rerandomize_remaining_preparation_broadcast_heights<
             .map_err(|e| format!("Read remaining denomination catch-up stage: {e}"))?
     };
 
-    let mut preceding_height = observed_height;
+    let mut preceding_height = chain_tip_height;
     for (stage_index, scheduled_height, existing_not_before_height) in &remaining {
         let randomized_height = preceding_height
             .checked_add(preparation_delay_with_rng(network, timing_policy, rng))

--- a/rust/src/wallet/sync/migration/preparation_policy.rs
+++ b/rust/src/wallet/sync/migration/preparation_policy.rs
@@ -92,31 +92,72 @@ fn preparation_delay_with_rng<R: RngCore + CryptoRng + ?Sized>(
     }
 }
 
-fn preparation_policies_for_run_with_conn(
-    conn: &rusqlite::Connection,
-    run_id: &str,
-) -> Result<(PreparationTimingPolicy, MigrationTimingPolicy), String> {
-    let (preparation_value, migration_value) = conn
-        .query_row(
-            &format!(
-                "SELECT preparation_timing_policy, timing_policy
-                 FROM {RUNS_TABLE} WHERE run_id = ?1"
-            ),
-            params![run_id],
-            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
-        )
-        .map_err(|e| format!("Read migration preparation policies: {e}"))?;
-    Ok((
-        PreparationTimingPolicy::from_str(&preparation_value)?,
-        MigrationTimingPolicy::from_str(&migration_value)?,
-    ))
+/// Draws and assigns every preparation transaction's broadcast height before
+/// the transaction is signed. Later layers are based past the preceding
+/// layer's schedule so their inputs have time to become spendable.
+pub(crate) fn planned_preparation_scheduled_heights<
+    R: RngCore + CryptoRng + ?Sized,
+>(
+    network: WalletNetwork,
+    preparation_policy: PreparationTimingPolicy,
+    timing_policy: MigrationTimingPolicy,
+    target_height: u32,
+    stage_layers: &[usize],
+    rng: &mut R,
+) -> Result<Vec<u32>, String> {
+    let Some(last_layer) = stage_layers.iter().copied().max() else {
+        return Ok(Vec::new());
+    };
+    let mut heights = vec![0; stage_layers.len()];
+    let mut layer_base = target_height.saturating_sub(1);
+
+    for layer_index in 0..=last_layer {
+        let mut stage_indices = stage_layers
+            .iter()
+            .enumerate()
+            .filter_map(|(stage_index, layer)| (*layer == layer_index).then_some(stage_index))
+            .collect::<Vec<_>>();
+        if stage_indices.is_empty() {
+            return Err(format!(
+                "Migration preparation schedule is missing layer {layer_index}"
+            ));
+        }
+        if preparation_policy == PreparationTimingPolicy::Zip318Spaced {
+            stage_indices.shuffle(rng);
+        }
+
+        let mut scheduled_height = layer_base;
+        for stage_index in stage_indices {
+            if preparation_policy == PreparationTimingPolicy::Zip318Spaced {
+                scheduled_height = scheduled_height
+                    .checked_add(preparation_delay_with_rng(network, timing_policy, rng))
+                    .ok_or("Migration preparation scheduled height overflow")?;
+            }
+            heights[stage_index] = scheduled_height;
+        }
+        layer_base = scheduled_height
+            .checked_add(denomination_confirmations_required())
+            .ok_or("Migration preparation layer height overflow")?;
+    }
+
+    Ok(heights)
 }
 
 fn preparation_timing_policy_for_run_with_conn(
     conn: &rusqlite::Connection,
     run_id: &str,
 ) -> Result<PreparationTimingPolicy, String> {
-    preparation_policies_for_run_with_conn(conn, run_id).map(|(policy, _)| policy)
+    let value = conn
+        .query_row(
+            &format!(
+                "SELECT preparation_timing_policy
+                 FROM {RUNS_TABLE} WHERE run_id = ?1"
+            ),
+            params![run_id],
+            |row| row.get::<_, String>(0),
+        )
+        .map_err(|e| format!("Read migration preparation timing policy: {e}"))?;
+    PreparationTimingPolicy::from_str(&value)
 }
 
 pub(crate) fn preparation_timing_policy_for_run(
@@ -126,206 +167,4 @@ pub(crate) fn preparation_timing_policy_for_run(
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
     ensure_schema(&conn)?;
     preparation_timing_policy_for_run_with_conn(&conn, run_id)
-}
-
-fn initialize_preparation_schedule_with_tx<R: RngCore + CryptoRng + ?Sized>(
-    tx: &rusqlite::Transaction<'_>,
-    run_id: &str,
-    network: WalletNetwork,
-    policy: PreparationTimingPolicy,
-    rng: &mut R,
-) -> Result<(), String> {
-    if policy == PreparationTimingPolicy::Immediate {
-        return Ok(());
-    }
-    let (_, timing_policy) = preparation_policies_for_run_with_conn(tx, run_id)?;
-
-    let mut stmt = tx
-        .prepare_cached(&format!(
-            "SELECT stage_index, target_height
-             FROM {STAGES_TABLE}
-             WHERE run_id = ?1 AND status = 'pending'
-             ORDER BY stage_index ASC"
-        ))
-        .map_err(|e| format!("Prepare root denomination schedule query: {e}"))?;
-    let mut roots = stmt
-        .query_map(params![run_id], |row| {
-            Ok((row.get::<_, u32>(0)?, row.get::<_, u32>(1)?))
-        })
-        .map_err(|e| format!("Query root denomination schedule: {e}"))?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| format!("Read root denomination schedule: {e}"))?;
-    drop(stmt);
-    if roots.is_empty() {
-        return Err("Migration denomination plan has no broadcastable root".to_string());
-    }
-
-    roots.shuffle(rng);
-    let mut scheduled_height = roots
-        .iter()
-        .map(|(_, target_height)| target_height.saturating_sub(1))
-        .min()
-        .unwrap_or(0);
-    for (stage_index, _) in roots {
-        scheduled_height = scheduled_height
-            .checked_add(preparation_delay_with_rng(network, timing_policy, rng))
-            .ok_or("Migration preparation scheduled height overflow")?;
-        tx.execute(
-            &format!(
-                "UPDATE {STAGES_TABLE}
-                 SET scheduled_height = ?1
-                 WHERE run_id = ?2 AND stage_index = ?3 AND status = 'pending'"
-            ),
-            params![scheduled_height, run_id, stage_index],
-        )
-        .map_err(|e| format!("Schedule root denomination stage: {e}"))?;
-    }
-    Ok(())
-}
-
-fn reschedule_pending_preparation_stages_with_tx<R: RngCore + CryptoRng + ?Sized>(
-    tx: &rusqlite::Transaction<'_>,
-    run_id: &str,
-    network: WalletNetwork,
-    rng: &mut R,
-) -> Result<(), String> {
-    let (preparation_policy, timing_policy) =
-        preparation_policies_for_run_with_conn(tx, run_id)?;
-    if preparation_policy == PreparationTimingPolicy::Immediate {
-        return Ok(());
-    }
-
-    let mut stmt = tx
-        .prepare_cached(&format!(
-            "SELECT stage_index, target_height
-             FROM {STAGES_TABLE}
-             WHERE run_id = ?1 AND status = 'pending'
-             ORDER BY scheduled_height ASC, stage_index ASC"
-        ))
-        .map_err(|e| format!("Prepare denomination reschedule query: {e}"))?;
-    let pending = stmt
-        .query_map(params![run_id], |row| {
-            Ok((row.get::<_, u32>(0)?, row.get::<_, u32>(1)?))
-        })
-        .map_err(|e| format!("Query denomination stages to reschedule: {e}"))?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| format!("Read denomination stages to reschedule: {e}"))?;
-    drop(stmt);
-    if pending.is_empty() {
-        return Ok(());
-    }
-
-    let previous_scheduled_height = tx
-        .query_row(
-            &format!(
-                "SELECT MAX(scheduled_height)
-                 FROM {STAGES_TABLE}
-                 WHERE run_id = ?1 AND status != 'pending'
-                   AND scheduled_height > 0"
-            ),
-            params![run_id],
-            |row| row.get::<_, Option<u32>>(0),
-        )
-        .map_err(|e| format!("Read previous denomination schedule: {e}"))?;
-    let mut scheduled_height = previous_scheduled_height.unwrap_or_else(|| {
-        pending
-            .iter()
-            .map(|(_, target_height)| target_height.saturating_sub(1))
-            .min()
-            .unwrap_or(0)
-    });
-    for (stage_index, _) in pending {
-        scheduled_height = scheduled_height
-            .checked_add(preparation_delay_with_rng(network, timing_policy, rng))
-            .ok_or("Migration preparation scheduled height overflow")?;
-        tx.execute(
-            &format!(
-                "UPDATE {STAGES_TABLE}
-                 SET scheduled_height = ?1
-                 WHERE run_id = ?2 AND stage_index = ?3 AND status = 'pending'"
-            ),
-            params![scheduled_height, run_id, stage_index],
-        )
-        .map_err(|e| format!("Reschedule denomination stage: {e}"))?;
-    }
-    Ok(())
-}
-
-pub(crate) fn next_preparation_scheduled_height<R: RngCore + CryptoRng + ?Sized>(
-    conn: &rusqlite::Connection,
-    run_id: &str,
-    network: WalletNetwork,
-    observed_height: u32,
-    rng: &mut R,
-) -> Result<u32, String> {
-    let (preparation_policy, timing_policy) =
-        preparation_policies_for_run_with_conn(conn, run_id)?;
-    if preparation_policy == PreparationTimingPolicy::Immediate {
-        return Ok(0);
-    }
-    let last_scheduled_height = conn
-        .query_row(
-            &format!(
-                "SELECT MAX(scheduled_height)
-                 FROM {STAGES_TABLE}
-                 WHERE run_id = ?1 AND scheduled_height > 0"
-            ),
-            params![run_id],
-            |row| row.get::<_, Option<u32>>(0),
-        )
-        .map_err(|e| format!("Read latest denomination schedule: {e}"))?
-        .unwrap_or(observed_height);
-    observed_height
-        .max(last_scheduled_height)
-        .checked_add(preparation_delay_with_rng(network, timing_policy, rng))
-        .ok_or_else(|| "Migration preparation scheduled height overflow".to_string())
-}
-
-pub(crate) fn reschedule_remaining_preparation_stages<R: RngCore + CryptoRng + ?Sized>(
-    conn: &rusqlite::Connection,
-    run_id: &str,
-    network: WalletNetwork,
-    observed_height: u32,
-    rng: &mut R,
-) -> Result<(), String> {
-    let (preparation_policy, timing_policy) =
-        preparation_policies_for_run_with_conn(conn, run_id)?;
-    if preparation_policy == PreparationTimingPolicy::Immediate {
-        return Ok(());
-    }
-    let mut stmt = conn
-        .prepare_cached(&format!(
-            "SELECT stage_index
-             FROM {STAGES_TABLE}
-             WHERE run_id = ?1 AND status = 'pending'
-             ORDER BY scheduled_height ASC, stage_index ASC"
-        ))
-        .map_err(|e| format!("Prepare remaining denomination schedule query: {e}"))?;
-    let remaining = stmt
-        .query_map(params![run_id], |row| row.get::<_, u32>(0))
-        .map_err(|e| format!("Query remaining denomination schedule: {e}"))?
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| format!("Read remaining denomination schedule: {e}"))?;
-    drop(stmt);
-
-    let tx = conn
-        .unchecked_transaction()
-        .map_err(|e| format!("Begin remaining denomination reschedule: {e}"))?;
-    let mut scheduled_height = observed_height;
-    for stage_index in remaining {
-        scheduled_height = scheduled_height
-            .checked_add(preparation_delay_with_rng(network, timing_policy, rng))
-            .ok_or("Migration preparation scheduled height overflow")?;
-        tx.execute(
-            &format!(
-                "UPDATE {STAGES_TABLE}
-                 SET scheduled_height = ?1
-                 WHERE run_id = ?2 AND stage_index = ?3 AND status = 'pending'"
-            ),
-            params![scheduled_height, run_id, stage_index],
-        )
-        .map_err(|e| format!("Reschedule remaining denomination stage: {e}"))?;
-    }
-    tx.commit()
-        .map_err(|e| format!("Commit remaining denomination reschedule: {e}"))
 }

--- a/rust/src/wallet/sync/migration/preparation_policy.rs
+++ b/rust/src/wallet/sync/migration/preparation_policy.rs
@@ -143,6 +143,75 @@ pub(crate) fn planned_preparation_scheduled_heights<
     Ok(heights)
 }
 
+/// Re-randomizes the operational broadcast heights of every remaining stage
+/// after a preparation broadcast misses its planned height. The original
+/// schedule remains unchanged because it determines the signed expiry height.
+pub(crate) fn rerandomize_remaining_preparation_broadcast_heights<
+    R: RngCore + CryptoRng + ?Sized,
+>(
+    tx: &rusqlite::Transaction<'_>,
+    run_id: &str,
+    network: WalletNetwork,
+    observed_height: u32,
+    rng: &mut R,
+) -> Result<u32, String> {
+    if preparation_timing_policy_for_run_with_conn(tx, run_id)?
+        == PreparationTimingPolicy::Immediate
+    {
+        return Ok(0);
+    }
+    let timing_policy = timing_policy_for_run_with_conn(tx, run_id, network)?;
+    let remaining = {
+        let mut stmt = tx
+            .prepare_cached(&format!(
+                "SELECT stage_index, scheduled_height,
+                        broadcast_not_before_height
+                 FROM {STAGES_TABLE}
+                 WHERE run_id = ?1
+                   AND status IN ('awaiting_inputs', 'pending')
+                 ORDER BY MAX(scheduled_height,
+                              COALESCE(broadcast_not_before_height, 0)) ASC,
+                          stage_index ASC"
+            ))
+            .map_err(|e| format!("Prepare remaining denomination catch-up query: {e}"))?;
+        let rows = stmt
+            .query_map(params![run_id], |row| {
+                Ok((
+                    row.get::<_, u32>(0)?,
+                    row.get::<_, u32>(1)?,
+                    row.get::<_, Option<u32>>(2)?,
+                ))
+            })
+            .map_err(|e| format!("Query remaining denomination catch-up stages: {e}"))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Read remaining denomination catch-up stage: {e}"))?
+    };
+
+    let mut preceding_height = observed_height;
+    for (stage_index, scheduled_height, existing_not_before_height) in &remaining {
+        let randomized_height = preceding_height
+            .checked_add(preparation_delay_with_rng(network, timing_policy, rng))
+            .ok_or("Migration preparation catch-up height overflow")?;
+        let effective_height = randomized_height
+            .max(*scheduled_height)
+            .max(existing_not_before_height.unwrap_or(0));
+        tx.execute(
+            &format!(
+                "UPDATE {STAGES_TABLE}
+                 SET broadcast_not_before_height = ?1
+                 WHERE run_id = ?2 AND stage_index = ?3
+                   AND status IN ('awaiting_inputs', 'pending')"
+            ),
+            params![effective_height, run_id, stage_index],
+        )
+        .map_err(|e| format!("Reschedule migration denomination catch-up stage: {e}"))?;
+        preceding_height = effective_height;
+    }
+
+    u32::try_from(remaining.len())
+        .map_err(|_| "Migration preparation catch-up count exceeds u32".to_string())
+}
+
 fn preparation_timing_policy_for_run_with_conn(
     conn: &rusqlite::Connection,
     run_id: &str,

--- a/rust/src/wallet/sync/migration/split_plan.rs
+++ b/rust/src/wallet/sync/migration/split_plan.rs
@@ -50,6 +50,7 @@ pub(crate) struct SplitStageOutput {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct SplitStagePlan {
+    pub layer_index: usize,
     pub inputs: Vec<SplitStageInput>,
     pub outputs: Vec<SplitStageOutput>,
     pub fee_zatoshi: u64,
@@ -364,6 +365,7 @@ fn translate_preparation_plan(
             let stage_index = stages.len();
             coordinates.insert((layer_index, transaction_index), stage_index);
             stages.push(SplitStagePlan {
+                layer_index,
                 inputs,
                 outputs,
                 fee_zatoshi: fee_per_stage_zatoshi,

--- a/rust/src/wallet/sync/migration/stages.rs
+++ b/rust/src/wallet/sync/migration/stages.rs
@@ -126,6 +126,7 @@ pub(crate) struct DenominationStage {
     pub expected_txid_hex: String,
     pub target_height: u32,
     pub scheduled_height: u32,
+    pub broadcast_not_before_height: Option<u32>,
     pub expiry_height: u32,
     pub fee_zatoshi: u64,
     pub status: DenominationStageStatus,
@@ -145,8 +146,17 @@ pub(crate) struct PendingRawDenominationStage {
     pub raw_tx: Vec<u8>,
     pub target_height: u32,
     pub scheduled_height: u32,
+    pub broadcast_not_before_height: Option<u32>,
     pub expiry_height: u32,
     pub fee_zatoshi: u64,
+}
+
+impl PendingRawDenominationStage {
+    pub(crate) fn effective_broadcast_height(&self) -> u32 {
+        self.broadcast_not_before_height
+            .unwrap_or(0)
+            .max(self.scheduled_height)
+    }
 }
 
 /// Per-state counts for all denomination stages belonging to one run.
@@ -185,6 +195,7 @@ pub(super) fn ensure_schema(conn: &Connection) -> Result<(), String> {
             expected_txid_hex TEXT NOT NULL,
             target_height INTEGER NOT NULL,
             scheduled_height INTEGER NOT NULL DEFAULT 0,
+            broadcast_not_before_height INTEGER,
             expiry_height INTEGER NOT NULL,
             fee_zatoshi INTEGER NOT NULL,
             confirmed_mined_height INTEGER,
@@ -260,6 +271,7 @@ pub(super) fn ensure_schema(conn: &Connection) -> Result<(), String> {
         "scheduled_height",
         "INTEGER NOT NULL DEFAULT 0",
     )?;
+    add_column_if_missing(conn, STAGES_TABLE, "broadcast_not_before_height", "INTEGER")?;
     add_column_if_missing(conn, STAGE_OUTPUTS_TABLE, "part_index", "INTEGER")?;
 
     Ok(())
@@ -533,8 +545,9 @@ pub(crate) fn denomination_stages_for_run(
         .prepare_cached(&format!(
             "SELECT stage_index, encrypted_base_pczt, encrypted_compact_sigs,
                     encrypted_raw_tx, expected_txid_hex, target_height,
-                    scheduled_height, expiry_height, fee_zatoshi, status,
-                    confirmed_mined_height, confirmed_block_hash
+                    scheduled_height, broadcast_not_before_height,
+                    expiry_height, fee_zatoshi, status, confirmed_mined_height,
+                    confirmed_block_hash
              FROM {STAGES_TABLE}
              WHERE run_id = ?1
              ORDER BY stage_index ASC"
@@ -550,11 +563,12 @@ pub(crate) fn denomination_stages_for_run(
                 row.get::<_, String>(4)?,
                 row.get::<_, u32>(5)?,
                 row.get::<_, u32>(6)?,
-                row.get::<_, u32>(7)?,
-                row.get::<_, u64>(8)?,
-                row.get::<_, String>(9)?,
-                row.get::<_, Option<u32>>(10)?,
-                row.get::<_, Option<Vec<u8>>>(11)?,
+                row.get::<_, Option<u32>>(7)?,
+                row.get::<_, u32>(8)?,
+                row.get::<_, u64>(9)?,
+                row.get::<_, String>(10)?,
+                row.get::<_, Option<u32>>(11)?,
+                row.get::<_, Option<Vec<u8>>>(12)?,
             ))
         })
         .map_err(|e| format!("Query migration denomination stages: {e}"))?;
@@ -569,6 +583,7 @@ pub(crate) fn denomination_stages_for_run(
             expected_txid_hex,
             target_height,
             scheduled_height,
+            broadcast_not_before_height,
             expiry_height,
             fee_zatoshi,
             status,
@@ -600,6 +615,7 @@ pub(crate) fn denomination_stages_for_run(
             expected_txid_hex,
             target_height,
             scheduled_height,
+            broadcast_not_before_height,
             expiry_height,
             fee_zatoshi,
             status: DenominationStageStatus::parse(&status)?,
@@ -679,6 +695,55 @@ fn stage_outputs(
     Ok(outputs)
 }
 
+/// Counts signed stages that have expired before they could be broadcast.
+/// Zero expiry is excluded because it is not part of the shipped stage format.
+pub(crate) fn expired_unbroadcast_denomination_stage_count(
+    conn: &Connection,
+    run_id: &str,
+    observed_height: u32,
+) -> Result<u32, String> {
+    ensure_schema(conn)?;
+    let count = conn
+        .query_row(
+            &format!(
+                "SELECT COUNT(*)
+                 FROM {STAGES_TABLE}
+                 WHERE run_id = ?1
+                   AND status IN ('awaiting_inputs', 'pending')
+                   AND expiry_height > 0
+                   AND expiry_height <= ?2"
+            ),
+            params![run_id, observed_height],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|e| format!("Count expired unbroadcast denomination stages: {e}"))?;
+    count_to_u32(count)
+}
+
+/// Counts broadcasted stages that were not mined before their expiry height.
+pub(crate) fn expired_broadcasted_denomination_stage_count(
+    conn: &Connection,
+    run_id: &str,
+    observed_height: u32,
+) -> Result<u32, String> {
+    ensure_schema(conn)?;
+    let count = conn
+        .query_row(
+            &format!(
+                "SELECT COUNT(*)
+                 FROM {STAGES_TABLE}
+                 WHERE run_id = ?1
+                   AND status = 'broadcasted'
+                   AND expiry_height > 0
+                   AND expiry_height <= ?2"
+            ),
+            params![run_id, observed_height],
+            |row| row.get::<_, i64>(0),
+        )
+        .map_err(|e| format!("Count expired broadcasted denomination stages: {e}"))?;
+    count_to_u32(count)
+}
+
 /// Lists decrypted raw transactions that are ready to broadcast, in stage
 /// order.
 pub(crate) fn pending_raw_denomination_stages(
@@ -693,10 +758,13 @@ pub(crate) fn pending_raw_denomination_stages(
     let mut stmt = conn
         .prepare_cached(&format!(
             "SELECT stage_index, expected_txid_hex, encrypted_raw_tx,
-                    target_height, scheduled_height, expiry_height, fee_zatoshi
+                    target_height, scheduled_height,
+                    broadcast_not_before_height, expiry_height, fee_zatoshi
              FROM {STAGES_TABLE}
              WHERE run_id = ?1 AND status = 'pending' AND encrypted_raw_tx IS NOT NULL
-             ORDER BY scheduled_height ASC, stage_index ASC"
+             ORDER BY MAX(scheduled_height,
+                          COALESCE(broadcast_not_before_height, 0)) ASC,
+                      stage_index ASC"
         ))
         .map_err(|e| format!("Prepare pending migration denomination stages query: {e}"))?;
     let rows = stmt
@@ -707,8 +775,9 @@ pub(crate) fn pending_raw_denomination_stages(
                 row.get::<_, String>(2)?,
                 row.get::<_, u32>(3)?,
                 row.get::<_, u32>(4)?,
-                row.get::<_, u32>(5)?,
-                row.get::<_, u64>(6)?,
+                row.get::<_, Option<u32>>(5)?,
+                row.get::<_, u32>(6)?,
+                row.get::<_, u64>(7)?,
             ))
         })
         .map_err(|e| format!("Query pending migration denomination stages: {e}"))?;
@@ -720,6 +789,7 @@ pub(crate) fn pending_raw_denomination_stages(
             encrypted_raw_tx,
             target_height,
             scheduled_height,
+            broadcast_not_before_height,
             expiry_height,
             fee_zatoshi,
         ) = row.map_err(|e| format!("Read pending migration denomination stage: {e}"))?;
@@ -734,6 +804,7 @@ pub(crate) fn pending_raw_denomination_stages(
             raw_tx: raw_tx.to_vec(),
             target_height,
             scheduled_height,
+            broadcast_not_before_height,
             expiry_height,
             fee_zatoshi,
         });
@@ -1718,11 +1789,22 @@ mod tests {
             SALT_BASE64,
         )
         .unwrap();
+        conn.execute(
+            &format!(
+                "UPDATE {STAGES_TABLE}
+                 SET broadcast_not_before_height = 3000200
+                 WHERE run_id = 'run-1' AND stage_index = 0"
+            ),
+            [],
+        )
+        .unwrap();
         let pending =
             pending_raw_denomination_stages(&conn, "run-1", PASSWORD, SALT_BASE64).unwrap();
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].raw_tx, vec![1, 2, 3, 4]);
         assert_eq!(pending[0].scheduled_height, 3_000_123);
+        assert_eq!(pending[0].broadcast_not_before_height, Some(3_000_200));
+        assert_eq!(pending[0].effective_broadcast_height(), 3_000_200);
         assert_eq!(pending[0].expiry_height, 3_041_280);
 
         mark_denomination_stage_broadcasted(&conn, "run-1", &expected_txid).unwrap();

--- a/rust/src/wallet/sync/migration/stages.rs
+++ b/rust/src/wallet/sync/migration/stages.rs
@@ -107,6 +107,7 @@ pub(crate) struct DenominationStageInsert {
     pub raw_tx: Option<Vec<u8>>,
     pub expected_txid_hex: String,
     pub target_height: u32,
+    pub scheduled_height: u32,
     pub expiry_height: u32,
     pub fee_zatoshi: u64,
     pub status: DenominationStageStatus,
@@ -451,7 +452,7 @@ fn insert_stage(
              (run_id, stage_index, encrypted_base_pczt, encrypted_compact_sigs,
               encrypted_raw_tx, expected_txid_hex, target_height, expiry_height,
               fee_zatoshi, status, scheduled_height)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, 0)"
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)"
         ),
         params![
             run_id,
@@ -464,6 +465,7 @@ fn insert_stage(
             stage.expiry_height,
             stage.fee_zatoshi,
             stage.status.as_str(),
+            stage.scheduled_height,
         ],
     )
     .map_err(|e| format!("Insert migration denomination stage: {e}"))?;
@@ -747,7 +749,6 @@ pub(crate) fn promote_awaiting_denomination_stage(
     stage_index: u32,
     expected_txid_hex: &str,
     raw_tx: Vec<u8>,
-    scheduled_height: u32,
     password: &[u8],
     salt_base64: &str,
 ) -> Result<(), String> {
@@ -764,15 +765,13 @@ pub(crate) fn promote_awaiting_denomination_stage(
         .execute(
             &format!(
                 "UPDATE {STAGES_TABLE}
-                 SET encrypted_raw_tx = ?1, status = 'pending',
-                     scheduled_height = ?2
-                 WHERE run_id = ?3 AND stage_index = ?4
-                   AND expected_txid_hex = ?5 AND status = 'awaiting_inputs'
+                 SET encrypted_raw_tx = ?1, status = 'pending'
+                 WHERE run_id = ?2 AND stage_index = ?3
+                   AND expected_txid_hex = ?4 AND status = 'awaiting_inputs'
                    AND encrypted_raw_tx IS NULL"
             ),
             params![
                 encrypted_raw_tx,
-                scheduled_height,
                 run_id,
                 stage_index,
                 expected_txid_hex.to_ascii_lowercase(),
@@ -1445,6 +1444,7 @@ mod tests {
             raw_tx: None,
             expected_txid_hex: txid(txid_byte),
             target_height: 3_000_000 + stage_index,
+            scheduled_height: 0,
             expiry_height: 0,
             fee_zatoshi: 80_000,
             status: DenominationStageStatus::AwaitingInputs,
@@ -1552,6 +1552,8 @@ mod tests {
         let mut stage_zero = awaiting_stage(0, 0x10);
         stage_zero.raw_tx = Some(vec![0xde, 0xad, 0xbe, 0xef]);
         stage_zero.status = DenominationStageStatus::Pending;
+        stage_zero.scheduled_height = 3_000_123;
+        stage_zero.expiry_height = 3_041_280;
         stage_zero.outputs = vec![output(7, 420_000, DenominationStageOutputKind::Change)];
 
         let tx = conn.unchecked_transaction().unwrap();
@@ -1585,6 +1587,8 @@ mod tests {
         assert_eq!(stages[0].base_pczt, stage_zero.base_pczt);
         assert_eq!(stages[0].sigs, stage_zero.sigs);
         assert_eq!(stages[0].raw_tx, stage_zero.raw_tx);
+        assert_eq!(stages[0].scheduled_height, stage_zero.scheduled_height);
+        assert_eq!(stages[0].expiry_height, stage_zero.expiry_height);
         assert_eq!(stages[0].outputs, stage_zero.outputs);
         assert_eq!(stages[1].stage_index, 1);
         assert_eq!(stages[1].inputs, stage_one.inputs);
@@ -1679,7 +1683,9 @@ mod tests {
     #[test]
     fn promotion_and_state_updates_keep_recovery_material_and_locks() {
         let conn = setup();
-        let stage = awaiting_stage(0, 0x10);
+        let mut stage = awaiting_stage(0, 0x10);
+        stage.scheduled_height = 3_000_123;
+        stage.expiry_height = 3_041_280;
         let expected_txid = stage.expected_txid_hex.clone();
         let expected_input = (
             stage.inputs[0].txid_hex.clone(),
@@ -1708,7 +1714,6 @@ mod tests {
             0,
             &expected_txid,
             vec![1, 2, 3, 4],
-            0,
             PASSWORD,
             SALT_BASE64,
         )
@@ -1717,6 +1722,8 @@ mod tests {
             pending_raw_denomination_stages(&conn, "run-1", PASSWORD, SALT_BASE64).unwrap();
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].raw_tx, vec![1, 2, 3, 4]);
+        assert_eq!(pending[0].scheduled_height, 3_000_123);
+        assert_eq!(pending[0].expiry_height, 3_041_280);
 
         mark_denomination_stage_broadcasted(&conn, "run-1", &expected_txid).unwrap();
         assert_eq!(
@@ -1766,7 +1773,6 @@ mod tests {
             0,
             &expected_txid,
             vec![5, 6, 7, 8],
-            0,
             PASSWORD,
             SALT_BASE64,
         )

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -2237,20 +2237,32 @@ fn late_preparation_broadcast_rerandomizes_remaining_effective_heights() {
 }
 
 #[test]
-fn recovered_pending_preparation_stage_rerandomizes_remaining_peers_once() {
+fn recovered_pending_preparation_stage_uses_chain_tip_and_rerandomizes_once() {
     let temp_dir = tempfile::tempdir().unwrap();
     let db_path = temp_dir.path().join("wallet.db");
     let db_path = db_path.to_str().unwrap();
     let conn = rusqlite::Connection::open(db_path).unwrap();
     ensure_schema(&conn).unwrap();
     let run_id = "recovered-preparation-catch-up";
-    insert_recovered_pending_preparation_test_run(&conn, run_id, [100, 150, 175], 200);
+    let scanned_inclusion_height = 200;
+    let chain_tip_height = 500;
+    insert_recovered_pending_preparation_test_run(
+        &conn,
+        run_id,
+        [100, 150, 175],
+        scanned_inclusion_height,
+    );
     let before = preparation_catch_up_test_rows(&conn, run_id);
     drop(conn);
 
     let mut rng = StdRng::seed_from_u64(0x318);
-    reconcile_denomination_stage_chain_state_with_rng(db_path, run_id, Some(250), &mut rng)
-        .unwrap();
+    reconcile_denomination_stage_chain_state_with_rng(
+        db_path,
+        run_id,
+        Some(chain_tip_height),
+        &mut rng,
+    )
+    .unwrap();
 
     let conn = rusqlite::Connection::open(db_path).unwrap();
     let statuses = conn
@@ -2281,13 +2293,14 @@ fn recovered_pending_preparation_stage_rerandomizes_remaining_peers_once() {
         .iter()
         .map(|row| row.1.max(row.2.unwrap_or(0)))
         .collect::<Vec<_>>();
-    assert!(recovered_heights[0] >= 250);
+    assert!(scanned_inclusion_height < chain_tip_height);
+    assert!(recovered_heights[0] >= chain_tip_height);
     assert!(recovered_heights.windows(2).all(|pair| pair[0] <= pair[1]));
     drop(conn);
 
     let first_recovery = after.iter().map(|row| row.2).collect::<Vec<Option<u32>>>();
     let mut second_rng = StdRng::seed_from_u64(0x123);
-    reconcile_denomination_stage_chain_state_with_rng(db_path, run_id, Some(300), &mut second_rng)
+    reconcile_denomination_stage_chain_state_with_rng(db_path, run_id, Some(600), &mut second_rng)
         .unwrap();
     let conn = rusqlite::Connection::open(db_path).unwrap();
     assert_eq!(

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -153,6 +153,7 @@ fn pending_test_stage(expected_txid_hex: &str, raw_tx: Vec<u8>) -> DenominationS
         raw_tx: Some(raw_tx),
         expected_txid_hex: expected_txid_hex.to_string(),
         target_height: 3_000_000,
+        scheduled_height: 0,
         expiry_height: 0,
         fee_zatoshi: 80_000,
         status: DenominationStageStatus::Pending,
@@ -1975,87 +1976,43 @@ fn schedule_offsets_delay_every_transfer_and_cap_each_gap() {
 }
 
 #[test]
-fn preparation_schedule_delays_every_root() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    ensure_schema(&conn).unwrap();
-    insert_preparation_policy_test_run(
-        &conn,
-        "spaced-roots",
-        PreparationTimingPolicy::Zip318Spaced,
-        8,
-        101,
-    );
-
-    let tx = conn.unchecked_transaction().unwrap();
+fn preparation_schedule_is_planned_across_dependency_layers() {
     let mut rng = StdRng::seed_from_u64(0x318);
-    initialize_preparation_schedule_with_tx(
-        &tx,
-        "spaced-roots",
+    let heights = planned_preparation_scheduled_heights(
         WalletNetwork::Main,
         PreparationTimingPolicy::Zip318Spaced,
+        MigrationTimingPolicy::Standard,
+        3_455_990,
+        &[0, 0, 1, 1],
         &mut rng,
     )
     .unwrap();
-    tx.commit().unwrap();
 
-    let mut stmt = conn
-        .prepare(&format!(
-            "SELECT scheduled_height FROM {STAGES_TABLE}
-             WHERE run_id = 'spaced-roots'
-             ORDER BY scheduled_height ASC"
-        ))
-        .unwrap();
-    let heights = stmt
-        .query_map([], |row| row.get::<_, u32>(0))
-        .unwrap()
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
-    assert_ne!(heights[0], 100);
-    assert!(heights[0] <= 100 + ZIP318_PREPARATION_MAX_DELAY_BLOCKS);
-    assert!(heights
-        .windows(2)
-        .all(|heights| { heights[1] - heights[0] <= ZIP318_PREPARATION_MAX_DELAY_BLOCKS }));
+    assert_eq!(heights.len(), 4);
+    let root_end = heights[..2].iter().copied().max().unwrap();
+    let descendant_start = heights[2..].iter().copied().min().unwrap();
+    assert!(root_end >= 3_455_989);
+    assert!(descendant_start >= root_end + denomination_confirmations_required());
+    assert!(heights.iter().all(|height| {
+        zip318_canonical_migration_expiry_height(*height)
+            .is_ok_and(|expiry_height| expiry_height > *height)
+    }));
 }
 
 #[test]
-fn descendant_preparation_schedule_follows_observed_and_existing_heights() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    ensure_schema(&conn).unwrap();
-    insert_preparation_policy_test_run(
-        &conn,
-        "spaced-descendant",
-        PreparationTimingPolicy::Zip318Spaced,
-        1,
-        101,
-    );
-    conn.execute(
-        &format!(
-            "UPDATE {STAGES_TABLE} SET scheduled_height = 140
-             WHERE run_id = 'spaced-descendant'"
-        ),
-        [],
-    )
-    .unwrap();
+fn immediate_preparation_schedule_still_serializes_dependency_layers() {
     let mut rng = StdRng::seed_from_u64(0x318);
-    let after_existing = next_preparation_scheduled_height(
-        &conn,
-        "spaced-descendant",
+    let heights = planned_preparation_scheduled_heights(
         WalletNetwork::Main,
-        100,
+        PreparationTimingPolicy::Immediate,
+        MigrationTimingPolicy::Standard,
+        101,
+        &[0, 0, 1],
         &mut rng,
     )
     .unwrap();
-    assert!((140..=140 + ZIP318_PREPARATION_MAX_DELAY_BLOCKS).contains(&after_existing));
 
-    let after_observed = next_preparation_scheduled_height(
-        &conn,
-        "spaced-descendant",
-        WalletNetwork::Main,
-        200,
-        &mut rng,
-    )
-    .unwrap();
-    assert!((200..=200 + ZIP318_PREPARATION_MAX_DELAY_BLOCKS).contains(&after_observed));
+    assert_eq!(heights, vec![100, 100, 103]);
 }
 
 #[test]
@@ -2090,17 +2047,17 @@ fn fast_testnet_uses_accelerated_preparation_delays() {
             .unwrap(),
         MigrationTimingPolicy::FastTestnet,
     );
-
     let mut rng = StdRng::seed_from_u64(0x318);
     for _ in 0..32 {
-        let scheduled_height = next_preparation_scheduled_height(
-            &conn,
-            "fast-testnet-preparation",
+        let scheduled_height = planned_preparation_scheduled_heights(
             WalletNetwork::Test,
-            200,
+            PreparationTimingPolicy::Zip318Spaced,
+            MigrationTimingPolicy::FastTestnet,
+            201,
+            &[0],
             &mut rng,
         )
-        .unwrap();
+        .unwrap()[0];
         assert!((200..=200 + FAST_TESTNET_PREPARATION_MAX_DELAY_BLOCKS).contains(&scheduled_height));
     }
 }
@@ -2122,66 +2079,6 @@ fn preparation_delay_rounds_to_nearest_block() {
     assert!(delays
         .iter()
         .all(|delay| *delay <= ZIP318_PREPARATION_MAX_DELAY_BLOCKS));
-}
-
-#[test]
-fn all_remaining_preparation_stages_are_rescheduled_after_a_late_broadcast() {
-    let conn = rusqlite::Connection::open_in_memory().unwrap();
-    ensure_schema(&conn).unwrap();
-    insert_preparation_policy_test_run(
-        &conn,
-        "spaced-overdue",
-        PreparationTimingPolicy::Zip318Spaced,
-        4,
-        101,
-    );
-    conn.execute(
-        &format!(
-            "UPDATE {STAGES_TABLE}
-             SET scheduled_height = CASE stage_index
-                     WHEN 0 THEN 100
-                     WHEN 1 THEN 150
-                     WHEN 2 THEN 250
-                     ELSE 1000
-                 END,
-                 status = CASE stage_index
-                     WHEN 0 THEN 'broadcasted'
-                     ELSE 'pending'
-                 END
-             WHERE run_id = 'spaced-overdue'"
-        ),
-        [],
-    )
-    .unwrap();
-
-    let mut rng = StdRng::seed_from_u64(0x318);
-    reschedule_remaining_preparation_stages(
-        &conn,
-        "spaced-overdue",
-        WalletNetwork::Main,
-        200,
-        &mut rng,
-    )
-    .unwrap();
-
-    let mut stmt = conn
-        .prepare(&format!(
-            "SELECT scheduled_height FROM {STAGES_TABLE}
-             WHERE run_id = 'spaced-overdue' AND status = 'pending'
-             ORDER BY scheduled_height ASC"
-        ))
-        .unwrap();
-    let heights = stmt
-        .query_map([], |row| row.get::<_, u32>(0))
-        .unwrap()
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap();
-    assert_eq!(heights.len(), 3);
-    assert!((200..=200 + ZIP318_PREPARATION_MAX_DELAY_BLOCKS).contains(&heights[0]));
-    assert!(heights
-        .windows(2)
-        .all(|heights| { heights[1] - heights[0] <= ZIP318_PREPARATION_MAX_DELAY_BLOCKS }));
-    assert!(heights[2] <= 200 + 3 * ZIP318_PREPARATION_MAX_DELAY_BLOCKS);
 }
 
 #[test]
@@ -2375,7 +2272,7 @@ fn fast_testnet_adopts_unstarted_run_and_replaces_schedule() {
 }
 
 #[test]
-fn fast_testnet_adoption_retimes_pending_preparation_stages() {
+fn fast_testnet_adoption_preserves_signed_preparation_schedule() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     ensure_schema(&conn).unwrap();
     insert_preparation_policy_test_run(
@@ -2390,6 +2287,7 @@ fn fast_testnet_adoption_retimes_pending_preparation_stages() {
             "UPDATE {STAGES_TABLE}
              SET scheduled_height = CASE stage_index
                  WHEN 0 THEN 100 WHEN 1 THEN 150 ELSE 200 END,
+                 expiry_height = 69120,
                  status = CASE stage_index
                      WHEN 0 THEN 'broadcasted' ELSE 'pending' END
              WHERE run_id = 'run-fast-preparation'"
@@ -2430,8 +2328,7 @@ fn fast_testnet_adoption_retimes_pending_preparation_stages() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
     assert_eq!(heights.len(), 2);
-    assert!((100..=100 + FAST_TESTNET_PREPARATION_MAX_DELAY_BLOCKS).contains(&heights[0]));
-    assert!(heights[1] - heights[0] <= FAST_TESTNET_PREPARATION_MAX_DELAY_BLOCKS);
+    assert_eq!(heights, vec![150, 200]);
 }
 
 #[test]

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -655,6 +655,27 @@ fn insert_preparation_policy_test_run(
     }
 }
 
+fn preparation_catch_up_test_rows(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+) -> Vec<(u32, u32, Option<u32>, u32)> {
+    let mut stmt = conn
+        .prepare(&format!(
+            "SELECT stage_index, scheduled_height,
+                    broadcast_not_before_height, expiry_height
+             FROM {STAGES_TABLE}
+             WHERE run_id = ?1
+             ORDER BY stage_index ASC"
+        ))
+        .unwrap();
+    stmt.query_map(params![run_id], |row| {
+        Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+    })
+    .unwrap()
+    .collect::<Result<Vec<_>, _>>()
+    .unwrap()
+}
+
 fn seed_account_migration_rows(
     conn: &rusqlite::Connection,
     run_id: &str,
@@ -2079,6 +2100,128 @@ fn preparation_delay_rounds_to_nearest_block() {
     assert!(delays
         .iter()
         .all(|delay| *delay <= ZIP318_PREPARATION_MAX_DELAY_BLOCKS));
+}
+
+#[test]
+fn late_preparation_broadcast_rerandomizes_remaining_effective_heights() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    ensure_schema(&conn).unwrap();
+    insert_preparation_policy_test_run(
+        &conn,
+        "preparation-catch-up",
+        PreparationTimingPolicy::Zip318Spaced,
+        4,
+        101,
+    );
+    conn.execute(
+        &format!(
+            "UPDATE {STAGES_TABLE}
+             SET scheduled_height = CASE stage_index
+                     WHEN 0 THEN 100
+                     WHEN 1 THEN 150
+                     WHEN 2 THEN 250
+                     ELSE 1000
+                 END,
+                 broadcast_not_before_height = CASE stage_index
+                     WHEN 2 THEN 275
+                     ELSE NULL
+                 END,
+                 expiry_height = 3490560
+             WHERE run_id = 'preparation-catch-up'"
+        ),
+        [],
+    )
+    .unwrap();
+    let before = preparation_catch_up_test_rows(&conn, "preparation-catch-up");
+    let tx = conn.unchecked_transaction().unwrap();
+    mark_denomination_stage_broadcasted(&tx, "preparation-catch-up", &format!("{:064x}", 1))
+        .unwrap();
+    let mut rng = StdRng::seed_from_u64(0x318);
+    assert_eq!(
+        rerandomize_remaining_preparation_broadcast_heights(
+            &tx,
+            "preparation-catch-up",
+            WalletNetwork::Test,
+            200,
+            &mut rng,
+        )
+        .unwrap(),
+        3,
+    );
+    tx.commit().unwrap();
+    let after = preparation_catch_up_test_rows(&conn, "preparation-catch-up");
+
+    assert_eq!(
+        before
+            .iter()
+            .map(|row| (row.0, row.1, row.3))
+            .collect::<Vec<_>>(),
+        after
+            .iter()
+            .map(|row| (row.0, row.1, row.3))
+            .collect::<Vec<_>>(),
+        "the expiry-derived schedule must stay immutable",
+    );
+    assert!(after[0].2.is_none(), "the broadcasted stage is unchanged");
+    assert!(after[1..].iter().all(|row| row.2.is_some()));
+
+    let effective_heights = after[1..]
+        .iter()
+        .map(|row| row.1.max(row.2.unwrap_or(0)))
+        .collect::<Vec<_>>();
+    assert!(effective_heights[0] >= 200);
+    assert!(effective_heights[0] <= 200 + ZIP318_PREPARATION_MAX_DELAY_BLOCKS);
+    assert!(effective_heights[1] - effective_heights[0] <= ZIP318_PREPARATION_MAX_DELAY_BLOCKS);
+    assert_eq!(effective_heights[2], 1000);
+    assert!(effective_heights.windows(2).all(|pair| pair[0] <= pair[1]));
+    for (before, after) in before[1..].iter().zip(&after[1..]) {
+        let old_effective = before.1.max(before.2.unwrap_or(0));
+        let new_effective = after.1.max(after.2.unwrap_or(0));
+        assert!(new_effective >= old_effective);
+    }
+    let displayed_heights = migration_preparation_transactions_for_run(
+        &conn,
+        "preparation-catch-up",
+        denomination_confirmations_required(),
+    )
+    .unwrap()
+    .into_iter()
+    .skip(1)
+    .map(|stage| stage.scheduled_height.unwrap())
+    .collect::<Vec<_>>();
+    assert_eq!(displayed_heights, effective_heights);
+}
+
+#[test]
+fn immediate_preparation_does_not_create_catch_up_schedule() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    ensure_schema(&conn).unwrap();
+    insert_preparation_policy_test_run(
+        &conn,
+        "immediate-preparation-catch-up",
+        PreparationTimingPolicy::Immediate,
+        2,
+        101,
+    );
+    let tx = conn.unchecked_transaction().unwrap();
+    let mut rng = StdRng::seed_from_u64(0x318);
+    assert_eq!(
+        rerandomize_remaining_preparation_broadcast_heights(
+            &tx,
+            "immediate-preparation-catch-up",
+            WalletNetwork::Test,
+            200,
+            &mut rng,
+        )
+        .unwrap(),
+        0,
+    );
+    tx.commit().unwrap();
+    assert!(
+        preparation_catch_up_test_rows(&conn, "immediate-preparation-catch-up")
+            .iter()
+            .all(|row| row.2.is_none())
+    );
 }
 
 #[test]

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -676,6 +676,50 @@ fn preparation_catch_up_test_rows(
     .unwrap()
 }
 
+fn insert_recovered_pending_preparation_test_run(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    scheduled_heights: [u32; 3],
+    mined_height: u32,
+) {
+    conn.execute_batch(
+        "CREATE TABLE blocks (height INTEGER PRIMARY KEY, hash BLOB NOT NULL);
+         CREATE TABLE transactions (
+             txid BLOB PRIMARY KEY,
+             block INTEGER,
+             mined_height INTEGER
+         );",
+    )
+    .unwrap();
+    insert_preparation_policy_test_run(conn, run_id, PreparationTimingPolicy::Zip318Spaced, 3, 101);
+    for (stage_index, scheduled_height) in scheduled_heights.into_iter().enumerate() {
+        conn.execute(
+            &format!(
+                "UPDATE {STAGES_TABLE}
+                 SET scheduled_height = ?1, expiry_height = 3490560
+                 WHERE run_id = ?2 AND stage_index = ?3"
+            ),
+            params![scheduled_height, run_id, stage_index],
+        )
+        .unwrap();
+    }
+
+    let block_hash = [0xabu8; 32];
+    conn.execute(
+        "INSERT INTO blocks (height, hash) VALUES (?1, ?2)",
+        params![mined_height, block_hash.as_slice()],
+    )
+    .unwrap();
+    let mut stored_txid = hex::decode(format!("{:064x}", 1)).unwrap();
+    stored_txid.reverse();
+    conn.execute(
+        "INSERT INTO transactions (txid, block, mined_height)
+         VALUES (?1, ?2, ?2)",
+        params![stored_txid, mined_height],
+    )
+    .unwrap();
+}
+
 fn seed_account_migration_rows(
     conn: &rusqlite::Connection,
     run_id: &str,
@@ -2190,6 +2234,184 @@ fn late_preparation_broadcast_rerandomizes_remaining_effective_heights() {
     .map(|stage| stage.scheduled_height.unwrap())
     .collect::<Vec<_>>();
     assert_eq!(displayed_heights, effective_heights);
+}
+
+#[test]
+fn recovered_pending_preparation_stage_rerandomizes_remaining_peers_once() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_str().unwrap();
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    ensure_schema(&conn).unwrap();
+    let run_id = "recovered-preparation-catch-up";
+    insert_recovered_pending_preparation_test_run(&conn, run_id, [100, 150, 175], 200);
+    let before = preparation_catch_up_test_rows(&conn, run_id);
+    drop(conn);
+
+    let mut rng = StdRng::seed_from_u64(0x318);
+    reconcile_denomination_stage_chain_state_with_rng(db_path, run_id, Some(250), &mut rng)
+        .unwrap();
+
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    let statuses = conn
+        .prepare(&format!(
+            "SELECT status FROM {STAGES_TABLE}
+             WHERE run_id = ?1 ORDER BY stage_index"
+        ))
+        .unwrap()
+        .query_map(params![run_id], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(statuses, vec!["confirmed", "pending", "pending"]);
+    let after = preparation_catch_up_test_rows(&conn, run_id);
+    assert_eq!(
+        before
+            .iter()
+            .map(|row| (row.0, row.1, row.3))
+            .collect::<Vec<_>>(),
+        after
+            .iter()
+            .map(|row| (row.0, row.1, row.3))
+            .collect::<Vec<_>>(),
+        "recovery must preserve every signed schedule and expiry",
+    );
+    assert!(after[0].2.is_none());
+    let recovered_heights = after[1..]
+        .iter()
+        .map(|row| row.1.max(row.2.unwrap_or(0)))
+        .collect::<Vec<_>>();
+    assert!(recovered_heights[0] >= 250);
+    assert!(recovered_heights.windows(2).all(|pair| pair[0] <= pair[1]));
+    drop(conn);
+
+    let first_recovery = after.iter().map(|row| row.2).collect::<Vec<Option<u32>>>();
+    let mut second_rng = StdRng::seed_from_u64(0x123);
+    reconcile_denomination_stage_chain_state_with_rng(db_path, run_id, Some(300), &mut second_rng)
+        .unwrap();
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    assert_eq!(
+        preparation_catch_up_test_rows(&conn, run_id)
+            .iter()
+            .map(|row| row.2)
+            .collect::<Vec<Option<u32>>>(),
+        first_recovery,
+        "a confirmed recovery must not re-randomize peers again",
+    );
+}
+
+#[test]
+fn recovered_pending_preparation_stage_conservatively_delays_near_future_peers() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_str().unwrap();
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    ensure_schema(&conn).unwrap();
+    let run_id = "recovered-preparation-on-time";
+    insert_recovered_pending_preparation_test_run(&conn, run_id, [100, 251, 252], 200);
+    drop(conn);
+
+    let mut rng = StdRng::seed_from_u64(0x318);
+    reconcile_denomination_stage_chain_state_with_rng(db_path, run_id, Some(250), &mut rng)
+        .unwrap();
+
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    let rows = preparation_catch_up_test_rows(&conn, run_id);
+    assert!(rows[0].2.is_none());
+    assert!(rows[1..].iter().all(|row| row.2.is_some()));
+    assert!(rows[1].1.max(rows[1].2.unwrap_or(0)) > rows[1].1);
+    for row in &rows[1..] {
+        assert!(row.1.max(row.2.unwrap_or(0)) >= row.1);
+    }
+    let status: String = conn
+        .query_row(
+            &format!(
+                "SELECT status FROM {STAGES_TABLE}
+                 WHERE run_id = ?1 AND stage_index = 0"
+            ),
+            params![run_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(status, "confirmed");
+}
+
+#[test]
+fn recovered_pending_preparation_stage_rolls_back_if_rescheduling_fails() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_str().unwrap();
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    ensure_schema(&conn).unwrap();
+    let run_id = "recovered-preparation-rollback";
+    insert_recovered_pending_preparation_test_run(&conn, run_id, [100, 150, 175], 200);
+    conn.execute(
+        &format!(
+            "UPDATE {RUNS_TABLE} SET timing_policy = 'invalid'
+             WHERE run_id = ?1"
+        ),
+        params![run_id],
+    )
+    .unwrap();
+    drop(conn);
+
+    let mut rng = StdRng::seed_from_u64(0x318);
+    let error =
+        reconcile_denomination_stage_chain_state_with_rng(db_path, run_id, Some(250), &mut rng)
+            .unwrap_err();
+    assert!(error.contains("Unsupported migration timing policy"));
+
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    let rows = preparation_catch_up_test_rows(&conn, run_id);
+    assert!(rows.iter().all(|row| row.2.is_none()));
+    let status: String = conn
+        .query_row(
+            &format!(
+                "SELECT status FROM {STAGES_TABLE}
+                 WHERE run_id = ?1 AND stage_index = 0"
+            ),
+            params![run_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(status, "pending");
+}
+
+#[test]
+fn recovered_pending_immediate_stage_does_not_require_catch_up_context() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_str().unwrap();
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    ensure_schema(&conn).unwrap();
+    let run_id = "recovered-immediate-preparation";
+    insert_recovered_pending_preparation_test_run(&conn, run_id, [100, 150, 175], 200);
+    conn.execute(
+        &format!(
+            "UPDATE {RUNS_TABLE} SET preparation_timing_policy = 'immediate'
+             WHERE run_id = ?1"
+        ),
+        params![run_id],
+    )
+    .unwrap();
+    drop(conn);
+
+    reconcile_denomination_stage_chain_state(db_path, run_id).unwrap();
+
+    let conn = rusqlite::Connection::open(db_path).unwrap();
+    let rows = preparation_catch_up_test_rows(&conn, run_id);
+    assert!(rows.iter().all(|row| row.2.is_none()));
+    let status: String = conn
+        .query_row(
+            &format!(
+                "SELECT status FROM {STAGES_TABLE}
+                 WHERE run_id = ?1 AND stage_index = 0"
+            ),
+            params![run_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(status, "confirmed");
 }
 
 #[test]

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -523,7 +523,6 @@ pub(crate) struct KeystoneMigrationProofStatus {
 }
 
 const SHIELDING_THRESHOLD_ZATOSHI: u64 = 100_000;
-const MIGRATION_NO_EXPIRY_HEIGHT: u32 = 0;
 const MIGRATION_ORCHARD_ACTION_COUNT: usize = 2;
 const MIGRATION_IRONWOOD_ACTION_COUNT: usize = 1;
 static ACTIVE_IRONWOOD_MIGRATIONS: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
@@ -1454,8 +1453,26 @@ pub(crate) async fn migrate_orchard_to_ironwood(
         Some(run) => super::migration::approved_schedule_for_run(db_path, &run.run_id)?,
         None => approved_schedule.clone(),
     };
+    let (preparation_policy_for_build, migration_policy_for_build) = match &draft_run {
+        Some(run) => (
+            super::migration::preparation_timing_policy_for_run(db_path, &run.run_id)?,
+            super::migration::timing_policy_for_run(db_path, &run.run_id, network)?,
+        ),
+        None => (
+            preparation_timing_policy,
+            super::migration::configured_timing_policy(network),
+        ),
+    };
     let prepared = with_wallet_db_write_lock("send.migration.create_denominations", move || {
-        prepare_software_migration_run(db_path, network, account_uuid, seed, &signing_schedule)
+        prepare_software_migration_run(
+            db_path,
+            network,
+            account_uuid,
+            seed,
+            &signing_schedule,
+            preparation_policy_for_build,
+            migration_policy_for_build,
+        )
     })?;
 
     let Some(prepared) = prepared else {
@@ -2727,6 +2744,7 @@ pub(crate) fn retain_prepared_note_anchor_checkpoints_after_scan(
 fn make_orchard_split_builder_with_type(
     network: WalletNetwork,
     target_height: u32,
+    expiry_height: u32,
     orchard_anchor: orchard::Anchor,
     orchard_inputs: &[(orchard::Note, orchard::tree::MerklePath)],
     orchard_fvk: &orchard::keys::FullViewingKey,
@@ -2749,7 +2767,7 @@ fn make_orchard_split_builder_with_type(
             ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
         },
     )
-    .with_expiry_height(BlockHeight::from(MIGRATION_NO_EXPIRY_HEIGHT));
+    .with_expiry_height(BlockHeight::from(expiry_height));
 
     if network.is_nu_active(
         zcash_protocol::consensus::NetworkUpgrade::Nu6_3,
@@ -4261,20 +4279,12 @@ fn finalize_ready_denomination_stages(
         }
 
         let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
-        let scheduled_height = super::migration::next_preparation_scheduled_height(
-            &conn,
-            run_id,
-            network,
-            current_migration_scanned_height(db_path, network)?,
-            &mut OsRng,
-        )?;
         super::migration::promote_awaiting_denomination_stage(
             &conn,
             run_id,
             stage.stage_index,
             &stage.expected_txid_hex,
             extracted.raw_tx,
-            scheduled_height,
             pending_password,
             pending_salt_base64,
         )?;
@@ -4411,19 +4421,6 @@ async fn broadcast_pending_denomination_stages(
             stage.expected_txid_hex
         );
     }
-    if broadcasted_count > 0
-        && preparation_timing_policy == super::migration::PreparationTimingPolicy::Zip318Spaced
-    {
-        let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
-        super::migration::reschedule_remaining_preparation_stages(
-            &conn,
-            run_id,
-            network,
-            observed_height,
-            &mut OsRng,
-        )?;
-    }
-
     Ok(Some(CreatedBroadcastResult {
         txids,
         status: if broadcasted_count == 0 {

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -4295,30 +4295,39 @@ fn finalize_ready_denomination_stages(
     Ok(promoted_count)
 }
 
+fn expired_denomination_stage_count(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    observed_height: u32,
+) -> Result<u32, String> {
+    let expired_unbroadcast = super::migration::expired_unbroadcast_denomination_stage_count(
+        conn,
+        run_id,
+        observed_height,
+    )?;
+    let expired_broadcasted = super::migration::expired_broadcasted_denomination_stage_count(
+        conn,
+        run_id,
+        observed_height,
+    )?;
+    let expired_count = expired_unbroadcast
+        .checked_add(expired_broadcasted)
+        .ok_or("Expired migration preparation count overflow")?;
+    Ok(expired_count)
+}
+
+/// Retires a run only after wallet scanning reaches a stage expiry. Retirement
+/// unlocks inputs, so an unscanned chain tip cannot be used here.
 fn retire_expired_denomination_run(
     db_path: &str,
     network: WalletNetwork,
     run_id: &str,
-    observed_height: u32,
+    scanned_height: u32,
 ) -> Result<Option<CreatedBroadcastResult>, String> {
-    let (expired_unbroadcast, expired_broadcasted) = {
+    let expired_count = {
         let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
-        (
-            super::migration::expired_unbroadcast_denomination_stage_count(
-                &conn,
-                run_id,
-                observed_height,
-            )?,
-            super::migration::expired_broadcasted_denomination_stage_count(
-                &conn,
-                run_id,
-                observed_height,
-            )?,
-        )
+        expired_denomination_stage_count(&conn, run_id, scanned_height)?
     };
-    let expired_count = expired_unbroadcast
-        .checked_add(expired_broadcasted)
-        .ok_or("Expired migration preparation count overflow")?;
     if expired_count == 0 {
         return Ok(None);
     }
@@ -4336,13 +4345,40 @@ fn retire_expired_denomination_run(
     }))
 }
 
-fn denomination_stage_is_due(
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DenominationStageBroadcastReadiness {
+    AwaitingHeight,
+    AwaitingExpiryScan,
+    Ready,
+}
+
+fn denomination_stage_broadcast_readiness(
     preparation_timing_policy: super::migration::PreparationTimingPolicy,
     stage: &super::migration::PendingRawDenominationStage,
-    observed_height: u32,
-) -> bool {
-    preparation_timing_policy == super::migration::PreparationTimingPolicy::Immediate
-        || stage.effective_broadcast_height() <= observed_height
+    chain_tip_height: u32,
+) -> DenominationStageBroadcastReadiness {
+    if stage.expiry_height <= chain_tip_height {
+        DenominationStageBroadcastReadiness::AwaitingExpiryScan
+    } else if preparation_timing_policy == super::migration::PreparationTimingPolicy::Immediate
+        || stage.effective_broadcast_height() <= chain_tip_height
+    {
+        DenominationStageBroadcastReadiness::Ready
+    } else {
+        DenominationStageBroadcastReadiness::AwaitingHeight
+    }
+}
+
+fn denomination_expiry_scan_wait_result(txids: &str, total_count: u32) -> CreatedBroadcastResult {
+    CreatedBroadcastResult {
+        txids: txids.to_string(),
+        status: CreatedBroadcastResult::PENDING_BROADCAST,
+        broadcasted_count: 0,
+        total_count,
+        message: Some(
+            "Migration preparation reached its expiry height. Waiting for wallet sync to determine whether the preparation schedule must be rebuilt."
+                .to_string(),
+        ),
+    }
 }
 
 async fn broadcast_pending_denomination_stages(
@@ -4354,43 +4390,55 @@ async fn broadcast_pending_denomination_stages(
     pending_salt_base64: &str,
     policy: MigrationBroadcastPolicy<'_>,
 ) -> Result<Option<CreatedBroadcastResult>, String> {
-    let observed_height = current_migration_scanned_height(db_path, network)?;
-    if let Some(result) =
-        retire_expired_denomination_run(db_path, network, run_id, observed_height)?
+    let progress = super::get_sync_progress(db_path, network)?;
+    let scanned_height = u32::try_from(progress.scanned_height)
+        .map_err(|_| "Migration scanned height exceeds u32".to_string())?;
+    let known_chain_tip_height = u32::try_from(progress.chain_tip_height)
+        .map_err(|_| "Migration chain tip exceeds u32".to_string())?;
+    if let Some(result) = retire_expired_denomination_run(db_path, network, run_id, scanned_height)?
     {
         return Ok(Some(result));
     }
-    let pending = {
+    let (pending, expired_at_known_tip, stage_count) = {
         let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
-        super::migration::pending_raw_denomination_stages(
+        let pending = super::migration::pending_raw_denomination_stages(
             &conn,
             run_id,
             pending_password,
             pending_salt_base64,
-        )?
+        )?;
+        let expired_at_known_tip =
+            expired_denomination_stage_count(&conn, run_id, known_chain_tip_height)?;
+        let stage_count = super::migration::denomination_stage_status_counts(&conn, run_id)?.total;
+        (pending, expired_at_known_tip, stage_count)
     };
-    if pending.is_empty() {
-        return Ok(None);
-    }
-    let preparation_timing_policy =
-        super::migration::preparation_timing_policy_for_run(db_path, run_id)?;
-    let due = pending
-        .iter()
-        .filter(|stage| {
-            denomination_stage_is_due(preparation_timing_policy, stage, observed_height)
-        })
-        .collect::<Vec<_>>();
-    if due.is_empty() {
-        return Ok(None);
-    }
-
     let txids = pending
         .iter()
         .map(|stage| stage.expected_txid_hex.as_str())
         .collect::<Vec<_>>()
         .join(",");
+    if expired_at_known_tip > 0 {
+        return Ok(Some(denomination_expiry_scan_wait_result(
+            &txids,
+            stage_count,
+        )));
+    }
+    if pending.is_empty() {
+        return Ok(None);
+    }
+    let preparation_timing_policy =
+        super::migration::preparation_timing_policy_for_run(db_path, run_id)?;
     let total_count = u32::try_from(pending.len())
         .map_err(|_| "Pending denomination stage count exceeds u32".to_string())?;
+    if !pending.iter().any(|stage| {
+        denomination_stage_broadcast_readiness(
+            preparation_timing_policy,
+            stage,
+            known_chain_tip_height,
+        ) == DenominationStageBroadcastReadiness::Ready
+    }) {
+        return Ok(None);
+    }
     if policy.is_cancelled() {
         return Ok(Some(CreatedBroadcastResult {
             txids,
@@ -4414,6 +4462,43 @@ async fn broadcast_pending_denomination_stages(
             }));
         }
     };
+    let live_chain_tip_height =
+        match crate::wallet::sync_engine::get_latest_block(&mut client).await {
+            Ok(tip) => u32::try_from(tip.height)
+                .map_err(|_| "Live migration chain tip exceeds u32".to_string())?,
+            Err(e) => {
+                return Ok(Some(CreatedBroadcastResult {
+                    txids,
+                    status: CreatedBroadcastResult::PENDING_BROADCAST,
+                    broadcasted_count: 0,
+                    total_count,
+                    message: Some(format!(
+                        "Denomination split broadcast could not refresh the chain tip: {e}"
+                    )),
+                }));
+            }
+        };
+    let chain_tip_height = known_chain_tip_height.max(live_chain_tip_height);
+    let expired_at_live_tip = {
+        let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+        expired_denomination_stage_count(&conn, run_id, chain_tip_height)?
+    };
+    if expired_at_live_tip > 0 {
+        return Ok(Some(denomination_expiry_scan_wait_result(
+            &txids,
+            stage_count,
+        )));
+    }
+    let due = pending
+        .iter()
+        .filter(|stage| {
+            denomination_stage_broadcast_readiness(
+                preparation_timing_policy,
+                stage,
+                chain_tip_height,
+            ) == DenominationStageBroadcastReadiness::Ready
+        })
+        .collect::<Vec<_>>();
 
     let mut broadcasted_count = 0u32;
     let broadcast_limit =
@@ -4423,7 +4508,7 @@ async fn broadcast_pending_denomination_stages(
             policy.limit(due.len())
         };
     for stage in due.into_iter().take(broadcast_limit) {
-        let stage_was_overdue = stage.effective_broadcast_height() < observed_height;
+        let stage_was_overdue = stage.effective_broadcast_height() < chain_tip_height;
         if policy.is_cancelled() {
             break;
         }
@@ -4477,7 +4562,7 @@ async fn broadcast_pending_denomination_stages(
                 &tx,
                 run_id,
                 network,
-                observed_height,
+                chain_tip_height,
                 &mut OsRng,
             )?;
         }

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -4295,6 +4295,56 @@ fn finalize_ready_denomination_stages(
     Ok(promoted_count)
 }
 
+fn retire_expired_denomination_run(
+    db_path: &str,
+    network: WalletNetwork,
+    run_id: &str,
+    observed_height: u32,
+) -> Result<Option<CreatedBroadcastResult>, String> {
+    let (expired_unbroadcast, expired_broadcasted) = {
+        let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+        (
+            super::migration::expired_unbroadcast_denomination_stage_count(
+                &conn,
+                run_id,
+                observed_height,
+            )?,
+            super::migration::expired_broadcasted_denomination_stage_count(
+                &conn,
+                run_id,
+                observed_height,
+            )?,
+        )
+    };
+    let expired_count = expired_unbroadcast
+        .checked_add(expired_broadcasted)
+        .ok_or("Expired migration preparation count overflow")?;
+    if expired_count == 0 {
+        return Ok(None);
+    }
+
+    let message = format!(
+        "{expired_count} migration preparation transaction(s) expired before confirmation. Restart migration to rebuild the preparation schedule with fresh expiry heights."
+    );
+    super::migration::retire_run_for_rebuild(db_path, network, run_id, &message)?;
+    Ok(Some(CreatedBroadcastResult {
+        txids: String::new(),
+        status: super::migration::PHASE_FAILED_TERMINAL,
+        broadcasted_count: 0,
+        total_count: expired_count,
+        message: Some(message),
+    }))
+}
+
+fn denomination_stage_is_due(
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
+    stage: &super::migration::PendingRawDenominationStage,
+    observed_height: u32,
+) -> bool {
+    preparation_timing_policy == super::migration::PreparationTimingPolicy::Immediate
+        || stage.effective_broadcast_height() <= observed_height
+}
+
 async fn broadcast_pending_denomination_stages(
     db_path: &str,
     lightwalletd_url: &str,
@@ -4304,6 +4354,12 @@ async fn broadcast_pending_denomination_stages(
     pending_salt_base64: &str,
     policy: MigrationBroadcastPolicy<'_>,
 ) -> Result<Option<CreatedBroadcastResult>, String> {
+    let observed_height = current_migration_scanned_height(db_path, network)?;
+    if let Some(result) =
+        retire_expired_denomination_run(db_path, network, run_id, observed_height)?
+    {
+        return Ok(Some(result));
+    }
     let pending = {
         let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
         super::migration::pending_raw_denomination_stages(
@@ -4318,12 +4374,10 @@ async fn broadcast_pending_denomination_stages(
     }
     let preparation_timing_policy =
         super::migration::preparation_timing_policy_for_run(db_path, run_id)?;
-    let observed_height = current_migration_scanned_height(db_path, network)?;
     let due = pending
         .iter()
         .filter(|stage| {
-            preparation_timing_policy == super::migration::PreparationTimingPolicy::Immediate
-                || stage.scheduled_height <= observed_height
+            denomination_stage_is_due(preparation_timing_policy, stage, observed_height)
         })
         .collect::<Vec<_>>();
     if due.is_empty() {
@@ -4369,6 +4423,7 @@ async fn broadcast_pending_denomination_stages(
             policy.limit(due.len())
         };
     for stage in due.into_iter().take(broadcast_limit) {
+        let stage_was_overdue = stage.effective_broadcast_height() < observed_height;
         if policy.is_cancelled() {
             break;
         }
@@ -4407,11 +4462,27 @@ async fn broadcast_pending_denomination_stages(
         }
 
         let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
+        let tx = conn
+            .unchecked_transaction()
+            .map_err(|e| format!("Begin migration denomination broadcast transition: {e}"))?;
         super::migration::mark_denomination_stage_broadcasted(
-            &conn,
+            &tx,
             run_id,
             &stage.expected_txid_hex,
         )?;
+        if preparation_timing_policy == super::migration::PreparationTimingPolicy::Zip318Spaced
+            && stage_was_overdue
+        {
+            super::migration::rerandomize_remaining_preparation_broadcast_heights(
+                &tx,
+                run_id,
+                network,
+                observed_height,
+                &mut OsRng,
+            )?;
+        }
+        tx.commit()
+            .map_err(|e| format!("Commit migration denomination broadcast transition: {e}"))?;
         broadcasted_count = broadcasted_count
             .checked_add(1)
             .ok_or("Broadcasted denomination stage count overflow")?;

--- a/rust/src/wallet/sync/send/ironwood_migration.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration.rs
@@ -27,6 +27,7 @@ pub(crate) fn prepare_orchard_migration_denominations_pczt(
     db_path: &str,
     network: WalletNetwork,
     account_uuid: &str,
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
 ) -> Result<KeystoneMigrationSigningRequest, String> {
     let _migration_guard = ActiveIronwoodMigration::acquire(db_path, account_uuid)?;
     let draft_run = super::migration::active_migration_run(db_path, account_uuid, network)?;
@@ -58,8 +59,24 @@ pub(crate) fn prepare_orchard_migration_denominations_pczt(
         ensure_no_live_denomination_request(&mut request_store, account_uuid, network)?;
     }
 
+    let (preparation_policy_for_build, migration_policy_for_build) = match &draft_run {
+        Some(run) => (
+            super::migration::preparation_timing_policy_for_run(db_path, &run.run_id)?,
+            super::migration::timing_policy_for_run(db_path, &run.run_id, network)?,
+        ),
+        None => (
+            preparation_timing_policy,
+            super::migration::configured_timing_policy(network),
+        ),
+    };
     let split = with_wallet_db_write_lock("send.migration.prepare_denominations_pczt", || {
-        create_padded_orchard_denomination_pczts(db_path, network, account_uuid)
+        create_padded_orchard_denomination_pczts(
+            db_path,
+            network,
+            account_uuid,
+            preparation_policy_for_build,
+            migration_policy_for_build,
+        )
     })?;
     let Some(split) = split else {
         return Err(
@@ -107,6 +124,7 @@ pub(crate) fn prepare_orchard_migration_denominations_pczt(
         StoredDenominationPczt {
             account_uuid: account_uuid.to_string(),
             network,
+            preparation_timing_policy: preparation_policy_for_build,
             state: request_state,
             proof_error: None,
             draft_run_id: draft_run.map(|run| run.run_id),
@@ -138,7 +156,6 @@ pub(crate) async fn complete_orchard_migration_denominations_pczt(
     pending_password: &[u8],
     pending_salt_base64: &str,
     approved_schedule: Vec<super::migration::MigrationScheduleEntry>,
-    preparation_timing_policy: super::migration::PreparationTimingPolicy,
 ) -> Result<IronwoodMigrationResult, String> {
     let _migration_guard = ActiveIronwoodMigration::acquire(db_path, account_uuid)?;
     let signed_by_id = if signed_messages.is_empty() {
@@ -191,6 +208,7 @@ pub(crate) async fn complete_orchard_migration_denominations_pczt(
         stored.state = KeystoneMigrationRequestState::Completing;
         StoredDenominationCompletion {
             draft_run_id: stored.draft_run_id.clone(),
+            preparation_timing_policy: stored.preparation_timing_policy,
             split_stages: stored.split_stages.clone(),
             direct_prepared_refs: stored.direct_prepared_refs.clone(),
             total_migratable_zatoshi: stored.total_migratable_zatoshi,
@@ -235,7 +253,7 @@ pub(crate) async fn complete_orchard_migration_denominations_pczt(
                 Vec::new(),
                 denomination_stages,
                 Some(&approved_schedule),
-                preparation_timing_policy,
+                stored.preparation_timing_policy,
                 pending_password,
                 pending_salt_base64,
             )
@@ -299,6 +317,7 @@ pub(crate) fn prepare_orchard_migration_single_qr_pczt(
     network: WalletNetwork,
     account_uuid: &str,
     approved_schedule: Vec<super::migration::MigrationScheduleEntry>,
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
 ) -> Result<KeystoneMigrationSigningRequest, String> {
     let _migration_guard = ActiveIronwoodMigration::acquire(db_path, account_uuid)?;
     if super::migration::migration_reserves_orchard_inputs(db_path, account_uuid, network)? {
@@ -318,7 +337,13 @@ pub(crate) fn prepare_orchard_migration_single_qr_pczt(
     }
 
     let split = with_wallet_db_write_lock("send.migration.prepare_single_qr_pczt", || {
-        create_padded_orchard_denomination_pczts(db_path, network, account_uuid)
+        create_padded_orchard_denomination_pczts(
+            db_path,
+            network,
+            account_uuid,
+            preparation_timing_policy,
+            super::migration::configured_timing_policy(network),
+        )
     })?;
     let Some(split) = split else {
         return Err(
@@ -398,6 +423,7 @@ pub(crate) fn prepare_orchard_migration_single_qr_pczt(
         StoredSingleQrMigrationPczt {
             account_uuid: account_uuid.to_string(),
             network,
+            preparation_timing_policy,
             state: request_state,
             proof_error: None,
             split_stages: split.stages,
@@ -429,7 +455,6 @@ pub(crate) async fn complete_orchard_migration_single_qr_pczt(
     signed_messages: Vec<KeystoneSignedMigrationMessage>,
     pending_password: &[u8],
     pending_salt_base64: &str,
-    preparation_timing_policy: super::migration::PreparationTimingPolicy,
 ) -> Result<IronwoodMigrationResult, String> {
     let _migration_guard = ActiveIronwoodMigration::acquire(db_path, account_uuid)?;
     let signed_by_id = signed_migration_messages_by_id(request_id, signed_messages)?;
@@ -486,6 +511,7 @@ pub(crate) async fn complete_orchard_migration_single_qr_pczt(
         }
         stored.state = KeystoneMigrationRequestState::Completing;
         StoredSingleQrMigrationCompletion {
+            preparation_timing_policy: stored.preparation_timing_policy,
             split_stages: stored.split_stages.clone(),
             direct_prepared_refs: stored.direct_prepared_refs.clone(),
             total_migratable_zatoshi: stored.total_migratable_zatoshi,
@@ -555,7 +581,7 @@ pub(crate) async fn complete_orchard_migration_single_qr_pczt(
             signed_children,
             denomination_stages,
             Some(&stored.approved_schedule),
-            preparation_timing_policy,
+            stored.preparation_timing_policy,
             pending_password,
             pending_salt_base64,
         )

--- a/rust/src/wallet/sync/send/ironwood_migration/denomination_split.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/denomination_split.rs
@@ -68,6 +68,7 @@ fn signed_denomination_stage_inserts(
                 raw_tx,
                 expected_txid_hex: stage.expected_txid_hex.clone(),
                 target_height: stage.target_height,
+                scheduled_height: stage.scheduled_height,
                 expiry_height: stage.expiry_height,
                 fee_zatoshi: stage.fee_zatoshi,
                 status: if stage.deferred {
@@ -242,6 +243,8 @@ fn create_padded_orchard_denomination_pczts(
     db_path: &str,
     network: WalletNetwork,
     account_uuid: &str,
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
+    migration_timing_policy: super::migration::MigrationTimingPolicy,
 ) -> Result<Option<CreatedPaddedDenominationPczts>, String> {
     let mut db = open_wallet_db(db_path, network)?;
     let fee_rule = ConservativeZip317FeeRule;
@@ -325,6 +328,19 @@ fn create_padded_orchard_denomination_pczts(
         MIN_IRONWOOD_MIGRATION_OUTPUT_ZATOSHI,
     )?
     .ok_or("Insufficient spendable Orchard funds for denomination split")?;
+    let stage_layers = padded_plan
+        .stages
+        .iter()
+        .map(|stage| stage.layer_index)
+        .collect::<Vec<_>>();
+    let scheduled_heights = super::migration::planned_preparation_scheduled_heights(
+        network,
+        preparation_timing_policy,
+        migration_timing_policy,
+        target_height.into(),
+        &stage_layers,
+        &mut OsRng,
+    )?;
 
     let padded_bundle_type = orchard::builder::BundleType::Transactional {
         bundle_required: false,
@@ -374,6 +390,11 @@ fn create_padded_orchard_denomination_pczts(
     }
 
     for (stage_index, stage_plan) in padded_plan.stages.iter().enumerate() {
+        let scheduled_height = *scheduled_heights
+            .get(stage_index)
+            .ok_or("Migration preparation schedule is missing a stage")?;
+        let expiry_height =
+            super::migration::zip318_canonical_migration_expiry_height(scheduled_height)?;
         let mut stage_notes = Vec::new();
         let mut stage_input_refs = Vec::new();
         let mut root_inputs = Vec::new();
@@ -452,6 +473,7 @@ fn create_padded_orchard_denomination_pczts(
         let builder = make_orchard_split_builder_with_type(
             network,
             target_height.into(),
+            expiry_height,
             stage_anchor,
             &stage_inputs,
             &orchard_fvk,
@@ -470,7 +492,9 @@ fn create_padded_orchard_denomination_pczts(
         let build_result = builder
             .build_for_pczt(rand_core::OsRng, &fee_rule)
             .map_err(|e| format!("Build padded denomination PCZT failed: {e}"))?;
-        let expiry_height = u32::from(build_result.pczt_parts.expiry_height);
+        if u32::from(build_result.pczt_parts.expiry_height) != expiry_height {
+            return Err("Padded denomination expiry changed during PCZT construction".to_string());
+        }
         let orchard_bundle = build_result
             .pczt_parts
             .orchard
@@ -577,6 +601,7 @@ fn create_padded_orchard_denomination_pczts(
             pczt_with_proofs: None,
             expected_txid_hex,
             target_height: target_height.into(),
+            scheduled_height,
             expiry_height,
             fee_zatoshi: u64::from(split_fee),
             deferred,

--- a/rust/src/wallet/sync/send/ironwood_migration/keystone_requests.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/keystone_requests.rs
@@ -38,6 +38,7 @@ struct CreatedDenominationStagePczt {
     pczt_with_proofs: Option<Vec<u8>>,
     expected_txid_hex: String,
     target_height: u32,
+    scheduled_height: u32,
     expiry_height: u32,
     fee_zatoshi: u64,
     deferred: bool,
@@ -56,6 +57,7 @@ struct CreatedPaddedDenominationPczts {
 struct StoredDenominationPczt {
     account_uuid: String,
     network: WalletNetwork,
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
     state: KeystoneMigrationRequestState,
     proof_error: Option<String>,
     draft_run_id: Option<String>,
@@ -67,6 +69,7 @@ struct StoredDenominationPczt {
 
 struct StoredDenominationCompletion {
     draft_run_id: Option<String>,
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
     split_stages: Vec<CreatedDenominationStagePczt>,
     direct_prepared_refs: Vec<super::migration::PreparedOrchardNoteRef>,
     total_migratable_zatoshi: u64,
@@ -113,6 +116,7 @@ struct StoredMigrationBatchCompletion {
 struct StoredSingleQrMigrationPczt {
     account_uuid: String,
     network: WalletNetwork,
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
     state: KeystoneMigrationRequestState,
     proof_error: Option<String>,
     split_stages: Vec<CreatedDenominationStagePczt>,
@@ -124,6 +128,7 @@ struct StoredSingleQrMigrationPczt {
 }
 
 struct StoredSingleQrMigrationCompletion {
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
     split_stages: Vec<CreatedDenominationStagePczt>,
     direct_prepared_refs: Vec<super::migration::PreparedOrchardNoteRef>,
     total_migratable_zatoshi: u64,

--- a/rust/src/wallet/sync/send/ironwood_migration/status_advance.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/status_advance.rs
@@ -111,7 +111,6 @@ fn reconcile_mined_denomination_stages(
             stage.stage_index,
             &stage.expected_txid_hex,
             raw_tx,
-            0,
             pending_password,
             pending_salt_base64,
         )?;
@@ -309,9 +308,17 @@ fn prepare_software_migration_run(
     account_uuid: &str,
     seed: SecretVec<u8>,
     approved_schedule: &[super::migration::MigrationScheduleEntry],
+    preparation_timing_policy: super::migration::PreparationTimingPolicy,
+    migration_timing_policy: super::migration::MigrationTimingPolicy,
 ) -> Result<Option<PreparedSoftwareMigrationRun>, String> {
     let usk = derive_migration_usk(db_path, network, account_uuid, seed)?;
-    let Some(mut split) = create_padded_orchard_denomination_pczts(db_path, network, account_uuid)?
+    let Some(mut split) = create_padded_orchard_denomination_pczts(
+        db_path,
+        network,
+        account_uuid,
+        preparation_timing_policy,
+        migration_timing_policy,
+    )?
     else {
         return Ok(None);
     };

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -236,6 +236,7 @@ fn deleting_account_discards_only_its_keystone_migration_requests() {
             StoredDenominationPczt {
                 account_uuid: account_uuid.to_string(),
                 network: WalletNetwork::Test,
+                preparation_timing_policy: migration::PreparationTimingPolicy::Zip318Spaced,
                 state: KeystoneMigrationRequestState::ProofReady,
                 proof_error: None,
                 draft_run_id: None,
@@ -277,6 +278,7 @@ fn deleting_account_discards_only_its_keystone_migration_requests() {
                 StoredSingleQrMigrationPczt {
                     account_uuid: account_uuid.to_string(),
                     network: WalletNetwork::Test,
+                    preparation_timing_policy: migration::PreparationTimingPolicy::Zip318Spaced,
                     state: KeystoneMigrationRequestState::ProofReady,
                     proof_error: None,
                     split_stages: vec![],
@@ -560,6 +562,7 @@ fn migration_test_stage(
         raw_tx: Some(vec![1, 2, 3, 4]),
         expected_txid_hex: output_txid_hex.to_string(),
         target_height: 90,
+        scheduled_height: 91,
         expiry_height: 120,
         fee_zatoshi: 10_000,
         status: migration::DenominationStageStatus::Pending,
@@ -1647,6 +1650,7 @@ fn built_v6_split_pczt() -> (BuiltPczt, orchard::keys::SpendingKey) {
     crate::wallet::network::configure_regtest_nu6_3_activation_height(2).unwrap();
     let network = WalletNetwork::Regtest;
     let target_height = 120;
+    let expiry_height = 69_120;
     let sk = orchard::keys::SpendingKey::from_bytes([7; 32]).unwrap();
     let fvk = orchard::keys::FullViewingKey::from(&sk);
     let recipient_scope = orchard::keys::Scope::Internal;
@@ -1676,6 +1680,7 @@ fn built_v6_split_pczt() -> (BuiltPczt, orchard::keys::SpendingKey) {
         make_orchard_split_builder_with_type(
             network,
             target_height,
+            expiry_height,
             orchard_anchor,
             &[(note, merkle_path)],
             &fvk,
@@ -1695,6 +1700,10 @@ fn built_v6_split_pczt() -> (BuiltPczt, orchard::keys::SpendingKey) {
     let build_result = builder.build_for_pczt(rand_core::OsRng, &fee_rule).unwrap();
 
     assert_eq!(build_result.pczt_parts.version, TxVersion::V6);
+    assert_eq!(
+        u32::from(build_result.pczt_parts.expiry_height),
+        expiry_height
+    );
     let built_pczt = pczt_from_build_result(build_result, network, None, 1, 1).unwrap();
     (built_pczt, sk)
 }
@@ -1710,6 +1719,7 @@ fn padded_denomination_split_builds_exactly_sixteen_actions() {
     crate::wallet::network::configure_regtest_nu6_3_activation_height(2).unwrap();
     let network = WalletNetwork::Regtest;
     let target_height = 120;
+    let expiry_height = 69_120;
     let usk = UnifiedSpendingKey::from_seed(&network, &[9; 32], zip32::AccountId::ZERO).unwrap();
     let fvk = orchard::keys::FullViewingKey::from(usk.orchard());
     let recipient_scope = orchard::keys::Scope::Internal;
@@ -1742,6 +1752,7 @@ fn padded_denomination_split_builds_exactly_sixteen_actions() {
         make_orchard_split_builder_with_type(
             network,
             target_height,
+            expiry_height,
             anchor,
             &[(note, merkle_path)],
             &fvk,
@@ -1763,6 +1774,10 @@ fn padded_denomination_split_builds_exactly_sixteen_actions() {
         .unwrap()
         .build_for_pczt(rand_core::OsRng, &fee_rule)
         .unwrap();
+    assert_eq!(
+        u32::from(build_result.pczt_parts.expiry_height),
+        expiry_height
+    );
     assert_eq!(
         build_result
             .pczt_parts

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -1536,21 +1536,109 @@ fn rerandomized_preparation_stage_waits_for_its_effective_height() {
         fee_zatoshi: 10_000,
     };
 
-    assert!(!denomination_stage_is_due(
-        migration::PreparationTimingPolicy::Zip318Spaced,
-        &stage,
-        123,
-    ));
-    assert!(denomination_stage_is_due(
-        migration::PreparationTimingPolicy::Zip318Spaced,
-        &stage,
-        124,
-    ));
-    assert!(denomination_stage_is_due(
-        migration::PreparationTimingPolicy::Immediate,
-        &stage,
-        0,
-    ));
+    assert_eq!(
+        denomination_stage_broadcast_readiness(
+            migration::PreparationTimingPolicy::Zip318Spaced,
+            &stage,
+            123,
+        ),
+        DenominationStageBroadcastReadiness::AwaitingHeight,
+    );
+    assert_eq!(
+        denomination_stage_broadcast_readiness(
+            migration::PreparationTimingPolicy::Zip318Spaced,
+            &stage,
+            124,
+        ),
+        DenominationStageBroadcastReadiness::Ready,
+    );
+    assert_eq!(
+        denomination_stage_broadcast_readiness(
+            migration::PreparationTimingPolicy::Immediate,
+            &stage,
+            0,
+        ),
+        DenominationStageBroadcastReadiness::Ready,
+    );
+}
+
+#[test]
+fn preparation_stage_expired_at_tip_waits_for_scanned_retirement() {
+    let (_temp_dir, db_path, run_id) =
+        create_denomination_expiry_test_run(migration::DenominationStageStatus::Pending);
+    let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+    let stage = migration::pending_raw_denomination_stages(
+        &conn,
+        &run_id,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap()
+    .remove(0);
+
+    assert_eq!(
+        expired_denomination_stage_count(&conn, &run_id, 119).unwrap(),
+        0
+    );
+    assert_eq!(
+        expired_denomination_stage_count(&conn, &run_id, 120).unwrap(),
+        1
+    );
+    assert!(
+        retire_expired_denomination_run(&db_path, WalletNetwork::Test, &run_id, 119)
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        denomination_stage_broadcast_readiness(
+            migration::PreparationTimingPolicy::Immediate,
+            &stage,
+            120,
+        ),
+        DenominationStageBroadcastReadiness::AwaitingExpiryScan,
+    );
+    assert!(
+        migration::active_migration_run(&db_path, MIGRATION_TEST_ACCOUNT, WalletNetwork::Test,)
+            .unwrap()
+            .is_some()
+    );
+
+    assert!(
+        retire_expired_denomination_run(&db_path, WalletNetwork::Test, &run_id, 120)
+            .unwrap()
+            .is_some()
+    );
+}
+
+#[test]
+fn immediate_preparation_policy_does_not_bypass_expiry() {
+    let stage = migration::PendingRawDenominationStage {
+        stage_index: 0,
+        expected_txid_hex: "10".repeat(32),
+        raw_tx: vec![1, 2, 3, 4],
+        target_height: 100,
+        scheduled_height: 100,
+        broadcast_not_before_height: None,
+        expiry_height: 120,
+        fee_zatoshi: 10_000,
+    };
+
+    assert_eq!(
+        denomination_stage_broadcast_readiness(
+            migration::PreparationTimingPolicy::Immediate,
+            &stage,
+            120,
+        ),
+        DenominationStageBroadcastReadiness::AwaitingExpiryScan,
+    );
+    assert_eq!(
+        denomination_stage_broadcast_readiness(
+            migration::PreparationTimingPolicy::Zip318Spaced,
+            &stage,
+            119,
+        ),
+        DenominationStageBroadcastReadiness::Ready,
+    );
 }
 
 #[test]

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -1421,6 +1421,138 @@ fn split_broadcast_result_preserves_status_and_migrated_amount() {
     assert_eq!(result.migrated_zatoshi, 180_000);
 }
 
+fn create_denomination_expiry_test_run(
+    status: migration::DenominationStageStatus,
+) -> (tempfile::TempDir, String, String) {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("wallet.db")
+        .to_string_lossy()
+        .to_string();
+    let denomination_input_txid = "30".repeat(32);
+    let selected_note_txid = "10".repeat(32);
+    let selected_note = migration_test_note(&selected_note_txid);
+    let mut stage = migration_test_stage(&denomination_input_txid, &selected_note_txid);
+    let stage_txid = stage.expected_txid_hex.clone();
+    match status {
+        migration::DenominationStageStatus::AwaitingInputs => {
+            stage.raw_tx = None;
+            stage.status = status;
+        }
+        migration::DenominationStageStatus::Pending
+        | migration::DenominationStageStatus::Broadcasted => {}
+        other => panic!("unsupported expiry test stage status: {other:?}"),
+    }
+    let run_id = migration::create_run_with_staged_denominations_and_signed_children(
+        &db_path,
+        MIGRATION_TEST_ACCOUNT,
+        WalletNetwork::Test,
+        &migration_test_plan(),
+        &[selected_note],
+        Vec::new(),
+        vec![stage],
+        None,
+        migration::PreparationTimingPolicy::Immediate,
+        MIGRATION_TEST_PASSWORD,
+        MIGRATION_TEST_SALT,
+    )
+    .unwrap();
+    if status == migration::DenominationStageStatus::Broadcasted {
+        let conn = open_wallet_raw_conn_with_timeout(&db_path, READ_DB_BUSY_TIMEOUT).unwrap();
+        migration::mark_denomination_stage_broadcasted(&conn, &run_id, &stage_txid).unwrap();
+    }
+    (temp_dir, db_path, run_id)
+}
+
+#[test]
+fn expired_unbroadcast_preparation_stages_retire_at_scanned_expiry() {
+    for status in [
+        migration::DenominationStageStatus::AwaitingInputs,
+        migration::DenominationStageStatus::Pending,
+    ] {
+        let (_temp_dir, db_path, run_id) = create_denomination_expiry_test_run(status);
+
+        assert!(
+            retire_expired_denomination_run(&db_path, WalletNetwork::Test, &run_id, 119,)
+                .unwrap()
+                .is_none()
+        );
+
+        let result = retire_expired_denomination_run(&db_path, WalletNetwork::Test, &run_id, 120)
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.status, migration::PHASE_FAILED_TERMINAL);
+        assert!(result
+            .message
+            .unwrap()
+            .contains("expired before confirmation"));
+        assert!(migration::active_migration_run(
+            &db_path,
+            MIGRATION_TEST_ACCOUNT,
+            WalletNetwork::Test,
+        )
+        .unwrap()
+        .is_none());
+    }
+}
+
+#[test]
+fn expired_broadcasted_preparation_stage_retires_at_scanned_expiry() {
+    let (_temp_dir, db_path, run_id) =
+        create_denomination_expiry_test_run(migration::DenominationStageStatus::Broadcasted);
+
+    assert!(
+        retire_expired_denomination_run(&db_path, WalletNetwork::Test, &run_id, 119,)
+            .unwrap()
+            .is_none()
+    );
+
+    let result = retire_expired_denomination_run(&db_path, WalletNetwork::Test, &run_id, 120)
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.status, migration::PHASE_FAILED_TERMINAL);
+    assert!(result
+        .message
+        .unwrap()
+        .contains("expired before confirmation"));
+    assert!(
+        migration::active_migration_run(&db_path, MIGRATION_TEST_ACCOUNT, WalletNetwork::Test,)
+            .unwrap()
+            .is_none()
+    );
+}
+
+#[test]
+fn rerandomized_preparation_stage_waits_for_its_effective_height() {
+    let stage = migration::PendingRawDenominationStage {
+        stage_index: 0,
+        expected_txid_hex: "10".repeat(32),
+        raw_tx: vec![1, 2, 3, 4],
+        target_height: 100,
+        scheduled_height: 100,
+        broadcast_not_before_height: Some(124),
+        expiry_height: 1_000,
+        fee_zatoshi: 10_000,
+    };
+
+    assert!(!denomination_stage_is_due(
+        migration::PreparationTimingPolicy::Zip318Spaced,
+        &stage,
+        123,
+    ));
+    assert!(denomination_stage_is_due(
+        migration::PreparationTimingPolicy::Zip318Spaced,
+        &stage,
+        124,
+    ));
+    assert!(denomination_stage_is_due(
+        migration::PreparationTimingPolicy::Immediate,
+        &stage,
+        0,
+    ));
+}
+
 #[test]
 fn scheduled_storage_failure_after_acceptance_leaves_tx_scheduled() {
     let temp_dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
ZIP 318 now recommends canonical expiration heights for note-preparation transactions, derived from each transaction’s scheduled broadcast height. This plans the full preparation schedule before software or Keystone signing, embeds and persists each expiration height, and keeps the signed expiry-derived schedule immutable.

Broadcast eligibility, expiry guards, overdue detection, and catch-up timing use the current chain tip, with a live refresh immediately before submission. Vizor only retires a preparation run after wallet scanning reaches an unconfirmed stage’s expiration height; this preserves crash recovery for transactions that may have mined but are not scanned yet, and releases migration locks so the run can be rebuilt when needed. When a spaced preparation broadcast misses its planned height, Vizor persists freshly randomized not-before heights for the remaining unbroadcast stages so they do not catch up as a cluster; these operational heights never move a stage earlier or alter its signed expiration height.