### PR TITLE
Polish Ironwood Keystone migration QR flow

### DIFF
--- a/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
@@ -1425,7 +1425,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
                 ? 'Preparing migration request'
                 : '${signingRound.length} ${widget.step.messageUnit}'
                       '${signingRound.length == 1 ? '' : 's'} to sign'
-                      ' · Click QR to enlarge',
+                      ' · click QR to enlarge',
             textAlign: TextAlign.center,
             style: AppTypography.bodyMedium.copyWith(
               color: colors.text.secondary,

--- a/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/keystone_signing.dart
@@ -7,16 +7,25 @@ const _keystoneMigrationQrFrameInterval = Duration(milliseconds: 200);
 class IronwoodMigrationKeystoneCombinedSignScreen extends StatelessWidget {
   const IronwoodMigrationKeystoneCombinedSignScreen({
     required this.approvedSchedule,
+    this.previewRequest,
+    this.previewUrParts = const [],
+    this.previewStartScanning = false,
     super.key,
   });
 
   final List<rust_sync.MigrationScheduledTransfer> approvedSchedule;
+  final rust_sync.KeystoneMigrationSigningRequest? previewRequest;
+  final List<String> previewUrParts;
+  final bool previewStartScanning;
 
   @override
   Widget build(BuildContext context) {
     return _IronwoodMigrationKeystonePrivateSignScreen(
       step: _KeystonePrivateSignStep.combined,
       approvedSchedule: approvedSchedule,
+      previewRequest: previewRequest,
+      previewUrParts: previewUrParts,
+      previewStartScanning: previewStartScanning,
     );
   }
 }
@@ -301,11 +310,11 @@ extension _KeystonePrivateSignStepCopy on _KeystonePrivateSignStep {
     _KeystonePrivateSignStep.immediate =>
       'Scan the QR code with your Keystone wallet to confirm migration.',
     _KeystonePrivateSignStep.combined =>
-      'Scan this QR code with Keystone to sign the split and migration transactions together.',
+      'Scan this request QR with Keystone. Keystone will show a new signed QR when it finishes.',
     _KeystonePrivateSignStep.denominations =>
-      'Scan this QR code with Keystone to sign the private split transactions.',
+      'Scan this request QR with Keystone. Keystone will show a new signed QR when it finishes.',
     _KeystonePrivateSignStep.batch =>
-      'Scan this QR code with Keystone to sign the Ironwood migration batch.',
+      'Scan this request QR with Keystone. Keystone will show a new signed QR when it finishes.',
   };
 
   String get messageUnit => switch (this) {
@@ -571,7 +580,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
       if (!mounted) return;
       setState(() {
         _stage = _KeystoneDenominationSignStage.failed;
-        _error = _keystoneMigrationSigningErrorMessage(e);
+        _error = ironwoodMigrationKeystoneSigningErrorMessage(e);
       });
     }
   }
@@ -585,7 +594,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
 
   String? get _signingRoundLabel => _signingRounds.length <= 1
       ? null
-      : 'Keystone round ${_signingRoundIndex + 1} of ${_signingRounds.length}';
+      : 'Round ${_signingRoundIndex + 1} of ${_signingRounds.length}';
 
   Future<void> _handleScanComplete(ScanResult result) async {
     if (_decoding ||
@@ -662,7 +671,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
       setState(() {
         _stage = _KeystoneDenominationSignStage.scanning;
         _decoding = false;
-        _error = _keystoneMigrationSigningErrorMessage(e);
+        _error = ironwoodMigrationKeystoneSigningErrorMessage(e);
       });
     }
   }
@@ -722,7 +731,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
         return;
       }
       setState(() {
-        _error = _keystoneMigrationSigningErrorMessage(e);
+        _error = ironwoodMigrationKeystoneSigningErrorMessage(e);
       });
     }
   }
@@ -807,7 +816,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
             : _KeystoneDenominationSignStage.scanning;
         _pendingSignedMessages = null;
         _decoding = false;
-        _error = _keystoneMigrationSigningErrorMessage(e);
+        _error = ironwoodMigrationKeystoneSigningErrorMessage(e);
       });
     }
   }
@@ -942,7 +951,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
     final accountUuid = _accountUuid;
     _stopProofPolling();
     _request = null;
-    if (requestId != null && accountUuid != null) {
+    if (!_requestCompleted && requestId != null && accountUuid != null) {
       await _discardRequest(accountUuid, requestId);
     }
     if (!mounted) return;
@@ -953,6 +962,14 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
       _ => widget.step.previousRoute,
     };
     context.go(previousRoute);
+  }
+
+  void _handleBack() {
+    if (_stage == _KeystoneDenominationSignStage.scanning) {
+      _showRequestQrAgain();
+      return;
+    }
+    unawaited(_returnToReview());
   }
 
   void _handleDecodeError(Object error) {
@@ -975,7 +992,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
     if (status.isFailed) {
       return ironwoodMigrationKeystoneProofFailureMessage(status);
     }
-    if (status.isReady) return 'Local proofs ready';
+    if (status.isReady) return null;
     if (status.totalCount > 0) {
       return 'Preparing local proofs ${status.readyCount}/${status.totalCount}';
     }
@@ -992,7 +1009,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
     return _IronwoodMigrationFrame(
       toolbar: _keystoneDenominationToolbar(
         label: widget.step.toolbarLabel,
-        onBack: () => unawaited(_returnToReview()),
+        onBack: _handleBack,
       ),
       disableSidebarActions: true,
       child: SizedBox(
@@ -1104,7 +1121,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
     return PopScope<void>(
       canPop: false,
       onPopInvokedWithResult: (didPop, _) {
-        if (!didPop && !completing) unawaited(_returnToReview());
+        if (!didPop && !completing) _handleBack();
       },
       child: KeyedSubtree(
         key: const ValueKey('mobile_ironwood_keystone_sign_screen'),
@@ -1231,17 +1248,17 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
               ? 'Applying the Keystone signature.'
               : waitingForProofs
               ? 'Signature captured. Waiting for local proofs.'
-              : _signingRoundLabel == null
-              ? null
-              : '$_signingRoundLabel. Scan the signed QR from Keystone.'),
+              : 'Scan the new signed QR shown on Keystone.'),
+      signingRoundLabel: _signingRoundLabel,
+      scannerMessageIsError: _error != null,
       onToggleFlashlight:
           completing || waitingForProofs || scannerControls == null
           ? null
           : () => unawaited(scannerControls.toggleTorch()),
       onShowRequestQr: completing || waitingForProofs
           ? null
-          : _showMobileRequestQrAgain,
-      onCancel: completing ? null : _showMobileRequestQrAgain,
+          : _showRequestQrAgain,
+      onCancel: completing ? null : _showRequestQrAgain,
     );
   }
 
@@ -1250,7 +1267,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
     setState(() => _scannerControls = controls);
   }
 
-  void _showMobileRequestQrAgain() {
+  void _showRequestQrAgain() {
     if (!mounted) return;
     setState(() {
       _stage = _KeystoneDenominationSignStage.showQr;
@@ -1258,6 +1275,43 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
       _decoding = false;
       _scannerControls = null;
     });
+  }
+
+  Future<void> _showEnlargedRequestQr() async {
+    final urParts = List<String>.of(_urParts);
+    if (urParts.isEmpty) return;
+
+    await showDialog<void>(
+      context: context,
+      barrierColor: Colors.black.withValues(alpha: 0.82),
+      builder: (dialogContext) {
+        final viewport = MediaQuery.sizeOf(dialogContext);
+        final availableSize = math.min(
+          viewport.width - AppSpacing.xl * 2,
+          viewport.height - AppSpacing.xl * 2,
+        );
+        final qrSize = math
+            .min(520.0, availableSize)
+            .clamp(264.0, 520.0)
+            .toDouble();
+        return Dialog(
+          backgroundColor: Colors.transparent,
+          shadowColor: Colors.transparent,
+          insetPadding: EdgeInsets.zero,
+          child: Semantics(
+            label: 'Enlarged Keystone request QR',
+            child: KeystonePcztQrStage(
+              key: const ValueKey('keystone_migration_enlarged_qr'),
+              phase: KeystonePcztQrStagePhase.ready,
+              urParts: urParts,
+              error: null,
+              size: qrSize,
+              frameInterval: _keystoneMigrationQrFrameInterval,
+            ),
+          ),
+        );
+      },
+    );
   }
 
   Widget _buildMobileFailureContent(BuildContext context) {
@@ -1315,8 +1369,20 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (signingRoundLabel != null) ...[
+            Text(
+              signingRoundLabel,
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xxs),
+          ],
           Text(
-            widget.step.qrTitle,
+            widget.step == _KeystonePrivateSignStep.immediate
+                ? widget.step.qrTitle
+                : 'Scan request with Keystone',
             textAlign: TextAlign.center,
             style: AppTypography.headlineLarge.copyWith(
               color: colors.text.accent,
@@ -1334,34 +1400,37 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
             ),
           ),
           const SizedBox(height: AppSpacing.lg),
-          KeystonePcztQrStage(
-            phase: KeystonePcztQrStagePhase.ready,
-            urParts: _urParts,
-            error: _error,
-            size: 264,
-            frameInterval: _keystoneMigrationQrFrameInterval,
+          Semantics(
+            label: 'Enlarge Keystone request QR',
+            button: true,
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: GestureDetector(
+                key: const ValueKey('keystone_migration_enlarge_qr'),
+                onTap: () => unawaited(_showEnlargedRequestQr()),
+                behavior: HitTestBehavior.opaque,
+                child: KeystonePcztQrStage(
+                  phase: KeystonePcztQrStagePhase.ready,
+                  urParts: _urParts,
+                  error: _error,
+                  size: 264,
+                  frameInterval: _keystoneMigrationQrFrameInterval,
+                ),
+              ),
+            ),
           ),
           const SizedBox(height: AppSpacing.base),
           Text(
             request == null || signingRound == null
                 ? 'Preparing migration request'
                 : '${signingRound.length} ${widget.step.messageUnit}'
-                      '${signingRound.length == 1 ? '' : 's'} to sign',
+                      '${signingRound.length == 1 ? '' : 's'} to sign'
+                      ' · Click QR to enlarge',
             textAlign: TextAlign.center,
             style: AppTypography.bodyMedium.copyWith(
               color: colors.text.secondary,
             ),
           ),
-          if (signingRoundLabel != null) ...[
-            const SizedBox(height: AppSpacing.xxs),
-            Text(
-              signingRoundLabel,
-              textAlign: TextAlign.center,
-              style: AppTypography.bodySmall.copyWith(
-                color: colors.text.secondary,
-              ),
-            ),
-          ],
           if (proofStatusText != null) ...[
             const SizedBox(height: AppSpacing.xs),
             SizedBox(
@@ -1391,7 +1460,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
             height: 44,
             minWidth: 230,
             trailing: const AppIcon(AppIcons.chevronForward, size: 20),
-            child: const Text('Scan signature'),
+            child: const Text('Scan Keystone signature'),
           ),
           const SizedBox(height: AppSpacing.sm),
           AppButton(
@@ -1408,6 +1477,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
 
   Widget _buildScannerContent(BuildContext context) {
     final colors = context.colors;
+    final signingRoundLabel = _signingRoundLabel;
     final completing = _stage == _KeystoneDenominationSignStage.completing;
     final waitingForProofs =
         _stage == _KeystoneDenominationSignStage.waitingForProofs;
@@ -1420,6 +1490,16 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
+          if (signingRoundLabel != null) ...[
+            Text(
+              signingRoundLabel,
+              textAlign: TextAlign.center,
+              style: AppTypography.bodyMediumStrong.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.xxs),
+          ],
           Text(
             widget.step == _KeystonePrivateSignStep.immediate
                 ? 'Scan QR Code'
@@ -1441,9 +1521,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
                   ? 'Applying the Keystone signature to your migration plan.'
                   : waitingForProofs
                   ? 'Signature captured. Vizor will continue when local proofs are ready.'
-                  : _signingRoundLabel != null
-                  ? '$_signingRoundLabel. Show the signed QR on Keystone and scan it here.'
-                  : 'Show the signed migration QR on Keystone and scan it here.',
+                  : 'Scan the new signed QR shown on Keystone.',
               textAlign: TextAlign.center,
               style:
                   (widget.step == _KeystonePrivateSignStep.immediate
@@ -1453,7 +1531,7 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
             ),
           ),
           const SizedBox(height: AppSpacing.base),
-          if (widget.previewRequest != null && widget.previewStartScanning)
+          if (widget.previewRequest != null)
             const _ImmediateKeystoneScannerPreviewCard()
           else
             KeystoneQrScannerCard(
@@ -1474,24 +1552,6 @@ class _IronwoodMigrationKeystonePrivateSignScreenState
                   'Keystone migration signing uses camera QR scanning only. '
                   'Connect a camera and try again.',
             ),
-          if (widget.step != _KeystonePrivateSignStep.immediate) ...[
-            const SizedBox(height: AppSpacing.sm),
-            AppButton(
-              onPressed: completing || waitingForProofs
-                  ? null
-                  : () {
-                      setState(() {
-                        _stage = _KeystoneDenominationSignStage.showQr;
-                        _error = null;
-                        _decoding = false;
-                      });
-                    },
-              variant: AppButtonVariant.ghost,
-              height: 36,
-              minWidth: 230,
-              child: const Text('Back to QR'),
-            ),
-          ],
         ],
       ),
     );
@@ -1829,9 +1889,15 @@ bool _keystoneMigrationRequestMissingError(Object error) {
       (lower.contains('not found') || lower.contains('already used'));
 }
 
-String _keystoneMigrationSigningErrorMessage(Object error) {
+@visibleForTesting
+String ironwoodMigrationKeystoneSigningErrorMessage(Object error) {
   final message = error.toString();
   final lower = message.toLowerCase();
+  if (lower.contains('batch result request id') &&
+      lower.contains('does not match')) {
+    return 'This signed QR is from another round. Go back, scan the current '
+        'request with Keystone, then scan its new signed QR.';
+  }
   if (lower.contains('not a keystone')) {
     return 'Use a Keystone account to sign this migration.';
   }

--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -357,6 +357,15 @@ class _MigrationLiveStatusContent extends StatelessWidget {
                             key: const ValueKey('preparing-ring-label'),
                             mainAxisSize: MainAxisSize.min,
                             children: [
+                              AppIcon(
+                                AppIcons.loader,
+                                key: const ValueKey(
+                                  'ironwood_migration_preparation_loader',
+                                ),
+                                size: AppIconSize.large,
+                                color: colors.text.accent,
+                              ),
+                              const SizedBox(height: 6),
                               Text(
                                 preparationPresentation.label,
                                 textAlign: TextAlign.center,

--- a/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow_screen.dart
@@ -6,9 +6,11 @@ import 'package:flutter/material.dart'
     show
         Colors,
         CircularProgressIndicator,
+        Dialog,
         Divider,
         LinearProgressIndicator,
-        Scaffold;
+        Scaffold,
+        showDialog;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';

--- a/lib/src/features/migration/widgets/mobile/mobile_ironwood_keystone_signing_view.dart
+++ b/lib/src/features/migration/widgets/mobile/mobile_ironwood_keystone_signing_view.dart
@@ -96,6 +96,7 @@ class MobileIronwoodKeystoneSigningView extends StatelessWidget {
         MobileIronwoodKeystoneSigningViewState.scanner => _ScannerContent(
           camera: camera,
           round: round,
+          signingRoundLabel: signingRoundLabel,
           onToggleFlashlight: onToggleFlashlight,
           onShowRequestQr: onShowRequestQr,
           onCancel: onCancel,
@@ -188,8 +189,8 @@ class _StepOneContent extends StatelessWidget {
                         key: const ValueKey(
                           'mobile_ironwood_keystone_signing_round',
                         ),
-                        style: AppTypography.bodySmall.copyWith(
-                          color: colors.text.secondary,
+                        style: AppTypography.bodyMediumStrong.copyWith(
+                          color: colors.text.accent,
                         ),
                       ),
                     ],
@@ -449,6 +450,7 @@ class _ScannerContent extends StatelessWidget {
   const _ScannerContent({
     required this.camera,
     required this.round,
+    required this.signingRoundLabel,
     required this.onToggleFlashlight,
     required this.onShowRequestQr,
     required this.onCancel,
@@ -458,6 +460,7 @@ class _ScannerContent extends StatelessWidget {
 
   final Widget? camera;
   final MobileIronwoodKeystoneSigningRound round;
+  final String? signingRoundLabel;
   final VoidCallback? onToggleFlashlight;
   final VoidCallback? onShowRequestQr;
   final VoidCallback? onCancel;
@@ -563,6 +566,18 @@ class _ScannerContent extends StatelessWidget {
                           color: const Color(0xFFFFFFFF),
                         ),
                       ),
+                      if (signingRoundLabel != null) ...[
+                        const SizedBox(height: AppSpacing.xxs),
+                        Text(
+                          signingRoundLabel!,
+                          key: const ValueKey(
+                            'mobile_ironwood_keystone_signing_round',
+                          ),
+                          style: AppTypography.bodyMediumStrong.copyWith(
+                            color: const Color(0xFFFFFFFF),
+                          ),
+                        ),
+                      ],
                     ],
                   ),
                 ),

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -15,6 +15,8 @@ import 'package:zcash_wallet/src/core/profile_pictures.dart';
 import 'package:zcash_wallet/src/core/theme/app_theme.dart';
 import 'package:zcash_wallet/src/core/storage/app_secure_store.dart';
 import 'package:zcash_wallet/src/core/widgets/app_button.dart';
+import 'package:zcash_wallet/src/core/widgets/app_icon.dart';
+import 'package:zcash_wallet/src/core/widgets/app_loading_icon.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_announcement_provider.dart';
 import 'package:zcash_wallet/src/features/migration/providers/ironwood_migration_coordinator_provider.dart';
 import 'package:zcash_wallet/src/features/migration/screens/ironwood_migration_flow_screen.dart';
@@ -783,6 +785,11 @@ void main() {
       await tester.pump(const Duration(milliseconds: 500));
 
       expect(find.text('Next split'), findsOneWidget);
+      final loader = tester.widget<AppIcon>(
+        find.byKey(const ValueKey('ironwood_migration_preparation_loader')),
+      );
+      expect(loader.name, AppIcons.loader);
+      expect(loader.size, AppIconSize.large);
       expect(find.text('Split 1 of 6'), findsOneWidget);
       expect(find.textContaining('confirmations'), findsNothing);
       expect(
@@ -857,6 +864,12 @@ void main() {
       findsOneWidget,
     );
     expect(find.text('Next split'), findsOneWidget);
+    final loader = find.descendant(
+      of: find.byKey(const ValueKey('ironwood_migration_preparation_loader')),
+      matching: find.byType(AppLoadingIcon),
+    );
+    expect(loader, findsOneWidget);
+    expect(MediaQuery.maybeDisableAnimationsOf(tester.element(loader)), isTrue);
   });
 
   testWidgets('private preparing status does not expose note progress', (

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -499,6 +499,118 @@ void main() {
     },
   );
 
+  test(
+    'Keystone migration explains a signed QR from another signing round',
+    () {
+      final message = ironwoodMigrationKeystoneSigningErrorMessage(
+        Exception(
+          'Keystone batch result request id does not match the request',
+        ),
+      );
+
+      expect(
+        message,
+        'This signed QR is from another round. Go back, scan the current '
+        'request with Keystone, then scan its new signed QR.',
+      );
+    },
+  );
+
+  testWidgets(
+    'desktop Keystone scanner back returns to the current request QR',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1440, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final request = rust_sync.KeystoneMigrationSigningRequest(
+        requestId: 'preview-request',
+        messages: [
+          rust_sync.KeystoneMigrationMessage(
+            id: 'split-1',
+            redactedPczt: Uint8List.fromList([1]),
+          ),
+          rust_sync.KeystoneMigrationMessage(
+            id: 'split-2',
+            redactedPczt: Uint8List.fromList([2]),
+          ),
+        ],
+        signingBatchLimit: 1,
+      );
+      await tester.pumpWidget(
+        _migrationOptionsHarness(
+          initialLocation: '/migration/private/keystone/sign',
+          activeAccountIsHardware: true,
+          previewCombinedSigningRequest: request,
+          previewCombinedSigningUrParts: const ['UR:ZCASH-SIGN-BATCH/PREVIEW'],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text('Step 1 of 2'), findsNothing);
+      expect(find.text('Round 1 of 2'), findsOneWidget);
+      expect(find.text('Scan request with Keystone'), findsOneWidget);
+      expect(
+        find.text(
+          'Scan this request QR with Keystone. Keystone will show a new '
+          'signed QR when it finishes.',
+        ),
+        findsOneWidget,
+      );
+
+      final enlargeQr = find.byKey(
+        const ValueKey('keystone_migration_enlarge_qr'),
+      );
+      expect(enlargeQr, findsOneWidget);
+      await tester.tap(enlargeQr);
+      await tester.pumpAndSettle();
+
+      final enlargedQr = find.byKey(
+        const ValueKey('keystone_migration_enlarged_qr'),
+      );
+      expect(enlargedQr, findsOneWidget);
+      expect(tester.getSize(enlargedQr), const Size.square(520));
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pumpAndSettle();
+      expect(enlargedQr, findsNothing);
+
+      await tester.tap(
+        find.widgetWithText(AppButton, 'Scan Keystone signature'),
+      );
+      await tester.pump();
+
+      expect(find.text('Step 2 of 2'), findsNothing);
+      expect(find.text('Round 1 of 2'), findsOneWidget);
+      expect(find.text('Scan Keystone signature'), findsOneWidget);
+      expect(
+        find.text('Scan the new signed QR shown on Keystone.'),
+        findsOneWidget,
+      );
+      expect(find.text('Back to QR'), findsNothing);
+
+      final back = find.bySemanticsLabel('Back to Review migration');
+      await tester.tap(back);
+      await tester.pump();
+
+      expect(find.text('Step 1 of 2'), findsNothing);
+      expect(find.text('Scan request with Keystone'), findsOneWidget);
+      expect(
+        find.byKey(const ValueKey('ironwood_migration_review_screen')),
+        findsNothing,
+      );
+
+      await tester.tap(back);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byKey(const ValueKey('ironwood_migration_review_screen')),
+        findsOneWidget,
+      );
+    },
+  );
+
   test('Keystone migration proof helpers distinguish pending states', () {
     const pending = rust_sync.KeystoneMigrationProofStatus(
       readyCount: 1,
@@ -3245,6 +3357,8 @@ Widget _migrationOptionsHarness({
   Duration analyzingMinimumDuration = Duration.zero,
   bool disableAnimations = true,
   bool useImmediatePreview = true,
+  rust_sync.KeystoneMigrationSigningRequest? previewCombinedSigningRequest,
+  List<String> previewCombinedSigningUrParts = const [],
 }) {
   final router = GoRouter(
     initialLocation: initialLocation,
@@ -3315,6 +3429,14 @@ Widget _migrationOptionsHarness({
       GoRoute(
         path: '/migration/private/keystone/sign',
         builder: (_, state) {
+          final previewRequest = previewCombinedSigningRequest;
+          if (previewRequest != null) {
+            return IronwoodMigrationKeystoneCombinedSignScreen(
+              approvedSchedule: const [],
+              previewRequest: previewRequest,
+              previewUrParts: previewCombinedSigningUrParts,
+            );
+          }
           final schedule =
               state.extra! as List<rust_sync.MigrationScheduledTransfer>;
           return Text(

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -560,6 +560,10 @@ void main() {
         ),
         findsOneWidget,
       );
+      expect(
+        find.text('1 transaction to sign · click QR to enlarge'),
+        findsOneWidget,
+      );
 
       final enlargeQr = find.byKey(
         const ValueKey('keystone_migration_enlarge_qr'),

--- a/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/mobile_ironwood_migration_flow_screen_test.dart
@@ -2687,7 +2687,7 @@ void main() {
           redactedPczt: Uint8List.fromList([2]),
         ),
       ],
-      signingBatchLimit: 50,
+      signingBatchLimit: 1,
     );
 
     await tester.pumpWidget(
@@ -2708,6 +2708,7 @@ void main() {
 
     expect(find.text('Step 1/2'), findsOneWidget);
     expect(find.text('Scan with Keystone'), findsOneWidget);
+    expect(find.text('Round 1 of 2'), findsOneWidget);
     expect(
       find.byKey(const ValueKey('mobile_ironwood_keystone_qr')),
       findsOneWidget,
@@ -2728,8 +2729,21 @@ void main() {
 
     expect(find.text('Step 2/2'), findsOneWidget);
     expect(find.text('Confirm with Keystone'), findsOneWidget);
-    expect(find.textContaining('Scan the QR code'), findsOneWidget);
+    expect(find.text('Round 1 of 2'), findsOneWidget);
+    expect(
+      find.text('Scan the new signed QR shown on Keystone.'),
+      findsOneWidget,
+    );
     expect(tester.takeException(), isNull);
+
+    await tester.binding.handlePopRoute();
+    await tester.pump();
+
+    expect(find.text('Step 1/2'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey('mobile_ironwood_keystone_qr')),
+      findsOneWidget,
+    );
   });
 
   testWidgets('reuses the mobile Keystone flow for Immediate migration', (


### PR DESCRIPTION
## Problem

The Ironwood Keystone migration flow did not present QR signing actions consistently across desktop and mobile. The desktop preparation state also used a loader pattern that did not match the shared app loader, and the QR enlargement hint did not follow sentence case.

## Solution

- Improve the Keystone migration request and signature QR flow across desktop and mobile.
- Keep signing actions visible and make QR enlargement easier to discover.
- Use the shared app loader in the desktop preparation state while preserving the current split status details.
- Apply sentence case to the Keystone QR hint.

## Commit scope

- Cherry-picked `6b0bb408cacc62afd2fb2f2f08f01c6c305fef9a`.
- Cherry-picked and adapted `49f39b0d888b31243c1aa18fa93a30a4cf14cecd` to the current `main` preparation UI.
- Cherry-picked `556ad8dfcab18094f576e57b4a8b80efa15dd491`.
- `649ed7037e4e47a84beb07e621441e14c893fad7` is already included in `main` through PR #367, so it is part of the base rather than this PR diff.
- The unrelated intermediate commit `965858fc7faacc0e404cf83ab50f06e70d2fb511` is intentionally excluded.

## Validation

- `fvm flutter test test/features/migration/ironwood_migration_flow_screen_test.dart` — 77 passed.
- `fvm flutter test --tags mobile --run-skipped --dart-define=VIZOR_FORM_FACTOR=mobile test/features/migration/mobile_ironwood_migration_flow_screen_test.dart` — 102 passed.
- `fvm dart analyze` on all six changed Dart files — no issues.
- Full `fvm flutter analyze` still reports 23 existing unused-declaration warnings in untouched migration files; this PR adds no changed-file analyzer findings.

## Visual verification

Not yet verified on a rendered desktop or mobile surface; the PR remains draft pending that UI check.