### PR TITLE
Fix Ironwood migration prompts on desktop

### DIFF
--- a/lib/src/core/layout/app_main_sidebar.dart
+++ b/lib/src/core/layout/app_main_sidebar.dart
@@ -528,7 +528,11 @@ class _SidebarMigrationHomeSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
-    final needsInput = isHardware && status.phase == 'ready_to_migrate';
+    final signingPartIndices = status.currentSigningPartIndices;
+    final needsInput =
+        isHardware &&
+        status.phase == kIronwoodMigrationReadyToMigratePhase &&
+        (signingPartIndices == null || signingPartIndices.isNotEmpty);
     final orchardLabel = hideAmountIfPrivacyMode(
       '${ZecAmount.fromZatoshi(orchardBalance).balance.amountText} ZEC',
       privacyModeEnabled: privacyModeEnabled,

--- a/lib/src/features/home/screens/home_screen.dart
+++ b/lib/src/features/home/screens/home_screen.dart
@@ -317,11 +317,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
         ? 'importing'
         : 'default';
     final backgroundTheme = isDark ? 'dark' : 'light';
-    final ironwoodAnnouncement = ref
-        .watch(ironwoodMigrationAnnouncementProvider)
-        .value;
+    final ironwoodAnnouncementAsync = ref.watch(
+      ironwoodMigrationAnnouncementProvider,
+    );
+    final ironwoodAnnouncement = ironwoodAnnouncementAsync.value;
     final latestVisibleIronwoodAnnouncement =
-        (ironwoodAnnouncement?.visible ?? false) ? ironwoodAnnouncement : null;
+        (ironwoodAnnouncement?.visible ?? false) &&
+            ironwoodAnnouncement?.accountUuid == activeAccountUuid
+        ? ironwoodAnnouncement
+        : null;
     if (_visibleIronwoodAnnouncement?.accountUuid != null &&
         _visibleIronwoodAnnouncement?.accountUuid != activeAccountUuid) {
       _visibleIronwoodAnnouncement = null;
@@ -332,6 +336,19 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     if (latestVisibleIronwoodAnnouncement != null &&
         latestIronwoodScope != _suppressedIronwoodAnnouncementScope) {
       _visibleIronwoodAnnouncement = latestVisibleIronwoodAnnouncement;
+    }
+    final announcementResolvedHidden = switch (ironwoodAnnouncementAsync) {
+      AsyncData(:final value) => !value.visible,
+      _ => false,
+    };
+    final preserveAnnouncementDuringRefresh =
+        !sync.hasAccountScopedData ||
+        sync.isSyncing ||
+        sync.isBackgroundMode ||
+        sync.failure != null ||
+        sync.error != null;
+    if (announcementResolvedHidden && !preserveAnnouncementDuringRefresh) {
+      _visibleIronwoodAnnouncement = null;
     }
     final visibleIronwoodAnnouncement = _visibleIronwoodAnnouncement;
     return AppDesktopBackdropShell(

--- a/test/app_main_sidebar_test.dart
+++ b/test/app_main_sidebar_test.dart
@@ -162,7 +162,7 @@ void main() {
     expect(find.textContaining('/3'), findsNothing);
   });
 
-  testWidgets('sidebar requests input only for Keystone migration', (
+  testWidgets('sidebar keeps Keystone migration automatic after signing', (
     tester,
   ) async {
     await tester.pumpWidget(
@@ -176,12 +176,52 @@ void main() {
     );
     await tester.pump();
 
+    expect(find.text('Migrating...'), findsOneWidget);
+    expect(find.text('Needs input'), findsNothing);
+    expect(
+      find.byKey(const ValueKey('sidebar_migration_progress_button')),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('sidebar requests input for pending Keystone signing parts', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _sidebarHarness(
+        _syncedSyncState,
+        accountState: _hardwareAccountState,
+        migrationCoordinatorState: IronwoodMigrationCoordinatorState(
+          statuses: {'account-1': _readyMigrationNeedsInputStatus},
+        ),
+      ),
+    );
+    await tester.pump();
+
     expect(find.text('Needs input'), findsOneWidget);
     expect(find.text('Migrating...'), findsNothing);
     expect(
       find.byKey(const ValueKey('sidebar_migration_progress_button')),
       findsOneWidget,
     );
+  });
+
+  testWidgets('sidebar preserves legacy Keystone needs-input status', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _sidebarHarness(
+        _syncedSyncState,
+        accountState: _hardwareAccountState,
+        migrationCoordinatorState: IronwoodMigrationCoordinatorState(
+          statuses: {'account-1': _legacyReadyMigrationStatus},
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Needs input'), findsOneWidget);
+    expect(find.text('Migrating...'), findsNothing);
   });
 
   testWidgets('sidebar keeps Home active and clickable on send routes', (
@@ -997,7 +1037,10 @@ const _hardwareAccountState = AccountState(
   activeAddress: 'u1accountsaddress',
 );
 
-final _readyMigrationStatus = rust_sync.MigrationStatus(
+rust_sync.MigrationStatus _buildReadyMigrationStatus({
+  int signedChildPcztCount = 6,
+  List<int>? currentSigningPartIndices = const [],
+}) => rust_sync.MigrationStatus(
   phase: 'ready_to_migrate',
   activeRunId: 'run-1',
   targetValuesZatoshi: frb.Uint64List.fromList([
@@ -1017,14 +1060,29 @@ final _readyMigrationStatus = rust_sync.MigrationStatus(
   broadcastedTxCount: 0,
   confirmedTxCount: 0,
   totalCount: 6,
-  signedChildPcztCount: 6,
+  signedChildPcztCount: signedChildPcztCount,
   pendingSplitStageCount: 0,
   canAbandon: false,
   signingBatchLimit: 50,
   scheduleMeanDelayBlocks: 144,
   scheduleMaxDelayBlocks: 576,
+  currentSigningPartIndices: currentSigningPartIndices == null
+      ? null
+      : frb.Uint32List.fromList(currentSigningPartIndices),
   scheduledBroadcasts: const [],
   parts: const [],
+);
+
+final _readyMigrationStatus = _buildReadyMigrationStatus();
+
+final _readyMigrationNeedsInputStatus = _buildReadyMigrationStatus(
+  signedChildPcztCount: 0,
+  currentSigningPartIndices: const [0, 1, 2, 3, 4, 5],
+);
+
+final _legacyReadyMigrationStatus = _buildReadyMigrationStatus(
+  signedChildPcztCount: 0,
+  currentSigningPartIndices: null,
 );
 
 final _mixedMigrationStatus = rust_sync.MigrationStatus(

--- a/test/features/home/home_desktop_screen_test.dart
+++ b/test/features/home/home_desktop_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/misc.dart' show ProviderListenable;
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart'
     as frb;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:zcash_wallet/app.dart';
 import 'package:zcash_wallet/src/app_bootstrap.dart';
 import 'package:zcash_wallet/src/core/config/rpc_endpoint_config.dart';
@@ -427,18 +428,19 @@ void main() {
   testWidgets('home keeps Ironwood announcement visible during sync changes', (
     tester,
   ) async {
+    final syncedState = SyncState(
+      accountUuid: 'account-1',
+      hasAccountScopedData: true,
+      orchardBalance: BigInt.from(14_312_000_000),
+      spendableBalance: BigInt.from(14_312_000_000),
+      totalBalance: BigInt.from(14_312_000_000),
+    );
     await tester.pumpWidget(
       _appHarness(
         '/home',
         ironwoodMigrationAnnouncementStateListenable:
             _ironwoodAnnouncementTestProvider,
-        syncState: SyncState(
-          accountUuid: 'account-1',
-          hasAccountScopedData: true,
-          orchardBalance: BigInt.from(14_312_000_000),
-          spendableBalance: BigInt.from(14_312_000_000),
-          totalBalance: BigInt.from(14_312_000_000),
-        ),
+        syncState: syncedState,
       ),
     );
     await tester.pumpAndSettle();
@@ -463,13 +465,73 @@ void main() {
     expect(overlay, findsOneWidget);
     expect(tester.widget<AppPaneModalOverlay>(overlay).scrimColor, isNull);
 
+    (container.read(syncProvider.notifier) as FakeSyncNotifier).emit(
+      syncedState.copyWith(isSyncing: true),
+    );
+    await tester.pump();
     container
         .read(_ironwoodAnnouncementTestProvider.notifier)
         .setAnnouncement(const IronwoodMigrationAnnouncementState.hidden());
-    await tester.pumpAndSettle();
+    await container.read(ironwoodMigrationAnnouncementProvider.future);
+    await tester.pump();
 
     expect(overlay, findsOneWidget);
   });
+
+  testWidgets(
+    'home clears a stale Ironwood announcement after migration completes',
+    (tester) async {
+      await tester.pumpWidget(
+        _appHarness(
+          '/home',
+          ironwoodMigrationAnnouncementStateListenable:
+              _ironwoodAnnouncementTestProvider,
+          syncState: SyncState(
+            accountUuid: 'account-1',
+            hasAccountScopedData: true,
+            ironwoodBalance: BigInt.from(14_312_000_000),
+            spendableBalance: BigInt.from(14_312_000_000),
+            totalBalance: BigInt.from(14_312_000_000),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ZcashWalletApp)),
+      );
+      container
+          .read(_ironwoodAnnouncementTestProvider.notifier)
+          .setAnnouncement(
+            IronwoodMigrationAnnouncementState.visible(
+              network: 'main',
+              accountUuid: 'account-1',
+              status: _migrationStatus(kIronwoodMigrationReadyPhase),
+            ),
+          );
+      await tester.pumpAndSettle();
+
+      final router = GoRouter.of(tester.element(find.byType(HomeScreen)));
+      router.go('/migration/intro');
+      await tester.pumpAndSettle();
+      expect(find.byType(HomeScreen), findsNothing);
+
+      router.go('/home');
+      await tester.pump();
+      final overlay = find.byKey(
+        const ValueKey('ironwood_migration_announcement_overlay'),
+      );
+      await _pumpUntilPresent(tester, overlay);
+      expect(overlay, findsOneWidget);
+
+      container
+          .read(_ironwoodAnnouncementTestProvider.notifier)
+          .setAnnouncement(const IronwoodMigrationAnnouncementState.hidden());
+      await tester.pumpAndSettle();
+
+      expect(overlay, findsNothing);
+    },
+  );
 
   testWidgets(
     'home desktop uses Ironwood balance and enables actions during migration',


### PR DESCRIPTION
## Problem

- The desktop sidebar showed `Needs input` for every Keystone `ready_to_migrate` state, including after the current signing batch had already been completed.
- The Home screen could retain and re-latch a stale Ironwood announcement after navigating away and returning, leaving a false `Start Migration` prompt after migration completion.

## Solution

- Derive the sidebar attention state from `currentSigningPartIndices`, while preserving the legacy `null` fallback.
- Keep the announcement latched only through transient sync, background, and error gaps, then clear it once a settled hidden state is available.
- Ignore a previously visible announcement when it belongs to a different active account.
- Add regression coverage for pending, signed, and legacy Keystone states plus the route-away/return completion sequence.

## Validation

- `fvm flutter test test/app_main_sidebar_test.dart` — 37 passed
- Targeted desktop announcement regression tests — 2 passed
- Targeted mobile lane tests with `VIZOR_FORM_FACTOR=mobile` — 2 passed
- `fvm dart analyze` on all four changed files — no issues
- Desktop Widgetbook check — signed state renders `Migrating...`; Ironwood announcement modal capture rendered successfully

## Baseline note

The full `home_desktop_screen_test.dart` still includes an existing `home desktop uses Ironwood balance and enables actions during migration` failure. It reproduces unchanged on `origin/main` and is not introduced by this PR. Full `fvm flutter analyze` also reports 23 pre-existing unused-code warnings outside the changed files.