### PR TITLE
Use released Ironwood crate family

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -956,7 +956,8 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -981,7 +982,8 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1809,7 +1811,8 @@ dependencies = [
 [[package]]
 name = "incrementalmerkletree"
 version = "0.8.2"
-source = "git+https://github.com/zcash/incrementalmerkletree?rev=decefc469dbf1e686b20b7e7dcaa7cb4f122125b#decefc469dbf1e686b20b7e7dcaa7cb4f122125b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30821f91f0fa8660edca547918dc59812893b497d07c1144f326f07fdd94aba9"
 dependencies = [
  "either",
 ]
@@ -2270,8 +2273,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
-source = "git+https://github.com/zcash/orchard.git?rev=3bd2b736d1273226595773265313fc3f3428af16#3bd2b736d1273226595773265313fc3f3428af16"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793e2e8c2323f35f082d1b3467ca8f576d646f9c93aef8c5168809d099245af8"
 dependencies = [
  "aes",
  "bitvec",
@@ -2349,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "pasta_curves"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+checksum = "3437083215c505e867eea5478371feba43d7689d6d15ec0a209eb46fb0d4cda6"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -2381,8 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.8.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d4693dcb3d72f30064e0fdab122292d803bd9325a95b25df08679cf895452f"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -4059,8 +4064,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree"
-version = "0.3.2"
-source = "git+https://github.com/valargroup/zcash_voting?rev=5818d3ed53ea463eab31643e857bbf5de8a0b34d#5818d3ed53ea463eab31643e857bbf5de8a0b34d"
+version = "0.4.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d09351e41a71fdad388bd51417e3acc6e7b530ba364dd38296e79bf6ab41f6"
 dependencies = [
  "anyhow",
  "ff",
@@ -4075,8 +4081,9 @@ dependencies = [
 
 [[package]]
 name = "vote-commitment-tree-client"
-version = "0.5.2"
-source = "git+https://github.com/valargroup/zcash_voting?rev=5818d3ed53ea463eab31643e857bbf5de8a0b34d#5818d3ed53ea463eab31643e857bbf5de8a0b34d"
+version = "0.6.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4406af8a4eedbc0cdedb94d4dba44dd402f229c48d982c2e7e59155edd213b8b"
 dependencies = [
  "base64",
  "ff",
@@ -4594,7 +4601,8 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
 dependencies = [
  "bech32",
  "bs58",
@@ -4606,8 +4614,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+version = "0.24.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e019c2adb1eb2c3479603f4556e85c01022723f14ce8837a3bb225cb2af4d3f"
 dependencies = [
  "async-trait",
  "base64",
@@ -4660,8 +4669,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+version = "0.22.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a496ad83b77e790bd0ea1013db14961b3ff825550097a2658837dc7e92a23d53"
 dependencies = [
  "bip32",
  "bitflags",
@@ -4697,7 +4707,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys",
- "zcash_pool_migration_backend",
+ "zcash_pool_migration",
  "zcash_primitives",
  "zcash_protocol",
  "zcash_script",
@@ -4708,7 +4718,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -4717,8 +4728,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
 dependencies = [
  "bech32",
  "bip32",
@@ -4746,9 +4758,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_note_encryption"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77efec759c3798b6e4d829fcc762070d9b229b0f13338c40bf993b7b609c2272"
+checksum = "e1cb1b9170c94370e3d66c5cc0877661db743337588b64de7711239eed462198"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -4758,22 +4770,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "zcash_pool_migration_backend"
-version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+name = "zcash_pool_migration"
+version = "0.1.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e4169a96a25de216d4a7265fe772003aaeea05ed2566b14cfc0b8146b1f99e"
 dependencies = [
  "corez",
  "getset",
+ "incrementalmerkletree",
  "libm",
+ "orchard",
+ "pczt",
  "rand_core",
+ "shardtree",
+ "zcash_client_backend",
+ "zcash_keys",
  "zcash_primitives",
  "zcash_protocol",
 ]
 
 [[package]]
 name = "zcash_primitives"
-version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -4802,8 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -4823,8 +4844,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
 dependencies = [
  "corez",
  "document-features",
@@ -4861,8 +4883,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
 dependencies = [
  "bip32",
  "bs58",
@@ -4885,8 +4908,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_voting"
-version = "1.0.0"
-source = "git+https://github.com/valargroup/zcash_voting?rev=5818d3ed53ea463eab31643e857bbf5de8a0b34d#5818d3ed53ea463eab31643e857bbf5de8a0b34d"
+version = "2.0.0-rc.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63091832093471b1e34261490bb039a49689455b50dbd90c5e358aa1f134b7ef"
 dependencies = [
  "anyhow",
  "base64",
@@ -5048,7 +5072,8 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash?rev=3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb#3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
 dependencies = [
  "base64",
  "nom",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -71,24 +71,24 @@ url = "2.5.8"
 
 # Zcash core
 [dependencies.zcash_primitives]
-version = "0.29.0-pre.0"
+version = "0.30.0"
 
 [dependencies.zcash_address]
 version = "0.13.0"
 
 [dependencies.zcash_keys]
-version = "0.15.0"
+version = "0.16.0"
 features = ["orchard"]
 
 [dependencies.zcash_protocol]
-version = "0.10.0-pre.0"
+version = "0.10.1"
 
 [dependencies.transparent]
 package = "zcash_transparent"
-version = "0.9.0-pre.0"
+version = "0.10.0"
 
 [dependencies.zcash_client_backend]
-version = "0.24.0-rc.1"
+version = "0.24.0-rc.4"
 features = [
     "orchard",
     "transparent-inputs",
@@ -99,24 +99,24 @@ features = [
 ]
 
 [dependencies.zcash_client_sqlite]
-version = "0.22.0-rc.1"
+version = "0.22.0-rc.4"
 features = ["orchard", "transparent-inputs", "unstable", "serde"]
 
 # Voting clients need PIR lookup support and vote-commitment-tree sync.
 [dependencies.zcash_voting]
-version = "1.0.0"
+version = "2.0.0-rc.2"
 
-# Must match the Orchard release used by the pinned librustzcash and
-# zcash_voting revisions to avoid type conflicts.
+# Keep Orchard aligned with the released librustzcash and zcash_voting family
+# to avoid type conflicts.
 [dependencies.orchard]
-version = "0.15.0"
+version = "0.15.4"
 
 # Proofs
 [dependencies.zcash_proofs]
-version = "0.29.0-pre.0"
+version = "0.30.0"
 
 [dependencies.pczt]
-version = "0.8.0-rc.1"
+version = "0.9.1"
 features = [
     "orchard",
     "io-finalizer",
@@ -152,37 +152,7 @@ rusqlite = "0.37"
 zcash_note_encryption = "0.4"
 
 [dev-dependencies.vote-commitment-tree]
-version = "0.3.2"
-
-[patch.crates-io]
-# Keep the voting crates on the revision tested by this application.
-vote-commitment-tree = { git = "https://github.com/valargroup/zcash_voting", rev = "5818d3ed53ea463eab31643e857bbf5de8a0b34d" }
-vote-commitment-tree-client = { git = "https://github.com/valargroup/zcash_voting", rev = "5818d3ed53ea463eab31643e857bbf5de8a0b34d" }
-zcash_voting = { git = "https://github.com/valargroup/zcash_voting", rev = "5818d3ed53ea463eab31643e857bbf5de8a0b34d" }
-
-# Keep the complete librustzcash family on one integration revision. This
-# includes the Ironwood rewind tolerance and owner-scoped wallet note locks,
-# while remaining on the zcash_primitives 0.29 / PCZT 0.8-rc.1 family required
-# by the current zcash_voting integration. The subsequent release boundary
-# moves to zcash_primitives 0.30 before zcash_voting does and cannot form a
-# single-source dependency graph.
-orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }
-equihash = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-f4jumble = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-pczt = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_address = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-zip321 = { git = "https://github.com/zcash/librustzcash", rev = "3a10e7fec7afd3a9748cb4fa7f7db853f4537eeb" }
-
-# Keep the direct tree dependency aligned with the patched graph.
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree", rev = "decefc469dbf1e686b20b7e7dcaa7cb4f122125b" }
+version = "0.4.0-rc.1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)', 'cfg(ironwood_masquerade)'] }

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -471,7 +471,7 @@ pub(super) struct StoredProposal {
     pub proposed_tx_version: Option<zcash_primitives::transaction::TxVersion>,
     /// When `true`, the proposal was fee-counted with unpadded Orchard-pool
     /// bundles (migration children only) and the PCZT must be built with
-    /// `BundleType::UNPADDED` to balance. See `zip317_helper`.
+    /// `BundlePadding::UNPADDED` to balance. See `zip317_helper`.
     pub unpadded_orchard_pool_bundles: bool,
     pub network: WalletNetwork,
     pub account_id: AccountUuid,

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -75,7 +75,7 @@ use std::convert::Infallible;
 use std::sync::OnceLock;
 
 use zcash_client_backend::data_api::WalletWrite;
-use zcash_primitives::transaction::{Transaction, TxId};
+use zcash_primitives::transaction::{builder::BundlePadding, Transaction, TxId};
 use zcash_proofs::prover::LocalTxProver;
 
 use crate::wallet::db::with_wallet_db_write_lock;
@@ -308,13 +308,13 @@ pub async fn create_pczt_from_proposal(
         )
         .map_err(|e| format!("Revalidate hardware proposal input locks: {e:?}"))?;
         super::proposal_locks::update_expiry(db_path, current_lock.owner, live_expiry_height)?;
-        // Build with the bundle type the proposal was fee-counted against
+        // Build with the padding policy the proposal was fee-counted against
         // (see `StoredProposal::unpadded_orchard_pool_bundles`), so the
         // builder's balance check matches the proposal's fee.
-        let bundle_type = if stored.unpadded_orchard_pool_bundles {
-            ::orchard::builder::BundleType::UNPADDED
+        let bundle_padding = if stored.unpadded_orchard_pool_bundles {
+            BundlePadding::UNPADDED
         } else {
-            ::orchard::builder::BundleType::DEFAULT
+            BundlePadding::DEFAULT
         };
         // The transaction version rides on the proposal; expiry is pinned to
         // the live chain tip obtained immediately before this DB operation.
@@ -329,7 +329,7 @@ pub async fn create_pczt_from_proposal(
             OvkPolicy::Sender,
             &proposal_for_pczt,
             Some(live_expiry_height),
-            bundle_type,
+            bundle_padding,
         )
         .map_err(|e| format!("Create PCZT failed: {e}"))?;
         let pczt_bytes = pczt

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -78,7 +78,7 @@ use zcash_client_sqlite::{wallet::commitment_tree, AccountUuid, ReceivedNoteId};
 use zcash_keys::{address::Address, keys::UnifiedSpendingKey};
 use zcash_primitives::transaction::TxVersion;
 use zcash_primitives::transaction::{
-    builder::{BuildConfig, Builder},
+    builder::{BuildConfig, Builder, BundlePadding},
     fees::{
         transparent::InputSize as TransparentInputSize,
         zip317::{P2PKH_STANDARD_INPUT_SIZE, P2PKH_STANDARD_OUTPUT_SIZE},
@@ -982,7 +982,7 @@ fn create_shield_transparent_pczt_with_expiry(
             OvkPolicy::Sender,
             &proposal,
             expiry_height,
-            orchard::builder::BundleType::DEFAULT,
+            BundlePadding::DEFAULT,
         )
         .map_err(|e| format!("Create shielding PCZT failed: {e}"))?;
         let pczt_bytes = pczt
@@ -2724,7 +2724,7 @@ pub(crate) fn retain_prepared_note_anchor_checkpoints_after_scan(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn make_orchard_split_builder_with_type(
+fn make_orchard_split_builder_with_padding(
     network: WalletNetwork,
     target_height: u32,
     orchard_anchor: orchard::Anchor,
@@ -2734,7 +2734,7 @@ fn make_orchard_split_builder_with_type(
     recipient: orchard::Address,
     outputs: &[u64],
     memo: &MemoBytes,
-    bundle_type: orchard::builder::BundleType,
+    bundle_padding: BundlePadding,
 ) -> Result<Builder<WalletNetwork, ()>, String> {
     let mut builder = Builder::new(
         network,
@@ -2745,8 +2745,8 @@ fn make_orchard_split_builder_with_type(
             ironwood_anchor: Some(orchard::Anchor::empty_tree()),
             // A denomination stage is an ordinary private Orchard-to-Orchard split;
             // keep it padded like regular sends.
-            orchard_bundle_type: bundle_type,
-            ironwood_bundle_type: orchard::builder::BundleType::DEFAULT,
+            orchard_padding: bundle_padding,
+            ironwood_padding: BundlePadding::DEFAULT,
         },
     )
     .with_expiry_height(BlockHeight::from(MIGRATION_NO_EXPIRY_HEIGHT));

--- a/rust/src/wallet/sync/send/ironwood_migration/denomination_split.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/denomination_split.rs
@@ -326,7 +326,7 @@ fn create_padded_orchard_denomination_pczts(
     )?
     .ok_or("Insufficient spendable Orchard funds for denomination split")?;
 
-    let padded_bundle_type = orchard::builder::BundleType::Transactional {
+    let padded_bundle_padding = BundlePadding {
         bundle_required: false,
         pad_to_minimum: Some(
             u8::try_from(super::migration::DENOMINATION_SPLIT_ACTIONS)
@@ -449,7 +449,7 @@ fn create_padded_orchard_denomination_pczts(
             .iter()
             .map(|output| output.value_zatoshi)
             .collect::<Vec<_>>();
-        let builder = make_orchard_split_builder_with_type(
+        let builder = make_orchard_split_builder_with_padding(
             network,
             target_height.into(),
             stage_anchor,
@@ -459,7 +459,7 @@ fn create_padded_orchard_denomination_pczts(
             recipient,
             &output_values,
             &memo,
-            padded_bundle_type,
+            padded_bundle_padding,
         )?;
         let exact_fee = builder
             .get_fee(&fee_rule)

--- a/rust/src/wallet/sync/send/ironwood_migration/plan_child.rs
+++ b/rust/src/wallet/sync/send/ironwood_migration/plan_child.rs
@@ -280,8 +280,8 @@ pub(super) fn migration_child_builder<P: consensus::Parameters>(
             sapling_anchor: None,
             orchard_anchor: Some(orchard_anchor),
             ironwood_anchor: Some(orchard::Anchor::empty_tree()),
-            orchard_bundle_type: orchard::builder::BundleType::DEFAULT,
-            ironwood_bundle_type: orchard::builder::BundleType::UNPADDED,
+            orchard_padding: BundlePadding::DEFAULT,
+            ironwood_padding: BundlePadding::UNPADDED,
         },
     )
     .with_expiry_height(BlockHeight::from(expiry_height)))

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -1673,7 +1673,7 @@ fn built_v6_split_pczt() -> (BuiltPczt, orchard::keys::SpendingKey) {
         let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
         let orchard_anchor = merkle_path.root(cmx);
 
-        make_orchard_split_builder_with_type(
+        make_orchard_split_builder_with_padding(
             network,
             target_height,
             orchard_anchor,
@@ -1683,7 +1683,7 @@ fn built_v6_split_pczt() -> (BuiltPczt, orchard::keys::SpendingKey) {
             recipient,
             &[output_value],
             &memo,
-            orchard::builder::BundleType::DEFAULT,
+            BundlePadding::DEFAULT,
         )
     };
 
@@ -1718,7 +1718,7 @@ fn padded_denomination_split_builds_exactly_sixteen_actions() {
     let memo = MemoBytes::empty();
     let outputs = vec![100_000u64; 10];
     let fee_rule = ConservativeZip317FeeRule;
-    let bundle_type = orchard::builder::BundleType::Transactional {
+    let bundle_padding = BundlePadding {
         bundle_required: false,
         pad_to_minimum: Some(16),
     };
@@ -1739,7 +1739,7 @@ fn padded_denomination_split_builds_exactly_sixteen_actions() {
         let merkle_path = dummy_orchard_merkle_path().unwrap();
         let cmx: orchard::note::ExtractedNoteCommitment = note.commitment().into();
         let anchor = merkle_path.root(cmx);
-        make_orchard_split_builder_with_type(
+        make_orchard_split_builder_with_padding(
             network,
             target_height,
             anchor,
@@ -1749,7 +1749,7 @@ fn padded_denomination_split_builds_exactly_sixteen_actions() {
             recipient,
             &outputs,
             &memo,
-            bundle_type,
+            bundle_padding,
         )
     };
 


### PR DESCRIPTION
Replaces the temporary Zcash, Orchard, and voting Git patches with the published Ironwood release family, including zcash_voting 2.0.0-rc.2 and its RC tree and client crates. Adapts PCZT and migration builders to the released BundlePadding API while preserving their padding behavior.\n\nValidated with cargo check --manifest-path rust/Cargo.toml --locked --all-targets and cargo test --manifest-path rust/Cargo.toml --locked --lib (453 passed, 1 ignored).