### PR TITLE
Restore efficient Ironwood preparation ring animation

### DIFF
--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -1342,23 +1342,11 @@ class _MigrationMorphingRing extends StatefulWidget {
 
 class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     with TickerProviderStateMixin {
-  static const _minimumWeight = 0.035;
-  static const _maximumWeight = 0.22;
-  static const _stepDuration = Duration(milliseconds: 390);
-  static const _stepBreather = Duration(milliseconds: 105);
-  static const _spinDuration = Duration(milliseconds: 1800);
-  static const _restBetweenBlocks = Duration(milliseconds: 900);
+  static const _preparationRotationDuration = Duration(seconds: 8);
   static const _motionDuration = Duration(milliseconds: 1600);
 
-  final math.Random _random = math.Random(704075305);
-  late final AnimationController _stepController = AnimationController(
-    vsync: this,
-    duration: _stepDuration,
-  );
-  late final AnimationController _spinController = AnimationController(
-    vsync: this,
-    duration: _spinDuration,
-  );
+  late final AnimationController _preparationRotationController =
+      AnimationController(vsync: this, duration: _preparationRotationDuration);
   late final AnimationController _morphController = AnimationController(
     vsync: this,
     duration: const Duration(milliseconds: 920),
@@ -1367,10 +1355,6 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     vsync: this,
     duration: _motionDuration,
   );
-  late List<double> _weights;
-  late List<double> _fromWeights;
-  late List<double> _toWeights;
-  Timer? _idleTimer;
   bool _reduceMotion = false;
   List<_MigrationRingVisualSegment> _morphFrom = const [];
   List<_MigrationRingVisualSegment> _morphTo = const [];
@@ -1380,14 +1364,12 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
   void initState() {
     super.initState();
     _morphController.addStatusListener(_handleMorphStatus);
-    _weights = List.of(_MigrationPreparationRingPainter.initialSegmentRatios);
-    _fromWeights = List.of(_weights);
-    _toWeights = List.of(_weights);
-    _lastPreparationSegments = _preparationSegments(_weights);
+    _lastPreparationSegments = _preparationSegments(
+      _MigrationPreparationRingPainter.initialSegmentRatios,
+    );
     if (widget.preparing) {
       _morphFrom = _lastPreparationSegments;
       _morphTo = _lastPreparationSegments;
-      _runIdleLoop();
     } else {
       _morphFrom = _liveSegments(
         values: widget.values,
@@ -1403,6 +1385,7 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
   @override
   void didUpdateWidget(covariant _MigrationMorphingRing oldWidget) {
     super.didUpdateWidget(oldWidget);
+    _syncPreparationRotationController();
     if (widget.preparing) {
       _syncMotionController();
       return;
@@ -1428,9 +1411,6 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
           );
     _morphFrom = current;
     _morphTo = next;
-    _idleTimer?.cancel();
-    _stepController.stop();
-    _spinController.stop();
     if (_reduceMotion) {
       _morphController.value = 1;
     } else {
@@ -1443,6 +1423,7 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
   void didChangeDependencies() {
     super.didChangeDependencies();
     _reduceMotion = MediaQuery.maybeDisableAnimationsOf(context) ?? false;
+    _syncPreparationRotationController();
     _syncMotionController();
   }
 
@@ -1466,73 +1447,22 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     }
   }
 
-  Future<void> _runIdleLoop() async {
-    // Keep the Figma-comparison first frame stable before starting idle motion.
-    await _wait(const Duration(milliseconds: 400));
-    try {
-      while (mounted) {
-        if (!widget.preparing) return;
-        if (_reduceMotion) {
-          await _wait(const Duration(seconds: 1));
-          continue;
-        }
-        for (var cycle = 0; cycle < 3 && mounted; cycle++) {
-          await _adjustSegmentWeights();
-          if (!mounted) return;
-          await _spinController.forward(from: 0);
-        }
-        await _wait(_restBetweenBlocks);
+  void _syncPreparationRotationController() {
+    final shouldRun = !_reduceMotion && widget.preparing;
+    if (shouldRun) {
+      if (!_preparationRotationController.isAnimating) {
+        _preparationRotationController.repeat();
       }
-    } on TickerCanceled {
-      // Disposal can stop either controller while an idle cycle is running.
+    } else {
+      _preparationRotationController
+        ..stop()
+        ..value = 0;
     }
-  }
-
-  Future<void> _adjustSegmentWeights() async {
-    final steps = 3 + _random.nextInt(3);
-    for (var step = 0; step < steps; step++) {
-      if (!mounted) return;
-      final fromIndex = _random.nextInt(_weights.length);
-      var toIndex = _random.nextInt(_weights.length - 1);
-      if (toIndex >= fromIndex) toIndex++;
-
-      final availableToGive = math.min(
-        _weights[fromIndex] - _minimumWeight,
-        _maximumWeight - _weights[toIndex],
-      );
-      final availableToTake = math.min(
-        _maximumWeight - _weights[fromIndex],
-        _weights[toIndex] - _minimumWeight,
-      );
-      final gives = availableToGive >= availableToTake;
-      final available = gives ? availableToGive : availableToTake;
-      if (available <= 0.005) continue;
-      final amount = available * (0.4 + _random.nextDouble() * 0.6);
-
-      setState(() {
-        _fromWeights = List.of(_weights);
-        _toWeights = List.of(_weights);
-        _toWeights[fromIndex] += gives ? -amount : amount;
-        _toWeights[toIndex] += gives ? amount : -amount;
-      });
-      await _stepController.forward(from: 0);
-      _weights = List.of(_toWeights);
-      await _wait(_stepBreather);
-    }
-  }
-
-  Future<void> _wait(Duration duration) {
-    final completer = Completer<void>();
-    _idleTimer?.cancel();
-    _idleTimer = Timer(duration, completer.complete);
-    return completer.future;
   }
 
   @override
   void dispose() {
-    _idleTimer?.cancel();
-    _stepController.dispose();
-    _spinController.dispose();
+    _preparationRotationController.dispose();
     _morphController.dispose();
     _motionController.dispose();
     super.dispose();
@@ -1553,53 +1483,55 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
       container: true,
       excludeSemantics: true,
       label: semanticsLabel,
-      child: AnimatedBuilder(
-        animation: Listenable.merge([
-          _stepController,
-          _spinController,
-          _morphController,
-          _motionController,
-        ]),
-        builder: (context, _) {
-          final eased = Curves.easeOutBack.transform(_stepController.value);
-          final weights = List.generate(
-            _weights.length,
-            (index) =>
-                _fromWeights[index] +
-                ((_toWeights[index] - _fromWeights[index]) * eased),
-          );
-          final preparationSegments = _preparationSegments(weights);
-          _lastPreparationSegments = preparationSegments;
-          final visualSegments = widget.preparing
-              ? preparationSegments
-              : _interpolateVisualSegments(
-                  _morphFrom,
-                  _morphTo,
-                  Curves.easeInOutCubic.transform(_morphController.value),
-                );
-          return Stack(
-            alignment: Alignment.center,
-            children: [
-              if (widget.preparing)
-                const SizedBox.shrink(
-                  key: ValueKey('ironwood_migration_preparation_ring'),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          if (widget.preparing)
+            RotationTransition(
+              key: const ValueKey(
+                'ironwood_migration_preparation_ring_rotation',
+              ),
+              turns: _preparationRotationController,
+              child: RepaintBoundary(
+                child: CustomPaint(
+                  key: const ValueKey('ironwood_migration_ring_paint'),
+                  size: const Size.square(256),
+                  painter: _MigrationRingVisualPainter(
+                    segments: _lastPreparationSegments,
+                    rotation: 0,
+                    motionPhase: 0,
+                    reduceMotion: _reduceMotion,
+                  ),
                 ),
-              CustomPaint(
+              ),
+            )
+          else
+            AnimatedBuilder(
+              animation: Listenable.merge([
+                _morphController,
+                _motionController,
+              ]),
+              builder: (context, _) => CustomPaint(
                 key: const ValueKey('ironwood_migration_ring_paint'),
                 size: const Size.square(256),
                 painter: _MigrationRingVisualPainter(
-                  segments: visualSegments,
-                  rotation: widget.preparing
-                      ? Curves.easeInOutCubic.transform(_spinController.value)
-                      : 0,
+                  segments: _interpolateVisualSegments(
+                    _morphFrom,
+                    _morphTo,
+                    Curves.easeInOutCubic.transform(_morphController.value),
+                  ),
+                  rotation: 0,
                   motionPhase: _motionController.value,
                   reduceMotion: _reduceMotion,
                 ),
               ),
-              widget.child,
-            ],
-          );
-        },
+            ),
+          if (widget.preparing)
+            const SizedBox.shrink(
+              key: ValueKey('ironwood_migration_preparation_ring'),
+            ),
+          widget.child,
+        ],
       ),
     );
   }

--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -1342,11 +1342,27 @@ class _MigrationMorphingRing extends StatefulWidget {
 
 class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     with TickerProviderStateMixin {
-  static const _preparationRotationDuration = Duration(seconds: 8);
+  static const _minimumWeight = 0.035;
+  static const _maximumWeight = 0.22;
+  static const _stepDuration = Duration(milliseconds: 390);
+  static const _stepBreather = Duration(milliseconds: 105);
+  static const _spinDuration = Duration(milliseconds: 1800);
+  static const _restBetweenBlocks = Duration(milliseconds: 900);
   static const _motionDuration = Duration(milliseconds: 1600);
 
-  late final AnimationController _preparationRotationController =
-      AnimationController(vsync: this, duration: _preparationRotationDuration);
+  final math.Random _random = math.Random(704075305);
+  late final AnimationController _stepController = AnimationController(
+    vsync: this,
+    duration: _stepDuration,
+  );
+  late final AnimationController _spinController = AnimationController(
+    vsync: this,
+    duration: _spinDuration,
+  );
+  late final CurvedAnimation _spinAnimation = CurvedAnimation(
+    parent: _spinController,
+    curve: Curves.easeInOutCubic,
+  );
   late final AnimationController _morphController = AnimationController(
     vsync: this,
     duration: const Duration(milliseconds: 920),
@@ -1355,21 +1371,26 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     vsync: this,
     duration: _motionDuration,
   );
+  late List<double> _weights;
+  late List<double> _fromWeights;
+  late List<double> _toWeights;
+  Timer? _idleTimer;
   bool _reduceMotion = false;
   List<_MigrationRingVisualSegment> _morphFrom = const [];
   List<_MigrationRingVisualSegment> _morphTo = const [];
-  List<_MigrationRingVisualSegment> _lastPreparationSegments = const [];
 
   @override
   void initState() {
     super.initState();
     _morphController.addStatusListener(_handleMorphStatus);
-    _lastPreparationSegments = _preparationSegments(
-      _MigrationPreparationRingPainter.initialSegmentRatios,
-    );
+    _weights = List.of(_MigrationPreparationRingPainter.initialSegmentRatios);
+    _fromWeights = List.of(_weights);
+    _toWeights = List.of(_weights);
+    final initialPreparationSegments = _preparationSegments(_weights);
     if (widget.preparing) {
-      _morphFrom = _lastPreparationSegments;
-      _morphTo = _lastPreparationSegments;
+      _morphFrom = initialPreparationSegments;
+      _morphTo = initialPreparationSegments;
+      _runIdleLoop();
     } else {
       _morphFrom = _liveSegments(
         values: widget.values,
@@ -1385,7 +1406,6 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
   @override
   void didUpdateWidget(covariant _MigrationMorphingRing oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _syncPreparationRotationController();
     if (widget.preparing) {
       _syncMotionController();
       return;
@@ -1403,7 +1423,7 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     }
 
     final current = oldWidget.preparing
-        ? _lastPreparationSegments
+        ? _preparationSegments(_currentPreparationWeights())
         : _interpolateVisualSegments(
             _morphFrom,
             _morphTo,
@@ -1411,6 +1431,9 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
           );
     _morphFrom = current;
     _morphTo = next;
+    _idleTimer?.cancel();
+    _stepController.stop();
+    _spinController.stop();
     if (_reduceMotion) {
       _morphController.value = 1;
     } else {
@@ -1423,7 +1446,6 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
   void didChangeDependencies() {
     super.didChangeDependencies();
     _reduceMotion = MediaQuery.maybeDisableAnimationsOf(context) ?? false;
-    _syncPreparationRotationController();
     _syncMotionController();
   }
 
@@ -1447,22 +1469,84 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     }
   }
 
-  void _syncPreparationRotationController() {
-    final shouldRun = !_reduceMotion && widget.preparing;
-    if (shouldRun) {
-      if (!_preparationRotationController.isAnimating) {
-        _preparationRotationController.repeat();
+  Future<void> _runIdleLoop() async {
+    // Keep the Figma-comparison first frame stable before starting idle motion.
+    await _wait(const Duration(milliseconds: 400));
+    try {
+      while (mounted) {
+        if (!widget.preparing) return;
+        if (_reduceMotion) {
+          await _wait(const Duration(seconds: 1));
+          continue;
+        }
+        for (var cycle = 0; cycle < 3 && mounted; cycle++) {
+          await _adjustSegmentWeights();
+          if (!mounted) return;
+          await _spinController.forward(from: 0);
+        }
+        await _wait(_restBetweenBlocks);
       }
-    } else {
-      _preparationRotationController
-        ..stop()
-        ..value = 0;
+    } on TickerCanceled {
+      // Disposal can stop either controller while an idle cycle is running.
     }
+  }
+
+  Future<void> _adjustSegmentWeights() async {
+    final steps = 3 + _random.nextInt(3);
+    for (var step = 0; step < steps; step++) {
+      if (!mounted) return;
+      final fromIndex = _random.nextInt(_weights.length);
+      var toIndex = _random.nextInt(_weights.length - 1);
+      if (toIndex >= fromIndex) toIndex++;
+
+      final availableToGive = math.min(
+        _weights[fromIndex] - _minimumWeight,
+        _maximumWeight - _weights[toIndex],
+      );
+      final availableToTake = math.min(
+        _maximumWeight - _weights[fromIndex],
+        _weights[toIndex] - _minimumWeight,
+      );
+      final gives = availableToGive >= availableToTake;
+      final available = gives ? availableToGive : availableToTake;
+      if (available <= 0.005) continue;
+      final amount = available * (0.4 + _random.nextDouble() * 0.6);
+
+      setState(() {
+        _fromWeights = List.of(_weights);
+        _toWeights = List.of(_weights);
+        _toWeights[fromIndex] += gives ? -amount : amount;
+        _toWeights[toIndex] += gives ? amount : -amount;
+      });
+      await _stepController.forward(from: 0);
+      _weights = List.of(_toWeights);
+      await _wait(_stepBreather);
+    }
+  }
+
+  List<double> _currentPreparationWeights() {
+    final eased = Curves.easeOutBack.transform(_stepController.value);
+    return List.generate(
+      _weights.length,
+      (index) =>
+          _fromWeights[index] +
+          ((_toWeights[index] - _fromWeights[index]) * eased),
+    );
+  }
+
+  Future<void> _wait(Duration duration) {
+    final completer = Completer<void>();
+    _idleTimer?.cancel();
+    _idleTimer = Timer(duration, completer.complete);
+    return completer.future;
   }
 
   @override
   void dispose() {
-    _preparationRotationController.dispose();
+    _idleTimer?.cancel();
+    _stepController.dispose();
+    _spinAnimation.dispose();
+    _spinController.dispose();
     _morphController.dispose();
     _motionController.dispose();
     super.dispose();
@@ -1491,15 +1575,16 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
               key: const ValueKey(
                 'ironwood_migration_preparation_ring_rotation',
               ),
-              turns: _preparationRotationController,
+              turns: _spinAnimation,
               child: RepaintBoundary(
                 child: CustomPaint(
                   key: const ValueKey('ironwood_migration_ring_paint'),
                   size: const Size.square(256),
-                  painter: _MigrationRingVisualPainter(
-                    segments: _lastPreparationSegments,
-                    rotation: 0,
-                    motionPhase: 0,
+                  painter: _MigrationPreparationAnimatedRingPainter(
+                    fromWeights: _fromWeights,
+                    toWeights: _toWeights,
+                    color: widget.preparationColor,
+                    progress: _stepController,
                     reduceMotion: _reduceMotion,
                   ),
                 ),
@@ -1546,6 +1631,55 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
         highlightColor: widget.preparationColor,
       ),
   ];
+}
+
+class _MigrationPreparationAnimatedRingPainter extends CustomPainter {
+  _MigrationPreparationAnimatedRingPainter({
+    required this.fromWeights,
+    required this.toWeights,
+    required this.color,
+    required this.progress,
+    required this.reduceMotion,
+  }) : super(repaint: progress);
+
+  final List<double> fromWeights;
+  final List<double> toWeights;
+  final Color color;
+  final Animation<double> progress;
+  final bool reduceMotion;
+
+  List<_MigrationRingVisualSegment> get segments {
+    final eased = Curves.easeOutBack.transform(progress.value);
+    return [
+      for (var index = 0; index < fromWeights.length; index++)
+        _MigrationRingVisualSegment(
+          weight:
+              fromWeights[index] +
+              ((toWeights[index] - fromWeights[index]) * eased),
+          color: color,
+          highlightColor: color,
+        ),
+    ];
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    _MigrationRingVisualPainter(
+      segments: segments,
+      rotation: 0,
+      motionPhase: 0,
+      reduceMotion: reduceMotion,
+    ).paint(canvas, size);
+  }
+
+  @override
+  bool shouldRepaint(
+    covariant _MigrationPreparationAnimatedRingPainter oldDelegate,
+  ) =>
+      oldDelegate.fromWeights != fromWeights ||
+      oldDelegate.toWeights != toWeights ||
+      oldDelegate.color != color ||
+      oldDelegate.reduceMotion != reduceMotion;
 }
 
 typedef _MigrationRingPalette = ({

--- a/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
+++ b/lib/src/features/migration/screens/ironwood_migration_flow/transfer_status.dart
@@ -1342,8 +1342,23 @@ class _MigrationMorphingRing extends StatefulWidget {
 
 class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     with TickerProviderStateMixin {
+  static const _minimumWeight = 0.035;
+  static const _maximumWeight = 0.22;
+  static const _stepDuration = Duration(milliseconds: 390);
+  static const _stepBreather = Duration(milliseconds: 105);
+  static const _spinDuration = Duration(milliseconds: 1800);
+  static const _restBetweenBlocks = Duration(milliseconds: 900);
   static const _motionDuration = Duration(milliseconds: 1600);
 
+  final math.Random _random = math.Random(704075305);
+  late final AnimationController _stepController = AnimationController(
+    vsync: this,
+    duration: _stepDuration,
+  );
+  late final AnimationController _spinController = AnimationController(
+    vsync: this,
+    duration: _spinDuration,
+  );
   late final AnimationController _morphController = AnimationController(
     vsync: this,
     duration: const Duration(milliseconds: 920),
@@ -1352,6 +1367,10 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     vsync: this,
     duration: _motionDuration,
   );
+  late List<double> _weights;
+  late List<double> _fromWeights;
+  late List<double> _toWeights;
+  Timer? _idleTimer;
   bool _reduceMotion = false;
   List<_MigrationRingVisualSegment> _morphFrom = const [];
   List<_MigrationRingVisualSegment> _morphTo = const [];
@@ -1361,12 +1380,14 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
   void initState() {
     super.initState();
     _morphController.addStatusListener(_handleMorphStatus);
-    _lastPreparationSegments = _preparationSegments(
-      _MigrationPreparationRingPainter.initialSegmentRatios,
-    );
+    _weights = List.of(_MigrationPreparationRingPainter.initialSegmentRatios);
+    _fromWeights = List.of(_weights);
+    _toWeights = List.of(_weights);
+    _lastPreparationSegments = _preparationSegments(_weights);
     if (widget.preparing) {
       _morphFrom = _lastPreparationSegments;
       _morphTo = _lastPreparationSegments;
+      _runIdleLoop();
     } else {
       _morphFrom = _liveSegments(
         values: widget.values,
@@ -1407,6 +1428,9 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
           );
     _morphFrom = current;
     _morphTo = next;
+    _idleTimer?.cancel();
+    _stepController.stop();
+    _spinController.stop();
     if (_reduceMotion) {
       _morphController.value = 1;
     } else {
@@ -1442,8 +1466,73 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
     }
   }
 
+  Future<void> _runIdleLoop() async {
+    // Keep the Figma-comparison first frame stable before starting idle motion.
+    await _wait(const Duration(milliseconds: 400));
+    try {
+      while (mounted) {
+        if (!widget.preparing) return;
+        if (_reduceMotion) {
+          await _wait(const Duration(seconds: 1));
+          continue;
+        }
+        for (var cycle = 0; cycle < 3 && mounted; cycle++) {
+          await _adjustSegmentWeights();
+          if (!mounted) return;
+          await _spinController.forward(from: 0);
+        }
+        await _wait(_restBetweenBlocks);
+      }
+    } on TickerCanceled {
+      // Disposal can stop either controller while an idle cycle is running.
+    }
+  }
+
+  Future<void> _adjustSegmentWeights() async {
+    final steps = 3 + _random.nextInt(3);
+    for (var step = 0; step < steps; step++) {
+      if (!mounted) return;
+      final fromIndex = _random.nextInt(_weights.length);
+      var toIndex = _random.nextInt(_weights.length - 1);
+      if (toIndex >= fromIndex) toIndex++;
+
+      final availableToGive = math.min(
+        _weights[fromIndex] - _minimumWeight,
+        _maximumWeight - _weights[toIndex],
+      );
+      final availableToTake = math.min(
+        _maximumWeight - _weights[fromIndex],
+        _weights[toIndex] - _minimumWeight,
+      );
+      final gives = availableToGive >= availableToTake;
+      final available = gives ? availableToGive : availableToTake;
+      if (available <= 0.005) continue;
+      final amount = available * (0.4 + _random.nextDouble() * 0.6);
+
+      setState(() {
+        _fromWeights = List.of(_weights);
+        _toWeights = List.of(_weights);
+        _toWeights[fromIndex] += gives ? -amount : amount;
+        _toWeights[toIndex] += gives ? amount : -amount;
+      });
+      await _stepController.forward(from: 0);
+      _weights = List.of(_toWeights);
+      await _wait(_stepBreather);
+    }
+  }
+
+  Future<void> _wait(Duration duration) {
+    final completer = Completer<void>();
+    _idleTimer?.cancel();
+    _idleTimer = Timer(duration, completer.complete);
+    return completer.future;
+  }
+
   @override
   void dispose() {
+    _idleTimer?.cancel();
+    _stepController.dispose();
+    _spinController.dispose();
     _morphController.dispose();
     _motionController.dispose();
     super.dispose();
@@ -1465,10 +1554,24 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
       excludeSemantics: true,
       label: semanticsLabel,
       child: AnimatedBuilder(
-        animation: Listenable.merge([_morphController, _motionController]),
+        animation: Listenable.merge([
+          _stepController,
+          _spinController,
+          _morphController,
+          _motionController,
+        ]),
         builder: (context, _) {
+          final eased = Curves.easeOutBack.transform(_stepController.value);
+          final weights = List.generate(
+            _weights.length,
+            (index) =>
+                _fromWeights[index] +
+                ((_toWeights[index] - _fromWeights[index]) * eased),
+          );
+          final preparationSegments = _preparationSegments(weights);
+          _lastPreparationSegments = preparationSegments;
           final visualSegments = widget.preparing
-              ? _lastPreparationSegments
+              ? preparationSegments
               : _interpolateVisualSegments(
                   _morphFrom,
                   _morphTo,
@@ -1486,7 +1589,9 @@ class _MigrationMorphingRingState extends State<_MigrationMorphingRing>
                 size: const Size.square(256),
                 painter: _MigrationRingVisualPainter(
                   segments: visualSegments,
-                  rotation: 0,
+                  rotation: widget.preparing
+                      ? Curves.easeInOutCubic.transform(_spinController.value)
+                      : 0,
                   motionPhase: _motionController.value,
                   reduceMotion: _reduceMotion,
                 ),

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -1010,6 +1010,45 @@ void main() {
     },
   );
 
+  testWidgets('preparation ring rotates without repainting its segments', (
+    tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1440, 900);
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      _privateStatusHarness(status: _status(), disableAnimations: false),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    final rotation = tester.widget<RotationTransition>(
+      find.byKey(
+        const ValueKey('ironwood_migration_preparation_ring_rotation'),
+      ),
+    );
+    final initialTurns = rotation.turns.value;
+    final initialPainter = tester
+        .widget<CustomPaint>(
+          find.byKey(const ValueKey('ironwood_migration_ring_paint')),
+        )
+        .painter;
+
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(rotation.turns.value, greaterThan(initialTurns));
+    expect(
+      tester
+          .widget<CustomPaint>(
+            find.byKey(const ValueKey('ironwood_migration_ring_paint')),
+          )
+          .painter,
+      same(initialPainter),
+    );
+  });
+
   testWidgets('private preparing status does not expose note progress', (
     tester,
   ) async {

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -1010,39 +1010,6 @@ void main() {
     },
   );
 
-  testWidgets('preparation ring stays still while the carousel is waiting', (
-    tester,
-  ) async {
-    tester.view.devicePixelRatio = 1;
-    tester.view.physicalSize = const Size(1440, 900);
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
-
-    await tester.pumpWidget(
-      _privateStatusHarness(status: _status(), disableAnimations: false),
-    );
-    await tester.pump(const Duration(milliseconds: 400));
-
-    List<double> ringWeights() {
-      final dynamic painter = tester
-          .widget<CustomPaint>(
-            find.byKey(const ValueKey('ironwood_migration_ring_paint')),
-          )
-          .painter;
-      return [
-        for (final dynamic segment in painter.segments as List<dynamic>)
-          segment.weight as double,
-      ];
-    }
-
-    final initialWeights = ringWeights();
-    for (var frame = 0; frame < 20; frame++) {
-      await tester.pump(const Duration(milliseconds: 100));
-    }
-
-    expect(ringWeights(), initialWeights);
-  });
-
   testWidgets('private preparing status does not expose note progress', (
     tester,
   ) async {

--- a/test/features/migration/ironwood_migration_flow_screen_test.dart
+++ b/test/features/migration/ironwood_migration_flow_screen_test.dart
@@ -1010,44 +1010,69 @@ void main() {
     },
   );
 
-  testWidgets('preparation ring rotates without repainting its segments', (
-    tester,
-  ) async {
-    tester.view.devicePixelRatio = 1;
-    tester.view.physicalSize = const Size(1440, 900);
-    addTearDown(tester.view.resetPhysicalSize);
-    addTearDown(tester.view.resetDevicePixelRatio);
+  testWidgets(
+    'preparation ring reshapes and spins without rebuilding the paint layer',
+    (tester) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1440, 900);
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
 
-    await tester.pumpWidget(
-      _privateStatusHarness(status: _status(), disableAnimations: false),
-    );
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpWidget(
+        _privateStatusHarness(status: _status(), disableAnimations: false),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
 
-    final rotation = tester.widget<RotationTransition>(
-      find.byKey(
-        const ValueKey('ironwood_migration_preparation_ring_rotation'),
-      ),
-    );
-    final initialTurns = rotation.turns.value;
-    final initialPainter = tester
-        .widget<CustomPaint>(
-          find.byKey(const ValueKey('ironwood_migration_ring_paint')),
-        )
-        .painter;
+      final paintFinder = find.byKey(
+        const ValueKey('ironwood_migration_ring_paint'),
+      );
+      dynamic initialPainter;
+      for (var frame = 0; frame < 20; frame++) {
+        await tester.pump(const Duration(milliseconds: 100));
+        initialPainter = tester.widget<CustomPaint>(paintFinder).painter;
+        final fromWeights = initialPainter.fromWeights as List<double>;
+        final toWeights = initialPainter.toWeights as List<double>;
+        if (fromWeights.indexed.any(
+          (entry) => entry.$2 != toWeights[entry.$1],
+        )) {
+          break;
+        }
+      }
+      expect(
+        initialPainter.toWeights as List<double>,
+        isNot(equals(initialPainter.fromWeights as List<double>)),
+      );
+      final initialWeights = [
+        for (final dynamic segment in initialPainter.segments as List<dynamic>)
+          segment.weight as double,
+      ];
 
-    await tester.pump(const Duration(milliseconds: 400));
+      await tester.pump(const Duration(milliseconds: 100));
 
-    expect(rotation.turns.value, greaterThan(initialTurns));
-    expect(
-      tester
-          .widget<CustomPaint>(
-            find.byKey(const ValueKey('ironwood_migration_ring_paint')),
-          )
-          .painter,
-      same(initialPainter),
-    );
-  });
+      final dynamic reshapedPainter = tester
+          .widget<CustomPaint>(paintFinder)
+          .painter;
+      final reshapedWeights = [
+        for (final dynamic segment in reshapedPainter.segments as List<dynamic>)
+          segment.weight as double,
+      ];
+      expect(reshapedPainter, same(initialPainter));
+      expect(reshapedWeights, isNot(equals(initialWeights)));
+
+      final rotation = tester.widget<RotationTransition>(
+        find.byKey(
+          const ValueKey('ironwood_migration_preparation_ring_rotation'),
+        ),
+      );
+      var observedSpin = rotation.turns.value > 0;
+      for (var frame = 0; frame < 50 && !observedSpin; frame++) {
+        await tester.pump(const Duration(milliseconds: 100));
+        observedSpin = rotation.turns.value > 0;
+      }
+      expect(observedSpin, isTrue);
+    },
+  );
 
   testWidgets('private preparing status does not expose note progress', (
     tester,


### PR DESCRIPTION
## Summary

- restore the original Ironwood note-split preparation ring animation, including its organic segment reshaping, timing, easing, and spin phases
- move segment interpolation into a repaint-driven CustomPainter so animation frames do not rebuild the ring widget tree
- isolate the painted ring behind a RepaintBoundary and perform spin phases as compositor transforms over the cached layer
- preserve reduced-motion behavior and the preparation-to-migration morph
- add coverage that observes both reshaping and spinning while confirming the paint layer is not rebuilt per frame

## Root cause

The preparation ring idle animation was removed to keep the migration guidance carousel smooth. The first attempted replacement reduced it to a simple continuous rotation, which changed the intended visual behavior. The final implementation retains the original animation exactly while separating paint-only work from compositor-only work so the carousel and ring no longer rebuild through the same per-frame path.

## Validation

- targeted `fvm flutter analyze` on the changed migration implementation and tests
- preparation ring reshape/spin regression test
- preparation-to-migration morph test
- reduced-motion preparation ring test
- prior full migration/carousel widget test run (94 tests)
- deterministic widget capture of `ironwood-migration-private-status-waiting`

Regtest, E2E, Docker, and test-node workflows were intentionally not run because another test session was active.