### PR TITLE
fix(send): reduce routine payment action fingerprint

### DIFF
--- a/rust/src/wallet/sync/send.rs
+++ b/rust/src/wallet/sync/send.rs
@@ -115,6 +115,8 @@ use super::{
 
 const UNBROADCAST_MIGRATION_RECOVERY_SAFETY_BLOCKS: u32 = 10;
 const SEND_PROPOSAL_LOCK_BLOCKS: u32 = 40;
+const NOTE_MANAGEMENT_TARGET_OUTPUT_COUNT: usize = 4;
+const MIN_NOTE_MANAGEMENT_OUTPUT_ZATOSHI: u64 = 10_000_000;
 
 fn send_proposal_lock_expiry(min_target_height: BlockHeight) -> BlockHeight {
     min_target_height + SEND_PROPOSAL_LOCK_BLOCKS
@@ -2861,7 +2863,8 @@ fn build_shielding_proposal(
 
     // Regular shielding transactions stay padded (`DEFAULT`); only migration
     // children opt in to unpadded Orchard-pool bundles.
-    let (change_strategy, input_selector) = zip317_helper::<WalletDatabase>(None, None, false);
+    let (change_strategy, input_selector) =
+        zip317_helper::<WalletDatabase>(None, None, note_management_split_policy(), false);
     let proposal = propose_shielding::<_, _, _, _, Infallible>(
         db,
         &network,
@@ -2927,6 +2930,7 @@ fn propose_send_with_reserved_notes(
     let (change_strategy, input_selector) = zip317_helper::<ReservedInputSource<'_>>(
         None,
         proposed_tx_version,
+        ordinary_payment_split_policy(),
         unpadded_orchard_pool_bundles,
     );
 
@@ -5514,13 +5518,23 @@ where
     stats
 }
 
-/// ZIP-317 change-strategy / input-selector factory used by both
-/// `propose_send` and `estimate_fee`. Keeps the configuration
-/// (Orchard-preferred change, minimum 0.1 ZEC output split) in one
-/// place so the two entry points can't drift.
+fn ordinary_payment_split_policy() -> SplitPolicy {
+    SplitPolicy::single_output()
+}
+
+fn note_management_split_policy() -> SplitPolicy {
+    SplitPolicy::with_min_output_value(
+        NonZeroUsize::new(NOTE_MANAGEMENT_TARGET_OUTPUT_COUNT).unwrap(),
+        Zatoshis::const_from_u64(MIN_NOTE_MANAGEMENT_OUTPUT_ZATOSHI),
+    )
+}
+
+/// ZIP-317 change-strategy / input-selector factory used by payment and
+/// shielding proposals.
 fn zip317_helper<DbT: InputSource>(
     change_memo: Option<MemoBytes>,
     proposed_tx_version: Option<TxVersion>,
+    split_policy: SplitPolicy,
     unpadded_orchard_pool_bundles: bool,
 ) -> (
     MultiOutputChangeStrategy<WalletFeeRule, DbT>,
@@ -5531,10 +5545,7 @@ fn zip317_helper<DbT: InputSource>(
         change_memo,
         ShieldedPool::Orchard,
         DustOutputPolicy::default(),
-        SplitPolicy::with_min_output_value(
-            NonZeroUsize::new(4).unwrap(),
-            Zatoshis::const_from_u64(1000_0000),
-        ),
+        split_policy,
     );
     // Migration children only: count exactly the requested actions so the
     // proposal's fee matches the unpadded bundle the PCZT builder produces.

--- a/rust/src/wallet/sync/send/tests.rs
+++ b/rust/src/wallet/sync/send/tests.rs
@@ -13,6 +13,28 @@ const MIGRATION_TEST_PASSWORD: &[u8] = b"correct horse battery staple";
 const MIGRATION_TEST_SALT: &str = "AQIDBAUGBwgJCgsMDQ4PEA==";
 
 #[test]
+fn ordinary_payment_change_is_not_split_for_note_management() {
+    let policy = ordinary_payment_split_policy();
+
+    assert_eq!(policy.target_output_count(), NonZeroUsize::MIN);
+    assert_eq!(policy.min_split_output_value(), None);
+}
+
+#[test]
+fn shielding_keeps_note_management_split_policy() {
+    let policy = note_management_split_policy();
+
+    assert_eq!(
+        policy.target_output_count().get(),
+        NOTE_MANAGEMENT_TARGET_OUTPUT_COUNT
+    );
+    assert_eq!(
+        policy.min_split_output_value(),
+        Some(Zatoshis::const_from_u64(MIN_NOTE_MANAGEMENT_OUTPUT_ZATOSHI))
+    );
+}
+
+#[test]
 fn send_proposal_expires_at_its_lock_boundary() {
     let min_target = BlockHeight::from_u32(1_000);
     assert!(!send_proposal_is_expired(


### PR DESCRIPTION
## Summary

- use a single change output for ordinary payment proposals and fee estimates
- keep librustzcash's default two-action Orchard/Ironwood bundle padding
- retain the existing four-note management target for transparent shielding
- leave migration transaction construction unchanged

## Why

[CipherScan's wallet analysis](https://cipherscan.app/privacy/wallets) currently describes Vizor as producing "4 actions always" while grouping ZODL and other librustzcash wallets under a "2 actions (min)" baseline. The existing four-note change-management target can make a routine Vizor payment create extra change outputs while the account is below that target, producing a more distinctive action-count shape.

This change makes ordinary payments use `SplitPolicy::single_output()`. A common one-recipient/one-change transaction can therefore stay at the standard two-action floor. Transactions with multiple inputs, recipients, or cross-pool components may still legitimately require more than two actions.

Important source-level nuance: this is a Vizor fingerprint-reduction choice, not strict ZODL parity. The current official ZODL SDKs also configure a target of four sufficiently valued wallet notes:

- [ZODL Android SDK change policy](https://github.com/zcash/zcash-android-wallet-sdk/blob/6b5ba375c457257e28ec2f971dc89c6402ea241e/backend-lib/src/main/rust/lib.rs#L2094-L2097)
- [ZODL Swift SDK change policy](https://github.com/zcash/zcash-swift-wallet-sdk/blob/f51ed74aa70df959eee7af501f0f920438abe07d/rust/src/lib.rs#L2167-L2170)

CipherScan appears to compare Vizor's change-splitting behavior with the SDK family's lower-level two-action bundle minimum. This PR deliberately removes proactive splitting only from ordinary Vizor payments, which avoids relying on that ambiguous comparison.

## Testing

- `cargo test note_management` — 2 passed
- `cargo test --lib` — 472 passed, 1 ignored
- `cargo fmt --all -- --check`
