### PR TITLE
Rotate migration lightwalletd endpoints

### DIFF
--- a/ios/Runner/BackgroundMigrationOutbox.swift
+++ b/ios/Runner/BackgroundMigrationOutbox.swift
@@ -84,6 +84,8 @@ struct BackgroundMigrationOutboxBatch: Codable, Equatable {
   let accountUuid: String
   let runId: String
   var lightwalletdUrl: String
+  var lightwalletdUrls: [String]? = nil
+  var nextLightwalletdIndex: Int? = nil
   let timingMeanBlocks: UInt64
   let timingMaxBlocks: UInt64
   let createdAt: Date
@@ -104,6 +106,27 @@ struct BackgroundMigrationOutboxBatch: Codable, Equatable {
   var items: [BackgroundMigrationOutboxItem]
 
   var scopeKey: String { "\(network):\(accountUuid)" }
+
+  var rotationUrls: [String] {
+    guard let lightwalletdUrls, !lightwalletdUrls.isEmpty else {
+      return [lightwalletdUrl]
+    }
+    return lightwalletdUrls
+  }
+
+  var activeLightwalletdUrl: String {
+    let urls = rotationUrls
+    let index = nextLightwalletdIndex ?? 0
+    guard index >= 0 else { return urls[0] }
+    return urls[index % urls.count]
+  }
+
+  mutating func advanceLightwalletdEndpoint() {
+    let urls = rotationUrls
+    guard urls.count > 1 else { return }
+    let index = nextLightwalletdIndex ?? 0
+    nextLightwalletdIndex = index < 0 ? 0 : (index + 1) % urls.count
+  }
 
   /// Whether this batch still owes the user a proof-ready announcement.
   ///
@@ -209,11 +232,18 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
   var announcedBroadcastCompleteBatchIds: [String]?
 
   mutating func stage(_ batch: BackgroundMigrationOutboxBatch) throws {
+    let rotationUrls = batch.rotationUrls
     guard !batch.batchId.isEmpty,
       !batch.network.isEmpty,
       !batch.accountUuid.isEmpty,
       !batch.runId.isEmpty,
       !batch.lightwalletdUrl.isEmpty,
+      batch.lightwalletdUrls?.isEmpty != true,
+      rotationUrls.first == batch.lightwalletdUrl,
+      rotationUrls.allSatisfy({ !$0.isEmpty }),
+      Set(rotationUrls).count == rotationUrls.count,
+      (batch.nextLightwalletdIndex ?? 0) >= 0,
+      (batch.nextLightwalletdIndex ?? 0) < rotationUrls.count,
       batch.timingMeanBlocks > 0,
       batch.timingMaxBlocks > 0,
       batch.timingMeanBlocks <= batch.timingMaxBlocks,
@@ -246,11 +276,19 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
       else {
         throw BackgroundMigrationOutboxError.conflictingBatch
       }
-      if existing.lightwalletdUrl != batch.lightwalletdUrl {
+      if existing.lightwalletdUrls == nil && existing.lightwalletdUrl != batch.lightwalletdUrl {
         guard !existing.items.contains(where: { $0.status == .submitting }) else {
           throw BackgroundMigrationOutboxError.conflictingBatch
         }
         batches[batchIndex].lightwalletdUrl = batch.lightwalletdUrl
+      }
+      if existing.lightwalletdUrls == nil, batch.lightwalletdUrls != nil {
+        guard !existing.items.contains(where: { $0.status == .submitting }) else {
+          throw BackgroundMigrationOutboxError.conflictingBatch
+        }
+        batches[batchIndex].lightwalletdUrl = batch.lightwalletdUrl
+        batches[batchIndex].lightwalletdUrls = batch.lightwalletdUrls
+        batches[batchIndex].nextLightwalletdIndex = 0
       }
       var addedItem = false
       for incoming in batch.items {
@@ -360,7 +398,9 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
       }
       batches[batchIndex].items[itemIndex] = item
     }
-    batches[batchIndex].lightwalletdUrl = lightwalletdUrl
+    if batches[batchIndex].lightwalletdUrls == nil {
+      batches[batchIndex].lightwalletdUrl = lightwalletdUrl
+    }
     if batches[batchIndex].items.contains(where: { $0.status == .armed }) {
       batches[batchIndex].armedAt = batches[batchIndex].armedAt ?? date
     }
@@ -414,13 +454,20 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
     }
   }
 
+  mutating func advanceLightwalletdEndpoints(afterPreflightFailure endpoint: String) {
+    for batchIndex in batches.indices
+    where batches[batchIndex].activeLightwalletdUrl == endpoint {
+      batches[batchIndex].advanceLightwalletdEndpoint()
+    }
+  }
+
   mutating func nextEndpointForInspection() -> String? {
     let endpoints = Set(
       batches.filter { batch in
         batch.armedAt != nil
           && (batch.items.contains(where: { $0.status == .armed })
             || (batch.nextProofHeight != nil && batch.awaitsProofReadyAnnouncement))
-      }.map(\.lightwalletdUrl)
+      }.map(\.activeLightwalletdUrl)
     ).sorted()
     guard !endpoints.isEmpty else { return nil }
     let selected: String
@@ -435,13 +482,15 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
     return selected
   }
 
-  func nextActionHeight(endpoint: String) -> UInt64? {
-    let transactionHeight = batches.filter { $0.lightwalletdUrl == endpoint }.flatMap(\.items)
+  func nextActionHeight(endpoint: String? = nil) -> UInt64? {
+    let transactionHeight = batches.filter {
+      endpoint == nil || $0.activeLightwalletdUrl == endpoint
+    }.flatMap(\.items)
       .filter { $0.status == .armed }
       .map(\.scheduledHeight)
       .min()
     let proofHeight = batches.filter {
-      $0.lightwalletdUrl == endpoint
+      (endpoint == nil || $0.activeLightwalletdUrl == endpoint)
         && $0.armedAt != nil
         && $0.awaitsProofReadyAnnouncement
         && $0.proofReadyNotificationPendingAt == nil
@@ -452,7 +501,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
   func nextActionAccountUuid(endpoint: String, height: UInt64) -> String? {
     return batches
       .filter { batch in
-        guard batch.lightwalletdUrl == endpoint else { return false }
+        guard batch.activeLightwalletdUrl == endpoint else { return false }
         let hasTransaction = batch.items.contains {
           $0.status == .armed && $0.scheduledHeight == height
         }
@@ -494,7 +543,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
     batches
       .filter { batch in
         guard let nextProofHeight = batch.nextProofHeight else { return false }
-        return batch.lightwalletdUrl == endpoint
+        return batch.activeLightwalletdUrl == endpoint
           && batch.armedAt != nil
           && batch.awaitsProofReadyAnnouncement
           && nextProofHeight <= remoteHeight
@@ -707,7 +756,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
 
   mutating func expireItems(remoteHeight: UInt64, endpoint: String, at date: Date) {
     for batchIndex in batches.indices {
-      guard batches[batchIndex].lightwalletdUrl == endpoint else { continue }
+      guard batches[batchIndex].activeLightwalletdUrl == endpoint else { continue }
       var expiredAnyItem = false
       for itemIndex in batches[batchIndex].items.indices {
         let item = batches[batchIndex].items[itemIndex]
@@ -743,7 +792,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
       return
     }
     for batchIndex in batches.indices {
-      guard batches[batchIndex].lightwalletdUrl == endpoint else { continue }
+      guard batches[batchIndex].activeLightwalletdUrl == endpoint else { continue }
       var foundNoncanonicalItem = false
       for itemIndex in batches[batchIndex].items.indices {
         let item = batches[batchIndex].items[itemIndex]
@@ -780,7 +829,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
   ) -> BackgroundMigrationOutboxSelection? {
     let candidates = batches.enumerated().compactMap {
       batchIndex, batch -> (Int, BackgroundMigrationOutboxBatch)? in
-      guard endpoint == nil || batch.lightwalletdUrl == endpoint,
+      guard endpoint == nil || batch.activeLightwalletdUrl == endpoint,
         batch.armedAt != nil,
         batch.items.contains(where: {
           $0.status == .armed && $0.scheduledHeight <= remoteHeight
@@ -819,7 +868,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
       batchId: batch.batchId,
       accountUuid: batch.accountUuid,
       scopeKey: batch.scopeKey,
-      lightwalletdUrl: batch.lightwalletdUrl,
+      lightwalletdUrl: batch.activeLightwalletdUrl,
       item: item
     )
   }
@@ -910,6 +959,7 @@ struct BackgroundMigrationOutboxSnapshot: Codable, Equatable {
         at: date
       )
     )
+    batches[location.batch].advanceLightwalletdEndpoint()
   }
 
   mutating func recordRejected(

--- a/ios/Runner/BackgroundMigrationOutboxChannel.swift
+++ b/ios/Runner/BackgroundMigrationOutboxChannel.swift
@@ -193,6 +193,16 @@ enum BackgroundMigrationOutboxChannel {
 
   private static func decodeBatch(_ raw: Any?) throws -> BackgroundMigrationOutboxBatch {
     let arguments = try dictionary(raw)
+    let lightwalletdUrl = try string(arguments, "lightwalletdUrl")
+    let lightwalletdUrls: [String]
+    if let rawUrls = arguments["lightwalletdUrls"] {
+      guard let urls = rawUrls as? [String] else {
+        throw BackgroundMigrationOutboxChannelError.invalidArguments("lightwalletdUrls")
+      }
+      lightwalletdUrls = urls
+    } else {
+      lightwalletdUrls = [lightwalletdUrl]
+    }
     guard let rawItems = arguments["items"] as? [[String: Any]] else {
       throw BackgroundMigrationOutboxChannelError.invalidArguments("items")
     }
@@ -216,7 +226,9 @@ enum BackgroundMigrationOutboxChannel {
       network: try string(arguments, "network"),
       accountUuid: try string(arguments, "accountUuid"),
       runId: try string(arguments, "runId"),
-      lightwalletdUrl: try string(arguments, "lightwalletdUrl"),
+      lightwalletdUrl: lightwalletdUrl,
+      lightwalletdUrls: lightwalletdUrls,
+      nextLightwalletdIndex: 0,
       timingMeanBlocks: try uint64(arguments, "timingMeanBlocks"),
       timingMaxBlocks: try uint64(arguments, "timingMaxBlocks"),
       createdAt: Date(

--- a/ios/Runner/BackgroundMigrationOutboxRunner.swift
+++ b/ios/Runner/BackgroundMigrationOutboxRunner.swift
@@ -97,6 +97,9 @@ enum BackgroundMigrationOutboxRunner {
         broadcastComplete: broadcastComplete
       )
     case .failure:
+      _ = try? store.update { snapshot in
+        snapshot.advanceLightwalletdEndpoints(afterPreflightFailure: endpoint)
+      }
       return BackgroundMigrationOutboxRunResult(
         transport: .temporarilyUnavailable,
         proofReady: nil,
@@ -269,7 +272,7 @@ enum BackgroundMigrationOutboxRunner {
                 at: now
               ) ?? broadcastComplete
           }
-          let nextHeight = snapshot.nextActionHeight(endpoint: endpoint)
+          let nextHeight = snapshot.nextActionHeight()
           return BackgroundMigrationOutboxRunResult(
             transport: .accepted(
               nextHeight: nextHeight,

--- a/ios/RunnerTests/BackgroundMigrationOutboxTests.swift
+++ b/ios/RunnerTests/BackgroundMigrationOutboxTests.swift
@@ -88,6 +88,19 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     XCTAssertNil(snapshot.announcedBroadcastCompleteBatchIds)
   }
 
+  func testLegacyBatchDecodesAsSingleEndpointRotation() throws {
+    let batch = makeBatch(batchId: "batch-a", account: "account-a")
+    let encoded = try JSONEncoder().encode(batch)
+    let decoded = try JSONDecoder().decode(
+      BackgroundMigrationOutboxBatch.self,
+      from: encoded
+    )
+
+    XCTAssertNil(decoded.lightwalletdUrls)
+    XCTAssertEqual(decoded.rotationUrls, [batch.lightwalletdUrl])
+    XCTAssertEqual(decoded.activeLightwalletdUrl, batch.lightwalletdUrl)
+  }
+
   func testDiscardBatchRemovesAnIdleRecordButKeepsTheAccountScope() throws {
     var snapshot = BackgroundMigrationOutboxSnapshot()
     let batch = makeBatch(batchId: "batch-a", account: "account-a")
@@ -299,6 +312,23 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     XCTAssertThrowsError(try snapshot.stage(replacement)) { error in
       XCTAssertEqual(error as? BackgroundMigrationOutboxError, .conflictingBatch)
     }
+  }
+
+  func testRestagingDoesNotResetPersistedEndpointCursor() throws {
+    let endpoints = ["https://one.example:443", "https://two.example:443"]
+    let batch = makeBatch(
+      batchId: "batch-a",
+      account: "account-a",
+      lightwalletdUrls: endpoints
+    )
+    var snapshot = BackgroundMigrationOutboxSnapshot()
+    try snapshot.stage(batch)
+    snapshot.batches[0].nextLightwalletdIndex = 1
+
+    try snapshot.stage(batch)
+
+    XCTAssertEqual(snapshot.batches[0].nextLightwalletdIndex, 1)
+    XCTAssertEqual(snapshot.batches[0].activeLightwalletdUrl, endpoints[1])
   }
 
   func testWatchOnlyBatchIsValidButEmptyBatchWithoutWatchIsRejected() throws {
@@ -687,6 +717,137 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
       (receipt["rawTransaction"] as? FlutterStandardTypedData)?.data,
       batch.items[0].rawTransaction
     )
+  }
+
+  func testRunnerRotatesEndpointAfterEachAcceptedTransaction() throws {
+    let harness = try makeStoreHarness()
+    defer { harness.cleanup() }
+    let endpoints = ["https://one.example:443", "https://two.example:443"]
+    let batch = makeBatch(
+      batchId: "batch-a",
+      account: "account-a",
+      heights: [100, 300],
+      lightwalletdUrls: endpoints
+    )
+    try stageAndArm(batch, in: harness.store)
+    var queriedEndpoints: [String] = []
+    var submissionEndpoints: [String] = []
+    var remoteHeight: UInt64 = 200
+    let dependencies = BackgroundMigrationOutboxRunnerDependencies(
+      latestBlockHeight: { endpoint, _ in
+        queriedEndpoints.append(endpoint)
+        return .success(remoteHeight)
+      },
+      sendTransaction: { endpoint, _, _ in
+        submissionEndpoints.append(endpoint)
+        return .success(
+          NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
+        )
+      }
+    )
+
+    _ = BackgroundMigrationOutboxRunner.runOnce(
+      store: harness.store,
+      cancellation: BackgroundMigrationCancellation(),
+      now: now,
+      dependencies: dependencies
+    )
+    remoteHeight = 300
+    _ = BackgroundMigrationOutboxRunner.runOnce(
+      store: harness.store,
+      cancellation: BackgroundMigrationCancellation(),
+      now: now.addingTimeInterval(60),
+      dependencies: dependencies
+    )
+
+    XCTAssertEqual(queriedEndpoints, endpoints)
+    XCTAssertEqual(submissionEndpoints, endpoints)
+  }
+
+  func testRunnerKeepsUncertainRetryOnTheSameEndpoint() throws {
+    let harness = try makeStoreHarness()
+    defer { harness.cleanup() }
+    let endpoints = ["https://one.example:443", "https://two.example:443"]
+    let batch = makeBatch(
+      batchId: "batch-a",
+      account: "account-a",
+      heights: [100],
+      lightwalletdUrls: endpoints
+    )
+    try stageAndArm(batch, in: harness.store)
+    var submissionEndpoints: [String] = []
+    let dependencies = BackgroundMigrationOutboxRunnerDependencies(
+      latestBlockHeight: { _, _ in .success(200) },
+      sendTransaction: { endpoint, _, _ in
+        submissionEndpoints.append(endpoint)
+        if submissionEndpoints.count == 1 { return .failure(.timedOut) }
+        return .success(
+          NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
+        )
+      }
+    )
+
+    _ = BackgroundMigrationOutboxRunner.runOnce(
+      store: harness.store,
+      cancellation: BackgroundMigrationCancellation(),
+      now: now,
+      dependencies: dependencies
+    )
+    _ = BackgroundMigrationOutboxRunner.runOnce(
+      store: harness.store,
+      cancellation: BackgroundMigrationCancellation(),
+      now: now.addingTimeInterval(60),
+      dependencies: dependencies
+    )
+
+    XCTAssertEqual(submissionEndpoints, [endpoints[0], endpoints[0]])
+  }
+
+  func testRunnerAdvancesEndpointAfterPreflightFailure() throws {
+    let harness = try makeStoreHarness()
+    defer { harness.cleanup() }
+    let endpoints = ["https://one.example:443", "https://two.example:443"]
+    let batch = makeBatch(
+      batchId: "batch-a",
+      account: "account-a",
+      heights: [100],
+      lightwalletdUrls: endpoints
+    )
+    try stageAndArm(batch, in: harness.store)
+    var queriedEndpoints: [String] = []
+    var submissionEndpoints: [String] = []
+    let dependencies = BackgroundMigrationOutboxRunnerDependencies(
+      latestBlockHeight: { endpoint, _ in
+        queriedEndpoints.append(endpoint)
+        return endpoint == endpoints[0] ? .failure(.timedOut) : .success(200)
+      },
+      sendTransaction: { endpoint, _, _ in
+        submissionEndpoints.append(endpoint)
+        return .success(
+          NativeLightwalletdSendResponse(errorCode: 0, errorMessage: "")
+        )
+      }
+    )
+
+    let first = BackgroundMigrationOutboxRunner.runOnce(
+      store: harness.store,
+      cancellation: BackgroundMigrationCancellation(),
+      now: now,
+      dependencies: dependencies
+    )
+    let second = BackgroundMigrationOutboxRunner.runOnce(
+      store: harness.store,
+      cancellation: BackgroundMigrationCancellation(),
+      now: now.addingTimeInterval(60),
+      dependencies: dependencies
+    )
+
+    XCTAssertEqual(first.transport, .temporarilyUnavailable)
+    guard case .accepted = second.transport else {
+      return XCTFail("Expected the fallback endpoint to submit the transaction")
+    }
+    XCTAssertEqual(queriedEndpoints, endpoints)
+    XCTAssertEqual(submissionEndpoints, [endpoints[1]])
   }
 
   func testRunnerReportsBroadcastCompleteAfterLastAcceptedEquivalentItem() throws {
@@ -1536,14 +1697,18 @@ final class BackgroundMigrationOutboxTests: XCTestCase {
     batchId: String,
     account: String,
     heights: [UInt64] = [100, 101, 102],
-    nextProofHeight: UInt64? = nil
+    nextProofHeight: UInt64? = nil,
+    lightwalletdUrls: [String]? = nil
   ) -> BackgroundMigrationOutboxBatch {
-    BackgroundMigrationOutboxBatch(
+    let lightwalletdUrl = lightwalletdUrls?.first ?? "https://testnet.zec.rocks:443"
+    return BackgroundMigrationOutboxBatch(
       batchId: batchId,
       network: "test",
       accountUuid: account,
       runId: "run-\(account)",
-      lightwalletdUrl: "https://testnet.zec.rocks:443",
+      lightwalletdUrl: lightwalletdUrl,
+      lightwalletdUrls: lightwalletdUrls,
+      nextLightwalletdIndex: lightwalletdUrls == nil ? nil : 0,
       timingMeanBlocks: 144,
       timingMaxBlocks: 576,
       createdAt: now,

--- a/lib/src/core/config/rpc_endpoint_config.dart
+++ b/lib/src/core/config/rpc_endpoint_config.dart
@@ -49,6 +49,7 @@ class RpcEndpointPreset {
     required this.region,
     required this.label,
     required this.url,
+    this.operatorId,
     this.isDefault = false,
   });
 
@@ -56,9 +57,14 @@ class RpcEndpointPreset {
   final String region;
   final String label;
   final String url;
+
+  /// Groups regional replicas that share one lightwalletd operator.
+  final String? operatorId;
   final bool isDefault;
 
   String get hostPort => rpcEndpointHostPort(url);
+
+  String get effectiveOperatorId => operatorId ?? id;
 }
 
 // Public lightwalletd presets. Keep the mainnet default aligned with Zodl's
@@ -68,6 +74,7 @@ const kIronwoodMasqueradeRpcEndpointPreset = RpcEndpointPreset(
   region: 'Ironwood',
   label: 'Ironwood Masquerade',
   url: 'https://lwd.157.245.208.35.sslip.io:443',
+  operatorId: 'ironwood-masquerade',
   isDefault: true,
 );
 
@@ -77,6 +84,7 @@ final kMainnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
     region: 'Default',
     label: 'Stardust US',
     url: ZcashNetwork.mainnet.lightwalletdUrl,
+    operatorId: 'stardust',
     isDefault: true,
   ),
   const RpcEndpointPreset(
@@ -84,66 +92,77 @@ final kMainnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
     region: 'Europe',
     label: 'Stardust Europe',
     url: 'https://eu.zec.stardust.rest:443',
+    operatorId: 'stardust',
   ),
   const RpcEndpointPreset(
     id: 'eu2-zec-stardust',
     region: 'Europe',
     label: 'Stardust Europe 2',
     url: 'https://eu2.zec.stardust.rest:443',
+    operatorId: 'stardust',
   ),
   const RpcEndpointPreset(
     id: 'jp-zec-stardust',
     region: 'Asia Pacific',
     label: 'Stardust Japan',
     url: 'https://jp.zec.stardust.rest:443',
+    operatorId: 'stardust',
   ),
   const RpcEndpointPreset(
     id: 'zec-rocks',
     region: 'Global',
     label: 'Zec Rocks',
     url: 'https://zec.rocks:443',
+    operatorId: 'zec-rocks',
   ),
   const RpcEndpointPreset(
     id: 'na-zec-rocks',
     region: 'Americas',
     label: 'Zec Rocks North America',
     url: 'https://na.zec.rocks:443',
+    operatorId: 'zec-rocks',
   ),
   const RpcEndpointPreset(
     id: 'sa-zec-rocks',
     region: 'Americas',
     label: 'Zec Rocks South America',
     url: 'https://sa.zec.rocks:443',
+    operatorId: 'zec-rocks',
   ),
   const RpcEndpointPreset(
     id: 'eu-zec-rocks',
     region: 'Europe',
     label: 'Zec Rocks Europe',
     url: 'https://eu.zec.rocks:443',
+    operatorId: 'zec-rocks',
   ),
   const RpcEndpointPreset(
     id: 'ap-zec-rocks',
     region: 'Asia Pacific',
     label: 'Zec Rocks Asia Pacific',
     url: 'https://ap.zec.rocks:443',
+    operatorId: 'zec-rocks',
   ),
   const RpcEndpointPreset(
     id: 'z3-deepikaw',
     region: 'Community',
     label: 'Deepikaw Z3',
     url: 'https://z3.deepikaw.xyz:443',
+    operatorId: 'deepikaw',
   ),
   const RpcEndpointPreset(
     id: 'zprivacy',
     region: 'Community',
     label: 'ZPrivacy',
     url: 'https://zprivacy.online:443',
+    operatorId: 'zprivacy',
   ),
   const RpcEndpointPreset(
     id: 'zcash-explorer',
     region: 'Community',
     label: 'Zcash Explorer',
     url: 'https://lwd.zcashexplorer.app:9067',
+    operatorId: 'zcash-explorer',
   ),
 ]);
 
@@ -153,6 +172,7 @@ final kTestnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
     region: 'Testnet',
     label: 'Zec Rocks Testnet',
     url: 'https://testnet.zec.rocks:443',
+    operatorId: 'zec-rocks',
     isDefault: true,
   ),
   const RpcEndpointPreset(
@@ -160,6 +180,7 @@ final kTestnetRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
     region: 'Community',
     label: 'My Side of the Web Testnet',
     url: 'https://zcash.mysideoftheweb.com:19067',
+    operatorId: 'mysideoftheweb',
   ),
 ]);
 
@@ -169,6 +190,7 @@ final kRegtestRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
     region: 'Regtest',
     label: 'Local Regtest',
     url: ZcashNetwork.regtest.lightwalletdUrl,
+    operatorId: 'local-regtest',
     isDefault: true,
   ),
   const RpcEndpointPreset(
@@ -176,12 +198,14 @@ final kRegtestRpcEndpointPresets = List<RpcEndpointPreset>.unmodifiable([
     region: 'Regtest',
     label: 'Slow Regtest',
     url: 'http://127.0.0.1:19068',
+    operatorId: 'slow-regtest',
   ),
   const RpcEndpointPreset(
     id: kRegtestUnavailableRpcEndpointPresetId,
     region: 'Regtest',
     label: 'Unavailable Regtest',
     url: 'http://127.0.0.1:19067',
+    operatorId: 'unavailable-regtest',
   ),
 ]);
 
@@ -270,6 +294,30 @@ List<RpcEndpointConfig> fallbackRpcEndpointCandidatesFor(
 RpcEndpointConfig? fallbackRpcEndpointConfigFor(RpcEndpointConfig primary) {
   final candidates = fallbackRpcEndpointCandidatesFor(primary);
   return candidates.isEmpty ? null : candidates.first;
+}
+
+/// Returns one managed endpoint per operator, beginning with [primary].
+///
+/// Custom endpoints intentionally remain a single-endpoint rotation.
+List<RpcEndpointConfig> migrationRpcEndpointRotationFor(
+  RpcEndpointConfig primary,
+) {
+  final primaryPreset = explicitRpcEndpointPresetFor(primary);
+  if (primaryPreset == null) return List.unmodifiable([primary]);
+
+  final seenOperators = <String>{};
+  final endpoints = <RpcEndpointConfig>[];
+  for (final endpoint in [
+    primary,
+    ...fallbackRpcEndpointCandidatesFor(primary),
+  ]) {
+    final preset = explicitRpcEndpointPresetFor(endpoint);
+    if (preset == null || !seenOperators.add(preset.effectiveOperatorId)) {
+      continue;
+    }
+    endpoints.add(endpoint);
+  }
+  return List.unmodifiable(endpoints);
 }
 
 RpcEndpointPreset? _selectedFallbackPrimaryPreset(RpcEndpointConfig primary) {

--- a/lib/src/features/migration/services/ironwood_migration_service.dart
+++ b/lib/src/features/migration/services/ironwood_migration_service.dart
@@ -2213,6 +2213,25 @@ class IronwoodMigrationService {
     }
   }
 
+  List<String> _migrationOutboxLightwalletdUrls(
+    _MigrationCredentialContext context,
+  ) {
+    final primaryUrl = context.lightwalletdUrl;
+    if (primaryUrl == null) return const [];
+    try {
+      final configured = getEndpoint();
+      if (configured.networkName != context.network ||
+          configured.normalizedLightwalletdUrl != primaryUrl) {
+        return [primaryUrl];
+      }
+      return migrationRpcEndpointRotationFor(configured)
+          .map((endpoint) => endpoint.normalizedLightwalletdUrl)
+          .toList(growable: false);
+    } catch (_) {
+      return [primaryUrl];
+    }
+  }
+
   Future<_MigrationCredential> _legacyCredential(
     _MigrationCredentialContext context,
   ) async {
@@ -2398,12 +2417,14 @@ class IronwoodMigrationService {
     }
 
     final batchId = _migrationOutboxBatchId(context, batch.runId);
+    final lightwalletdUrls = _migrationOutboxLightwalletdUrls(context);
     final stagePayload = <String, Object?>{
       'batchId': batchId,
       'network': context.network,
       'accountUuid': context.accountUuid,
       'runId': batch.runId,
       'lightwalletdUrl': lightwalletdUrl,
+      'lightwalletdUrls': lightwalletdUrls,
       'timingMeanBlocks': batch.timingMeanBlocks,
       'timingMaxBlocks': batch.timingMaxBlocks,
       'createdAtMs': DateTime.now().millisecondsSinceEpoch,

--- a/test/core/config/rpc_endpoint_config_test.dart
+++ b/test/core/config/rpc_endpoint_config_test.dart
@@ -374,6 +374,49 @@ void main() {
     });
   });
 
+  group('migrationRpcEndpointRotationFor', () {
+    test('keeps one mainnet endpoint per operator', () {
+      final endpoints = migrationRpcEndpointRotationFor(
+        defaultRpcEndpointConfig('main'),
+      );
+
+      expect(endpoints.map((endpoint) => endpoint.presetId), [
+        kDefaultRpcEndpointPresetId,
+        'zec-rocks',
+        'z3-deepikaw',
+        'zprivacy',
+        'zcash-explorer',
+      ]);
+    });
+
+    test('starts with the selected managed endpoint', () {
+      final endpoints = migrationRpcEndpointRotationFor(
+        const RpcEndpointConfig(
+          networkName: 'main',
+          lightwalletdUrl: 'https://eu.zec.rocks:443',
+          presetId: 'eu-zec-rocks',
+        ),
+      );
+
+      expect(endpoints.first.presetId, 'eu-zec-rocks');
+      expect(
+        endpoints.map((endpoint) => endpoint.presetId),
+        isNot(contains('zec-rocks')),
+      );
+      expect(endpoints[1].presetId, kDefaultRpcEndpointPresetId);
+    });
+
+    test('keeps custom endpoints isolated', () {
+      const custom = RpcEndpointConfig(
+        networkName: 'main',
+        lightwalletdUrl: 'https://custom.example:443',
+        presetId: kCustomRpcEndpointPresetId,
+      );
+
+      expect(migrationRpcEndpointRotationFor(custom), [custom]);
+    });
+  });
+
   group('rpcEndpointHostPort', () {
     test('keeps IPv6 brackets so custom endpoint fields can round-trip', () {
       expect(rpcEndpointHostPort('https://[::1]:9067'), '[::1]:9067');

--- a/test/features/migration/ironwood_migration_service_test.dart
+++ b/test/features/migration/ironwood_migration_service_test.dart
@@ -4159,7 +4159,7 @@ void main() {
             storage: const FlutterSecureStorage(),
           ),
           backgroundCredentialStore: _backgroundCredentialStore(),
-          getEndpoint: _testEndpoint,
+          getEndpoint: () => defaultRpcEndpointConfig('test'),
           getSessionPassword: () => throw StateError('session password used'),
           getMnemonicBytesForAccount: (_) async =>
               Uint8List.fromList([1, 2, 3]),
@@ -4230,6 +4230,14 @@ void main() {
         ]);
         expect(stagedPayload?['batchId'], 'test:account-1:run-1');
         expect(stagedPayload?['nextProofHeight'], 576);
+        expect(
+          stagedPayload?['lightwalletdUrl'],
+          'https://testnet.zec.rocks:443',
+        );
+        expect(stagedPayload?['lightwalletdUrls'], [
+          'https://testnet.zec.rocks:443',
+          'https://zcash.mysideoftheweb.com:19067',
+        ]);
         final items = stagedPayload?['items'] as List<Object?>;
         final item = items.single as Map<Object?, Object?>;
         expect(item['rawTransaction'], isA<Uint8List>());


### PR DESCRIPTION
Stage iOS background migration batches with an operator-deduplicated lightwalletd endpoint ring, keeping the user's selected endpoint first. Advance after each accepted transfer and after safe preflight failures, while uncertain submissions remain pinned to the same endpoint so exact retries cannot cross servers.

Custom endpoints remain isolated, and snapshots written before endpoint rotation continue to decode and run as single-endpoint batches.