### PR TITLE
Pad regular Orchard and Ironwood payments to four actions

### DIFF
--- a/rust/src/wallet/sync/mod.rs
+++ b/rust/src/wallet/sync/mod.rs
@@ -452,6 +452,16 @@ pub fn validate_address(address: &str) -> Result<String, String> {
 
 // ======================== Send ========================
 
+/// Privacy padding for ordinary Orchard-family payments.
+///
+/// Orchard-to-Ironwood migration transactions deliberately use
+/// `BundlePadding::UNPADDED` instead.
+const PAYMENT_BUNDLE_PADDING: zcash_primitives::transaction::builder::BundlePadding =
+    zcash_primitives::transaction::builder::BundlePadding {
+        bundle_required: false,
+        pad_to_minimum: Some(4),
+    };
+
 /// Propose a transfer. Returns (proposal_id, needs_sapling_params, fee_zatoshi).
 /// The proposal is stored internally and referenced by proposal_id for execute_proposal.
 // In-memory proposal store (proposals are short-lived, between
@@ -469,10 +479,6 @@ pub(super) struct StoredProposal {
         zcash_client_sqlite::ReceivedNoteId,
     >,
     pub proposed_tx_version: Option<zcash_primitives::transaction::TxVersion>,
-    /// When `true`, the proposal was fee-counted with unpadded Orchard-pool
-    /// bundles (migration children only) and the PCZT must be built with
-    /// `BundlePadding::UNPADDED` to balance. See `zip317_helper`.
-    pub unpadded_orchard_pool_bundles: bool,
     pub network: WalletNetwork,
     pub account_id: AccountUuid,
     pub send_flow_id: String,

--- a/rust/src/wallet/sync/pczt.rs
+++ b/rust/src/wallet/sync/pczt.rs
@@ -75,7 +75,7 @@ use std::convert::Infallible;
 use std::sync::OnceLock;
 
 use zcash_client_backend::data_api::WalletWrite;
-use zcash_primitives::transaction::{builder::BundlePadding, Transaction, TxId};
+use zcash_primitives::transaction::{Transaction, TxId};
 use zcash_proofs::prover::LocalTxProver;
 
 use crate::wallet::db::with_wallet_db_write_lock;
@@ -308,14 +308,9 @@ pub async fn create_pczt_from_proposal(
         )
         .map_err(|e| format!("Revalidate hardware proposal input locks: {e:?}"))?;
         super::proposal_locks::update_expiry(db_path, current_lock.owner, live_expiry_height)?;
-        // Build with the padding policy the proposal was fee-counted against
-        // (see `StoredProposal::unpadded_orchard_pool_bundles`), so the
-        // builder's balance check matches the proposal's fee.
-        let bundle_padding = if stored.unpadded_orchard_pool_bundles {
-            BundlePadding::UNPADDED
-        } else {
-            BundlePadding::DEFAULT
-        };
+        // Normal hardware payments use the same four-action padding floor
+        // that the proposal fee was calculated against.
+        let bundle_padding = super::PAYMENT_BUNDLE_PADDING;
         // The transaction version rides on the proposal; expiry is pinned to
         // the live chain tip obtained immediately before this DB operation.
         let proposal_for_pczt = stored
@@ -440,6 +435,112 @@ pub fn add_proofs_to_pczt(
         .finish()
         .serialize()
         .map_err(|e| format!("Serialize PCZT with proofs: {e:?}"))
+}
+
+/// Builds, proves, signs, and stores one ordinary software payment with the
+/// wallet's payment padding policy.
+///
+/// The pinned librustzcash software-construction API always uses its default
+/// two-action padding. Its PCZT API accepts an explicit [`BundlePadding`], so
+/// software and hardware payments share this path when Vizor raises the
+/// privacy floor.
+///
+/// [`BundlePadding`]: zcash_primitives::transaction::builder::BundlePadding
+#[allow(clippy::too_many_arguments)]
+pub(super) fn create_and_store_payment_transaction(
+    wallet_db: &mut super::WalletDatabase,
+    network: &WalletNetwork,
+    account_id: zcash_client_sqlite::AccountUuid,
+    proposal: &zcash_client_backend::proposal::Proposal<
+        super::send::WalletFeeRule,
+        zcash_client_sqlite::ReceivedNoteId,
+    >,
+    usk: &zcash_keys::keys::UnifiedSpendingKey,
+    expiry_height: zcash_protocol::consensus::BlockHeight,
+    spend_params_path: Option<&str>,
+    output_params_path: Option<&str>,
+) -> Result<TxId, String> {
+    use zcash_client_backend::data_api::wallet::{
+        create_pczt_from_proposal as zcb_create_pczt, extract_and_store_transaction_from_pczt,
+    };
+    use zcash_client_backend::wallet::OvkPolicy;
+
+    let base = zcb_create_pczt::<_, _, Infallible, _, Infallible, _>(
+        wallet_db,
+        network,
+        account_id,
+        OvkPolicy::Sender,
+        proposal,
+        Some(expiry_height),
+        super::PAYMENT_BUNDLE_PADDING,
+    )
+    .map_err(|e| format!("Create payment PCZT: {e}"))?
+    .serialize()
+    .map_err(|e| format!("Serialize payment PCZT: {e:?}"))?;
+
+    let proofed = add_proofs_to_pczt(&base, spend_params_path, output_params_path)?;
+    let signed = sign_payment_pczt_with_usk(&proofed, usk)?;
+    let consensus_branch_id = *signed.global().consensus_branch_id();
+    let orchard_vk = orchard_verifying_key_for_consensus_branch(consensus_branch_id);
+    let sapling_vks = load_sapling_verifying_keys(spend_params_path, output_params_path);
+    let sapling_vk_pair = sapling_vks.as_ref().map(|(spend, output)| (spend, output));
+
+    extract_and_store_transaction_from_pczt::<_, zcash_client_sqlite::ReceivedNoteId>(
+        wallet_db,
+        signed,
+        sapling_vk_pair,
+        Some(&orchard_vk),
+    )
+    .map_err(|e| format!("Store payment PCZT: {e}"))
+}
+
+fn sign_payment_pczt_with_usk(
+    pczt_bytes: &[u8],
+    usk: &zcash_keys::keys::UnifiedSpendingKey,
+) -> Result<pczt::Pczt, String> {
+    use pczt::roles::signer::Signer;
+
+    let pczt = pczt::Pczt::parse(pczt_bytes).map_err(|e| format!("Parse payment PCZT: {e:?}"))?;
+    let orchard_indices = pczt
+        .orchard()
+        .actions()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, action)| action.spend().spend_auth_sig().is_none().then_some(index))
+        .collect::<Vec<_>>();
+    let ironwood_indices = pczt
+        .ironwood()
+        .actions()
+        .iter()
+        .enumerate()
+        .filter_map(|(index, action)| action.spend().spend_auth_sig().is_none().then_some(index))
+        .collect::<Vec<_>>();
+
+    let mut signer = Signer::new(pczt).map_err(|e| format!("Create payment PCZT signer: {e:?}"))?;
+    for index in 0.. {
+        match signer.sign_sapling(index, &usk.sapling().expsk.ask) {
+            Err(pczt::roles::signer::Error::InvalidIndex) => break,
+            Ok(())
+            | Err(pczt::roles::signer::Error::SaplingSign(
+                sapling_crypto::pczt::SignerError::WrongSpendAuthorizingKey,
+            )) => {}
+            Err(e) => return Err(format!("Sign payment Sapling spend {index}: {e:?}")),
+        }
+    }
+
+    let orchard_ask = orchard::keys::SpendAuthorizingKey::from(usk.orchard());
+    for index in orchard_indices {
+        signer
+            .sign_orchard(index, &orchard_ask)
+            .map_err(|e| format!("Sign payment Orchard action {index}: {e:?}"))?;
+    }
+    for index in ironwood_indices {
+        signer
+            .sign_ironwood(index, &orchard_ask)
+            .map_err(|e| format!("Sign payment Ironwood action {index}: {e:?}"))?;
+    }
+
+    Ok(signer.finish())
 }
 
 /// Redact information from a PCZT that the signer role doesn't need

--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -24,15 +24,10 @@
 //! PCZT pipeline also consumes from it (see `sync/pczt.rs`) and
 //! keeping it in the parent avoids a cross-submodule cycle.
 //!
-//! **Sapling-proofs shortcut**: Orchard-only sends (recipient has an
-//! Orchard receiver) go through [`NoOpSpendProver`] /
-//! [`NoOpOutputProver`] so we don't have to ship the 50MB Sapling
-//! params with the app. `create_proposed_transactions` only touches
-//! the provers for Sapling spend/output circuits, so for an
-//! Orchard-only proposal these never get called — if they do get
-//! called it's a bug (the proposal contained unexpected Sapling
-//! components) and the provers log+fail loudly rather than produce a
-//! silently-invalid proof.
+//! Ordinary software payments use the local PCZT path so Vizor can
+//! apply the same explicit Orchard-family padding as hardware
+//! payments. Orchard-only payments still do not require the Sapling
+//! parameter files.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::Infallible;
@@ -86,7 +81,6 @@ use zcash_primitives::transaction::{
     },
     TxId,
 };
-use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{
     consensus::{self, BlockHeight, NetworkConstants, Parameters},
     memo::{Memo, MemoBytes},
@@ -559,8 +553,6 @@ impl<NoteRef> NoteRetention<NoteRef> for RetainAllNotes {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(in crate::wallet) struct ConservativeZip317FeeRule;
 
-pub(in crate::wallet) type WalletFeeRule = ConservativeZip317FeeRule;
-
 impl FeeRule for ConservativeZip317FeeRule {
     type Error = <StandardFeeRule as FeeRule>::Error;
 
@@ -603,6 +595,77 @@ impl Zip317FeeRule for ConservativeZip317FeeRule {
 
     fn grace_actions(&self) -> usize {
         StandardFeeRule::Zip317.grace_actions()
+    }
+}
+
+/// ZIP-317 fee rule for wallet proposals with an explicit Orchard-family
+/// padding policy.
+///
+/// The upstream change strategies count their default two-action floor before
+/// invoking [`FeeRule`]. This wrapper raises each non-empty Orchard or Ironwood
+/// bundle to the configured floor so proposal fees match transaction
+/// construction.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(in crate::wallet) struct WalletFeeRule {
+    orchard_pool_padding: BundlePadding,
+}
+
+impl WalletFeeRule {
+    const fn new(orchard_pool_padding: BundlePadding) -> Self {
+        Self {
+            orchard_pool_padding,
+        }
+    }
+
+    fn padded_action_count(&self, action_count: usize) -> usize {
+        if action_count == 0 && !self.orchard_pool_padding.bundle_required {
+            return 0;
+        }
+
+        let minimum = self
+            .orchard_pool_padding
+            .pad_to_minimum
+            .map(usize::from)
+            .unwrap_or_else(|| usize::from(self.orchard_pool_padding.bundle_required));
+        action_count.max(minimum)
+    }
+}
+
+impl FeeRule for WalletFeeRule {
+    type Error = <ConservativeZip317FeeRule as FeeRule>::Error;
+
+    #[allow(clippy::too_many_arguments)]
+    fn fee_required<P: consensus::Parameters>(
+        &self,
+        params: &P,
+        target_height: zcash_protocol::consensus::BlockHeight,
+        transparent_input_sizes: impl IntoIterator<Item = TransparentInputSize>,
+        transparent_output_sizes: impl IntoIterator<Item = usize>,
+        sapling_input_count: usize,
+        sapling_output_count: usize,
+        orchard_action_count: usize,
+        ironwood_action_count: usize,
+    ) -> Result<Zatoshis, Self::Error> {
+        ConservativeZip317FeeRule.fee_required(
+            params,
+            target_height,
+            transparent_input_sizes,
+            transparent_output_sizes,
+            sapling_input_count,
+            sapling_output_count,
+            self.padded_action_count(orchard_action_count),
+            self.padded_action_count(ironwood_action_count),
+        )
+    }
+}
+
+impl Zip317FeeRule for WalletFeeRule {
+    fn marginal_fee(&self) -> Zatoshis {
+        ConservativeZip317FeeRule.marginal_fee()
+    }
+
+    fn grace_actions(&self) -> usize {
+        ConservativeZip317FeeRule.grace_actions()
     }
 }
 
@@ -690,7 +753,6 @@ pub fn propose_send(
             &migration_locks,
             &spend_policy,
             proposed_tx_version,
-            false,
         )?;
         let (proposal, stored_tx_version) = propose_with_note_version_downgrade(
             pass1_proposal,
@@ -706,7 +768,6 @@ pub fn propose_send(
                     &migration_locks,
                     &spend_policy,
                     tx_version,
-                    false,
                 )
             },
         );
@@ -783,8 +844,6 @@ pub fn propose_send(
                 proposal_id: id,
                 proposal,
                 proposed_tx_version: stored_tx_version,
-                // Regular sends stay padded; only migration children opt in.
-                unpadded_orchard_pool_bundles: false,
                 network,
                 account_id,
                 send_flow_id: send_flow_id.to_string(),
@@ -828,7 +887,6 @@ pub fn estimate_fee(
         &migration_locks,
         &spend_policy,
         proposed_tx_version,
-        false,
     )?;
     // Same two-pass rule as `propose_send`, so the displayed estimate equals
     // the stored proposal's fee.
@@ -844,7 +902,6 @@ pub fn estimate_fee(
                 &migration_locks,
                 &spend_policy,
                 tx_version,
-                false,
             )
         });
 
@@ -1253,40 +1310,20 @@ async fn execute_stored_proposal(
                 .clone()
                 .with_proposed_version(stored.proposed_tx_version);
 
-            let txids = match (spend_params_path, output_params_path) {
-                (Some(sp), Some(op)) if !sp.is_empty() && !op.is_empty() => {
-                    let prover =
-                        LocalTxProver::new(std::path::Path::new(sp), std::path::Path::new(op));
-                    create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
-                        &mut db,
-                        &network,
-                        &prover,
-                        &prover,
-                        &wallet::SpendingKeys::from_unified_spending_key(usk),
-                        OvkPolicy::Sender,
-                        &proposal,
-                        Some(live_expiry_height),
-                    )
-                    .map_err(|e| format!("Create TX failed: {e}"))?
-                }
-                _ => {
-                    let spend_prover = NoOpSpendProver;
-                    let output_prover = NoOpOutputProver;
-                    create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
-                        &mut db,
-                        &network,
-                        &spend_prover,
-                        &output_prover,
-                        &wallet::SpendingKeys::from_unified_spending_key(usk),
-                        OvkPolicy::Sender,
-                        &proposal,
-                        Some(live_expiry_height),
-                    )
-                    .map_err(|e| format!("Create TX failed: {e}"))?
-                }
-            };
+            let spend_params_path = spend_params_path.filter(|path| !path.is_empty());
+            let output_params_path = output_params_path.filter(|path| !path.is_empty());
+            let txid = super::pczt::create_and_store_payment_transaction(
+                &mut db,
+                &network,
+                account_id,
+                &proposal,
+                &usk,
+                live_expiry_height,
+                spend_params_path,
+                output_params_path,
+            )?;
             // USK and derived spending keys dropped here, before broadcast.
-            Ok::<_, String>(txids)
+            Ok::<_, String>(vec![txid])
         });
     let txids = match create_result {
         Ok(txids) => {
@@ -1308,7 +1345,6 @@ async fn execute_stored_proposal(
         }
     };
 
-    let txids: Vec<TxId> = txids.iter().cloned().collect();
     Ok(
         broadcast_created_transactions(db_path, lightwalletd_url, &txids, "send")
             .await
@@ -2859,9 +2895,8 @@ fn build_shielding_proposal(
         .map_err(|e| format!("Failed to get transparent balances: {e}"))?;
     let (from_addrs, selected_value) = select_shielding_sources(balances, shielding_threshold)?;
 
-    // Regular shielding transactions stay padded (`DEFAULT`); only migration
-    // children opt in to unpadded Orchard-pool bundles.
-    let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None, None, false);
+    let (change_strategy, input_selector) =
+        zip317_helper::<WalletDatabase>(None, None, BundlePadding::DEFAULT);
     let proposal = propose_shielding::<_, _, _, _, Infallible>(
         db,
         &network,
@@ -2912,7 +2947,6 @@ fn propose_send_with_reserved_notes(
     migration_locks: &BTreeSet<(String, u32)>,
     spend_policy: &SpendPolicy,
     proposed_tx_version: Option<TxVersion>,
-    unpadded_orchard_pool_bundles: bool,
 ) -> Result<Proposal<WalletFeeRule, ReceivedNoteId>, String> {
     let confirmations_policy = ConfirmationsPolicy::default();
     let (target_height, anchor_height) = db
@@ -2927,7 +2961,7 @@ fn propose_send_with_reserved_notes(
     let (change_strategy, input_selector) = zip317_helper::<ReservedInputSource<'_>>(
         None,
         proposed_tx_version,
-        unpadded_orchard_pool_bundles,
+        super::PAYMENT_BUNDLE_PADDING,
     );
 
     input_selector
@@ -3278,7 +3312,7 @@ fn build_send_max_proposal(
         }
         None => None,
     };
-    let fee_rule = ConservativeZip317FeeRule;
+    let fee_rule = WalletFeeRule::new(super::PAYMENT_BUNDLE_PADDING);
 
     if matches!(recipient_address, Address::Transparent(_)) {
         return build_transparent_recipient_send_max_proposal(
@@ -5521,13 +5555,13 @@ where
 fn zip317_helper<DbT: InputSource>(
     change_memo: Option<MemoBytes>,
     proposed_tx_version: Option<TxVersion>,
-    unpadded_orchard_pool_bundles: bool,
+    orchard_pool_padding: BundlePadding,
 ) -> (
     MultiOutputChangeStrategy<WalletFeeRule, DbT>,
     GreedyInputSelector<DbT>,
 ) {
     let change_strategy = MultiOutputChangeStrategy::new(
-        ConservativeZip317FeeRule,
+        WalletFeeRule::new(orchard_pool_padding),
         change_memo,
         ShieldedPool::Orchard,
         DustOutputPolicy::default(),
@@ -5536,9 +5570,7 @@ fn zip317_helper<DbT: InputSource>(
             Zatoshis::const_from_u64(1000_0000),
         ),
     );
-    // Migration children only: count exactly the requested actions so the
-    // proposal's fee matches the unpadded bundle the PCZT builder produces.
-    let change_strategy = if unpadded_orchard_pool_bundles {
+    let change_strategy = if orchard_pool_padding == BundlePadding::UNPADDED {
         change_strategy.with_unpadded_orchard_pool_bundles()
     } else {
         change_strategy
@@ -5552,12 +5584,10 @@ fn zip317_helper<DbT: InputSource>(
 }
 
 // ======================== No-op Sapling Provers ========================
-// Used for Orchard-only transactions where Sapling params are not
-// available. `create_proposed_transactions` only invokes the
-// Sapling prover methods for proposals that actually contain a
-// Sapling bundle, so for an Orchard-only proposal these methods
-// should never be called. If they are called we log and fail noisily
-// rather than producing a silently-invalid all-zero proof.
+// Used for transparent shielding when Sapling params are unavailable.
+// Orchard/Ironwood-only proposals never invoke these methods. If one
+// is called, log and fail noisily rather than producing a silently
+// invalid all-zero proof.
 
 use sapling_crypto::{
     bundle::GrothProofBytes,

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -986,7 +986,7 @@ fn fabricated_shielded_spend_proposal(
         recipient,
         None,
         ReceivedNotes::new(sapling_notes, orchard_notes, vec![]),
-        ConservativeZip317FeeRule,
+        WalletFeeRule::new(super::super::PAYMENT_BUNDLE_PADDING),
     )
     .expect("fabricated proposal should build")
 }
@@ -1047,8 +1047,8 @@ fn fabricated_proposal_with_payment_pool(payment_pool: PoolType) -> Proposal<Wal
 
     // No change: amount + fee must equal the single 100_000-zat input, or
     // `Proposal::single_step` rejects the unbalanced proposal.
-    let fee = Zatoshis::const_from_u64(10_000);
-    let amount = Zatoshis::const_from_u64(90_000);
+    let fee = Zatoshis::const_from_u64(20_000);
+    let amount = Zatoshis::const_from_u64(80_000);
     let payment = Payment::new(to, Some(amount), None, None, None, vec![]).unwrap();
     let request = TransactionRequest::new(vec![payment]).unwrap();
     // `ShieldedInputs` wants `ReceivedNote<_, wallet::Note>`; wrap the
@@ -1064,7 +1064,7 @@ fn fabricated_proposal_with_payment_pool(payment_pool: PoolType) -> Proposal<Wal
         Some(shielded_inputs),
         BlockHeight::from_u32(900),
         balance,
-        ConservativeZip317FeeRule,
+        WalletFeeRule::new(super::super::PAYMENT_BUNDLE_PADDING),
         TargetHeight::from(BlockHeight::from_u32(1_000)),
         ConfirmationsPolicy::default(),
         false,
@@ -1862,6 +1862,52 @@ fn migration_child_bundle_shape_and_fee_are_two_plus_one() {
 }
 
 #[test]
+fn payment_fee_rule_prices_four_actions_per_orchard_family_bundle() {
+    let fee_rule = WalletFeeRule::new(super::super::PAYMENT_BUNDLE_PADDING);
+    let fee_for_actions = |orchard_action_count, ironwood_action_count| {
+        fee_rule
+            .fee_required(
+                &WalletNetwork::Regtest,
+                BlockHeight::from_u32(120),
+                std::iter::empty::<TransparentInputSize>(),
+                std::iter::empty::<usize>(),
+                0,
+                0,
+                orchard_action_count,
+                ironwood_action_count,
+            )
+            .unwrap()
+    };
+
+    assert_eq!(u64::from(fee_for_actions(1, 0)), 20_000);
+    assert_eq!(u64::from(fee_for_actions(0, 1)), 20_000);
+    assert_eq!(u64::from(fee_for_actions(1, 1)), 40_000);
+    assert_eq!(u64::from(fee_for_actions(0, 0)), 10_000);
+}
+
+#[test]
+fn payment_padding_builds_four_orchard_and_ironwood_actions() {
+    let bundle_type = super::super::PAYMENT_BUNDLE_PADDING.bundle_type();
+    let orchard_actions = bundle_type
+        .num_actions(
+            orchard::bundle::BundleVersion::orchard_v2().default_flags(),
+            1,
+            1,
+        )
+        .unwrap();
+    let ironwood_actions = bundle_type
+        .num_actions(
+            orchard::bundle::BundleVersion::ironwood_v3().default_flags(),
+            1,
+            1,
+        )
+        .unwrap();
+
+    assert_eq!(orchard_actions, 4);
+    assert_eq!(ironwood_actions, 4);
+}
+
+#[test]
 fn conservative_zip317_fee_rule_clamps_known_transparent_inputs_to_p2pkh_size() {
     let network = WalletNetwork::Regtest;
     let height = BlockHeight::from_u32(1_000);
@@ -2122,7 +2168,7 @@ fn transparent_recipient_send_max_proposal_spends_shielded_notes() {
         recipient,
         None,
         ReceivedNotes::new(vec![received_note], vec![], vec![]),
-        ConservativeZip317FeeRule,
+        WalletFeeRule::new(super::super::PAYMENT_BUNDLE_PADDING),
     )
     .expect("transparent-recipient send-max should build from shielded notes");
 
@@ -2175,7 +2221,7 @@ fn transparent_recipient_send_max_supports_ironwood_only_inputs() {
         transparent_recipient,
         None,
         ReceivedNotes::new(vec![], vec![], vec![received_note]),
-        ConservativeZip317FeeRule,
+        WalletFeeRule::new(super::super::PAYMENT_BUNDLE_PADDING),
     )
     .expect("transparent-recipient send-max should build from Ironwood notes");
 


### PR DESCRIPTION
## Summary

- raise the privacy padding floor for ordinary Orchard and Ironwood payment bundles from two actions to four
- price proposal fees against the same per-bundle action floor used during transaction construction
- apply the policy consistently to software and Keystone payment paths, including send-max
- leave Orchard-to-Ironwood migrations and transparent shielding on their existing padding policies

## Implementation notes

The pinned high-level software transaction API hard-codes its default two-action padding. Ordinary software payments now use the existing PCZT construction/proving/signing path, which accepts an explicit `BundlePadding`, so proposal fees and built transactions share one payment policy.

## References

- LRZ exposes the explicit Orchard/Ironwood [`BundlePadding` argument on `create_pczt_from_proposal`](https://github.com/zcash/librustzcash/blob/8e27b7159980604c6b3985ea8ae4b196ef1108ae/zcash_client_backend/src/data_api/wallet.rs#L2571-L2638) that this implementation uses.
- LRZ defines the related [`SplitPolicy` target-output behavior](https://github.com/zcash/librustzcash/blob/8e27b7159980604c6b3985ea8ae4b196ef1108ae/zcash_client_backend/src/fees.rs#L420-L462).
- The ZODL wallet SDKs configure that split target to four in both [Android](https://github.com/zcash/zcash-android-wallet-sdk/blob/6b5ba375c457257e28ec2f971dc89c6402ea241e/backend-lib/src/main/rust/lib.rs#L2083-L2105) and [Swift](https://github.com/zcash/zcash-swift-wallet-sdk/blob/f51ed74aa70df959eee7af501f0f920438abe07d/rust/src/lib.rs#L2156-L2178).

The SDK references are a four-change-output policy, not a hard four-action bundle floor. This PR keeps that existing policy and additionally uses LRZ's explicit `BundlePadding` control to guarantee the per-bundle four-action minimum.

## Testing

- `cargo fmt --all -- --check`
- `cargo test --no-run`
- `cargo test --lib` (472 passed, 1 pre-existing ignored)
- focused payment-padding, migration-shape, and transparent send-max tests

`cargo clippy --lib --tests` remains blocked by the repository's existing denied `clippy::not_unsafe_ptr_arg_deref` errors in `rust/src/ffi.rs`; it reported no new errors in the changed payment code.