### PR TITLE
Fix mobile v0.0.18 database compatibility

### DIFF
--- a/rust/examples/db_upgrade_mobile_v0_0_18.rs
+++ b/rust/examples/db_upgrade_mobile_v0_0_18.rs
@@ -1,0 +1,437 @@
+use std::{fs, path::Path};
+
+use rust_lib_zcash_wallet::api::wallet;
+use serde::{Deserialize, Serialize};
+
+const NETWORK: &str = "regtest";
+const PRIMARY_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";
+const SECONDARY_MNEMONIC: &str =
+    "legal winner thank year wave sausage worth useful legal winner thank yellow";
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct LegacyState {
+    scenario: String,
+    migration_count: i64,
+    accounts: Vec<AccountRow>,
+    addresses: Vec<AddressRow>,
+    scan_queue: Vec<ScanRangeRow>,
+    transaction_count: i64,
+    sapling_note_count: i64,
+    orchard_note_count: i64,
+    transparent_output_count: i64,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct AccountRow {
+    uuid_hex: String,
+    account_kind: i64,
+    name: Option<String>,
+    birthday_height: i64,
+    has_ufvk: bool,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct AddressRow {
+    account_uuid_hex: String,
+    diversifier_index_be_hex: String,
+    address: Option<String>,
+    cached_transparent_receiver_address: Option<String>,
+    key_scope: i64,
+    transparent_child_index: Option<i64>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+struct ScanRangeRow {
+    start: i64,
+    end: i64,
+    priority: i64,
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mode = args.next().expect(
+        "usage: db_upgrade_mobile_v0_0_18 \
+             <create|verify|open-old> <scenario> <db> <manifest>",
+    );
+    let scenario = args.next().expect("scenario");
+    let db_path = args.next().expect("database path");
+    let manifest_path = args.next().expect("manifest path");
+
+    match mode.as_str() {
+        "create" => create_fixture(&scenario, &db_path, &manifest_path),
+        "verify" => verify_upgraded(&scenario, &db_path, &manifest_path),
+        "open-old" => verify_old_reopen(&scenario, &db_path, &manifest_path),
+        other => panic!("unknown mode {other}"),
+    }
+}
+
+fn create_fixture(scenario: &str, db_path: &str, manifest_path: &str) {
+    assert!(
+        !Path::new(db_path).exists(),
+        "fixture DB already exists: {db_path}"
+    );
+
+    let primary = wallet::import_wallet(
+        PRIMARY_MNEMONIC.to_string(),
+        Some(1),
+        NETWORK.to_string(),
+        db_path.to_string(),
+        Some("Primary".to_string()),
+    )
+    .expect("create primary account");
+
+    match scenario {
+        "single-derived" => {}
+        "multi-seed" | "imported-only" => {
+            wallet::add_account(
+                db_path.to_string(),
+                NETWORK.to_string(),
+                "Secondary".to_string(),
+                SECONDARY_MNEMONIC.to_string(),
+                Some(1),
+            )
+            .expect("add secondary imported account");
+            if scenario == "imported-only" {
+                wallet::delete_account(
+                    db_path.to_string(),
+                    NETWORK.to_string(),
+                    primary.account_uuid,
+                )
+                .expect("delete primary derived account");
+            }
+        }
+        other => panic!("unknown fixture scenario {other}"),
+    }
+
+    let state = read_legacy_state(db_path, scenario);
+    assert_scenario_shape(&state);
+    let conn = rusqlite::Connection::open(db_path).expect("open mobile/v0.0.18 DB");
+    assert!(
+        object_exists(&conn, "table", "orchard_ironwood_migrations"),
+        "mobile/v0.0.18 Ironwood migration table is missing"
+    );
+    assert!(
+        !column_exists(
+            &conn,
+            "orchard_ironwood_migrations",
+            "anchor_bucket_interval"
+        ),
+        "mobile/v0.0.18 fixture unexpectedly has anchor_bucket_interval"
+    );
+    let error = conn
+        .query_row(
+            "SELECT anchor_bucket_interval FROM orchard_ironwood_migrations LIMIT 1",
+            [],
+            |_| Ok(()),
+        )
+        .expect_err("current backend query must fail against the mobile/v0.0.18 schema");
+    assert!(
+        error.to_string().contains("no such column"),
+        "unexpected mobile/v0.0.18 schema failure: {error}"
+    );
+    conn.execute(
+        "INSERT INTO orchard_ironwood_migrations (
+             account_id, status, note_split_fee_buffer, note_split_change,
+             note_split_prep_fees, note_split_total_input,
+             note_split_total_migratable
+         ) VALUES (
+             (SELECT id FROM accounts ORDER BY id LIMIT 1),
+             'committed', 0, NULL, 0, 0, 0
+         )",
+        [],
+    )
+    .expect("insert representative mobile/v0.0.18 in-flight migration");
+    assert_sqlite_health(db_path);
+    fs::write(
+        manifest_path,
+        serde_json::to_vec_pretty(&state).expect("encode manifest"),
+    )
+    .expect("write manifest");
+    println!(
+        "created scenario={} accounts={} migrations={}",
+        state.scenario,
+        state.accounts.len(),
+        state.migration_count
+    );
+}
+
+fn verify_upgraded(scenario: &str, db_path: &str, manifest_path: &str) {
+    let expected = read_manifest(manifest_path);
+    assert_eq!(expected.scenario, scenario);
+
+    let accounts = wallet::list_accounts(db_path.to_string(), NETWORK.to_string())
+        .expect("open and migrate wallet");
+    assert_eq!(accounts.len(), expected.accounts.len());
+
+    let actual = read_legacy_state(db_path, scenario);
+    assert_eq!(
+        actual.accounts, expected.accounts,
+        "account rows changed during upgrade"
+    );
+    assert_eq!(
+        actual.addresses, expected.addresses,
+        "address rows changed during upgrade"
+    );
+    assert_eq!(
+        actual.scan_queue, expected.scan_queue,
+        "scan queue changed below the disabled regtest Ironwood activation"
+    );
+    assert_eq!(actual.transaction_count, expected.transaction_count);
+    assert_eq!(actual.sapling_note_count, expected.sapling_note_count);
+    assert_eq!(actual.orchard_note_count, expected.orchard_note_count);
+    assert_eq!(
+        actual.transparent_output_count,
+        expected.transparent_output_count
+    );
+    assert_eq!(
+        actual.migration_count, expected.migration_count,
+        "unexpected upstream migration count"
+    );
+
+    assert_current_schema(db_path);
+    let conn = rusqlite::Connection::open(db_path).expect("open upgraded DB");
+    let migrated: (i64, String, u32) = conn
+        .query_row(
+            "SELECT COUNT(*), MIN(status), MIN(anchor_bucket_interval)
+             FROM orchard_ironwood_migrations",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .expect("read upgraded in-flight migration");
+    assert_eq!(
+        migrated,
+        (1, "committed".to_string(), 144),
+        "mobile/v0.0.18 in-flight migration was not preserved with the ZIP 318 grid"
+    );
+    assert_sqlite_health(db_path);
+    println!(
+        "verified scenario={} accounts={} migrations={} integrity=ok",
+        scenario,
+        actual.accounts.len(),
+        actual.migration_count
+    );
+}
+
+fn verify_old_reopen(scenario: &str, db_path: &str, manifest_path: &str) {
+    let expected = read_manifest(manifest_path);
+    assert_eq!(expected.scenario, scenario);
+
+    let accounts = wallet::list_accounts(db_path.to_string(), NETWORK.to_string())
+        .expect("old build reopens upgraded pre-Ironwood wallet");
+    assert_eq!(accounts.len(), expected.accounts.len());
+
+    let actual = read_legacy_state(db_path, scenario);
+    assert_eq!(actual.accounts, expected.accounts);
+    assert_eq!(actual.addresses, expected.addresses);
+    assert_eq!(actual.transaction_count, expected.transaction_count);
+    assert_eq!(actual.sapling_note_count, expected.sapling_note_count);
+    assert_eq!(actual.orchard_note_count, expected.orchard_note_count);
+    assert_sqlite_health(db_path);
+    println!(
+        "old-reopen scenario={} accounts={} migrations={} integrity=ok",
+        scenario,
+        actual.accounts.len(),
+        actual.migration_count
+    );
+}
+
+fn read_manifest(path: &str) -> LegacyState {
+    serde_json::from_slice(&fs::read(path).expect("read manifest")).expect("decode manifest")
+}
+
+fn read_legacy_state(db_path: &str, scenario: &str) -> LegacyState {
+    let conn = rusqlite::Connection::open(db_path).expect("open wallet DB");
+
+    let accounts = conn
+        .prepare(
+            "SELECT hex(uuid), account_kind, name, birthday_height, ufvk IS NOT NULL
+             FROM accounts ORDER BY id",
+        )
+        .expect("prepare accounts")
+        .query_map([], |row| {
+            Ok(AccountRow {
+                uuid_hex: row.get(0)?,
+                account_kind: row.get(1)?,
+                name: row.get(2)?,
+                birthday_height: row.get(3)?,
+                has_ufvk: row.get(4)?,
+            })
+        })
+        .expect("query accounts")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("read accounts");
+
+    let addresses = conn
+        .prepare(
+            "SELECT hex(accounts.uuid), hex(addresses.diversifier_index_be),
+                    addresses.address, addresses.cached_transparent_receiver_address,
+                    addresses.key_scope, addresses.transparent_child_index
+             FROM addresses
+             JOIN accounts ON accounts.id = addresses.account_id
+             ORDER BY accounts.id, addresses.id",
+        )
+        .expect("prepare addresses")
+        .query_map([], |row| {
+            Ok(AddressRow {
+                account_uuid_hex: row.get(0)?,
+                diversifier_index_be_hex: row.get(1)?,
+                address: row.get(2)?,
+                cached_transparent_receiver_address: row.get(3)?,
+                key_scope: row.get(4)?,
+                transparent_child_index: row.get(5)?,
+            })
+        })
+        .expect("query addresses")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("read addresses");
+
+    let scan_queue = conn
+        .prepare(
+            "SELECT block_range_start, block_range_end, priority
+             FROM scan_queue ORDER BY block_range_start",
+        )
+        .expect("prepare scan queue")
+        .query_map([], |row| {
+            Ok(ScanRangeRow {
+                start: row.get(0)?,
+                end: row.get(1)?,
+                priority: row.get(2)?,
+            })
+        })
+        .expect("query scan queue")
+        .collect::<Result<Vec<_>, _>>()
+        .expect("read scan queue");
+
+    LegacyState {
+        scenario: scenario.to_string(),
+        migration_count: scalar_i64(&conn, "SELECT COUNT(*) FROM schemer_migrations"),
+        accounts,
+        addresses,
+        scan_queue,
+        transaction_count: scalar_i64(&conn, "SELECT COUNT(*) FROM transactions"),
+        sapling_note_count: scalar_i64(&conn, "SELECT COUNT(*) FROM sapling_received_notes"),
+        orchard_note_count: scalar_i64(&conn, "SELECT COUNT(*) FROM orchard_received_notes"),
+        transparent_output_count: scalar_i64(
+            &conn,
+            "SELECT COUNT(*) FROM transparent_received_outputs",
+        ),
+    }
+}
+
+fn assert_scenario_shape(state: &LegacyState) {
+    match state.scenario.as_str() {
+        "single-derived" => {
+            assert_eq!(state.accounts.len(), 1);
+            assert_eq!(state.accounts[0].account_kind, 0);
+        }
+        "multi-seed" => {
+            assert_eq!(state.accounts.len(), 2);
+            assert_eq!(state.accounts[0].account_kind, 0);
+            assert_eq!(state.accounts[1].account_kind, 1);
+        }
+        "imported-only" => {
+            assert_eq!(state.accounts.len(), 1);
+            assert_eq!(state.accounts[0].account_kind, 1);
+        }
+        other => panic!("unknown scenario {other}"),
+    }
+}
+
+fn assert_current_schema(db_path: &str) {
+    let conn = rusqlite::Connection::open(db_path).expect("open upgraded DB");
+    for table in [
+        "ironwood_received_notes",
+        "ironwood_received_note_spends",
+        "ironwood_tree_shards",
+        "ironwood_tree_cap",
+        "ironwood_tree_checkpoints",
+        "ironwood_tree_checkpoint_marks_removed",
+        "ironwood_tree_retained_checkpoints",
+        "orchard_tree_retained_checkpoints",
+        "sapling_tree_retained_checkpoints",
+        "orchard_ironwood_migrations",
+        "orchard_ironwood_migration_transactions",
+    ] {
+        assert!(
+            object_exists(&conn, "table", table),
+            "missing upgraded table {table}"
+        );
+    }
+    for view in [
+        "v_ironwood_shard_scan_ranges",
+        "v_ironwood_shard_unscanned_ranges",
+        "v_ironwood_shards_scan_state",
+    ] {
+        assert!(
+            object_exists(&conn, "view", view),
+            "missing upgraded view {view}"
+        );
+    }
+    for (table, column) in [
+        ("orchard_received_notes", "note_version"),
+        ("sapling_received_notes", "lock_expiry_height"),
+        ("sapling_received_notes", "lock_owner"),
+        ("orchard_received_notes", "lock_expiry_height"),
+        ("orchard_received_notes", "lock_owner"),
+        ("ironwood_received_notes", "lock_expiry_height"),
+        ("ironwood_received_notes", "lock_owner"),
+        ("transparent_received_outputs", "lock_expiry_height"),
+        ("transparent_received_outputs", "lock_owner"),
+        ("blocks", "ironwood_commitment_tree_size"),
+        ("blocks", "ironwood_action_count"),
+        ("orchard_ironwood_migrations", "anchor_bucket_interval"),
+    ] {
+        assert!(
+            column_exists(&conn, table, column),
+            "missing upgraded column {table}.{column}"
+        );
+    }
+    assert!(
+        object_exists(
+            &conn,
+            "index",
+            "idx_addresses_cached_transparent_receiver_address"
+        ),
+        "missing transparent receiver unique index"
+    );
+}
+
+fn assert_sqlite_health(db_path: &str) {
+    let conn = rusqlite::Connection::open(db_path).expect("open DB for health check");
+    let integrity: String = conn
+        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .expect("integrity_check");
+    assert_eq!(integrity, "ok");
+    assert_eq!(
+        scalar_i64(&conn, "SELECT COUNT(*) FROM pragma_foreign_key_check"),
+        0,
+        "foreign key violations"
+    );
+}
+
+fn scalar_i64(conn: &rusqlite::Connection, sql: &str) -> i64 {
+    conn.query_row(sql, [], |row| row.get(0))
+        .unwrap_or_else(|error| panic!("query failed ({sql}): {error}"))
+}
+
+fn object_exists(conn: &rusqlite::Connection, kind: &str, name: &str) -> bool {
+    conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM sqlite_master WHERE type = ?1 AND name = ?2
+         )",
+        [kind, name],
+        |row| row.get(0),
+    )
+    .expect("check sqlite object")
+}
+
+fn column_exists(conn: &rusqlite::Connection, table: &str, column: &str) -> bool {
+    conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM pragma_table_info(?1) WHERE name = ?2
+         )",
+        [table, column],
+        |row| row.get(0),
+    )
+    .expect("check table column")
+}

--- a/rust/src/wallet/db.rs
+++ b/rust/src/wallet/db.rs
@@ -10,6 +10,15 @@ use crate::wallet::network::WalletNetwork;
 
 pub(crate) type WalletDatabase = WalletDb<rusqlite::Connection, WalletNetwork, SystemClock, OsRng>;
 
+const ORCHARD_IRONWOOD_MIGRATIONS_TABLE: &str = "orchard_ironwood_migrations";
+const ANCHOR_BUCKET_INTERVAL_COLUMN: &str = "anchor_bucket_interval";
+// mobile/v0.0.18 used the production ZIP 318 schedule, whose anchor grid is
+// fixed at 144 blocks. zcash_client_sqlite later made that implicit value
+// persistent without changing the already-applied migration ID
+// 7b2f6a41-9c3d-4e58-8a17-2f6b9d0c4e11, so init_wallet_db cannot repair an
+// existing mobile/v0.0.18 database by itself.
+const ZIP_318_ANCHOR_BUCKET_INTERVAL: u32 = 144;
+
 /// User-driven wallet operations can afford a longer wait for a short sync write.
 pub(crate) const WALLET_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(10);
 /// Account creation/import runs after sync is paused, so a shorter wait exposes real stalls.
@@ -26,6 +35,7 @@ pub(crate) fn open_wallet_db_with_timeout(
     let conn = rusqlite::Connection::open(db_path)
         .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
     configure_wallet_connection(&conn, timeout, true)?;
+    repair_legacy_ironwood_pool_migration_schema(&conn)?;
     Ok(WalletDb::from_connection(conn, network, SystemClock, OsRng))
 }
 
@@ -37,6 +47,7 @@ pub(crate) fn open_wallet_db_for_read_with_timeout(
     let conn = rusqlite::Connection::open(db_path)
         .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
     configure_wallet_connection(&conn, timeout, false)?;
+    repair_legacy_ironwood_pool_migration_schema(&conn)?;
     Ok(WalletDb::from_connection(conn, network, SystemClock, OsRng))
 }
 
@@ -56,7 +67,59 @@ pub(crate) fn open_wallet_raw_conn_with_timeout(
     let conn = rusqlite::Connection::open(db_path)
         .map_err(|e| format!("Failed to open wallet DB: {e}"))?;
     configure_wallet_connection(&conn, timeout, true)?;
+    repair_legacy_ironwood_pool_migration_schema(&conn)?;
     Ok(conn)
+}
+
+fn repair_legacy_ironwood_pool_migration_schema(conn: &rusqlite::Connection) -> Result<(), String> {
+    let table_exists: bool = conn
+        .query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM sqlite_schema
+                 WHERE type = 'table' AND name = ?1
+             )",
+            [ORCHARD_IRONWOOD_MIGRATIONS_TABLE],
+            |row| row.get(0),
+        )
+        .map_err(|e| format!("Failed to inspect Ironwood migration schema: {e}"))?;
+    if !table_exists || ironwood_anchor_bucket_column_exists(conn)? {
+        return Ok(());
+    }
+
+    let alter_result = conn.execute_batch(&format!(
+        "ALTER TABLE {ORCHARD_IRONWOOD_MIGRATIONS_TABLE}
+         ADD COLUMN {ANCHOR_BUCKET_INTERVAL_COLUMN} INTEGER NOT NULL
+         DEFAULT {ZIP_318_ANCHOR_BUCKET_INTERVAL};"
+    ));
+    if let Err(error) = alter_result {
+        // A second connection may have repaired the schema after our initial
+        // inspection. Only accept the error when the required column now
+        // exists; otherwise preserve the original failure.
+        if !ironwood_anchor_bucket_column_exists(conn)? {
+            return Err(format!(
+                "Failed to upgrade legacy Ironwood migration schema: {error}"
+            ));
+        }
+    }
+
+    log::info!(
+        "wallet DB compatibility: ensured {ORCHARD_IRONWOOD_MIGRATIONS_TABLE}.{ANCHOR_BUCKET_INTERVAL_COLUMN}"
+    );
+    Ok(())
+}
+
+fn ironwood_anchor_bucket_column_exists(conn: &rusqlite::Connection) -> Result<bool, String> {
+    conn.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM pragma_table_info(?1) WHERE name = ?2
+         )",
+        [
+            ORCHARD_IRONWOOD_MIGRATIONS_TABLE,
+            ANCHOR_BUCKET_INTERVAL_COLUMN,
+        ],
+        |row| row.get(0),
+    )
+    .map_err(|e| format!("Failed to inspect Ironwood migration columns: {e}"))
 }
 
 fn configure_wallet_connection(
@@ -175,5 +238,74 @@ mod tests {
         });
 
         assert!(called);
+    }
+
+    #[test]
+    fn repairs_mobile_v0_0_18_ironwood_pool_migration_schema() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE orchard_ironwood_migrations (
+                 id INTEGER PRIMARY KEY,
+                 account_id INTEGER NOT NULL,
+                 status TEXT NOT NULL,
+                 note_split_fee_buffer INTEGER NOT NULL,
+                 note_split_change INTEGER,
+                 note_split_prep_fees INTEGER NOT NULL,
+                 note_split_total_input INTEGER NOT NULL,
+                 note_split_total_migratable INTEGER NOT NULL
+             );
+             INSERT INTO orchard_ironwood_migrations (
+                 id, account_id, status, note_split_fee_buffer, note_split_change,
+                 note_split_prep_fees, note_split_total_input, note_split_total_migratable
+             ) VALUES (7, 11, 'committed', 1000, NULL, 2000, 3000, 4000);",
+        )
+        .unwrap();
+
+        repair_legacy_ironwood_pool_migration_schema(&conn).unwrap();
+        repair_legacy_ironwood_pool_migration_schema(&conn).unwrap();
+
+        assert!(ironwood_anchor_bucket_column_exists(&conn).unwrap());
+        let repaired: (i64, u32) = conn
+            .query_row(
+                "SELECT id, anchor_bucket_interval
+                 FROM orchard_ironwood_migrations",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(repaired, (7, ZIP_318_ANCHOR_BUCKET_INTERVAL));
+    }
+
+    #[test]
+    fn preserves_existing_ironwood_anchor_bucket_interval() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE orchard_ironwood_migrations (
+                 id INTEGER PRIMARY KEY,
+                 anchor_bucket_interval INTEGER NOT NULL
+             );
+             INSERT INTO orchard_ironwood_migrations
+                 (id, anchor_bucket_interval) VALUES (7, 12);",
+        )
+        .unwrap();
+
+        repair_legacy_ironwood_pool_migration_schema(&conn).unwrap();
+
+        let interval: u32 = conn
+            .query_row(
+                "SELECT anchor_bucket_interval
+                 FROM orchard_ironwood_migrations WHERE id = 7",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(interval, 12);
+    }
+
+    #[test]
+    fn legacy_ironwood_repair_is_noop_before_table_creation() {
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        repair_legacy_ironwood_pool_migration_schema(&conn).unwrap();
+        assert!(!ironwood_anchor_bucket_column_exists(&conn).unwrap());
     }
 }

--- a/scripts/test-db-upgrade-mobile-v0.0.18.sh
+++ b/scripts/test-db-upgrade-mobile-v0.0.18.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TAG_REF='mobile/v0.0.18^{}'
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vizor-db-upgrade-mobile-v0.0.18.XXXXXX")"
+OLD_WORKTREE="$TEMP_DIR/mobile-v0.0.18"
+TARGET_DIR="${CARGO_TARGET_DIR:-$ROOT_DIR/rust/target/db-upgrade-mobile-v0.0.18}"
+OLD_WORKTREE_ADDED=false
+
+cleanup() {
+  if [[ "$OLD_WORKTREE_ADDED" == true ]]; then
+    git -C "$ROOT_DIR" worktree remove --force "$OLD_WORKTREE" >/dev/null 2>&1 || true
+  fi
+  find "$TEMP_DIR" -depth -mindepth 1 -delete 2>/dev/null || true
+  rmdir "$TEMP_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+git -C "$ROOT_DIR" worktree add --detach "$OLD_WORKTREE" "$TAG_REF"
+OLD_WORKTREE_ADDED=true
+cp "$ROOT_DIR/rust/examples/db_upgrade_mobile_v0_0_18.rs" \
+  "$OLD_WORKTREE/rust/examples/db_upgrade_mobile_v0_0_18.rs"
+
+run_probe() {
+  local worktree="$1"
+  shift
+  (
+    cd "$worktree/rust"
+    CARGO_TARGET_DIR="$TARGET_DIR" \
+      cargo run --locked --quiet --example db_upgrade_mobile_v0_0_18 -- "$@"
+  )
+}
+
+for scenario in single-derived multi-seed imported-only; do
+  db_path="$TEMP_DIR/$scenario.db"
+  manifest_path="$TEMP_DIR/$scenario.json"
+
+  run_probe "$OLD_WORKTREE" create "$scenario" "$db_path" "$manifest_path"
+  run_probe "$ROOT_DIR" verify "$scenario" "$db_path" "$manifest_path"
+  run_probe "$ROOT_DIR" verify "$scenario" "$db_path" "$manifest_path"
+  run_probe "$OLD_WORKTREE" open-old "$scenario" "$db_path" "$manifest_path"
+done
+
+echo "ok: mobile/v0.0.18 database upgrade compatibility"


### PR DESCRIPTION
## Summary

- repair `mobile/v0.0.18` wallet databases whose applied Ironwood migration lacks `orchard_ironwood_migrations.anchor_bucket_interval`
- backfill the implicit ZIP 318 anchor interval (`144`) without replacing existing wallet or migration data
- add an end-to-end compatibility harness that creates databases with the exact `mobile/v0.0.18` tag, upgrades them with current code, verifies idempotency, and reopens them with the old code

## Root cause

`mobile/v0.0.18` shipped a patched `zcash_client_sqlite` schema where the Ironwood pool-migration table did not contain `anchor_bucket_interval`. The current backend expects that column, but the upstream migration UUID did not change, so `init_wallet_db` considers the migration already applied and cannot repair the schema. Current scanner/database operations can therefore fail with `no such column: anchor_bucket_interval` after an app upgrade.

## Impact

Existing mobile wallets can be opened by the current application without resetting or rebuilding the wallet database. Existing accounts, addresses, scan queues, note/transaction rows, and in-flight migration state are preserved.

## Validation

- `cd rust && cargo test --lib wallet::db::tests` — 6 passed
- `scripts/test-db-upgrade-mobile-v0.0.18.sh` — passed for single-derived, multi-seed, and imported-only wallets
- each compatibility scenario verifies two current-version opens, SQLite integrity and foreign keys, schema/data preservation, and reopening with `mobile/v0.0.18`