### PR TITLE
Show Android migration options before Immediate migration

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -215,6 +215,13 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     mobile: true,
   ),
   FigmaCompareScenario(
+    id: 'mobile-ironwood-migration-android-options',
+    description: 'Android Ironwood migration type screen',
+    builder: buildMobileIronwoodMigrationAndroidOptionsUseCase,
+    desktop: false,
+    mobile: true,
+  ),
+  FigmaCompareScenario(
     id: 'mobile-ironwood-migration-fast-review',
     description: 'Mobile immediate Ironwood migration review screen',
     builder: buildMobileIronwoodMigrationFastReviewUseCase,

--- a/lib/src/core/navigation/mobile_routes.dart
+++ b/lib/src/core/navigation/mobile_routes.dart
@@ -301,7 +301,6 @@ List<RouteBase> buildMobileRoutes({required List<RouteBase> entryRoutes}) {
     ),
     GoRoute(
       path: '/migration/options',
-      redirect: _redirectUnsupportedPrivateMigration,
       pageBuilder: (context, state) => CupertinoPage(
         key: state.pageKey,
         child: const MobileIronwoodMigrationFlowScreen(

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_intro_options.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_intro_options.dart
@@ -298,7 +298,7 @@ class _MobileMigrationOptionsState
             ? 'Choose between more privacy over time or a faster migration. '
                   'You can review the details before anything moves.'
             : 'Private migration is temporarily unavailable on Android. '
-                  'Choose Immediate to continue.',
+                  'Choose immediate to continue.',
         bottom: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_intro_options.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_intro_options.dart
@@ -125,11 +125,7 @@ class _MobileMigrationHowItWorks extends StatelessWidget {
       bottom: _MobileMigrationPrimaryButton(
         key: const ValueKey('mobile_ironwood_steps_continue_button'),
         label: 'Continue',
-        onPressed: () => context.go(
-          supportsPrivateMobileIronwoodMigration()
-              ? '/migration/options'
-              : '/migration/fast/review',
-        ),
+        onPressed: () => context.go('/migration/options'),
       ),
       child: const _MobileMigrationProcessCard(),
     );
@@ -139,8 +135,12 @@ class _MobileMigrationHowItWorks extends StatelessWidget {
 enum _MobileMigrationOption { private, immediate }
 
 class _MobileMigrationOptions extends ConsumerStatefulWidget {
-  const _MobileMigrationOptions({required this.immediateEnabled});
+  const _MobileMigrationOptions({
+    required this.privateEnabled,
+    required this.immediateEnabled,
+  });
 
+  final bool privateEnabled;
   final bool immediateEnabled;
 
   @override
@@ -150,17 +150,26 @@ class _MobileMigrationOptions extends ConsumerStatefulWidget {
 
 class _MobileMigrationOptionsState
     extends ConsumerState<_MobileMigrationOptions> {
-  var _selectedOption = _MobileMigrationOption.private;
+  late _MobileMigrationOption _selectedOption;
   var _isContinuing = false;
   String? _continueError;
+
+  @override
+  void initState() {
+    super.initState();
+    _selectedOption = widget.privateEnabled
+        ? _MobileMigrationOption.private
+        : _MobileMigrationOption.immediate;
+  }
 
   void _select(_MobileMigrationOption option) {
     // Continue commits to the selected option: it prepares that plan, saves a
     // draft, and routes on. Switching underneath that would apply one option's
     // work to the other's screen.
     if (_isContinuing) return;
-    if (option == _MobileMigrationOption.immediate &&
-        !widget.immediateEnabled) {
+    if ((option == _MobileMigrationOption.private && !widget.privateEnabled) ||
+        (option == _MobileMigrationOption.immediate &&
+            !widget.immediateEnabled)) {
       return;
     }
     if (_selectedOption == option) return;
@@ -285,9 +294,11 @@ class _MobileMigrationOptionsState
         topGap: 91,
         childGap: 24,
         title: 'Choose How to Migrate',
-        subtitle:
-            'Choose between more privacy over time or a faster migration. '
-            'You can review the details before anything moves.',
+        subtitle: widget.privateEnabled
+            ? 'Choose between more privacy over time or a faster migration. '
+                  'You can review the details before anything moves.'
+            : 'Private migration is temporarily unavailable on Android. '
+                  'Choose Immediate to continue.',
         bottom: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -314,13 +325,14 @@ class _MobileMigrationOptionsState
             _MobileMigrationOptionCard(
               key: const ValueKey('mobile_ironwood_private_option'),
               title: 'Private',
-              body:
-                  'Splits transactions into multiple parts to minimize '
-                  'traceability, but takes longer.',
+              body: widget.privateEnabled
+                  ? 'Splits transactions into multiple parts to minimize '
+                        'traceability, but takes longer.'
+                  : 'Not available on Android.',
               selected: privateSelected,
               icon: _MigrationChoiceIcon.private,
-              recommended: true,
-              onTap: _isContinuing
+              recommended: widget.privateEnabled,
+              onTap: _isContinuing || !widget.privateEnabled
                   ? null
                   : () => _select(_MobileMigrationOption.private),
             ),

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_review.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_review.dart
@@ -36,12 +36,10 @@ class _MobileMigrationFastReview extends ConsumerStatefulWidget {
   const _MobileMigrationFastReview({
     required this.data,
     required this.previewPlan,
-    required this.privateMigrationEnabled,
   });
 
   final IronwoodMigrationFlowData data;
   final rust_sync.OrchardMigrationImmediatePlan? previewPlan;
-  final bool privateMigrationEnabled;
 
   @override
   ConsumerState<_MobileMigrationFastReview> createState() =>
@@ -123,27 +121,21 @@ class _MobileMigrationFastReviewState
         ? (planUnavailable ? 'Unavailable' : 'Calculating…')
         : '${ZecAmount.fromZatoshi(plan.migratedZatoshi).pretty(minFractionDigits: 2, maxFractionDigits: 2).amountText} ZEC';
     return _MobileMigrationReviewScaffold(
-      onBack: () => context.go(
-        widget.privateMigrationEnabled
-            ? '/migration/options'
-            : '/migration/how-it-works',
-      ),
+      onBack: () => context.go('/migration/options'),
       bottom: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          if (widget.privateMigrationEnabled) ...[
-            AppButton(
-              variant: AppButtonVariant.secondary,
-              expand: true,
-              height: 50,
-              onPressed: _isBroadcasting
-                  ? null
-                  : () => context.go('/migration/options'),
-              leading: const AppIcon(AppIcons.chevronBackward, size: 20),
-              child: const Text('Consider another option'),
-            ),
-            const SizedBox(height: AppSpacing.s),
-          ],
+          AppButton(
+            variant: AppButtonVariant.secondary,
+            expand: true,
+            height: 50,
+            onPressed: _isBroadcasting
+                ? null
+                : () => context.go('/migration/options'),
+            leading: const AppIcon(AppIcons.chevronBackward, size: 20),
+            child: const Text('Consider another option'),
+          ),
+          const SizedBox(height: AppSpacing.s),
           if (_broadcastError != null) ...[
             Text(
               _broadcastError!,

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_routes.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_routes.dart
@@ -88,7 +88,6 @@ class _MobileIronwoodMigrationContent extends ConsumerWidget {
         (previewMode || supportsPrivateMobileIronwoodMigration());
     if (!privateMigrationEnabled &&
         switch (step) {
-          MobileIronwoodMigrationStep.options ||
           MobileIronwoodMigrationStep.notifications => true,
           _ => false,
         }) {
@@ -102,6 +101,7 @@ class _MobileIronwoodMigrationContent extends ConsumerWidget {
       MobileIronwoodMigrationStep.howItWorks =>
         const _MobileMigrationHowItWorks(),
       MobileIronwoodMigrationStep.options => _MobileMigrationOptions(
+        privateEnabled: privateMigrationEnabled,
         immediateEnabled: true,
       ),
       MobileIronwoodMigrationStep.notifications =>
@@ -111,7 +111,6 @@ class _MobileIronwoodMigrationContent extends ConsumerWidget {
       MobileIronwoodMigrationStep.fastReview => _MobileMigrationFastReview(
         data: data,
         previewPlan: previewImmediatePlan,
-        privateMigrationEnabled: privateMigrationEnabled,
       ),
       MobileIronwoodMigrationStep.preparing => _MobileMigrationPreparing(
         data: data,

--- a/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_step_options.dart
+++ b/lib/src/features/migration/screens/mobile/mobile_ironwood_migration_step_options.dart
@@ -27,131 +27,136 @@ class _MobileMigrationOptionCard extends StatelessWidget {
       selected: selected,
       enabled: onTap != null,
       button: onTap != null,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: onTap,
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: colors.background.ground,
-            borderRadius: BorderRadius.circular(AppRadii.large),
-            border: selected
-                ? Border.all(color: colors.border.strong, width: 2)
-                : null,
-            boxShadow: appSurfaceShadow(colors),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(12, 16, 16, 16),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Opacity(
-                  opacity: selected ? 1 : 0.5,
-                  child: SizedBox.square(
-                    dimension: 32,
-                    child: Center(
-                      child: AppIcon(
-                        switch (icon) {
-                          _MigrationChoiceIcon.private =>
-                            AppIcons.shieldKeyhole,
-                          _MigrationChoiceIcon.immediate =>
-                            AppIcons.migrationFast,
-                        },
-                        key: ValueKey('mobile_ironwood_${icon.name}_icon'),
-                        size: 20,
-                        color: colors.icon.accent,
+      child: AnimatedOpacity(
+        key: ValueKey('mobile_ironwood_${icon.name}_option_opacity'),
+        opacity: onTap == null ? 0.5 : 1,
+        duration: const Duration(milliseconds: 150),
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: colors.background.ground,
+              borderRadius: BorderRadius.circular(AppRadii.large),
+              border: selected
+                  ? Border.all(color: colors.border.strong, width: 2)
+                  : null,
+              boxShadow: appSurfaceShadow(colors),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(12, 16, 16, 16),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Opacity(
+                    opacity: selected ? 1 : 0.5,
+                    child: SizedBox.square(
+                      dimension: 32,
+                      child: Center(
+                        child: AppIcon(
+                          switch (icon) {
+                            _MigrationChoiceIcon.private =>
+                              AppIcons.shieldKeyhole,
+                            _MigrationChoiceIcon.immediate =>
+                              AppIcons.migrationFast,
+                          },
+                          key: ValueKey('mobile_ironwood_${icon.name}_icon'),
+                          size: 20,
+                          color: colors.icon.accent,
+                        ),
                       ),
                     ),
                   ),
-                ),
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: AppSpacing.xs,
-                      vertical: AppSpacing.xxs,
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        SizedBox(
-                          height: 24,
-                          child: Row(
-                            children: [
-                              Text(
-                                title,
-                                style: AppTypography.bodyLarge.copyWith(
-                                  color: colors.text.accent,
-                                  fontWeight: FontWeight.w600,
+                  Expanded(
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.xs,
+                        vertical: AppSpacing.xxs,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          SizedBox(
+                            height: 24,
+                            child: Row(
+                              children: [
+                                Text(
+                                  title,
+                                  style: AppTypography.bodyLarge.copyWith(
+                                    color: colors.text.accent,
+                                    fontWeight: FontWeight.w600,
+                                  ),
                                 ),
-                              ),
-                              if (recommended) ...[
-                                const SizedBox(width: AppSpacing.xs),
-                                Flexible(
-                                  child: DecoratedBox(
-                                    key: const ValueKey(
-                                      'mobile_ironwood_recommended_badge',
-                                    ),
-                                    decoration: BoxDecoration(
-                                      color: const Color(0xFF00A460),
-                                      borderRadius: BorderRadius.circular(
-                                        AppRadii.xSmall,
+                                if (recommended) ...[
+                                  const SizedBox(width: AppSpacing.xs),
+                                  Flexible(
+                                    child: DecoratedBox(
+                                      key: const ValueKey(
+                                        'mobile_ironwood_recommended_badge',
                                       ),
-                                    ),
-                                    child: Padding(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: AppSpacing.xs,
-                                        vertical: AppSpacing.xxs,
+                                      decoration: BoxDecoration(
+                                        color: const Color(0xFF00A460),
+                                        borderRadius: BorderRadius.circular(
+                                          AppRadii.xSmall,
+                                        ),
                                       ),
-                                      child: Text(
-                                        'Recommended',
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: AppTypography.labelLarge
-                                            .copyWith(
-                                              color: const Color(0xFFD3FFE4),
-                                              fontWeight: FontWeight.w600,
-                                            ),
+                                      child: Padding(
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: AppSpacing.xs,
+                                          vertical: AppSpacing.xxs,
+                                        ),
+                                        child: Text(
+                                          'Recommended',
+                                          maxLines: 1,
+                                          overflow: TextOverflow.ellipsis,
+                                          style: AppTypography.labelLarge
+                                              .copyWith(
+                                                color: const Color(0xFFD3FFE4),
+                                                fontWeight: FontWeight.w600,
+                                              ),
+                                        ),
                                       ),
                                     ),
                                   ),
-                                ),
+                                ],
                               ],
-                            ],
+                            ),
                           ),
-                        ),
-                        const SizedBox(height: AppSpacing.xs),
-                        Text(
-                          body,
-                          style: AppTypography.bodyMediumStrong.copyWith(
-                            color: colors.text.secondary,
+                          const SizedBox(height: AppSpacing.xs),
+                          Text(
+                            body,
+                            style: AppTypography.bodyMediumStrong.copyWith(
+                              color: colors.text.secondary,
+                            ),
                           ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
-                ),
-                Container(
-                  key: ValueKey(
-                    selected
-                        ? 'mobile_ironwood_selected_radio'
-                        : 'mobile_ironwood_unselected_radio',
+                  Container(
+                    key: ValueKey(
+                      selected
+                          ? 'mobile_ironwood_selected_radio'
+                          : 'mobile_ironwood_unselected_radio',
+                    ),
+                    width: 20,
+                    height: 20,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: selected
+                          ? colors.background.inverse
+                          : colors.background.neutralSubtleOpacity,
+                    ),
+                    child: selected
+                        ? AppIcon(
+                            AppIcons.check,
+                            size: 16,
+                            color: colors.text.inverse,
+                          )
+                        : null,
                   ),
-                  width: 20,
-                  height: 20,
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: selected
-                        ? colors.background.inverse
-                        : colors.background.neutralSubtleOpacity,
-                  ),
-                  child: selected
-                      ? AppIcon(
-                          AppIcons.check,
-                          size: 16,
-                          color: colors.text.inverse,
-                        )
-                      : null,
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -982,6 +982,13 @@ Widget buildMobileIronwoodMigrationOptionsUseCase(BuildContext context) {
   );
 }
 
+Widget buildMobileIronwoodMigrationAndroidOptionsUseCase(BuildContext context) {
+  return _buildMobileIronwoodMigrationUseCase(
+    step: MobileIronwoodMigrationStep.options,
+    privateMigrationSupported: false,
+  );
+}
+
 Widget buildMobileIronwoodMigrationFastReviewUseCase(BuildContext context) {
   return _buildMobileIronwoodMigrationUseCase(
     step: MobileIronwoodMigrationStep.fastReview,
@@ -1200,6 +1207,7 @@ Widget _buildMobileIronwoodMigrationUseCase({
   required MobileIronwoodMigrationStep step,
   rust_sync.OrchardMigrationImmediatePlan? previewImmediatePlan,
   MobileIronwoodMigrationPreviewSurface? previewSurface,
+  bool? privateMigrationSupported,
 }) {
   final zatoshi = switch (step) {
     MobileIronwoodMigrationStep.intro => BigInt.from(14_223_000_000),
@@ -1226,6 +1234,7 @@ Widget _buildMobileIronwoodMigrationUseCase({
         previewPrivatePlan: _previewMobilePrivateMigrationPlan(),
         previewImmediatePlan: previewImmediatePlan,
         previewSurface: previewSurface,
+        privateMigrationSupported: privateMigrationSupported,
       ),
     ),
   );

--- a/test/core/navigation/mobile_routes_test.dart
+++ b/test/core/navigation/mobile_routes_test.dart
@@ -107,6 +107,21 @@ void main() {
     expect(paths, isNot(contains('/migration/private/review')));
   });
 
+  test('shows migration options while guarding private-only routes', () {
+    final routes = buildMobileRoutes(
+      entryRoutes: const [],
+    ).whereType<GoRoute>();
+    final options = routes.singleWhere(
+      (route) => route.path == '/migration/options',
+    );
+    final notifications = routes.singleWhere(
+      (route) => route.path == '/migration/private/notifications',
+    );
+
+    expect(options.redirect, isNull);
+    expect(notifications.redirect, isNotNull);
+  });
+
   testWidgets('tab shell renders all four tabs and switches branches', (
     tester,
   ) async {

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -2200,6 +2200,26 @@ void main() {
       matching: find.byType(GestureDetector),
     );
     expect(tester.widget<GestureDetector>(privateGesture).onTap, isNull);
+    expect(
+      tester
+          .widget<AnimatedOpacity>(
+            find.byKey(
+              const ValueKey('mobile_ironwood_private_option_opacity'),
+            ),
+          )
+          .opacity,
+      0.5,
+    );
+    expect(
+      tester
+          .widget<AnimatedOpacity>(
+            find.byKey(
+              const ValueKey('mobile_ironwood_immediate_option_opacity'),
+            ),
+          )
+          .opacity,
+      1,
+    );
 
     await tester.tap(
       find.byKey(const ValueKey('mobile_ironwood_options_continue_button')),

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -2169,6 +2169,13 @@ void main() {
     expect(find.text('Choose How to Migrate'), findsOneWidget);
     expect(find.text('Private'), findsOneWidget);
     expect(find.text('Immediate'), findsOneWidget);
+    expect(
+      find.text(
+        'Private migration is temporarily unavailable on Android. '
+        'Choose immediate to continue.',
+      ),
+      findsOneWidget,
+    );
     expect(find.text('Not available on Android.'), findsOneWidget);
     expect(find.text('Recommended'), findsNothing);
     expect(

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -2149,27 +2149,59 @@ void main() {
     expect(find.text('Authorise anyway'), findsNothing);
   });
 
-  testWidgets(
-    'Android options force Immediate review with a viable back exit',
-    (tester) async {
-      await tester.pumpWidget(
-        _app(
-          step: MobileIronwoodMigrationStep.options,
-          privateMigrationSupported: false,
+  testWidgets('Android shows Private disabled and selects Immediate', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _app(
+        step: MobileIronwoodMigrationStep.options,
+        privateMigrationSupported: false,
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final privateOption = find.byKey(
+      const ValueKey('mobile_ironwood_private_option'),
+    );
+    final immediateOption = find.byKey(
+      const ValueKey('mobile_ironwood_immediate_option'),
+    );
+    expect(find.text('Choose How to Migrate'), findsOneWidget);
+    expect(find.text('Private'), findsOneWidget);
+    expect(find.text('Immediate'), findsOneWidget);
+    expect(find.text('Not available on Android.'), findsOneWidget);
+    expect(find.text('Recommended'), findsNothing);
+    expect(
+      find.descendant(
+        of: privateOption,
+        matching: find.byKey(
+          const ValueKey('mobile_ironwood_unselected_radio'),
         ),
-      );
-      await tester.pumpAndSettle();
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+        of: immediateOption,
+        matching: find.byKey(const ValueKey('mobile_ironwood_selected_radio')),
+      ),
+      findsOneWidget,
+    );
 
-      expect(find.text('Fast Migration'), findsOneWidget);
-      expect(find.text('Consider another option'), findsNothing);
+    final privateGesture = find.descendant(
+      of: privateOption,
+      matching: find.byType(GestureDetector),
+    );
+    expect(tester.widget<GestureDetector>(privateGesture).onTap, isNull);
 
-      await tester.tap(find.bySemanticsLabel('Back'));
-      await tester.pumpAndSettle();
+    await tester.tap(
+      find.byKey(const ValueKey('mobile_ironwood_options_continue_button')),
+    );
+    await tester.pumpAndSettle();
 
-      expect(find.text('How Migration Works'), findsOneWidget);
-      expect(find.text('Fast Migration'), findsNothing);
-    },
-  );
+    expect(find.text('Fast Migration'), findsOneWidget);
+    expect(find.text('Consider another option'), findsOneWidget);
+  });
 
   testWidgets(
     'shows the computed immediate completion estimate in production',


### PR DESCRIPTION
## Problem

After Private migration was disabled on Android, the flow skipped the migration option screen and routed users directly to the Immediate migration review. That made it unclear which migration type was available and being used.

## Solution

- Keep the migration option screen visible on Android.
- Show Private as unavailable and non-selectable, following the existing disabled-option pattern used when Keystone cannot use Immediate migration.
- Select Immediate by default and continue to its review screen explicitly.
- Keep navigation from the Immediate review back to the option screen so users can revisit the available migration types.
- Preserve existing Private migration status and recovery routes for previously started internal-test migrations.

## User impact

Android users can now see that Private migration exists but is unavailable, and can clearly confirm that their migration will use Immediate mode before proceeding.

## Verification

- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/migration/mobile_ironwood_migration_flow_screen_test.dart` — 102 tests passed
- `git diff --check` — passed
- `fvm flutter analyze` — no new errors; exits non-zero on 23 existing unused-code warnings