### PR TITLE
Shorten migration transfer spacing to 90 minutes

### DIFF
--- a/rust/src/wallet/sync/migration.rs
+++ b/rust/src/wallet/sync/migration.rs
@@ -621,11 +621,8 @@ pub(crate) struct ActiveRun {
 fn timing_policy_for_run_with_conn(
     conn: &rusqlite::Connection,
     run_id: &str,
-    network: WalletNetwork,
+    _network: WalletNetwork,
 ) -> Result<MigrationTimingPolicy, String> {
-    if !matches!(network, WalletNetwork::Test | WalletNetwork::Regtest) {
-        return Ok(MigrationTimingPolicy::Standard);
-    }
     let value = conn
         .query_row(
             &format!("SELECT timing_policy FROM {RUNS_TABLE} WHERE run_id = ?1"),
@@ -689,7 +686,7 @@ fn adopt_timing_policy_for_active_run(
         &format!(
             "UPDATE {RUNS_TABLE}
              SET timing_policy = ?1, schedule_json = ?2, updated_at_ms = ?3
-             WHERE run_id = ?4 AND timing_policy = 'standard'"
+             WHERE run_id = ?4 AND timing_policy != 'fast_testnet'"
         ),
         params![
             MigrationTimingPolicy::FastTestnet.as_str(),
@@ -1871,11 +1868,7 @@ fn insert_pending_txs_with_tx(
         .map_err(|e| format!("Read migration run policy: {e}"))?;
     let network = WalletNetwork::from_str(&network)
         .ok_or_else(|| format!("Unsupported migration run network: {network}"))?;
-    let timing_policy = if matches!(network, WalletNetwork::Test | WalletNetwork::Regtest) {
-        MigrationTimingPolicy::from_str(&timing_policy)?
-    } else {
-        MigrationTimingPolicy::Standard
-    };
+    let timing_policy = MigrationTimingPolicy::from_str(&timing_policy)?;
     let target_values: Vec<u64> = serde_json::from_str(&target_values_json)
         .map_err(|e| format!("Decode migration run target values: {e}"))?;
     let schedule_json = tx

--- a/rust/src/wallet/sync/migration/policy.rs
+++ b/rust/src/wallet/sync/migration/policy.rs
@@ -5,8 +5,10 @@ pub(crate) const ZIP318_ANCHOR_BUCKET_MODULUS: u32 = 144;
 pub(crate) const REGTEST_ANCHOR_BUCKET_MODULUS: u32 = 1;
 pub(crate) const ZIP318_ANCHOR_AGE_CAP: u32 = 16;
 pub(crate) const ZIP318_EXPIRY_MODULUS: u32 = 34_560;
+// Keep the original value readable for runs created before the shorter policy.
 pub(crate) const ZIP318_TRANSFER_MEAN_DELAY_BLOCKS: u32 = 144;
 pub(crate) const ZIP318_TRANSFER_MAX_DELAY_BLOCKS: u32 = 576;
+pub(crate) const NINETY_MINUTE_TRANSFER_MEAN_DELAY_BLOCKS: u32 = 72;
 pub(crate) const REGTEST_TRANSFER_MEAN_DELAY_BLOCKS: u32 = 1;
 pub(crate) const REGTEST_TRANSFER_MAX_DELAY_BLOCKS: u32 = 4;
 pub(crate) const FAST_TESTNET_TRANSFER_MEAN_DELAY_BLOCKS: u32 = 12;
@@ -26,6 +28,7 @@ static FAST_TESTNET_MIGRATION_ENABLED: AtomicBool = AtomicBool::new(false);
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum MigrationTimingPolicy {
     Standard,
+    Standard90Minutes,
     FastTestnet,
 }
 
@@ -33,6 +36,7 @@ impl MigrationTimingPolicy {
     const fn as_str(self) -> &'static str {
         match self {
             Self::Standard => "standard",
+            Self::Standard90Minutes => "standard_90m",
             Self::FastTestnet => "fast_testnet",
         }
     }
@@ -40,6 +44,7 @@ impl MigrationTimingPolicy {
     fn from_str(value: &str) -> Result<Self, String> {
         match value {
             "standard" => Ok(Self::Standard),
+            "standard_90m" => Ok(Self::Standard90Minutes),
             "fast_testnet" => Ok(Self::FastTestnet),
             _ => Err(format!("Unsupported migration timing policy: {value}")),
         }
@@ -55,8 +60,10 @@ pub(crate) fn configured_timing_policy(network: WalletNetwork) -> MigrationTimin
         && FAST_TESTNET_MIGRATION_ENABLED.load(Ordering::Relaxed)
     {
         MigrationTimingPolicy::FastTestnet
-    } else {
+    } else if network == WalletNetwork::Regtest {
         MigrationTimingPolicy::Standard
+    } else {
+        MigrationTimingPolicy::Standard90Minutes
     }
 }
 
@@ -81,6 +88,14 @@ fn schedule_parameters_with_policy(
             FAST_TESTNET_TRANSFER_MEAN_DELAY_BLOCKS,
             FAST_TESTNET_TRANSFER_MAX_DELAY_BLOCKS,
         ),
+        WalletNetwork::Main | WalletNetwork::Test
+            if timing_policy == MigrationTimingPolicy::Standard90Minutes =>
+        {
+            (
+                NINETY_MINUTE_TRANSFER_MEAN_DELAY_BLOCKS,
+                ZIP318_TRANSFER_MAX_DELAY_BLOCKS,
+            )
+        }
         WalletNetwork::Main | WalletNetwork::Test => (
             ZIP318_TRANSFER_MEAN_DELAY_BLOCKS,
             ZIP318_TRANSFER_MAX_DELAY_BLOCKS,

--- a/rust/src/wallet/sync/migration/tests.rs
+++ b/rust/src/wallet/sync/migration/tests.rs
@@ -2646,7 +2646,7 @@ fn schedule_validation_keeps_legacy_positive_first_offsets_compatible() {
 }
 
 #[test]
-fn regtest_schedule_is_short_but_still_requires_blocks() {
+fn configured_schedule_uses_ninety_minute_mean_without_changing_regtest() {
     assert_eq!(
         schedule_parameters(WalletNetwork::Regtest),
         (1, REGTEST_TRANSFER_MAX_DELAY_BLOCKS)
@@ -2654,10 +2654,110 @@ fn regtest_schedule_is_short_but_still_requires_blocks() {
     assert_eq!(
         schedule_parameters(WalletNetwork::Test),
         (
+            NINETY_MINUTE_TRANSFER_MEAN_DELAY_BLOCKS,
+            ZIP318_TRANSFER_MAX_DELAY_BLOCKS
+        )
+    );
+    assert_eq!(
+        schedule_parameters(WalletNetwork::Main),
+        (
+            NINETY_MINUTE_TRANSFER_MEAN_DELAY_BLOCKS,
+            ZIP318_TRANSFER_MAX_DELAY_BLOCKS
+        )
+    );
+}
+
+#[test]
+fn legacy_and_ninety_minute_policies_keep_distinct_parameters() {
+    assert_eq!(
+        schedule_parameters_with_policy(WalletNetwork::Main, MigrationTimingPolicy::Standard),
+        (
             ZIP318_TRANSFER_MEAN_DELAY_BLOCKS,
             ZIP318_TRANSFER_MAX_DELAY_BLOCKS
         )
     );
+    assert_eq!(
+        schedule_parameters_with_policy(
+            WalletNetwork::Main,
+            MigrationTimingPolicy::Standard90Minutes,
+        ),
+        (
+            NINETY_MINUTE_TRANSFER_MEAN_DELAY_BLOCKS,
+            ZIP318_TRANSFER_MAX_DELAY_BLOCKS
+        )
+    );
+}
+
+#[test]
+fn mainnet_run_reads_its_persisted_timing_policy() {
+    let conn = rusqlite::Connection::open_in_memory().unwrap();
+    ensure_schema(&conn).unwrap();
+    for (run_id, timing_policy) in [("legacy", "standard"), ("shorter", "standard_90m")] {
+        conn.execute(
+            &format!(
+                "INSERT INTO {RUNS_TABLE}
+                 (run_id, account_uuid, network, db_fingerprint, phase,
+                  created_at_ms, updated_at_ms, target_values_json, timing_policy)
+                 VALUES (?1, ?1, 'main', 'wallet.db', ?2, 1, 1, '[100]', ?3)"
+            ),
+            params![run_id, PHASE_READY_TO_MIGRATE, timing_policy],
+        )
+        .unwrap();
+    }
+
+    assert_eq!(
+        timing_policy_for_run_with_conn(&conn, "legacy", WalletNetwork::Main).unwrap(),
+        MigrationTimingPolicy::Standard,
+    );
+    assert_eq!(
+        timing_policy_for_run_with_conn(&conn, "shorter", WalletNetwork::Main).unwrap(),
+        MigrationTimingPolicy::Standard90Minutes,
+    );
+}
+
+#[test]
+fn new_mainnet_draft_persists_ninety_minute_policy() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("wallet.db");
+    let db_path = db_path.to_string_lossy().to_string();
+    let schedule = [MigrationScheduleEntry {
+        part_index: Some(0),
+        value_zatoshi: 100,
+        block_offset: NINETY_MINUTE_TRANSFER_MEAN_DELAY_BLOCKS,
+    }];
+
+    let run_id = create_or_resume_private_migration_draft(
+        &db_path,
+        "account-1",
+        WalletNetwork::Main,
+        &[100],
+        &schedule,
+        PreparationTimingPolicy::Zip318Spaced,
+    )
+    .unwrap();
+
+    assert_eq!(
+        timing_policy_for_run(&db_path, &run_id, WalletNetwork::Main).unwrap(),
+        MigrationTimingPolicy::Standard90Minutes,
+    );
+}
+
+#[test]
+fn ninety_minute_schedule_samples_the_truncated_distribution() {
+    let count = 20_000;
+    let mut rng = StdRng::seed_from_u64(0x90);
+    let offsets = random_schedule_block_offsets_with_rng(
+        count,
+        NINETY_MINUTE_TRANSFER_MEAN_DELAY_BLOCKS,
+        ZIP318_TRANSFER_MAX_DELAY_BLOCKS,
+        &mut rng,
+    );
+    let total_delay = u64::from(*offsets.last().unwrap());
+
+    // Redrawing samples above the 12-hour cap makes the realized mean
+    // slightly lower than the untruncated 72-block parameter.
+    assert!(total_delay > count as u64 * 70);
+    assert!(total_delay < count as u64 * 74);
 }
 
 #[test]


### PR DESCRIPTION
Shortens newly created Mainnet and Testnet migration transfer schedules from a nominal 144-block mean to 72 blocks while retaining the 576-block maximum. The timing policy is versioned so existing `standard` runs keep their approved 144-block behavior, and all mainnet read and materialization paths now honor the persisted run policy.

This intentionally changes Vizor wallet scheduling relative to the current proposed ZIP 318 text, which still names a 144-block mean, so that proposal should be aligned before release. Validated with the full Rust test suite and the focused Flutter migration presentation tests.