### PR TITLE
Improve Keystone migration UX and privacy state lifecycle

### DIFF
--- a/lib/figma_compare/figma_compare_scenarios.dart
+++ b/lib/figma_compare/figma_compare_scenarios.dart
@@ -144,6 +144,11 @@ const figmaCompareScenarios = <FigmaCompareScenario>[
     builder: buildIronwoodMigrationImmediateKeystoneScannerUseCase,
   ),
   FigmaCompareScenario(
+    id: 'ironwood-migration-private-keystone-request',
+    description: 'Private migration Keystone request QR',
+    builder: buildIronwoodMigrationPrivateKeystoneRequestUseCase,
+  ),
+  FigmaCompareScenario(
     id: 'ironwood-migration-analyzing',
     description: 'Ironwood migration balance analysis loader',
     builder: buildIronwoodMigrationAnalyzingUseCase,

--- a/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_coordinator_provider.dart
@@ -203,6 +203,7 @@ class IronwoodMigrationCoordinator
   bool _refreshPending = false;
   bool _forceAdvancePending = false;
   bool _foreground = true;
+  int _accountStateEpoch = 0;
   final _desktopOpenFallbackGate = DesktopOpenMigrationFallbackGate();
   bool _hasObservedInitialAccountList = false;
   Future<void>? _backgroundPreparationRecovery;
@@ -215,8 +216,18 @@ class IronwoodMigrationCoordinator
   @override
   IronwoodMigrationCoordinatorState build() {
     ref.listen(accountProvider, (_, next) {
-      final hasAccounts = next.value?.accounts.isNotEmpty ?? false;
-      if (!_hasObservedInitialAccountList && hasAccounts) {
+      _accountStateEpoch += 1;
+      final accountState = next.value;
+      if (accountState == null) {
+        unawaited(refreshNow());
+        return;
+      }
+      final hasAccounts = accountState.accounts.isNotEmpty;
+      if (!hasAccounts) {
+        _clearProcessLocalStateForNoAccounts();
+        return;
+      }
+      if (!_hasObservedInitialAccountList) {
         _hasObservedInitialAccountList = true;
         unawaited(resumeBackgroundPreparations());
         unawaited(refreshNow());
@@ -353,7 +364,11 @@ class IronwoodMigrationCoordinator
     if (ref.read(appSecurityProvider).requiresUnlock) return;
 
     final accountState = ref.read(accountProvider).value;
-    if (accountState == null || accountState.accounts.isEmpty) return;
+    if (accountState == null) return;
+    if (accountState.accounts.isEmpty) {
+      _clearProcessLocalStateForNoAccounts();
+      return;
+    }
     _hasObservedInitialAccountList = true;
 
     final service = ref.read(ironwoodMigrationServiceProvider);
@@ -559,13 +574,14 @@ class IronwoodMigrationCoordinator
 
     final accountState = ref.read(accountProvider).value;
     if (accountState == null || accountState.accounts.isEmpty) return;
+    final accountStateEpoch = _accountStateEpoch;
     if (kAppFormFactor == AppFormFactor.desktop &&
         _desktopOpenFallbackGate.needsAuthoritativeEntryHeight) {
       try {
         final entryHeight = await ref
             .read(rpcEndpointFailoverProvider.notifier)
             .getLatestBlockHeight();
-        if (!ref.mounted) return;
+        if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
         _desktopOpenFallbackGate.observeForegroundEntryHeight(
           entryHeight.toInt(),
         );
@@ -592,7 +608,7 @@ class IronwoodMigrationCoordinator
             network: endpoint.networkName,
             accountUuid: account.uuid,
           );
-          if (!ref.mounted) return;
+          if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
         } catch (error) {
           snapshotComplete = false;
           log(
@@ -622,7 +638,7 @@ class IronwoodMigrationCoordinator
               network: endpoint.networkName,
               accountUuid: account.uuid,
             );
-        if (!ref.mounted) return;
+        if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
         nextStatuses[account.uuid] = status;
         nextErrors.remove(account.uuid);
 
@@ -635,12 +651,12 @@ class IronwoodMigrationCoordinator
             network: endpoint.networkName,
             accountUuid: account.uuid,
           );
-          if (!ref.mounted) return;
+          if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
           status = await service.status(
             network: endpoint.networkName,
             accountUuid: account.uuid,
           );
-          if (!ref.mounted) return;
+          if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
           nextStatuses[account.uuid] = status;
           final stillDue = migrationHasDueScheduledBroadcast(
             status,
@@ -670,12 +686,12 @@ class IronwoodMigrationCoordinator
           accountUuid: account.uuid,
         )) {
           await _advance(account.uuid, status: status);
-          if (!ref.mounted) return;
+          if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
           status = await service.status(
             network: endpoint.networkName,
             accountUuid: account.uuid,
           );
-          if (!ref.mounted) return;
+          if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
           nextStatuses[account.uuid] = status;
         }
         if (account.uuid == accountState.activeAccountUuid &&
@@ -690,7 +706,7 @@ class IronwoodMigrationCoordinator
       }
     }
 
-    if (!ref.mounted) return;
+    if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
     if (activeBalanceMayHaveChanged) {
       try {
         // Migration status reads reconcile the database, but the home card
@@ -702,10 +718,38 @@ class IronwoodMigrationCoordinator
         // refresh races with a normal sync.
         log('Ironwood migration balance refresh failed: $error');
       }
-      if (!ref.mounted) return;
+      if (!_canApplyRefreshForAccountEpoch(accountStateEpoch)) return;
     }
     state = state.copyWith(statuses: nextStatuses, errors: nextErrors);
     _invalidateMigrationProviders(accountState.activeAccountUuid);
+  }
+
+  bool _canApplyRefreshForAccountEpoch(int accountStateEpoch) =>
+      ref.mounted && accountStateEpoch == _accountStateEpoch;
+
+  void _clearProcessLocalStateForNoAccounts() {
+    final hadWalletState =
+        _hasObservedInitialAccountList ||
+        state.statuses.isNotEmpty ||
+        state.errors.isNotEmpty ||
+        state.advancingAccounts.isNotEmpty ||
+        state.foregroundProgressPermits.isNotEmpty ||
+        state.childProofBatchPermits.isNotEmpty ||
+        _lastAdvanceAt.isNotEmpty ||
+        _outboxRecoveryWindows.isNotEmpty ||
+        _lastAdvanceProgressKeys.isNotEmpty;
+    if (!hadWalletState) return;
+
+    _hasObservedInitialAccountList = false;
+    _lastAdvanceAt.clear();
+    _outboxRecoveryWindows.clear();
+    _lastAdvanceProgressKeys.clear();
+    _desktopOpenFallbackGate.leaveForeground();
+    if (_foreground) {
+      _desktopOpenFallbackGate.enterForeground();
+    }
+    state = const IronwoodMigrationCoordinatorState();
+    _invalidateMigrationProviders(null);
   }
 
   bool _migrationBalanceMayHaveChanged(

--- a/lib/src/features/migration/providers/ironwood_migration_privacy_lock_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_privacy_lock_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/config/ironwood_migration_privacy_lock_config.dart';
 import '../../../core/layout/app_form_factor.dart';
+import '../../../providers/account_provider.dart';
 import '../../../providers/app_security_provider.dart';
 import '../models/ironwood_migration_phases.dart';
 import 'ironwood_migration_coordinator_provider.dart';
@@ -45,11 +46,11 @@ final ironwoodMigrationPrivacyLockSuppressionProvider =
       IronwoodMigrationPrivacyLockSuppression?
     >(IronwoodMigrationPrivacyLockSuppressionNotifier.new);
 
-final ironwoodMigrationPrivacyLockEligibleProvider = Provider<bool>((ref) {
+final ironwoodMigrationPrivacyLockRequiredProvider = Provider<bool>((ref) {
   if (kAppFormFactor != AppFormFactor.desktop ||
       !ref.watch(ironwoodMigrationPrivacyLockFeatureEnabledProvider) ||
-      ref.watch(appSecurityProvider).requiresUnlock ||
-      ref.watch(ironwoodMigrationPrivacyLockSuppressionProvider) != null) {
+      !(ref.watch(accountProvider).value?.accounts.isNotEmpty ?? false) ||
+      ref.watch(appSecurityProvider).requiresUnlock) {
     return false;
   }
 
@@ -61,6 +62,11 @@ final ironwoodMigrationPrivacyLockEligibleProvider = Provider<bool>((ref) {
         status.activeRunId != null ||
         isIronwoodMigrationInProgressPhase(status.phase),
   );
+});
+
+final ironwoodMigrationPrivacyLockEligibleProvider = Provider<bool>((ref) {
+  return ref.watch(ironwoodMigrationPrivacyLockRequiredProvider) &&
+      ref.watch(ironwoodMigrationPrivacyLockSuppressionProvider) == null;
 });
 
 class IronwoodMigrationPrivacyLockState {

--- a/lib/src/features/migration/providers/ironwood_migration_privacy_lock_provider.dart
+++ b/lib/src/features/migration/providers/ironwood_migration_privacy_lock_provider.dart
@@ -12,10 +12,44 @@ final ironwoodMigrationPrivacyLockFeatureEnabledProvider = Provider<bool>((_) {
   return kIronwoodMigrationPrivacyLockEnabled;
 });
 
+class IronwoodMigrationPrivacyLockSuppression {
+  const IronwoodMigrationPrivacyLockSuppression({required this.token});
+
+  final int token;
+}
+
+class IronwoodMigrationPrivacyLockSuppressionNotifier
+    extends Notifier<IronwoodMigrationPrivacyLockSuppression?> {
+  int _nextToken = 0;
+
+  @override
+  IronwoodMigrationPrivacyLockSuppression? build() => null;
+
+  IronwoodMigrationPrivacyLockSuppression acquire() {
+    final suppression = IronwoodMigrationPrivacyLockSuppression(
+      token: _nextToken++,
+    );
+    state = suppression;
+    return suppression;
+  }
+
+  void release(IronwoodMigrationPrivacyLockSuppression suppression) {
+    if (state?.token != suppression.token) return;
+    state = null;
+  }
+}
+
+final ironwoodMigrationPrivacyLockSuppressionProvider =
+    NotifierProvider<
+      IronwoodMigrationPrivacyLockSuppressionNotifier,
+      IronwoodMigrationPrivacyLockSuppression?
+    >(IronwoodMigrationPrivacyLockSuppressionNotifier.new);
+
 final ironwoodMigrationPrivacyLockEligibleProvider = Provider<bool>((ref) {
   if (kAppFormFactor != AppFormFactor.desktop ||
       !ref.watch(ironwoodMigrationPrivacyLockFeatureEnabledProvider) ||
-      ref.watch(appSecurityProvider).requiresUnlock) {
+      ref.watch(appSecurityProvider).requiresUnlock ||
+      ref.watch(ironwoodMigrationPrivacyLockSuppressionProvider) != null) {
     return false;
   }
 

--- a/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
@@ -419,11 +419,23 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
   bool _requestCompleted = false;
   bool _showImmediateScanHelp = true;
   Future<void>? _completionOperation;
+  IronwoodMigrationPrivacyLockSuppressionNotifier?
+  _privacyLockSuppressionNotifier;
+  IronwoodMigrationPrivacyLockSuppression? _privacyLockSuppression;
 
   @override
   void initState() {
     super.initState();
     _migrationService = ref.read(ironwoodMigrationServiceProvider);
+    if (!widget.mobileLayout) {
+      _privacyLockSuppressionNotifier = ref.read(
+        ironwoodMigrationPrivacyLockSuppressionProvider.notifier,
+      );
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || _privacyLockSuppression != null) return;
+        _privacyLockSuppression = _privacyLockSuppressionNotifier?.acquire();
+      });
+    }
     final previewRequest = widget.previewRequest;
     if (previewRequest != null) {
       _request = previewRequest;
@@ -454,6 +466,18 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
   @override
   void dispose() {
     _stopProofPolling();
+    final privacyLockSuppression = _privacyLockSuppression;
+    final privacyLockSuppressionNotifier = _privacyLockSuppressionNotifier;
+    if (privacyLockSuppression != null &&
+        privacyLockSuppressionNotifier != null) {
+      // Riverpod disallows provider mutations while Flutter is finalizing this
+      // route. Release immediately after the current widget lifecycle pass.
+      scheduleMicrotask(() {
+        privacyLockSuppressionNotifier.release(privacyLockSuppression);
+      });
+    }
+    _privacyLockSuppression = null;
+    _privacyLockSuppressionNotifier = null;
     if (!_requestCompleted) {
       final requestId = _request?.requestId;
       final accountUuid = _accountUuid;

--- a/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
@@ -1008,7 +1008,9 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
 
     return _IronwoodMigrationFrame(
       toolbar: _keystoneDenominationToolbar(
-        label: widget.step.toolbarLabel,
+        label: _stage == _KeystoneDenominationSignStage.scanning
+            ? 'Request QR'
+            : widget.step.toolbarLabel,
         onBack: _handleBack,
       ),
       disableSidebarActions: true,
@@ -1466,7 +1468,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
           AppButton(
             onPressed: () => unawaited(_returnToReview()),
             variant: AppButtonVariant.ghost,
-            height: 36,
+            height: 44,
             minWidth: 230,
             child: Text(widget.step.previousButtonLabel),
           ),

--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -357,15 +357,6 @@ class _MigrationLiveStatusContent extends StatelessWidget {
                             key: const ValueKey('preparing-ring-label'),
                             mainAxisSize: MainAxisSize.min,
                             children: [
-                              AppIcon(
-                                AppIcons.loader,
-                                key: const ValueKey(
-                                  'ironwood_migration_preparation_loader',
-                                ),
-                                size: AppIconSize.large,
-                                color: colors.text.accent,
-                              ),
-                              const SizedBox(height: 6),
                               Text(
                                 preparationPresentation.label,
                                 textAlign: TextAlign.center,

--- a/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
@@ -49,6 +49,7 @@ import '../models/ironwood_migration_presentation.dart';
 import '../models/mobile_ironwood_migration_status_entry.dart';
 import '../providers/ironwood_migration_announcement_provider.dart';
 import '../providers/ironwood_migration_coordinator_provider.dart';
+import '../providers/ironwood_migration_privacy_lock_provider.dart';
 import '../services/ironwood_migration_service.dart';
 import '../widgets/ironwood_migration_shimmer_text.dart';
 import '../widgets/mobile/mobile_ironwood_keystone_signing_view.dart';

--- a/lib/src/features/migration/widgets/ironwood_migration_privacy_lock_host.dart
+++ b/lib/src/features/migration/widgets/ironwood_migration_privacy_lock_host.dart
@@ -65,14 +65,11 @@ class _IronwoodMigrationPrivacyLockHostState
       return widget.child;
     }
 
-    ref.listen(
-      appSecurityProvider.select((security) => security.requiresUnlock),
-      (_, requiresUnlock) {
-        if (!requiresUnlock) return;
-        _lastInteractionAt = _now();
-        ref.read(ironwoodMigrationPrivacyLockProvider.notifier).clear();
-      },
-    );
+    ref.listen(appSecurityProvider, (_, security) {
+      if (!security.requiresUnlock && security.isPasswordConfigured) return;
+      _lastInteractionAt = _now();
+      ref.read(ironwoodMigrationPrivacyLockProvider.notifier).clear();
+    });
     ref.listen(
       ironwoodMigrationPrivacyLockProvider.select((state) => state.isLocked),
       (wasLocked, isLocked) {
@@ -82,6 +79,9 @@ class _IronwoodMigrationPrivacyLockHostState
       },
     );
 
+    final privacyLockRequired = ref.watch(
+      ironwoodMigrationPrivacyLockRequiredProvider,
+    );
     final eligible = ref.watch(ironwoodMigrationPrivacyLockEligibleProvider);
     final locked = ref.watch(
       ironwoodMigrationPrivacyLockProvider.select((state) => state.isLocked),
@@ -106,7 +106,7 @@ class _IronwoodMigrationPrivacyLockHostState
               child: _PrivacyLockOverlay(
                 child: IronwoodMigrationVirtualUnlockScreen(
                   key: ironwoodMigrationVirtualUnlockScreenKey,
-                  showMigrationInProgress: eligible,
+                  showMigrationInProgress: privacyLockRequired,
                 ),
               ),
             ),
@@ -195,11 +195,17 @@ class _IronwoodMigrationPrivacyLockHostState
 
   void _evaluateIdleAfterResume() {
     if (!_featureEnabled ||
-        !ref.read(ironwoodMigrationPrivacyLockEligibleProvider) ||
+        !ref.read(ironwoodMigrationPrivacyLockRequiredProvider) ||
         ref.read(ironwoodMigrationPrivacyLockProvider).isLocked) {
       return;
     }
-    _lockIfStillIdle();
+    if (_now().difference(_lastInteractionAt) < widget.idleTimeout) {
+      if (ref.read(ironwoodMigrationPrivacyLockEligibleProvider)) {
+        _armTimer();
+      }
+      return;
+    }
+    _lock();
   }
 
   void _lockFromTimer() => _lockIfStillIdle(timerExpired: true);
@@ -216,6 +222,10 @@ class _IronwoodMigrationPrivacyLockHostState
       _armTimer();
       return;
     }
+    _lock();
+  }
+
+  void _lock() {
     FocusManager.instance.primaryFocus?.unfocus();
     ref.read(ironwoodMigrationPrivacyLockProvider.notifier).lock();
   }

--- a/lib/src/features/migration/widgets/mobile/mobile_ironwood_keystone_signing_view.dart
+++ b/lib/src/features/migration/widgets/mobile/mobile_ironwood_keystone_signing_view.dart
@@ -478,15 +478,35 @@ class _ScannerContent extends StatelessWidget {
         child: LayoutBuilder(
           builder: (context, constraints) {
             final topInset = MediaQuery.paddingOf(context).top;
+            final displayHeight = _measuredTextHeight(
+              context,
+              text: 'Step 2/2',
+              style: AppTypography.displayLarge,
+              maxWidth: constraints.maxWidth,
+            );
+            final titleHeight = _measuredTextHeight(
+              context,
+              text: 'Confirm with Keystone',
+              style: AppTypography.bodyMediumStrong,
+              maxWidth: constraints.maxWidth,
+            );
+            final signingRoundReserve = signingRoundLabel == null
+                ? 0.0
+                : AppSpacing.xxs +
+                      _measuredTextHeight(
+                        context,
+                        text: signingRoundLabel!,
+                        style: AppTypography.bodyMediumStrong,
+                        maxWidth: constraints.maxWidth,
+                      );
             final headerReserve =
                 topInset +
                 kMobileTopNavHeight +
                 AppSpacing.s +
-                (AppTypography.displayLarge.fontSize ?? 40) *
-                    (AppTypography.displayLarge.height ?? 1) +
+                displayHeight +
                 AppSpacing.s +
-                (AppTypography.bodyMediumStrong.fontSize ?? 16) *
-                    (AppTypography.bodyMediumStrong.height ?? 1);
+                titleHeight +
+                signingRoundReserve;
             const chromeReserve =
                 12 +
                 _scannerCaptionHeight +
@@ -667,6 +687,20 @@ class _ScannerContent extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  double _measuredTextHeight(
+    BuildContext context, {
+    required String text,
+    required TextStyle style,
+    required double maxWidth,
+  }) {
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: Directionality.of(context),
+      textScaler: MediaQuery.textScalerOf(context),
+    )..layout(maxWidth: maxWidth);
+    return painter.height;
   }
 
   double _scaledTop(

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -859,6 +859,17 @@ Widget buildIronwoodMigrationImmediateKeystoneScannerUseCase(
   );
 }
 
+Widget buildIronwoodMigrationPrivateKeystoneRequestUseCase(
+  BuildContext context,
+) {
+  return _buildIronwoodMigrationUseCase(
+    initialLocation: '/migration/private/keystone/sign',
+    step: IronwoodMigrationFlowStep.review,
+    data: _ironwoodMigrationFlowData(zatoshi: BigInt.from(14_224_000_000)),
+    isHardware: true,
+  );
+}
+
 Widget buildIronwoodMigrationAnalyzingUseCase(BuildContext context) {
   return _buildIronwoodMigrationUseCase(
     initialLocation: '/migration/private/review',
@@ -1177,6 +1188,7 @@ Widget _buildMobileIronwoodMigrationKeystoneSigningUseCase(
       child: MobileIronwoodKeystoneSigningView(
         state: state,
         round: MobileIronwoodKeystoneSigningRound.denominationSplit,
+        signingRoundLabel: 'Round 1 of 2',
         qrCode: const _KeystoneMigrationQrPreview(),
         camera: const _KeystoneMigrationCameraPreview(),
         onNext: () {},
@@ -2287,6 +2299,29 @@ class _IronwoodMigrationHarnessState extends State<_IronwoodMigrationHarness> {
               previewStartScanning: widget.previewImmediateKeystoneScanner,
             );
           },
+        ),
+        GoRoute(
+          path: '/migration/private/keystone/sign',
+          builder: (_, _) => IronwoodMigrationKeystoneCombinedSignScreen(
+            approvedSchedule: const [],
+            previewRequest: rust_sync.KeystoneMigrationSigningRequest(
+              requestId: 'preview-private',
+              messages: [
+                rust_sync.KeystoneMigrationMessage(
+                  id: 'preview-private-split-1',
+                  redactedPczt: Uint8List.fromList(const [1, 2, 3]),
+                ),
+                rust_sync.KeystoneMigrationMessage(
+                  id: 'preview-private-split-2',
+                  redactedPczt: Uint8List.fromList(const [4, 5, 6]),
+                ),
+              ],
+              signingBatchLimit: 1,
+            ),
+            previewUrParts: const [
+              'ur:zcash-sign-request/preview-private-split-1',
+            ],
+          ),
         ),
         GoRoute(
           path: '/home',

--- a/test/features/migration/ironwood_migration_coordinator_provider_test.dart
+++ b/test/features/migration/ironwood_migration_coordinator_provider_test.dart
@@ -1392,6 +1392,91 @@ void main() {
     );
   });
 
+  test('wallet reset clears process-local migration state', () async {
+    final container = _container(
+      statuses: {
+        _softwareUuid: _status('waiting_denom_confirmations'),
+        _hardwareUuid: _status('complete', activeRunId: null),
+      },
+      softwareStarts: [],
+      broadcasts: [],
+      mutableAccounts: true,
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      ironwoodMigrationCoordinatorProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+    final coordinator = container.read(
+      ironwoodMigrationCoordinatorProvider.notifier,
+    );
+
+    coordinator.grantForegroundProgressPermit(_softwareUuid);
+    coordinator.grantChildProofBatchPermit(_softwareUuid);
+    await coordinator.refreshNow();
+    expect(
+      container.read(ironwoodMigrationCoordinatorProvider).statuses,
+      isNotEmpty,
+    );
+
+    (container.read(accountProvider.notifier) as _MutableAccountNotifier)
+        .clearAccounts();
+    await coordinator.refreshNow();
+
+    final state = container.read(ironwoodMigrationCoordinatorProvider);
+    expect(state.statuses, isEmpty);
+    expect(state.errors, isEmpty);
+    expect(state.advancingAccounts, isEmpty);
+    expect(state.foregroundProgressPermits, isEmpty);
+    expect(state.childProofBatchPermits, isEmpty);
+  });
+
+  test('wallet reset discards an in-flight status refresh', () async {
+    final statuses = {
+      _softwareUuid: _status('waiting_denom_confirmations'),
+      _hardwareUuid: _status('complete', activeRunId: null),
+    };
+    final statusStarted = Completer<void>();
+    final releaseStatus = Completer<void>();
+    final container = _container(
+      statuses: statuses,
+      softwareStarts: [],
+      broadcasts: [],
+      mutableAccounts: true,
+      loadStatus: (accountUuid) async {
+        if (!statusStarted.isCompleted) {
+          statusStarted.complete();
+          await releaseStatus.future;
+        }
+        return statuses[accountUuid]!;
+      },
+    );
+    addTearDown(container.dispose);
+    final subscription = container.listen(
+      ironwoodMigrationCoordinatorProvider,
+      (_, _) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+    final coordinator = container.read(
+      ironwoodMigrationCoordinatorProvider.notifier,
+    );
+
+    final refresh = coordinator.refreshNow();
+    await statusStarted.future;
+    (container.read(accountProvider.notifier) as _MutableAccountNotifier)
+        .clearAccounts();
+    releaseStatus.complete();
+    await refresh;
+
+    expect(
+      container.read(ironwoodMigrationCoordinatorProvider).statuses,
+      isEmpty,
+    );
+  });
+
   testWidgets(
     'initial status refresh does not restart bound background preparation',
     (tester) async {
@@ -1727,6 +1812,10 @@ class _MutableAccountNotifier extends AccountNotifier {
     state = AsyncData(
       current.copyWith(accounts: List<AccountInfo>.of(current.accounts)),
     );
+  }
+
+  void clearAccounts() {
+    state = const AsyncData(AccountState());
   }
 }
 

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -15,8 +15,6 @@ import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
-import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
-import 'package:zcash_wallet/src/core/widgets/app_loading_icon.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
 import 'package:zcash_wallet/src/features/migration/screens/ironwood_migration_flow_screen.dart';
@@ -798,11 +796,10 @@ void main() {
       await tester.pump(const Duration(milliseconds: 500));
 
       expect(find.text('Next split'), findsOneWidget);
-      final loader = tester.widget<AppIcon>(
+      expect(
         find.byKey(const ValueKey('ironwood_migration_preparation_loader')),
+        findsNothing,
       );
-      expect(loader.name, AppIcons.loader);
-      expect(loader.size, AppIconSize.large);
       expect(find.text('Split 1 of 6'), findsOneWidget);
       expect(find.textContaining('confirmations'), findsNothing);
       expect(
@@ -858,32 +855,31 @@ void main() {
     expect(find.text('Schedule pending'), findsOneWidget);
   });
 
-  testWidgets('preparation ring remains available with reduced motion', (
-    tester,
-  ) async {
-    tester.view.devicePixelRatio = 1;
-    tester.view.physicalSize = const Size(1440, 900);
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
+  testWidgets(
+    'detailed preparation ring omits the loader with reduced motion',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1440, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
 
-    await tester.pumpWidget(
-      _privateStatusHarness(status: _status(), disableAnimations: true),
-    );
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpWidget(
+        _privateStatusHarness(status: _status(), disableAnimations: true),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
 
-    expect(
-      find.byKey(const ValueKey('ironwood_migration_preparation_ring')),
-      findsOneWidget,
-    );
-    expect(find.text('Next split'), findsOneWidget);
-    final loader = find.descendant(
-      of: find.byKey(const ValueKey('ironwood_migration_preparation_loader')),
-      matching: find.byType(AppLoadingIcon),
-    );
-    expect(loader, findsOneWidget);
-    expect(MediaQuery.maybeDisableAnimationsOf(tester.element(loader)), isTrue);
-  });
+      expect(
+        find.byKey(const ValueKey('ironwood_migration_preparation_ring')),
+        findsOneWidget,
+      );
+      expect(find.text('Next split'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('ironwood_migration_preparation_loader')),
+        findsNothing,
+      );
+    },
+  );
 
   testWidgets('private preparing status does not expose note progress', (
     tester,

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -564,6 +564,12 @@ void main() {
         find.text('1 transaction to sign · click QR to enlarge'),
         findsOneWidget,
       );
+      final backToReviewButton = find.widgetWithText(
+        AppButton,
+        'Back to review',
+      );
+      expect(backToReviewButton, findsOneWidget);
+      expect(tester.getSize(backToReviewButton).height, 44);
 
       final enlargeQr = find.byKey(
         const ValueKey('keystone_migration_enlarge_qr'),
@@ -596,8 +602,9 @@ void main() {
       );
       expect(find.text('Back to QR'), findsNothing);
 
-      final back = find.bySemanticsLabel('Back to Review migration');
-      await tester.tap(back);
+      final backToRequestQr = find.bySemanticsLabel('Back to Request QR');
+      expect(backToRequestQr, findsOneWidget);
+      await tester.tap(backToRequestQr);
       await tester.pump();
 
       expect(find.text('Step 1 of 2'), findsNothing);
@@ -607,7 +614,9 @@ void main() {
         findsNothing,
       );
 
-      await tester.tap(back);
+      final backToReview = find.bySemanticsLabel('Back to Review migration');
+      expect(backToReview, findsOneWidget);
+      await tester.tap(backToReview);
       await tester.pumpAndSettle();
 
       expect(

--- a/test/features/migration/ironwood_migration_privacy_lock_host_test.dart
+++ b/test/features/migration/ironwood_migration_privacy_lock_host_test.dart
@@ -63,7 +63,7 @@ void main() {
     final security = _FakeSecurityNotifier();
     final container = ProviderContainer(
       overrides: [
-        appBootstrapProvider.overrideWithValue(_bootstrap()),
+        appBootstrapProvider.overrideWithValue(_bootstrap(hasWallet: true)),
         appSecurityProvider.overrideWith(() => security),
         ironwoodMigrationPrivacyLockFeatureEnabledProvider.overrideWithValue(
           true,
@@ -97,7 +97,7 @@ void main() {
     final security = _FakeSecurityNotifier();
     final container = ProviderContainer(
       overrides: [
-        appBootstrapProvider.overrideWithValue(_bootstrap()),
+        appBootstrapProvider.overrideWithValue(_bootstrap(hasWallet: true)),
         appSecurityProvider.overrideWith(() => security),
         ironwoodMigrationPrivacyLockFeatureEnabledProvider.overrideWithValue(
           true,
@@ -130,6 +130,36 @@ void main() {
     expect(
       container.read(ironwoodMigrationPrivacyLockEligibleProvider),
       isTrue,
+    );
+  });
+
+  test('wallet reset disables eligibility for stale migration status', () {
+    final security = _FakeSecurityNotifier();
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_bootstrap()),
+        appSecurityProvider.overrideWith(() => security),
+        ironwoodMigrationPrivacyLockFeatureEnabledProvider.overrideWithValue(
+          true,
+        ),
+        ironwoodMigrationCoordinatorProvider.overrideWith(
+          () => _FakeMigrationCoordinator(
+            IronwoodMigrationCoordinatorState(
+              statuses: {
+                'deleted-account': _migrationStatus(
+                  'waiting_denom_confirmations',
+                ),
+              },
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    expect(
+      container.read(ironwoodMigrationPrivacyLockEligibleProvider),
+      isFalse,
     );
   });
 
@@ -287,6 +317,36 @@ void main() {
     expect(find.text('Migration in progress'), findsOneWidget);
   });
 
+  testWidgets(
+    'Keystone signing suppression still locks after background timeout',
+    (tester) async {
+      final clock = _TestClock();
+      final container = ProviderContainer(
+        overrides: _overrides(_FakeSecurityNotifier()),
+      );
+      addTearDown(container.dispose);
+      container
+          .read(ironwoodMigrationPrivacyLockSuppressionProvider.notifier)
+          .acquire();
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: _themedHost(clock),
+        ),
+      );
+      await tester.pump();
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+      await tester.pump();
+      clock.elapse(const Duration(minutes: 1));
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+
+      expect(find.text('Migration in progress'), findsOneWidget);
+    },
+  );
+
   testWidgets('confirmation only clears the virtual lock', (tester) async {
     final clock = _TestClock();
     final security = _FakeSecurityNotifier();
@@ -325,6 +385,23 @@ void main() {
 
     expect(find.text('Incorrect password. Try again.'), findsOneWidget);
     expect(find.text('Migration in progress'), findsOneWidget);
+  });
+
+  testWidgets('wallet password reset clears the active privacy lock', (
+    tester,
+  ) async {
+    final clock = _TestClock();
+    final security = _FakeSecurityNotifier();
+    await tester.pumpWidget(_app(clock: clock, security: security));
+    await tester.pump();
+    await _elapseIdleInterval(tester, clock);
+    expect(find.byKey(ironwoodMigrationVirtualUnlockScreenKey), findsOneWidget);
+
+    security.reset();
+    await tester.pump();
+
+    expect(find.byKey(ironwoodMigrationVirtualUnlockScreenKey), findsNothing);
+    expect(find.text('Protected content'), findsOneWidget);
   });
 
   testWidgets(
@@ -395,10 +472,8 @@ List<Override> _overrides(_FakeSecurityNotifier security) {
     appBootstrapProvider.overrideWithValue(_bootstrap()),
     appSecurityProvider.overrideWith(() => security),
     ironwoodMigrationPrivacyLockFeatureEnabledProvider.overrideWithValue(true),
-    ironwoodMigrationPrivacyLockEligibleProvider.overrideWith(
-      (ref) =>
-          ref.watch(_eligibilityProvider) &&
-          ref.watch(ironwoodMigrationPrivacyLockSuppressionProvider) == null,
+    ironwoodMigrationPrivacyLockRequiredProvider.overrideWith(
+      (ref) => ref.watch(_eligibilityProvider),
     ),
   ];
 }
@@ -440,10 +515,22 @@ Future<void> _elapseIdleInterval(WidgetTester tester, _TestClock clock) async {
   await tester.pump();
 }
 
-AppBootstrapState _bootstrap() {
+AppBootstrapState _bootstrap({bool hasWallet = false}) {
   return AppBootstrapState(
     initialLocation: '/home',
-    initialAccountState: const AccountState(),
+    initialAccountState: hasWallet
+        ? const AccountState(
+            accounts: [
+              AccountInfo(
+                uuid: 'active-account',
+                name: 'Account',
+                order: 0,
+                isSeedAnchor: true,
+              ),
+            ],
+            activeAccountUuid: 'active-account',
+          )
+        : const AccountState(),
     initialSyncSnapshot: AppSyncSnapshot.empty,
     network: kZcashDefaultNetworkName,
     rpcEndpointConfig: defaultRpcEndpointConfig(kZcashDefaultNetworkName),

--- a/test/features/migration/ironwood_migration_privacy_lock_host_test.dart
+++ b/test/features/migration/ironwood_migration_privacy_lock_host_test.dart
@@ -93,6 +93,46 @@ void main() {
     );
   });
 
+  test('Keystone signing suppresses privacy idle lock eligibility', () {
+    final security = _FakeSecurityNotifier();
+    final container = ProviderContainer(
+      overrides: [
+        appBootstrapProvider.overrideWithValue(_bootstrap()),
+        appSecurityProvider.overrideWith(() => security),
+        ironwoodMigrationPrivacyLockFeatureEnabledProvider.overrideWithValue(
+          true,
+        ),
+        ironwoodMigrationCoordinatorProvider.overrideWith(
+          () => _FakeMigrationCoordinator(
+            IronwoodMigrationCoordinatorState(
+              statuses: {
+                'active-account': _migrationStatus(
+                  'waiting_denom_confirmations',
+                ),
+              },
+            ),
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    final notifier = container.read(
+      ironwoodMigrationPrivacyLockSuppressionProvider.notifier,
+    );
+
+    final suppression = notifier.acquire();
+    expect(
+      container.read(ironwoodMigrationPrivacyLockEligibleProvider),
+      isFalse,
+    );
+
+    notifier.release(suppression);
+    expect(
+      container.read(ironwoodMigrationPrivacyLockEligibleProvider),
+      isTrue,
+    );
+  });
+
   testWidgets('disabled feature leaves the child unwrapped and idle', (
     tester,
   ) async {
@@ -191,6 +231,45 @@ void main() {
     await tester.pump();
     expect(find.text('Migration in progress'), findsOneWidget);
   });
+
+  testWidgets(
+    'releasing Keystone signing suppression restarts the default idle timer',
+    (tester) async {
+      final clock = _TestClock();
+      final container = ProviderContainer(
+        overrides: _overrides(_FakeSecurityNotifier()),
+      );
+      addTearDown(container.dispose);
+      final notifier = container.read(
+        ironwoodMigrationPrivacyLockSuppressionProvider.notifier,
+      );
+      final suppression = notifier.acquire();
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: _themedHost(clock),
+        ),
+      );
+      await tester.pump();
+
+      clock.elapse(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(find.text('Migration in progress'), findsNothing);
+
+      notifier.release(suppression);
+      await tester.pump();
+
+      clock.elapse(const Duration(milliseconds: 49));
+      await tester.pump(const Duration(milliseconds: 49));
+      expect(find.text('Migration in progress'), findsNothing);
+
+      clock.elapse(const Duration(milliseconds: 1));
+      await tester.pump(const Duration(milliseconds: 1));
+      await tester.pump();
+      expect(find.text('Migration in progress'), findsOneWidget);
+    },
+  );
 
   testWidgets('background idle time locks immediately on resume', (
     tester,
@@ -317,7 +396,9 @@ List<Override> _overrides(_FakeSecurityNotifier security) {
     appSecurityProvider.overrideWith(() => security),
     ironwoodMigrationPrivacyLockFeatureEnabledProvider.overrideWithValue(true),
     ironwoodMigrationPrivacyLockEligibleProvider.overrideWith(
-      (ref) => ref.watch(_eligibilityProvider),
+      (ref) =>
+          ref.watch(_eligibilityProvider) &&
+          ref.watch(ironwoodMigrationPrivacyLockSuppressionProvider) == null,
     ),
   ];
 }

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -2734,6 +2734,16 @@ void main() {
       find.text('Scan the new signed QR shown on Keystone.'),
       findsOneWidget,
     );
+    final signingRoundLabel = find.byKey(
+      const ValueKey('mobile_ironwood_keystone_signing_round'),
+    );
+    final scanTarget = find.byKey(
+      const ValueKey('mobile_ironwood_keystone_signing_scan_target'),
+    );
+    expect(
+      tester.getBottomLeft(signingRoundLabel).dy,
+      lessThanOrEqualTo(tester.getTopLeft(scanTarget).dy),
+    );
     expect(tester.takeException(), isNull);
 
     await tester.binding.handlePopRoute();


### PR DESCRIPTION
## Problem

Keystone private migrations can span multiple signing rounds and require the user to spend time interacting with the hardware device. The current flow had several related UX and lifecycle problems:

- Scanner navigation did not clearly identify the active request QR as the Back destination, and the mobile scanner did not reserve the measured space required by the signing-round label on compact or text-scaled layouts.
- The desktop migration privacy timer could interrupt active Keystone signing. Suppressing the shared eligibility state fixed foreground inactivity, but also disabled the required lock when the app returned after spending longer than the privacy timeout in the background.
- Resetting the last wallet account could leave process-local migration status behind. That stale state could reactivate the migration privacy overlay after the password verifier had already been removed, leaving no valid unlock path.
- The detailed split preparation status already shows the active split, amount, dependency, and timing, so an additional spinner above `Next split` was redundant and visually misleading.

## Solution

### Keystone signing UX

- Label the desktop scanner Back destination as `Request QR`, so returning from signature scanning leads to the currently active signing request.
- Measure the complete mobile scanner header, including text scaling and the optional signing-round label, before positioning the scan target.
- Match the secondary `Back to review` action to the primary action height.
- Add deterministic preview coverage for the private-migration Keystone request state.

### Privacy and wallet reset lifecycle

- Keep a route-scoped suppression token while the desktop Keystone signing screen is mounted, so time spent operating the hardware device does not trigger the foreground idle timer.
- Separate “migration data still requires privacy protection” from “foreground idle locking is currently eligible.” Background timeout protection now remains active even while foreground Keystone suppression is held.
- Require a real wallet account before migration state can enable the privacy lock, and clear the virtual lock when wallet password configuration is removed during reset.
- Clear process-local migration statuses, errors, permits, and recovery throttles when the account list becomes empty.
- Version account state during coordinator refreshes so an in-flight status request from the deleted wallet cannot repopulate stale migration state after reset.

### Preparation status

- Remove the redundant spinner from the detailed split preparation ring while keeping the active split details and ring animation.

This PR does not change the Keystone signing protocol, QR fragment size, Rust migration scheduler, or transaction construction.

## Validation

- `fvm flutter analyze` on all 13 changed Dart and test files — no issues.
- `fvm flutter test test/features/migration/ironwood_migration_flow_screen_test.dart` — 77 passed.
- `fvm flutter test test/features/migration/mobile_ironwood_migration_flow_screen_test.dart --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile` — 102 passed.
- Privacy lock, wallet mutation, and desktop account-reset suite — 53 passed.
- Mobile coordinator wallet-reset and in-flight refresh regressions — 2 passed.
- `git diff --check` — passed.
