### PR TITLE
Improve Ironwood preparation schedule projections

### DIFF
--- a/lib/src/features/migration/screens/ironwood_migration_flow/schedule.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/schedule.dart
@@ -174,8 +174,22 @@ class _MigrationPreparationScheduleContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
     final transactions = _orderedPreparationTransactions(status);
-    final remaining = _preparationRemainingCount(status);
-    final total = _preparationTotalCount(status);
+    final rounds = _preparationRounds(transactions);
+    final currentRound = _currentPreparationRound(rounds);
+    final projectionIsRecalculating = transactions.any(
+      (transaction) =>
+          transaction.state ==
+              rust_sync.MigrationPreparationTransactionState.awaitingInputs &&
+          transaction.projectedHeight <= currentHeight,
+    );
+    final hasCompletionProjection =
+        transactions.isNotEmpty && !projectionIsRecalculating;
+    final finalProjectedHeight = transactions.fold<int>(
+      currentHeight,
+      (height, transaction) =>
+          math.max(height, transaction.projectedCompletionHeight),
+    );
+    final remainingBlocks = math.max(0, finalProjectedHeight - currentHeight);
 
     return SizedBox(
       width: 420,
@@ -183,7 +197,7 @@ class _MigrationPreparationScheduleContent extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          const SizedBox(height: 18),
+          const SizedBox(height: 34),
           Text(
             'Preparation Schedule',
             textAlign: TextAlign.center,
@@ -197,16 +211,19 @@ class _MigrationPreparationScheduleContent extends StatelessWidget {
             child: Column(
               children: [
                 _MigrationSummaryMetric(
-                  label: 'Splits remaining',
-                  value: '$remaining of $total',
+                  label: 'Current round',
+                  value: rounds.isEmpty
+                      ? 'Preparing'
+                      : '$currentRound of ${rounds.length}',
                 ),
                 const SizedBox(height: 16),
                 _MigrationSummaryMetric(
-                  label: 'Est. completion',
-                  value: _preparationCompletionEstimateDisplay(
-                    status,
-                    currentHeight,
-                  ),
+                  label: 'Ready to migrate',
+                  value: !hasCompletionProjection
+                      ? 'Calculating'
+                      : '#${formatGroupedInteger(finalProjectedHeight)}'
+                            '${remainingBlocks > 0 ? ' · ${_formatPreparationDuration(remainingBlocks)}' : ''}',
+                  valueIcon: hasCompletionProjection ? AppIcons.block : null,
                   secondary: true,
                 ),
                 const SizedBox(height: 16),
@@ -231,22 +248,22 @@ class _MigrationPreparationScheduleContent extends StatelessWidget {
                     ),
                   )
                 : Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 12),
-                    child: ListView.separated(
+                    padding: const EdgeInsets.symmetric(horizontal: 28),
+                    child: ListView.builder(
                       key: const ValueKey(
                         'ironwood_migration_preparation_schedule_list',
                       ),
-                      padding: const EdgeInsets.only(top: 8, bottom: 8),
-                      itemCount: transactions.length,
-                      separatorBuilder: (_, _) => const SizedBox(height: 8),
-                      itemBuilder: (context, index) =>
-                          _MigrationPreparationScheduleRow(
-                            key: ValueKey(
-                              'ironwood_migration_preparation_schedule_stage_${transactions[index].stageIndex}',
-                            ),
-                            number: index + 1,
-                            transaction: transactions[index],
-                          ),
+                      padding: const EdgeInsets.only(top: 4, bottom: 12),
+                      itemCount: rounds.length,
+                      itemBuilder: (context, index) => Padding(
+                        padding: EdgeInsets.only(
+                          bottom: index == rounds.length - 1 ? 0 : 20,
+                        ),
+                        child: _MigrationPreparationRoundSection(
+                          round: rounds[index],
+                          currentHeight: currentHeight,
+                        ),
+                      ),
                     ),
                   ),
           ),
@@ -256,15 +273,120 @@ class _MigrationPreparationScheduleContent extends StatelessWidget {
   }
 }
 
-class _MigrationPreparationScheduleRow extends StatelessWidget {
-  const _MigrationPreparationScheduleRow({
+typedef _NumberedPreparationTransaction = ({
+  int number,
+  rust_sync.MigrationPreparationTransactionStatus transaction,
+});
+
+class _PreparationRound {
+  const _PreparationRound({required this.number, required this.transactions});
+
+  final int number;
+  final List<_NumberedPreparationTransaction> transactions;
+}
+
+List<_PreparationRound> _preparationRounds(
+  List<rust_sync.MigrationPreparationTransactionStatus> transactions,
+) {
+  final grouped = <int, List<_NumberedPreparationTransaction>>{};
+  for (var index = 0; index < transactions.length; index++) {
+    final transaction = transactions[index];
+    grouped.putIfAbsent(transaction.round, () => []).add((
+      number: index + 1,
+      transaction: transaction,
+    ));
+  }
+  final rounds = grouped.entries.toList()
+    ..sort((a, b) => a.key.compareTo(b.key));
+  return rounds
+      .map(
+        (entry) =>
+            _PreparationRound(number: entry.key, transactions: entry.value),
+      )
+      .toList(growable: false);
+}
+
+int _currentPreparationRound(List<_PreparationRound> rounds) {
+  for (final round in rounds) {
+    if (round.transactions.any(
+      (item) =>
+          item.transaction.state !=
+          rust_sync.MigrationPreparationTransactionState.completed,
+    )) {
+      return round.number;
+    }
+  }
+  return rounds.isEmpty ? 0 : rounds.last.number;
+}
+
+class _MigrationPreparationRoundSection extends StatelessWidget {
+  const _MigrationPreparationRoundSection({
+    required this.round,
+    required this.currentHeight,
+  });
+
+  final _PreparationRound round;
+  final int currentHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final projectedHeight = round.transactions.fold<int>(
+      0,
+      (height, item) => math.max(height, item.transaction.projectedHeight),
+    );
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                'Split round ${round.number}',
+                style: AppTypography.labelLarge.copyWith(
+                  color: colors.text.accent,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+            if (projectedHeight > currentHeight)
+              Text(
+                'Expected by #${formatGroupedInteger(projectedHeight)}',
+                style: AppTypography.bodySmall.copyWith(
+                  color: colors.text.secondary,
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        for (var index = 0; index < round.transactions.length; index++) ...[
+          _MigrationPreparationStageCard(
+            key: ValueKey(
+              'ironwood_migration_preparation_schedule_stage_${round.transactions[index].transaction.stageIndex}',
+            ),
+            number: round.transactions[index].number,
+            transaction: round.transactions[index].transaction,
+            currentHeight: currentHeight,
+          ),
+          if (index != round.transactions.length - 1)
+            const SizedBox(height: 10),
+        ],
+      ],
+    );
+  }
+}
+
+class _MigrationPreparationStageCard extends StatelessWidget {
+  const _MigrationPreparationStageCard({
     required this.number,
     required this.transaction,
+    required this.currentHeight,
     super.key,
   });
 
   final int number;
   final rust_sync.MigrationPreparationTransactionStatus transaction;
+  final int currentHeight;
 
   @override
   Widget build(BuildContext context) {
@@ -272,43 +394,113 @@ class _MigrationPreparationScheduleRow extends StatelessWidget {
     return Semantics(
       label: _preparationScheduleRowSemantics(number, transaction),
       excludeSemantics: true,
-      child: SizedBox(
-        height: 56,
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: colors.background.ground,
-            borderRadius: BorderRadius.circular(AppRadii.large),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    '$number. ~${_formatZecAmountCompact(transaction.approximateValueZatoshi)} ZEC',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: AppTypography.labelLarge.copyWith(
-                      color: colors.text.accent,
-                      fontWeight: FontWeight.w500,
+      child: Column(
+        children: [
+          SizedBox(
+            height: 50,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: colors.background.ground,
+                borderRadius: BorderRadius.circular(AppRadii.medium),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        '$number. ${_formatZecAmountCompact(transaction.approximateValueZatoshi)} ZEC',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: AppTypography.labelLarge.copyWith(
+                          color: colors.text.accent,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
                     ),
-                  ),
+                    const SizedBox(width: 12),
+                    _MigrationPreparationScheduleStatus(
+                      transaction: transaction,
+                      currentHeight: currentHeight,
+                    ),
+                  ],
                 ),
-                const SizedBox(width: 12),
-                _MigrationPreparationScheduleStatus(transaction: transaction),
-              ],
+              ),
             ),
           ),
-        ),
+          if (transaction.outputs.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 6, 12, 0),
+              child: Column(
+                children: [
+                  for (final output in transaction.outputs)
+                    _MigrationPreparationOutputRow(output: output),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MigrationPreparationOutputRow extends StatelessWidget {
+  const _MigrationPreparationOutputRow({required this.output});
+
+  final rust_sync.MigrationPreparationOutputStatus output;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final destination = switch (output.kind) {
+      rust_sync.MigrationPreparationOutputKind.migration => 'Final',
+      rust_sync.MigrationPreparationOutputKind.change => 'Stays in Orchard',
+      rust_sync.MigrationPreparationOutputKind.continuation =>
+        'Used in round ${output.nextRound ?? 1}',
+    };
+    return SizedBox(
+      height: 26,
+      child: Row(
+        children: [
+          Text(
+            '↳',
+            style: AppTypography.bodyMedium.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              '${_formatZecAmountCompact(output.valueZatoshi)} ZEC',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.bodyMedium.copyWith(
+                color: colors.text.accent,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Text(
+            destination,
+            textAlign: TextAlign.right,
+            style: AppTypography.bodySmall.copyWith(
+              color: colors.text.secondary,
+            ),
+          ),
+        ],
       ),
     );
   }
 }
 
 class _MigrationPreparationScheduleStatus extends StatelessWidget {
-  const _MigrationPreparationScheduleStatus({required this.transaction});
+  const _MigrationPreparationScheduleStatus({
+    required this.transaction,
+    required this.currentHeight,
+  });
 
   final rust_sync.MigrationPreparationTransactionStatus transaction;
+  final int currentHeight;
 
   @override
   Widget build(BuildContext context) {
@@ -321,16 +513,22 @@ class _MigrationPreparationScheduleStatus extends StatelessWidget {
         state == rust_sync.MigrationPreparationTransactionState.completed;
     final awaiting =
         state == rust_sync.MigrationPreparationTransactionState.awaitingInputs;
-    final height =
-        completed ||
-            state == rust_sync.MigrationPreparationTransactionState.confirming
-        ? transaction.minedHeight
-        : transaction.scheduledHeight;
-    final label = height == null
-        ? awaiting
-              ? 'Pending'
-              : 'Due now'
-        : formatGroupedInteger(height);
+    final overdueForecast =
+        awaiting && transaction.projectedHeight <= currentHeight;
+    final label = switch (state) {
+      rust_sync.MigrationPreparationTransactionState.completed => 'Completed',
+      rust_sync.MigrationPreparationTransactionState.confirming =>
+        '${transaction.confirmationCount} of '
+            '${transaction.confirmationTarget} confirmations',
+      rust_sync.MigrationPreparationTransactionState.broadcasted =>
+        'Broadcasting',
+      rust_sync.MigrationPreparationTransactionState.scheduled =>
+        '#${formatGroupedInteger(transaction.projectedHeight)}',
+      rust_sync.MigrationPreparationTransactionState.awaitingInputs =>
+        overdueForecast
+            ? 'Recalculating'
+            : 'Expected #${formatGroupedInteger(transaction.projectedHeight)}',
+    };
     final style = AppTypography.labelLarge.copyWith(
       color: completed
           ? colors.text.positiveStrong
@@ -376,24 +574,56 @@ class _MigrationPreparationScheduleStatus extends StatelessWidget {
   }
 }
 
+String _formatPreparationDuration(int blocks) {
+  final minutes =
+      (blocks * _migrationEstimatedSecondsPerBlock / Duration.secondsPerMinute)
+          .ceil();
+  if (minutes < 60) return minutes == 1 ? '~1 min' : '~$minutes mins';
+  final halfHours = (minutes / 30).ceil();
+  final wholeHours = halfHours ~/ 2;
+  if (halfHours.isEven) {
+    return wholeHours == 1 ? '~1 hr' : '~$wholeHours hrs';
+  }
+  return '~$wholeHours.5 hrs';
+}
+
 String _preparationScheduleRowSemantics(
   int number,
   rust_sync.MigrationPreparationTransactionStatus transaction,
 ) {
   final state = switch (transaction.state) {
     rust_sync.MigrationPreparationTransactionState.awaitingInputs =>
-      'waiting for previous split',
-    rust_sync.MigrationPreparationTransactionState.scheduled => 'scheduled',
+      'waiting for previous split, expected at block '
+          '${transaction.projectedHeight}',
+    rust_sync.MigrationPreparationTransactionState.scheduled =>
+      'scheduled at block ${transaction.projectedHeight}',
     rust_sync.MigrationPreparationTransactionState.broadcasted =>
-      'broadcast, waiting to be mined',
+      'broadcast, waiting to be mined, projected completion at block '
+          '${transaction.projectedCompletionHeight}',
     rust_sync.MigrationPreparationTransactionState.confirming =>
       'confirming, ${transaction.confirmationCount} of '
-          '${transaction.confirmationTarget} confirmations',
-    rust_sync.MigrationPreparationTransactionState.completed => 'completed',
+          '${transaction.confirmationTarget} confirmations, projected '
+          'completion at block ${transaction.projectedCompletionHeight}',
+    rust_sync.MigrationPreparationTransactionState.completed =>
+      'completed${transaction.minedHeight == null ? '' : ' at block ${transaction.minedHeight}'}',
   };
-  return 'Split $number, approximately '
-      '${_formatZecAmountCompact(transaction.approximateValueZatoshi)} ZEC, '
-      '$state.';
+  final outputs = transaction.outputs
+      .map((output) {
+        final destination = switch (output.kind) {
+          rust_sync.MigrationPreparationOutputKind.migration => 'final',
+          rust_sync.MigrationPreparationOutputKind.change => 'stays in Orchard',
+          rust_sync.MigrationPreparationOutputKind.continuation =>
+            'used in round ${output.nextRound ?? 1}',
+        };
+        return '${_formatZecAmountCompact(output.valueZatoshi)} ZEC, $destination';
+      })
+      .join('; ');
+  return [
+    'Split $number, '
+        '${_formatZecAmountCompact(transaction.approximateValueZatoshi)} ZEC, '
+        '$state.',
+    if (outputs.isNotEmpty) 'Outputs: $outputs.',
+  ].join(' ');
 }
 
 class _MigrationScheduleErrorContent extends StatelessWidget {

--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -727,9 +727,9 @@ List<rust_sync.MigrationPreparationTransactionStatus>
 _orderedPreparationTransactions(rust_sync.MigrationStatus status) {
   final transactions = [..._preparationTransactions(status)];
   transactions.sort((a, b) {
-    final heightCompare = (a.scheduledHeight ?? 0x7fffffff).compareTo(
-      b.scheduledHeight ?? 0x7fffffff,
-    );
+    final roundCompare = a.round.compareTo(b.round);
+    if (roundCompare != 0) return roundCompare;
+    final heightCompare = a.projectedHeight.compareTo(b.projectedHeight);
     return heightCompare != 0
         ? heightCompare
         : a.stageIndex.compareTo(b.stageIndex);
@@ -760,34 +760,11 @@ String _preparationCompletionEstimateDisplay(
     return _formatMigrationBlockDurationEstimate(remainingBlocks);
   }
 
-  var projectedHeight = currentHeight;
-  for (final transaction in transactions) {
-    final int transactionCompletionHeight = switch (transaction.state) {
-      rust_sync.MigrationPreparationTransactionState.awaitingInputs ||
-      rust_sync.MigrationPreparationTransactionState.completed => currentHeight,
-      rust_sync.MigrationPreparationTransactionState.scheduled =>
-        math.max(currentHeight, transaction.scheduledHeight ?? currentHeight) +
-            confirmationTarget,
-      rust_sync.MigrationPreparationTransactionState.broadcasted =>
-        currentHeight + confirmationTarget,
-      rust_sync.MigrationPreparationTransactionState.confirming =>
-        currentHeight +
-            math.max(
-              0,
-              transaction.confirmationTarget - transaction.confirmationCount,
-            ),
-    };
-    projectedHeight = math.max(projectedHeight, transactionCompletionHeight);
-  }
-
-  final awaitingInputCount = transactions
-      .where(
-        (item) =>
-            item.state ==
-            rust_sync.MigrationPreparationTransactionState.awaitingInputs,
-      )
-      .length;
-  projectedHeight += awaitingInputCount * (meanDelay + confirmationTarget);
+  final projectedHeight = transactions.fold<int>(
+    currentHeight,
+    (height, transaction) =>
+        math.max(height, transaction.projectedCompletionHeight),
+  );
   final remainingBlocks = math.max(1, projectedHeight - currentHeight);
   return _formatMigrationBlockDurationEstimate(remainingBlocks);
 }

--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -374,12 +374,22 @@ class _MigrationLiveStatusContent extends StatelessWidget {
                                 ),
                               ),
                               const SizedBox(height: 6),
-                              Text(
-                                preparationPresentation.splitLabel,
-                                textAlign: TextAlign.center,
-                                style: AppTypography.labelLarge.copyWith(
-                                  color: colors.text.primary,
-                                  fontWeight: FontWeight.w400,
+                              ConstrainedBox(
+                                constraints: const BoxConstraints(
+                                  maxWidth: 208,
+                                ),
+                                child: FittedBox(
+                                  fit: BoxFit.scaleDown,
+                                  child: Text(
+                                    preparationPresentation.splitLabel,
+                                    maxLines: 1,
+                                    softWrap: false,
+                                    textAlign: TextAlign.center,
+                                    style: AppTypography.labelLarge.copyWith(
+                                      color: colors.text.primary,
+                                      fontWeight: FontWeight.w400,
+                                    ),
+                                  ),
                                 ),
                               ),
                               const SizedBox(height: 6),
@@ -479,9 +489,8 @@ class _MigrationLiveStatusContent extends StatelessWidget {
                     ? Column(
                         children: [
                           _MigrationSummaryMetric(
-                            label: 'Splits remaining',
-                            value:
-                                '${_preparationRemainingCount(status)} of ${_preparationTotalCount(status)}',
+                            label: 'Overall progress',
+                            value: _overallPreparationProgressDisplay(status),
                           ),
                           const SizedBox(height: 16),
                           _MigrationSummaryMetric(
@@ -616,7 +625,8 @@ _PreparationRingPresentation _preparationRingPresentation(
   rust_sync.MigrationStatus status,
 ) {
   final transactions = _orderedPreparationTransactions(status);
-  final total = _preparationTotalCount(status);
+  final preparationTotal = _preparationTotalCount(status);
+  final overallTotal = _overallTransactionTotalCount(status);
   final completed = _preparationCompletedCount(status);
   rust_sync.MigrationPreparationTransactionStatus? selected;
   for (final state in const [
@@ -642,14 +652,17 @@ _PreparationRingPresentation _preparationRingPresentation(
 
   if (selected == null) {
     return _PreparationRingPresentation(
-      label: completed >= total && total > 0
+      label: completed >= preparationTotal && preparationTotal > 0
           ? 'Preparation complete'
           : 'Next split',
-      splitLabel: total > 0
-          ? 'Split ${math.min(completed + 1, total)} of $total'
+      splitLabel: preparationTotal > 0
+          ? _overallTransactionOrdinalDisplay(
+              math.min(completed + 1, preparationTotal),
+              overallTotal,
+            )
           : 'Preparing schedule',
       amount: _sumTargetValues(status),
-      detail: completed >= total && total > 0
+      detail: completed >= preparationTotal && preparationTotal > 0
           ? 'All splits completed'
           : 'Schedule pending',
     );
@@ -661,7 +674,7 @@ _PreparationRingPresentation _preparationRingPresentation(
     rust_sync.MigrationPreparationTransactionState.scheduled =>
       _PreparationRingPresentation(
         label: 'Next split',
-        splitLabel: 'Split $ordinal of $total',
+        splitLabel: _overallTransactionOrdinalDisplay(ordinal, overallTotal),
         amount: amount,
         detail: selected.scheduledHeight == null ? 'Due now' : 'Scheduled',
         height: selected.scheduledHeight,
@@ -669,7 +682,7 @@ _PreparationRingPresentation _preparationRingPresentation(
     rust_sync.MigrationPreparationTransactionState.broadcasted =>
       _PreparationRingPresentation(
         label: 'Split in progress',
-        splitLabel: 'Split $ordinal of $total',
+        splitLabel: _overallTransactionOrdinalDisplay(ordinal, overallTotal),
         amount: amount,
         detail: 'Waiting for block',
         height: selected.scheduledHeight,
@@ -678,7 +691,7 @@ _PreparationRingPresentation _preparationRingPresentation(
     rust_sync.MigrationPreparationTransactionState.confirming =>
       _PreparationRingPresentation(
         label: 'Confirming split',
-        splitLabel: 'Split $ordinal of $total',
+        splitLabel: _overallTransactionOrdinalDisplay(ordinal, overallTotal),
         amount: amount,
         detail:
             '${selected.confirmationCount} of ${selected.confirmationTarget} confirmations',
@@ -688,14 +701,14 @@ _PreparationRingPresentation _preparationRingPresentation(
     rust_sync.MigrationPreparationTransactionState.awaitingInputs =>
       _PreparationRingPresentation(
         label: 'Next split',
-        splitLabel: 'Split $ordinal of $total',
+        splitLabel: _overallTransactionOrdinalDisplay(ordinal, overallTotal),
         amount: amount,
         detail: 'Waiting for previous split',
       ),
     rust_sync.MigrationPreparationTransactionState.completed =>
       _PreparationRingPresentation(
         label: 'Preparation complete',
-        splitLabel: 'Split $ordinal of $total',
+        splitLabel: _overallTransactionOrdinalDisplay(ordinal, overallTotal),
         amount: amount,
         detail: 'All splits completed',
         height: selected.minedHeight,
@@ -741,6 +754,29 @@ int _preparationRemainingCount(rust_sync.MigrationStatus status) => math.max(
   0,
   _preparationTotalCount(status) - _preparationCompletedCount(status),
 );
+
+int? _overallTransactionTotalCount(rust_sync.MigrationStatus status) {
+  final migrationTotal = status.totalCount;
+  if (migrationTotal <= 0) return null;
+  return _preparationTotalCount(status) + migrationTotal;
+}
+
+int _overallCompletedTransactionCount(rust_sync.MigrationStatus status) {
+  final completedMigrations = status.parts
+      .where((part) => part.state == rust_sync.MigrationPartState.completed)
+      .length;
+  return _preparationCompletedCount(status) + completedMigrations;
+}
+
+String _overallTransactionOrdinalDisplay(int ordinal, int? total) =>
+    total == null ? 'Transaction $ordinal' : 'Transaction $ordinal of $total';
+
+String _overallPreparationProgressDisplay(rust_sync.MigrationStatus status) {
+  final total = _overallTransactionTotalCount(status);
+  if (total == null) return 'Calculating total';
+  final completed = math.min(total, _overallCompletedTransactionCount(status));
+  return '$completed of $total complete';
+}
 
 String _preparationCompletionEstimateDisplay(
   rust_sync.MigrationStatus status,
@@ -1040,7 +1076,19 @@ class _MigrationSummaryMetric extends StatelessWidget {
           AppIcon(valueIcon!, size: 16, color: context.colors.icon.regular),
           const SizedBox(width: 4),
         ],
-        Text(value, textAlign: TextAlign.right, style: style),
+        Flexible(
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.centerRight,
+            child: Text(
+              value,
+              maxLines: 1,
+              softWrap: false,
+              textAlign: TextAlign.right,
+              style: style,
+            ),
+          ),
+        ),
       ],
     );
   }

--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -761,20 +761,15 @@ int? _overallTransactionTotalCount(rust_sync.MigrationStatus status) {
   return _preparationTotalCount(status) + migrationTotal;
 }
 
-int _overallCompletedTransactionCount(rust_sync.MigrationStatus status) {
-  final completedMigrations = status.parts
-      .where((part) => part.state == rust_sync.MigrationPartState.completed)
-      .length;
-  return _preparationCompletedCount(status) + completedMigrations;
-}
-
 String _overallTransactionOrdinalDisplay(int ordinal, int? total) =>
     total == null ? 'Transaction $ordinal' : 'Transaction $ordinal of $total';
 
 String _overallPreparationProgressDisplay(rust_sync.MigrationStatus status) {
   final total = _overallTransactionTotalCount(status);
   if (total == null) return 'Calculating total';
-  final completed = math.min(total, _overallCompletedTransactionCount(status));
+  // During preparation, completed parts are prepared Orchard notes rather
+  // than completed Orchard-to-Ironwood transfers.
+  final completed = math.min(total, _preparationCompletedCount(status));
   return '$completed of $total complete';
 }
 

--- a/lib/src/rust/api/sync.dart
+++ b/lib/src/rust/api/sync.dart
@@ -1452,6 +1452,33 @@ class MigrationPartStatus {
           confirmationTarget == other.confirmationTarget;
 }
 
+enum MigrationPreparationOutputKind { migration, change, continuation }
+
+class MigrationPreparationOutputStatus {
+  final BigInt valueZatoshi;
+  final MigrationPreparationOutputKind kind;
+  final int? nextRound;
+
+  const MigrationPreparationOutputStatus({
+    required this.valueZatoshi,
+    required this.kind,
+    this.nextRound,
+  });
+
+  @override
+  int get hashCode =>
+      valueZatoshi.hashCode ^ kind.hashCode ^ nextRound.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MigrationPreparationOutputStatus &&
+          runtimeType == other.runtimeType &&
+          valueZatoshi == other.valueZatoshi &&
+          kind == other.kind &&
+          nextRound == other.nextRound;
+}
+
 enum MigrationPreparationTransactionState {
   awaitingInputs,
   scheduled,
@@ -1463,6 +1490,12 @@ enum MigrationPreparationTransactionState {
 class MigrationPreparationTransactionStatus {
   final int stageIndex;
   final BigInt approximateValueZatoshi;
+  final int round;
+  final BigInt feeZatoshi;
+  final int plannedHeight;
+  final int projectedHeight;
+  final int projectedCompletionHeight;
+  final List<MigrationPreparationOutputStatus> outputs;
   final MigrationPreparationTransactionState state;
   final int? scheduledHeight;
   final int? minedHeight;
@@ -1472,6 +1505,12 @@ class MigrationPreparationTransactionStatus {
   const MigrationPreparationTransactionStatus({
     required this.stageIndex,
     required this.approximateValueZatoshi,
+    required this.round,
+    required this.feeZatoshi,
+    required this.plannedHeight,
+    required this.projectedHeight,
+    required this.projectedCompletionHeight,
+    required this.outputs,
     required this.state,
     this.scheduledHeight,
     this.minedHeight,
@@ -1483,6 +1522,12 @@ class MigrationPreparationTransactionStatus {
   int get hashCode =>
       stageIndex.hashCode ^
       approximateValueZatoshi.hashCode ^
+      round.hashCode ^
+      feeZatoshi.hashCode ^
+      plannedHeight.hashCode ^
+      projectedHeight.hashCode ^
+      projectedCompletionHeight.hashCode ^
+      outputs.hashCode ^
       state.hashCode ^
       scheduledHeight.hashCode ^
       minedHeight.hashCode ^
@@ -1496,6 +1541,12 @@ class MigrationPreparationTransactionStatus {
           runtimeType == other.runtimeType &&
           stageIndex == other.stageIndex &&
           approximateValueZatoshi == other.approximateValueZatoshi &&
+          round == other.round &&
+          feeZatoshi == other.feeZatoshi &&
+          plannedHeight == other.plannedHeight &&
+          projectedHeight == other.projectedHeight &&
+          projectedCompletionHeight == other.projectedCompletionHeight &&
+          outputs == other.outputs &&
           state == other.state &&
           scheduledHeight == other.scheduledHeight &&
           minedHeight == other.minedHeight &&

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -8599,6 +8599,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<MigrationPreparationOutputStatus>
+  dco_decode_list_migration_preparation_output_status(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>)
+        .map(dco_decode_migration_preparation_output_status)
+        .toList();
+  }
+
+  @protected
   List<MigrationPreparationTransactionStatus>
   dco_decode_list_migration_preparation_transaction_status(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -8889,6 +8898,28 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  MigrationPreparationOutputKind dco_decode_migration_preparation_output_kind(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return MigrationPreparationOutputKind.values[raw as int];
+  }
+
+  @protected
+  MigrationPreparationOutputStatus
+  dco_decode_migration_preparation_output_status(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return MigrationPreparationOutputStatus(
+      valueZatoshi: dco_decode_u_64(arr[0]),
+      kind: dco_decode_migration_preparation_output_kind(arr[1]),
+      nextRound: dco_decode_opt_box_autoadd_u_32(arr[2]),
+    );
+  }
+
+  @protected
   MigrationPreparationTransactionState
   dco_decode_migration_preparation_transaction_state(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -8900,16 +8931,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   dco_decode_migration_preparation_transaction_status(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 7)
-      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
+    if (arr.length != 13)
+      throw Exception('unexpected arr length: expect 13 but see ${arr.length}');
     return MigrationPreparationTransactionStatus(
       stageIndex: dco_decode_u_32(arr[0]),
       approximateValueZatoshi: dco_decode_u_64(arr[1]),
-      state: dco_decode_migration_preparation_transaction_state(arr[2]),
-      scheduledHeight: dco_decode_opt_box_autoadd_u_32(arr[3]),
-      minedHeight: dco_decode_opt_box_autoadd_u_32(arr[4]),
-      confirmationCount: dco_decode_u_32(arr[5]),
-      confirmationTarget: dco_decode_u_32(arr[6]),
+      round: dco_decode_u_32(arr[2]),
+      feeZatoshi: dco_decode_u_64(arr[3]),
+      plannedHeight: dco_decode_u_32(arr[4]),
+      projectedHeight: dco_decode_u_32(arr[5]),
+      projectedCompletionHeight: dco_decode_u_32(arr[6]),
+      outputs: dco_decode_list_migration_preparation_output_status(arr[7]),
+      state: dco_decode_migration_preparation_transaction_state(arr[8]),
+      scheduledHeight: dco_decode_opt_box_autoadd_u_32(arr[9]),
+      minedHeight: dco_decode_opt_box_autoadd_u_32(arr[10]),
+      confirmationCount: dco_decode_u_32(arr[11]),
+      confirmationTarget: dco_decode_u_32(arr[12]),
     );
   }
 
@@ -11052,6 +11089,21 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<MigrationPreparationOutputStatus>
+  sse_decode_list_migration_preparation_output_status(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <MigrationPreparationOutputStatus>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_migration_preparation_output_status(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
   List<MigrationPreparationTransactionStatus>
   sse_decode_list_migration_preparation_transaction_status(
     SseDeserializer deserializer,
@@ -11503,6 +11555,29 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  MigrationPreparationOutputKind sse_decode_migration_preparation_output_kind(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_32(deserializer);
+    return MigrationPreparationOutputKind.values[inner];
+  }
+
+  @protected
+  MigrationPreparationOutputStatus
+  sse_decode_migration_preparation_output_status(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_valueZatoshi = sse_decode_u_64(deserializer);
+    var var_kind = sse_decode_migration_preparation_output_kind(deserializer);
+    var var_nextRound = sse_decode_opt_box_autoadd_u_32(deserializer);
+    return MigrationPreparationOutputStatus(
+      valueZatoshi: var_valueZatoshi,
+      kind: var_kind,
+      nextRound: var_nextRound,
+    );
+  }
+
+  @protected
   MigrationPreparationTransactionState
   sse_decode_migration_preparation_transaction_state(
     SseDeserializer deserializer,
@@ -11520,6 +11595,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     var var_stageIndex = sse_decode_u_32(deserializer);
     var var_approximateValueZatoshi = sse_decode_u_64(deserializer);
+    var var_round = sse_decode_u_32(deserializer);
+    var var_feeZatoshi = sse_decode_u_64(deserializer);
+    var var_plannedHeight = sse_decode_u_32(deserializer);
+    var var_projectedHeight = sse_decode_u_32(deserializer);
+    var var_projectedCompletionHeight = sse_decode_u_32(deserializer);
+    var var_outputs = sse_decode_list_migration_preparation_output_status(
+      deserializer,
+    );
     var var_state = sse_decode_migration_preparation_transaction_state(
       deserializer,
     );
@@ -11530,6 +11613,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return MigrationPreparationTransactionStatus(
       stageIndex: var_stageIndex,
       approximateValueZatoshi: var_approximateValueZatoshi,
+      round: var_round,
+      feeZatoshi: var_feeZatoshi,
+      plannedHeight: var_plannedHeight,
+      projectedHeight: var_projectedHeight,
+      projectedCompletionHeight: var_projectedCompletionHeight,
+      outputs: var_outputs,
       state: var_state,
       scheduledHeight: var_scheduledHeight,
       minedHeight: var_minedHeight,
@@ -13803,6 +13892,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_migration_preparation_output_status(
+    List<MigrationPreparationOutputStatus> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_migration_preparation_output_status(item, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_list_migration_preparation_transaction_status(
     List<MigrationPreparationTransactionStatus> self,
     SseSerializer serializer,
@@ -14199,6 +14300,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_migration_preparation_output_kind(
+    MigrationPreparationOutputKind self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.index, serializer);
+  }
+
+  @protected
+  void sse_encode_migration_preparation_output_status(
+    MigrationPreparationOutputStatus self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_u_64(self.valueZatoshi, serializer);
+    sse_encode_migration_preparation_output_kind(self.kind, serializer);
+    sse_encode_opt_box_autoadd_u_32(self.nextRound, serializer);
+  }
+
+  @protected
   void sse_encode_migration_preparation_transaction_state(
     MigrationPreparationTransactionState self,
     SseSerializer serializer,
@@ -14215,6 +14336,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_u_32(self.stageIndex, serializer);
     sse_encode_u_64(self.approximateValueZatoshi, serializer);
+    sse_encode_u_32(self.round, serializer);
+    sse_encode_u_64(self.feeZatoshi, serializer);
+    sse_encode_u_32(self.plannedHeight, serializer);
+    sse_encode_u_32(self.projectedHeight, serializer);
+    sse_encode_u_32(self.projectedCompletionHeight, serializer);
+    sse_encode_list_migration_preparation_output_status(
+      self.outputs,
+      serializer,
+    );
     sse_encode_migration_preparation_transaction_state(self.state, serializer);
     sse_encode_opt_box_autoadd_u_32(self.scheduledHeight, serializer);
     sse_encode_opt_box_autoadd_u_32(self.minedHeight, serializer);

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -335,6 +335,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<MigrationPartStatus> dco_decode_list_migration_part_status(dynamic raw);
 
   @protected
+  List<MigrationPreparationOutputStatus>
+  dco_decode_list_migration_preparation_output_status(dynamic raw);
+
+  @protected
   List<MigrationPreparationTransactionStatus>
   dco_decode_list_migration_preparation_transaction_status(dynamic raw);
 
@@ -455,6 +459,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   MigrationPartStatus dco_decode_migration_part_status(dynamic raw);
+
+  @protected
+  MigrationPreparationOutputKind dco_decode_migration_preparation_output_kind(
+    dynamic raw,
+  );
+
+  @protected
+  MigrationPreparationOutputStatus
+  dco_decode_migration_preparation_output_status(dynamic raw);
 
   @protected
   MigrationPreparationTransactionState
@@ -1116,6 +1129,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  List<MigrationPreparationOutputStatus>
+  sse_decode_list_migration_preparation_output_status(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<MigrationPreparationTransactionStatus>
   sse_decode_list_migration_preparation_transaction_status(
     SseDeserializer deserializer,
@@ -1266,6 +1285,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   MigrationPartStatus sse_decode_migration_part_status(
     SseDeserializer deserializer,
   );
+
+  @protected
+  MigrationPreparationOutputKind sse_decode_migration_preparation_output_kind(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  MigrationPreparationOutputStatus
+  sse_decode_migration_preparation_output_status(SseDeserializer deserializer);
 
   @protected
   MigrationPreparationTransactionState
@@ -2070,6 +2098,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_migration_preparation_output_status(
+    List<MigrationPreparationOutputStatus> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_migration_preparation_transaction_status(
     List<MigrationPreparationTransactionStatus> self,
     SseSerializer serializer,
@@ -2261,6 +2295,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_migration_part_status(
     MigrationPartStatus self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_migration_preparation_output_kind(
+    MigrationPreparationOutputKind self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_migration_preparation_output_status(
+    MigrationPreparationOutputStatus self,
     SseSerializer serializer,
   );
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -337,6 +337,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<MigrationPartStatus> dco_decode_list_migration_part_status(dynamic raw);
 
   @protected
+  List<MigrationPreparationOutputStatus>
+  dco_decode_list_migration_preparation_output_status(dynamic raw);
+
+  @protected
   List<MigrationPreparationTransactionStatus>
   dco_decode_list_migration_preparation_transaction_status(dynamic raw);
 
@@ -457,6 +461,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   MigrationPartStatus dco_decode_migration_part_status(dynamic raw);
+
+  @protected
+  MigrationPreparationOutputKind dco_decode_migration_preparation_output_kind(
+    dynamic raw,
+  );
+
+  @protected
+  MigrationPreparationOutputStatus
+  dco_decode_migration_preparation_output_status(dynamic raw);
 
   @protected
   MigrationPreparationTransactionState
@@ -1118,6 +1131,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  List<MigrationPreparationOutputStatus>
+  sse_decode_list_migration_preparation_output_status(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   List<MigrationPreparationTransactionStatus>
   sse_decode_list_migration_preparation_transaction_status(
     SseDeserializer deserializer,
@@ -1268,6 +1287,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   MigrationPartStatus sse_decode_migration_part_status(
     SseDeserializer deserializer,
   );
+
+  @protected
+  MigrationPreparationOutputKind sse_decode_migration_preparation_output_kind(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  MigrationPreparationOutputStatus
+  sse_decode_migration_preparation_output_status(SseDeserializer deserializer);
 
   @protected
   MigrationPreparationTransactionState
@@ -2072,6 +2100,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_migration_preparation_output_status(
+    List<MigrationPreparationOutputStatus> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void sse_encode_list_migration_preparation_transaction_status(
     List<MigrationPreparationTransactionStatus> self,
     SseSerializer serializer,
@@ -2263,6 +2297,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_migration_part_status(
     MigrationPartStatus self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_migration_preparation_output_kind(
+    MigrationPreparationOutputKind self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_migration_preparation_output_status(
+    MigrationPreparationOutputStatus self,
     SseSerializer serializer,
   );
 

--- a/lib/widgetbook/screen_use_cases.dart
+++ b/lib/widgetbook/screen_use_cases.dart
@@ -3074,6 +3074,43 @@ rust_sync.MigrationStatus _previewMobileHomeMigrationStatus() {
   );
 }
 
+rust_sync.MigrationPreparationOutputStatus _previewPreparationOutput(
+  int valueZatoshi,
+  rust_sync.MigrationPreparationOutputKind kind, {
+  int? nextRound,
+}) => rust_sync.MigrationPreparationOutputStatus(
+  valueZatoshi: BigInt.from(valueZatoshi),
+  kind: kind,
+  nextRound: nextRound,
+);
+
+rust_sync.MigrationPreparationTransactionStatus _previewPreparationTransaction({
+  required int stageIndex,
+  required int valueZatoshi,
+  required int round,
+  required int plannedHeight,
+  required int projectedHeight,
+  required rust_sync.MigrationPreparationTransactionState state,
+  required List<rust_sync.MigrationPreparationOutputStatus> outputs,
+  int? scheduledHeight,
+  int? minedHeight,
+  int confirmationCount = 0,
+}) => rust_sync.MigrationPreparationTransactionStatus(
+  stageIndex: stageIndex,
+  approximateValueZatoshi: BigInt.from(valueZatoshi),
+  round: round,
+  feeZatoshi: BigInt.from(10_000),
+  plannedHeight: plannedHeight,
+  projectedHeight: projectedHeight,
+  projectedCompletionHeight: (minedHeight ?? projectedHeight) + 3,
+  outputs: outputs,
+  state: state,
+  scheduledHeight: scheduledHeight,
+  minedHeight: minedHeight,
+  confirmationCount: confirmationCount,
+  confirmationTarget: 3,
+);
+
 rust_sync.MigrationStatus _previewPrivateMigrationStatus() {
   return rust_sync.MigrationStatus(
     phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
@@ -3104,53 +3141,106 @@ rust_sync.MigrationStatus _previewPrivateMigrationStatus() {
     preparationMeanDelayBlocks: 24,
     scheduledBroadcasts: const [],
     preparationTransactions: [
-      rust_sync.MigrationPreparationTransactionStatus(
+      _previewPreparationTransaction(
         stageIndex: 0,
-        approximateValueZatoshi: BigInt.from(14_220_000_000),
+        valueZatoshi: 14_220_000_000,
+        round: 1,
+        plannedHeight: 2_999_712,
+        projectedHeight: 2_999_716,
         state: rust_sync.MigrationPreparationTransactionState.completed,
         scheduledHeight: 2_999_712,
         minedHeight: 2_999_716,
         confirmationCount: 3,
-        confirmationTarget: 3,
+        outputs: [
+          _previewPreparationOutput(
+            10_000_000_000,
+            rust_sync.MigrationPreparationOutputKind.continuation,
+            nextRound: 2,
+          ),
+          _previewPreparationOutput(
+            4_219_990_000,
+            rust_sync.MigrationPreparationOutputKind.migration,
+          ),
+        ],
       ),
-      rust_sync.MigrationPreparationTransactionStatus(
+      _previewPreparationTransaction(
         stageIndex: 1,
-        approximateValueZatoshi: BigInt.from(8_000_000_000),
+        valueZatoshi: 8_000_000_000,
+        round: 1,
+        plannedHeight: 2_999_856,
+        projectedHeight: 2_999_998,
         state: rust_sync.MigrationPreparationTransactionState.confirming,
         scheduledHeight: 2_999_856,
         minedHeight: 2_999_998,
         confirmationCount: 2,
-        confirmationTarget: 3,
+        outputs: [
+          _previewPreparationOutput(
+            5_000_000_000,
+            rust_sync.MigrationPreparationOutputKind.migration,
+          ),
+          _previewPreparationOutput(
+            2_999_990_000,
+            rust_sync.MigrationPreparationOutputKind.change,
+          ),
+        ],
       ),
-      rust_sync.MigrationPreparationTransactionStatus(
+      _previewPreparationTransaction(
         stageIndex: 2,
-        approximateValueZatoshi: BigInt.from(4_000_000_000),
+        valueZatoshi: 4_000_000_000,
+        round: 1,
+        plannedHeight: 3_000_000,
+        projectedHeight: 3_000_000,
         state: rust_sync.MigrationPreparationTransactionState.broadcasted,
         scheduledHeight: 3_000_000,
-        confirmationCount: 0,
-        confirmationTarget: 3,
+        outputs: [
+          _previewPreparationOutput(
+            3_999_990_000,
+            rust_sync.MigrationPreparationOutputKind.migration,
+          ),
+        ],
       ),
-      rust_sync.MigrationPreparationTransactionStatus(
+      _previewPreparationTransaction(
         stageIndex: 3,
-        approximateValueZatoshi: BigInt.from(2_000_000_000),
+        valueZatoshi: 2_000_000_000,
+        round: 1,
+        plannedHeight: 3_000_144,
+        projectedHeight: 3_000_144,
         state: rust_sync.MigrationPreparationTransactionState.scheduled,
         scheduledHeight: 3_000_144,
-        confirmationCount: 0,
-        confirmationTarget: 3,
+        outputs: [
+          _previewPreparationOutput(
+            1_999_990_000,
+            rust_sync.MigrationPreparationOutputKind.migration,
+          ),
+        ],
       ),
-      rust_sync.MigrationPreparationTransactionStatus(
+      _previewPreparationTransaction(
         stageIndex: 4,
-        approximateValueZatoshi: BigInt.from(1_000_000_000),
+        valueZatoshi: 10_000_000_000,
+        round: 2,
+        plannedHeight: 3_000_171,
+        projectedHeight: 3_000_171,
         state: rust_sync.MigrationPreparationTransactionState.awaitingInputs,
-        confirmationCount: 0,
-        confirmationTarget: 3,
+        outputs: [
+          _previewPreparationOutput(
+            9_999_990_000,
+            rust_sync.MigrationPreparationOutputKind.migration,
+          ),
+        ],
       ),
-      rust_sync.MigrationPreparationTransactionStatus(
+      _previewPreparationTransaction(
         stageIndex: 5,
-        approximateValueZatoshi: BigInt.from(500_000_000),
+        valueZatoshi: 500_000_000,
+        round: 2,
+        plannedHeight: 3_000_195,
+        projectedHeight: 3_000_195,
         state: rust_sync.MigrationPreparationTransactionState.awaitingInputs,
-        confirmationCount: 0,
-        confirmationTarget: 3,
+        outputs: [
+          _previewPreparationOutput(
+            499_990_000,
+            rust_sync.MigrationPreparationOutputKind.change,
+          ),
+        ],
       ),
     ],
     parts: const [],

--- a/rust/src/api/sync.rs
+++ b/rust/src/api/sync.rs
@@ -767,9 +767,27 @@ pub enum MigrationPreparationTransactionState {
     Completed,
 }
 
+pub enum MigrationPreparationOutputKind {
+    Migration,
+    Change,
+    Continuation,
+}
+
+pub struct MigrationPreparationOutputStatus {
+    pub value_zatoshi: u64,
+    pub kind: MigrationPreparationOutputKind,
+    pub next_round: Option<u32>,
+}
+
 pub struct MigrationPreparationTransactionStatus {
     pub stage_index: u32,
     pub approximate_value_zatoshi: u64,
+    pub round: u32,
+    pub fee_zatoshi: u64,
+    pub planned_height: u32,
+    pub projected_height: u32,
+    pub projected_completion_height: u32,
+    pub outputs: Vec<MigrationPreparationOutputStatus>,
     pub state: MigrationPreparationTransactionState,
     pub scheduled_height: Option<u32>,
     pub mined_height: Option<u32>,
@@ -1317,6 +1335,30 @@ pub fn get_orchard_migration_status(
                     .map(|transaction| MigrationPreparationTransactionStatus {
                         stage_index: transaction.stage_index,
                         approximate_value_zatoshi: transaction.approximate_value_zatoshi,
+                        round: transaction.round,
+                        fee_zatoshi: transaction.fee_zatoshi,
+                        planned_height: transaction.planned_height,
+                        projected_height: transaction.projected_height,
+                        projected_completion_height: transaction.projected_completion_height,
+                        outputs: transaction
+                            .outputs
+                            .into_iter()
+                            .map(|output| MigrationPreparationOutputStatus {
+                                value_zatoshi: output.value_zatoshi,
+                                kind: match output.kind {
+                                    wallet_sync::MigrationPreparationOutputKind::Migration => {
+                                        MigrationPreparationOutputKind::Migration
+                                    }
+                                    wallet_sync::MigrationPreparationOutputKind::Change => {
+                                        MigrationPreparationOutputKind::Change
+                                    }
+                                    wallet_sync::MigrationPreparationOutputKind::Continuation => {
+                                        MigrationPreparationOutputKind::Continuation
+                                    }
+                                },
+                                next_round: output.next_round,
+                            })
+                            .collect(),
                         state: match transaction.state {
                             wallet_sync::MigrationPreparationTransactionState::AwaitingInputs => {
                                 MigrationPreparationTransactionState::AwaitingInputs

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -7501,6 +7501,20 @@ impl SseDecode for Vec<crate::api::sync::MigrationPartStatus> {
     }
 }
 
+impl SseDecode for Vec<crate::api::sync::MigrationPreparationOutputStatus> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(
+                <crate::api::sync::MigrationPreparationOutputStatus>::sse_decode(deserializer),
+            );
+        }
+        return ans_;
+    }
+}
+
 impl SseDecode for Vec<crate::api::sync::MigrationPreparationTransactionStatus> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -7939,6 +7953,37 @@ impl SseDecode for crate::api::sync::MigrationPartStatus {
     }
 }
 
+impl SseDecode for crate::api::sync::MigrationPreparationOutputKind {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => crate::api::sync::MigrationPreparationOutputKind::Migration,
+            1 => crate::api::sync::MigrationPreparationOutputKind::Change,
+            2 => crate::api::sync::MigrationPreparationOutputKind::Continuation,
+            _ => unreachable!(
+                "Invalid variant for MigrationPreparationOutputKind: {}",
+                inner
+            ),
+        };
+    }
+}
+
+impl SseDecode for crate::api::sync::MigrationPreparationOutputStatus {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_valueZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_kind =
+            <crate::api::sync::MigrationPreparationOutputKind>::sse_decode(deserializer);
+        let mut var_nextRound = <Option<u32>>::sse_decode(deserializer);
+        return crate::api::sync::MigrationPreparationOutputStatus {
+            value_zatoshi: var_valueZatoshi,
+            kind: var_kind,
+            next_round: var_nextRound,
+        };
+    }
+}
+
 impl SseDecode for crate::api::sync::MigrationPreparationTransactionState {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -7962,6 +8007,13 @@ impl SseDecode for crate::api::sync::MigrationPreparationTransactionStatus {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_stageIndex = <u32>::sse_decode(deserializer);
         let mut var_approximateValueZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_round = <u32>::sse_decode(deserializer);
+        let mut var_feeZatoshi = <u64>::sse_decode(deserializer);
+        let mut var_plannedHeight = <u32>::sse_decode(deserializer);
+        let mut var_projectedHeight = <u32>::sse_decode(deserializer);
+        let mut var_projectedCompletionHeight = <u32>::sse_decode(deserializer);
+        let mut var_outputs =
+            <Vec<crate::api::sync::MigrationPreparationOutputStatus>>::sse_decode(deserializer);
         let mut var_state =
             <crate::api::sync::MigrationPreparationTransactionState>::sse_decode(deserializer);
         let mut var_scheduledHeight = <Option<u32>>::sse_decode(deserializer);
@@ -7971,6 +8023,12 @@ impl SseDecode for crate::api::sync::MigrationPreparationTransactionStatus {
         return crate::api::sync::MigrationPreparationTransactionStatus {
             stage_index: var_stageIndex,
             approximate_value_zatoshi: var_approximateValueZatoshi,
+            round: var_round,
+            fee_zatoshi: var_feeZatoshi,
+            planned_height: var_plannedHeight,
+            projected_height: var_projectedHeight,
+            projected_completion_height: var_projectedCompletionHeight,
+            outputs: var_outputs,
             state: var_state,
             scheduled_height: var_scheduledHeight,
             mined_height: var_minedHeight,
@@ -10503,6 +10561,50 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::MigrationPartStatus>
     }
 }
 // Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sync::MigrationPreparationOutputKind {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            Self::Migration => 0.into_dart(),
+            Self::Change => 1.into_dart(),
+            Self::Continuation => 2.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sync::MigrationPreparationOutputKind
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::MigrationPreparationOutputKind>
+    for crate::api::sync::MigrationPreparationOutputKind
+{
+    fn into_into_dart(self) -> crate::api::sync::MigrationPreparationOutputKind {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::sync::MigrationPreparationOutputStatus {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.value_zatoshi.into_into_dart().into_dart(),
+            self.kind.into_into_dart().into_dart(),
+            self.next_round.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::sync::MigrationPreparationOutputStatus
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::sync::MigrationPreparationOutputStatus>
+    for crate::api::sync::MigrationPreparationOutputStatus
+{
+    fn into_into_dart(self) -> crate::api::sync::MigrationPreparationOutputStatus {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for crate::api::sync::MigrationPreparationTransactionState {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         match self {
@@ -10532,6 +10634,14 @@ impl flutter_rust_bridge::IntoDart for crate::api::sync::MigrationPreparationTra
         [
             self.stage_index.into_into_dart().into_dart(),
             self.approximate_value_zatoshi.into_into_dart().into_dart(),
+            self.round.into_into_dart().into_dart(),
+            self.fee_zatoshi.into_into_dart().into_dart(),
+            self.planned_height.into_into_dart().into_dart(),
+            self.projected_height.into_into_dart().into_dart(),
+            self.projected_completion_height
+                .into_into_dart()
+                .into_dart(),
+            self.outputs.into_into_dart().into_dart(),
             self.state.into_into_dart().into_dart(),
             self.scheduled_height.into_into_dart().into_dart(),
             self.mined_height.into_into_dart().into_dart(),
@@ -12631,6 +12741,16 @@ impl SseEncode for Vec<crate::api::sync::MigrationPartStatus> {
     }
 }
 
+impl SseEncode for Vec<crate::api::sync::MigrationPreparationOutputStatus> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::sync::MigrationPreparationOutputStatus>::sse_encode(item, serializer);
+        }
+    }
+}
+
 impl SseEncode for Vec<crate::api::sync::MigrationPreparationTransactionStatus> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -12960,6 +13080,32 @@ impl SseEncode for crate::api::sync::MigrationPartStatus {
     }
 }
 
+impl SseEncode for crate::api::sync::MigrationPreparationOutputKind {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                crate::api::sync::MigrationPreparationOutputKind::Migration => 0,
+                crate::api::sync::MigrationPreparationOutputKind::Change => 1,
+                crate::api::sync::MigrationPreparationOutputKind::Continuation => 2,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
+    }
+}
+
+impl SseEncode for crate::api::sync::MigrationPreparationOutputStatus {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <u64>::sse_encode(self.value_zatoshi, serializer);
+        <crate::api::sync::MigrationPreparationOutputKind>::sse_encode(self.kind, serializer);
+        <Option<u32>>::sse_encode(self.next_round, serializer);
+    }
+}
+
 impl SseEncode for crate::api::sync::MigrationPreparationTransactionState {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -12984,6 +13130,15 @@ impl SseEncode for crate::api::sync::MigrationPreparationTransactionStatus {
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <u32>::sse_encode(self.stage_index, serializer);
         <u64>::sse_encode(self.approximate_value_zatoshi, serializer);
+        <u32>::sse_encode(self.round, serializer);
+        <u64>::sse_encode(self.fee_zatoshi, serializer);
+        <u32>::sse_encode(self.planned_height, serializer);
+        <u32>::sse_encode(self.projected_height, serializer);
+        <u32>::sse_encode(self.projected_completion_height, serializer);
+        <Vec<crate::api::sync::MigrationPreparationOutputStatus>>::sse_encode(
+            self.outputs,
+            serializer,
+        );
         <crate::api::sync::MigrationPreparationTransactionState>::sse_encode(
             self.state, serializer,
         );

--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -311,10 +311,30 @@ pub(crate) enum MigrationPreparationTransactionState {
     Completed,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MigrationPreparationOutputKind {
+    Migration,
+    Change,
+    Continuation,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct MigrationPreparationOutputStatus {
+    pub value_zatoshi: u64,
+    pub kind: MigrationPreparationOutputKind,
+    pub next_round: Option<u32>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct MigrationPreparationTransactionStatus {
     pub stage_index: u32,
     pub approximate_value_zatoshi: u64,
+    pub round: u32,
+    pub fee_zatoshi: u64,
+    pub planned_height: u32,
+    pub projected_height: u32,
+    pub projected_completion_height: u32,
+    pub outputs: Vec<MigrationPreparationOutputStatus>,
     pub state: MigrationPreparationTransactionState,
     pub scheduled_height: Option<u32>,
     pub mined_height: Option<u32>,
@@ -408,16 +428,45 @@ pub(crate) fn migration_status(
     ironwood_spendable: u64,
     ironwood_pending: u64,
 ) -> Result<MigrationStatus, String> {
+    migration_status_with_projection_height(
+        db_path,
+        network,
+        account_uuid,
+        orchard_spendable,
+        orchard_pending,
+        ironwood_spendable,
+        ironwood_pending,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn migration_status_with_projection_height(
+    db_path: &str,
+    network: WalletNetwork,
+    account_uuid: &str,
+    orchard_spendable: u64,
+    orchard_pending: u64,
+    ironwood_spendable: u64,
+    ironwood_pending: u64,
+    projection_scanned_height: Option<u32>,
+) -> Result<MigrationStatus, String> {
     let conn = open_wallet_raw_conn_with_timeout(db_path, READ_DB_BUSY_TIMEOUT)?;
 
     if let Some(run) = active_run(&conn, account_uuid, network)? {
-        return status_for_run(&conn, run);
+        let current_scanned_height = projection_scanned_height
+            .map(Ok)
+            .unwrap_or_else(|| migration_projection_scanned_height(db_path, network))?;
+        return status_for_run(&conn, run, current_scanned_height);
     }
 
     let orchard_migratable = orchard_balance_can_create_migration_output(orchard_spendable)?;
     if orchard_pending == 0 && !orchard_migratable {
         if let Some(run) = latest_completed_run(&conn, account_uuid, network)? {
-            let mut status = status_for_run(&conn, run)?;
+            let current_scanned_height = projection_scanned_height
+                .map(Ok)
+                .unwrap_or_else(|| migration_projection_scanned_height(db_path, network))?;
+            let mut status = status_for_run(&conn, run, current_scanned_height)?;
             // Completed runs are receipts, not resumable work. Preserve their
             // target values for completion UI without exposing an active run.
             status.active_run_id = None;
@@ -474,6 +523,16 @@ pub(crate) fn migration_status(
         scheduled_broadcasts: Vec::new(),
         preparation_transactions: Vec::new(),
         parts: Vec::new(),
+    })
+}
+
+fn migration_projection_scanned_height(
+    db_path: &str,
+    network: WalletNetwork,
+) -> Result<u32, String> {
+    super::get_sync_progress(db_path, network).and_then(|progress| {
+        u32::try_from(progress.scanned_height)
+            .map_err(|_| "Migration scanned height exceeds u32".to_string())
     })
 }
 
@@ -4518,7 +4577,11 @@ fn backfill_ready_migration_proof_retry_height(
     Ok(())
 }
 
-fn status_for_run(conn: &rusqlite::Connection, run: ActiveRun) -> Result<MigrationStatus, String> {
+fn status_for_run(
+    conn: &rusqlite::Connection,
+    run: ActiveRun,
+    current_scanned_height: u32,
+) -> Result<MigrationStatus, String> {
     let network = conn
         .query_row(
             &format!("SELECT network FROM {RUNS_TABLE} WHERE run_id = ?1"),
@@ -4556,6 +4619,7 @@ fn status_for_run(conn: &rusqlite::Connection, run: ActiveRun) -> Result<Migrati
         conn,
         &run.run_id,
         denomination_confirmation_target,
+        current_scanned_height,
     )?;
     // A private-migration draft is persisted before Keystone signs its
     // denomination PCZTs. It deliberately has no staged transactions yet;
@@ -4672,24 +4736,51 @@ fn migration_preparation_transactions_for_run(
     conn: &rusqlite::Connection,
     run_id: &str,
     confirmation_target: u32,
+    current_scanned_height: u32,
 ) -> Result<Vec<MigrationPreparationTransactionStatus>, String> {
     if !table_exists(conn, STAGES_TABLE)? {
         return Ok(Vec::new());
     }
 
     let chain_records = denomination_stage_chain_records(conn, run_id)?;
+    let stage_index_by_txid = chain_records
+        .iter()
+        .map(|record| {
+            (
+                record.expected_txid_hex.to_ascii_lowercase(),
+                record.stage_index,
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut round_by_stage = BTreeMap::<u32, u32>::new();
+    for record in &chain_records {
+        let parent_round = record
+            .parent_txids
+            .iter()
+            .filter_map(|txid| stage_index_by_txid.get(&txid.to_ascii_lowercase()))
+            .filter_map(|stage_index| round_by_stage.get(stage_index))
+            .copied()
+            .max();
+        round_by_stage.insert(
+            record.stage_index,
+            parent_round.map_or(1, |round| round.saturating_add(1)),
+        );
+    }
+
     let mut stmt = conn
         .prepare_cached(&format!(
             "SELECT s.stage_index,
+                    s.scheduled_height,
                     MAX(s.scheduled_height,
                         COALESCE(s.broadcast_not_before_height, 0)),
+                    s.fee_zatoshi,
                     COALESCE(SUM(i.value_zatoshi), 0)
              FROM {STAGES_TABLE} s
              LEFT JOIN {STAGE_INPUTS_TABLE} i
                ON i.run_id = s.run_id AND i.stage_index = s.stage_index
              WHERE s.run_id = ?1
              GROUP BY s.stage_index, s.scheduled_height,
-                      s.broadcast_not_before_height
+                      s.broadcast_not_before_height, s.fee_zatoshi
              ORDER BY s.stage_index ASC"
         ))
         .map_err(|e| format!("Prepare migration preparation schedule query: {e}"))?;
@@ -4698,15 +4789,34 @@ fn migration_preparation_transactions_for_run(
             Ok((
                 row.get::<_, u32>(0)?,
                 row.get::<_, u32>(1)?,
-                row.get::<_, u64>(2)?,
+                row.get::<_, u32>(2)?,
+                row.get::<_, u64>(3)?,
+                row.get::<_, u64>(4)?,
             ))
         })
         .map_err(|e| format!("Query migration preparation schedule: {e}"))?;
 
+    let stage_rows = rows
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Read migration preparation schedule: {e}"))?;
+    drop(stmt);
+
+    let planned_max_by_round =
+        stage_rows
+            .iter()
+            .fold(BTreeMap::<u32, u32>::new(), |mut result, row| {
+                let round = round_by_stage.get(&row.0).copied().unwrap_or(1);
+                result
+                    .entry(round)
+                    .and_modify(|height| *height = (*height).max(row.1))
+                    .or_insert(row.1);
+                result
+            });
+    let mut projected_completion_by_stage = BTreeMap::<u32, u32>::new();
     let mut transactions = Vec::new();
-    for row in rows {
-        let (stage_index, scheduled_height, approximate_value_zatoshi) =
-            row.map_err(|e| format!("Read migration preparation schedule: {e}"))?;
+    for (stage_index, planned_height, effective_height, fee_zatoshi, approximate_value_zatoshi) in
+        stage_rows
+    {
         let chain = chain_records
             .iter()
             .find(|record| record.stage_index == stage_index)
@@ -4737,13 +4847,80 @@ fn migration_preparation_transactions_for_run(
             None => local_denomination_chain_identity(conn, &chain.expected_txid_hex)?
                 .map(|identity| identity.mined_height),
         };
+        let round = round_by_stage.get(&stage_index).copied().unwrap_or(1);
+        let parent_projected_completion = chain
+            .parent_txids
+            .iter()
+            .filter_map(|txid| stage_index_by_txid.get(&txid.to_ascii_lowercase()))
+            .filter_map(|parent_stage| projected_completion_by_stage.get(parent_stage))
+            .copied()
+            .max();
+        let original_round_base = if round <= 1 {
+            0
+        } else {
+            planned_max_by_round
+                .get(&round.saturating_sub(1))
+                .copied()
+                .unwrap_or(0)
+                .saturating_add(confirmation_target)
+        };
+        let planned_offset = planned_height.saturating_sub(original_round_base);
+        let dependency_projection = parent_projected_completion
+            .map(|height| height.saturating_add(planned_offset))
+            .unwrap_or(planned_height);
+        // A pending stage whose operational height has passed can broadcast at
+        // the current scanned tip. Once broadcast, keep this height stable
+        // because the UI uses it to preserve transaction order; only its
+        // completion forecast should continue moving until it is mined.
+        let projected_height = effective_height.max(dependency_projection).max(
+            (state == MigrationPreparationTransactionState::Scheduled)
+                .then_some(current_scanned_height)
+                .unwrap_or(0),
+        );
+        let projected_completion_height = mined_height.map_or_else(
+            || {
+                let projected_from_schedule = projected_height.saturating_add(confirmation_target);
+                if state == MigrationPreparationTransactionState::Broadcasted {
+                    projected_from_schedule
+                        .max(current_scanned_height.saturating_add(confirmation_target))
+                } else {
+                    projected_from_schedule
+                }
+            },
+            |height| height.saturating_add(confirmation_target.saturating_sub(1)),
+        );
+        projected_completion_by_stage.insert(stage_index, projected_completion_height);
+        let outputs = chain
+            .outputs
+            .iter()
+            .map(|output| MigrationPreparationOutputStatus {
+                value_zatoshi: output.value_zatoshi,
+                kind: match output.kind {
+                    DenominationStageOutputKind::Migration => {
+                        MigrationPreparationOutputKind::Migration
+                    }
+                    DenominationStageOutputKind::Change => MigrationPreparationOutputKind::Change,
+                    DenominationStageOutputKind::Continuation => {
+                        MigrationPreparationOutputKind::Continuation
+                    }
+                },
+                next_round: (output.kind == DenominationStageOutputKind::Continuation)
+                    .then_some(round.saturating_add(1)),
+            })
+            .collect();
         transactions.push(MigrationPreparationTransactionStatus {
             stage_index,
             approximate_value_zatoshi,
+            round,
+            fee_zatoshi,
+            planned_height,
+            projected_height,
+            projected_completion_height,
+            outputs,
             state,
             scheduled_height: (state != MigrationPreparationTransactionState::AwaitingInputs
-                && scheduled_height > 0)
-                .then_some(scheduled_height),
+                && effective_height > 0)
+                .then_some(effective_height),
             mined_height,
             confirmation_count,
             confirmation_target,

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -2008,7 +2008,7 @@ fn timing_projection_failure_does_not_block_migration_status() {
     let run = active_run(&conn, "account-1", WalletNetwork::Test)
         .unwrap()
         .unwrap();
-    let status = status_for_run(&conn, run).unwrap();
+    let status = status_for_run(&conn, run, 0).unwrap();
 
     assert_eq!(status.phase, PHASE_BROADCAST_SCHEDULED);
     assert_eq!(status.next_action_height, None);
@@ -2231,6 +2231,7 @@ fn late_preparation_broadcast_rerandomizes_remaining_effective_heights() {
         &conn,
         "preparation-catch-up",
         denomination_confirmations_required(),
+        0,
     )
     .unwrap()
     .into_iter()
@@ -3937,6 +3938,19 @@ fn migration_status_treats_non_migratable_residual_as_complete() {
 }
 
 #[test]
+fn projection_height_lookup_does_not_treat_wallet_db_errors_as_genesis() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    rusqlite::Connection::open(&db_path).unwrap();
+
+    assert!(migration_projection_scanned_height(
+        db_path.to_string_lossy().as_ref(),
+        WalletNetwork::Test,
+    )
+    .is_err(),);
+}
+
+#[test]
 fn migration_status_treats_sub_minimum_plan_value_as_complete() {
     let temp_dir = tempfile::tempdir().unwrap();
     let db_path = temp_dir.path().join("wallet.db");
@@ -3988,7 +4002,7 @@ fn migration_status_keeps_completed_run_complete_with_residual_orchard() {
     .unwrap();
     mark_run_phase(&db_path, &run_id, PHASE_COMPLETE, None).unwrap();
 
-    let status = migration_status(
+    let status = migration_status_with_projection_height(
         &db_path,
         WalletNetwork::Test,
         "account-1",
@@ -3996,6 +4010,7 @@ fn migration_status_keeps_completed_run_complete_with_residual_orchard() {
         0,
         ZATOSHIS_PER_ZEC,
         0,
+        Some(0),
     )
     .unwrap();
 
@@ -4152,8 +4167,17 @@ fn private_migration_draft_persists_plan_and_finalizes_in_place() {
     );
     drop(conn);
 
-    let draft_status =
-        migration_status(&db_path, WalletNetwork::Test, "account-1", 0, 0, 0, 0).unwrap();
+    let draft_status = migration_status_with_projection_height(
+        &db_path,
+        WalletNetwork::Test,
+        "account-1",
+        0,
+        0,
+        0,
+        0,
+        Some(0),
+    )
+    .unwrap();
     assert_eq!(draft_status.phase, PHASE_AWAITING_PREPARATION);
     assert_eq!(draft_status.denomination_split_total_count, 0);
     assert_eq!(draft_status.denomination_split_completed_count, 0);
@@ -4732,6 +4756,7 @@ fn confirmation_reconciliation_completes_run_and_releases_locks() {
             target_values_zatoshi: vec![100_000_000],
             last_error: None,
         },
+        0,
     )
     .unwrap();
 
@@ -4836,7 +4861,7 @@ fn confirmation_reconciliation_requeues_child_reorged_before_trusted_depth() {
     };
 
     reconcile_run_confirmations(&conn, run_id).unwrap();
-    let status = status_for_run(&conn, stale_run.clone()).unwrap();
+    let status = status_for_run(&conn, stale_run.clone(), 0).unwrap();
     assert_eq!(status.phase, PHASE_WAITING_MIGRATION_CONFIRMATIONS);
     assert_eq!(status.confirmed_tx_count, 1);
     assert_eq!(status.parts.len(), 1);
@@ -4872,7 +4897,7 @@ fn confirmation_reconciliation_requeues_child_reorged_before_trusted_depth() {
     assert_eq!(pending_status, "scheduled");
     assert!(scheduled_at_ms > 1);
 
-    let status = status_for_run(&conn, stale_run).unwrap();
+    let status = status_for_run(&conn, stale_run, 0).unwrap();
     assert_eq!(status.phase, PHASE_BROADCAST_SCHEDULED);
     assert_eq!(status.confirmed_tx_count, 0);
     assert_eq!(status.parts.len(), 1);
@@ -5366,7 +5391,7 @@ fn denomination_reconciliation_marks_confirmed_notes_ready_to_migrate() {
         .unwrap();
     assert_eq!(retry_height, Some(290));
 
-    let status = status_for_run(&conn, run.clone()).unwrap();
+    let status = status_for_run(&conn, run.clone(), 0).unwrap();
     assert_eq!(status.phase, PHASE_READY_TO_MIGRATE);
     assert_eq!(status.signed_child_pczt_count, 1);
     assert_eq!(status.next_action_height, Some(290));
@@ -5383,10 +5408,10 @@ fn denomination_reconciliation_marks_confirmed_notes_ready_to_migrate() {
         params![run_id],
     )
     .unwrap();
-    let stale_status = status_for_run(&conn, run.clone()).unwrap();
+    let stale_status = status_for_run(&conn, run.clone(), 0).unwrap();
     assert_eq!(stale_status.next_action_height, None);
     backfill_ready_migration_proof_retry_height(&conn, run_id).unwrap();
-    let recovered_status = status_for_run(&conn, run).unwrap();
+    let recovered_status = status_for_run(&conn, run, 0).unwrap();
     assert_eq!(recovered_status.next_action_height, Some(290));
     let recovered_retry_height: Option<u32> = conn
         .query_row(
@@ -5487,7 +5512,7 @@ fn status_keeps_migration_stage_while_waiting_for_spend_metadata() {
         target_values_zatoshi: vec![100_000_000],
         last_error: None,
     };
-    let status = status_for_run(&conn, run.clone()).unwrap();
+    let status = status_for_run(&conn, run.clone(), 0).unwrap();
     assert_eq!(status.phase, PHASE_READY_TO_MIGRATE);
     assert_eq!(status.signed_child_pczt_count, 0);
     assert_eq!(status.pending_split_stage_count, 0);
@@ -5513,7 +5538,7 @@ fn status_keeps_migration_stage_while_waiting_for_spend_metadata() {
     )
     .unwrap();
 
-    let status = status_for_run(&conn, run.clone()).unwrap();
+    let status = status_for_run(&conn, run.clone(), 0).unwrap();
     assert_eq!(status.phase, PHASE_READY_TO_MIGRATE);
     assert_eq!(status.signed_child_pczt_count, 1);
     assert_eq!(status.pending_split_stage_count, 0);
@@ -5524,7 +5549,7 @@ fn status_keeps_migration_stage_while_waiting_for_spend_metadata() {
     )
     .unwrap();
 
-    let status = status_for_run(&conn, run).unwrap();
+    let status = status_for_run(&conn, run, 0).unwrap();
     assert_eq!(status.phase, PHASE_READY_TO_MIGRATE);
     assert_eq!(status.pending_split_stage_count, 0);
 }
@@ -5993,7 +6018,17 @@ fn status_reconciliation_preserves_reincluded_parent_and_resets_offchain_depende
     drop(conn);
 
     reconcile_wallet_locks_after_sync(db_path, WalletNetwork::Test).unwrap();
-    let status = migration_status(db_path, WalletNetwork::Test, "account-1", 0, 0, 0, 0).unwrap();
+    let status = migration_status_with_projection_height(
+        db_path,
+        WalletNetwork::Test,
+        "account-1",
+        0,
+        0,
+        0,
+        0,
+        Some(0),
+    )
+    .unwrap();
     assert_eq!(status.phase, PHASE_WAITING_DENOM_CONFIRMATIONS);
 
     let conn = rusqlite::Connection::open(db_path).unwrap();
@@ -6278,13 +6313,13 @@ fn denomination_reconciliation_waits_for_trusted_confirmations() {
     assert_eq!(phase, PHASE_WAITING_DENOM_CONFIRMATIONS);
     assert!(nullifier_hex.is_none());
 
-    let status = status_for_run(&conn, run).unwrap();
+    let status = status_for_run(&conn, run, 0).unwrap();
     assert_eq!(status.denomination_confirmation_count, 2);
     assert_eq!(status.denomination_confirmation_target, 3);
 }
 
 #[test]
-fn staged_split_progress_tracks_the_active_frontier_without_future_outputs() {
+fn staged_split_progress_tracks_the_active_frontier_and_projects_future_rounds() {
     let conn = rusqlite::Connection::open_in_memory().unwrap();
     ensure_schema(&conn).unwrap();
     conn.execute_batch(
@@ -6337,6 +6372,22 @@ fn staged_split_progress_tracks_the_active_frontier_without_future_outputs() {
             )
             .unwrap();
         }
+        conn.execute(
+            "INSERT INTO vizor_migration_denomination_stage_outputs
+             (run_id, stage_index, output_order, output_index,
+              value_zatoshi, note_version, kind, part_index)
+             VALUES (?1, ?2, 0, 0, 99920000, 2, ?3, NULL)",
+            params![
+                run_id,
+                stage_index as u32,
+                if stage_index + 1 == stage_txids.len() {
+                    "migration"
+                } else {
+                    "continuation"
+                }
+            ],
+        )
+        .unwrap();
     }
     conn.execute(
         "UPDATE vizor_migration_denomination_stages
@@ -6352,11 +6403,63 @@ fn staged_split_progress_tracks_the_active_frontier_without_future_outputs() {
         target_values_zatoshi: vec![100_000_000],
         last_error: None,
     };
-    let status = status_for_run(&conn, run.clone()).unwrap();
+    let status = status_for_run(&conn, run.clone(), 0).unwrap();
     assert_eq!(status.denomination_confirmation_count, 0);
     assert_eq!(status.denomination_split_completed_count, 0);
     assert_eq!(status.denomination_split_total_count, 3);
     assert_eq!(status.preparation_transactions[2].scheduled_height, None);
+    assert_eq!(
+        status
+            .preparation_transactions
+            .iter()
+            .map(|transaction| transaction.round)
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3],
+    );
+    assert_eq!(status.preparation_transactions[2].planned_height, 19);
+    assert_eq!(status.preparation_transactions[2].projected_height, 22);
+    assert_eq!(
+        status.preparation_transactions[2].projected_completion_height,
+        25,
+    );
+    assert_eq!(
+        status.preparation_transactions[0].outputs[0],
+        MigrationPreparationOutputStatus {
+            value_zatoshi: 99_920_000,
+            kind: MigrationPreparationOutputKind::Continuation,
+            next_round: Some(2),
+        },
+    );
+    assert_eq!(
+        status.preparation_transactions[2].outputs[0].kind,
+        MigrationPreparationOutputKind::Migration,
+    );
+
+    let delayed_status = status_for_run(&conn, run.clone(), 30).unwrap();
+    assert_eq!(
+        delayed_status.preparation_transactions[0].state,
+        MigrationPreparationTransactionState::Broadcasted,
+    );
+    assert_eq!(
+        delayed_status.preparation_transactions[0].projected_height,
+        status.preparation_transactions[0].projected_height,
+    );
+    assert_eq!(
+        delayed_status.preparation_transactions[0].projected_completion_height,
+        33,
+    );
+    assert_eq!(
+        delayed_status.preparation_transactions[1].projected_height,
+        33,
+    );
+    assert_eq!(
+        delayed_status.preparation_transactions[2].projected_height,
+        52,
+    );
+    assert_eq!(
+        delayed_status.preparation_transactions[2].projected_completion_height,
+        55,
+    );
 
     let mut stage_0_txid = hex::decode(&stage_txids[0]).unwrap();
     stage_0_txid.reverse();
@@ -6370,7 +6473,7 @@ fn staged_split_progress_tracks_the_active_frontier_without_future_outputs() {
         [],
     )
     .unwrap();
-    let status = status_for_run(&conn, run.clone()).unwrap();
+    let status = status_for_run(&conn, run.clone(), 0).unwrap();
     assert_eq!(status.denomination_confirmation_count, 1);
     assert_eq!(status.denomination_split_completed_count, 0);
     assert_eq!(
@@ -6384,7 +6487,7 @@ fn staged_split_progress_tracks_the_active_frontier_without_future_outputs() {
         [],
     )
     .unwrap();
-    let status = status_for_run(&conn, run.clone()).unwrap();
+    let status = status_for_run(&conn, run.clone(), 0).unwrap();
     assert_eq!(status.denomination_confirmation_count, 2);
     assert_eq!(status.denomination_split_completed_count, 0);
 
@@ -6393,7 +6496,7 @@ fn staged_split_progress_tracks_the_active_frontier_without_future_outputs() {
         [],
     )
     .unwrap();
-    let status = status_for_run(&conn, run.clone()).unwrap();
+    let status = status_for_run(&conn, run.clone(), 0).unwrap();
     assert_eq!(status.denomination_confirmation_count, 0);
     assert_eq!(status.denomination_split_completed_count, 1);
     assert_eq!(status.denomination_split_total_count, 3);
@@ -6417,7 +6520,7 @@ fn staged_split_progress_tracks_the_active_frontier_without_future_outputs() {
         [],
     )
     .unwrap();
-    let status = status_for_run(&conn, run.clone()).unwrap();
+    let status = status_for_run(&conn, run.clone(), 0).unwrap();
     assert_eq!(status.denomination_confirmation_count, 1);
     assert_eq!(status.denomination_split_completed_count, 1);
     assert_eq!(status.preparation_transactions[1].mined_height, Some(23));
@@ -6427,7 +6530,7 @@ fn staged_split_progress_tracks_the_active_frontier_without_future_outputs() {
          INSERT INTO orchard_tree_checkpoints (checkpoint_id) VALUES (25);",
     )
     .unwrap();
-    let status = status_for_run(&conn, run).unwrap();
+    let status = status_for_run(&conn, run, 0).unwrap();
     assert_eq!(status.denomination_confirmation_count, 0);
     assert_eq!(status.denomination_split_completed_count, 2);
     assert_eq!(status.denomination_split_total_count, 3);

--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -43,8 +43,8 @@ mod transactions;
 pub(crate) use migration::{
     configure_fast_testnet_migration, delete_account_migration_rows_with_tx, migration_status,
     proof_retry_height, reconcile_wallet_locks_after_sync, MigrationPartState,
-    MigrationPreparationTransactionState, MigrationScheduleEntry, MigrationStatus,
-    PreparationTimingPolicy,
+    MigrationPreparationOutputKind, MigrationPreparationTransactionState, MigrationScheduleEntry,
+    MigrationStatus, PreparationTimingPolicy,
 };
 pub(crate) use pczt::extract_compact_sigs_from_pczt;
 pub use pczt::{

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -747,7 +747,7 @@ void main() {
       find.byKey(const ValueKey('ironwood_migration_preparation_ring')),
       findsOneWidget,
     );
-    expect(find.text('Splits remaining'), findsOneWidget);
+    expect(find.text('Overall progress'), findsOneWidget);
     expect(find.text('Est. completion'), findsOneWidget);
     expect(find.text('Current block'), findsOneWidget);
     expect(find.widgetWithText(AppButton, 'View Schedule'), findsOneWidget);
@@ -794,7 +794,8 @@ void main() {
       );
       expect(loader.name, AppIcons.loader);
       expect(loader.size, AppIconSize.large);
-      expect(find.text('Split 1 of 6'), findsOneWidget);
+      expect(find.text('Transaction 1 of 12'), findsOneWidget);
+      expect(find.text('0 of 12 complete'), findsOneWidget);
       expect(find.textContaining('confirmations'), findsNothing);
       expect(
         find.bySemanticsLabel('Preparing migration notes.'),
@@ -829,7 +830,8 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.text('Split 3 of 8'), findsOneWidget);
+    expect(find.text('Transaction 3 of 16'), findsOneWidget);
+    expect(find.text('2 of 16 complete'), findsOneWidget);
     expect(find.textContaining('confirmations'), findsNothing);
 
     harnessKey.currentState!.setStatus(
@@ -845,7 +847,7 @@ void main() {
     );
     await tester.pump();
 
-    expect(find.text('Split 3 of 8'), findsOneWidget);
+    expect(find.text('Transaction 3 of 16'), findsOneWidget);
     expect(find.text('Schedule pending'), findsOneWidget);
   });
 
@@ -2567,7 +2569,7 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(find.text('Split 3 of 5'), findsOneWidget);
+    expect(find.text('Transaction 3'), findsOneWidget);
   });
 
   testWidgets('preparation ETA starts unscheduled delays at current height', (

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -2468,6 +2468,17 @@ void main() {
           0,
           500_000_000,
           rust_sync.MigrationPreparationTransactionState.completed,
+          outputs: [
+            rust_sync.MigrationPreparationOutputStatus(
+              valueZatoshi: BigInt.from(400_000_000),
+              kind: rust_sync.MigrationPreparationOutputKind.continuation,
+              nextRound: 2,
+            ),
+            rust_sync.MigrationPreparationOutputStatus(
+              valueZatoshi: BigInt.from(99_990_000),
+              kind: rust_sync.MigrationPreparationOutputKind.change,
+            ),
+          ],
           scheduledHeight: 980,
           minedHeight: 984,
           confirmationCount: 3,
@@ -2496,6 +2507,10 @@ void main() {
           4,
           100_000_000,
           rust_sync.MigrationPreparationTransactionState.awaitingInputs,
+          round: 2,
+          plannedHeight: 1_171,
+          projectedHeight: 1_171,
+          projectedCompletionHeight: 1_174,
         ),
       ],
     );
@@ -2519,19 +2534,21 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Preparation Schedule'), findsOneWidget);
-    expect(find.text('Splits remaining'), findsOneWidget);
-    expect(find.text('4 of 5'), findsOneWidget);
+    expect(find.text('Current round'), findsOneWidget);
+    expect(find.text('1 of 2'), findsOneWidget);
+    expect(find.text('Ready to migrate'), findsOneWidget);
     expect(find.text('Current block'), findsOneWidget);
     expect(find.text('1,000'), findsOneWidget);
-    expect(find.text('1,010'), findsOneWidget);
-    expect(find.text('1,144'), findsOneWidget);
-    expect(find.text('Pending'), findsOneWidget);
-    expect(find.text('3. ~2 ZEC'), findsOneWidget);
-    expect(find.text('4. ~3 ZEC'), findsOneWidget);
+    expect(find.text('#1,010'), findsOneWidget);
+    expect(find.text('Expected by #1,171'), findsOneWidget);
+    expect(find.text('Expected #1,171'), findsOneWidget);
+    expect(find.text('3. 2 ZEC'), findsOneWidget);
+    expect(find.text('4. 3 ZEC'), findsOneWidget);
+    expect(find.text('Used in round 2'), findsOneWidget);
+    expect(find.text('Stays in Orchard'), findsOneWidget);
     expect(
       find.bySemanticsLabel(
-        'Split 2, approximately 4 ZEC, confirming, '
-        '2 of 3 confirmations.',
+        RegExp(r'Outputs: 4 ZEC, used in round 2; .* ZEC, stays in Orchard'),
       ),
       findsOneWidget,
     );
@@ -2581,6 +2598,10 @@ void main() {
           1,
           400_000_000,
           rust_sync.MigrationPreparationTransactionState.awaitingInputs,
+          round: 2,
+          plannedHeight: 1_024,
+          projectedHeight: 1_024,
+          projectedCompletionHeight: 1_027,
         ),
       ],
     );
@@ -2602,6 +2623,55 @@ void main() {
     expect(find.text('~34 mins'), findsOneWidget);
     expect(find.text('~2 mins'), findsNothing);
   });
+
+  testWidgets(
+    'preparation schedule hides an overdue awaiting-input projection',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1440, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      final status = _migrationStatus(
+        phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
+        activeRunId: 'run-1',
+        denominationConfirmationTarget: 3,
+        denominationSplitTotalCount: 1,
+        preparationTransactions: [
+          _preparationTransaction(
+            0,
+            400_000_000,
+            rust_sync.MigrationPreparationTransactionState.awaitingInputs,
+            plannedHeight: 990,
+            projectedHeight: 990,
+            projectedCompletionHeight: 993,
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        _migrationEntryHarness(
+          ctaState: IronwoodHomeMigrationCtaState.resume(
+            network: 'test',
+            accountUuid: 'account-1',
+            status: status,
+          ),
+          initialLocation: '/migration/private/preparation-schedule',
+          syncState: SyncState(
+            accountUuid: 'account-1',
+            hasAccountScopedData: true,
+            scannedHeight: 1_000,
+            chainTipHeight: 1_000,
+          ),
+          disableAnimations: true,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Ready to migrate'), findsOneWidget);
+      expect(find.text('Calculating'), findsOneWidget);
+      expect(find.text('Recalculating'), findsOneWidget);
+    },
+  );
 
   testWidgets(
     'preparation ETA includes confirmation depth between dependent splits',
@@ -2631,11 +2701,19 @@ void main() {
             1,
             400_000_000,
             rust_sync.MigrationPreparationTransactionState.awaitingInputs,
+            round: 2,
+            plannedHeight: 1_004,
+            projectedHeight: 1_004,
+            projectedCompletionHeight: 1_007,
           ),
           _preparationTransaction(
             2,
             300_000_000,
             rust_sync.MigrationPreparationTransactionState.awaitingInputs,
+            round: 3,
+            plannedHeight: 1_011,
+            projectedHeight: 1_011,
+            projectedCompletionHeight: 1_014,
           ),
         ],
       );
@@ -4339,6 +4417,12 @@ rust_sync.MigrationPreparationTransactionStatus _preparationTransaction(
   int stageIndex,
   int approximateValueZatoshi,
   rust_sync.MigrationPreparationTransactionState state, {
+  int round = 1,
+  int feeZatoshi = 10_000,
+  int? plannedHeight,
+  int? projectedHeight,
+  int? projectedCompletionHeight,
+  List<rust_sync.MigrationPreparationOutputStatus> outputs = const [],
   int? scheduledHeight,
   int? minedHeight,
   int confirmationCount = 0,
@@ -4346,6 +4430,15 @@ rust_sync.MigrationPreparationTransactionStatus _preparationTransaction(
 }) => rust_sync.MigrationPreparationTransactionStatus(
   stageIndex: stageIndex,
   approximateValueZatoshi: BigInt.from(approximateValueZatoshi),
+  round: round,
+  feeZatoshi: BigInt.from(feeZatoshi),
+  plannedHeight: plannedHeight ?? scheduledHeight ?? 0,
+  projectedHeight: projectedHeight ?? scheduledHeight ?? 0,
+  projectedCompletionHeight:
+      projectedCompletionHeight ??
+      (minedHeight ?? projectedHeight ?? scheduledHeight ?? 0) +
+          confirmationTarget,
+  outputs: outputs,
   state: state,
   scheduledHeight: scheduledHeight,
   minedHeight: minedHeight,

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -927,6 +927,42 @@ void main() {
   });
 
   testWidgets(
+    'preparation progress does not count prepared notes as migrated transactions',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1440, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _privateStatusHarness(
+          status: _migrationStatus(
+            phase: kIronwoodMigrationWaitingDenomConfirmationsPhase,
+            activeRunId: 'run-1',
+            denominationSplitCompletedCount: 1,
+            denominationSplitTotalCount: 8,
+            totalCount: 12,
+            parts: List.generate(
+              4,
+              (index) => _migrationPart(
+                index,
+                1_000_000,
+                rust_sync.MigrationPartState.completed,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.text('Transaction 2 of 20'), findsOneWidget);
+      expect(find.text('1 of 20 complete'), findsOneWidget);
+      expect(find.text('5 of 20 complete'), findsNothing);
+    },
+  );
+
+  testWidgets(
     'private ready-to-migrate status does not treat prepared denominations as completed transfers',
     (tester) async {
       tester.view.devicePixelRatio = 1;


### PR DESCRIPTION
## Summary

- expand the preparation schedule to show projected split rounds, block heights, fees, and output destinations
- show overall preparation and migration transaction progress instead of the current split count alone
- derive future preparation timing from the persisted split dependency graph and scanned height
- avoid counting prepared Orchard notes as completed Orchard-to-Ironwood transfers

## User impact

Desktop users can see the full expected preparation path and a more accurate estimate of when migration can begin. The overall transaction count now represents both preparation splits and migration transfers without overstating completed work.

## Validation

- `cargo test --lib` — 465 passed, 1 ignored
- `fvm flutter test test/features/migration/ironwood_migration_flow_screen_test.dart` — 79 passed
- focused `fvm flutter analyze` — no issues
- `git diff --check`