### PR TITLE
Finalize migration children inside their ZIP 318 anchor windows

### DIFF
--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -212,6 +212,9 @@ pub(crate) struct SignedMigrationPczt {
 pub(crate) struct SignedChildProofCandidate {
     pub selected_note: PreparedOrchardNoteRef,
     pub anchor_boundary_height: Option<u32>,
+    /// `None` marks a legacy row that requires fresh signatures; see
+    /// `signed_child_pczts_for_run`.
+    pub scheduled_height: Option<u32>,
 }
 
 pub(crate) struct DuePendingMigrationTx {
@@ -2335,7 +2338,7 @@ pub(crate) fn signed_child_proof_candidates_for_run(
     let conn = open_readonly_conn_with_timeout(db_path, Some(READ_DB_BUSY_TIMEOUT))?;
     let mut stmt = conn
         .prepare_cached(&format!(
-            "SELECT c.selected_note_json, c.anchor_boundary_height
+            "SELECT c.selected_note_json, c.anchor_boundary_height, c.scheduled_height
              FROM {SIGNED_CHILD_PCZTS_TABLE} c
              WHERE c.run_id = ?1
                AND NOT EXISTS (
@@ -2347,19 +2350,24 @@ pub(crate) fn signed_child_proof_candidates_for_run(
         .map_err(|e| format!("Prepare signed migration proof candidate query: {e}"))?;
     let rows = stmt
         .query_map(params![run_id], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, Option<u32>>(1)?))
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<u32>>(1)?,
+                row.get::<_, Option<u32>>(2)?,
+            ))
         })
         .map_err(|e| format!("Query signed migration proof candidates: {e}"))?;
 
     let mut candidates = Vec::new();
     for row in rows {
-        let (selected_note_json, anchor_boundary_height) =
+        let (selected_note_json, anchor_boundary_height, scheduled_height) =
             row.map_err(|e| format!("Read signed migration proof candidate: {e}"))?;
         let selected_note = serde_json::from_str::<PreparedOrchardNoteRef>(&selected_note_json)
             .map_err(|e| format!("Decode signed migration proof candidate note: {e}"))?;
         candidates.push(SignedChildProofCandidate {
             selected_note,
             anchor_boundary_height,
+            scheduled_height,
         });
     }
     Ok(candidates)

--- a/rust/src/wallet/sync/migration/denomination_policy.rs
+++ b/rust/src/wallet/sync/migration/denomination_policy.rs
@@ -81,6 +81,38 @@ pub(crate) fn zip318_canonical_migration_expiry_height(
         .ok_or_else(|| "ZIP 318 canonical expiry height overflow".to_string())
 }
 
+/// Height at which a pre-signed migration child's anchor window opens: one
+/// anchor bucket before its scheduled broadcast height. See
+/// [`presigned_child_anchor_window_open`] for the invariant this protects.
+pub(crate) fn presigned_child_anchor_window_open_height(
+    network: WalletNetwork,
+    timing_policy: MigrationTimingPolicy,
+    scheduled_height: u32,
+) -> u32 {
+    scheduled_height.saturating_sub(anchor_bucket_modulus(network, timing_policy))
+}
+
+/// Whether a pre-signed migration child may be anchored and proved now.
+///
+/// ZIP 318 anchors are drawn 1..=[`ZIP318_ANCHOR_AGE_CAP`] buckets behind the
+/// broadcast height, so a transfer's anchor must be resolved close to its
+/// scheduled broadcast: freezing it earlier ages the anchor past the shared
+/// cohort window by the time the transfer is mined, which both distinguishes
+/// the transfer from every conforming wallet's and orders a run's transfers
+/// by schedule position. One bucket of lead is the earliest point at which
+/// the full candidate set relative to the scheduled height is scannable.
+/// Overdue children (scheduled at or below the scanned height) are always
+/// open: they broadcast immediately, so a draw against the current height is
+/// cohort-fresh.
+pub(crate) fn presigned_child_anchor_window_open(
+    network: WalletNetwork,
+    timing_policy: MigrationTimingPolicy,
+    scheduled_height: u32,
+    scanned_height: u32,
+) -> bool {
+    scanned_height >= presigned_child_anchor_window_open_height(network, timing_policy, scheduled_height)
+}
+
 fn largest_zip318_denomination_at_or_below(value_zatoshi: u64) -> Option<u64> {
     if value_zatoshi < ZIP318_MAX_RESIDUAL_VALUE_ZATOSHI {
         return None;

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -1546,6 +1546,79 @@ fn anchor_bucket_draw_renormalizes_over_available_checkpoint_boundaries() {
 }
 
 #[test]
+fn presigned_child_anchor_window_opens_one_bucket_before_broadcast() {
+    // Main-network buckets are 144 blocks: the window opens at scheduled - 144.
+    assert!(!presigned_child_anchor_window_open(
+        WalletNetwork::Main,
+        MigrationTimingPolicy::Standard,
+        10_144,
+        9_999,
+    ));
+    assert!(presigned_child_anchor_window_open(
+        WalletNetwork::Main,
+        MigrationTimingPolicy::Standard,
+        10_144,
+        10_000,
+    ));
+    // Overdue children stay open: they broadcast immediately, so a draw
+    // against the current height is cohort-fresh.
+    assert!(presigned_child_anchor_window_open(
+        WalletNetwork::Main,
+        MigrationTimingPolicy::Standard,
+        9_000,
+        10_000,
+    ));
+    // Fast-Testnet buckets are 12 blocks.
+    assert!(!presigned_child_anchor_window_open(
+        WalletNetwork::Test,
+        MigrationTimingPolicy::FastTestnet,
+        1_012,
+        999,
+    ));
+    assert!(presigned_child_anchor_window_open(
+        WalletNetwork::Test,
+        MigrationTimingPolicy::FastTestnet,
+        1_012,
+        1_000,
+    ));
+}
+
+#[test]
+fn scheduled_reference_draw_keeps_child_anchor_in_cohort_at_broadcast() {
+    let scheduled: u32 = 3_456_100;
+    let latest_boundary = scheduled - (scheduled % ZIP318_ANCHOR_BUCKET_MODULUS);
+    let candidates = zip318_anchor_candidate_boundaries_with_policy(
+        WalletNetwork::Main,
+        MigrationTimingPolicy::Standard,
+        scheduled,
+        1,
+        0,
+    );
+    assert_eq!(candidates.len() as u32, ZIP318_ANCHOR_AGE_CAP);
+
+    // By the window-open height every candidate relative to the scheduled
+    // broadcast is already scannable, so the weighted draw sees the full
+    // 1..=cap cohort and every anchor it returns is cohort-aged at broadcast.
+    let window_open = presigned_child_anchor_window_open_height(
+        WalletNetwork::Main,
+        MigrationTimingPolicy::Standard,
+        scheduled,
+    );
+    assert!(candidates.iter().all(|boundary| *boundary <= window_open));
+    for _ in 0..32 {
+        let drawn = zip318_draw_anchor_boundary_from_available_with_policy(
+            WalletNetwork::Main,
+            MigrationTimingPolicy::Standard,
+            scheduled,
+            &candidates,
+        )
+        .unwrap();
+        let age = (latest_boundary - drawn) / ZIP318_ANCHOR_BUCKET_MODULUS;
+        assert!((1..=ZIP318_ANCHOR_AGE_CAP).contains(&age));
+    }
+}
+
+#[test]
 fn planner_drains_balance_beyond_the_old_run_cap() {
     let input = 1_999_999_950_000_000;
     let migration_fee = 10_000;
@@ -3030,6 +3103,7 @@ fn approved_schedule_keeps_unpromoted_anchor_retention_candidates() {
                 nullifier_hex: None,
             },
             anchor_boundary_height: None,
+            scheduled_height: Some(501),
         }]
     );
     promote_signed_child_pczts_to_pending_txs(

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -2083,12 +2083,28 @@ pub(crate) fn orchard_migration_proof_readiness_at_scanned_height(
         return Ok(Some(false));
     }
     any_migration_proof_candidate_ready(&candidates, |candidate| {
+        // A child without a persisted schedule requires fresh signatures and
+        // can never be proved; one whose anchor window has not opened yet is
+        // deliberately not finalizable (see
+        // `presigned_child_anchor_window_open`).
+        let Some(scheduled_height) = candidate.scheduled_height else {
+            return Ok(false);
+        };
+        if !super::migration::presigned_child_anchor_window_open(
+            network,
+            timing_policy,
+            scheduled_height,
+            scanned_height,
+        ) {
+            return Ok(false);
+        }
         orchard_witness_is_available_for_prepared_note(
             db_path,
             network,
             account_uuid,
             &candidate.selected_note,
             candidate.anchor_boundary_height,
+            scheduled_height,
             timing_policy,
         )
     })
@@ -3682,12 +3698,23 @@ fn orchard_anchor_and_witnesses_for_denomination_inputs(
     )))
 }
 
+/// Resolves the ZIP 318 anchor boundary and witness for one pre-signed
+/// migration child.
+///
+/// Candidacy and the weighted draw are evaluated against
+/// `max(scheduled_height, anchor height)`, so the anchor's bucket age is
+/// measured relative to the height the transfer will actually broadcast at:
+/// an on-time child draws a boundary that is 1..=cap buckets old *at its
+/// scheduled height*, and an overdue child draws against the present.
+/// Callers gate on `presigned_child_anchor_window_open` so the candidate set
+/// relative to that reference is fully scannable when the draw happens.
 fn orchard_anchor_and_witness_for_prepared_note(
     db_path: &str,
     network: WalletNetwork,
     account_uuid: &str,
     note_ref: &super::migration::PreparedOrchardNoteRef,
     preferred_anchor_boundary_height: Option<u32>,
+    scheduled_height: u32,
     timing_policy: super::migration::MigrationTimingPolicy,
 ) -> Result<Option<(u32, orchard::Anchor, orchard::tree::MerklePath)>, String> {
     if note_ref.note_version != 2 {
@@ -3725,6 +3752,7 @@ fn orchard_anchor_and_witness_for_prepared_note(
         return Err("Prepared note value changed during revalidation".to_string());
     }
     let anchor_height_u32 = u32::from(anchor_height);
+    let draw_reference_height = anchor_height_u32.max(scheduled_height);
     let nu6_3_activation_height = nu6_3_activation_height_u32(network)?;
     let mined_height = selected
         .mined_height()
@@ -3734,7 +3762,7 @@ fn orchard_anchor_and_witness_for_prepared_note(
     let policy_candidates = super::migration::zip318_anchor_candidate_boundaries_with_policy(
         network,
         timing_policy,
-        anchor_height_u32,
+        draw_reference_height,
         mined_height,
         nu6_3_activation_height,
     );
@@ -3755,7 +3783,7 @@ fn orchard_anchor_and_witness_for_prepared_note(
             network,
             timing_policy,
             *boundary,
-            anchor_height_u32,
+            draw_reference_height,
             mined_height,
             nu6_3_activation_height,
         ) && available_anchor_candidates
@@ -3789,7 +3817,7 @@ fn orchard_anchor_and_witness_for_prepared_note(
             super::migration::zip318_draw_anchor_boundary_from_available_with_policy(
                 network,
                 timing_policy,
-                anchor_height_u32,
+                draw_reference_height,
                 &witnessable_boundaries,
             )
         });
@@ -3803,12 +3831,17 @@ fn orchard_anchor_and_witness_for_prepared_note(
     Ok(Some(witnessable_candidates.swap_remove(selected_index)))
 }
 
+/// Read-only readiness probe mirroring
+/// `orchard_anchor_and_witness_for_prepared_note`: candidates are evaluated
+/// against the same `max(scheduled_height, anchor height)` reference so a
+/// positive answer means the finalize path could resolve an anchor now.
 fn orchard_witness_is_available_for_prepared_note(
     db_path: &str,
     network: WalletNetwork,
     account_uuid: &str,
     note_ref: &super::migration::PreparedOrchardNoteRef,
     preferred_anchor_boundary_height: Option<u32>,
+    scheduled_height: u32,
     timing_policy: super::migration::MigrationTimingPolicy,
 ) -> Result<bool, String> {
     if note_ref.note_version != 2 {
@@ -3850,7 +3883,7 @@ fn orchard_witness_is_available_for_prepared_note(
         return Err("Prepared note value changed during revalidation".to_string());
     }
 
-    let anchor_height_u32 = u32::from(anchor_height);
+    let draw_reference_height = u32::from(anchor_height).max(scheduled_height);
     let mined_height = selected
         .mined_height()
         .ok_or("Prepared migration note mined height unavailable")?;
@@ -3859,7 +3892,7 @@ fn orchard_witness_is_available_for_prepared_note(
     let policy_candidates = super::migration::zip318_anchor_candidate_boundaries_with_policy(
         network,
         timing_policy,
-        anchor_height_u32,
+        draw_reference_height,
         mined_height,
         nu6_3_activation_height_u32(network)?,
     );
@@ -4052,6 +4085,7 @@ fn finalize_presigned_migration_children(
     let proof_limit = policy.proof_limit(signed_child_count);
     let mut finalized_count = 0usize;
     let mut deferred_child_seen = false;
+    let mut earliest_gated_window_open: Option<u32> = None;
     let mut stopped_at_proof_limit = false;
     for (child_index, child) in signed_children.into_iter().enumerate() {
         if policy.is_cancelled() {
@@ -4067,6 +4101,24 @@ fn finalize_presigned_migration_children(
         )) {
             continue;
         }
+        if !super::migration::presigned_child_anchor_window_open(
+            network,
+            timing_policy,
+            child.scheduled_height,
+            current_scanned_height,
+        ) {
+            let window_open_height = super::migration::presigned_child_anchor_window_open_height(
+                network,
+                timing_policy,
+                child.scheduled_height,
+            );
+            earliest_gated_window_open = Some(
+                earliest_gated_window_open.map_or(window_open_height, |existing| {
+                    existing.min(window_open_height)
+                }),
+            );
+            continue;
+        }
         let current_note = current_prepared
             .iter()
             .find(|note| same_prepared_note_without_nullifier(note, &child.selected_note))
@@ -4078,6 +4130,7 @@ fn finalize_presigned_migration_children(
                 account_uuid,
                 current_note,
                 child.anchor_boundary_height,
+                child.scheduled_height,
                 timing_policy,
             ) {
                 Ok(result) => result,
@@ -4182,9 +4235,17 @@ fn finalize_presigned_migration_children(
         )? {
             retry_height = retry_height.max(ready_height);
         }
+        if let Some(window_open_height) = earliest_gated_window_open {
+            // A window-gated child needs no new anchor bucket or note
+            // readiness; it becomes finalizable at its own window-open height.
+            retry_height = retry_height.min(window_open_height);
+        }
         if deferred_child_seen && !stopped_at_proof_limit {
             defer_presigned_proof_until(db_path, run_id, retry_height)?;
-        } else if finalized_count > 0 || stopped_at_proof_limit {
+        } else if finalized_count > 0
+            || stopped_at_proof_limit
+            || earliest_gated_window_open.is_some()
+        {
             super::migration::set_proof_retry_height(db_path, run_id, retry_height)?;
         }
     }


### PR DESCRIPTION
Pre-signed migration transfers were anchored and proved as soon as their denomination notes became spendable, so a transfer broadcast N buckets after finalization mined with an anchor about N buckets old. That ages late transfers out of the shared 1..=16-bucket ZIP 318 anchor cohort and orders a run's transfers by schedule position on-chain.

Each child now finalizes inside its own anchor window (one bucket before its scheduled broadcast), and anchor candidacy plus the weighted draw are evaluated against `max(scheduled height, current anchor height)`: an on-time child draws a boundary that is cohort-aged at its broadcast height, while an overdue child draws against the present. Window-gated children contribute their window-open heights to the proof retry height, and the proof-readiness probe applies the same gate so status reads match what finalization would do. A side effect is that proving is now spread across the schedule instead of bursting when the denominations confirm.

Follow-up not included here: the software expired-part rebuild proves immediately with a now-relative anchor while re-applying the original schedule offset, so a rebuilt far-offset part has the same staleness; routing rebuilds through the gated finalize lane is a larger change.

Validation: `cargo test --lib` (455 passed, including two new tests pinning the window boundary and the cohort age of scheduled-reference draws) and `cargo fmt`. Regtest E2E not run.