### PR TITLE
Keep migration preparation carousel smooth

### DIFF
--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -1342,23 +1342,8 @@ class _MigrationMorphingRing extends StatefulWidget {
 
 class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     with TickerProviderStateMixin {
-  static const _minimumWeight = 0.035;
-  static const _maximumWeight = 0.22;
-  static const _stepDuration = Duration(milliseconds: 390);
-  static const _stepBreather = Duration(milliseconds: 105);
-  static const _spinDuration = Duration(milliseconds: 1800);
-  static const _restBetweenBlocks = Duration(milliseconds: 900);
   static const _motionDuration = Duration(milliseconds: 1600);
 
-  final math.Random _random = math.Random(704075305);
-  late final AnimationController _stepController = AnimationController(
-    vsync: this,
-    duration: _stepDuration,
-  );
-  late final AnimationController _spinController = AnimationController(
-    vsync: this,
-    duration: _spinDuration,
-  );
   late final AnimationController _morphController = AnimationController(
     vsync: this,
     duration: const Duration(milliseconds: 920),
@@ -1367,10 +1352,6 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     vsync: this,
     duration: _motionDuration,
   );
-  late List<double> _weights;
-  late List<double> _fromWeights;
-  late List<double> _toWeights;
-  Timer? _idleTimer;
   bool _reduceMotion = false;
   List<_MigrationRingVisualSegment> _morphFrom = const [];
   List<_MigrationRingVisualSegment> _morphTo = const [];
@@ -1380,14 +1361,12 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
   void initState() {
     super.initState();
     _morphController.addStatusListener(_handleMorphStatus);
-    _weights = List.of(_MigrationPreparationRingPainter.initialSegmentRatios);
-    _fromWeights = List.of(_weights);
-    _toWeights = List.of(_weights);
-    _lastPreparationSegments = _preparationSegments(_weights);
+    _lastPreparationSegments = _preparationSegments(
+      _MigrationPreparationRingPainter.initialSegmentRatios,
+    );
     if (widget.preparing) {
       _morphFrom = _lastPreparationSegments;
       _morphTo = _lastPreparationSegments;
-      _runIdleLoop();
     } else {
       _morphFrom = _liveSegments(
         values: widget.values,
@@ -1428,9 +1407,6 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
           );
     _morphFrom = current;
     _morphTo = next;
-    _idleTimer?.cancel();
-    _stepController.stop();
-    _spinController.stop();
     if (_reduceMotion) {
       _morphController.value = 1;
     } else {
@@ -1466,73 +1442,8 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     }
   }
 
-  Future<void> _runIdleLoop() async {
-    // Keep the Figma-comparison first frame stable before starting idle motion.
-    await _wait(const Duration(milliseconds: 400));
-    try {
-      while (mounted) {
-        if (!widget.preparing) return;
-        if (_reduceMotion) {
-          await _wait(const Duration(seconds: 1));
-          continue;
-        }
-        for (var cycle = 0; cycle < 3 && mounted; cycle++) {
-          await _adjustSegmentWeights();
-          if (!mounted) return;
-          await _spinController.forward(from: 0);
-        }
-        await _wait(_restBetweenBlocks);
-      }
-    } on TickerCanceled {
-      // Disposal can stop either controller while an idle cycle is running.
-    }
-  }
-
-  Future<void> _adjustSegmentWeights() async {
-    final steps = 3 + _random.nextInt(3);
-    for (var step = 0; step < steps; step++) {
-      if (!mounted) return;
-      final fromIndex = _random.nextInt(_weights.length);
-      var toIndex = _random.nextInt(_weights.length - 1);
-      if (toIndex >= fromIndex) toIndex++;
-
-      final availableToGive = math.min(
-        _weights[fromIndex] - _minimumWeight,
-        _maximumWeight - _weights[toIndex],
-      );
-      final availableToTake = math.min(
-        _maximumWeight - _weights[fromIndex],
-        _weights[toIndex] - _minimumWeight,
-      );
-      final gives = availableToGive >= availableToTake;
-      final available = gives ? availableToGive : availableToTake;
-      if (available <= 0.005) continue;
-      final amount = available * (0.4 + _random.nextDouble() * 0.6);
-
-      setState(() {
-        _fromWeights = List.of(_weights);
-        _toWeights = List.of(_weights);
-        _toWeights[fromIndex] += gives ? -amount : amount;
-        _toWeights[toIndex] += gives ? amount : -amount;
-      });
-      await _stepController.forward(from: 0);
-      _weights = List.of(_toWeights);
-      await _wait(_stepBreather);
-    }
-  }
-
-  Future<void> _wait(Duration duration) {
-    final completer = Completer<void>();
-    _idleTimer?.cancel();
-    _idleTimer = Timer(duration, completer.complete);
-    return completer.future;
-  }
-
   @override
   void dispose() {
-    _idleTimer?.cancel();
-    _stepController.dispose();
-    _spinController.dispose();
     _morphController.dispose();
     _motionController.dispose();
     super.dispose();
@@ -1554,24 +1465,10 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
       excludeSemantics: true,
       label: semanticsLabel,
       child: AnimatedBuilder(
-        animation: Listenable.merge([
-          _stepController,
-          _spinController,
-          _morphController,
-          _motionController,
-        ]),
+        animation: Listenable.merge([_morphController, _motionController]),
         builder: (context, _) {
-          final eased = Curves.easeOutBack.transform(_stepController.value);
-          final weights = List.generate(
-            _weights.length,
-            (index) =>
-                _fromWeights[index] +
-                ((_toWeights[index] - _fromWeights[index]) * eased),
-          );
-          final preparationSegments = _preparationSegments(weights);
-          _lastPreparationSegments = preparationSegments;
           final visualSegments = widget.preparing
-              ? preparationSegments
+              ? _lastPreparationSegments
               : _interpolateVisualSegments(
                   _morphFrom,
                   _morphTo,
@@ -1589,9 +1486,7 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
                 size: const Size.square(256),
                 painter: _MigrationRingVisualPainter(
                   segments: visualSegments,
-                  rotation: widget.preparing
-                      ? Curves.easeInOutCubic.transform(_spinController.value)
-                      : 0,
+                  rotation: 0,
                   motionPhase: _motionController.value,
                   reduceMotion: _reduceMotion,
                 ),

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -1008,6 +1008,39 @@ void main() {
     },
   );
 
+  testWidgets('preparation ring stays still while the carousel is waiting', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1440, 900);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      _privateStatusHarness(status: _status(), disableAnimations: false),
+    );
+    await tester.pump(const Duration(milliseconds: 400));
+
+    List<double> ringWeights() {
+      final dynamic painter = tester
+          .widget<CustomPaint>(
+            find.byKey(const ValueKey('ironwood_migration_ring_paint')),
+          )
+          .painter;
+      return [
+        for (final dynamic segment in painter.segments as List<dynamic>)
+          segment.weight as double,
+      ];
+    }
+
+    final initialWeights = ringWeights();
+    for (var frame = 0; frame < 20; frame++) {
+      await tester.pump(const Duration(milliseconds: 100));
+    }
+
+    expect(ringWeights(), initialWeights);
+  });
+
   testWidgets('private preparing status does not expose note progress', (
     tester,
   ) async {


### PR DESCRIPTION
## Problem

The migration carousel is smooth on the Migrating status screen but visibly
stutters on the Preparing screen. Both screens use the same carousel.

The difference is the Preparing ring: it continuously shuffled segment weights
and spun through an idle animation while the carousel was transitioning. Those
controllers, timers, state updates, and repaints competed for the same frame
budget and made the faded neighboring carousel cards appear to shake.

## Solution

- Keep the preparation ring visually static while preparation is in progress.
- Remove the preparation-only idle shuffle/spin controllers and timer loop.
- Preserve the existing preparation-to-migration ring morph.
- Preserve the in-progress migration note motion.
- Add a regression test that verifies preparation ring weights stay stable
  while the carousel is waiting to advance.

## Verification

- Visually verified in Widgetbook at
  `Screens → Ironwood migration → Desktop → Preparing`.
- `fvm flutter test test/features/migration/ironwood_migration_flow_screen_test.dart --plain-name "preparation ring stays still while the carousel is waiting"`
- `fvm flutter test test/features/migration/ironwood_migration_flow_screen_test.dart --plain-name "preparation ring morphs in place into processing-ordered note segments"`
- `fvm flutter test test/core/widgets/app_carousel_test.dart test/widgetbook/carousel_use_cases_test.dart`
- `fvm flutter analyze lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart test/features/migration/ironwood_migration_flow_screen_test.dart`

## Test note

A broad run of the full migration screen test file still encounters
`pumpAndSettle` timeouts in continuously animated Migrating and schedule cases.
The focused preparation regression, ring morph, carousel, Widgetbook, and
analysis checks above pass.
